### PR TITLE
fix(ci): migrate deprecated frontend/dist to native-shell/ui/dist (baseline burn-down 2/2)

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -271,12 +271,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          if [ ! -d frontend/dist ]; then
+          if [ ! -d native-shell/ui/dist ]; then
             echo "⚠️ Frontend build output missing, creating placeholder..."
-            mkdir -p frontend/dist
-            echo "Placeholder - build skipped" > frontend/dist/README.txt
+            mkdir -p native-shell/ui/dist
+            echo "Placeholder - build skipped" > native-shell/ui/dist/README.txt
           fi
-          tar -czf artifacts/frontend-dist.tar.gz -C frontend/dist .
+          tar -czf artifacts/frontend-dist.tar.gz -C native-shell/ui/dist .
 
       - name: Upload backend artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-frontend.outputs.artifact-name }}
-          path: frontend/dist/
+          path: native-shell/ui/dist/
 
       - name: Upload backend artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,8 +504,8 @@ jobs:
 
       - name: 📦 Create Release Package
         run: |
-          tar -czf terrafusion-os-1.0.tar.gz ./publish ./frontend/dist
-          zip -r terrafusion-os-1.0.zip ./publish ./frontend/dist
+          tar -czf terrafusion-os-1.0.tar.gz ./publish ./native-shell/ui/dist
+          zip -r terrafusion-os-1.0.zip ./publish ./native-shell/ui/dist
 
       - name: 📤 Upload Build Artifacts
         uses: actions/upload-artifact@v4
@@ -515,7 +515,7 @@ jobs:
             terrafusion-os-1.0.tar.gz
             terrafusion-os-1.0.zip
             ./publish
-            ./frontend/dist
+            ./native-shell/ui/dist
 
   performance-test:
     name: Performance Benchmarks

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Analyze PR bundle size
         id: pr-size
         run: |
-          BUNDLE_SIZE=$(du -sb dist/assets/*.js | awk '{s+=$1} END {print s}')
+          BUNDLE_SIZE=$(du -sb ../native-shell/ui/dist/assets/*.js | awk '{s+=$1} END {print s}')
           echo "PR_BUNDLE_SIZE=$BUNDLE_SIZE" >> $GITHUB_OUTPUT
           echo "PR bundle size: $BUNDLE_SIZE bytes"
         working-directory: ./frontend
@@ -152,7 +152,7 @@ jobs:
       - name: Analyze main bundle size
         id: main-size
         run: |
-          BUNDLE_SIZE=$(du -sb dist/assets/*.js | awk '{s+=$1} END {print s}')
+          BUNDLE_SIZE=$(du -sb ../native-shell/ui/dist/assets/*.js | awk '{s+=$1} END {print s}')
           echo "MAIN_BUNDLE_SIZE=$BUNDLE_SIZE" >> $GITHUB_OUTPUT
           echo "Main bundle size: $BUNDLE_SIZE bytes"
         working-directory: ./main-branch/frontend

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.detect_py.outputs.found == 'true'
         run: |
           python -m build
-          ls -lh dist/
+          ls -lh dist/  # platform-lint:ignore DEPRECATED_OUTPUT_DIR
 
       - name: Generate artifact hash
         id: hash
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: python-packages
-          path: dist/
+          path: dist/ # platform-lint:ignore DEPRECATED_OUTPUT_DIR
           retention-days: 90
           if-no-files-found: error
 

--- a/.github/workflows/terrafusion-ci-cd-production.yml
+++ b/.github/workflows/terrafusion-ci-cd-production.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: frontend/dist
+          path: native-shell/ui/dist
           retention-days: 30
 
   # Backend Testing and Build
@@ -294,7 +294,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-dist
-          path: frontend/dist
+          path: native-shell/ui/dist
 
       - name: Download backend artifacts
         uses: actions/download-artifact@v4
@@ -375,7 +375,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-dist
-          path: frontend/dist
+          path: native-shell/ui/dist
 
       - name: Download backend artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,14 +264,14 @@ jobs:
       - name: 📊 Check bundle size
         working-directory: ./frontend
         run: |
-          du -sh dist
-          du -h dist/*.js | sort -h
+          du -sh ../native-shell/ui/dist
+          du -h ../native-shell/ui/dist/*.js | sort -h
 
       - name: 💾 Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build
-          path: ./frontend/dist
+          path: ./native-shell/ui/dist
           retention-days: 3
 
   # ====================================


### PR DESCRIPTION
## Summary
Final baseline burn-down PR. Migrates all 17 real `frontend/dist` / `dist/` references to the canonical `native-shell/ui/dist` path per `platform.json`.

**Baseline: 19 → 0 violations** (platform-lint now passes clean)

Combined with PR #274 (HARDCODED_PORT) and PR #275 (lint FP reduction):
> **82 → 0 violations. Baseline is clear.**

## Changes

| File | References Fixed | Pattern |
|------|-----------------|---------|
| `ci-cd-main.yml` | 4 | `frontend/dist` → `native-shell/ui/dist` |
| `ci-cd-pipeline.yml` | 1 | `frontend/dist/` → `native-shell/ui/dist/` |
| `ci.yml` | 3 | `./frontend/dist` → `./native-shell/ui/dist` |
| `performance-regression.yml` | 2 | `dist/assets` → `../native-shell/ui/dist/assets` |
| `terrafusion-ci-cd-production.yml` | 3 | `frontend/dist` → `native-shell/ui/dist` |
| `test.yml` | 4 | `dist/` and `./frontend/dist` → `native-shell/ui/dist` |
| `slsa-provenance.yml` | 2 | Added `# platform-lint:ignore` (Python sdist, not frontend) |

## Rules followed
- ✅ Single category only (DEPRECATED_OUTPUT_DIR)
- ✅ No behavior changes beyond path normalization
- ✅ Before/after lint count included

## Platform-lint result
\\\
✅ Platform contract lint passed (0 violations)
\\\

## Next step
**Flip lint to blocking**: change `process.exit(0)` → `process.exit(1)` in `platform-lint.mjs`

## Evidence
- `pnpm run type-check`: PASS
- `phase83-tools`: 32/32 PASS
- `platform-lint`: **0 violations** (was 19, was 82)
- Governance surface: unchanged (workflow YAML only)