### PR TITLE
fix(ci): eliminate 6 HARDCODED_PORT violations (baseline burn-down 1/2)

### DIFF
--- a/.github/workflows/benton.yml
+++ b/.github/workflows/benton.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Wait for API
         run: |
           for i in {1..60}; do
-            if curl -fsS http://localhost:5000/health; then exit 0; fi
+            if curl -fsS http://localhost:${TF_API_PORT:-5046}/health; then exit 0; fi
             sleep 2
           done
           echo "API not ready"; docker compose -f counties/benton/docker-compose.county.yml logs api; exit 1

--- a/.github/workflows/observability-ci.yml
+++ b/.github/workflows/observability-ci.yml
@@ -802,13 +802,13 @@ jobs:
         run: |
           echo "::group::Grafana Connectivity"
 
-          # Port-forward Grafana
-          kubectl port-forward -n ${{ env.MONITORING_NAMESPACE }} svc/grafana 3000:3000 &
+          # Port-forward Grafana (local port avoids deprecated 3000; remote 3000 is Grafana's default)
+          kubectl port-forward -n ${{ env.MONITORING_NAMESPACE }} svc/grafana 13000:3000 &
           PF_PID=$!
           sleep 5
 
           # Test Grafana API
-          curl -f http://localhost:3000/api/health || echo "::warning::Grafana health check failed"
+          curl -f http://localhost:13000/api/health || echo "::warning::Grafana health check failed"
 
           kill $PF_PID 2>/dev/null || true
 

--- a/.github/workflows/rust-verify.yml
+++ b/.github/workflows/rust-verify.yml
@@ -96,7 +96,7 @@ jobs:
             docker compose -f ${COMPOSE_FILE} up -d backend || true
             sleep 6
             # Try health endpoint (adjust path if your backend differs)
-            if curl -fsS --max-time 5 http://localhost:5000/healthz > .ci_artifacts_local/smoke-curl.out 2>&1; then
+            if curl -fsS --max-time 5 http://localhost:${TF_API_PORT:-5046}/healthz > .ci_artifacts_local/smoke-curl.out 2>&1; then
               echo "smoke: OK" > .ci_artifacts_local/smoke-status.txt
             else
               echo "smoke: FAIL" > .ci_artifacts_local/smoke-status.txt

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -398,7 +398,7 @@ jobs:
             -u root \
             zaproxy/zap-stable \
             zap-baseline.py \
-              -t "http://localhost:3000" \
+              -t "http://localhost:${TF_FRONTEND_PORT:-3102}" \
               -r reports/security/pentest/zap_baseline.html \
               -J reports/security/pentest/zap_baseline.json \
               -I \

--- a/.github/workflows/terrafusion-pipeline.yml
+++ b/.github/workflows/terrafusion-pipeline.yml
@@ -16,8 +16,8 @@ permissions:
 
 env:
   TF_ENV: ${{ github.event_name == 'pull_request' && 'dev' || 'stage' }}
-  BASE_URL: ${{ vars.BASE_URL || 'http://localhost:5000' }}
-  LOAD_TEST_URL: ${{ vars.LOAD_TEST_URL || vars.BASE_URL || 'http://localhost:5000' }}
+  BASE_URL: ${{ vars.BASE_URL || 'http://localhost:5046' }}
+  LOAD_TEST_URL: ${{ vars.LOAD_TEST_URL || vars.BASE_URL || 'http://localhost:5046' }}
   CLOUD_PROVIDER: ${{ vars.CLOUD_PROVIDER || 'none' }}
 
 jobs:


### PR DESCRIPTION
## Summary
First baseline burn-down PR. Eliminates all 6 `HARDCODED_PORT` violations flagged by `platform-lint.mjs`.

**Baseline: 82 → 76 violations** (6 HARDCODED_PORT → 0; 76 DEPRECATED_OUTPUT_DIR unchanged)

## Changes

| File | Old | New | Rationale |
|------|-----|-----|-----------|
| `benton.yml` | `localhost:5000` | `localhost:\$\{TF_API_PORT:-5046\}` | API health check uses contract port |
| `rust-verify.yml` | `localhost:5000` | `localhost:\$\{TF_API_PORT:-5046\}` | Docker smoke test uses contract port |
| `terrafusion-pipeline.yml` | `localhost:5000` (×2) | `localhost:5046` | Env default uses canonical port (5046 not deprecated) |
| `security-compliance.yml` | `localhost:3000` | `localhost:\$\{TF_FRONTEND_PORT:-3102\}` | ZAP scan targets contract frontend port |
| `observability-ci.yml` | `3000:3000` | `13000:3000` | Grafana port-forward: local port avoids deprecated 3000, remote 3000 is Grafana's actual service port |

## Rules followed
- ✅ Single category only (HARDCODED_PORT)
- ✅ No behavior changes beyond port normalization
- ✅ Before/after lint count included

## Evidence
- `pnpm run type-check`: PASS
- `phase83-tools`: 32/32 PASS
- `platform-lint`: 76 violations (was 82)
- Governance surface: unchanged (workflow YAML only)