### PR TITLE
feat(ui): PropertyAtlas MWUX slice with query_parcel_layers tool

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * PropertyAtlas.test.tsx
+ *
+ * Phase 5.3: Property Atlas Tab - GIS/Mapping MWUX Slice
+ * Tests: map view → layer selection → query_parcel_layers tool → correlationId UX
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import * as pilotApi from '../../api/pilotApi';
+import PropertyAtlas from '../../pages/workbench/tabs/PropertyAtlas';
+
+// Mock the pilotApi module
+jest.mock('../../api/pilotApi');
+
+const mockInvokeTool = pilotApi.invokeTool as jest.MockedFunction<typeof pilotApi.invokeTool>;
+
+// Test wrapper providing parcel context via outlet
+const TestWrapper: React.FC<{ parcelId: string }> = ({ parcelId }) => {
+  return (
+    <MemoryRouter initialEntries={[`/property/${parcelId}/atlas`]}>
+      <Routes>
+        <Route
+          path='/property/:parcelId'
+          element={
+            <div>
+              <Outlet context={{ parcelId }} />
+            </div>
+          }
+        >
+          <Route path='atlas' element={<PropertyAtlas />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('PropertyAtlas', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders with parcel context', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      expect(screen.getByTestId('property-atlas-tab')).toBeInTheDocument();
+      expect(screen.getByText(/TerraAtlas/i)).toBeInTheDocument();
+      // ParcelId may appear in multiple places
+      expect(screen.getAllByText(/12345-001/).length).toBeGreaterThan(0);
+    });
+
+    it('displays available map layers', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Should show layer toggle options - use getAllByText for items that may appear multiple times
+      expect(screen.getAllByText(/Parcel Boundary/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Zoning/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Flood/i).length).toBeGreaterThan(0);
+    });
+
+    it('displays map placeholder area', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Should have a map container
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+  });
+
+  describe('Layer Selection', () => {
+    it('toggles layer visibility on click', async () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Find and click a layer toggle
+      const zoningLayer = screen.getByTestId('layer-toggle-zoning');
+      
+      // Initially off (or check aria-pressed)
+      expect(zoningLayer).toHaveAttribute('aria-pressed', 'false');
+
+      fireEvent.click(zoningLayer);
+
+      await waitFor(() => {
+        expect(zoningLayer).toHaveAttribute('aria-pressed', 'true');
+      });
+    });
+
+    it('enables query button when at least one layer is selected', async () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Query button starts disabled when no layers selected
+      const queryBtn = screen.getByRole('button', { name: /query layers/i });
+      expect(queryBtn).toBeDisabled();
+
+      // Select a layer
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+
+      await waitFor(() => {
+        expect(queryBtn).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('Query Tool Invocation', () => {
+    it('invokes query_parcel_layers tool successfully', async () => {
+      const mockResponse = {
+        success: true,
+        correlationId: 'corr-atlas-abc123',
+        result: {
+          toolId: 'query_parcel_layers',
+          output: JSON.stringify({
+            parcelId: '12345-001',
+            layers: {
+              boundary: {
+                type: 'Polygon',
+                area: '0.25 acres',
+                perimeter: '420 ft',
+              },
+              zoning: {
+                code: 'R-1',
+                description: 'Single Family Residential',
+              },
+            },
+            centroid: { lat: 46.2804, lng: -119.2752 },
+          }),
+        },
+      };
+
+      mockInvokeTool.mockResolvedValue(mockResponse);
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Select layers
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+      fireEvent.click(screen.getByTestId('layer-toggle-zoning'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /query layers/i })).not.toBeDisabled();
+      });
+
+      // Click query
+      fireEvent.click(screen.getByRole('button', { name: /query layers/i }));
+
+      // Verify tool invoked with correct params
+      await waitFor(() => {
+        expect(mockInvokeTool).toHaveBeenCalledWith({
+          toolId: 'query_parcel_layers',
+          params: expect.objectContaining({
+            parcelId: '12345-001',
+            layers: expect.arrayContaining(['boundary', 'zoning']),
+          }),
+          parcelId: '12345-001',
+        });
+      });
+
+      // Verify success display
+      await waitFor(() => {
+        expect(screen.getByText(/0\.25 acres/i)).toBeInTheDocument();
+        expect(screen.getByText(/R-1/i)).toBeInTheDocument();
+        // Truncated display shows first 16 chars
+        expect(screen.getAllByText(/corr-atlas-abc/).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('surfaces tool error with correlationId', async () => {
+      const mockError = {
+        success: false,
+        correlationId: 'corr-atlas-error-789',
+        error: {
+          code: 'GIS_SERVICE_UNAVAILABLE',
+          message: 'GIS service temporarily unavailable',
+          severity: 'error' as const,
+        },
+      };
+
+      mockInvokeTool.mockResolvedValue(mockError);
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Select layer and query
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /query layers/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /query layers/i }));
+
+      // Verify error display with correlationId
+      await waitFor(() => {
+        expect(screen.getByText(/GIS service temporarily unavailable/i)).toBeInTheDocument();
+        // Truncated display shows first portion
+        expect(screen.getAllByText(/corr-atlas-error/).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('handles network errors gracefully', async () => {
+      mockInvokeTool.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /query layers/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /query layers/i }));
+
+      // Should show error with client-generated correlationId
+      await waitFor(() => {
+        expect(screen.getByText(/network error|failed to fetch/i)).toBeInTheDocument();
+        // Should have a net-* correlationId
+        const correlationTexts = screen.getAllByText(/net-/);
+        expect(correlationTexts.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('Loading States', () => {
+    it('shows loading indicator during query', async () => {
+      // Create a delayed response
+      mockInvokeTool.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  success: true,
+                  correlationId: 'corr-loading-test',
+                  result: { toolId: 'query_parcel_layers', output: '{}' },
+                }),
+              100
+            )
+          )
+      );
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /query layers/i })).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /query layers/i }));
+
+      // Should show loading state
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  describe('Query History', () => {
+    it('tracks layer query history', async () => {
+      mockInvokeTool.mockResolvedValue({
+        success: true,
+        correlationId: 'corr-history-test-atlas',
+        result: { toolId: 'query_parcel_layers', output: '{"layers":{}}' },
+      });
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // First query
+      fireEvent.click(screen.getByTestId('layer-toggle-boundary'));
+      await waitFor(() => screen.getByRole('button', { name: /query layers/i }));
+      fireEvent.click(screen.getByRole('button', { name: /query layers/i }));
+
+      // Wait for success - correlationId may appear truncated
+      await waitFor(() => {
+        expect(screen.getAllByText(/corr-history-tes/).length).toBeGreaterThan(0);
+      });
+
+      // Verify history section exists with entry
+      expect(screen.getByText(/Query History/i)).toBeInTheDocument();
+      expect(screen.getByText(/query_parcel_layers/i)).toBeInTheDocument();
+
+      // Verify there's a copy button in history
+      const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+      expect(copyButtons.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -1,34 +1,444 @@
 /**
- * Property Atlas Tab - GIS & Mapping
- * Placeholder - will integrate TerraAtlas suite
+ * PropertyAtlas.tsx
+ *
+ * Phase 5.3: Property Atlas Tab - GIS/Mapping MWUX Slice
+ * Real MWUX with layer selection, map placeholder, and query_parcel_layers tool invocation.
+ *
+ * Architecture: UI → select layers → query_parcel_layers tool → correlationId UX
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { invokeTool } from '../../../api/pilotApi';
+import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
+import type { ErrorInfo } from '../../../hooks/useErrorHandler';
+import { getEnv } from '../../../runtime/env';
+
+/** Available map layers */
+const MAP_LAYERS = [
+  { id: 'boundary', label: 'Parcel Boundary', icon: '📐', description: 'Property boundaries' },
+  { id: 'zoning', label: 'Zoning', icon: '🏘️', description: 'Zoning classifications' },
+  { id: 'flood', label: 'Flood Zone', icon: '🌊', description: 'FEMA flood zones' },
+  { id: 'aerial', label: 'Aerial Imagery', icon: '🛰️', description: 'Satellite/aerial photos' },
+] as const;
+
+type LayerId = (typeof MAP_LAYERS)[number]['id'];
+
+interface LayerData {
+  boundary?: {
+    type: string;
+    area: string;
+    perimeter: string;
+  };
+  zoning?: {
+    code: string;
+    description: string;
+  };
+  flood?: {
+    zone: string;
+    risk: string;
+  };
+  aerial?: {
+    date: string;
+    resolution: string;
+  };
+}
+
+interface QueryResult {
+  parcelId: string;
+  layers: LayerData;
+  centroid?: { lat: number; lng: number };
+}
+
+interface InvocationRecord {
+  id: string;
+  toolId: string;
+  status: 'success' | 'error';
+  correlationId: string;
+  timestamp: Date;
+  layers: LayerId[];
+  output?: QueryResult;
+  error?: ErrorInfo;
+}
+
+interface QueryState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  result?: QueryResult;
+  correlationId?: string;
+  error?: ErrorInfo;
+}
 
 export const PropertyAtlas: React.FC = () => {
   const { parcelId } = useOutletContext<{ parcelId: string }>();
 
+  const [selectedLayers, setSelectedLayers] = useState<Set<LayerId>>(new Set());
+  const [queryState, setQueryState] = useState<QueryState>({ status: 'idle' });
+  const [queryHistory, setQueryHistory] = useState<InvocationRecord[]>([]);
+
+  const toggleLayer = useCallback((layerId: LayerId) => {
+    setSelectedLayers((prev) => {
+      const next = new Set(prev);
+      if (next.has(layerId)) {
+        next.delete(layerId);
+      } else {
+        next.add(layerId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleQueryLayers = useCallback(async () => {
+    if (selectedLayers.size === 0) return;
+
+    setQueryState({ status: 'loading' });
+
+    try {
+      const response = await invokeTool({
+        toolId: 'query_parcel_layers',
+        params: {
+          parcelId,
+          layers: Array.from(selectedLayers),
+          format: 'summary',
+        },
+        parcelId,
+      });
+
+      if (response.success && response.result) {
+        let parsed: QueryResult;
+        try {
+          parsed =
+            typeof response.result.output === 'string'
+              ? JSON.parse(response.result.output)
+              : response.result.output;
+        } catch {
+          parsed = { parcelId, layers: {} };
+        }
+
+        setQueryState({
+          status: 'success',
+          result: parsed,
+          correlationId: response.correlationId,
+        });
+
+        // Add to history
+        setQueryHistory((prev) => [
+          {
+            id: crypto.randomUUID(),
+            toolId: 'query_parcel_layers',
+            status: 'success',
+            correlationId: response.correlationId || 'unknown',
+            timestamp: new Date(),
+            layers: Array.from(selectedLayers),
+            output: parsed,
+          },
+          ...prev.slice(0, 9), // Keep last 10
+        ]);
+      } else {
+        const errorInfo: ErrorInfo = {
+          code: response.error?.code || 'QUERY_FAILED',
+          message: response.error?.message || 'Failed to query parcel layers',
+          severity: 'error' as const,
+          correlationId: response.correlationId,
+        };
+
+        setQueryState({
+          status: 'error',
+          correlationId: response.correlationId,
+          error: errorInfo,
+        });
+
+        // Add to history
+        setQueryHistory((prev) => [
+          {
+            id: crypto.randomUUID(),
+            toolId: 'query_parcel_layers',
+            status: 'error',
+            correlationId: response.correlationId || 'unknown',
+            timestamp: new Date(),
+            layers: Array.from(selectedLayers),
+            error: errorInfo,
+          },
+          ...prev.slice(0, 9),
+        ]);
+      }
+    } catch (err) {
+      // Network error - generate client-side correlationId
+      const clientCorrelationId = `net-${crypto.randomUUID().slice(0, 8)}`;
+      const networkError: ErrorInfo = {
+        code: 'NETWORK_ERROR',
+        message: err instanceof Error ? err.message : 'Network error occurred',
+        severity: 'error' as const,
+        correlationId: clientCorrelationId,
+      };
+
+      setQueryState({
+        status: 'error',
+        correlationId: clientCorrelationId,
+        error: networkError,
+      });
+
+      // Add to history
+      setQueryHistory((prev) => [
+        {
+          id: crypto.randomUUID(),
+          toolId: 'query_parcel_layers',
+          status: 'error',
+          correlationId: clientCorrelationId,
+          timestamp: new Date(),
+          layers: Array.from(selectedLayers),
+          error: networkError,
+        },
+        ...prev.slice(0, 9),
+      ]);
+    }
+  }, [selectedLayers, parcelId]);
+
+  const copyToClipboard = useCallback((text: string) => {
+    navigator.clipboard.writeText(text).catch(console.error);
+  }, []);
+
+  const isDev = getEnv('MODE') === 'development';
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <span className="text-3xl">🗺️</span>
-        <h2 className="text-2xl font-bold text-white">TerraAtlas</h2>
+    <div className='space-y-6' data-testid='property-atlas-tab'>
+      {/* Header */}
+      <div className='flex items-center gap-3'>
+        <span className='text-3xl'>🗺️</span>
+        <div>
+          <h2 className='text-2xl font-bold text-white'>TerraAtlas</h2>
+          <p className='text-white/60 text-sm'>Geospatial analysis for {parcelId}</p>
+        </div>
       </div>
-      <p className="text-white/60">Geospatial analysis and mapping for {parcelId}</p>
-      
-      <div className="bg-gradient-to-br from-blue-500/20 to-cyan-600/20 rounded-xl p-8 border border-blue-500/30">
-        <h3 className="text-white text-lg font-semibold mb-4">🚧 Integration Pending</h3>
-        <p className="text-white/70">
-          TerraAtlas suite integration coming soon. This tab will provide:
-        </p>
-        <ul className="list-disc list-inside text-white/60 mt-2 space-y-1">
-          <li>Parcel boundary visualization</li>
-          <li>Aerial imagery layers</li>
-          <li>Neighborhood analysis</li>
-          <li>Distance/area measurements</li>
-        </ul>
+
+      {/* Main Content Grid */}
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6'>
+        {/* Layer Controls */}
+        <div className='bg-white/5 rounded-xl p-4 border border-white/10'>
+          <h3 className='text-white font-semibold mb-4 flex items-center gap-2'>
+            <span>📚</span> Map Layers
+          </h3>
+
+          <div className='space-y-2'>
+            {MAP_LAYERS.map((layer) => (
+              <button
+                key={layer.id}
+                data-testid={`layer-toggle-${layer.id}`}
+                onClick={() => toggleLayer(layer.id)}
+                aria-pressed={selectedLayers.has(layer.id)}
+                className={`w-full flex items-center gap-3 p-3 rounded-lg border transition-all ${
+                  selectedLayers.has(layer.id)
+                    ? 'bg-blue-500/20 border-blue-500/50 text-white'
+                    : 'bg-white/5 border-white/10 text-white/70 hover:bg-white/10'
+                }`}
+              >
+                <span className='text-xl'>{layer.icon}</span>
+                <div className='text-left'>
+                  <div className='font-medium'>{layer.label}</div>
+                  <div className='text-xs text-white/50'>{layer.description}</div>
+                </div>
+                {selectedLayers.has(layer.id) && (
+                  <span className='ml-auto text-blue-400'>✓</span>
+                )}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={handleQueryLayers}
+            disabled={selectedLayers.size === 0 || queryState.status === 'loading'}
+            className={`mt-4 w-full py-2 px-4 rounded-lg font-semibold transition-all ${
+              selectedLayers.size === 0 || queryState.status === 'loading'
+                ? 'bg-white/10 text-white/40 cursor-not-allowed'
+                : 'bg-blue-600 hover:bg-blue-500 text-white'
+            }`}
+          >
+            {queryState.status === 'loading' ? 'Querying...' : 'Query Layers'}
+          </button>
+        </div>
+
+        {/* Map Container */}
+        <div className='lg:col-span-2 bg-white/5 rounded-xl border border-white/10 overflow-hidden'>
+          <div
+            data-testid='map-container'
+            className='aspect-video bg-gradient-to-br from-blue-900/30 to-cyan-900/30 flex items-center justify-center'
+          >
+            {queryState.status === 'loading' ? (
+              <div role='status' className='flex flex-col items-center gap-3'>
+                <div className='animate-spin rounded-full h-10 w-10 border-2 border-white/20 border-t-blue-500' />
+                <span className='text-white/60'>Loading layer data...</span>
+              </div>
+            ) : queryState.status === 'success' && queryState.result ? (
+              <div className='text-center p-4'>
+                <div className='text-4xl mb-2'>🗺️</div>
+                <p className='text-white/80'>Map visualization placeholder</p>
+                <p className='text-white/50 text-sm'>
+                  Centroid: {queryState.result.centroid?.lat.toFixed(4)},{' '}
+                  {queryState.result.centroid?.lng.toFixed(4)}
+                </p>
+              </div>
+            ) : (
+              <div className='text-center p-4'>
+                <div className='text-4xl mb-2'>🌍</div>
+                <p className='text-white/60'>Select layers and query to view map data</p>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
+
+      {/* Query Results */}
+      {queryState.status === 'success' && queryState.result && (
+        <div className='bg-green-500/10 border border-green-500/30 rounded-xl p-4'>
+          <div className='flex items-center justify-between mb-3'>
+            <h4 className='text-green-400 font-semibold flex items-center gap-2'>
+              <span>✅</span> Query Results
+            </h4>
+            {queryState.correlationId && (
+              <div className='flex items-center gap-2 text-xs'>
+                <span className='text-white/50'>ID:</span>
+                <code className='text-green-400 font-mono'>
+                  {queryState.correlationId.slice(0, 16)}...
+                </code>
+                <button
+                  onClick={() => copyToClipboard(queryState.correlationId!)}
+                  className='text-white/60 hover:text-white'
+                  aria-label='Copy correlation ID'
+                >
+                  📋
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+            {queryState.result.layers.boundary && (
+              <div className='bg-white/5 rounded-lg p-3'>
+                <h5 className='text-white/80 font-medium mb-2'>📐 Boundary</h5>
+                <div className='text-sm text-white/60 space-y-1'>
+                  <p>
+                    Area: <span className='text-white'>{queryState.result.layers.boundary.area}</span>
+                  </p>
+                  <p>
+                    Perimeter:{' '}
+                    <span className='text-white'>{queryState.result.layers.boundary.perimeter}</span>
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {queryState.result.layers.zoning && (
+              <div className='bg-white/5 rounded-lg p-3'>
+                <h5 className='text-white/80 font-medium mb-2'>🏘️ Zoning</h5>
+                <div className='text-sm text-white/60 space-y-1'>
+                  <p>
+                    Code: <span className='text-white'>{queryState.result.layers.zoning.code}</span>
+                  </p>
+                  <p>
+                    Description:{' '}
+                    <span className='text-white'>{queryState.result.layers.zoning.description}</span>
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {queryState.result.layers.flood && (
+              <div className='bg-white/5 rounded-lg p-3'>
+                <h5 className='text-white/80 font-medium mb-2'>🌊 Flood Zone</h5>
+                <div className='text-sm text-white/60 space-y-1'>
+                  <p>
+                    Zone: <span className='text-white'>{queryState.result.layers.flood.zone}</span>
+                  </p>
+                  <p>
+                    Risk: <span className='text-white'>{queryState.result.layers.flood.risk}</span>
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {queryState.result.layers.aerial && (
+              <div className='bg-white/5 rounded-lg p-3'>
+                <h5 className='text-white/80 font-medium mb-2'>🛰️ Aerial</h5>
+                <div className='text-sm text-white/60 space-y-1'>
+                  <p>
+                    Date: <span className='text-white'>{queryState.result.layers.aerial.date}</span>
+                  </p>
+                  <p>
+                    Resolution:{' '}
+                    <span className='text-white'>{queryState.result.layers.aerial.resolution}</span>
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {isDev && queryState.correlationId && (
+            <div className='mt-3 text-xs text-white/40 border-t border-white/10 pt-3'>
+              <details>
+                <summary className='cursor-pointer hover:text-white/60'>Developer Info</summary>
+                <pre className='mt-2 bg-black/30 rounded p-2 overflow-x-auto'>
+                  pnpm run trace:query --correlation {queryState.correlationId}
+                </pre>
+              </details>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Error Display */}
+      {queryState.status === 'error' && queryState.error && (
+        <ErrorDisplay error={{
+          message: queryState.error.message,
+          errorCode: queryState.error.code,
+          correlationId: queryState.correlationId,
+        }} />
+      )}
+
+      {/* Query History */}
+      {queryHistory.length > 0 && (
+        <div className='bg-white/5 rounded-xl p-4 border border-white/10'>
+          <h3 className='text-white font-semibold mb-3 flex items-center gap-2'>
+            <span>📜</span> Query History
+          </h3>
+
+          <div className='space-y-2'>
+            {queryHistory.map((record) => (
+              <div
+                key={record.id}
+                className={`flex items-center justify-between p-3 rounded-lg border ${
+                  record.status === 'success'
+                    ? 'bg-green-500/10 border-green-500/20'
+                    : 'bg-red-500/10 border-red-500/20'
+                }`}
+              >
+                <div className='flex items-center gap-3'>
+                  <span className={record.status === 'success' ? 'text-green-400' : 'text-red-400'}>
+                    {record.status === 'success' ? '✅' : '❌'}
+                  </span>
+                  <div>
+                    <div className='text-white/80 text-sm font-mono'>{record.toolId}</div>
+                    <div className='text-white/50 text-xs'>
+                      Layers: {record.layers.join(', ')} •{' '}
+                      {record.timestamp.toLocaleTimeString()}
+                    </div>
+                  </div>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <code className='text-white/40 text-xs font-mono'>
+                    {record.correlationId.slice(0, 12)}...
+                  </code>
+                  <button
+                    onClick={() => copyToClipboard(record.correlationId)}
+                    className='text-white/40 hover:text-white text-sm'
+                    aria-label='Copy correlation ID'
+                  >
+                    📋
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/os-platform/core/tests/phase83-tools.test.mjs
+++ b/os-platform/core/tests/phase83-tools.test.mjs
@@ -144,9 +144,9 @@ describe('Phase 8.3 Tools - Gate Validation', () => {
     await registry.initialize(MANIFEST_PATH);
   });
 
-  it('loads the canonical manifest (v1.3.0, 23 tools)', () => {
+  it('loads the canonical manifest (v1.3.0, 24 tools)', () => {
     assert.strictEqual(registry.getVersion(), '1.3.0');
-    assert.strictEqual(registry.listTools().length, 23);
+    assert.strictEqual(registry.listTools().length, 24);
   });
 
   it('enforces registry invariants', () => {

--- a/tools/registry/terrapilot.tools.json
+++ b/tools/registry/terrapilot.tools.json
@@ -393,6 +393,35 @@
       "piiHandling": "payload_ref",
       "tracePolicy": "payload_ref",
       "payloadStore": "dossier"
+    },
+    {
+      "toolId": "query_parcel_layers",
+      "displayName": "Query Parcel Layers",
+      "suite": "atlas",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["parcel"],
+      "description": "Query GIS layers and parcel boundary data for mapping visualization. Returns parcel geometry, available layers, and overlay metadata.",
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "parcelId": { "type": "string", "description": "Parcel identifier" },
+          "layers": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Layers to include (e.g., boundary, zoning, flood, aerial)"
+          },
+          "format": {
+            "type": "string",
+            "enum": ["geojson", "wkt", "summary"],
+            "default": "summary"
+          }
+        },
+        "required": ["parcelId"]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Phase 5.3: Atlas MWUX Slice

Wire PropertyAtlas tab as real MWUX slice with GIS layer query capability.

### Changes
- **Tool Manifest**: Add \query_parcel_layers\ tool (atlas suite, read_only)
- **PropertyAtlas.tsx**: Full MWUX implementation with layer selection, tool invocation, correlationId UX
- **PropertyAtlas.test.tsx**: 10 tests covering render, layers, query success/error, network errors, history
- **phase83-tools.test.mjs**: Update expected tool count (23 → 24)

### Test Coverage
- Render: parcel context, layer display, map container
- Layer Selection: toggle, button enable/disable
- Query Tool: success with correlationId, error handling, network errors
- Loading: spinner during query
- History: query history tracking with copy button

### Gates
- \pnpm run type-check\ ✓
- \
ode --test phase83-tools\ 32 pass
- Workbench tests: 20 pass (Atlas 10 + Dossier 10)

### Architecture
Follows same pattern as Pilot/Dossier: \pilotApi.invokeTool()\ → correlationId UX → invocation history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PropertyAtlas component now features layer selection toggles, real-time parcel data querying, and a query history panel with copy functionality.
  * Added Query Parcel Layers tool for retrieving GIS layers and parcel boundary data with error handling and correlation IDs.

* **Tests**
  * Added comprehensive test coverage for PropertyAtlas component functionality including layer selection, query invocation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->