### PR TITLE
test(governance): clarify governance test totals by suite

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -383,11 +383,18 @@ jobs:
         shell: bash
         run: node scripts/platform-lint.mjs
 
-      - name: Quarantine toolchain tests
+      - name: Quarantine toolchain tests (23 tests / 4 suites)
+        id: quarantine-tests
         shell: bash
         run: node --test scripts/quarantine/__tests__/*.test.mjs
 
-      - name: Workflow path integrity
+      - name: Phase83 platform tests (32 tests / 11 suites)
+        id: phase83-tests
+        shell: bash
+        run: node --test os-platform/core/tests/phase83-tools.test.mjs
+
+      - name: Workflow path integrity (13 tests / 5 suites)
+        id: workflow-tests
         shell: bash
         run: node --test scripts/governance/__tests__/workflow-paths.test.mjs
 
@@ -425,8 +432,10 @@ jobs:
           echo "| Workspace Sanity | ${{ steps.shape-guard.outcome != '' && '✅' || '⏭️' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| AGENTS.md Compliance | ✅ |" >> $GITHUB_STEP_SUMMARY
           echo "| Drift Guard | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Quarantine Tests | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| Workflow Path Integrity | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "| Quarantine Tests (23t/4s) | ${{ steps.quarantine-tests.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Phase83 Tests (32t/11s) | ${{ steps.phase83-tests.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Workflow Paths (13t/5s) | ${{ steps.workflow-tests.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Total: 68 tests / 20 suites** | |" >> $GITHUB_STEP_SUMMARY
           echo "| Repo Shape Guard | ${{ steps.shape-guard.outcome == 'success' && '✅' || '⚠️' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Quarantine Plan | ${{ vars.QUARANTINE_STRICT == 'true' && '✅ (strict)' || '⏭️ (not strict)' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,17 @@ governance: ## Run quarantine governance gates (guard + plan + tests)
 	@echo "════════════════════════════════════════════════════════════════"
 	@node scripts/repo-shape-guard.mjs
 	@node scripts/quarantine/plan.mjs --check
-	@node --test scripts/quarantine/__tests__/*.test.mjs os-platform/core/tests/phase83-tools.test.mjs
+	@echo ""
+	@echo "[suite] Quarantine toolchain (23 tests / 4 suites)"
+	@node --test scripts/quarantine/__tests__/*.test.mjs
+	@echo ""
+	@echo "[suite] Phase83 platform (32 tests / 11 suites)"
+	@node --test os-platform/core/tests/phase83-tools.test.mjs
+	@echo ""
+	@echo "[suite] Workflow path integrity (13 tests / 5 suites)"
 	@node --test scripts/governance/__tests__/workflow-paths.test.mjs
 	@echo ""
-	@echo "✅ All governance gates passed"
+	@echo "✅ All governance gates passed (68 tests / 20 suites)"
 
 db-migrate: ## Database migrations
 	psql "$$DB_OLTP_DSN" -f db/migrations/001_init_ontology.sql

--- a/docs/governance/QUARANTINE_SOP.md
+++ b/docs/governance/QUARANTINE_SOP.md
@@ -1,6 +1,6 @@
 # Quarantine Governance SOP
 
-**Version:** 1.1  
+**Version:** 1.2  
 **Status:** Active (strict enforcement)  
 **Last Updated:** 2026-02-12
 
@@ -21,6 +21,9 @@ The quarantine system is a **permanent, Git-native control plane** that enforces
 | Planner | `scripts/quarantine/plan.mjs` | Deterministic move-plan computation |
 | Applier | `scripts/quarantine/apply.mjs` | Batch-safe `git mv` execution |
 | Tests | `scripts/quarantine/__tests__/*.test.mjs` | 23 quarantine tests, 4 suites (zero deps) |
+| Workflow Guard | `scripts/governance/__tests__/workflow-paths.test.mjs` | 13 workflow-path tests, 5 suites (zero deps) |
+| Phase83 Tests | `os-platform/core/tests/phase83-tools.test.mjs` | 32 platform tests, 11 suites (zero deps) |
+| **Total** | 3 test files | **68 tests / 20 suites** |
 
 ### Enforcement Variables (GitHub Actions)
 
@@ -63,7 +66,7 @@ Two root directories are **silently ignored** by the guard and planner (they exi
 
 ## Local Verification Commands
 
-Run all three gates before pushing:
+Run all five gates before pushing:
 
 ```bash
 # Option A: Make (Linux/macOS/WSL)
@@ -75,7 +78,9 @@ pwsh tools/dev/governance.ps1
 # Option C: Individual commands
 node scripts/repo-shape-guard.mjs           # Guard: root spine check
 node scripts/quarantine/plan.mjs --check    # Plan: no pending moves
-node --test scripts/quarantine/__tests__/*.test.mjs os-platform/core/tests/phase83-tools.test.mjs
+node --test scripts/quarantine/__tests__/*.test.mjs                     # Quarantine tests (23t/4s)
+node --test os-platform/core/tests/phase83-tools.test.mjs               # Phase83 tests (32t/11s)
+node --test scripts/governance/__tests__/workflow-paths.test.mjs        # Workflow paths (13t/5s)
 ```
 
 ---

--- a/tools/dev/governance.ps1
+++ b/tools/dev/governance.ps1
@@ -5,8 +5,9 @@
   Executes the governance checks that SEAL enforces in CI:
     1. Repo shape guard (root spine allowlist)
     2. Quarantine plan --check (no pending moves)
-    3. Quarantine + platform test suites
-    4. Workflow path integrity (no stale working-directory refs)
+    3. Quarantine toolchain tests (23 tests / 4 suites)
+    4. Phase83 platform tests (32 tests / 11 suites)
+    5. Workflow path integrity (13 tests / 5 suites)
 .EXAMPLE
   pwsh tools/dev/governance.ps1
 #>
@@ -20,23 +21,28 @@ Write-Host "`n🔒 Quarantine Governance Gates" -ForegroundColor Cyan
 Write-Host ("═" * 60)
 
 # Gate 1: Repo shape guard
-Write-Host "`n[1/4] Repo shape guard..." -ForegroundColor Yellow
+Write-Host "`n[1/5] Repo shape guard..." -ForegroundColor Yellow
 node scripts/repo-shape-guard.mjs
 if ($LASTEXITCODE -ne 0) { Write-Error "Repo shape guard FAILED"; exit 1 }
 
 # Gate 2: Quarantine plan --check
-Write-Host "`n[2/4] Quarantine plan --check..." -ForegroundColor Yellow
+Write-Host "`n[2/5] Quarantine plan --check..." -ForegroundColor Yellow
 node scripts/quarantine/plan.mjs --check
 if ($LASTEXITCODE -ne 0) { Write-Error "Quarantine plan check FAILED"; exit 1 }
 
-# Gate 3: Test suites
-Write-Host "`n[3/4] Governance test suites..." -ForegroundColor Yellow
-node --test scripts/quarantine/__tests__/*.test.mjs os-platform/core/tests/phase83-tools.test.mjs
-if ($LASTEXITCODE -ne 0) { Write-Error "Governance tests FAILED"; exit 1 }
+# Gate 3: Quarantine toolchain tests (23 tests / 4 suites)
+Write-Host "`n[3/5] Quarantine toolchain tests (23t/4s)..." -ForegroundColor Yellow
+node --test scripts/quarantine/__tests__/*.test.mjs
+if ($LASTEXITCODE -ne 0) { Write-Error "Quarantine toolchain tests FAILED"; exit 1 }
 
-# Gate 4: Workflow path integrity
-Write-Host "`n[4/4] Workflow path integrity..." -ForegroundColor Yellow
+# Gate 4: Phase83 platform tests (32 tests / 11 suites)
+Write-Host "`n[4/5] Phase83 platform tests (32t/11s)..." -ForegroundColor Yellow
+node --test os-platform/core/tests/phase83-tools.test.mjs
+if ($LASTEXITCODE -ne 0) { Write-Error "Phase83 platform tests FAILED"; exit 1 }
+
+# Gate 5: Workflow path integrity (13 tests / 5 suites)
+Write-Host "`n[5/5] Workflow path integrity (13t/5s)..." -ForegroundColor Yellow
 node --test scripts/governance/__tests__/workflow-paths.test.mjs
 if ($LASTEXITCODE -ne 0) { Write-Error "Workflow path integrity FAILED"; exit 1 }
 
-Write-Host "`n✅ All governance gates passed" -ForegroundColor Green
+Write-Host "`n✅ All governance gates passed (68 tests / 20 suites)" -ForegroundColor Green


### PR DESCRIPTION
## Per-Suite Governance Metrics

Breaks the rolled-up \\68 tests / 20 suites\\ into explicit per-suite counts so governance summaries never look like mystery growth.

### Changes

| File | Change |
|------|--------|
| \\seal-gate-fast.yml\\ | 3 separate test steps (quarantine, phase83, workflow-paths) with IDs; summary table shows per-suite counts |
| \\Makefile\\ | \\governance\\ target runs 3 labelled test invocations |
| \\governance.ps1\\ | 5-gate structure (was 4) with per-suite labels |
| \\QUARANTINE_SOP.md\\ | v1.2: full test inventory in architecture table + 5-gate local commands |

### Suite Breakdown

| Suite | Tests | Suites |
|-------|-------|--------|
| Quarantine toolchain | 23 | 4 |
| Phase83 platform | 32 | 11 |
| Workflow path integrity | 13 | 5 |
| **Total** | **68** | **20** |

### Evidence
\\\\pwsh tools/dev/governance.ps1\\\\ passes with explicit per-suite output.

## Summary by Sourcery

Clarify and surface per-suite governance test counts across local scripts, CI workflow, and documentation so governance metrics are explicit instead of rolled up.

New Features:
- Expose separate governance test suites for quarantine toolchain, Phase83 platform, and workflow path integrity in CI summaries and local commands.

Enhancements:
- Split the governance test gate into three labelled suites with explicit test and suite counts in the PowerShell script and Makefile target.
- Update the fast SEAL gate GitHub Actions workflow to run the three governance suites as distinct steps and report their individual and total counts in the step summary.
- Refresh quarantine governance documentation to include a full test inventory, per-suite counts, and five-gate local verification instructions.

Documentation:
- Document detailed governance test inventory and updated five-gate workflow in the quarantine SOP, including per-suite and total test counts.