### PR TITLE
feat(security): phase4 jwt hardening + seal visibility

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -246,7 +246,12 @@ jobs:
           dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj \
             -c Release \
             --no-build \
-            --filter "FullyQualifiedName~SecurityTodoGateTests|FullyQualifiedName~AuthenticationRateLimitTests|FullyQualifiedName~AuditCorrelationTests|FullyQualifiedName~JwtTokenServiceSecurityTests" \
+            --filter "FullyQualifiedName~SecurityTodoGateTests|FullyQualifiedName~JwtTokenServiceSecurityTests" \
+            -v:minimal
+          dotnet test backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj \
+            -c Release \
+            --no-build \
+            --filter "FullyQualifiedName~AuthenticationRateLimitTests|FullyQualifiedName~AuditCorrelationTests" \
             -v:minimal
 
   # ═══════════════════════════════════════════════════════════════════════════

--- a/backend/src/TerraFusion.API/Services/JwtTokenService.cs
+++ b/backend/src/TerraFusion.API/Services/JwtTokenService.cs
@@ -139,7 +139,7 @@ namespace TerraFusion.API.Services
                     ValidateAudience = true,
                     ValidAudience = _audience,
                     ValidateLifetime = true,
-                    ClockSkew = TimeSpan.FromMinutes(1) // Allow 1 minute clock skew
+                    ClockSkew = TimeSpan.Zero
                 };
 
                 var principal = tokenHandler.ValidateToken(token, validationParameters, out var validatedToken);

--- a/backend/tests/TerraFusion.Integration.Tests/Phase37/GrafanaDashboardValidationTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/Phase37/GrafanaDashboardValidationTests.cs
@@ -53,8 +53,13 @@ public class GrafanaDashboardValidationTests
     private static string GetRepositoryRoot()
     {
         var current = Directory.GetCurrentDirectory();
-        while (current != null && !Directory.Exists(Path.Combine(current, ".git")))
+        while (current != null)
         {
+            var gitPath = Path.Combine(current, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return current;
+            }
             current = Directory.GetParent(current)?.FullName;
         }
         return current ?? Directory.GetCurrentDirectory();

--- a/backend/tests/TerraFusion.Integration.Tests/Phase38/AlertRuleValidationTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/Phase38/AlertRuleValidationTests.cs
@@ -52,8 +52,13 @@ public class AlertRuleValidationTests
     private static string GetRepositoryRoot()
     {
         var current = Directory.GetCurrentDirectory();
-        while (current != null && !Directory.Exists(Path.Combine(current, ".git")))
+        while (current != null)
         {
+            var gitPath = Path.Combine(current, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return current;
+            }
             current = Directory.GetParent(current)?.FullName;
         }
         return current ?? Directory.GetCurrentDirectory();

--- a/backend/tests/TerraFusion.Unit.Tests/Phase4/JwtTokenServiceSecurityTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Phase4/JwtTokenServiceSecurityTests.cs
@@ -1,0 +1,145 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.Tokens;
+using TerraFusion.API.Services;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Phase4;
+
+[Trait("Phase", "4")]
+[Trait("Component", "JwtTokenService")]
+[Trait("Category", "Security")]
+public sealed class JwtTokenServiceSecurityTests
+{
+    private const string ExpectedIssuer = "TerraFusion.Test.Issuer";
+    private const string ExpectedAudience = "TerraFusion.Test.Audience";
+    private const string ValidSecret = "this-is-a-test-secret-key-at-least-32-chars";
+    private const string AlternateSecret = "alternate-test-secret-key-at-least-32-chars";
+
+    private static JwtTokenService CreateSut()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = ValidSecret,
+                ["JwtSettings:Issuer"] = ExpectedIssuer,
+                ["JwtSettings:Audience"] = ExpectedAudience,
+                ["JwtSettings:ExpirationMinutes"] = "60",
+                ["JwtSettings:RefreshTokenExpirationDays"] = "7"
+            })
+            .Build();
+
+        return new JwtTokenService(config, NullLogger<JwtTokenService>.Instance);
+    }
+
+    private static string BuildToken(
+        string issuer,
+        string audience,
+        string signingSecret,
+        DateTime expiresUtc,
+        DateTime notBeforeUtc)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingSecret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "user-123"),
+                new Claim(ClaimTypes.Email, "user@terrafusion.test"),
+                new Claim("jti", Guid.NewGuid().ToString("N"))
+            },
+            notBefore: notBeforeUtc,
+            expires: expiresUtc,
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [Fact]
+    public void ValidateToken_WrongIssuer_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: "Wrong.Issuer",
+            audience: ExpectedAudience,
+            signingSecret: ValidSecret,
+            expiresUtc: DateTime.UtcNow.AddMinutes(5),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(-1));
+
+        var result = sut.ValidateToken(token);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateToken_WrongAudience_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: ExpectedIssuer,
+            audience: "Wrong.Audience",
+            signingSecret: ValidSecret,
+            expiresUtc: DateTime.UtcNow.AddMinutes(5),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(-1));
+
+        var result = sut.ValidateToken(token);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateToken_InvalidSignature_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: ExpectedIssuer,
+            audience: ExpectedAudience,
+            signingSecret: AlternateSecret,
+            expiresUtc: DateTime.UtcNow.AddMinutes(5),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(-1));
+
+        var result = sut.ValidateToken(token);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateToken_Expired_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: ExpectedIssuer,
+            audience: ExpectedAudience,
+            signingSecret: ValidSecret,
+            expiresUtc: DateTime.UtcNow.AddMinutes(-2),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(-10));
+
+        var result = sut.ValidateToken(token);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateToken_ClockSkewBeyondAllowed_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: ExpectedIssuer,
+            audience: ExpectedAudience,
+            signingSecret: ValidSecret,
+            expiresUtc: DateTime.UtcNow.AddSeconds(-30),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(-5));
+
+        var result = sut.ValidateToken(token);
+
+        // Strict validation target for Phase 4: recently expired tokens are rejected.
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Phase 4 Follow-through (Unit B + Unit D) and Worktree Reliability

### Changes
- `test(integration): support git worktree repo root detection` (`8849d4a0b`)
  - `backend/tests/TerraFusion.Integration.Tests/Phase37/GrafanaDashboardValidationTests.cs`
  - `backend/tests/TerraFusion.Integration.Tests/Phase38/AlertRuleValidationTests.cs`
- `test(security): add JWT edge-case validation suite` (`edaa645c2`)
  - `backend/tests/TerraFusion.Unit.Tests/Phase4/JwtTokenServiceSecurityTests.cs`
- `feat(security): enforce strict JWT clock skew validation` (`4f4a959de`)
  - `backend/src/TerraFusion.API/Services/JwtTokenService.cs`
- `ci(seal): run phase4 visibility tests in correct projects` (`d2d3127cb`)
  - `.github/workflows/seal-gate-fast.yml`

### Why
- Fixes integration test root detection for git worktree layouts.
- Adds and satisfies JWT negative-case security coverage (issuer/audience/signature/expiry/clock-skew).
- Ensures SEAL Phase 4 visibility runs tests from the correct projects:
  - Unit project: `SecurityTodoGateTests`, `JwtTokenServiceSecurityTests`
  - API tests project: `AuthenticationRateLimitTests`, `AuditCorrelationTests`

### Evidence
- `dotnet test backend/tests/TerraFusion.Integration.Tests/TerraFusion.Integration.Tests.csproj -c Release --filter "FullyQualifiedName~Phase37|FullyQualifiedName~Phase38"` ✅ (134/134)
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -c Release --filter "FullyQualifiedName~JwtTokenServiceSecurityTests"` ✅ (5/5)
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -c Release --filter "FullyQualifiedName~SecurityTodoGateTests|FullyQualifiedName~JwtTokenServiceSecurityTests"` ✅
- `dotnet test backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj -c Release --filter "FullyQualifiedName~AuthenticationRateLimitTests|FullyQualifiedName~AuditCorrelationTests"` ✅
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅ (8/8)
- `dotnet test TerraFusion.sln -c Release` ✅

### Lane Discipline
- Codex lane only: `C:\Users\bsval\terrafusion_phase4`
- Primary workspace (Claude lane) intentionally untouched.

## Summary by Sourcery

Harden JWT validation behavior and ensure related security and visibility tests run correctly across unit, API, and integration test projects.

New Features:
- Introduce strict JWT clock skew validation by removing tolerated time drift during token verification.

Bug Fixes:
- Correct repository root detection in integration tests to support git worktree repositories.

Enhancements:
- Add comprehensive negative-path unit tests covering JWT issuer, audience, signature, expiry, and clock skew validation behavior.

CI:
- Adjust SEAL gate workflow to execute JWT and security visibility tests in their appropriate unit and API test projects.