### PR TITLE
fix(ci): use literal value for reusable workflow input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     needs: [quality-gate, drift_guard, hint_drift_guard, warning_gate]
     uses: ./.github/workflows/dotnet-test.yml
     with:
-      dotnet_version: ${{ env.DOTNET_VERSION }}
+      dotnet_version: '8.0.x'
       configuration: Release
       solution: TerraFusion.sln
       connection_string: 'Host=localhost;Database=terrafusion_test;Username=postgres;Password=postgres'


### PR DESCRIPTION
The env context is not available in reusable workflow call inputs. Fixes CI workflow failure by replacing env.DOTNET_VERSION with the literal 8.0.x.

## Summary by Sourcery

Bug Fixes:
- Resolve CI failures caused by using an unavailable env context for the reusable workflow input in the .NET test job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use a fixed .NET version for backend tests, ensuring consistent test execution environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->