### PR TITLE
test(bucket-c): add bcrypt/multer/nodemailer smoke proofs

### DIFF
--- a/tests/unit/bucket-c/bcrypt_smoke.test.ts
+++ b/tests/unit/bucket-c/bcrypt_smoke.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Bucket C Smoke Test: bcrypt hash/compare contract
+ *
+ * Purpose: Verify bcrypt 6.x maintains the expected API contract
+ * before merging PR #189 (bcrypt 5.1.1 → 6.0.0)
+ *
+ * This test uses dynamic import to gracefully skip if bcrypt isn't installed.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+describe('bcrypt smoke', () => {
+  let bcrypt: typeof import('bcrypt') | null = null;
+
+  beforeAll(async () => {
+    try {
+      bcrypt = await import('bcrypt');
+    } catch {
+      // bcrypt not installed - test will skip
+    }
+  });
+
+  it('hash/compare contract holds', async () => {
+    if (!bcrypt) {
+      console.log('⏭️ bcrypt not installed - skipping smoke test');
+      return;
+    }
+
+    const pw = 'terraFusion🔒';
+    const hash = await bcrypt.hash(pw, 10);
+
+    // Hash should be a string with expected bcrypt format
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBeGreaterThan(10);
+    expect(hash).toMatch(/^\$2[aby]?\$/); // bcrypt prefix
+
+    // compare() should return true for correct password
+    expect(await bcrypt.compare(pw, hash)).toBe(true);
+
+    // compare() should return false for wrong password
+    expect(await bcrypt.compare('wrong', hash)).toBe(false);
+  });
+
+  it('getRounds returns expected value', async () => {
+    if (!bcrypt) {
+      return; // Skip if bcrypt not installed
+    }
+
+    const hash = await bcrypt.hash('test', 12);
+    expect(bcrypt.getRounds(hash)).toBe(12);
+  });
+});

--- a/tests/unit/bucket-c/multer_smoke.test.ts
+++ b/tests/unit/bucket-c/multer_smoke.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Bucket C Smoke Test: multer multipart upload contract
+ *
+ * Purpose: Verify multer 2.x maintains the expected API contract
+ * before merging PR #72 (multer 1.4.5 → 2.0.0)
+ *
+ * This test uses dynamic imports to gracefully skip if deps aren't installed.
+ * Requires: multer, express (as dev dep for testing)
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+describe('multer smoke', () => {
+  let multer: typeof import('multer') | null = null;
+  let available = false;
+
+  beforeAll(async () => {
+    try {
+      multer = await import('multer');
+      // Just check if multer is importable
+      available = true;
+    } catch {
+      // multer not installed - test will skip
+    }
+  });
+
+  it('memoryStorage and single() API exists', async () => {
+    if (!available || !multer) {
+      console.log('⏭️ multer not installed - skipping smoke test');
+      return;
+    }
+
+    // Verify core API shape
+    expect(typeof multer.default).toBe('function');
+    expect(typeof multer.memoryStorage).toBe('function');
+    expect(typeof multer.diskStorage).toBe('function');
+
+    // Create upload middleware
+    const upload = multer.default({ storage: multer.memoryStorage() });
+
+    // Verify middleware methods exist
+    expect(typeof upload.single).toBe('function');
+    expect(typeof upload.array).toBe('function');
+    expect(typeof upload.fields).toBe('function');
+    expect(typeof upload.none).toBe('function');
+    expect(typeof upload.any).toBe('function');
+  });
+
+  it('memoryStorage stores buffer correctly', async () => {
+    if (!available || !multer) {
+      return; // Skip if multer not installed
+    }
+
+    const storage = multer.memoryStorage();
+
+    // memoryStorage should have _handleFile method
+    expect(typeof storage._handleFile).toBe('function');
+  });
+});

--- a/tests/unit/bucket-c/nodemailer_smoke.test.ts
+++ b/tests/unit/bucket-c/nodemailer_smoke.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Bucket C Smoke Test: nodemailer transport contract
+ *
+ * Purpose: Verify nodemailer 7.x maintains the expected API contract
+ * before merging PR #58 (nodemailer 6.10.1 → 7.0.11)
+ *
+ * This test uses streamTransport - no network required.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+describe('nodemailer smoke', () => {
+  let nodemailer: typeof import('nodemailer') | null = null;
+  let available = false;
+
+  beforeAll(async () => {
+    try {
+      nodemailer = await import('nodemailer');
+      available = true;
+    } catch {
+      // nodemailer not installed - test will skip
+    }
+  });
+
+  it('createTransport API exists', async () => {
+    if (!available || !nodemailer) {
+      console.log('⏭️ nodemailer not installed - skipping smoke test');
+      return;
+    }
+
+    expect(typeof nodemailer.createTransport).toBe('function');
+    expect(typeof nodemailer.createTestAccount).toBe('function');
+    expect(typeof nodemailer.getTestMessageUrl).toBe('function');
+  });
+
+  it('can construct streamTransport and send (no network)', async () => {
+    if (!available || !nodemailer) {
+      return; // Skip if nodemailer not installed
+    }
+
+    // Use streamTransport to avoid network
+    const transport = nodemailer.createTransport({
+      streamTransport: true,
+      newline: 'unix',
+      buffer: true,
+    });
+
+    expect(transport).toBeTruthy();
+    expect(typeof transport.sendMail).toBe('function');
+    expect(typeof transport.verify).toBe('function');
+
+    // Send a test email (no network - goes to buffer)
+    const info = await transport.sendMail({
+      from: 'noreply@terrafusion.local',
+      to: 'devnull@terrafusion.local',
+      subject: 'Bucket C Smoke Test',
+      text: 'This is a test email for nodemailer 7.x upgrade validation.',
+    });
+
+    expect(info).toBeTruthy();
+    expect(info.messageId).toBeTruthy();
+
+    // Buffer should contain the email
+    expect(info.message).toBeInstanceOf(Buffer);
+    expect(info.message.length).toBeGreaterThan(0);
+  });
+
+  it('transport can be closed', async () => {
+    if (!available || !nodemailer) {
+      return;
+    }
+
+    const transport = nodemailer.createTransport({
+      streamTransport: true,
+    });
+
+    // close() should not throw
+    expect(() => transport.close()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Adds smoke tests for high-risk dependency upgrades:
- #189 bcrypt 5→6 (crypto)
- #72 multer 1→2 (file upload)
- #58 nodemailer 6→7 (email)

Tests use dynamic imports to gracefully skip if deps aren't installed,
then run automatically once Bucket C PRs land.

These proofs de-risk the highest blast-radius merges.

## Summary by Sourcery

Add smoke tests to validate core behaviors of high-risk dependencies in bucket C.

Tests:
- Add a bcrypt smoke test to exercise basic hashing and comparison behavior.
- Add a multer smoke test to verify basic file upload handling.
- Add a nodemailer smoke test to confirm basic email sending flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive smoke tests for bcrypt, multer, and nodemailer to validate API compatibility with these optional dependencies. Tests dynamically import dependencies and gracefully skip if unavailable, ensuring compatibility validation without requiring installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->