### PR TITLE
ci(seal): add explicit phase4 security regression visibility

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -239,6 +239,16 @@ jobs:
             -v:minimal \
             || dotnet test backend/TerraFusion.sln -c Release --no-build -v:minimal
 
+      - name: Phase 4 security regression visibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj \
+            -c Release \
+            --no-build \
+            --filter "FullyQualifiedName~SecurityTodoGateTests|FullyQualifiedName~AuthenticationRateLimitTests|FullyQualifiedName~AuditCorrelationTests|FullyQualifiedName~JwtTokenServiceSecurityTests" \
+            -v:minimal
+
   # ═══════════════════════════════════════════════════════════════════════════
   # Governance Fast Gate (drift guard, scope classifier)
   # ═══════════════════════════════════════════════════════════════════════════

--- a/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
+++ b/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
@@ -58,6 +58,54 @@ public sealed class AuditCorrelationTests
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("successful");
     }
 
+    [Fact]
+    public async Task AuthorizationDenied_EmitsAudit_WithCorrelationId()
+    {
+        var (auditLogger, provider, correlationId) = BuildAuditLogger();
+
+        await auditLogger.LogAuthorizationAsync("user-authz-denied", "api/secure-resource", granted: false);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var log = await db.AuditLogs
+            .OrderByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(x => x.UserId == "user-authz-denied");
+
+        log.Should().NotBeNull();
+        log!.Type.Should().StartWith("Authorization:");
+        log.CorrelationId.Should().Be(correlationId);
+
+        using var doc = JsonDocument.Parse(log.Data);
+        doc.RootElement.GetProperty("Details").GetString().Should().Contain("denied");
+    }
+
+    [Fact]
+    public async Task ConfigurationChange_EmitsAudit_WithCorrelationId()
+    {
+        var (auditLogger, provider, correlationId) = BuildAuditLogger();
+
+        await auditLogger.LogConfigurationChangeAsync(
+            setting: "Privileges:RoleAssignment",
+            oldValue: "Assessor",
+            newValue: "CountyAdmin",
+            userId: "user-config-change");
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var log = await db.AuditLogs
+            .OrderByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(x => x.UserId == "user-config-change");
+
+        log.Should().NotBeNull();
+        log!.Type.Should().StartWith("ConfigurationChange:");
+        log.CorrelationId.Should().Be(correlationId);
+
+        using var doc = JsonDocument.Parse(log.Data);
+        doc.RootElement.GetProperty("Details").GetString().Should().Contain("Configuration changed");
+        doc.RootElement.GetProperty("OldValue").GetString().Should().Be("Assessor");
+        doc.RootElement.GetProperty("NewValue").GetString().Should().Be("CountyAdmin");
+    }
+
     private static (AuditLogger AuditLogger, ServiceProvider Provider, string CorrelationId) BuildAuditLogger()
     {
         var correlationId = $"corr-{Guid.NewGuid():N}";

--- a/backend/TerraFusion.API.Tests/AuthenticationRateLimitTests.cs
+++ b/backend/TerraFusion.API.Tests/AuthenticationRateLimitTests.cs
@@ -52,18 +52,24 @@ public sealed class AuthenticationRateLimitTests : IClassFixture<ApiWebAppFactor
 
         using var client = configuredFactory.CreateClient();
 
-        var request = new LoginRequest
+        var baselineResponse = await client.PostAsJsonAsync("/api/auth/login", new LoginRequest
         {
-            // Intentionally invalid format to keep execution on model validation path
-            // and avoid auth service dependencies masking rate-limit behavior.
-            Email = "invalid-email",
-            Password = "TestPassword123!"
-        };
+            Email = "baseline@gov.",
+            Password = "BaselinePassword123!"
+        });
+
+        baselineResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "normal auth traffic should preserve expected login semantics");
 
         var statuses = new List<HttpStatusCode>();
 
         for (var i = 0; i < 40; i++)
         {
+            var request = new LoginRequest
+            {
+                Email = $"burst-{i}@gov.",
+                Password = "BurstPassword123!"
+            };
             var response = await client.PostAsJsonAsync("/api/auth/login", request);
             statuses.Add(response.StatusCode);
         }
@@ -76,5 +82,27 @@ public sealed class AuthenticationRateLimitTests : IClassFixture<ApiWebAppFactor
 
         statuses.Should().Contain(HttpStatusCode.TooManyRequests,
             "auth login endpoint must enforce burst throttling and return HTTP 429");
+
+        statuses.Should().Contain(HttpStatusCode.OK,
+            "rate limiting should throttle bursts without breaking normal successful auth outcomes");
+    }
+
+    [Fact]
+    public async Task NonAuthEndpoint_Burst_DoesNotReturn429()
+    {
+        using var client = _factory.CreateClient();
+
+        var statuses = new List<HttpStatusCode>();
+        for (var i = 0; i < 40; i++)
+        {
+            var response = await client.GetAsync("/healthz");
+            statuses.Add(response.StatusCode);
+        }
+
+        statuses.Should().NotContain(HttpStatusCode.NotFound,
+            "health endpoint must exist and remain routable during throttling validation");
+
+        statuses.Should().NotContain(HttpStatusCode.TooManyRequests,
+            "ApiPolicy is scoped to auth endpoints and must not throttle non-auth health probes");
     }
 }


### PR DESCRIPTION
## Summary
Add explicit Phase 4 security regression visibility in SEAL fast path backend gate.

## Change
- Update `.github/workflows/seal-gate-fast.yml`
- Add a targeted `dotnet test` step in `backend-fast` for:
  - `SecurityTodoGateTests`
  - `AuthenticationRateLimitTests`
  - `AuditCorrelationTests`
  - `JwtTokenServiceSecurityTests`

## Why
Make Phase 4 hardening checks visible and fail-fast in SEAL, without broadening workflow scope.

## Local verification
- `node --test scripts/governance/__tests__/workflow-paths.test.mjs`
- `node --test scripts/governance/__tests__/workflow-inventory.test.mjs scripts/governance/__tests__/workflow-inventory.integration.test.mjs`
- `node scripts/governance/workflow-inventory.mjs --check`
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~SecurityTodoGateTests|FullyQualifiedName~AuthenticationRateLimitTests|FullyQualifiedName~AuditCorrelationTests|FullyQualifiedName~JwtTokenServiceSecurityTests" -v:minimal`

## Summary by Sourcery

CI:
- Update the SEAL fast gate GitHub Actions workflow to run a focused dotnet test step covering key security regression test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced authentication rate limiting test coverage with improved validation scenarios
  * Added audit correlation verification tests
  * Strengthened security regression testing in the continuous integration pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->