### PR TITLE
test(security): extend JWT edge-case rejection coverage

### DIFF
--- a/backend/tests/TerraFusion.Unit.Tests/Phase4/JwtTokenServiceSecurityTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Phase4/JwtTokenServiceSecurityTests.cs
@@ -142,4 +142,30 @@ public sealed class JwtTokenServiceSecurityTests
         // Strict validation target for Phase 4: recently expired tokens are rejected.
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void ValidateToken_NotBeforeInFuture_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+        var token = BuildToken(
+            issuer: ExpectedIssuer,
+            audience: ExpectedAudience,
+            signingSecret: ValidSecret,
+            expiresUtc: DateTime.UtcNow.AddMinutes(10),
+            notBeforeUtc: DateTime.UtcNow.AddMinutes(2));
+
+        var result = sut.ValidateToken(token);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateToken_MalformedToken_ReturnsInvalid()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ValidateToken("not-a-jwt");
+
+        result.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary
Extend Phase 4 JWT validation coverage with additional edge-case rejection tests.

## Commit
- 8ba46f9d8 test(security): extend JWT edge-case rejection coverage

## Added tests
- ValidateToken_NotBeforeInFuture_ReturnsInvalid
- ValidateToken_MalformedToken_ReturnsInvalid

## Evidence
- dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -c Release --filter "FullyQualifiedName~JwtTokenServiceSecurityTests" ✅ (7/7)
- dotnet test TerraFusion.sln -c Release ✅

## Governance
- Tests-only atomic unit
- Isolated Phase 4 worktree used (C:\\Users\\bsval\\terrafusion_phase4)
- Primary workspace (eat/phase9-security-hardening) left untouched while Claude runs parallel