### PR TITLE
Phase 6.3: Legacy deprecation banner + legacy.ui_hit telemetry

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/legacy/LegacyDeprecationBanner.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/legacy/LegacyDeprecationBanner.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * LegacyDeprecationBanner.test.tsx
+ *
+ * Phase 6.3: Tests for legacy deprecation banner component.
+ *
+ * Success Criteria:
+ * - Banner renders on legacy routes with correct messaging
+ * - Dismiss button hides banner for session
+ * - Banner respects session storage dismissal
+ * - Accessibility: proper ARIA roles and keyboard navigation
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LegacyDeprecationBanner } from '../../components/legacy/LegacyDeprecationBanner';
+
+// Mock sessionStorage
+const mockSessionStorage: Record<string, string> = {};
+beforeEach(() => {
+  Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  jest
+    .spyOn(Storage.prototype, 'getItem')
+    .mockImplementation((key: string) => mockSessionStorage[key] ?? null);
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('LegacyDeprecationBanner', () => {
+  describe('Rendering', () => {
+    it('renders banner with deprecation message', () => {
+      render(<LegacyDeprecationBanner legacyAppId='suites.appraisal' route='/suites/appraisal' />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText(/legacy ui deprecated/i)).toBeInTheDocument();
+    });
+
+    it('displays upgrade prompt with OS link', () => {
+      render(<LegacyDeprecationBanner legacyAppId='modules.export' route='/modules/export' />);
+
+      expect(screen.getByText(/use os/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /go to os/i })).toBeInTheDocument();
+    });
+
+    it('shows legacy app identifier in banner', () => {
+      render(<LegacyDeprecationBanner legacyAppId='suites.valuation' route='/suites/valuation' />);
+
+      expect(screen.getByText(/suites\.valuation/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Dismiss Behavior', () => {
+    it('provides dismiss button', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
+    });
+
+    it('hides banner when dismissed', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      fireEvent.click(dismissButton);
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('persists dismissal to session storage', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      fireEvent.click(dismissButton);
+
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
+        'legacy_banner_dismissed_test.app',
+        expect.any(String)
+      );
+    });
+
+    it('respects previously dismissed state from session storage', () => {
+      mockSessionStorage['legacy_banner_dismissed_test.app'] = 'true';
+
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper alert role', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('dismiss button has accessible name', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      expect(dismissButton).toHaveAccessibleName();
+    });
+
+    it('provides keyboard navigation to OS link', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      const link = screen.getByRole('link', { name: /go to os/i });
+      expect(link).toHaveAttribute('href');
+    });
+  });
+
+  describe('Telemetry Integration', () => {
+    it('calls onTelemetry callback on mount', () => {
+      const onTelemetry = jest.fn();
+
+      render(
+        <LegacyDeprecationBanner legacyAppId='test.app' route='/test' onTelemetry={onTelemetry} />
+      );
+
+      expect(onTelemetry).toHaveBeenCalledWith({
+        legacyAppId: 'test.app',
+        route: '/test',
+        action: 'view',
+      });
+    });
+
+    it('calls onTelemetry callback with dismiss action', () => {
+      const onTelemetry = jest.fn();
+
+      render(
+        <LegacyDeprecationBanner legacyAppId='test.app' route='/test' onTelemetry={onTelemetry} />
+      );
+
+      const dismissButton = screen.getByRole('button', { name: /dismiss/i });
+      fireEvent.click(dismissButton);
+
+      expect(onTelemetry).toHaveBeenCalledWith({
+        legacyAppId: 'test.app',
+        route: '/test',
+        action: 'dismiss',
+      });
+    });
+
+    it('calls onTelemetry callback with upgrade action on link click', () => {
+      const onTelemetry = jest.fn();
+
+      render(
+        <LegacyDeprecationBanner legacyAppId='test.app' route='/test' onTelemetry={onTelemetry} />
+      );
+
+      const link = screen.getByRole('link', { name: /go to os/i });
+      fireEvent.click(link);
+
+      expect(onTelemetry).toHaveBeenCalledWith({
+        legacyAppId: 'test.app',
+        route: '/test',
+        action: 'upgrade',
+      });
+    });
+  });
+
+  describe('Styling', () => {
+    it('applies warning styling by default', () => {
+      render(<LegacyDeprecationBanner legacyAppId='test.app' route='/test' />);
+
+      const alert = screen.getByRole('alert');
+      expect(alert.className).toMatch(/warning|amber|yellow/i);
+    });
+
+    it('supports custom className override', () => {
+      render(
+        <LegacyDeprecationBanner legacyAppId='test.app' route='/test' className='custom-class' />
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveClass('custom-class');
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/legacy/legacyUiTelemetry.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/legacy/legacyUiTelemetry.test.ts
@@ -1,0 +1,286 @@
+/**
+ * legacyUiTelemetry.test.ts
+ *
+ * Phase 6.3: Tests for legacy UI telemetry emitter.
+ *
+ * Success Criteria:
+ * - Emits legacy.ui_hit event with correct structure
+ * - Rate-limits emissions (one per legacyAppId per session per N minutes)
+ * - Aggregates counts (firstSeen, lastSeen, count)
+ * - No PII fields present
+ * - Uses session-scoped storage for aggregation
+ */
+
+import {
+    emitLegacyUiHit,
+    getLegacyUiMetrics,
+    LegacyUiHitPayload,
+    resetLegacyUiMetrics,
+} from '../../telemetry/legacyUiTelemetry';
+
+// Mock sessionStorage
+const mockSessionStorage: Record<string, string> = {};
+beforeEach(() => {
+  Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  jest
+    .spyOn(Storage.prototype, 'getItem')
+    .mockImplementation((key: string) => mockSessionStorage[key] ?? null);
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  });
+
+  // Reset telemetry state between tests
+  resetLegacyUiMetrics();
+
+  // Mock Date.now for time-based rate limiting
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-02-05T12:00:00Z'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
+
+describe('legacyUiTelemetry', () => {
+  describe('emitLegacyUiHit', () => {
+    it('emits event with required fields', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'suites.appraisal',
+        route: '/suites/appraisal',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          eventType: 'legacy.ui_hit',
+          legacyAppId: 'suites.appraisal',
+          route: '/suites/appraisal',
+          timestamp: expect.any(String),
+        })
+      );
+    });
+
+    it('includes environment and appVersion', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'test.app',
+        route: '/test',
+      });
+
+      expect(result).toHaveProperty('environment');
+      expect(result).toHaveProperty('appVersion');
+    });
+
+    it('generates opaque sessionId (non-PII)', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'test.app',
+        route: '/test',
+      });
+
+      expect(result.sessionId).toBeDefined();
+      expect(result.sessionId).toMatch(/^session-[a-z0-9]+$/);
+      // Should not contain PII like email, IP, etc.
+      expect(result.sessionId).not.toMatch(/@|\.com|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
+    });
+
+    it('includes optional referrerRoute when provided', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'test.app',
+        route: '/test',
+        referrerRoute: '/workbench/parcel/123',
+      });
+
+      expect(result.referrerRoute).toBe('/workbench/parcel/123');
+    });
+  });
+
+  describe('Rate Limiting', () => {
+    it('returns event on first emission', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'rate.test',
+        route: '/rate-test',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.emitted).toBe(true);
+    });
+
+    it('rate-limits subsequent emissions within time window', () => {
+      // First emission
+      const first = emitLegacyUiHit({
+        legacyAppId: 'rate.test',
+        route: '/rate-test',
+      });
+      expect(first?.emitted).toBe(true);
+
+      // Second emission within window (should be rate-limited)
+      const second = emitLegacyUiHit({
+        legacyAppId: 'rate.test',
+        route: '/rate-test',
+      });
+      expect(second?.emitted).toBe(false);
+      expect(second?.rateLimited).toBe(true);
+    });
+
+    it('allows emission after rate limit window expires', () => {
+      // First emission
+      emitLegacyUiHit({
+        legacyAppId: 'rate.test',
+        route: '/rate-test',
+      });
+
+      // Advance time beyond rate limit window (5 minutes)
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1000);
+
+      // Should emit again
+      const result = emitLegacyUiHit({
+        legacyAppId: 'rate.test',
+        route: '/rate-test',
+      });
+      expect(result?.emitted).toBe(true);
+    });
+
+    it('rate-limits per legacyAppId independently', () => {
+      // First app
+      const app1First = emitLegacyUiHit({
+        legacyAppId: 'app1',
+        route: '/app1',
+      });
+      expect(app1First?.emitted).toBe(true);
+
+      // Second app (different legacyAppId - should not be rate-limited)
+      const app2First = emitLegacyUiHit({
+        legacyAppId: 'app2',
+        route: '/app2',
+      });
+      expect(app2First?.emitted).toBe(true);
+
+      // First app again (same legacyAppId - should be rate-limited)
+      const app1Second = emitLegacyUiHit({
+        legacyAppId: 'app1',
+        route: '/app1',
+      });
+      expect(app1Second?.emitted).toBe(false);
+    });
+  });
+
+  describe('Aggregation', () => {
+    it('tracks firstSeen timestamp', () => {
+      emitLegacyUiHit({
+        legacyAppId: 'agg.test',
+        route: '/agg',
+      });
+
+      const metrics = getLegacyUiMetrics('agg.test');
+      expect(metrics?.firstSeen).toBe('2026-02-05T12:00:00.000Z');
+    });
+
+    it('updates lastSeen on subsequent hits', () => {
+      emitLegacyUiHit({
+        legacyAppId: 'agg.test',
+        route: '/agg',
+      });
+
+      // Advance time
+      jest.advanceTimersByTime(60 * 1000);
+
+      emitLegacyUiHit({
+        legacyAppId: 'agg.test',
+        route: '/agg',
+      });
+
+      const metrics = getLegacyUiMetrics('agg.test');
+      expect(metrics?.lastSeen).toBe('2026-02-05T12:01:00.000Z');
+    });
+
+    it('increments count on each hit', () => {
+      emitLegacyUiHit({ legacyAppId: 'count.test', route: '/count' });
+      emitLegacyUiHit({ legacyAppId: 'count.test', route: '/count' });
+      emitLegacyUiHit({ legacyAppId: 'count.test', route: '/count' });
+
+      const metrics = getLegacyUiMetrics('count.test');
+      expect(metrics?.count).toBe(3);
+    });
+
+    it('aggregates across routes for same legacyAppId', () => {
+      emitLegacyUiHit({ legacyAppId: 'multi.route', route: '/path/a' });
+      emitLegacyUiHit({ legacyAppId: 'multi.route', route: '/path/b' });
+
+      const metrics = getLegacyUiMetrics('multi.route');
+      expect(metrics?.count).toBe(2);
+      expect(metrics?.routes).toContain('/path/a');
+      expect(metrics?.routes).toContain('/path/b');
+    });
+  });
+
+  describe('PII Compliance', () => {
+    it('does not include user identifiers', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'pii.test',
+        route: '/pii',
+      });
+
+      // Verify no PII fields
+      expect(result).not.toHaveProperty('userId');
+      expect(result).not.toHaveProperty('email');
+      expect(result).not.toHaveProperty('username');
+      expect(result).not.toHaveProperty('ip');
+      expect(result).not.toHaveProperty('userAgent');
+    });
+
+    it('sessionId is opaque and not traceable', () => {
+      const result1 = emitLegacyUiHit({ legacyAppId: 'pii.1', route: '/1' });
+      const result2 = emitLegacyUiHit({ legacyAppId: 'pii.2', route: '/2' });
+
+      // Same session, same sessionId
+      expect(result1?.sessionId).toBe(result2?.sessionId);
+
+      // Session ID format is opaque
+      expect(result1?.sessionId).toMatch(/^session-[a-z0-9]{8}$/);
+    });
+  });
+
+  describe('Payload Structure', () => {
+    it('matches LegacyUiHitPayload interface', () => {
+      const result = emitLegacyUiHit({
+        legacyAppId: 'structure.test',
+        route: '/structure',
+      });
+
+      // Type check: all required fields present
+      const payload: LegacyUiHitPayload = result!;
+      expect(payload.eventType).toBe('legacy.ui_hit');
+      expect(typeof payload.legacyAppId).toBe('string');
+      expect(typeof payload.route).toBe('string');
+      expect(typeof payload.environment).toBe('string');
+      expect(typeof payload.appVersion).toBe('string');
+      expect(typeof payload.sessionId).toBe('string');
+      expect(typeof payload.timestamp).toBe('string');
+    });
+  });
+
+  describe('Storage Persistence', () => {
+    it('persists metrics to sessionStorage', () => {
+      emitLegacyUiHit({ legacyAppId: 'persist.test', route: '/persist' });
+
+      expect(sessionStorage.setItem).toHaveBeenCalledWith('legacy_ui_metrics', expect.any(String));
+    });
+
+    it('restores metrics from sessionStorage on init', () => {
+      // Pre-populate storage
+      mockSessionStorage['legacy_ui_metrics'] = JSON.stringify({
+        'restore.test': {
+          firstSeen: '2026-02-05T10:00:00.000Z',
+          lastSeen: '2026-02-05T11:00:00.000Z',
+          count: 5,
+          routes: ['/restore'],
+        },
+      });
+
+      // Reset to load from storage
+      resetLegacyUiMetrics();
+
+      const metrics = getLegacyUiMetrics('restore.test');
+      expect(metrics?.count).toBe(5);
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/components/legacy/LegacyDeprecationBanner.tsx
+++ b/frontend/apps/os-shell/src/components/legacy/LegacyDeprecationBanner.tsx
@@ -1,0 +1,142 @@
+/**
+ * LegacyDeprecationBanner.tsx
+ *
+ * Phase 6.3: Deprecation banner for legacy UI routes.
+ *
+ * Displays a warning banner on legacy routes with:
+ * - Deprecation message
+ * - Upgrade link to the OS
+ * - Dismissible (session-scoped)
+ * - ARIA-compliant accessibility
+ */
+
+import { useEffect, useState } from 'react';
+
+export interface LegacyDeprecationBannerProps {
+  /** Unique identifier for the legacy app/module (e.g., 'suites.appraisal') */
+  legacyAppId: string;
+  /** Current route path */
+  route: string;
+  /** Optional callback for telemetry events */
+  onTelemetry?: (event: {
+    legacyAppId: string;
+    route: string;
+    action: 'view' | 'dismiss' | 'upgrade';
+  }) => void;
+  /** Optional additional CSS class */
+  className?: string;
+}
+
+const STORAGE_KEY_PREFIX = 'legacy_banner_dismissed_';
+
+export function LegacyDeprecationBanner({
+  legacyAppId,
+  route,
+  onTelemetry,
+  className,
+}: LegacyDeprecationBannerProps) {
+  const storageKey = `${STORAGE_KEY_PREFIX}${legacyAppId}`;
+
+  // Check if previously dismissed
+  const [isDismissed, setIsDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(storageKey) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  // Emit view telemetry on mount (only if not dismissed)
+  useEffect(() => {
+    if (!isDismissed && onTelemetry) {
+      onTelemetry({ legacyAppId, route, action: 'view' });
+    }
+  }, [isDismissed, onTelemetry, legacyAppId, route]);
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem(storageKey, 'true');
+    } catch {
+      // Ignore storage errors
+    }
+    if (onTelemetry) {
+      onTelemetry({ legacyAppId, route, action: 'dismiss' });
+    }
+    setIsDismissed(true);
+  };
+
+  const handleUpgradeClick = () => {
+    if (onTelemetry) {
+      onTelemetry({ legacyAppId, route, action: 'upgrade' });
+    }
+  };
+
+  // Don't render if dismissed
+  if (isDismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      role='alert'
+      className={`legacy-deprecation-banner warning-theme ${className ?? ''}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0.75rem 1rem',
+        backgroundColor: '#fef3c7', // amber-100
+        borderBottom: '1px solid #f59e0b', // amber-500
+        color: '#92400e', // amber-800
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: '0.875rem',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <span aria-hidden='true'>⚠️</span>
+        <span>
+          <strong>Legacy UI deprecated</strong> — use OS.{' '}
+          <code
+            style={{
+              fontSize: '0.75rem',
+              backgroundColor: 'rgba(0,0,0,0.1)',
+              padding: '0.125rem 0.25rem',
+              borderRadius: '0.25rem',
+            }}
+          >
+            {legacyAppId}
+          </code>{' '}
+          is transitioning to the new TerraFusion OS experience.
+        </span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <a
+          href='/os'
+          onClick={handleUpgradeClick}
+          style={{
+            color: '#92400e',
+            fontWeight: 600,
+            textDecoration: 'underline',
+          }}
+        >
+          Go to OS
+        </a>
+        <button
+          type='button'
+          onClick={handleDismiss}
+          aria-label='Dismiss deprecation banner'
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '0.25rem',
+            color: '#92400e',
+            fontSize: '1rem',
+          }}
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/suites/TerraPrimeSuite.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/TerraPrimeSuite.tsx
@@ -18,7 +18,9 @@ import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react
 import { useLocation, useNavigate } from 'react-router-dom';
 import ErrorBoundary from '../../components/errors/ErrorBoundary';
 import { ErrorDisplay } from '../../components/errors/ErrorDisplay';
+import { LegacyDeprecationBanner } from '../../components/legacy/LegacyDeprecationBanner';
 import { getViteEnv } from '../../shared/viteEnv';
+import { emitLegacyUiHit } from '../../telemetry/legacyUiTelemetry';
 
 // Get port from env or use default (Jest-compatible via getViteEnv)
 const env = getViteEnv();
@@ -204,12 +206,32 @@ export const TerraPrimeSuite: React.FC = () => {
     }
   }, [isLoading]);
 
+  // Emit legacy.ui_hit telemetry on first visit
+  const handleTelemetry = useCallback(
+    (event: { legacyAppId: string; route: string; action: 'view' | 'dismiss' | 'upgrade' }) => {
+      if (event.action === 'view') {
+        emitLegacyUiHit({
+          legacyAppId: event.legacyAppId,
+          route: event.route,
+        });
+      }
+    },
+    []
+  );
+
   if (hasError) {
     return <ConnectionError onRetry={handleRetry} />;
   }
 
   return (
     <div className='h-full w-full flex flex-col'>
+      {/* Legacy Deprecation Banner */}
+      <LegacyDeprecationBanner
+        legacyAppId='suites.terra-prime'
+        route={location.pathname}
+        onTelemetry={handleTelemetry}
+      />
+
       {/* Suite Header */}
       <div className='bg-white border-b px-4 py-2 flex items-center justify-between'>
         <div className='flex items-center gap-2'>

--- a/frontend/apps/os-shell/src/telemetry/legacyUiTelemetry.ts
+++ b/frontend/apps/os-shell/src/telemetry/legacyUiTelemetry.ts
@@ -1,0 +1,200 @@
+/**
+ * legacyUiTelemetry.ts
+ *
+ * Phase 6.3: Legacy UI telemetry emitter.
+ *
+ * Features:
+ * - Emits `legacy.ui_hit` events for legacy route visits
+ * - Rate-limited: one emission per legacyAppId per 5 minutes
+ * - Aggregates metrics: firstSeen, lastSeen, count, routes
+ * - Non-PII compliant: opaque sessionId, no user identifiers
+ * - Session-scoped storage persistence
+ */
+
+const STORAGE_KEY = 'legacy_ui_metrics';
+const RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface LegacyUiHitPayload {
+  eventType: 'legacy.ui_hit';
+  legacyAppId: string;
+  route: string;
+  environment: string;
+  appVersion: string;
+  sessionId: string;
+  timestamp: string;
+  referrerRoute?: string;
+  emitted: boolean;
+  rateLimited?: boolean;
+}
+
+export interface MetricsEntry {
+  firstSeen: string;
+  lastSeen: string;
+  count: number;
+  routes: string[];
+  lastEmittedAt?: number;
+}
+
+// In-memory state
+let metrics: Record<string, MetricsEntry> = {};
+let sessionId: string | null = null;
+
+// Initialize from storage
+function loadFromStorage(): void {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      metrics = JSON.parse(stored);
+    }
+  } catch {
+    metrics = {};
+  }
+}
+
+// Persist to storage
+function saveToStorage(): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(metrics));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+// Generate opaque session ID (non-PII)
+function getSessionId(): string {
+  if (sessionId) {
+    return sessionId;
+  }
+  // Generate random 8-char hex string
+  const randomPart = Math.random().toString(36).substring(2, 10);
+  sessionId = `session-${randomPart}`;
+  return sessionId;
+}
+
+// Get environment from build-time config or fallback
+function getEnvironment(): string {
+  // Use globalThis to avoid Jest import.meta issues
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (globalThis as any).import_meta_env;
+    if (meta?.MODE) {
+      return meta.MODE;
+    }
+    // Vite injects import.meta.env at build time
+    if (typeof process !== 'undefined' && process.env?.NODE_ENV) {
+      return process.env.NODE_ENV;
+    }
+  } catch {
+    // Ignore
+  }
+  return 'development';
+}
+
+// Get app version from build-time config or fallback
+function getAppVersion(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (globalThis as any).import_meta_env;
+    if (meta?.VITE_APP_VERSION) {
+      return meta.VITE_APP_VERSION;
+    }
+  } catch {
+    // Ignore
+  }
+  return '0.0.0';
+}
+
+/**
+ * Emit a legacy.ui_hit telemetry event.
+ *
+ * Rate-limited: returns event with `emitted: false` and `rateLimited: true`
+ * if within the rate limit window for this legacyAppId.
+ */
+export function emitLegacyUiHit(params: {
+  legacyAppId: string;
+  route: string;
+  referrerRoute?: string;
+}): LegacyUiHitPayload {
+  const { legacyAppId, route, referrerRoute } = params;
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+
+  // Ensure state is loaded
+  if (Object.keys(metrics).length === 0) {
+    loadFromStorage();
+  }
+
+  // Get or create entry for this legacyAppId
+  let entry = metrics[legacyAppId];
+  if (!entry) {
+    entry = {
+      firstSeen: nowIso,
+      lastSeen: nowIso,
+      count: 0,
+      routes: [],
+    };
+    metrics[legacyAppId] = entry;
+  }
+
+  // Update aggregation
+  entry.lastSeen = nowIso;
+  entry.count += 1;
+  if (!entry.routes.includes(route)) {
+    entry.routes.push(route);
+  }
+
+  // Check rate limiting
+  const isRateLimited =
+    entry.lastEmittedAt !== undefined && now - entry.lastEmittedAt < RATE_LIMIT_MS;
+  const shouldEmit = !isRateLimited;
+
+  if (shouldEmit) {
+    entry.lastEmittedAt = now;
+  }
+
+  // Persist
+  saveToStorage();
+
+  // Build payload
+  const payload: LegacyUiHitPayload = {
+    eventType: 'legacy.ui_hit',
+    legacyAppId,
+    route,
+    environment: getEnvironment(),
+    appVersion: getAppVersion(),
+    sessionId: getSessionId(),
+    timestamp: nowIso,
+    emitted: shouldEmit,
+  };
+
+  if (referrerRoute) {
+    payload.referrerRoute = referrerRoute;
+  }
+
+  if (isRateLimited) {
+    payload.rateLimited = true;
+  }
+
+  return payload;
+}
+
+/**
+ * Get aggregated metrics for a specific legacyAppId.
+ */
+export function getLegacyUiMetrics(legacyAppId: string): MetricsEntry | undefined {
+  // Ensure state is loaded
+  if (Object.keys(metrics).length === 0) {
+    loadFromStorage();
+  }
+  return metrics[legacyAppId];
+}
+
+/**
+ * Reset all metrics (primarily for testing).
+ * Reloads from storage to pick up any pre-populated test data.
+ */
+export function resetLegacyUiMetrics(): void {
+  metrics = {};
+  sessionId = null;
+  loadFromStorage();
+}


### PR DESCRIPTION
## Phase 6.3: Legacy Observability Layer

### Summary
Adds deprecation banners and telemetry for legacy UI routes to provide visibility into legacy usage patterns and encourage migration to OS.

### Changes

**New Components:**
- LegacyDeprecationBanner: Dismissible warning banner with OS upgrade link
- legacyUiTelemetry: Rate-limited legacy.ui_hit event emitter

**Features:**
- Session-scoped banner dismissal (sessionStorage)
- Rate limiting: 1 emit per legacyAppId per 5 minutes
- Aggregation: firstSeen, lastSeen, count, routes array
- PII-free: opaque sessionId, no user identifiers
- Wired to TerraPrimeSuite wrapper

### Test Coverage
- LegacyDeprecationBanner: 15/15 tests pass
- legacyUiTelemetry: 17/17 tests pass (32 total)

### Gates
- type-check: pass
- phase83-tools: 32/32 pass
- legacy tests: 32/32 pass

AI-Collaboration: GitHub Copilot
Government: FISMA compliance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a deprecation banner to legacy UI routes (TerraPrime suite) informing users about the upgrade path
* Banner includes a "Go to OS" link and can be dismissed (dismissal persists during the session)
* Implemented anonymous usage tracking for legacy UI to monitor adoption of the new platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->