### PR TITLE
feat(lint): flip platform-lint to BLOCKING mode

### DIFF
--- a/scripts/platform-lint.mjs
+++ b/scripts/platform-lint.mjs
@@ -224,13 +224,12 @@ for (const [rule, items] of Object.entries(byRule)) {
 if (process.env.CI) {
   for (const v of violations) {
     const loc = v.line > 0 ? `,line=${v.line}` : '';
-    console.log(`::warning file=.github/workflows/${v.file}${loc}::${v.rule}: ${v.message}`);
+    console.log(`::error file=.github/workflows/${v.file}${loc}::${v.rule}: ${v.message}`);
   }
 }
 
-// Exit with warning (non-blocking) for now — upgrade to exit(1) once baseline is clean
-// TODO: Change to process.exit(1) after initial cleanup
-console.log(
-  '\n⚠️  Platform lint running in WARNING mode. Will become blocking after baseline cleanup.'
-);
-process.exit(0);
+// BLOCKING MODE — baseline is clean (82 → 0 as of PR #276).
+// Any new violation will fail CI and block merge.
+console.error('\n❌ Platform contract violations detected. Fix all violations before merging.');
+console.error('   To suppress a false positive, add: # platform-lint:ignore RULE_NAME\n');
+process.exit(1);


### PR DESCRIPTION
## Summary
Flips `platform-lint.mjs` from warning mode to **blocking mode**. Any platform contract violation now fails the SEAL gate and blocks PR merge.

This is the culmination of the Platform Contract initiative:

| PR | What | Baseline |
|----|------|----------|
| #272 | Platform Contract + CI Diet + Guardrail (warn-mode) | 82 violations |
| #274 | Burn HARDCODED_PORT (6) | 82 → 76 |
| #275 | Reduce FP noise (76 → 19 real) | 76 → 19 |
| #276 | Migrate deprecated output dirs (17 real + 2 suppressed) | 19 → 0 |
| **#277** | **Flip to blocking** | **0 (enforced)** |

## Changes
- `process.exit(0)` → `process.exit(1)` on violations
- `::warning` → `::error` annotations in CI
- Updated messaging to include suppression hint

## Safety net
- Inline suppression: `# platform-lint:ignore RULE_NAME` (added in #275)
- 5 rules enforced: DEPRECATED_OUTPUT_DIR, HARDCODED_PORT, SDK_DRIFT, TRAILING_WHITESPACE, PR_TRIGGER_LEAK

## Evidence
- `platform-lint`: **0 violations** (clean baseline)
- Exit code test: clean → 0, violation → 1 (verified locally)
- `pnpm run type-check`: PASS
- `phase83-tools`: 32/32 PASS

## Summary by Sourcery

Enhancements:
- Promote platform-lint violations from warnings to errors in CI and make them fail the build with clearer guidance on handling false positives.