### PR TITLE
ci(governance): fix autonomy evidence workflow failures

### DIFF
--- a/.github/workflows/autonomy-break-glass-incident-publisher.yml
+++ b/.github/workflows/autonomy-break-glass-incident-publisher.yml
@@ -149,16 +149,16 @@ jobs:
           ref: ${{ needs.check-eligibility.outputs.merge_sha }}
           fetch-depth: 1
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -161,8 +161,7 @@ jobs:
           BUNDLE_NAME="autonomy-evidence-${{ needs.gate.outputs.run_id }}"
 
           npx tsx tools/registry/autonomy-viewer/src/bundle.ts \
-            --in ${{ env.OUT_DIR }} \
-            --in ${{ env.VIEWER_DIR }} \
+            --in ${{ github.workspace }} \
             --out ${{ env.VIEWER_DIR }} \
             --name "$BUNDLE_NAME" \
             --run-id "${{ needs.gate.outputs.run_id }}" \


### PR DESCRIPTION
## Summary
Surgical governance fix for recurring post-merge evidence workflow failures.

## Root causes fixed
1. `Load & Verify Evidence` failed because `actions/setup-node` used `cache: pnpm` before pnpm was installed.
2. `Publish Evidence to Release` failed because `bundle.ts` was invoked with two `--in` args; only the last value was used, breaking required file resolution.

## Changes
- `.github/workflows/autonomy-break-glass-incident-publisher.yml`
  - Install pnpm before `actions/setup-node`
  - Bump pnpm action to `pnpm/action-setup@v4`
- `.github/workflows/autonomy-evidence-publisher.yml`
  - Use a single bundle input root: `--in ${{ github.workspace }}`

## Commit
- `06bfedbda` ci(governance): fix evidence publisher bootstrap and bundle input root

## Validation
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅
- `dotnet test TerraFusion.sln -c Release` ✅

## Scope
Governance/workflow-only fix. No feature code changes.

## Summary by Sourcery

Fix governance evidence publishing workflows to resolve recurring post-merge failures.

CI:
- Install pnpm before Node setup and update pnpm/action-setup to v4 in the autonomy break-glass incident publisher workflow.
- Change the autonomy evidence publisher workflow to bundle from the repository workspace using a single input root.