### PR TITLE
feat(ui): PropertyDais MWUX slice with check_cert_status tool

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyDais.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyDais.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * PropertyDais.test.tsx
+ *
+ * Phase 5.5: Property Dais Tab - Workflow MWUX Slice
+ * Tests: workflow status → check_cert_status tool → correlationId UX
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import * as pilotApi from '../../api/pilotApi';
+import PropertyDais from '../../pages/workbench/tabs/PropertyDais';
+
+// Mock the pilotApi module
+jest.mock('../../api/pilotApi');
+
+const mockInvokeTool = pilotApi.invokeTool as jest.MockedFunction<typeof pilotApi.invokeTool>;
+
+// Test wrapper providing parcel context via outlet
+const TestWrapper: React.FC<{ parcelId: string }> = ({ parcelId }) => {
+  return (
+    <MemoryRouter initialEntries={[`/property/${parcelId}/dais`]}>
+      <Routes>
+        <Route
+          path='/property/:parcelId'
+          element={
+            <div>
+              <Outlet context={{ parcelId }} />
+            </div>
+          }
+        >
+          <Route path='dais' element={<PropertyDais />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('PropertyDais', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders with parcel context', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      expect(screen.getByTestId('property-dais-tab')).toBeInTheDocument();
+      expect(screen.getByText(/TerraDais/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/12345-001/).length).toBeGreaterThan(0);
+    });
+
+    it('displays workflow status controls', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      expect(screen.getByRole('button', { name: /check status/i })).toBeInTheDocument();
+    });
+
+    it('displays workflow type options', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      expect(screen.getByLabelText(/workflow type/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Controls', () => {
+    it('allows workflow type selection', () => {
+      render(<TestWrapper parcelId='12345-001' />);
+
+      const typeSelect = screen.getByLabelText(/workflow type/i);
+      fireEvent.change(typeSelect, { target: { value: 'appeal' } });
+
+      expect(typeSelect).toHaveValue('appeal');
+    });
+  });
+
+  describe('Tool Invocation', () => {
+    it('invokes check_cert_status tool successfully', async () => {
+      const mockResponse = {
+        success: true,
+        correlationId: 'corr-dais-abc123',
+        result: {
+          toolId: 'check_cert_status',
+          output: JSON.stringify({
+            parcelId: '12345-001',
+            certificationStatus: 'pending_review',
+            lastUpdated: '2026-02-05T10:30:00Z',
+            currentStep: 'Appraiser Review',
+            completedSteps: ['Intake', 'Data Verification'],
+            pendingSteps: ['Supervisor Approval', 'Final Certification'],
+            assignedTo: 'John Smith',
+            dueDate: '2026-02-15T00:00:00Z',
+          }),
+        },
+      };
+
+      mockInvokeTool.mockResolvedValue(mockResponse);
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      // Click check status
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      // Verify tool invoked
+      await waitFor(() => {
+        expect(mockInvokeTool).toHaveBeenCalledWith({
+          toolId: 'check_cert_status',
+          params: expect.objectContaining({
+            parcelId: '12345-001',
+          }),
+          parcelId: '12345-001',
+        });
+      });
+
+      // Verify success display
+      await waitFor(() => {
+        expect(screen.getAllByText(/pending_review/i).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Appraiser Review/i).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/corr-dais/).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('surfaces tool error with correlationId', async () => {
+      const mockError = {
+        success: false,
+        correlationId: 'corr-dais-error-789',
+        error: {
+          code: 'WORKFLOW_NOT_FOUND',
+          message: 'No active workflow found for parcel',
+          severity: 'high' as const,
+        },
+      };
+
+      mockInvokeTool.mockResolvedValue(mockError);
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/No active workflow found/i)).toBeInTheDocument();
+        expect(screen.getAllByText(/corr-dais-error/).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('handles network errors gracefully', async () => {
+      mockInvokeTool.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/network error|failed to fetch/i)).toBeInTheDocument();
+        const correlationTexts = screen.getAllByText(/net-/);
+        expect(correlationTexts.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('Loading States', () => {
+    it('shows loading indicator during check', async () => {
+      mockInvokeTool.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  success: true,
+                  correlationId: 'corr-loading-dais',
+                  result: { toolId: 'check_cert_status', output: '{}' },
+                }),
+              100
+            )
+          )
+      );
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  describe('Status History', () => {
+    it('tracks status check history', async () => {
+      mockInvokeTool.mockResolvedValue({
+        success: true,
+        correlationId: 'corr-dais-hist',
+        result: {
+          toolId: 'check_cert_status',
+          output: JSON.stringify({ parcelId: '12345-001', certificationStatus: 'pending' }),
+        },
+      });
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/corr-dais/).length).toBeGreaterThan(0);
+      });
+
+      expect(screen.getByText(/History/i)).toBeInTheDocument();
+      expect(screen.getByText(/check_cert_status/i)).toBeInTheDocument();
+
+      const copyButtons = screen.getAllByRole('button', { name: /copy/i });
+      expect(copyButtons.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Status Display', () => {
+    it('displays workflow steps when available', async () => {
+      mockInvokeTool.mockResolvedValue({
+        success: true,
+        correlationId: 'corr-steps-test',
+        result: {
+          toolId: 'check_cert_status',
+          output: JSON.stringify({
+            parcelId: '12345-001',
+            completedSteps: ['Intake', 'Verification'],
+            pendingSteps: ['Final Approval'],
+            currentStep: 'Supervisor Check',
+          }),
+        },
+      });
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/Intake/i).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Verification/i).length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Supervisor Check/i).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('displays assignee and due date when available', async () => {
+      mockInvokeTool.mockResolvedValue({
+        success: true,
+        correlationId: 'corr-assign-test',
+        result: {
+          toolId: 'check_cert_status',
+          output: JSON.stringify({
+            parcelId: '12345-001',
+            assignedTo: 'Jane Doe',
+            dueDate: '2026-02-20T00:00:00Z',
+          }),
+        },
+      });
+
+      render(<TestWrapper parcelId='12345-001' />);
+
+      fireEvent.click(screen.getByRole('button', { name: /check status/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Jane Doe/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx
@@ -1,34 +1,465 @@
 /**
- * Property Dais Tab - Workflow Orchestration
- * Placeholder - will integrate TerraDais suite
+ * PropertyDais.tsx
+ *
+ * Phase 5.5: Property Dais Tab - Workflow MWUX Slice
+ * Real MWUX with workflow status and check_cert_status tool invocation.
+ *
+ * Architecture: UI → select workflow type → check_cert_status tool → correlationId UX
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { invokeTool } from '../../../api/pilotApi';
+import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
+import type { ErrorInfo } from '../../../hooks/useErrorHandler';
+import { getEnv } from '../../../runtime/env';
+
+/** Workflow type options */
+const WORKFLOW_TYPES = [
+  { value: 'certification', label: 'Certification', description: 'Annual certification workflow' },
+  { value: 'appeal', label: 'Appeal', description: 'Property value appeal' },
+  { value: 'exemption', label: 'Exemption', description: 'Exemption application' },
+  { value: 'review', label: 'Review', description: 'Property review request' },
+] as const;
+
+type WorkflowType = (typeof WORKFLOW_TYPES)[number]['value'];
+
+interface WorkflowStep {
+  name: string;
+  status: 'completed' | 'current' | 'pending';
+}
+
+interface StatusResult {
+  parcelId: string;
+  certificationStatus?: string;
+  lastUpdated?: string;
+  currentStep?: string;
+  completedSteps?: string[];
+  pendingSteps?: string[];
+  assignedTo?: string;
+  dueDate?: string;
+  workflowType?: string;
+}
+
+interface InvocationRecord {
+  id: string;
+  toolId: string;
+  status: 'success' | 'error';
+  correlationId: string;
+  timestamp: Date;
+  workflowType: WorkflowType;
+  output?: StatusResult;
+  error?: ErrorInfo;
+}
+
+interface StatusState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  result?: StatusResult;
+  correlationId?: string;
+  error?: ErrorInfo;
+}
 
 export const PropertyDais: React.FC = () => {
   const { parcelId } = useOutletContext<{ parcelId: string }>();
 
+  const [workflowType, setWorkflowType] = useState<WorkflowType>('certification');
+  const [statusState, setStatusState] = useState<StatusState>({ status: 'idle' });
+  const [history, setHistory] = useState<InvocationRecord[]>([]);
+
+  const handleCheckStatus = useCallback(async () => {
+    setStatusState({ status: 'loading' });
+
+    const params: Record<string, unknown> = {
+      parcelId,
+      workflowType,
+    };
+
+    try {
+      const response = await invokeTool({
+        toolId: 'check_cert_status',
+        params,
+        parcelId,
+      });
+
+      if (response.success && response.result) {
+        let parsed: StatusResult;
+        try {
+          parsed =
+            typeof response.result.output === 'string'
+              ? JSON.parse(response.result.output)
+              : response.result.output;
+        } catch {
+          parsed = { parcelId };
+        }
+
+        setStatusState({
+          status: 'success',
+          result: parsed,
+          correlationId: response.correlationId,
+        });
+
+        setHistory((prev) => [
+          {
+            id: crypto.randomUUID(),
+            toolId: 'check_cert_status',
+            status: 'success',
+            correlationId: response.correlationId || 'unknown',
+            timestamp: new Date(),
+            workflowType,
+            output: parsed,
+          },
+          ...prev.slice(0, 9),
+        ]);
+      } else {
+        const errorInfo: ErrorInfo = {
+          code: response.error?.code || 'STATUS_CHECK_FAILED',
+          message: response.error?.message || 'Failed to check workflow status',
+          severity: 'error' as const,
+          correlationId: response.correlationId,
+        };
+
+        setStatusState({
+          status: 'error',
+          correlationId: response.correlationId,
+          error: errorInfo,
+        });
+
+        setHistory((prev) => [
+          {
+            id: crypto.randomUUID(),
+            toolId: 'check_cert_status',
+            status: 'error',
+            correlationId: response.correlationId || 'unknown',
+            timestamp: new Date(),
+            workflowType,
+            error: errorInfo,
+          },
+          ...prev.slice(0, 9),
+        ]);
+      }
+    } catch (err) {
+      const clientCorrelationId = `net-${crypto.randomUUID().slice(0, 8)}`;
+      const networkError: ErrorInfo = {
+        code: 'NETWORK_ERROR',
+        message: err instanceof Error ? err.message : 'Network error occurred',
+        severity: 'error' as const,
+        correlationId: clientCorrelationId,
+      };
+
+      setStatusState({
+        status: 'error',
+        correlationId: clientCorrelationId,
+        error: networkError,
+      });
+
+      setHistory((prev) => [
+        {
+          id: crypto.randomUUID(),
+          toolId: 'check_cert_status',
+          status: 'error',
+          correlationId: clientCorrelationId,
+          timestamp: new Date(),
+          workflowType,
+          error: networkError,
+        },
+        ...prev.slice(0, 9),
+      ]);
+    }
+  }, [parcelId, workflowType]);
+
+  const copyToClipboard = useCallback((text: string) => {
+    navigator.clipboard.writeText(text).catch(console.error);
+  }, []);
+
+  const formatDate = (dateStr: string | undefined) => {
+    if (!dateStr) return 'N/A';
+    try {
+      return new Date(dateStr).toLocaleDateString();
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const getStepIcon = (status: 'completed' | 'current' | 'pending') => {
+    switch (status) {
+      case 'completed':
+        return '✅';
+      case 'current':
+        return '🔄';
+      case 'pending':
+        return '⏳';
+    }
+  };
+
+  const buildWorkflowSteps = (result: StatusResult): WorkflowStep[] => {
+    const steps: WorkflowStep[] = [];
+
+    if (result.completedSteps) {
+      result.completedSteps.forEach((step) => {
+        steps.push({ name: step, status: 'completed' });
+      });
+    }
+
+    if (result.currentStep) {
+      steps.push({ name: result.currentStep, status: 'current' });
+    }
+
+    if (result.pendingSteps) {
+      result.pendingSteps.forEach((step) => {
+        steps.push({ name: step, status: 'pending' });
+      });
+    }
+
+    return steps;
+  };
+
+  const isDev = getEnv('MODE') === 'development';
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <span className="text-3xl">📊</span>
-        <h2 className="text-2xl font-bold text-white">TerraDais</h2>
+    <div className='space-y-6' data-testid='property-dais-tab'>
+      {/* Header */}
+      <div className='flex items-center gap-3'>
+        <span className='text-3xl'>📊</span>
+        <div>
+          <h2 className='text-2xl font-bold text-white'>TerraDais</h2>
+          <p className='text-white/60 text-sm'>Workflow orchestration for {parcelId}</p>
+        </div>
       </div>
-      <p className="text-white/60">Workflow orchestration for {parcelId}</p>
-      
-      <div className="bg-gradient-to-br from-purple-500/20 to-pink-600/20 rounded-xl p-8 border border-purple-500/30">
-        <h3 className="text-white text-lg font-semibold mb-4">🚧 Integration Pending</h3>
-        <p className="text-white/70">
-          TerraDais suite integration coming soon. This tab will provide:
-        </p>
-        <ul className="list-disc list-inside text-white/60 mt-2 space-y-1">
-          <li>Active workflow status</li>
-          <li>Task assignments</li>
-          <li>Approval chains</li>
-          <li>Timeline history</li>
-        </ul>
+
+      {/* Main Content Grid */}
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6'>
+        {/* Controls Panel */}
+        <div className='bg-white/5 rounded-xl p-4 border border-white/10'>
+          <h3 className='text-white font-semibold mb-4 flex items-center gap-2'>
+            <span>⚙️</span> Workflow Parameters
+          </h3>
+
+          {/* Workflow Type Selector */}
+          <div className='mb-4'>
+            <label htmlFor='workflow-type' className='block text-white/70 text-sm mb-2'>
+              Workflow Type
+            </label>
+            <select
+              id='workflow-type'
+              value={workflowType}
+              onChange={(e) => setWorkflowType(e.target.value as WorkflowType)}
+              className='w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-purple-500/50'
+            >
+              {WORKFLOW_TYPES.map((opt) => (
+                <option key={opt.value} value={opt.value} className='bg-gray-800'>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <p className='text-white/40 text-xs mt-1'>
+              {WORKFLOW_TYPES.find((t) => t.value === workflowType)?.description}
+            </p>
+          </div>
+
+          {/* Check Status Button */}
+          <button
+            onClick={handleCheckStatus}
+            disabled={statusState.status === 'loading'}
+            className={`w-full py-2 px-4 rounded-lg font-semibold transition-all ${
+              statusState.status === 'loading'
+                ? 'bg-white/10 text-white/40 cursor-not-allowed'
+                : 'bg-purple-600 hover:bg-purple-500 text-white'
+            }`}
+          >
+            {statusState.status === 'loading' ? 'Checking...' : 'Check Status'}
+          </button>
+        </div>
+
+        {/* Results Panel */}
+        <div className='lg:col-span-2 bg-white/5 rounded-xl border border-white/10 p-4'>
+          {statusState.status === 'loading' ? (
+            <div role='status' className='flex flex-col items-center justify-center py-12 gap-3'>
+              <div className='animate-spin rounded-full h-10 w-10 border-2 border-white/20 border-t-purple-500' />
+              <span className='text-white/60'>Checking workflow status...</span>
+            </div>
+          ) : statusState.status === 'success' && statusState.result ? (
+            <div className='space-y-4'>
+              {/* Status Summary */}
+              <div className='flex items-center justify-between mb-3'>
+                <h4 className='text-purple-400 font-semibold flex items-center gap-2'>
+                  <span>✅</span> Workflow Status
+                </h4>
+                {statusState.correlationId && (
+                  <div className='flex items-center gap-2 text-xs'>
+                    <span className='text-white/50'>ID:</span>
+                    <code className='text-purple-400 font-mono'>
+                      {statusState.correlationId.slice(0, 16)}...
+                    </code>
+                    <button
+                      onClick={() => copyToClipboard(statusState.correlationId!)}
+                      className='text-white/60 hover:text-white'
+                      aria-label='Copy correlation ID'
+                    >
+                      📋
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {/* Status Cards */}
+              <div className='grid grid-cols-2 gap-4'>
+                <div className='bg-white/5 rounded-lg p-4'>
+                  <div className='text-white/60 text-sm'>Status</div>
+                  <div className='text-xl font-bold text-white'>
+                    {statusState.result.certificationStatus || 'Unknown'}
+                  </div>
+                </div>
+                <div className='bg-white/5 rounded-lg p-4'>
+                  <div className='text-white/60 text-sm'>Current Step</div>
+                  <div className='text-xl font-bold text-white'>
+                    {statusState.result.currentStep || 'N/A'}
+                  </div>
+                </div>
+              </div>
+
+              {/* Workflow Steps */}
+              {(statusState.result.completedSteps?.length ||
+                statusState.result.pendingSteps?.length ||
+                statusState.result.currentStep) && (
+                <div className='bg-white/5 rounded-lg p-4'>
+                  <h5 className='text-white/80 font-medium mb-3'>📋 Workflow Steps</h5>
+                  <div className='space-y-2'>
+                    {buildWorkflowSteps(statusState.result).map((step, idx) => (
+                      <div
+                        key={idx}
+                        className={`flex items-center gap-3 py-2 px-3 rounded ${
+                          step.status === 'current'
+                            ? 'bg-purple-500/20 border border-purple-500/30'
+                            : step.status === 'completed'
+                            ? 'bg-green-500/10'
+                            : 'bg-white/5'
+                        }`}
+                      >
+                        <span>{getStepIcon(step.status)}</span>
+                        <span
+                          className={
+                            step.status === 'current'
+                              ? 'text-white font-medium'
+                              : step.status === 'completed'
+                              ? 'text-green-400'
+                              : 'text-white/50'
+                          }
+                        >
+                          {step.name}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Assignment Info */}
+              {(statusState.result.assignedTo || statusState.result.dueDate) && (
+                <div className='grid grid-cols-2 gap-4'>
+                  {statusState.result.assignedTo && (
+                    <div className='bg-white/5 rounded-lg p-3'>
+                      <div className='text-white/60 text-sm'>Assigned To</div>
+                      <div className='text-white font-medium'>{statusState.result.assignedTo}</div>
+                    </div>
+                  )}
+                  {statusState.result.dueDate && (
+                    <div className='bg-white/5 rounded-lg p-3'>
+                      <div className='text-white/60 text-sm'>Due Date</div>
+                      <div className='text-white font-medium'>
+                        {formatDate(statusState.result.dueDate)}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Last Updated */}
+              {statusState.result.lastUpdated && (
+                <div className='text-xs text-white/40'>
+                  Last updated: {formatDate(statusState.result.lastUpdated)}
+                </div>
+              )}
+
+              {/* Dev Info */}
+              {isDev && statusState.correlationId && (
+                <div className='text-xs text-white/40 border-t border-white/10 pt-3'>
+                  <details>
+                    <summary className='cursor-pointer hover:text-white/60'>Developer Info</summary>
+                    <pre className='mt-2 bg-black/30 rounded p-2 overflow-x-auto'>
+                      pnpm run trace:query --correlation {statusState.correlationId}
+                    </pre>
+                  </details>
+                </div>
+              )}
+            </div>
+          ) : statusState.status === 'idle' ? (
+            <div className='flex flex-col items-center justify-center py-12 text-center'>
+              <div className='text-4xl mb-2'>📊</div>
+              <p className='text-white/60'>Select workflow type and check status</p>
+              <p className='text-white/40 text-sm mt-1'>
+                View certification status, workflow steps, and assignments
+              </p>
+            </div>
+          ) : null}
+        </div>
       </div>
+
+      {/* Error Display */}
+      {statusState.status === 'error' && statusState.error && (
+        <ErrorDisplay
+          error={{
+            message: statusState.error.message,
+            errorCode: statusState.error.code,
+            correlationId: statusState.correlationId,
+          }}
+        />
+      )}
+
+      {/* History */}
+      {history.length > 0 && (
+        <div className='bg-white/5 rounded-xl p-4 border border-white/10'>
+          <h3 className='text-white font-semibold mb-3 flex items-center gap-2'>
+            <span>📜</span> History
+          </h3>
+
+          <div className='space-y-2'>
+            {history.map((record) => (
+              <div
+                key={record.id}
+                className={`flex items-center justify-between p-3 rounded-lg border ${
+                  record.status === 'success'
+                    ? 'bg-green-500/10 border-green-500/20'
+                    : 'bg-red-500/10 border-red-500/20'
+                }`}
+              >
+                <div className='flex items-center gap-3'>
+                  <span className={record.status === 'success' ? 'text-green-400' : 'text-red-400'}>
+                    {record.status === 'success' ? '✅' : '❌'}
+                  </span>
+                  <div>
+                    <div className='text-white/80 text-sm font-mono'>{record.toolId}</div>
+                    <div className='text-white/50 text-xs'>
+                      {record.workflowType} • {record.timestamp.toLocaleTimeString()}
+                    </div>
+                  </div>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <code className='text-white/40 text-xs font-mono'>
+                    {record.correlationId.slice(0, 12)}...
+                  </code>
+                  <button
+                    onClick={() => copyToClipboard(record.correlationId)}
+                    className='text-white/40 hover:text-white text-sm'
+                    aria-label='Copy correlation ID'
+                  >
+                    📋
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
PropertyDais MWUX slice wiring - final parcel-context tab.

## Changes
- Wire PropertyDais as final parcel-context MWUX slice
- Invoke \check_cert_status\ (dais suite, read_only) for workflow status
- Workflow type selector: certification, appeal, exemption, review
- Display workflow steps (completed/current/pending) with visual icons
- Show assignee and due date when available
- Full correlationId UX with ErrorDisplay
- Status check history tracking (last 10)
- 11 new tests

## Evidence
- Tests: 45/45 workbench tests pass
- Gates: type-check + phase83-tools (32/32) pass
- Tool count: 24 (unchanged - using existing tool)

## Phase 5.5 Complete
All 5 parcel-context tabs are now real MWUX slices:
- ✅ Pilot (assess)
- ✅ Dossier (summarize_dossier)
- ✅ Atlas (query_parcel_layers)
- ✅ Forge (explain_model_results)
- ✅ Dais (check_cert_status) ← this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fully implemented Property Dais tab with workflow type selection (certification, appeal, exemption, review).
  * Added status checking capability with results display including workflow steps and assignment information.
  * Introduced history tracking of invocations with copy-to-clipboard support for reference IDs.

* **Tests**
  * Added comprehensive unit test coverage for the Property Dais component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->