### PR TITLE
Phase 6.4: LegacyRedirect with telemetry for /modules/* routes

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense, lazy } from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { ErrorBoundary } from './components/errors/ErrorBoundary';
+import { LegacyRedirect } from './components/legacy/LegacyRedirect';
 
 // Loading component for Suspense fallback
 const LoadingFallback = () => (
@@ -92,9 +93,15 @@ const Router: React.FC = () => {
               <Route path='pilot' element={<PropertyPilot />} />
             </Route>
 
-            {/* Legacy Redirects - Demote broken defaults */}
-            <Route path='/modules/property-workbench' element={<Navigate to='/' replace />} />
-            <Route path='/modules/property-workbench/*' element={<Navigate to='/' replace />} />
+            {/* Legacy Redirects - Demote broken defaults with telemetry */}
+            <Route
+              path='/modules/property-workbench'
+              element={<LegacyRedirect to='/' legacyAppId='modules.property-workbench' />}
+            />
+            <Route
+              path='/modules/property-workbench/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.property-workbench' />}
+            />
 
             <Route path='/monitoring' element={<Monitoring />} />
             <Route path='/marketplace' element={<TerraFusionMarketplace />} />
@@ -123,8 +130,11 @@ const Router: React.FC = () => {
             {/* Phase 2: Pilot Tool Invocation Demo */}
             <Route path='/pilot-demo' element={<PilotDemo />} />
 
-            {/* Legacy module routes - redirect to home */}
-            <Route path='/modules/*' element={<Navigate to='/' replace />} />
+            {/* Legacy module routes - redirect to home with telemetry */}
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.unknown' />}
+            />
           </Routes>
         </Suspense>
       </ErrorBoundary>

--- a/frontend/apps/os-shell/src/__tests__/legacy/LegacyRedirect.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/legacy/LegacyRedirect.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * LegacyRedirect.test.tsx
+ *
+ * Phase 6.4: Tests for legacy redirect component with telemetry.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { LegacyRedirect } from '../../components/legacy/LegacyRedirect';
+import * as telemetry from '../../telemetry/legacyUiTelemetry';
+
+// Mock telemetry module
+jest.mock('../../telemetry/legacyUiTelemetry', () => ({
+  emitLegacyUiHit: jest.fn(() => ({
+    eventType: 'legacy.ui_hit',
+    legacyAppId: 'test.app',
+    route: '/test',
+    emitted: true,
+  })),
+}));
+
+// Helper to capture final location
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid='location'>{location.pathname}</div>;
+}
+
+describe('LegacyRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Telemetry Emission', () => {
+    it('emits legacy.ui_hit telemetry on mount', async () => {
+      render(
+        <MemoryRouter initialEntries={['/modules/old-route']}>
+          <Routes>
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.old-route' />}
+            />
+            <Route path='/' element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(telemetry.emitLegacyUiHit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legacyAppId: 'modules.old-route',
+            route: '/modules/old-route',
+          })
+        );
+      });
+    });
+
+    it('includes legacyAppId in telemetry payload', async () => {
+      render(
+        <MemoryRouter initialEntries={['/modules/property-workbench']}>
+          <Routes>
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.property-workbench' />}
+            />
+            <Route path='/' element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(telemetry.emitLegacyUiHit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legacyAppId: 'modules.property-workbench',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Redirect Behavior', () => {
+    it('redirects to target route', async () => {
+      const { getByTestId } = render(
+        <MemoryRouter initialEntries={['/modules/old-route']}>
+          <Routes>
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.old' />}
+            />
+            <Route path='/' element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('location').textContent).toBe('/');
+      });
+    });
+
+    it('redirects with replace by default', async () => {
+      // This is covered by the implementation using replace: true
+      const { getByTestId } = render(
+        <MemoryRouter initialEntries={['/modules/test']}>
+          <Routes>
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/home' legacyAppId='modules.test' />}
+            />
+            <Route path='/home' element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('location').textContent).toBe('/home');
+      });
+    });
+  });
+
+  describe('Route Capture', () => {
+    it('captures full route path in telemetry', async () => {
+      render(
+        <MemoryRouter initialEntries={['/modules/property-workbench/parcel/123']}>
+          <Routes>
+            <Route
+              path='/modules/*'
+              element={<LegacyRedirect to='/' legacyAppId='modules.property-workbench' />}
+            />
+            <Route path='/' element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(telemetry.emitLegacyUiHit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            route: '/modules/property-workbench/parcel/123',
+          })
+        );
+      });
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/components/legacy/LegacyRedirect.tsx
+++ b/frontend/apps/os-shell/src/components/legacy/LegacyRedirect.tsx
@@ -1,0 +1,48 @@
+/**
+ * LegacyRedirect.tsx
+ *
+ * Phase 6.4: Legacy redirect component with telemetry.
+ *
+ * Emits `legacy.ui_hit` telemetry before redirecting to the target route.
+ * Use this instead of `<Navigate />` for legacy paths that need tracking.
+ */
+
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { emitLegacyUiHit } from '../../telemetry/legacyUiTelemetry';
+
+export interface LegacyRedirectProps {
+  /** Target route to redirect to */
+  to: string;
+  /** Unique identifier for the legacy route (e.g., 'modules.property-workbench') */
+  legacyAppId: string;
+  /** Whether to replace the current history entry */
+  replace?: boolean;
+}
+
+/**
+ * LegacyRedirect - Redirect with telemetry emission
+ *
+ * Emits a `legacy.ui_hit` event before redirecting to track
+ * legacy route usage patterns for deprecation planning.
+ */
+export function LegacyRedirect({ to, legacyAppId, replace = true }: LegacyRedirectProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Emit telemetry for this legacy route hit
+    emitLegacyUiHit({
+      legacyAppId,
+      route: location.pathname,
+      referrerRoute: document.referrer ? new URL(document.referrer).pathname : undefined,
+    });
+
+    // Perform the redirect
+    navigate(to, { replace });
+  }, [legacyAppId, location.pathname, navigate, replace, to]);
+
+  // Render nothing while redirecting
+  return null;
+}

--- a/frontend/apps/os-shell/src/components/legacy/index.ts
+++ b/frontend/apps/os-shell/src/components/legacy/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Legacy Components Barrel Export
+ *
+ * Phase 6.3/6.4: Legacy deprecation and telemetry components.
+ */
+
+export { LegacyDeprecationBanner } from './LegacyDeprecationBanner';
+export type { LegacyDeprecationBannerProps } from './LegacyDeprecationBanner';
+
+export { LegacyRedirect } from './LegacyRedirect';
+export type { LegacyRedirectProps } from './LegacyRedirect';
+

--- a/frontend/apps/os-shell/src/telemetry/index.ts
+++ b/frontend/apps/os-shell/src/telemetry/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Telemetry Barrel Export
+ *
+ * Phase 6.3: Legacy UI telemetry functions.
+ */
+
+export {
+  emitLegacyUiHit,
+  getLegacyUiMetrics,
+  resetLegacyUiMetrics,
+} from './legacyUiTelemetry';
+
+export type { LegacyUiHitPayload, MetricsEntry } from './legacyUiTelemetry';


### PR DESCRIPTION
## Phase 6.4: Wire Legacy Telemetry to Redirect Paths

### Summary
Extends the legacy observability layer from Phase 6.3 to cover redirect paths. Now /modules/* routes emit legacy.ui_hit telemetry before redirecting to OS.

### Changes

**New Component:**
- LegacyRedirect: Emits legacy.ui_hit before redirecting

**Router Updates:**
- /modules/property-workbench -> LegacyRedirect(modules.property-workbench)
- /modules/* -> LegacyRedirect(modules.unknown)

### Test Coverage
- LegacyRedirect: 5 tests (telemetry emission, redirect behavior, route capture)
- Total legacy tests: 37/37 pass

### Gates
- type-check: pass
- phase83-tools: pass

### Legacy Telemetry Coverage
- TerraPrimeSuite: banner + telemetry (Phase 6.3)
- /modules/*: redirect telemetry (this PR)

AI-Collaboration: GitHub Copilot (Claude Opus 4.5)
Government: FISMA compliance