### PR TITLE
ci(governance): finalize autonomy evidence workflow resiliency

### DIFF
--- a/.github/workflows/autonomy-break-glass-incident-publisher.yml
+++ b/.github/workflows/autonomy-break-glass-incident-publisher.yml
@@ -151,8 +151,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -151,6 +151,13 @@ jobs:
             echo "ℹ️ Created fallback apply-proofs.json for deterministic bundling"
           fi
 
+      - name: Ensure governance contract file exists
+        run: |
+          if [ ! -f "AUTONOMY_V1_GOVERNANCE_CONTRACT.md" ] && [ -f "QUARANTINE/root-md/AUTONOMY_V1_GOVERNANCE_CONTRACT.md" ]; then
+            cp "QUARANTINE/root-md/AUTONOMY_V1_GOVERNANCE_CONTRACT.md" "AUTONOMY_V1_GOVERNANCE_CONTRACT.md"
+            echo "ℹ️ Restored AUTONOMY_V1_GOVERNANCE_CONTRACT.md from QUARANTINE/root-md"
+          fi
+
       - name: Generate CIO Dashboard
         run: |
           echo "📊 Generating County CIO Dashboard..."


### PR DESCRIPTION
## Summary
Carry forward the final surgical follow-up that missed PR #328 merge cut-off.

## Changes
- Remove explicit ersion override from pnpm/action-setup in break-glass incident publisher to avoid dual-version detection against packageManager.
- Add deterministic fallback step in autonomy evidence publisher to restore AUTONOMY_V1_GOVERNANCE_CONTRACT.md from QUARANTINE/root-md when missing at repo root.

## Validation
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- node scripts/repo-shape-guard.mjs
- node --test scripts/quarantine/__tests__/guard.test.mjs
- dotnet test TerraFusion.sln -c Release

## Summary by Sourcery

Improve resiliency and determinism of autonomy evidence publishing workflows.

CI:
- Add fallback creation of the apply-proofs artifact and restoration of the governance contract file in the autonomy evidence publisher workflow when missing.
- Remove explicit pnpm version override from the break-glass incident publisher workflow to rely on the default pnpm/action-setup configuration.