### PR TITLE
ci(scope): rely on packageManager pnpm version

### DIFF
--- a/.github/workflows/scope-drift-guard.yml
+++ b/.github/workflows/scope-drift-guard.yml
@@ -14,8 +14,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Remove pnpm version pin from Scope Drift Guard workflow so pnpm/action-setup uses packageManager from package.json.

## Summary by Sourcery

CI:
- Remove explicit pnpm version from the Scope Drift Guard workflow so pnpm/action-setup uses the packageManager-defined version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use default version behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->