### PR TITLE
test(docs): Benton routing validation

### DIFF
--- a/BENTON_ONPREM_PILOT.md
+++ b/BENTON_ONPREM_PILOT.md
@@ -1,6 +1,6 @@
 # Benton County On-Prem Runner Pilot
 
-**Status:** Wiring complete — awaiting runner provisioning (Docker NOT required)  
+**Status:** Routing validation in progress — `BENTON_RUNNER=true` set  
 **PR:** (this PR)  
 **Scope:** PR gates only (smallest critical surface)
 


### PR DESCRIPTION
## Purpose
Docs-only change to validate that BENTON_RUNNER=true correctly routes 8 compute jobs to [self-hosted, benton, linux-x64] labels.

No runner is provisioned. Routed jobs will queue (proving the routing expression evaluates correctly). Non-routed jobs proceed on ubuntu-latest.

## Expected Behavior
- 8 jobs queue on [self-hosted, benton, linux-x64] (no runner = stays queued)
- Remaining jobs (classify, skip-gates, autonomy guards) run on ubuntu-latest

## Cleanup
After observation, BENTON_RUNNER will be deleted and this PR closed without merge.

## Summary by Sourcery

Documentation:
- Clarify the Benton County on-prem runner pilot status to indicate active routing validation using the BENTON_RUNNER environment flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated on-premise pilot setup status and configuration documentation to reflect current validation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->