### PR TITLE
ci(phase4c): add paths filters to 16 heavy workflows - stop docs-only fan-out

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - 'src/**'
+      - '.github/workflows/accessibility.yml'
   pull_request:
+    paths:
+      - 'frontend/**'
+      - 'src/**'
+      - '.github/workflows/accessibility.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ai-swarm-safety.yml
+++ b/.github/workflows/ai-swarm-safety.yml
@@ -3,6 +3,13 @@ name: AI Swarm Safety Gate
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+    paths:
+      - 'config/ai-*'
+      - 'backend/**/AI/**'
+      - 'backend/**/Agents/**'
+      - 'frontend/**/ai/**'
+      - 'frontend/**/agents/**'
+      - '.github/workflows/ai-swarm-safety.yml'
 
 jobs:
   check-ai-swarm-safety:

--- a/.github/workflows/baseline-guard.yml
+++ b/.github/workflows/baseline-guard.yml
@@ -1,6 +1,12 @@
 name: Baseline Guard
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'tools/**'
+      - '.github/workflows/baseline-guard.yml'
 jobs:
   guard:
     runs-on: windows-latest

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -3,8 +3,20 @@ name: TerraFusion OS - Build Validation
 on:
   push:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - '*.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - '.github/workflows/build-validation.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - '*.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - '.github/workflows/build-validation.yml'
 
 jobs:
   validate-build:

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -12,8 +12,26 @@ name: 🏛️ TerraFusion OS - Main CI/CD Pipeline
 on:
   push:
     branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - 'Directory.Build.props'
+      - '.github/workflows/ci-cd-main.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - 'Directory.Build.props'
+      - '.github/workflows/ci-cd-main.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: TerraFusion OS 1.0 - Continuous Integration
 on:
   push:
     branches: [main, development]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main, development]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/ci.yml'
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/code-intel.yml
+++ b/.github/workflows/code-intel.yml
@@ -2,7 +2,19 @@ name: Code Intelligence
 on:
   push:
     branches: [main]
-  pull_request: {}
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'tools/**'
+      - '.github/workflows/code-intel.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'tools/**'
+      - '.github/workflows/code-intel.yml'
   workflow_dispatch: {}
 jobs:
   scan:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -2,6 +2,14 @@ name: E2E Smoke - TerraFusion cOS
 
 on:
   pull_request:
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'src/**'
+      - 'apps/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e-smoke.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/governance-proof.yml
+++ b/.github/workflows/governance-proof.yml
@@ -3,6 +3,13 @@ name: governance-proof
 on:
   pull_request:
     branches: [main, master]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'policy/**'
+      - 'tools/**'
+      - '.github/workflows/governance-proof.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,8 +8,20 @@ on:
   push:
     branches: [main, release/**]
     tags: ['v*']
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'backend/**/*.csproj'
+      - 'Directory.Packages.props'
+      - '.github/workflows/sbom.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'backend/**/*.csproj'
+      - 'Directory.Packages.props'
+      - '.github/workflows/sbom.yml'
   schedule:
     - cron: '0 6 * * *' # Daily at 6 AM UTC
   workflow_dispatch:

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -6,8 +6,26 @@ name: 🛡️ Security & Compliance Pipeline
 on:
   push:
     branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.csproj'
+      - 'Directory.Packages.props'
+      - '.github/workflows/security-compliance.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.csproj'
+      - 'Directory.Packages.props'
+      - '.github/workflows/security-compliance.yml'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight
   workflow_dispatch:

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -7,8 +7,20 @@ on:
   push:
     branches: [main, release/**]
     tags: ['v*']
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/slsa-provenance.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/slsa-provenance.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/spec-gates.yml
+++ b/.github/workflows/spec-gates.yml
@@ -3,8 +3,16 @@ name: TerraFusion Spec Gates
 on:
   push:
     branches: [main, develop, release/*]
+    paths:
+      - 'docs/architecture/specs/**'
+      - 'policy/**'
+      - '.github/workflows/spec-gates.yml'
   pull_request:
     branches: [main, develop]
+    paths:
+      - 'docs/architecture/specs/**'
+      - 'policy/**'
+      - '.github/workflows/spec-gates.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/tag-lint.yml
+++ b/.github/workflows/tag-lint.yml
@@ -1,6 +1,12 @@
 name: Tag Lint
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'tools/**'
+      - '.github/workflows/tag-lint.yml'
 jobs:
   lint:
     runs-on: windows-latest

--- a/.github/workflows/terrafusion-ci-cd-production.yml
+++ b/.github/workflows/terrafusion-ci-cd-production.yml
@@ -4,9 +4,25 @@ on:
   push:
     branches: [main, production]
     tags: ['v*']
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/terrafusion-ci-cd-production.yml'
   pull_request:
     branches: [main, production]
     types: [opened, synchronize, reopened]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/terrafusion-ci-cd-production.yml'
   workflow_dispatch:
     inputs:
       deploy_environment:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,8 +3,24 @@ name: TerraFusion OS Comprehensive Testing
 on:
   push:
     branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/testing.yml'
   pull_request:
     branches: [main, develop]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '*.sln'
+      - '.github/workflows/testing.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary by Sourcery

Restrict CI, security, and governance workflows to run only when relevant source, configuration, or policy files change, reducing unnecessary pipeline executions.

CI:
- Add path filters to core CI/CD, security, testing, build, provenance, and governance workflows so they only trigger on changes to backend/frontend/src, key project manifests, or their own workflow files.
- Limit auxiliary workflows such as code intelligence, baseline guard, tag lint, E2E smoke, accessibility, spec gates, SBOM, SLSA provenance, AI swarm safety, and governance proof to run only for changes in related code, configuration, or documentation paths.