### PR TITLE
ci(governance): harden autonomy evidence workflow reliability

### DIFF
--- a/.github/workflows/autonomy-break-glass-incident-publisher.yml
+++ b/.github/workflows/autonomy-break-glass-incident-publisher.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -143,6 +143,14 @@ jobs:
             echo "⚠️ No performance plan (may be empty run)"
           fi
 
+      - name: Ensure apply proofs artifact exists
+        run: |
+          mkdir -p "${{ env.OUT_DIR }}"
+          if [ ! -f "${{ env.OUT_DIR }}/apply-proofs.json" ]; then
+            echo "[]" > "${{ env.OUT_DIR }}/apply-proofs.json"
+            echo "ℹ️ Created fallback apply-proofs.json for deterministic bundling"
+          fi
+
       - name: Generate CIO Dashboard
         run: |
           echo "📊 Generating County CIO Dashboard..."


### PR DESCRIPTION
## Summary
Second surgical governance fix for autonomy evidence workflows.

### Fixes
- Align `pnpm/action-setup` with repo package manager version in break-glass publisher.
- Ensure deterministic presence of `apply-proofs.json` before bundle generation in evidence publisher.

## Why
Recent workflow failures showed:
1. `Multiple versions of pnpm specified` (action requested v8 while repo is `pnpm@9.0.0`).
2. Bundle generation failed in strict mode when `tools/registry/perf-skill-audit/out/apply-proofs.json` was absent.

## Validation
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `node scripts/repo-shape-guard.mjs`
- `node --test scripts/quarantine/__tests__/guard.test.mjs`
- `dotnet test TerraFusion.sln -c Release`

## Summary by Sourcery

Improve reliability of autonomy governance evidence workflows by aligning tooling versions and making evidence bundling deterministic.

Bug Fixes:
- Align pnpm setup in the break-glass incident publisher workflow with the repository's pnpm major version to avoid version conflicts.
- Ensure an apply-proofs.json artifact is always present in the evidence publisher workflow so bundle generation succeeds deterministically.