### PR TITLE
feat(platform): Platform Contract + CI Diet — stop the Groundhog Day loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,8 @@ TF_ENV=development
 COUNTY_NAME="Your County Name"
 COUNTY_CODE=US-STATE-COUNTY
 
-# ===== Service Ports =====
-TF_API_PORT=5055
-TF_LEVY_PORT=3202
-TF_TRENDS_PORT=3203
-TF_CONSCIOUSNESS_PORT=8080
-TF_SHELL_PORT=3000
+# ===== Service Ports (canonical: see platform.json) =====
+# Duplicates removed — single block below under "Dynamic Port Configuration"
 
 # ===== Networking =====
 TF_NETWORK=terrafusion_dev
@@ -58,10 +54,10 @@ TF_SHELL_PORT=3103
 TF_DESKTOP_PORT=3104
 TF_STATIC_PORT=8080
 
-# ===== API URLs =====
-VITE_API_URL=http://localhost:${TF_API_PORT:-5000}/api
-REACT_APP_API_GATEWAY=http://localhost:${TF_API_PORT:-5000}
-ASPNETCORE_URLS=http://localhost:${TF_API_PORT:-5000}
+# ===== API URLs (consume from ports above) =====
+VITE_API_URL=http://localhost:${TF_API_PORT:-5046}/api
+REACT_APP_API_GATEWAY=http://localhost:${TF_API_PORT:-5046}
+ASPNETCORE_URLS=http://localhost:${TF_API_PORT:-5046}
 
 # ===== Paths =====
 DATA_DIR=./data/dev

--- a/.github/workflows/accessibility-audit.yml
+++ b/.github/workflows/accessibility-audit.yml
@@ -1,13 +1,6 @@
 name: ♿ Accessibility Audit (WCAG 2.1)
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'frontend/src/components/**'
-      - 'frontend/src/pages/**'
-      - 'tests/e2e/frontend/accessibility/**'
-      - '.github/workflows/accessibility-audit.yml'
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -8,11 +8,6 @@ on:
       - 'frontend/**'
       - 'src/**'
       - '.github/workflows/accessibility.yml'
-  pull_request:
-    paths:
-      - 'frontend/**'
-      - 'src/**'
-      - '.github/workflows/accessibility.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/accreditation-compat.yml
+++ b/.github/workflows/accreditation-compat.yml
@@ -23,12 +23,6 @@ on:
       - 'tools/registry/autonomy-viewer/src/county-kit.ts'
       - 'tools/registry/autonomy-viewer/bin/accreditation-*.mjs'
       - 'tools/registry/autonomy-viewer/ACCREDITATION_REFERENCE.lock.json'
-  pull_request:
-    paths:
-      - 'tools/registry/autonomy-viewer/src/accreditation-*.ts'
-      - 'tools/registry/autonomy-viewer/src/county-kit.ts'
-      - 'tools/registry/autonomy-viewer/bin/accreditation-*.mjs'
-      - 'tools/registry/autonomy-viewer/ACCREDITATION_REFERENCE.lock.json'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/ai-swarm-safety.yml
+++ b/.github/workflows/ai-swarm-safety.yml
@@ -1,16 +1,8 @@
 name: AI Swarm Safety Gate
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
-    paths:
-      - 'config/ai-*'
-      - 'backend/**/AI/**'
-      - 'backend/**/Agents/**'
-      - 'frontend/**/ai/**'
-      - 'frontend/**/agents/**'
-      - '.github/workflows/ai-swarm-safety.yml'
-
+  push:
+    branches: [main]
 jobs:
   check-ai-swarm-safety:
     name: Check AI-swarm safety

--- a/.github/workflows/atlas-validation.yml
+++ b/.github/workflows/atlas-validation.yml
@@ -5,13 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
-    paths:
-      - 'terrafusion-atlas/**'
-      - '**/package.json'
-      - '**/Cargo.toml'
-      - '**/*.csproj'
-      - '**/*.sln'
   push:
     branches:
       - main

--- a/.github/workflows/baseline-guard.yml
+++ b/.github/workflows/baseline-guard.yml
@@ -1,12 +1,7 @@
 name: Baseline Guard
 on:
-  pull_request:
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'tools/**'
-      - '.github/workflows/baseline-guard.yml'
+  push:
+    branches: [main]
 jobs:
   guard:
     runs-on: windows-latest

--- a/.github/workflows/benton.yml
+++ b/.github/workflows/benton.yml
@@ -6,11 +6,6 @@ on:
       - 'backend/**'
       - 'counties/benton/**'
       - '.github/workflows/benton.yml'
-  pull_request:
-    paths:
-      - 'backend/**'
-      - 'counties/benton/**'
-
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -9,15 +9,6 @@ on:
       - 'Directory.Build.props'
       - 'Directory.Build.targets'
       - '.github/workflows/build-validation.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - '*.sln'
-      - 'Directory.Build.props'
-      - 'Directory.Build.targets'
-      - '.github/workflows/build-validation.yml'
-
 jobs:
   validate-build:
     name: Validate Perfect Build

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -25,17 +25,6 @@ on:
       - '*.sln'
       - 'Directory.Build.props'
       - '.github/workflows/ci-cd-main.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '*.sln'
-      - 'Directory.Build.props'
-      - '.github/workflows/ci-cd-main.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -7,8 +7,6 @@ concurrency:
 on:
   push:
     branches: [main, develop, staging]
-  pull_request:
-    branches: [main, develop]
   schedule:
     # Run nightly builds at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,10 +5,6 @@ name: TerraFusion master CI/CD
       - main
       - develop
       - staging
-  pull_request:
-    branches:
-      - main
-      - develop
   schedule:
     - cron: 0 2 * * *
 env:

--- a/.github/workflows/ci-verified.yml
+++ b/.github/workflows/ci-verified.yml
@@ -3,9 +3,6 @@ name: TerraFusion OS - Verified Build & Test
 on:
   push:
     branches: [main, develop, 'feature/**']
-  pull_request:
-    branches: [main, develop]
-
 env:
   DOTNET_VERSION: '8.0.x'
   NODE_VERSION: '20.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,6 @@ on:
       - 'pnpm-lock.yaml'
       - '*.sln'
       - '.github/workflows/ci.yml'
-  pull_request:
-    branches: [main, development]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '*.sln'
-      - '.github/workflows/ci.yml'
-
 env:
   NODE_VERSION: '20'
   DOTNET_VERSION: '8.0.x'

--- a/.github/workflows/code-intel.yml
+++ b/.github/workflows/code-intel.yml
@@ -8,13 +8,6 @@ on:
       - 'src/**'
       - 'tools/**'
       - '.github/workflows/code-intel.yml'
-  pull_request:
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'tools/**'
-      - '.github/workflows/code-intel.yml'
   workflow_dispatch: {}
 jobs:
   scan:

--- a/.github/workflows/county-kit-parity.yml
+++ b/.github/workflows/county-kit-parity.yml
@@ -19,12 +19,6 @@ on:
     paths:
       - 'tools/registry/autonomy-viewer/**'
       - '.github/workflows/county-kit-parity.yml'
-  pull_request:
-    branches: [main, master]
-    paths:
-      - 'tools/registry/autonomy-viewer/**'
-      - '.github/workflows/county-kit-parity.yml'
-
 jobs:
   parity-check:
     strategy:

--- a/.github/workflows/deps-fast-lane.yml
+++ b/.github/workflows/deps-fast-lane.yml
@@ -9,26 +9,8 @@
 name: 📦 Deps Fast Lane
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      # NPM/PNPM
-      - '**/package.json'
-      - '**/pnpm-lock.yaml'
-      - '**/yarn.lock'
-      - '**/package-lock.json'
-      # .NET
-      - '**/*.csproj'
-      - '**/Directory.Packages.props'
-      - '**/NuGet.config'
-      # Docker
-      - '**/Dockerfile'
-      - '**/*.dockerfile'
-      # Python
-      - '**/requirements*.txt'
-      - '**/pyproject.toml'
-      - '**/Pipfile*'
-
+  push:
+    branches: [main]
 permissions:
   contents: read
 

--- a/.github/workflows/designctl.yml
+++ b/.github/workflows/designctl.yml
@@ -1,9 +1,6 @@
 name: Design Token CI
 
 on:
-  pull_request:
-    paths:
-      - 'design/tokens.json'
   push:
     branches:
       - main

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,17 +1,10 @@
 name: E2E Smoke - TerraFusion cOS
 
 on:
-  pull_request:
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
-      - 'src/**'
-      - 'apps/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/e2e-smoke.yml'
   workflow_dispatch:
 
+  push:
+    branches: [main]
 jobs:
   smoke:
     runs-on: ubuntu-latest
@@ -29,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: pnpm
           cache-dependency-path: |
             terrafusion-cos/frontend_engine/pnpm-lock.yaml

--- a/.github/workflows/gate-pipeline.yml
+++ b/.github/workflows/gate-pipeline.yml
@@ -3,8 +3,6 @@ name: TerraFusion Gate Pipeline
 on:
   push:
     branches: [main, develop, 'feature/**']
-  pull_request:
-    branches: [main, develop]
   workflow_dispatch:
     inputs:
       skip_security:
@@ -49,7 +47,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '8.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -131,7 +129,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '8.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -242,7 +240,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '8.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/golden-corpus-compat.yml
+++ b/.github/workflows/golden-corpus-compat.yml
@@ -1,11 +1,6 @@
 name: Golden Corpus Compatibility Gate
 
 on:
-  pull_request:
-    paths:
-      - 'tools/registry/autonomy-viewer/src/**'
-      - 'tools/registry/autonomy-viewer/test/**'
-      - 'golden/**'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/governance-audit.yml
+++ b/.github/workflows/governance-audit.yml
@@ -10,12 +10,6 @@ name: 🔍 Governance Drift Detection
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/**'
-      - 'DURABILITY_MEASURES.md'
-      - 'AGENTS.md'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/governance-proof.yml
+++ b/.github/workflows/governance-proof.yml
@@ -1,17 +1,10 @@
 name: governance-proof
 
 on:
-  pull_request:
-    branches: [main, master]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'policy/**'
-      - 'tools/**'
-      - '.github/workflows/governance-proof.yml'
   workflow_dispatch:
 
+  push:
+    branches: [main]
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/gpt-rag.yml
+++ b/.github/workflows/gpt-rag.yml
@@ -14,11 +14,6 @@ on:
       - 'backend/src/TerraFusion.Core/RAG/**'
       - '.github/workflows/gpt-rag.yml'
     branches: [main, develop, 'feature/**']
-  pull_request:
-    paths:
-      - 'backend/src/TerraFusion.AI/**'
-      - 'backend/src/TerraFusion.Core/GPT/**'
-      - 'backend/src/TerraFusion.Core/RAG/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/grfe-ci.yaml
+++ b/.github/workflows/grfe-ci.yaml
@@ -7,8 +7,6 @@ concurrency:
 on:
   push:
     branches: [main]
-  pull_request:
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/infrastructure-cicd.yml
+++ b/.github/workflows/infrastructure-cicd.yml
@@ -6,12 +6,6 @@ on:
     paths:
       - 'infrastructure/**'
       - '.github/workflows/**'
-  pull_request:
-    branches: [main, master]
-    paths:
-      - 'infrastructure/**'
-      - '.github/workflows/**'
-
 env:
   TF_VERSION: '1.5.0'
   TF_VAR_region: 'us-east-1'

--- a/.github/workflows/kubernetes-infrastructure-ci.yml
+++ b/.github/workflows/kubernetes-infrastructure-ci.yml
@@ -34,15 +34,6 @@ on:
       - 'kustomize/**'
       - '.github/workflows/kubernetes-infrastructure-ci.yml'
 
-  pull_request:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'charts/**'
-      - 'manifests/**'
-      - 'kustomize/**'
-
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/manifest-contract-guard.yml
+++ b/.github/workflows/manifest-contract-guard.yml
@@ -1,13 +1,6 @@
 name: manifest-contract-guard
 
 on:
-  pull_request:
-    paths:
-      - 'applications/**/terrafusion.app.json'
-      - 'tools/registry/terrafusion.app.schema.json'
-      - 'tools/dev/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
   push:
     branches:
       - main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,14 +9,10 @@ name: 📄 Docs Fast Lane
 # ═══════════════════════════════════════════════════════════════════════════════
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.mdx'
-      - '.github/**/*.md'
   workflow_dispatch: {}
 
+  push:
+    branches: [main]
 concurrency:
   group: docs-fast-lane-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/observability-ci.yml
+++ b/.github/workflows/observability-ci.yml
@@ -36,16 +36,6 @@ on:
       - 'grafana/**'
       - '.github/workflows/observability-ci.yml'
 
-  pull_request:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'dashboards/**'
-      - 'prometheus/**'
-      - 'alerting/**'
-      - 'grafana/**'
-
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/opa-policy-tests.yml
+++ b/.github/workflows/opa-policy-tests.yml
@@ -12,12 +12,6 @@ on:
       - 'kubernetes/**/*.yml'
       - 'policies/**/*.rego'
       - '.github/workflows/opa-policy-tests.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'kubernetes/**/*.yaml'
-      - 'kubernetes/**/*.yml'
-      - 'policies/**/*.rego'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -1,11 +1,6 @@
 name: 'Performance Budget & Lighthouse'
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/performance-budget.yml'
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -23,12 +23,6 @@
 name: Performance Regression Detection
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'frontend/**'
-      - 'package.json'
-      - 'vite.config.ts'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -6,14 +6,6 @@ on:
     branches:
       - 'release/**'
       - 'release/*'
-  pull_request:
-    branches:
-      - main
-    # Only when PR is from a release branch
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rust-security-gates.yml
+++ b/.github/workflows/rust-security-gates.yml
@@ -6,11 +6,6 @@ on:
     paths:
       - 'rust-performance-engine/**'
       - '.github/workflows/rust-security.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'rust-performance-engine/**'
-
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/rust-verify.yml
+++ b/.github/workflows/rust-verify.yml
@@ -1,13 +1,10 @@
 name: CI • Rust Verify
 
 on:
-  pull_request:
-    paths:
-      - 'terrafusion-cos/**'
-      - 'ops/**'
-      - 'Makefile'
   workflow_dispatch: {}
 
+  push:
+    branches: [main]
 permissions:
   contents: read
 

--- a/.github/workflows/scope-drift-guard.yml
+++ b/.github/workflows/scope-drift-guard.yml
@@ -5,7 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
   push:
     branches: [main]
 

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -375,7 +375,13 @@ jobs:
           test -f .snyk && echo "✅ .snyk exists" || echo "⚠️ .snyk missing (optional)"
           # Solution file (CRITICAL - fail if missing)
           test -f backend/TerraFusion.sln || { echo "::error::Missing backend/TerraFusion.sln"; exit 1; }
-          echo "✅ Solution exists"
+          # Platform contract (CRITICAL - single source of truth)
+          test -f platform.json || { echo "::error::Missing platform.json (platform contract)"; exit 1; }
+          echo "✅ Critical files verified"
+
+      - name: Platform contract lint
+        shell: bash
+        run: node scripts/platform-lint.mjs
 
   # ═══════════════════════════════════════════════════════════════════════════
   # SEAL - Final gate (all fast checks must pass)

--- a/.github/workflows/security-compliance-ci.yml
+++ b/.github/workflows/security-compliance-ci.yml
@@ -37,16 +37,6 @@ on:
       - 'vulnerability-scanning/**'
       - '.github/workflows/security-compliance-ci.yml'
 
-  pull_request:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'policies/**'
-      - 'compliance/**'
-      - 'security-baselines/**'
-      - 'poam/**'
-
   schedule:
     # Run daily security scans at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -15,17 +15,6 @@ on:
       - '*.csproj'
       - 'Directory.Packages.props'
       - '.github/workflows/security-compliance.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '*.csproj'
-      - 'Directory.Packages.props'
-      - '.github/workflows/security-compliance.yml'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight
   workflow_dispatch:

--- a/.github/workflows/spec-gates.yml
+++ b/.github/workflows/spec-gates.yml
@@ -7,12 +7,6 @@ on:
       - 'docs/architecture/specs/**'
       - 'policy/**'
       - '.github/workflows/spec-gates.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'docs/architecture/specs/**'
-      - 'policy/**'
-      - '.github/workflows/spec-gates.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/tag-lint.yml
+++ b/.github/workflows/tag-lint.yml
@@ -1,12 +1,7 @@
 name: Tag Lint
 on:
-  pull_request:
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'tools/**'
-      - '.github/workflows/tag-lint.yml'
+  push:
+    branches: [main]
 jobs:
   lint:
     runs-on: windows-latest

--- a/.github/workflows/terra-levy-tests.yml
+++ b/.github/workflows/terra-levy-tests.yml
@@ -5,11 +5,6 @@ on:
     paths:
       - 'SDK/modules/terra-levy/**'
       - '.github/workflows/terra-levy-tests.yml'
-  pull_request:
-    paths:
-      - 'SDK/modules/terra-levy/**'
-      - '.github/workflows/terra-levy-tests.yml'
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraforge-ci.yml
+++ b/.github/workflows/terraforge-ci.yml
@@ -7,12 +7,6 @@ on:
       - 'applications/terraforge-suite/**'
       - 'scripts/e2e-pipeline.ts'
       - '.github/workflows/terraforge-ci.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'applications/terraforge-suite/**'
-      - 'scripts/e2e-pipeline.ts'
-      - '.github/workflows/terraforge-ci.yml'
   schedule:
     # Nightly at 3 AM UTC - runs steel mode E2E
     - cron: '0 3 * * *'

--- a/.github/workflows/terrafusion-ci-cd-production.yml
+++ b/.github/workflows/terrafusion-ci-cd-production.yml
@@ -16,17 +16,6 @@ on:
       - 'pnpm-lock.yaml'
       - '*.sln'
       - '.github/workflows/terrafusion-ci-cd-production.yml'
-  pull_request:
-    branches: [main, production]
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '*.sln'
-      - '.github/workflows/terrafusion-ci-cd-production.yml'
   workflow_dispatch:
     inputs:
       deploy_environment:
@@ -47,7 +36,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   NODE_VERSION: '20'
-  DOTNET_VERSION: '8.0'
+  DOTNET_VERSION: '8.0.x'
   PYTHON_VERSION: '3.11'
 
 jobs:

--- a/.github/workflows/terrafusion-gate-enforcement.yml
+++ b/.github/workflows/terrafusion-gate-enforcement.yml
@@ -7,8 +7,6 @@ concurrency:
 on:
   push:
     branches: [main, develop, release/*]
-  pull_request:
-    branches: [main, develop]
   workflow_dispatch:
     inputs:
       target_env:

--- a/.github/workflows/terrafusion-pipeline.yml
+++ b/.github/workflows/terrafusion-pipeline.yml
@@ -2,8 +2,6 @@ name: TerraFusion Gatekeeper
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,6 @@
 name: 🧪 Test Suite - THE TERRAFUSION WAY
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
-      - 'tests/**'
-      - 'package.json'
-      - '.github/workflows/test.yml'
   push:
     branches: [main, develop]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,17 +11,6 @@ on:
       - 'pnpm-lock.yaml'
       - '*.sln'
       - '.github/workflows/testing.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'src/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - '*.sln'
-      - '.github/workflows/testing.yml'
-
 jobs:
   test:
     name: Comprehensive Testing Suite

--- a/.github/workflows/tfctl-ci.yml
+++ b/.github/workflows/tfctl-ci.yml
@@ -2,24 +2,18 @@ name: tfctl CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'tfctl.py'
       - 'tests/**'
       - '.github/workflows/tfctl-ci.yml'
-  pull_request:
-    paths:
-      - 'tfctl.py'
-      - 'tests/**'
-      - '.github/workflows/tfctl-ci.yml'
-
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.10', '3.11', '3.12' ]
+        python: ['3.10', '3.11', '3.12']
     env:
       TF_API_PORT: 0
     steps:

--- a/.github/workflows/tier1-ui-harness.yml
+++ b/.github/workflows/tier1-ui-harness.yml
@@ -5,6 +5,8 @@
 name: Tier-1 UI Harness Suite
 
 on:
+  pull_request:
+    branches: [main, develop]
   workflow_dispatch:
     inputs:
       test_filter:
@@ -12,8 +14,6 @@ on:
         required: false
         type: string
         default: 'tier1'
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,13 +1,6 @@
 name: 📸 Visual Regression Testing
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'frontend/src/components/**'
-      - 'frontend/src/styles/**'
-      - 'tests/e2e/frontend/visual/**'
-      - '.github/workflows/visual-regression.yml'
   push:
     branches: [main]
 

--- a/.github/workflows/wave1-freeze-guard.yml
+++ b/.github/workflows/wave1-freeze-guard.yml
@@ -1,11 +1,8 @@
 name: Wave 1 Template Freeze
 
 on:
-  pull_request:
-    paths:
-      - 'docs/ops/WAVE_1_*.md'
-      - 'docs/ops/templates/WAVE_1_*.md'
-
+  push:
+    branches: [main]
 jobs:
   freeze-check:
     name: 🔒 Wave 1 Template Freeze Guard

--- a/.github/workflows/yaml-sanity.yml
+++ b/.github/workflows/yaml-sanity.yml
@@ -1,11 +1,10 @@
 name: yaml-sanity
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/**'
   workflow_dispatch:
 
+  push:
+    branches: [main]
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.ports.config
+++ b/.ports.config
@@ -1,24 +1,30 @@
 # TerraFusion OS - Dynamic Port Configuration
+# ─────────────────────────────────────────────
+# Canonical source: platform.json → ports section
 # DO NOT HARDCODE PORTS - Use environment variables or auto-detection
+#
+# This file is a shell-friendly view of platform.json ports.
+# If values drift, platform.json wins.
 
-# Default ports (will auto-increment if occupied)
-TERRAFUSION_API_PORT=\${{TF_API_PORT:-5000}}
-TERRAFUSION_FRONTEND_PORT=\${{TF_API_PORT:-5000}}
-TERRAFUSION_ELECTRON_PORT=\${{TF_API_PORT:-5000}}
+# Core services
+TERRAFUSION_API_PORT=${TF_API_PORT:-5046}
+TERRAFUSION_FRONTEND_PORT=${TF_FRONTEND_PORT:-3102}
+TERRAFUSION_SHELL_PORT=${TF_SHELL_PORT:-3103}
+TERRAFUSION_DESKTOP_PORT=${TF_DESKTOP_PORT:-3104}
 
-# MCP Server Ports (auto-increment from base)
-MCP_BASE_PORT=\${{TF_API_PORT:-5000}}
+# Domain services
+TERRAFUSION_LEVY_PORT=${TF_LEVY_PORT:-3202}
+TERRAFUSION_TRENDS_PORT=${TF_TRENDS_PORT:-3203}
 
-# AI Services Ports
-AI_SWARM_PORT=\${{TF_API_PORT:-5000}}
+# AI / Consciousness
+AI_SWARM_PORT=${TF_CONSCIOUSNESS_PORT:-8080}
 
-# Database Ports
-REDIS_PORT=\${{TF_API_PORT:-5000}}
-POSTGRES_PORT=\${{TF_API_PORT:-5000}}
+# Infrastructure
+POSTGRES_PORT=${TF_POSTGRES_PORT:-5432}
+REDIS_PORT=${TF_REDIS_PORT:-6379}
 
-# Development Ports
-VITE_DEV_PORT=\${{TF_API_PORT:-5000}}
-WEBPACK_DEV_PORT=\${{TF_API_PORT:-5000}}
+# Development (derived from frontend)
+VITE_DEV_PORT=${TF_FRONTEND_PORT:-3102}
 
-# NOTE: All ports should auto-detect availability and increment if occupied
-# Environment variables always override these defaults
+# NOTE: All ports should auto-detect availability and increment if occupied.
+# Environment variables always override these defaults.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "type-check": "tsc -p tsconfig.core.json",
     "typecheck:core": "tsc -p tsconfig.core.json",
     "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs",
+    "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",
     "trace:query": "node scripts/trace-query.mjs",
     "support:bundle": "node scripts/support-bundle.mjs",

--- a/platform.json
+++ b/platform.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://terrafusion.dev/platform-contract.schema.json",
+  "$comment": "Single source of truth. Every CI workflow, script, and config MUST consume from here—never hardcode.",
+
+  "sdk": {
+    "dotnet": "8.0.x",
+    "node": "20"
+  },
+
+  "paths": {
+    "backend": {
+      "root": "backend",
+      "solution": "backend/TerraFusion.sln",
+      "apiProject": "backend/src/TerraFusion.API",
+      "dockerfile": "backend/Dockerfile"
+    },
+    "frontend": {
+      "root": "frontend",
+      "buildOutput": "native-shell/ui/dist"
+    },
+    "osCore": {
+      "root": "os-platform/core",
+      "tests": "os-platform/core/tests"
+    }
+  },
+
+  "ports": {
+    "api": { "env": "TF_API_PORT", "default": 5046 },
+    "frontend": { "env": "TF_FRONTEND_PORT", "default": 3102 },
+    "shell": { "env": "TF_SHELL_PORT", "default": 3103 },
+    "desktop": { "env": "TF_DESKTOP_PORT", "default": 3104 },
+    "levy": { "env": "TF_LEVY_PORT", "default": 3202 },
+    "trends": { "env": "TF_TRENDS_PORT", "default": 3203 },
+    "consciousness": { "env": "TF_CONSCIOUSNESS_PORT", "default": 8080 },
+    "postgres": { "env": "TF_POSTGRES_PORT", "default": 5432 },
+    "redis": { "env": "TF_REDIS_PORT", "default": 6379 }
+  },
+
+  "ci": {
+    "prGates": [
+      "seal-gate-fast.yml",
+      "core-governance-gates.yml",
+      "tier1-ui-harness.yml"
+    ],
+    "eventReactive": [
+      "autonomy-break-glass-guard.yml",
+      "autonomy-break-glass-incident-publisher.yml",
+      "autonomy-evidence-publisher.yml",
+      "autonomy-incident-publisher.yml",
+      "autonomy-tpi-guard.yml",
+      "autonomy-incident-label-guard.yml",
+      "autonomy-incident-triage.yml"
+    ],
+    "pushSignal": [
+      "accreditation-compat.yml",
+      "build-validation.yml",
+      "ci-cd-main.yml",
+      "ci-verified.yml",
+      "ci.yml",
+      "code-intel.yml",
+      "county-kit-parity.yml",
+      "deployment.yml",
+      "frontend-ci-isolated.yml",
+      "gate-pipeline.yml",
+      "gpt-rag.yml",
+      "infrastructure-cicd.yml",
+      "release-validation.yml",
+      "sbom.yml",
+      "security-compliance-ci.yml",
+      "security-compliance.yml",
+      "slsa-provenance.yml",
+      "spec-gates.yml",
+      "terra-levy-tests.yml",
+      "terraforge-ci.yml",
+      "terrafusion-ci-cd-production.yml",
+      "terrafusion-gate-enforcement.yml",
+      "terrafusion-pipeline.yml",
+      "testing.yml",
+      "tfctl-ci.yml"
+    ],
+    "nightly": ["nightly.yml"],
+    "scheduled": ["accreditation-oracle-health.yml"],
+    "manual": [
+      "autonomy-pr-lane.yml",
+      "break-glass-drill.yml",
+      "external-verify.yml",
+      "oracle-health.yml",
+      "perf-skill-audit.yml"
+    ],
+    "reusable": ["dotnet-test.yml", "autonomy-casefile-publisher.yml"]
+  },
+
+  "deprecated": {
+    "outputDirs": ["frontend/dist", "dist/"],
+    "ports": {
+      "comment": "These raw numbers must never appear hardcoded in workflows or configs. Use env vars from ports section above.",
+      "values": [3000, 5000, 3002, 3004]
+    }
+  }
+}

--- a/scripts/ci-diet.mjs
+++ b/scripts/ci-diet.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// ═══════════════════════════════════════════════════════════════════════════
+// CI Diet: Remove pull_request triggers from non-constitutional workflows
+// ═══════════════════════════════════════════════════════════════════════════
+// This script is a ONE-SHOT tool. Run it, verify the diffs, delete it.
+//
+// What it does:
+//   1. Reads each target workflow YAML
+//   2. Removes the `pull_request:` trigger block
+//   3. If no `push:` trigger exists, adds `push: branches: [main]`
+//   4. Writes back
+//
+// What it preserves:
+//   - All other triggers (push, schedule, workflow_dispatch, etc.)
+//   - Comments, formatting, jobs, steps, etc.
+//
+// Usage: node scripts/ci-diet.mjs [--dry-run]
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(import.meta.url), '../..');
+const WORKFLOWS = join(ROOT, '.github', 'workflows');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// Workflows to diet (remove pull_request trigger)
+const targets = [
+  // Wave 1 (original 20)
+  'accessibility-audit.yml',
+  'ai-swarm-safety.yml',
+  'atlas-validation.yml',
+  'baseline-guard.yml',
+  'deps-fast-lane.yml',
+  'designctl.yml',
+  'e2e-smoke.yml',
+  'golden-corpus-compat.yml',
+  'governance-proof.yml',
+  'manifest-contract-guard.yml',
+  'markdown-lint.yml',
+  'performance-budget.yml',
+  'performance-regression.yml',
+  'rust-verify.yml',
+  'scope-drift-guard.yml',
+  'tag-lint.yml',
+  'test.yml',
+  'visual-regression.yml',
+  'wave1-freeze-guard.yml',
+  'yaml-sanity.yml',
+  // Wave 2 (push-signal workflows that also had PR triggers)
+  'accessibility.yml',
+  'accreditation-compat.yml',
+  'benton.yml',
+  'build-validation.yml',
+  'ci-cd-main.yml',
+  'ci-cd-pipeline.yml',
+  'ci-cd.yml',
+  'ci-verified.yml',
+  'ci.yml',
+  'code-intel.yml',
+  'county-kit-parity.yml',
+  'gate-pipeline.yml',
+  'governance-audit.yml',
+  'gpt-rag.yml',
+  'grfe-ci.yaml',
+  'infrastructure-cicd.yml',
+  'kubernetes-infrastructure-ci.yml',
+  'observability-ci.yml',
+  'opa-policy-tests.yml',
+  'release-validation.yml',
+  'rust-security-gates.yml',
+  'security-compliance-ci.yml',
+  'security-compliance.yml',
+  'spec-gates.yml',
+  'terra-levy-tests.yml',
+  'terraforge-ci.yml',
+  'terrafusion-ci-cd-production.yml',
+  'terrafusion-gate-enforcement.yml',
+  'terrafusion-pipeline.yml',
+  'testing.yml',
+  'tfctl-ci.yml',
+  'tier1-ui-harness.yml',
+];
+
+let modified = 0;
+let skipped = 0;
+
+for (const file of targets) {
+  const path = join(WORKFLOWS, file);
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch {
+    console.log(`⚠️  ${file}: not found, skipping`);
+    skipped++;
+    continue;
+  }
+
+  // Check it actually has pull_request
+  if (!/^\s*pull_request\s*:/m.test(content)) {
+    console.log(`⏭️  ${file}: no pull_request trigger, skipping`);
+    skipped++;
+    continue;
+  }
+
+  const lines = content.split('\n');
+  const result = [];
+  let inOnBlock = false;
+  let inPullRequest = false;
+  let prBlockIndent = 0;
+  let hasPush = /^\s*push\s*:/m.test(content);
+  let onBlockIndent = 0;
+  let removedPR = false;
+  let needsPush = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect `on:` top-level key
+    if (/^on\s*:/.test(line)) {
+      inOnBlock = true;
+      onBlockIndent = 0;
+      result.push(line);
+      continue;
+    }
+
+    // Detect end of `on:` block (next top-level key like `permissions:`, `env:`, `jobs:`, `concurrency:`, `name:`)
+    if (inOnBlock && /^[a-zA-Z]/.test(line) && !/^\s/.test(line)) {
+      inOnBlock = false;
+      inPullRequest = false;
+
+      // If we removed PR and no push exists, inject push before this line
+      if (removedPR && !hasPush) {
+        result.push(`  push:`);
+        result.push(`    branches: [main]`);
+        needsPush = false;
+      }
+    }
+
+    if (inOnBlock) {
+      // Detect `  pull_request:` or `  pull_request_review:`
+      const prMatch = line.match(/^(\s*)pull_request\s*:/);
+      if (prMatch && !/pull_request_target|pull_request_review/.test(line)) {
+        inPullRequest = true;
+        prBlockIndent = prMatch[1].length;
+        removedPR = true;
+        // Skip this line (remove it)
+        continue;
+      }
+
+      // If we're inside the pull_request block, skip sub-lines
+      if (inPullRequest) {
+        // Check if this line is still indented deeper than the pull_request key
+        const lineIndent = line.match(/^(\s*)/)[1].length;
+        if (line.trim() === '' || lineIndent > prBlockIndent) {
+          // Still inside PR block, skip
+          continue;
+        }
+        // We've exited the PR block
+        inPullRequest = false;
+      }
+    }
+
+    result.push(line);
+  }
+
+  // Handle edge case: on block was at end of file
+  if (removedPR && !hasPush) {
+    // Find the on: block and insert push after it
+    // Already handled above in the "end of on block" detection
+  }
+
+  const newContent = result.join('\n');
+
+  if (newContent === content) {
+    console.log(`⏭️  ${file}: no changes needed`);
+    skipped++;
+    continue;
+  }
+
+  if (DRY_RUN) {
+    console.log(`🔍 ${file}: would modify (dry run)`);
+  } else {
+    writeFileSync(path, newContent, 'utf8');
+    console.log(`✅ ${file}: pull_request trigger removed${!hasPush ? ' + push:main added' : ''}`);
+  }
+  modified++;
+}
+
+console.log(`\nDone: ${modified} modified, ${skipped} skipped${DRY_RUN ? ' (DRY RUN)' : ''}`);

--- a/scripts/platform-lint.mjs
+++ b/scripts/platform-lint.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// ═══════════════════════════════════════════════════════════════════════════
+// Platform Contract Lint — CI guardrail
+// ═══════════════════════════════════════════════════════════════════════════
+// Scans .github/workflows/ for violations of platform.json.
+// Designed to run inside SEAL gate. Zero dependencies (Node built-ins only).
+//
+// Exit 0 = clean, Exit 1 = violations found.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(import.meta.url), '../..');
+const CONTRACT_PATH = join(ROOT, 'platform.json');
+const WORKFLOWS_DIR = join(ROOT, '.github', 'workflows');
+
+// ── Load contract ──────────────────────────────────────────────────────────
+
+let contract;
+try {
+  contract = JSON.parse(readFileSync(CONTRACT_PATH, 'utf8'));
+} catch (err) {
+  console.error(`❌ Cannot read platform.json: ${err.message}`);
+  process.exit(1);
+}
+
+// ── Gather workflow files ──────────────────────────────────────────────────
+
+let workflowFiles;
+try {
+  workflowFiles = readdirSync(WORKFLOWS_DIR).filter(f => f.endsWith('.yml') || f.endsWith('.yaml'));
+} catch {
+  console.error('❌ Cannot read .github/workflows/');
+  process.exit(1);
+}
+
+// ── Checks ─────────────────────────────────────────────────────────────────
+
+const violations = [];
+
+function violation(file, line, rule, message) {
+  violations.push({ file, line, rule, message });
+}
+
+// Build lookup sets from contract
+const deprecatedDirs = new Set(contract.deprecated?.outputDirs || []);
+const deprecatedPorts = new Set(contract.deprecated?.ports?.values || []);
+const canonicalDotnet = contract.sdk.dotnet;
+const canonicalNode = contract.sdk.node;
+
+// Workflow intent: only these should have pull_request triggers
+const prGateSet = new Set([...(contract.ci.prGates || []), ...(contract.ci.eventReactive || [])]);
+
+for (const file of workflowFiles) {
+  const filePath = join(WORKFLOWS_DIR, file);
+  let content;
+  try {
+    content = readFileSync(filePath, 'utf8');
+  } catch {
+    continue; // skip unreadable
+  }
+
+  const lines = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+
+    // ── Rule 1: Deprecated output dirs ──────────────────────────────────
+    for (const dir of deprecatedDirs) {
+      // Match the dir as a path reference, not in comments
+      if (line.trimStart().startsWith('#')) continue;
+      // Escape for regex (handle the slash)
+      const escaped = dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const rx = new RegExp(`(?:^|[\\s'"/])${escaped}`, 'i');
+      if (rx.test(line)) {
+        violation(
+          file,
+          lineNum,
+          'DEPRECATED_OUTPUT_DIR',
+          `References deprecated output dir "${dir}" — use "${contract.paths.frontend.buildOutput}" instead`
+        );
+      }
+    }
+
+    // ── Rule 2: Hardcoded deprecated ports ──────────────────────────────
+    if (!line.trimStart().startsWith('#')) {
+      for (const port of deprecatedPorts) {
+        // Match port in URL patterns like localhost:PORT or 127.0.0.1:PORT
+        const portRx = new RegExp(`(?:localhost|127\\.0\\.0\\.1)[:.]${port}\\b`);
+        if (portRx.test(line)) {
+          // Find which env var this port should use
+          const portEntry = Object.entries(contract.ports).find(([, v]) => v.default === port);
+          const hint = portEntry
+            ? `Use \${${portEntry[1].env}:-${portEntry[1].default}}`
+            : `Use env var from platform.json ports section`;
+          violation(file, lineNum, 'HARDCODED_PORT', `Hardcoded port ${port} — ${hint}`);
+        }
+      }
+    }
+
+    // ── Rule 3: SDK version drift ───────────────────────────────────────
+    // Check for dotnet-version that doesn't match contract
+    if (!line.trimStart().startsWith('#')) {
+      const dotnetMatch = line.match(/dotnet[-_]version\s*[:=]\s*['"]?(\d+\.\S+?)['"]?\s*$/i);
+      if (dotnetMatch) {
+        const found = dotnetMatch[1];
+        if (found !== canonicalDotnet && found !== `'${canonicalDotnet}'`) {
+          violation(
+            file,
+            lineNum,
+            'SDK_DRIFT',
+            `dotnet version "${found}" differs from contract "${canonicalDotnet}"`
+          );
+        }
+      }
+
+      // node-version that doesn't match (allow variants like 20.x, 20.11.1)
+      const nodeMatch = line.match(/node[-_]version\s*[:=]\s*['"]?(\d+\S*?)['"]?\s*$/i);
+      if (nodeMatch) {
+        const found = nodeMatch[1].replace(/['"]/g, '');
+        // Accept if found starts with canonical major (e.g. "20" matches "20", "20.x", "20.11.1")
+        if (!found.startsWith(canonicalNode)) {
+          violation(
+            file,
+            lineNum,
+            'SDK_DRIFT',
+            `Node version "${found}" differs from contract "${canonicalNode}"`
+          );
+        }
+      }
+    }
+
+    // ── Rule 4: Trailing whitespace ─────────────────────────────────────
+    if (line !== line.trimEnd() && line.trim().length > 0) {
+      violation(file, lineNum, 'TRAILING_WHITESPACE', 'Line has trailing whitespace');
+    }
+  }
+
+  // ── Rule 5: Non-constitutional workflow with pull_request trigger ────
+  if (!prGateSet.has(file)) {
+    // Normalize for regex matching (CRLF handled above for lines, but content may still have \r)
+    const normalizedContent = content.replace(/\r/g, '');
+    // Check if this workflow has a pull_request trigger
+    const hasPRTrigger = /^\s*pull_request\s*:/m.test(normalizedContent);
+    // Also catch pull_request_target but allow it (different use case)
+    if (hasPRTrigger && !/pull_request_target/m.test(normalizedContent)) {
+      violation(
+        file,
+        0,
+        'PR_TRIGGER_LEAK',
+        `Non-constitutional workflow has pull_request trigger — should be push-only or nightly per platform.json`
+      );
+    }
+  }
+}
+
+// ── Report ─────────────────────────────────────────────────────────────────
+
+if (violations.length === 0) {
+  console.log('✅ Platform contract lint passed (0 violations)');
+  process.exit(0);
+}
+
+// Group by rule for clarity
+const byRule = {};
+for (const v of violations) {
+  if (!byRule[v.rule]) byRule[v.rule] = [];
+  byRule[v.rule].push(v);
+}
+
+console.error(`\n❌ Platform contract lint: ${violations.length} violation(s)\n`);
+
+for (const [rule, items] of Object.entries(byRule)) {
+  console.error(`── ${rule} (${items.length}) ──`);
+  for (const v of items) {
+    const loc = v.line > 0 ? `:${v.line}` : '';
+    console.error(`  ${v.file}${loc}: ${v.message}`);
+  }
+  console.error('');
+}
+
+// In CI, also emit annotations
+if (process.env.CI) {
+  for (const v of violations) {
+    const loc = v.line > 0 ? `,line=${v.line}` : '';
+    console.log(`::warning file=.github/workflows/${v.file}${loc}::${v.rule}: ${v.message}`);
+  }
+}
+
+// Exit with warning (non-blocking) for now — upgrade to exit(1) once baseline is clean
+// TODO: Change to process.exit(1) after initial cleanup
+console.log(
+  '\n⚠️  Platform lint running in WARNING mode. Will become blocking after baseline cleanup.'
+);
+process.exit(0);


### PR DESCRIPTION
## The Problem (year-long loop)

Every CI fix is a local patch because the repo has **no executable contract**:
- 3 competing output dir conventions (`frontend/dist`, `native-shell/ui/dist`, `dist/`)
- `.ports.config` was broken (all 9 ports mapped to `TF_API_PORT:-5000`)
- `.env.example` had duplicate conflicting port blocks
- 76 workflow files with duplicated SDK versions, paths, and port assumptions
- ~50+ workflows triggering on every PR — most redundant with SEAL

## The Fix (structural, not incremental)

### 1. Platform Contract — [platform.json](platform.json)

Single source of truth consumed by everything:

| Section | What it codifies |
|---------|-----------------|
| `sdk` | dotnet `8.0.x`, node `20` |
| `paths` | backend root/solution/project/Dockerfile, frontend output dir |
| `ports` | 9 services with env var names + defaults |
| `ci` | Workflow intent: prGates, eventReactive, pushSignal, nightly, etc. |
| `deprecated` | `frontend/dist`, `dist/`, hardcoded ports 3000/5000 |

### 2. CI Guardrail Lint — [scripts/platform-lint.mjs](scripts/platform-lint.mjs)

5 rules, zero dependencies, wired into SEAL:

| Rule | What it catches |
|------|----------------|
| `DEPRECATED_OUTPUT_DIR` | References to `frontend/dist` or `dist/` |
| `HARDCODED_PORT` | Raw `localhost:5000` or `localhost:3000` |
| `SDK_DRIFT` | dotnet/node versions that don't match contract |
| `TRAILING_WHITESPACE` | Whitespace at end of lines |
| `PR_TRIGGER_LEAK` | Non-constitutional workflow with `pull_request` trigger |

Running in **warning mode** until baseline is clean. Will become blocking.

### 3. CI Diet — 51 workflows pruned from PR triggers

| Before | After |
|--------|-------|
| ~50+ workflows on every PR | **2 PR gates** (SEAL + core-governance) |
| 7+ minute queue of noise checks | Constitutional checks only |
| Confusion about "is it safe to merge?" | Clear signal |

Event-reactive workflows (autonomy-* with `types: [closed, labeled]`) kept their PR triggers — they need PR lifecycle events.

### 4. Config Fixes

| File | Issue | Fix |
|------|-------|-----|
| `.ports.config` | All 9 ports mapped to `TF_API_PORT:-5000` | Correct env var per service |
| `.env.example` | Duplicate port block (5055 vs 5046) | Single canonical block |
| `gate-pipeline.yml` | dotnet `8.x` (drift) | `8.0.x` |
| `e2e-smoke.yml` | node `18` (drift) | `20` |
| `terrafusion-ci-cd-production.yml` | dotnet `8.0` (drift) | `8.0.x` |

## Baseline (82 known violations, warning mode)

- 76 DEPRECATED_OUTPUT_DIR — `dist/` references in push-only workflows
- 6 HARDCODED_PORT — ports 5000/3000 in push-only workflows
- 0 PR_TRIGGER_LEAK, 0 SDK_DRIFT, 0 TRAILING_WHITESPACE

These are inventoried tech debt, not new regressions.

## Evidence

- `pnpm run type-check`: PASS
- `phase83-tools`: 32/32 PASS
- `pnpm run lint:platform`: 82 warnings, 0 errors (pre-existing)
- Governance surface: platform.json + scripts are new files (additive)

## After this merges

**Next PR sequence:**
1. Burn down the 82 baseline violations (fix deprecated dirs + hardcoded ports)
2. Flip platform-lint to blocking mode (`process.exit(1)`)
3. Benton on-prem pilot (runner + PR gates only)

Part of #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized platform configuration for SDKs, ports, and CI pipelines.
  * Platform contract linting added (with an npm script) to surface policy violations.

* **Chores**
  * Default service port values consolidated (new canonical defaults).
  * CI/workflow triggers adjusted: many checks no longer run on PRs and now run on pushes or manual dispatch.
  * Bumped Node to 20 for e2e; standardized .NET version formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->