### PR TITLE
docs+guard: SEAL allowlist regression check

### DIFF
--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -51,6 +51,7 @@ pwsh tools/dev/verify.ps1      # run all gates
 | `--frozen-lockfile --filter ./frontend...` | Deterministic install scoped to frontend workspace. CI-safe. |
 | `nginx.conf` → `conf.d/default.conf` | File contains a `server {}` block, not a full `nginx.conf`. Must go to `conf.d/`. |
 | `.dockerignore` excludes `QUARANTINE/`, `backend/`, etc. | Keeps build context < 300 KB. |
+| SEAL legacy-frontend allowlist | `frontend/Dockerfile`, `frontend/nginx.conf`, `frontend/pnpm-lock.yaml`, `frontend/.dockerignore` are explicitly permitted in the governance gate. All other `frontend/` files (outside `apps/os-shell/`) are blocked. Removing these from the allowlist re-breaks the pipeline. |
 
 ## Tags
 

--- a/scripts/repo-shape-guard.mjs
+++ b/scripts/repo-shape-guard.mjs
@@ -1,0 +1,83 @@
+/**
+ * Repo Shape Guard – Entropy Lock for TerraFusion OS
+ *
+ * Prevents directory sprawl by asserting the number of top-level
+ * non-hidden directories stays within bounds. Run in CI (SEAL gate)
+ * or locally via: node scripts/repo-shape-guard.mjs
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+
+const IGNORED = new Set(['node_modules', 'QUARANTINE', '.git']);
+
+const dirs = readdirSync(ROOT)
+  .filter(name => {
+    if (name.startsWith('.') || IGNORED.has(name)) return false;
+    try {
+      return statSync(join(ROOT, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  })
+  .sort();
+
+const MAX_DIRS = 20; // Current: 16.  Headroom: 4.
+const MAX_ROOT_FILES = 40; // Current: 29.  Headroom: 11.
+
+const files = readdirSync(ROOT).filter(name => {
+  try {
+    return statSync(join(ROOT, name)).isFile();
+  } catch {
+    return false;
+  }
+});
+
+// ── SEAL allowlist regression guard ─────────────────────────────────
+// These frontend/ paths are permitted by the SEAL legacy-frontend gate
+// (seal-gate-fast.yml). If someone removes them from the workflow's
+// grep -v allowlist, the Docker build PR gate will silently break.
+let exitCode = 0;
+
+const SEAL_ALLOWLIST = [
+  'frontend/Dockerfile',
+  'frontend/nginx\\.conf',
+  'frontend/pnpm-lock\\.yaml',
+  'frontend/\\.dockerignore',
+];
+
+const sealGatePath = join(ROOT, '.github', 'workflows', 'seal-gate-fast.yml');
+try {
+  const sealGate = readFileSync(sealGatePath, 'utf8');
+  const missing = SEAL_ALLOWLIST.filter(p => !sealGate.includes(p));
+  if (missing.length) {
+    console.error(`\nSEAL ALLOWLIST REGRESSION: these paths are missing from seal-gate-fast.yml:`);
+    missing.forEach(p => console.error(`  ❌ ${p}`));
+    console.error('Re-add them to the legacy-frontend grep -v allowlist.');
+    exitCode = 1;
+  }
+} catch {
+  // seal-gate-fast.yml not found — skip (non-fatal in local dev)
+}
+// ────────────────────────────────────────────────────────────────────
+
+console.log(`Top-level directories: ${dirs.length} / ${MAX_DIRS} max`);
+dirs.forEach(d => console.log(`  ${d}`));
+
+console.log(`\nRoot files: ${files.length} / ${MAX_ROOT_FILES} max`);
+
+if (dirs.length > MAX_DIRS) {
+  console.error(`\nENTROPY VIOLATION: ${dirs.length} dirs exceed cap of ${MAX_DIRS}`);
+  exitCode = 1;
+}
+if (files.length > MAX_ROOT_FILES) {
+  console.error(`\nENTROPY VIOLATION: ${files.length} root files exceed cap of ${MAX_ROOT_FILES}`);
+  exitCode = 1;
+}
+
+if (exitCode === 0) {
+  console.log('\nRepo shape OK');
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## What

Two closure items from the deterministic Soul build work:

1. **REPO_MAP.md** — Documents that the SEAL legacy-frontend governance gate explicitly permits \rontend/Dockerfile\, \rontend/nginx.conf\, \rontend/pnpm-lock.yaml\, and \rontend/.dockerignore\. Removing these from the allowlist re-breaks the pipeline.

2. **scripts/repo-shape-guard.mjs** — Adds a regression assertion that those exact escaped paths remain present in \seal-gate-fast.yml\. If someone silently removes them, the guard fails with a clear error message.

No functional change to SEAL enforcement logic. Gate wiring only.

## Summary by Sourcery

Document SEAL’s legacy-frontend allowlist expectations and add a guard script that enforces them in CI by checking the workflow configuration.

Documentation:
- Clarify that specific legacy frontend paths are explicitly allowed by the SEAL governance gate and that removing them will break the pipeline.

Tests:
- Introduce a repo-shape guard script that also asserts the required SEAL allowlisted frontend paths remain present in the seal-gate-fast CI workflow.