### PR TITLE
feat(audit): complete audit payload coverage for config changes

### DIFF
--- a/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
+++ b/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
@@ -80,6 +80,28 @@ public sealed class AuditCorrelationTests
     }
 
     [Fact]
+    public async Task AuthorizationGranted_EmitsAudit_WithCorrelationId()
+    {
+        var (auditLogger, provider, correlationId) = BuildAuditLogger();
+
+        await auditLogger.LogAuthorizationAsync("user-authz-granted", "api/secure-resource", granted: true);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var log = await db.AuditLogs
+            .OrderByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(x => x.UserId == "user-authz-granted");
+
+        log.Should().NotBeNull();
+        log!.Type.Should().StartWith("Authorization:");
+        log.CorrelationId.Should().Be(correlationId);
+
+        using var doc = JsonDocument.Parse(log.Data);
+        doc.RootElement.GetProperty("Details").GetString().Should().Contain("granted");
+        doc.RootElement.GetProperty("Success").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ConfigurationChange_EmitsAudit_WithCorrelationId()
     {
         var (auditLogger, provider, correlationId) = BuildAuditLogger();
@@ -104,6 +126,29 @@ public sealed class AuditCorrelationTests
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("Configuration changed");
         doc.RootElement.GetProperty("OldValue").GetString().Should().Be("Assessor");
         doc.RootElement.GetProperty("NewValue").GetString().Should().Be("CountyAdmin");
+    }
+
+    [Fact]
+    public async Task ConfigurationChange_EmitsAudit_WithSettingName()
+    {
+        var (auditLogger, provider, _) = BuildAuditLogger();
+
+        await auditLogger.LogConfigurationChangeAsync(
+            setting: "Privileges:RoleAssignment",
+            oldValue: "Assessor",
+            newValue: "CountyAdmin",
+            userId: "user-config-setting");
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var log = await db.AuditLogs
+            .OrderByDescending(x => x.Timestamp)
+            .FirstOrDefaultAsync(x => x.UserId == "user-config-setting");
+
+        log.Should().NotBeNull();
+
+        using var doc = JsonDocument.Parse(log!.Data);
+        doc.RootElement.GetProperty("Setting").GetString().Should().Be("Privileges:RoleAssignment");
     }
 
     private static (AuditLogger AuditLogger, ServiceProvider Provider, string CorrelationId) BuildAuditLogger()

--- a/backend/src/TerraFusion.API/Services/AuditLogger.cs
+++ b/backend/src/TerraFusion.API/Services/AuditLogger.cs
@@ -154,6 +154,7 @@ namespace TerraFusion.API.Services
             var details = $"Configuration changed: {setting}";
             await LogEventAsync("ConfigurationChange", "System", details,
                 userId: userId,
+                setting: setting,
                 oldValue: oldValue,
                 newValue: newValue);
         }
@@ -169,6 +170,7 @@ namespace TerraFusion.API.Services
             double? duration = null,
             string? resourceType = null,
             string? resourceId = null,
+            string? setting = null,
             string? oldValue = null,
             string? newValue = null)
         {
@@ -185,6 +187,7 @@ namespace TerraFusion.API.Services
                 ErrorMessage = errorMessage,
                 ResponseCode = responseCode,
                 Duration = duration,
+                Setting = setting,
                 OldValue = oldValue,
                 NewValue = newValue,
                 ResourceType = resourceType ?? eventCategory,


### PR DESCRIPTION
## Summary
Complete Phase 4 audit completeness loop with tests-first change:
- Added coverage for authorization-granted and configuration-change audit payload integrity
- Persisted configuration Setting key in audit payload generation

## Commits
- 48d33e6cc test(security): extend audit completeness coverage for authz and config setting
- 7c6ce7ba7 feat(audit): persist setting key in configuration change audit payload

## Files
- ackend/TerraFusion.API.Tests/AuditCorrelationTests.cs
- ackend/src/TerraFusion.API/Services/AuditLogger.cs

## Evidence
- dotnet test backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj -c Release --filter "FullyQualifiedName~AuditCorrelationTests" ✅ (6/6)
- 
ode scripts/repo-shape-guard.mjs ✅
- 
ode --test scripts/quarantine/__tests__/guard.test.mjs ✅ (8/8)
- dotnet test TerraFusion.sln -c Release ✅

## Governance
- Work executed in isolated Phase 4 worktree (C:\\Users\\bsval\\terrafusion_phase4)
- Primary workspace left untouched while parallel Phase 6 work continues

## Summary by Sourcery

Extend audit logging for authorization and configuration changes and ensure audit payloads include configuration setting names.

New Features:
- Emit audit events for successful authorization actions with correlation IDs and success metadata.
- Include configuration setting names in configuration change audit payloads for improved traceability.

Tests:
- Add audit correlation tests covering authorization-granted events and configuration setting name persistence in audit logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added audit log tests for authorization and configuration change events with correlation tracking.

* **Chores**
  * Enhanced audit logging to capture setting information in configuration change events for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->