### PR TITLE
feat(ops): add no-Docker capability routing for Benton pilot

### DIFF
--- a/.github/workflows/benton-runner-smoke.yml
+++ b/.github/workflows/benton-runner-smoke.yml
@@ -127,6 +127,28 @@ jobs:
           fi
           echo "✅ git >=2.30.0 matched"
 
+      - name: Capability — Docker (informational)
+        id: docker-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Checking Docker availability (informational — not required for PR gates)..."
+          if command -v docker &>/dev/null; then
+            DOCKER_VER=$(docker --version 2>/dev/null || echo "unknown")
+            echo "  docker: $DOCKER_VER"
+            # Check if Docker daemon is responsive
+            if docker info &>/dev/null 2>&1; then
+              echo "  daemon: responsive"
+              echo "✅ Docker available (not required — all 8 PR-gate jobs are pure compute)"
+            else
+              echo "  daemon: not responding (rootless? socket permission?)"
+              echo "⚠️ Docker CLI present but daemon not responding — OK for PR gates"
+            fi
+          else
+            echo "  docker: not installed"
+            echo "⚠️ Docker not available — OK for PR gates (all 8 routed jobs are pure compute)"
+          fi
+
       - name: Network — GitHub API
         id: net-github
         shell: bash
@@ -235,6 +257,7 @@ jobs:
           echo "| node 20 | $(icon '${{ steps.node.outcome }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| pnpm >=9 | $(icon '${{ steps.pnpm.outcome }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| git >=2.30 | $(icon '${{ steps.git-check.outcome }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Docker (informational) | ${{ steps.docker-check.outcome == 'success' && '⚠️ See log' || '⚠️ See log' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GitHub API | $(icon '${{ steps.net-github.outcome }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| npm registry | $(icon '${{ steps.net-npm.outcome }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| NuGet registry | $(icon '${{ steps.net-nuget.outcome }}') |" >> $GITHUB_STEP_SUMMARY

--- a/BENTON_ONPREM_PILOT.md
+++ b/BENTON_ONPREM_PILOT.md
@@ -1,6 +1,6 @@
 # Benton County On-Prem Runner Pilot
 
-**Status:** Wiring complete — awaiting runner provisioning  
+**Status:** Wiring complete — awaiting runner provisioning (Docker NOT required)  
 **PR:** (this PR)  
 **Scope:** PR gates only (smallest critical surface)
 
@@ -16,7 +16,7 @@ with toolchain parity, artifact retrieval, and zero secrets exposure.
 
 | # | Criterion | How We Verify |
 |---|-----------|---------------|
-| 1 | Runner executes PR gates | All 3 PR-gate workflows route to `[self-hosted, benton, linux-x64]` when `BENTON_RUNNER=true` |
+| 1 | Runner executes PR gates | All 3 PR-gate workflows route to `[self-hosted, benton, linux-x64]` when `BENTON_RUNNER=true` (Docker not required) |
 | 2 | Toolchain parity | `benton-runner-smoke.yml` validates dotnet 8.0.x, node 20, pnpm ≥9, git ≥2.30 |
 | 3 | Artifacts retrievable | Smoke workflow tests upload → download roundtrip |
 | 4 | Secrets strategy | Documented below; PR gates use zero secrets |
@@ -43,6 +43,7 @@ with toolchain parity, artifact retrieval, and zero secrets exposure.
 │  │ BENTON_RUNNER≠true   │   │  self-hosted    │ │
 │  │                      │   │  benton         │ │
 │  └──────────────────────┘   │  linux-x64      │ │
+│                             │  no-docker      │ │
 │                             └─────────────────┘ │
 └─────────────────────────────────────────────────┘
 
@@ -58,7 +59,7 @@ Kill switch: Repository variable BENTON_RUNNER
 ### 3.1 `platform.json` — runners section
 
 New `runners` key declares:
-- Runner labels (`self-hosted`, `benton`, `linux-x64`)
+- Runner labels (`self-hosted`, `benton`, `linux-x64`, `no-docker`)
 - Scope (`prGates` only)
 - Kill switch variable (`BENTON_RUNNER`)
 - Fallback runner (`ubuntu-latest`)
@@ -92,6 +93,7 @@ runs-on: ${{ vars.BENTON_RUNNER == 'true'
 Validates runner health:
 - `RunnerLabels_Resolve` — job is picked up by runner with expected labels
 - `ToolchainVersions_MatchPlatformJson` — dotnet, node, pnpm, git versions match
+- `DockerCapability` — informational check (reports availability, never blocks)
 - `ArtifactRoundtrip` — upload + download pipeline works
 - `NetworkConnectivity` — outbound HTTPS to GitHub, npm, NuGet
 
@@ -165,6 +167,7 @@ endpoints automatically.
 - [ ] 4+ GB RAM, 2+ CPU cores
 - [ ] 20+ GB free disk space
 - [ ] Outbound HTTPS to hosts listed above
+- [ ] Docker is **NOT required** (all PR-gate jobs are pure compute)
 
 ### Software installation
 
@@ -195,7 +198,7 @@ tar xzf actions-runner-linux-x64.tar.gz
 
 # Configure with labels
 ./config.sh --url https://github.com/bsvalues/terrafusion_os_1.0 \
-  --labels self-hosted,benton,linux-x64 \
+  --labels self-hosted,benton,linux-x64,no-docker \
   --token <RUNNER_TOKEN>
 
 # Install as service
@@ -230,21 +233,43 @@ No PR required. No deployment. Immediate effect.
 
 ---
 
-## 8. Scope Expansion (Deferred)
+## 8. Docker Capability Audit
+
+All 8 routed PR-gate jobs were audited for Docker dependencies.
+**Result: ZERO Docker dependencies.** All jobs are pure compute.
+
+| # | Workflow | Job | Docker? | What it does |
+|---|----------|-----|---------|--------------|
+| 1 | `seal-gate-fast.yml` | `frontend-fast` | No | pnpm install, lint, typecheck, unit tests, IPC tests, build, bundle analysis |
+| 2 | `seal-gate-fast.yml` | `backend-fast` | No | dotnet restore, build (warnings-as-errors), unit tests |
+| 3 | `seal-gate-fast.yml` | `governance-fast` | No | governance enforcement, drift guard, platform-lint |
+| 4 | `core-governance-gates.yml` | `governed-spine` | No | pnpm test:governed (type-check + phase83-tools) |
+| 5 | `core-governance-gates.yml` | `phase85-tools` | No | node --test phase85-tools |
+| 6 | `core-governance-gates.yml` | `phase86-toolrunner` | No | node --test phase86-toolrunner |
+| 7 | `core-governance-gates.yml` | `check-generated-js` | No | pnpm build:core-js, git diff, check:generated |
+| 8 | `tier1-ui-harness.yml` | `tier1-harness` | No | pnpm test:tier1 (Vitest component suites) |
+
+**Guardrail:** No required check may depend on Docker when `BENTON_RUNNER=true`.
+Container build/scan jobs (Trivy, Grype, Docker build, image packaging) remain
+on `ubuntu-latest` regardless of pilot variable.
+
+---
+
+## 9. Scope Expansion (Deferred)
 
 The following are explicitly out of scope for this pilot:
 
 | Item | Why deferred |
 |------|-------------|
 | Deep scans (CodeQL, OWASP ZAP) | Slow, require different runner specs |
-| Container builds (Docker) | Requires Docker-in-Docker or rootless Docker |
+| Container builds (Docker) | Runner provisioned without Docker (`no-docker` label) |
 | Deployment workflows | Requires secrets strategy implementation |
 | Multi-runner matrix | Prove single runner first |
 | Windows/macOS runners | Linux-first, expand later |
 
 ---
 
-## 9. Observed Gaps
+## 10. Observed Gaps
 
 _(To be updated after first runner execution)_
 
@@ -254,7 +279,7 @@ _(To be updated after first runner execution)_
 
 ---
 
-## 10. Decision Log
+## 11. Decision Log
 
 | Date | Decision | Rationale |
 |------|----------|-----------|
@@ -262,3 +287,4 @@ _(To be updated after first runner execution)_
 | 2026-02-10 | Repo variable kill switch | Instant rollback without code changes |
 | 2026-02-10 | Trivial jobs stay on ubuntu-latest | No value in routing status-check jobs |
 | 2026-02-10 | Zero secrets baseline | PR gates don't use secrets; document future strategy |
+| 2026-02-10 | No-Docker runner | All 8 routed jobs audited — zero Docker deps; `no-docker` label added; smoke checks Docker informally |

--- a/platform.json
+++ b/platform.json
@@ -93,10 +93,14 @@
 
   "runners": {
     "pilot": {
-      "labels": ["self-hosted", "benton", "linux-x64"],
+      "labels": ["self-hosted", "benton", "linux-x64", "no-docker"],
       "scope": ["prGates"],
       "variable": "BENTON_RUNNER",
       "fallback": "ubuntu-latest",
+      "capabilities": {
+        "docker": false,
+        "comment": "All 8 routed PR-gate jobs are pure compute (lint/typecheck/unit-test/build). No Docker required. Container build/scan stays on ubuntu-latest."
+      },
       "toolchain": {
         "dotnet": "8.0.x",
         "node": "20",


### PR DESCRIPTION
## Summary

Docker capability audit + routing update for Benton on-prem pilot. All 8 routed PR-gate
jobs verified as pure compute — **zero Docker dependencies**. Runner can be provisioned
without Docker installed.

## Docker Capability Audit (8/8 jobs)

| # | Workflow | Job | Docker? | What it does |
|---|----------|-----|---------|----|
| 1 | `seal-gate-fast.yml` | `frontend-fast` | No | pnpm lint/typecheck/test/build |
| 2 | `seal-gate-fast.yml` | `backend-fast` | No | dotnet restore/build/test |
| 3 | `seal-gate-fast.yml` | `governance-fast` | No | governance checks, platform-lint |
| 4 | `core-governance-gates.yml` | `governed-spine` | No | type-check + phase83-tools |
| 5 | `core-governance-gates.yml` | `phase85-tools` | No | node --test |
| 6 | `core-governance-gates.yml` | `phase86-toolrunner` | No | node --test |
| 7 | `core-governance-gates.yml` | `check-generated-js` | No | build:core-js + diff |
| 8 | `tier1-ui-harness.yml` | `tier1-harness` | No | pnpm test:tier1 |

**Guardrail:** No required check depends on Docker when `BENTON_RUNNER=true`.

## Changes (3 files)

| File | Change |
|------|--------|
| `platform.json` | Add `no-docker` label + `capabilities.docker: false` |
| `benton-runner-smoke.yml` | Add Docker availability check (informational, non-blocking) |
| `BENTON_ONPREM_PILOT.md` | §8 Docker audit table, updated diagram/labels/provisioning/decision log |

## Evidence
- `pnpm run type-check`: PASS
- `phase83-tools`: 32/32 PASS
- `platform-lint`: 0 violations
- Governance surface: unchanged (no workflow routing logic changed)

## Provisioning Impact
- Runner labels: `self-hosted,benton,linux-x64,no-docker`
- Docker: **NOT required** for runner provisioning
- All container build/scan stays on `ubuntu-latest`