### PR TITLE
fix(governance): address PR #284 review — node_modules, entry validation, CI tests

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -383,6 +383,10 @@ jobs:
         shell: bash
         run: node scripts/platform-lint.mjs
 
+      - name: Quarantine toolchain tests
+        shell: bash
+        run: node --test scripts/quarantine/__tests__/*.test.mjs
+
       - name: Repo shape guard (root spine allowlist)
         id: shape-guard
         shell: bash

--- a/scripts/quarantine/__tests__/apply.test.mjs
+++ b/scripts/quarantine/__tests__/apply.test.mjs
@@ -140,4 +140,20 @@ describe('computeMovesToApply', () => {
     // We treat ANY non-empty porcelain output as dirty
     assert.equal(result.ok, false, 'untracked files = dirty');
   });
+
+  it('rejects_malformed_plan_entries', () => {
+    const malformed = [
+      { from: 'good.md', to: 'QUARANTINE/root-md/good.md' },
+      { from: 123, to: 'QUARANTINE/root-artifacts/bad' },
+      { from: 'also-good.js', to: 'QUARANTINE/root-artifacts/also-good.js' },
+    ];
+    const result = computeMovesToApply({
+      plan: malformed,
+      batch: 10,
+      statusOutput: '',
+    });
+    assert.equal(result.ok, false, 'should reject malformed entries');
+    assert.match(result.error, /malformed/i, 'error mentions malformed');
+    assert.match(result.error, /1/, 'error mentions the index of the bad entry');
+  });
 });

--- a/scripts/quarantine/__tests__/guard.test.mjs
+++ b/scripts/quarantine/__tests__/guard.test.mjs
@@ -24,7 +24,6 @@ describe('checkShape', () => {
       '.github',
       '.gitignore',
       '.husky', // hidden — auto-ignored
-      'node_modules', // ignored
       'QUARANTINE', // ignored
     ];
     const result = checkShape(rootEntries, keepList);
@@ -60,7 +59,7 @@ describe('checkShape', () => {
     assert.deepEqual(result.missingFiles, ['package.json']);
   });
 
-  it('ignores hidden entries, node_modules, and QUARANTINE', () => {
+  it('ignores hidden entries and QUARANTINE', () => {
     const rootEntries = [
       ...keepList.dirs,
       ...keepList.files,
@@ -68,12 +67,17 @@ describe('checkShape', () => {
       '.env',
       '.claude',
       'QUARANTINE',
-      'node_modules',
     ];
     const result = checkShape(rootEntries, keepList);
     assert.deepEqual(result.violations, []);
     assert.deepEqual(result.missingDirs, []);
     assert.deepEqual(result.missingFiles, []);
+  });
+
+  it('flags tracked node_modules as violation', () => {
+    const rootEntries = [...keepList.dirs, ...keepList.files, 'node_modules'];
+    const result = checkShape(rootEntries, keepList);
+    assert.ok(result.violations.includes('node_modules'), 'tracked node_modules is a violation');
   });
 });
 

--- a/scripts/quarantine/__tests__/plan.test.mjs
+++ b/scripts/quarantine/__tests__/plan.test.mjs
@@ -107,7 +107,6 @@ describe('computePlan', () => {
       { name: '.env', type: 'blob' },
       { name: '.claude', type: 'tree' },
       { name: '.ralph', type: 'tree' },
-      { name: 'node_modules', type: 'tree' },
       { name: 'QUARANTINE', type: 'tree' },
       { name: 'intruder', type: 'tree' },
     ];
@@ -115,12 +114,23 @@ describe('computePlan', () => {
     const fromNames = plan.map(m => m.from);
     // Hidden entries excluded
     assert.ok(!fromNames.some(f => f.startsWith('.')), 'no hidden entries in plan');
-    // Ignored entries excluded
-    assert.ok(!fromNames.includes('node_modules/'), 'node_modules excluded');
+    // QUARANTINE excluded
     assert.ok(!fromNames.includes('QUARANTINE/'), 'QUARANTINE excluded');
     // Only the intruder remains
     assert.equal(plan.length, 1);
     assert.equal(plan[0].from, 'intruder/');
     assert.equal(plan[0].to, 'QUARANTINE/top-level-dirs/intruder/');
+  });
+
+  it('plan_quarantines_tracked_node_modules', () => {
+    const entries = [
+      { name: 'node_modules', type: 'tree' },
+      { name: 'intruder', type: 'tree' },
+    ];
+    const plan = computePlan({ entries, keepList });
+    const fromNames = plan.map(m => m.from);
+    assert.ok(fromNames.includes('node_modules/'), 'tracked node_modules gets quarantined');
+    assert.ok(fromNames.includes('intruder/'), 'intruder also quarantined');
+    assert.equal(plan.length, 2);
   });
 });

--- a/scripts/quarantine/apply-core.mjs
+++ b/scripts/quarantine/apply-core.mjs
@@ -24,6 +24,17 @@ export function computeMovesToApply({ plan, batch, statusOutput }) {
     return { ok: false, error: 'No plan provided. Pipe planner output or use --plan <file>.' };
   }
 
+  // Validate entry shape — each entry must have string from/to
+  for (let i = 0; i < plan.length; i++) {
+    const entry = plan[i];
+    if (!entry || typeof entry.from !== 'string' || typeof entry.to !== 'string') {
+      return {
+        ok: false,
+        error: `Malformed plan entry at index ${i}: expected { from: string, to: string }.`,
+      };
+    }
+  }
+
   // Safety: refuse on dirty working tree
   if (statusOutput && statusOutput.trim().length > 0) {
     return {

--- a/scripts/quarantine/apply.mjs
+++ b/scripts/quarantine/apply.mjs
@@ -57,13 +57,27 @@ function readPlan(planFile) {
 
   // Read from stdin (piped JSON) — cross-platform via fd 0
   if (!process.stdin.isTTY) {
+    let raw;
     try {
-      const raw = readFileSync(0, 'utf8').trim();
-      if (raw.length > 0) {
-        return JSON.parse(raw);
-      }
+      raw = readFileSync(0, 'utf8');
     } catch {
       // EOF, pipe closed, or no stdin
+      return null;
+    }
+
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(trimmed);
+    } catch (err) {
+      console.error(
+        'FATAL: Failed to parse plan JSON from stdin: ' +
+          (err && err.message ? err.message : String(err))
+      );
+      process.exit(2);
     }
   }
 

--- a/scripts/quarantine/plan-core.mjs
+++ b/scripts/quarantine/plan-core.mjs
@@ -10,7 +10,7 @@
  *   blob (other) → QUARANTINE/root-artifacts/<name>
  */
 
-const IGNORED = new Set(['node_modules', 'QUARANTINE']);
+const IGNORED = new Set(['QUARANTINE']);
 const HIDDEN_RE = /^\./;
 
 /**

--- a/scripts/quarantine/plan.mjs
+++ b/scripts/quarantine/plan.mjs
@@ -6,7 +6,6 @@
  *   node scripts/quarantine/plan.mjs               # dry-run (human-readable)
  *   node scripts/quarantine/plan.mjs --json         # dry-run (machine-readable)
  *   node scripts/quarantine/plan.mjs --check        # exit 1 if plan is non-empty
- *   node scripts/quarantine/plan.mjs --dry-run      # explicit dry-run (default)
  *
  * All modes are read-only. No mutations are performed.
  */

--- a/scripts/repo-shape-guard.mjs
+++ b/scripts/repo-shape-guard.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = resolve(__filename, '../..');
 
-const IGNORED = new Set(['node_modules', 'QUARANTINE']);
+const IGNORED = new Set(['QUARANTINE']);
 const HIDDEN_RE = /^\./;
 
 /**


### PR DESCRIPTION
## Summary
Applies all 6 review comments from PR #284 (Copilot review).

## Changes
1. **node_modules no longer ignored** — tracked node_modules flagged as violation by guard & planner
2. **Removed --dry-run** from plan.mjs usage docs (flag doesn't exist)
3. **Separated stdin errors** — apply.mjs now distinguishes read vs parse failures
4. **Entry shape validation** — apply-core.mjs validates from/to are strings
5. **CI tests step** — quarantine toolchain tests run in SEAL gate workflow
6. **New tests** — flags_tracked_node_modules_as_violation, plan_quarantines_tracked_node_modules, rejects_malformed_plan_entries

## Evidence
- Tests: 54/54 pass (8 guard + 6 plan + 8 apply + 32 phase83)
- Gates: node --test all green
- No new dependencies

## Summary by Sourcery

Tighten quarantine tooling behavior, validation, and coverage around tracked node_modules, plan input handling, and CI execution.

Bug Fixes:
- Ensure apply.mjs cleanly distinguishes missing/empty stdin from malformed JSON and exits with an error on parse failures.
- Validate quarantine plan entries in apply-core.mjs, rejecting plans whose from/to fields are not strings.
- Treat tracked node_modules directories as violations instead of ignoring them in repo shape guard and quarantine planning.

Enhancements:
- Adjust quarantine planning and guard logic so QUARANTINE remains ignored while tracked node_modules are quarantined and reported appropriately.

CI:
- Add quarantine toolchain tests to the SEAL gate fast workflow to run under node --test.

Documentation:
- Correct quarantine plan.mjs usage documentation by removing the unsupported --dry-run flag.

Tests:
- Add tests for rejecting malformed plan entries, quarantining tracked node_modules, and flagging tracked node_modules as a repo shape violation.