### PR TITLE
chore(scope): quarantine workspace instructions + regen scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -497,6 +497,9 @@ workspaces/**/*.tsbuildinfo
 # Snyk Security Extension - AI Rules (auto-generated)
 .github/instructions/snyk_rules.instructions.md
 
+# Workspace-local GitHub instructions (not governed)
+workspaces/**/.github/instructions/
+
 # TS build cache
 frontend/.tsbuildinfo
 

--- a/DEPENDENCY_SCOPE_LEGACY_QUARANTINE.json
+++ b/DEPENDENCY_SCOPE_LEGACY_QUARANTINE.json
@@ -37,10 +37,10 @@
     "root": ".ai",
     "bucket": "QUARANTINE",
     "evidence": {
-      "score": 6,
-      "scoreLocal": 2,
-      "scoreTotal": 6,
-      "buildableLocal": true,
+      "score": 0,
+      "scoreLocal": 0,
+      "scoreTotal": 0,
+      "buildableLocal": false,
       "markers": ["package.json:buildOrTest"],
       "markerOrigins": [
         {
@@ -59,10 +59,10 @@
     "root": ".ci_artifacts_local",
     "bucket": "QUARANTINE",
     "evidence": {
-      "score": 5,
-      "scoreLocal": 2,
-      "scoreTotal": 5,
-      "buildableLocal": true,
+      "score": 0,
+      "scoreLocal": 0,
+      "scoreTotal": 0,
+      "buildableLocal": false,
       "markers": ["docker"],
       "markerOrigins": [
         {

--- a/DEPENDENCY_SCOPE_QUARANTINE.json
+++ b/DEPENDENCY_SCOPE_QUARANTINE.json
@@ -37,10 +37,10 @@
     "root": ".ai",
     "bucket": "QUARANTINE",
     "evidence": {
-      "score": 6,
-      "scoreLocal": 2,
-      "scoreTotal": 6,
-      "buildableLocal": true,
+      "score": 0,
+      "scoreLocal": 0,
+      "scoreTotal": 0,
+      "buildableLocal": false,
       "markers": ["package.json:buildOrTest"],
       "markerOrigins": [
         {
@@ -59,10 +59,10 @@
     "root": ".ci_artifacts_local",
     "bucket": "QUARANTINE",
     "evidence": {
-      "score": 5,
-      "scoreLocal": 2,
-      "scoreTotal": 5,
-      "buildableLocal": true,
+      "score": 0,
+      "scoreLocal": 0,
+      "scoreTotal": 0,
+      "buildableLocal": false,
       "markers": ["docker"],
       "markerOrigins": [
         {

--- a/DEPENDENCY_SCOPE_REPORT.md
+++ b/DEPENDENCY_SCOPE_REPORT.md
@@ -1,6 +1,6 @@
 # TerraFusion Scope Report
 
-Generated: 2026-01-16T04:55:23.454Z
+Generated: 2026-01-16T05:27:45.499Z
 SOLID_BASE: 567fbcec5
 ARCH_ANCHOR: 9af5bb291
 
@@ -12,8 +12,8 @@ ARCH_ANCHOR: 9af5bb291
 
 ## Top Evidence Samples
 - . -> CORE_OS_TOOLING (local=4; total=6; wiring=none)
-- .ai -> QUARANTINE (local=2; total=6; wiring=kernel-gateway-ref)
-- .ci_artifacts_local -> QUARANTINE (local=2; total=5; wiring=none)
+- .ai -> QUARANTINE (local=0; total=0; wiring=kernel-gateway-ref)
+- .ci_artifacts_local -> QUARANTINE (local=0; total=0; wiring=none)
 - BS_PACS -> QUARANTINE (local=2; total=3; wiring=none)
 - CONSOLIDATED_20250915_062012 -> QUARANTINE (local=2; total=3; wiring=none)
 - Dev -> CORE_OS_RUNTIME (local=8; total=16; wiring=kernel-gateway-ref,os-shell-mount-ref)

--- a/tools/scope-classifier/src/classify.ts
+++ b/tools/scope-classifier/src/classify.ts
@@ -36,8 +36,11 @@ export type Classification = {
 };
 
 export function classifyRoot(facts: RootFacts): Classification {
-  const forcedBucket = FORCE_BUCKETS[facts.root] ?? FORCE_BUCKET_PATTERNS.find((rule) => rule.pattern.test(facts.root))?.bucket;
-  if (QUARANTINE_PATTERNS.some((re) => re.test(facts.root))) {
+  const forcedBucket =
+    FORCE_BUCKETS[facts.root] ??
+    FORCE_BUCKET_PATTERNS.find((rule) => rule.pattern.test(facts.root))?.bucket;
+  const skipQuarantine = Boolean(forcedBucket && forcedBucket !== "QUARANTINE");
+  if (!skipQuarantine && QUARANTINE_PATTERNS.some((re) => re.test(facts.root))) {
     return {
       bucket: "QUARANTINE",
       evidence: {
@@ -56,7 +59,7 @@ export function classifyRoot(facts: RootFacts): Classification {
     };
   }
 
-  if (facts.pathFlags.includes("privacy-tier-only")) {
+  if (!skipQuarantine && facts.pathFlags.includes("privacy-tier-only")) {
     return {
       bucket: "QUARANTINE",
       evidence: {

--- a/tools/scope-classifier/src/config.ts
+++ b/tools/scope-classifier/src/config.ts
@@ -3,6 +3,8 @@ export const QUARANTINE_PATTERNS = [
   /^Dev - Copy\//,
   /^_pre_restore_safety_/,
   /^node_modules\//,
+  /^\.[^/]+/,
+  /^workspaces\/[^/]+\/\.github\/instructions/,
 ];
 
 export const PRIVACY_TIER_ONLY_MARKERS = [


### PR DESCRIPTION
- Ignores `workspaces/**/.github/instructions/` to keep local instructions out of governance/commits
- Quarantine patterns added for dot roots + workspace instructions
- Forced buckets win over quarantine when forced != QUARANTINE (`.` + `_CLEAN_BUILD_ZONE` stay TOOLING)
- Regenerated dual-anchor scope outputs (`567fbcec5` / `9af5bb291`)
- Tests: `pnpm -C tools/scope-classifier test` (passed)

## Summary by Sourcery

Update scope classifier quarantine behavior and configuration while regenerating scope reports.

Bug Fixes:
- Ensure forced scope buckets override quarantine classification when the forced bucket is not QUARANTINE.

Enhancements:
- Expand quarantine patterns to include dot-prefixed roots and workspace-specific GitHub instruction directories.

Tests:
- Regenerate dependency scope reports and adjust evidence samples to reflect updated quarantine rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency scope classification quarantine rules with expanded pattern matching for improved accuracy
  * Reset quarantine scoring adjustments for specific dependency entries to reflect current state
  * Implemented new capability allowing forced bucket assignments to override existing quarantine constraints
  * Updated git ignore configuration to properly exclude workspace-local files and instructions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->