### PR TITLE
docs: add lint escape hatch deadline to PR requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ git push -u origin feature/TF-123-your-feature
 - [ ] **Title:** Matches main commit format (`type(scope): summary`)
 - [ ] **Description:** Complete with context, impact, and evidence
 - [ ] **Tests:** All automated checks passing (CI/CD pipeline)
+- [ ] **Lint:** Must pass (blocking as of **2026-02-15** — do not extend without RFC)
 - [ ] **Security:** No secrets committed, security scan passed
 - [ ] **Compliance:** FISMA-High requirements verified
 - [ ] **Performance:** Impact assessment completed


### PR DESCRIPTION
Classifier proof PR - docs-only change.

**Expected behavior:**
- \classify\ marks \docs_only=true\
- Frontend/Backend gates skip
- Governance runs
- SEAL passes

Also locks lint escape hatch date (2026-02-15) into CONTRIBUTING.md.

## Summary by Sourcery

Documentation:
- Update CONTRIBUTING checklist to state that lint must pass and becomes a blocking requirement as of 2026-02-15, with changes beyond that date requiring an RFC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution guidelines with new linting requirement for pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->