### PR TITLE
fix(ci): disable stale workflows, add workflow-path integrity guard

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,10 +1,10 @@
 name: E2E Smoke - TerraFusion cOS
 
+# DISABLED: terrafusion-cos/ was quarantined (PR #291).
+# All jobs reference working-directory: terrafusion-cos/ which no longer exists.
+# Kept as workflow_dispatch for reference; re-enable when path is restored.
 on:
   workflow_dispatch:
-
-  push:
-    branches: [main]
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-ci-isolated.yml
+++ b/.github/workflows/frontend-ci-isolated.yml
@@ -1,8 +1,9 @@
 name: Frontend CI (isolated)
 
+# DISABLED: terrafusion-cos/ was quarantined (PR #291).
+# All jobs reference working-directory: terrafusion-cos which no longer exists.
+# Kept as workflow_dispatch for reference; re-enable when path is restored.
 on:
-  push:
-    branches: [main, develop]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/grfe-ci.yaml
+++ b/.github/workflows/grfe-ci.yaml
@@ -1,12 +1,15 @@
 name: grfe-ci
 
+# DISABLED: monorepo-scaffolding/ was quarantined.
+# All jobs reference working-directory: monorepo-scaffolding which no longer exists.
+# Kept as workflow_dispatch for reference; re-enable when path is restored.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -387,6 +387,10 @@ jobs:
         shell: bash
         run: node --test scripts/quarantine/__tests__/*.test.mjs
 
+      - name: Workflow path integrity
+        shell: bash
+        run: node --test scripts/governance/__tests__/workflow-paths.test.mjs
+
       - name: Repo shape guard (root spine allowlist)
         id: shape-guard
         shell: bash
@@ -422,6 +426,7 @@ jobs:
           echo "| AGENTS.md Compliance | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Drift Guard | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Quarantine Tests | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow Path Integrity | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Repo Shape Guard | ${{ steps.shape-guard.outcome == 'success' && '✅' || '⚠️' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Quarantine Plan | ${{ vars.QUARANTINE_STRICT == 'true' && '✅ (strict)' || '⏭️ (not strict)' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ governance: ## Run quarantine governance gates (guard + plan + tests)
 	@node scripts/repo-shape-guard.mjs
 	@node scripts/quarantine/plan.mjs --check
 	@node --test scripts/quarantine/__tests__/*.test.mjs os-platform/core/tests/phase83-tools.test.mjs
+	@node --test scripts/governance/__tests__/workflow-paths.test.mjs
 	@echo ""
 	@echo "✅ All governance gates passed"
 

--- a/scripts/governance/__tests__/workflow-paths.test.mjs
+++ b/scripts/governance/__tests__/workflow-paths.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * Workflow working-directory path validation tests.
+ *
+ * Prevents GitHub Actions workflows from referencing working directories
+ * that don't exist in the Git-tracked tree (e.g., after quarantine).
+ *
+ * Run: node --test scripts/governance/__tests__/workflow-paths.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  extractWorkingDirs,
+  getGitRootEntries,
+  normalizePath,
+  rootComponent,
+  STALE_PATH_EXEMPTIONS,
+  validateWorkflowPaths,
+} from '../workflow-paths.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const WORKFLOW_DIR = join(REPO_ROOT, '.github', 'workflows');
+
+// ── extractWorkingDirs ──────────────────────────────────────────────
+
+describe('extractWorkingDirs', () => {
+  it('extracts simple working-directory values', () => {
+    const yaml = `
+    steps:
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+      - name: Test
+        working-directory: ./backend
+        run: dotnet test
+    `;
+    const result = extractWorkingDirs(yaml);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].path, 'frontend');
+    assert.equal(result[1].path, './backend');
+  });
+
+  it('extracts quoted paths', () => {
+    const yaml = `        working-directory: "some/path"`;
+    const result = extractWorkingDirs(yaml);
+    assert.equal(result[0].path, 'some/path');
+  });
+
+  it('returns empty for yaml without working-directory', () => {
+    const yaml = `
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    `;
+    assert.deepEqual(extractWorkingDirs(yaml), []);
+  });
+});
+
+// ── normalizePath ───────────────────────────────────────────────────
+
+describe('normalizePath', () => {
+  it('strips leading ./', () => {
+    assert.equal(normalizePath('./frontend'), 'frontend');
+  });
+
+  it('strips trailing /', () => {
+    assert.equal(normalizePath('frontend/'), 'frontend');
+  });
+
+  it('returns null for current directory', () => {
+    assert.equal(normalizePath('.'), null);
+    assert.equal(normalizePath('./'), null);
+  });
+
+  it('returns null for dynamic expressions', () => {
+    assert.equal(normalizePath('${{ steps.rust.outputs.dir }}'), null);
+  });
+
+  it('preserves nested paths', () => {
+    assert.equal(normalizePath('./tools/scope-classifier'), 'tools/scope-classifier');
+  });
+});
+
+// ── rootComponent ───────────────────────────────────────────────────
+
+describe('rootComponent', () => {
+  it('returns first path segment', () => {
+    assert.equal(rootComponent('frontend'), 'frontend');
+    assert.equal(rootComponent('tools/scope-classifier'), 'tools');
+    assert.equal(rootComponent('applications/terraforge-suite/harness'), 'applications');
+  });
+});
+
+// ── validateWorkflowPaths (live) ────────────────────────────────────
+
+describe('validateWorkflowPaths (live)', () => {
+  const gitRootEntries = getGitRootEntries(REPO_ROOT);
+
+  it('finds no non-exempted violations in current workflows', () => {
+    const { violations, checked } = validateWorkflowPaths(WORKFLOW_DIR, gitRootEntries);
+    if (violations.length > 0) {
+      const detail = violations
+        .map(v => `  ${v.workflow}:${v.line} → working-directory: ${v.path} (root "${v.rootDir}" not in git tree)`)
+        .join('\n');
+      assert.fail(
+        `${violations.length} workflow(s) reference non-existent working directories:\n${detail}\n\n` +
+        'Fix: update the workflow path, or add to STALE_PATH_EXEMPTIONS in workflow-paths.mjs'
+      );
+    }
+    assert.ok(checked > 0, `expected to check at least 1 working-directory, checked ${checked}`);
+  });
+
+  it('exempted stale paths are documented with reason', () => {
+    for (const entry of STALE_PATH_EXEMPTIONS) {
+      assert.ok(entry.workflow, 'exemption must name a workflow');
+      assert.ok(entry.paths.length > 0, 'exemption must list at least one path');
+      assert.ok(entry.reason.length > 10, `exemption for ${entry.workflow} must have a meaningful reason`);
+    }
+  });
+
+  it('exempted paths actually reference missing root dirs', () => {
+    // Ensure exemptions aren't stale themselves (if path was restored, remove exemption)
+    for (const entry of STALE_PATH_EXEMPTIONS) {
+      for (const p of entry.paths) {
+        const root = rootComponent(p);
+        assert.ok(
+          !gitRootEntries.has(root),
+          `Stale exemption: ${entry.workflow} exempts "${p}" but "${root}" now exists in git. Remove the exemption.`
+        );
+      }
+    }
+  });
+});
+
+// ── validateWorkflowPaths (synthetic) ───────────────────────────────
+
+describe('validateWorkflowPaths (synthetic)', () => {
+  it('detects stale terrafusion-cos path in synthetic workflow', () => {
+    // This test uses the real git root entries but a synthetic scenario
+    const gitRootEntries = new Set(['frontend', 'backend', 'tools', 'scripts']);
+    const mockValidate = (paths) => {
+      const violations = [];
+      for (const p of paths) {
+        const normalized = normalizePath(p);
+        if (!normalized) continue;
+        const root = rootComponent(normalized);
+        if (!gitRootEntries.has(root)) {
+          violations.push({ path: normalized, rootDir: root });
+        }
+      }
+      return violations;
+    };
+
+    const violations = mockValidate(['terrafusion-cos', 'frontend', 'tools/scope-classifier']);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].path, 'terrafusion-cos');
+  });
+});

--- a/scripts/governance/workflow-paths.mjs
+++ b/scripts/governance/workflow-paths.mjs
@@ -1,0 +1,187 @@
+/**
+ * Workflow working-directory path validator.
+ *
+ * Extracts `working-directory:` values from GitHub Actions YAML files
+ * and validates that referenced paths exist in the Git-tracked tree.
+ *
+ * Zero dependencies — uses only Node built-ins.
+ */
+import { execSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Paths that are dynamically created during workflow execution and cannot
+ * be validated against the static git tree. Each entry must have a reason.
+ */
+const DYNAMIC_PATH_EXEMPTIONS = new Set([
+  // performance-regression.yml checks out main into a temp directory
+  'main-branch/frontend',
+]);
+
+/**
+ * Workflows that are known to reference stale working-directory paths.
+ * These are pre-existing tech debt documented here for visibility.
+ * Each entry: { workflow, paths[], reason }
+ */
+export const STALE_PATH_EXEMPTIONS = [
+  {
+    workflow: 'frontend-ci-isolated.yml',
+    paths: ['terrafusion-cos', 'terrafusion-cos/e2e'],
+    reason: 'terrafusion-cos/ was quarantined (PR #291); workflow disabled to workflow_dispatch only',
+  },
+  {
+    workflow: 'e2e-smoke.yml',
+    paths: ['terrafusion-cos/frontend_engine', 'terrafusion-cos/e2e'],
+    reason: 'terrafusion-cos/ was quarantined (PR #291); workflow disabled to workflow_dispatch only',
+  },
+  {
+    workflow: 'grfe-ci.yaml',
+    paths: ['monorepo-scaffolding'],
+    reason: 'monorepo-scaffolding/ was quarantined; workflow disabled to workflow_dispatch only',
+  },
+  {
+    workflow: 'benton.yml',
+    paths: ['counties/benton'],
+    reason: 'counties/ was quarantined; workflow triggers only on paths that no longer exist',
+  },
+  {
+    workflow: 'infrastructure-cicd.yml',
+    paths: ['infrastructure/terraform', 'infrastructure/helm'],
+    reason: 'infrastructure/ was quarantined; workflow is non-required',
+  },
+  {
+    workflow: 'rust-security-gates.yml',
+    paths: ['rust-performance-engine'],
+    reason: 'rust-performance-engine/ was quarantined; workflow is non-required',
+  },
+  {
+    workflow: 'terra-levy-tests.yml',
+    paths: ['SDK/modules/terra-levy'],
+    reason: 'SDK/ was quarantined; workflow is non-required',
+  },
+  {
+    workflow: 'terraforge-ci.yml',
+    paths: [
+      'applications/terraforge-suite/harness',
+      'applications/terraforge-suite/modules/terraforge.kernel.cost',
+      'applications/terraforge-suite/modules/terraforge.kernel.valuation',
+    ],
+    reason: 'applications/ is forbidden scope per AGENTS.md; workflow is non-required',
+  },
+];
+
+/**
+ * Extract working-directory values from a YAML string.
+ * Returns array of { line, path } objects.
+ */
+export function extractWorkingDirs(yamlContent) {
+  const results = [];
+  const lines = yamlContent.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^\s*working-directory:\s*(.+)$/);
+    if (!match) continue;
+    let raw = match[1].trim();
+    // Strip quotes if present
+    if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
+      raw = raw.slice(1, -1);
+    }
+    results.push({ line: i + 1, path: raw });
+  }
+  return results;
+}
+
+/**
+ * Normalize a working-directory path for validation.
+ * Returns null if the path should be skipped (dynamic expressions, current dir).
+ */
+export function normalizePath(rawPath) {
+  // Skip GitHub Actions expressions (dynamic paths)
+  if (rawPath.includes('${{')) return null;
+  // Skip current directory
+  if (rawPath === '.' || rawPath === './') return null;
+  // Strip leading ./
+  let p = rawPath.replace(/^\.\//, '');
+  // Strip trailing /
+  p = p.replace(/\/+$/, '');
+  return p || null;
+}
+
+/**
+ * Get the first path component (root directory) of a normalized path.
+ */
+export function rootComponent(normalizedPath) {
+  return normalizedPath.split('/')[0];
+}
+
+/**
+ * Get the set of root entries tracked by Git.
+ * Runs `git ls-tree --name-only HEAD` from the given cwd.
+ */
+export function getGitRootEntries(cwd) {
+  const output = execSync('git ls-tree --name-only HEAD', {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return new Set(output.trim().split('\n').filter(Boolean));
+}
+
+/**
+ * Build a set of exempted (workflow, path) pairs from STALE_PATH_EXEMPTIONS.
+ */
+function buildExemptionSet() {
+  const set = new Set();
+  for (const entry of STALE_PATH_EXEMPTIONS) {
+    for (const p of entry.paths) {
+      set.add(`${entry.workflow}::${p}`);
+    }
+  }
+  return set;
+}
+
+/**
+ * Validate all workflow files under workflowDir.
+ * Returns { violations: [{ workflow, line, path, rootDir }], checked: number }
+ */
+export function validateWorkflowPaths(workflowDir, gitRootEntries) {
+  const exemptions = buildExemptionSet();
+  const violations = [];
+  let checked = 0;
+
+  let files;
+  try {
+    files = readdirSync(workflowDir).filter(f => f.endsWith('.yml') || f.endsWith('.yaml'));
+  } catch {
+    return { violations: [], checked: 0 };
+  }
+
+  for (const file of files) {
+    const content = readFileSync(join(workflowDir, file), 'utf8');
+    const workdirs = extractWorkingDirs(content);
+
+    for (const { line, path: rawPath } of workdirs) {
+      const normalized = normalizePath(rawPath);
+      if (!normalized) continue;
+
+      // Skip dynamic path exemptions
+      if (DYNAMIC_PATH_EXEMPTIONS.has(normalized)) continue;
+
+      checked++;
+
+      const root = rootComponent(normalized);
+      if (!gitRootEntries.has(root)) {
+        // Check if this is an exempted stale path
+        const key = `${file}::${normalized}`;
+        const keyRoot = `${file}::${root}`;
+        const isExempt = exemptions.has(key) ||
+          [...exemptions].some(e => e.startsWith(`${file}::`) && normalized.startsWith(e.split('::')[1]));
+        if (!isExempt) {
+          violations.push({ workflow: file, line, path: normalized, rootDir: root });
+        }
+      }
+    }
+  }
+
+  return { violations, checked };
+}

--- a/tools/dev/governance.ps1
+++ b/tools/dev/governance.ps1
@@ -2,10 +2,11 @@
 .SYNOPSIS
   Run quarantine governance gates locally.
 .DESCRIPTION
-  Executes the three governance checks that SEAL enforces in CI:
+  Executes the governance checks that SEAL enforces in CI:
     1. Repo shape guard (root spine allowlist)
     2. Quarantine plan --check (no pending moves)
     3. Quarantine + platform test suites
+    4. Workflow path integrity (no stale working-directory refs)
 .EXAMPLE
   pwsh tools/dev/governance.ps1
 #>
@@ -19,18 +20,23 @@ Write-Host "`n🔒 Quarantine Governance Gates" -ForegroundColor Cyan
 Write-Host ("═" * 60)
 
 # Gate 1: Repo shape guard
-Write-Host "`n[1/3] Repo shape guard..." -ForegroundColor Yellow
+Write-Host "`n[1/4] Repo shape guard..." -ForegroundColor Yellow
 node scripts/repo-shape-guard.mjs
 if ($LASTEXITCODE -ne 0) { Write-Error "Repo shape guard FAILED"; exit 1 }
 
 # Gate 2: Quarantine plan --check
-Write-Host "`n[2/3] Quarantine plan --check..." -ForegroundColor Yellow
+Write-Host "`n[2/4] Quarantine plan --check..." -ForegroundColor Yellow
 node scripts/quarantine/plan.mjs --check
 if ($LASTEXITCODE -ne 0) { Write-Error "Quarantine plan check FAILED"; exit 1 }
 
 # Gate 3: Test suites
-Write-Host "`n[3/3] Governance test suites..." -ForegroundColor Yellow
+Write-Host "`n[3/4] Governance test suites..." -ForegroundColor Yellow
 node --test scripts/quarantine/__tests__/*.test.mjs os-platform/core/tests/phase83-tools.test.mjs
 if ($LASTEXITCODE -ne 0) { Write-Error "Governance tests FAILED"; exit 1 }
+
+# Gate 4: Workflow path integrity
+Write-Host "`n[4/4] Workflow path integrity..." -ForegroundColor Yellow
+node --test scripts/governance/__tests__/workflow-paths.test.mjs
+if ($LASTEXITCODE -ne 0) { Write-Error "Workflow path integrity FAILED"; exit 1 }
 
 Write-Host "`n✅ All governance gates passed" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Fixes Frontend CI (isolated) regression on main caused by quarantined `terrafusion-cos/` working directory. Adds a permanent guard to prevent this class of bug.

### Problem

Three workflows reference `working-directory:` paths that no longer exist after quarantine:
- `frontend-ci-isolated.yml` → `terrafusion-cos`
- `e2e-smoke.yml` → `terrafusion-cos/frontend_engine`, `terrafusion-cos/e2e`
- `grfe-ci.yaml` → `monorepo-scaffolding`

### Fix

1. **Disable push triggers** on all three workflows (retained as `workflow_dispatch` for reference)
2. **New test suite**: `scripts/governance/__tests__/workflow-paths.test.mjs` (13 tests, 5 suites)
   - Extracts all `working-directory:` values from workflow YAML
   - Validates root directories exist in `git ls-tree HEAD`
   - Supports exemptions for pre-existing known-stale paths (documented)
3. **Wired into SEAL**: governance-fast gate now runs workflow-path integrity check
4. **Updated local tools**: `make governance` and `pwsh tools/dev/governance.ps1`

### Pre-existing Stale Exemptions (documented, not blocking)

| Workflow | Stale Path | Reason |
|----------|-----------|--------|
| benton.yml | counties/benton | counties/ quarantined |
| infrastructure-cicd.yml | infrastructure/{terraform,helm} | infrastructure/ quarantined |
| rust-security-gates.yml | rust-performance-engine | quarantined |
| terra-levy-tests.yml | SDK/modules/terra-levy | SDK/ quarantined |
| terraforge-ci.yml | applications/terraforge-suite/* | forbidden scope per AGENTS.md |

### Gates
- Guard: 0 violations
- Plan: 0 moves
- Tests: 68/68 pass (20 suites)

### Files

| File | Change |
|------|--------|
| `.github/workflows/frontend-ci-isolated.yml` | Remove push trigger |
| `.github/workflows/e2e-smoke.yml` | Remove push trigger |
| `.github/workflows/grfe-ci.yaml` | Remove push trigger |
| `.github/workflows/seal-gate-fast.yml` | Add workflow-paths test step |
| `scripts/governance/workflow-paths.mjs` | New: path validator + exemptions |
| `scripts/governance/__tests__/workflow-paths.test.mjs` | New: 13 tests |
| `Makefile` | Add workflow-paths to governance target |
| `tools/dev/governance.ps1` | Add gate 4: workflow-path integrity |

## Summary by Sourcery

Disable CI workflows that reference quarantined directories and add an automated guard to prevent future stale workflow working-directory paths.

New Features:
- Introduce a workflow working-directory path validator and test suite to detect workflow references to non-existent Git-tracked paths.
- Add workflow-path integrity as a governance gate runnable locally and in the fast SEAL gate.

Bug Fixes:
- Stop running workflows whose working directories were quarantined by disabling their push triggers and retaining only manual dispatch.

Enhancements:
- Document and centrally manage exemptions for known stale or dynamic workflow paths to keep the guard signal focused.

Build:
- Wire workflow-path integrity tests into the Makefile governance target used for local checks.

CI:
- Update SEAL fast gate workflow to run workflow-path integrity checks and surface their status in the gate summary.

Tests:
- Add unit and integration tests around workflow path extraction, normalization, exemption handling, and live validation against current workflows.

Chores:
- Clarify local governance script messaging and step numbering to account for the new workflow-path integrity gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced workflow path validation system to identify and prevent invalid or stale working-directory references in CI/CD configurations.

* **Tests**
  * Added comprehensive test suite for workflow path validation with real and synthetic test scenarios.

* **Chores**
  * Changed automatic CI triggers to manual dispatch for specified workflows.
  * Enhanced governance gates to include workflow path integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->