### PR TITLE
feat(governance): quarantine toolchain + CI wiring (v2 — review fixes)

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -383,6 +383,33 @@ jobs:
         shell: bash
         run: node scripts/platform-lint.mjs
 
+      - name: Quarantine toolchain tests
+        shell: bash
+        run: node --test scripts/quarantine/__tests__/*.test.mjs
+
+      - name: Repo shape guard (root spine allowlist)
+        id: shape-guard
+        shell: bash
+        run: node scripts/repo-shape-guard.mjs
+        continue-on-error: true
+
+      - name: Repo shape guard enforcement
+        if: steps.shape-guard.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ vars.QUARANTINE_GUARD_STRICT }}" = "true" ]; then
+            echo "::error::Repo shape guard failed (QUARANTINE_GUARD_STRICT=true). Root spine must be clean."
+            exit 1
+          else
+            echo "::warning::Repo shape guard failed (quarantine in progress). Will become blocking when QUARANTINE_GUARD_STRICT=true."
+          fi
+
+      - name: Quarantine plan check (strict — gated)
+        if: vars.QUARANTINE_STRICT == 'true'
+        shell: bash
+        run: node scripts/quarantine/plan.mjs --check
+
   # ═══════════════════════════════════════════════════════════════════════════
   # SEAL - Final gate (all fast checks must pass)
   # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/quarantine/__tests__/apply.test.mjs
+++ b/scripts/quarantine/__tests__/apply.test.mjs
@@ -1,0 +1,155 @@
+/**
+ * Apply tests — Quarantine apply script safety + batching
+ *
+ * Run: node --test scripts/quarantine/__tests__/apply.test.mjs
+ *
+ * These tests exercise the pure core (computeMovesToApply) only.
+ * Actual git-mv execution is tested via integration (Increment 4).
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { computeMovesToApply } from '../apply-core.mjs';
+
+// A realistic plan (mirrors planner output)
+const SAMPLE_PLAN = [
+  { from: 'ACCESSIBILITY_REPORT.md', to: 'QUARANTINE/root-md/ACCESSIBILITY_REPORT.md' },
+  {
+    from: 'AdvancedAnalyticsEngine.ts',
+    to: 'QUARANTINE/root-artifacts/AdvancedAnalyticsEngine.ts',
+  },
+  { from: 'agents/', to: 'QUARANTINE/top-level-dirs/agents/' },
+  { from: 'ai-swarm-service.js', to: 'QUARANTINE/root-artifacts/ai-swarm-service.js' },
+  {
+    from: 'autonomous_excellence_monitor.py',
+    to: 'QUARANTINE/root-artifacts/autonomous_excellence_monitor.py',
+  },
+  { from: 'marketplace/', to: 'QUARANTINE/top-level-dirs/marketplace/' },
+  { from: 'stale.txt', to: 'QUARANTINE/root-artifacts/stale.txt' },
+];
+
+describe('computeMovesToApply', () => {
+  it('refuses_when_working_tree_dirty', () => {
+    // statusOutput simulates `git status --porcelain` output
+    const result = computeMovesToApply({
+      plan: SAMPLE_PLAN,
+      batch: 10,
+      statusOutput: ' M some-file.txt\n',
+    });
+    assert.equal(result.ok, false, 'should refuse on dirty tree');
+    assert.match(result.error, /dirty/i, 'error mentions dirty');
+    assert.equal(result.moves, undefined, 'no moves on dirty tree');
+  });
+
+  it('applies_git_mv_for_batch_n_only', () => {
+    const result = computeMovesToApply({
+      plan: SAMPLE_PLAN,
+      batch: 3,
+      statusOutput: '',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.moves.length, 3, 'batch 3 → exactly 3 moves');
+    // Should be the first 3 in plan order (plan is already sorted by from)
+    assert.equal(result.moves[0].from, SAMPLE_PLAN[0].from);
+    assert.equal(result.moves[1].from, SAMPLE_PLAN[1].from);
+    assert.equal(result.moves[2].from, SAMPLE_PLAN[2].from);
+  });
+
+  it('uses_categories_correctly_md_vs_other_vs_dir', () => {
+    // Full batch — all 7 moves
+    const result = computeMovesToApply({
+      plan: SAMPLE_PLAN,
+      batch: Infinity,
+      statusOutput: '',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.moves.length, SAMPLE_PLAN.length);
+
+    // Category verification: each move preserves planner's bucket assignment
+    for (const move of result.moves) {
+      const planEntry = SAMPLE_PLAN.find(p => p.from === move.from);
+      assert.ok(planEntry, `${move.from} should exist in plan`);
+      assert.equal(move.to, planEntry.to, `${move.from} destination must match plan`);
+    }
+
+    // Spot-check: .md → root-md
+    const mdMove = result.moves.find(m => m.from === 'ACCESSIBILITY_REPORT.md');
+    assert.ok(mdMove.to.startsWith('QUARANTINE/root-md/'));
+
+    // Spot-check: dir → top-level-dirs
+    const dirMove = result.moves.find(m => m.from === 'agents/');
+    assert.ok(dirMove.to.startsWith('QUARANTINE/top-level-dirs/'));
+
+    // Spot-check: other → root-artifacts
+    const artifactMove = result.moves.find(m => m.from === 'ai-swarm-service.js');
+    assert.ok(artifactMove.to.startsWith('QUARANTINE/root-artifacts/'));
+  });
+
+  it('does_not_run_without_plan', () => {
+    // Empty plan → ok but zero moves
+    const resultEmpty = computeMovesToApply({
+      plan: [],
+      batch: 10,
+      statusOutput: '',
+    });
+    assert.equal(resultEmpty.ok, true);
+    assert.equal(resultEmpty.moves.length, 0, 'empty plan → 0 moves');
+
+    // Null/undefined plan → error
+    const resultNull = computeMovesToApply({
+      plan: null,
+      batch: 10,
+      statusOutput: '',
+    });
+    assert.equal(resultNull.ok, false, 'null plan → error');
+    assert.match(resultNull.error, /plan/i, 'error mentions plan');
+  });
+
+  it('is_deterministic_first_n_moves', () => {
+    // Same plan + same batch → identical result every time
+    const r1 = computeMovesToApply({ plan: SAMPLE_PLAN, batch: 4, statusOutput: '' });
+    const r2 = computeMovesToApply({ plan: SAMPLE_PLAN, batch: 4, statusOutput: '' });
+    assert.deepEqual(r1.moves, r2.moves, 'deterministic: identical on repeat');
+
+    // Shuffled plan should still produce same first-4 (plan is pre-sorted by planner)
+    // But apply-core trusts plan order — it does NOT re-sort.
+    // So shuffled input → different first-4 (this is correct: the planner is responsible for ordering).
+    const shuffled = [...SAMPLE_PLAN].reverse();
+    const r3 = computeMovesToApply({ plan: shuffled, batch: 4, statusOutput: '' });
+    // r3 should use first 4 of shuffled, which differ from first 4 of original
+    assert.equal(r3.moves.length, 4);
+    assert.equal(r3.moves[0].from, shuffled[0].from, 'uses plan order as-is');
+  });
+
+  it('batch_zero_applies_nothing', () => {
+    const result = computeMovesToApply({
+      plan: SAMPLE_PLAN,
+      batch: 0,
+      statusOutput: '',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.moves.length, 0, 'batch 0 → no moves');
+  });
+
+  it('clean_tree_with_untracked_only_is_dirty', () => {
+    // Untracked files also make the tree "dirty" for our purposes
+    const result = computeMovesToApply({
+      plan: SAMPLE_PLAN,
+      batch: 10,
+      statusOutput: '?? new-file.txt\n',
+    });
+    // We treat ANY non-empty porcelain output as dirty
+    assert.equal(result.ok, false, 'untracked files = dirty');
+  });
+
+  it('rejects_malformed_plan_entries', () => {
+    const badPlan = [
+      { from: 'ok.md', to: 'QUARANTINE/root-md/ok.md' },
+      { from: 123, to: 'bad' }, // from is not a string
+      { from: 'also-ok.md', to: 'QUARANTINE/root-md/also-ok.md' },
+    ];
+    const result = computeMovesToApply({ plan: badPlan, batch: 10, statusOutput: '' });
+    assert.equal(result.ok, false, 'should reject malformed entry');
+    assert.match(result.error, /malformed/i, 'error mentions malformed');
+    assert.match(result.error, /index 1/, 'error identifies index');
+  });
+});

--- a/scripts/quarantine/__tests__/guard.test.mjs
+++ b/scripts/quarantine/__tests__/guard.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * Guard tests — Hard allowlist enforcement + SEAL coupling
+ *
+ * Run: node --test scripts/quarantine/__tests__/guard.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { checkSealAllowlist, checkShape } from '../../repo-shape-guard.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const keepList = JSON.parse(readFileSync(join(__dirname, '..', 'keep-list.json'), 'utf8'));
+
+// ── checkShape ──────────────────────────────────────────────────────
+
+describe('checkShape', () => {
+  it('passes with exact allowlist shape', () => {
+    const rootEntries = [
+      ...keepList.dirs,
+      ...keepList.files,
+      '.git',
+      '.github',
+      '.gitignore',
+      '.husky', // hidden — auto-ignored
+      'QUARANTINE', // ignored
+    ];
+    const result = checkShape(rootEntries, keepList);
+    assert.deepEqual(result.violations, []);
+    assert.deepEqual(result.missingDirs, []);
+    assert.deepEqual(result.missingFiles, []);
+  });
+
+  it('fails when non-allowlisted root entries exist', () => {
+    const rootEntries = [...keepList.dirs, ...keepList.files, 'extra-dir', 'stale-artifact.txt'];
+    const result = checkShape(rootEntries, keepList);
+    assert.ok(result.violations.includes('extra-dir'), 'expected extra-dir in violations');
+    assert.ok(
+      result.violations.includes('stale-artifact.txt'),
+      'expected stale-artifact.txt in violations'
+    );
+    assert.equal(result.violations.length, 2);
+  });
+
+  it('detects missing keep-list dirs (soft warning)', () => {
+    const rootEntries = [...keepList.dirs.filter(d => d !== 'backend'), ...keepList.files];
+    const result = checkShape(rootEntries, keepList);
+    assert.deepEqual(result.violations, []);
+    assert.deepEqual(result.missingDirs, ['backend']);
+    assert.deepEqual(result.missingFiles, []);
+  });
+
+  it('detects missing keep-list files (hard fail)', () => {
+    const rootEntries = [...keepList.dirs, ...keepList.files.filter(f => f !== 'package.json')];
+    const result = checkShape(rootEntries, keepList);
+    assert.deepEqual(result.violations, []);
+    assert.deepEqual(result.missingDirs, []);
+    assert.deepEqual(result.missingFiles, ['package.json']);
+  });
+
+  it('ignores hidden entries and QUARANTINE', () => {
+    const rootEntries = [
+      ...keepList.dirs,
+      ...keepList.files,
+      '.hidden-dir',
+      '.env',
+      '.claude',
+      'QUARANTINE',
+    ];
+    const result = checkShape(rootEntries, keepList);
+    assert.deepEqual(result.violations, []);
+    assert.deepEqual(result.missingDirs, []);
+    assert.deepEqual(result.missingFiles, []);
+  });
+
+  it('flags tracked node_modules as violation', () => {
+    const rootEntries = [...keepList.dirs, ...keepList.files, 'node_modules'];
+    const result = checkShape(rootEntries, keepList);
+    assert.ok(result.violations.includes('node_modules'), 'tracked node_modules is a violation');
+  });
+});
+
+// ── checkSealAllowlist ──────────────────────────────────────────────
+
+describe('checkSealAllowlist', () => {
+  it('passes when all required patterns present', () => {
+    const content = [
+      'grep -v -E "',
+      'frontend/Dockerfile',
+      '|frontend/nginx\\.conf',
+      '|frontend/pnpm-lock\\.yaml',
+      '|frontend/\\.dockerignore',
+      '"',
+    ].join('');
+    const missing = checkSealAllowlist(content);
+    assert.deepEqual(missing, []);
+  });
+
+  it('detects missing SEAL allowlist entries', () => {
+    const content = 'grep -v -E "frontend/Dockerfile|frontend/nginx\\.conf"';
+    const missing = checkSealAllowlist(content);
+    assert.ok(missing.includes('frontend/pnpm-lock\\.yaml'));
+    assert.ok(missing.includes('frontend/\\.dockerignore'));
+    assert.equal(missing.length, 2);
+  });
+});

--- a/scripts/quarantine/__tests__/plan.test.mjs
+++ b/scripts/quarantine/__tests__/plan.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * Planner tests — Deterministic quarantine move plan from git-tracked entries
+ *
+ * Run: node --test scripts/quarantine/__tests__/plan.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { computePlan } from '../plan-core.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const keepList = JSON.parse(readFileSync(join(__dirname, '..', 'keep-list.json'), 'utf8'));
+
+describe('computePlan', () => {
+  it('plan_respects_keep_list', () => {
+    const entries = [
+      ...keepList.dirs.map(d => ({ name: d, type: 'tree' })),
+      ...keepList.files.map(f => ({ name: f, type: 'blob' })),
+      { name: 'agents', type: 'tree' },
+      { name: 'stale.txt', type: 'blob' },
+    ];
+    const plan = computePlan({ entries, keepList });
+    const fromNames = plan.map(m => m.from);
+    // Only intruders appear in plan
+    assert.ok(fromNames.includes('agents/'), 'expected agents/ in plan');
+    assert.ok(fromNames.includes('stale.txt'), 'expected stale.txt in plan');
+    assert.equal(plan.length, 2, 'only 2 intruders expected');
+    // No keep-list entry scheduled for move
+    for (const d of keepList.dirs) {
+      assert.ok(!fromNames.includes(d + '/'), `${d}/ should not be in plan`);
+    }
+    for (const f of keepList.files) {
+      assert.ok(!fromNames.includes(f), `${f} should not be in plan`);
+    }
+  });
+
+  it('plan_is_deterministic_sorted', () => {
+    const entries = [
+      { name: 'zebra', type: 'tree' },
+      { name: 'alpha', type: 'blob' },
+      { name: 'middle', type: 'tree' },
+    ];
+    const reversed = [...entries].reverse();
+    const plan1 = computePlan({ entries, keepList });
+    const plan2 = computePlan({ entries: reversed, keepList });
+    // Identical output regardless of input order
+    assert.deepEqual(plan1, plan2, 'plans should be byte-identical regardless of input order');
+    // Output is sorted by `from`
+    for (let i = 1; i < plan1.length; i++) {
+      assert.ok(
+        plan1[i].from > plan1[i - 1].from,
+        `${plan1[i].from} should sort after ${plan1[i - 1].from}`
+      );
+    }
+  });
+
+  it('plan_uses_git_ls_tree', () => {
+    // Validates the core function accepts entries in git ls-tree format
+    // (name + type) and produces the correct output contract:
+    //   dirs  → trailing /  → QUARANTINE/top-level-dirs/
+    //   blobs → no trailing → QUARANTINE/root-artifacts/ or root-md/
+    const entries = [
+      { name: 'agents', type: 'tree' },
+      { name: 'stale.txt', type: 'blob' },
+      { name: 'TROPHY.md', type: 'blob' },
+    ];
+    const plan = computePlan({ entries, keepList });
+    assert.equal(plan.length, 3);
+    // Dir gets trailing / and goes to top-level-dirs
+    const dirMove = plan.find(m => m.from === 'agents/');
+    assert.ok(dirMove, 'dir entry should have trailing /');
+    assert.equal(dirMove.to, 'QUARANTINE/top-level-dirs/agents/');
+    // Non-md blob goes to root-artifacts
+    const fileMove = plan.find(m => m.from === 'stale.txt');
+    assert.ok(fileMove);
+    assert.equal(fileMove.to, 'QUARANTINE/root-artifacts/stale.txt');
+    // .md blob goes to root-md
+    const mdMove = plan.find(m => m.from === 'TROPHY.md');
+    assert.ok(mdMove);
+    assert.equal(mdMove.to, 'QUARANTINE/root-md/TROPHY.md');
+  });
+
+  it('dry_run_reports_without_writing', () => {
+    // computePlan is a pure function — no side effects.
+    // Verify: returns fresh arrays, no shared references, no mutations.
+    const entries = [
+      { name: 'junk', type: 'blob' },
+      { name: 'debris', type: 'tree' },
+    ];
+    const plan1 = computePlan({ entries, keepList });
+    assert.ok(Array.isArray(plan1), 'plan is an array');
+    assert.equal(plan1.length, 2);
+    // Mutating result must not affect subsequent calls
+    plan1.push({ from: 'fake', to: 'fake' });
+    plan1[0].from = 'corrupted';
+    const plan2 = computePlan({ entries, keepList });
+    assert.equal(plan2.length, 2, 'second call unaffected by mutation of first result');
+    assert.notEqual(plan2[0].from, 'corrupted', 'no shared object references');
+  });
+
+  it('plan_excludes_hidden_and_ignored', () => {
+    const entries = [
+      { name: '.git', type: 'tree' },
+      { name: '.github', type: 'tree' },
+      { name: '.env', type: 'blob' },
+      { name: '.claude', type: 'tree' },
+      { name: '.ralph', type: 'tree' },
+      { name: 'QUARANTINE', type: 'tree' },
+      { name: 'intruder', type: 'tree' },
+    ];
+    const plan = computePlan({ entries, keepList });
+    const fromNames = plan.map(m => m.from);
+    // Hidden entries excluded
+    assert.ok(!fromNames.some(f => f.startsWith('.')), 'no hidden entries in plan');
+    // QUARANTINE excluded
+    assert.ok(!fromNames.includes('QUARANTINE/'), 'QUARANTINE excluded');
+    // Only the intruder remains
+    assert.equal(plan.length, 1);
+    assert.equal(plan[0].from, 'intruder/');
+    assert.equal(plan[0].to, 'QUARANTINE/top-level-dirs/intruder/');
+  });
+
+  it('plan_quarantines_tracked_node_modules', () => {
+    const entries = [
+      { name: 'node_modules', type: 'tree' },
+      { name: 'intruder', type: 'tree' },
+    ];
+    const plan = computePlan({ entries, keepList });
+    const fromNames = plan.map(m => m.from);
+    assert.ok(fromNames.includes('node_modules/'), 'tracked node_modules gets quarantined');
+    assert.ok(fromNames.includes('intruder/'), 'intruder also quarantined');
+    assert.equal(plan.length, 2);
+  });
+});

--- a/scripts/quarantine/apply-core.mjs
+++ b/scripts/quarantine/apply-core.mjs
@@ -1,0 +1,51 @@
+/**
+ * Quarantine Apply Core — Pure logic for computing moves to execute
+ *
+ * Zero side effects. Takes a plan + options, returns either
+ * { ok: true, moves: [...] } or { ok: false, error: string }.
+ *
+ * Safety invariants:
+ *   1. Refuses when working tree is dirty (statusOutput non-empty)
+ *   2. Applies only the first `batch` moves from plan order
+ *   3. Does not re-sort — trusts planner's deterministic ordering
+ */
+
+/**
+ * @param {{
+ *   plan: Array<{from: string, to: string}> | null | undefined,
+ *   batch: number,
+ *   statusOutput: string
+ * }} opts
+ * @returns {{ ok: true, moves: Array<{from: string, to: string}> } | { ok: false, error: string }}
+ */
+export function computeMovesToApply({ plan, batch, statusOutput }) {
+  // Validate plan
+  if (!Array.isArray(plan)) {
+    return { ok: false, error: 'No plan provided. Pipe planner output or use --plan <file>.' };
+  }
+
+  // Validate entry shape — each entry must have string from/to
+  for (let i = 0; i < plan.length; i++) {
+    const entry = plan[i];
+    if (!entry || typeof entry.from !== 'string' || typeof entry.to !== 'string') {
+      return {
+        ok: false,
+        error: `Malformed plan entry at index ${i}: expected { from: string, to: string }.`,
+      };
+    }
+  }
+
+  // Safety: refuse on dirty working tree
+  if (statusOutput && statusOutput.trim().length > 0) {
+    return {
+      ok: false,
+      error: 'Working tree is dirty. Commit or stash changes before applying quarantine moves.',
+    };
+  }
+
+  // Apply batch limit (first N moves in plan order)
+  const limit = Math.max(0, Math.min(batch, plan.length));
+  const moves = plan.slice(0, limit).map(m => ({ from: m.from, to: m.to }));
+
+  return { ok: true, moves };
+}

--- a/scripts/quarantine/apply.mjs
+++ b/scripts/quarantine/apply.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Quarantine Apply CLI — Execute git mv operations from a quarantine plan
+ *
+ * Usage:
+ *   node scripts/quarantine/plan.mjs --json | node scripts/quarantine/apply.mjs
+ *   node scripts/quarantine/apply.mjs --plan plan.json
+ *   node scripts/quarantine/apply.mjs --plan plan.json --batch 50
+ *
+ * Safety:
+ *   - Refuses to run if working tree is dirty (git status --porcelain)
+ *   - Only performs `git mv` — no raw filesystem moves
+ *   - --batch N limits to first N moves in plan order
+ *   - --dry-run shows what would be done without executing
+ *
+ * All moves come from the planner's deterministic output.
+ * The apply script does NOT re-sort or re-categorize.
+ */
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeMovesToApply } from './apply-core.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(__filename, '../../..');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let planFile = null;
+  let batch = Infinity;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--plan' && i + 1 < args.length) {
+      planFile = args[++i];
+    } else if (args[i] === '--batch' && i + 1 < args.length) {
+      const n = parseInt(args[++i], 10);
+      if (!Number.isFinite(n) || n < 0) {
+        console.error('FATAL: --batch requires a non-negative integer.');
+        process.exit(2);
+      }
+      batch = n;
+    } else if (args[i] === '--dry-run') {
+      dryRun = true;
+    }
+  }
+
+  return { planFile, batch, dryRun };
+}
+
+function readPlan(planFile) {
+  if (planFile) {
+    const content = readFileSync(resolve(ROOT, planFile), 'utf8');
+    return JSON.parse(content);
+  }
+
+  // Read from stdin (piped JSON) — cross-platform via fd 0
+  if (!process.stdin.isTTY) {
+    let raw;
+    try {
+      raw = readFileSync(0, 'utf8');
+    } catch {
+      // EOF, pipe closed, or no stdin
+      return null;
+    }
+
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(trimmed);
+    } catch (err) {
+      console.error(
+        'FATAL: Failed to parse plan JSON from stdin: ' +
+          (err && err.message ? err.message : String(err))
+      );
+      process.exit(2);
+    }
+  }
+
+  return null;
+}
+
+function getWorkingTreeStatus(cwd) {
+  return execSync('git status --porcelain', { encoding: 'utf8', cwd });
+}
+
+function main() {
+  const { planFile, batch, dryRun } = parseArgs(process.argv);
+
+  // Load plan
+  const plan = readPlan(planFile);
+
+  // Get working tree status
+  let statusOutput;
+  try {
+    statusOutput = getWorkingTreeStatus(ROOT);
+  } catch {
+    console.error('FATAL: not in a git repo or git not available.');
+    process.exit(2);
+  }
+
+  // Compute moves
+  const result = computeMovesToApply({ plan, batch, statusOutput });
+
+  if (!result.ok) {
+    console.error(`FATAL: ${result.error}`);
+    process.exit(1);
+  }
+
+  if (result.moves.length === 0) {
+    console.log('Nothing to apply (empty plan or batch=0).');
+    process.exit(0);
+  }
+
+  // Report
+  console.log(`Quarantine apply: ${result.moves.length} moves${dryRun ? ' (DRY RUN)' : ''}`);
+  console.log('');
+
+  if (dryRun) {
+    for (const { from, to } of result.moves) {
+      console.log(`  [dry-run] git mv "${from}" "${to}"`);
+    }
+    console.log(`\nDry run complete. No files were moved.`);
+    process.exit(0);
+  }
+
+  // Execute git mv for each move
+  let applied = 0;
+  for (const { from, to } of result.moves) {
+    // Strip trailing slash for git mv (git mv operates on directory names without trailing /)
+    const src = from.endsWith('/') ? from.slice(0, -1) : from;
+    const dst = to.endsWith('/') ? to.slice(0, -1) : to;
+
+    try {
+      // Ensure QUARANTINE bucket directory exists (cross-platform)
+      const bucketDir = resolve(ROOT, dst.replace(/\/[^/]+$/, ''));
+      mkdirSync(bucketDir, { recursive: true });
+
+      // Use execFileSync (no shell) to avoid injection risks with arbitrary filenames
+      execFileSync('git', ['mv', src, dst], { cwd: ROOT, stdio: 'pipe' });
+      applied++;
+      console.log(`  ✓ git mv "${src}" → "${dst}"`);
+    } catch (err) {
+      console.error(`  ✗ git mv "${src}" → "${dst}" FAILED`);
+      console.error(`    ${err.stderr?.toString().trim() || err.message}`);
+      console.error(`\nStopping after ${applied} successful moves. Fix the error and re-run.`);
+      process.exit(1);
+    }
+  }
+
+  console.log(`\n✅ Applied ${applied} moves. Run 'git status' to review, then commit.`);
+}
+
+main();

--- a/scripts/quarantine/keep-list.json
+++ b/scripts/quarantine/keep-list.json
@@ -1,0 +1,49 @@
+{
+  "description": "Root spine allowlist. Non-hidden tracked root entries not in this list are quarantine candidates. Source of truth: REPO_MAP.md § Root Spine.",
+  "policy": {
+    "violations": "exit 1 — root entries not in this list",
+    "missingFiles": "exit 1 — required root files absent (indicates damage)",
+    "missingDirs": "warn (exit 0) during quarantine phase; flip to exit 1 post-quarantine via --strict"
+  },
+  "dirs": [
+    "backend",
+    "compose",
+    "config",
+    "data",
+    "database",
+    "docker",
+    "docs",
+    "frontend",
+    "golden",
+    "native-shell",
+    "ops",
+    "os-platform",
+    "packages",
+    "scripts",
+    "tests",
+    "tools"
+  ],
+  "files": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODEOWNERS",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "Makefile",
+    "README.md",
+    "REPO_MAP.md",
+    "STANDARD.md",
+    "SUSTAINMENT.md",
+    "TerraFusion.sln",
+    "global.json",
+    "package.json",
+    "platform.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "renovate.json",
+    "tsconfig.core.json",
+    "tsconfig.eslint.json",
+    "tsconfig.json",
+    "vitest.config.ts"
+  ]
+}

--- a/scripts/quarantine/plan-core.mjs
+++ b/scripts/quarantine/plan-core.mjs
@@ -1,0 +1,45 @@
+/**
+ * Quarantine Plan Core — Pure deterministic move plan computation
+ *
+ * Zero side effects. Takes git-tracked entries + keep-list, returns
+ * a sorted array of { from, to } moves.
+ *
+ * Buckets:
+ *   tree  → QUARANTINE/top-level-dirs/<name>/
+ *   blob (.md) → QUARANTINE/root-md/<name>
+ *   blob (other) → QUARANTINE/root-artifacts/<name>
+ */
+
+const IGNORED = new Set(['QUARANTINE']);
+const HIDDEN_RE = /^\./;
+
+/**
+ * @param {{ entries: Array<{name: string, type: string}>, keepList: {dirs: string[], files: string[]} }} input
+ * @returns {Array<{from: string, to: string}>}
+ */
+export function computePlan({ entries, keepList }) {
+  const allowed = new Set([...keepList.dirs, ...keepList.files]);
+
+  const moves = [];
+  for (const { name, type } of entries) {
+    if (HIDDEN_RE.test(name)) continue;
+    if (IGNORED.has(name)) continue;
+    if (allowed.has(name)) continue;
+
+    const isDir = type === 'tree';
+    const from = isDir ? `${name}/` : name;
+
+    let bucket;
+    if (isDir) {
+      bucket = 'top-level-dirs';
+    } else if (name.endsWith('.md')) {
+      bucket = 'root-md';
+    } else {
+      bucket = 'root-artifacts';
+    }
+
+    moves.push({ from, to: `QUARANTINE/${bucket}/${from}` });
+  }
+
+  return moves.sort((a, b) => a.from.localeCompare(b.from));
+}

--- a/scripts/quarantine/plan.mjs
+++ b/scripts/quarantine/plan.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Quarantine Planner CLI — Compute deterministic move plan from git-tracked root
+ *
+ * Usage:
+ *   node scripts/quarantine/plan.mjs               # dry-run (human-readable)
+ *   node scripts/quarantine/plan.mjs --json         # dry-run (machine-readable)
+ *   node scripts/quarantine/plan.mjs --check        # exit 1 if plan is non-empty
+ *
+ * All modes are read-only. No mutations are performed.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computePlan } from './plan-core.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(__filename, '../../..');
+
+/**
+ * Parse root entries from git ls-tree (full format) into { name, type } objects.
+ * @param {string} cwd  Repository root
+ * @returns {Array<{name: string, type: string}>}
+ */
+function getGitEntries(cwd) {
+  // Full format: "<mode> <type> <hash>\t<name>\0"
+  const raw = execSync('git ls-tree -z HEAD', { encoding: 'utf8', cwd });
+  return raw
+    .split('\0')
+    .filter(Boolean)
+    .map(line => {
+      const tabIdx = line.indexOf('\t');
+      const meta = line.slice(0, tabIdx); // "<mode> <type> <hash>"
+      const name = line.slice(tabIdx + 1);
+      const type = meta.split(' ')[1]; // "tree" or "blob"
+      return { name, type };
+    });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const checkMode = args.includes('--check');
+
+  // Load keep-list
+  const keepListPath = join(ROOT, 'scripts', 'quarantine', 'keep-list.json');
+  const keepList = JSON.parse(readFileSync(keepListPath, 'utf8'));
+
+  // Get tracked root entries via git
+  let entries;
+  try {
+    entries = getGitEntries(ROOT);
+  } catch {
+    console.error('FATAL: not in a git repo or git not available.');
+    process.exit(2);
+  }
+
+  const plan = computePlan({ entries, keepList });
+
+  // Summarize
+  const dirMoves = plan.filter(m => m.from.endsWith('/'));
+  const fileMoves = plan.filter(m => !m.from.endsWith('/'));
+
+  if (jsonMode) {
+    process.stdout.write(JSON.stringify(plan, null, 2) + '\n');
+  } else {
+    console.log(
+      `Quarantine plan: ${plan.length} moves (${dirMoves.length} dirs, ${fileMoves.length} files)`
+    );
+    if (plan.length > 0) {
+      console.log('');
+      for (const { from, to } of plan) {
+        console.log(`  ${from}  →  ${to}`);
+      }
+    }
+  }
+
+  if (checkMode) {
+    if (plan.length > 0) {
+      console.error(`\n❌ CHECK FAILED: ${plan.length} entries still need quarantine.`);
+      process.exit(1);
+    } else {
+      console.log('\n✅ CHECK PASSED: no quarantine moves needed.');
+    }
+  } else {
+    if (plan.length === 0) {
+      console.log('\n✅ Root is clean — nothing to quarantine.');
+    } else {
+      console.log(`\nℹ️  This is a dry-run. No files were moved.`);
+    }
+  }
+}
+
+main();

--- a/scripts/repo-shape-guard.mjs
+++ b/scripts/repo-shape-guard.mjs
@@ -1,83 +1,139 @@
 /**
- * Repo Shape Guard – Entropy Lock for TerraFusion OS
+ * Repo Shape Guard – Hard Allowlist Enforcement for TerraFusion OS
  *
- * Prevents directory sprawl by asserting the number of top-level
- * non-hidden directories stays within bounds. Run in CI (SEAL gate)
- * or locally via: node scripts/repo-shape-guard.mjs
+ * Enforces the root spine by checking tracked root entries against a
+ * hard allowlist (keep-list.json). Uses `git ls-tree` for git-aware truth
+ * instead of filesystem enumeration.
+ *
+ * Usage:
+ *   node scripts/repo-shape-guard.mjs           # enforce (warn on missing dirs)
+ *   node scripts/repo-shape-guard.mjs --strict   # also fail on missing dirs
+ *
+ * Policy:
+ *   violations (unknown root entries) → exit 1
+ *   missing keep-list files           → exit 1
+ *   missing keep-list dirs            → warn (exit 0), or exit 1 with --strict
  */
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(__filename, '../..');
 
-const IGNORED = new Set(['node_modules', 'QUARANTINE', '.git']);
+const IGNORED = new Set(['QUARANTINE']);
+const HIDDEN_RE = /^\./;
 
-const dirs = readdirSync(ROOT)
-  .filter(name => {
-    if (name.startsWith('.') || IGNORED.has(name)) return false;
-    try {
-      return statSync(join(ROOT, name)).isDirectory();
-    } catch {
-      return false;
-    }
-  })
-  .sort();
+/**
+ * Core enforcement: check root entries against keep-list.
+ * @param {string[]} rootEntries  All root-level entry names from git ls-tree
+ * @param {{ dirs: string[], files: string[] }} keepList
+ * @returns {{ violations: string[], missingDirs: string[], missingFiles: string[] }}
+ */
+export function checkShape(rootEntries, keepList) {
+  const allowed = new Set([...keepList.dirs, ...keepList.files]);
+  const visible = rootEntries.filter(e => !HIDDEN_RE.test(e) && !IGNORED.has(e));
 
-const MAX_DIRS = 20; // Current: 16.  Headroom: 4.
-const MAX_ROOT_FILES = 40; // Current: 29.  Headroom: 11.
+  const violations = visible.filter(e => !allowed.has(e)).sort();
+  const entrySet = new Set(rootEntries);
+  const missingDirs = keepList.dirs.filter(d => !entrySet.has(d)).sort();
+  const missingFiles = keepList.files.filter(f => !entrySet.has(f)).sort();
 
-const files = readdirSync(ROOT).filter(name => {
+  return { violations, missingDirs, missingFiles };
+}
+
+/**
+ * SEAL allowlist regression check.
+ * @param {string} content  Contents of seal-gate-fast.yml
+ * @returns {string[]}  Missing required escaped patterns
+ */
+export function checkSealAllowlist(content) {
+  const REQUIRED = [
+    'frontend/Dockerfile',
+    'frontend/nginx\\.conf',
+    'frontend/pnpm-lock\\.yaml',
+    'frontend/\\.dockerignore',
+  ];
+  return REQUIRED.filter(p => !content.includes(p));
+}
+
+function main() {
+  const strict = process.argv.includes('--strict');
+  let exitCode = 0;
+
+  // Load keep-list
+  const keepListPath = join(ROOT, 'scripts', 'quarantine', 'keep-list.json');
+  const keepList = JSON.parse(readFileSync(keepListPath, 'utf8'));
+
+  // Get tracked root entries via git (null-byte separator avoids quoting)
+  let rootEntries;
   try {
-    return statSync(join(ROOT, name)).isFile();
+    const output = execSync('git ls-tree --name-only -z HEAD', {
+      encoding: 'utf8',
+      cwd: ROOT,
+    });
+    rootEntries = output.split('\0').filter(Boolean);
   } catch {
-    return false;
+    console.error('FATAL: not in a git repo or git not available.');
+    process.exit(2);
   }
-});
 
-// ── SEAL allowlist regression guard ─────────────────────────────────
-// These frontend/ paths are permitted by the SEAL legacy-frontend gate
-// (seal-gate-fast.yml). If someone removes them from the workflow's
-// grep -v allowlist, the Docker build PR gate will silently break.
-let exitCode = 0;
+  const { violations, missingDirs, missingFiles } = checkShape(rootEntries, keepList);
 
-const SEAL_ALLOWLIST = [
-  'frontend/Dockerfile',
-  'frontend/nginx\\.conf',
-  'frontend/pnpm-lock\\.yaml',
-  'frontend/\\.dockerignore',
-];
+  // Report summary
+  const allowedCount = keepList.dirs.length + keepList.files.length;
+  const visibleCount = rootEntries.filter(e => !HIDDEN_RE.test(e) && !IGNORED.has(e)).length;
+  console.log(`Root entries: ${visibleCount} visible (${rootEntries.length} total)`);
+  console.log(
+    `Keep-list: ${allowedCount} allowed (${keepList.dirs.length} dirs + ${keepList.files.length} files)`
+  );
 
-const sealGatePath = join(ROOT, '.github', 'workflows', 'seal-gate-fast.yml');
-try {
-  const sealGate = readFileSync(sealGatePath, 'utf8');
-  const missing = SEAL_ALLOWLIST.filter(p => !sealGate.includes(p));
-  if (missing.length) {
-    console.error(`\nSEAL ALLOWLIST REGRESSION: these paths are missing from seal-gate-fast.yml:`);
-    missing.forEach(p => console.error(`  ❌ ${p}`));
-    console.error('Re-add them to the legacy-frontend grep -v allowlist.');
+  if (violations.length) {
+    console.error(`\n❌ VIOLATIONS: ${violations.length} root entries not in keep-list:`);
+    violations.forEach(v => console.error(`  ⛔ ${v}`));
     exitCode = 1;
   }
-} catch {
-  // seal-gate-fast.yml not found — skip (non-fatal in local dev)
+
+  if (missingFiles.length) {
+    console.error(`\n❌ MISSING FILES: ${missingFiles.length} required root files absent:`);
+    missingFiles.forEach(f => console.error(`  ⚠️  ${f}`));
+    exitCode = 1;
+  }
+
+  if (missingDirs.length) {
+    const icon = strict ? '❌' : '⚠️';
+    const label = strict ? 'MISSING DIRS (strict — exit 1)' : 'MISSING DIRS (warn — non-fatal)';
+    console.warn(`\n${icon} ${label}: ${missingDirs.length} keep-list dirs absent:`);
+    missingDirs.forEach(d => console.warn(`  📁 ${d}`));
+    if (strict) exitCode = 1;
+  }
+
+  // ── SEAL allowlist regression guard ─────────────────────────────
+  const sealGatePath = join(ROOT, '.github', 'workflows', 'seal-gate-fast.yml');
+  try {
+    const sealGate = readFileSync(sealGatePath, 'utf8');
+    const missingSeal = checkSealAllowlist(sealGate);
+    if (missingSeal.length) {
+      console.error(`\n❌ SEAL ALLOWLIST REGRESSION: missing from seal-gate-fast.yml:`);
+      missingSeal.forEach(p => console.error(`  ❌ ${p}`));
+      console.error('Re-add them to the legacy-frontend grep -v allowlist.');
+      exitCode = 1;
+    }
+  } catch {
+    // seal-gate-fast.yml not found — skip in local dev
+  }
+
+  if (exitCode === 0) {
+    console.log('\n✅ Repo shape OK');
+  } else {
+    console.error(`\n💥 Repo shape FAILED (exit ${exitCode})`);
+  }
+
+  process.exit(exitCode);
 }
-// ────────────────────────────────────────────────────────────────────
 
-console.log(`Top-level directories: ${dirs.length} / ${MAX_DIRS} max`);
-dirs.forEach(d => console.log(`  ${d}`));
-
-console.log(`\nRoot files: ${files.length} / ${MAX_ROOT_FILES} max`);
-
-if (dirs.length > MAX_DIRS) {
-  console.error(`\nENTROPY VIOLATION: ${dirs.length} dirs exceed cap of ${MAX_DIRS}`);
-  exitCode = 1;
+// Run main when executed directly
+if (resolve(process.argv[1] || '') === __filename) {
+  main();
 }
-if (files.length > MAX_ROOT_FILES) {
-  console.error(`\nENTROPY VIOLATION: ${files.length} root files exceed cap of ${MAX_ROOT_FILES}`);
-  exitCode = 1;
-}
-
-if (exitCode === 0) {
-  console.log('\nRepo shape OK');
-}
-
-process.exit(exitCode);


### PR DESCRIPTION
## Summary by Sourcery

Introduce a quarantine toolchain and hard root allowlist enforcement wired into CI.

New Features:
- Add quarantine planner and apply CLIs to compute and execute deterministic git-based move plans for non-allowlisted root entries.
- Introduce a JSON keep-list for allowed root directories and files to define the repository spine.

Enhancements:
- Replace the previous repo entropy guard with a git-aware root allowlist guard that surfaces violations, missing required files, and soft/strict handling of missing directories.
- Expose pure core modules for quarantine planning, applying, and repo-shape/SEAL checks to support reuse and testing.

CI:
- Extend the SEAL gate workflow to run quarantine unit tests, enforce the repo shape guard with configurable strictness, and optionally gate on the quarantine plan being clean.

Tests:
- Add unit tests for quarantine planning, apply-core safety and batching behavior, and repo-shape/SEAL guard logic against the keep-list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quarantine system to detect and relocate unexpected root-level files and folders, with dry-run and apply modes.
  * Configurable strict/non-strict enforcement for repository shape, plus an allowlist-driven check.
  * Quarantine validation steps integrated into the fast CI gate with conditional blocking.

* **Tests**
  * Extensive tests covering planning, move selection, guard validations, and edge cases.

* **Chores**
  * Added a keep-list configuration for repo spine allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->