### PR TITLE
ci(governance): fix autonomy evidence bundle manifest path check

### DIFF
--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -173,7 +173,7 @@ jobs:
         id: bundle
         run: |
           echo "📦 Generating Evidence Bundle..."
-          BUNDLE_NAME="autonomy-evidence-${{ needs.gate.outputs.run_id }}"
+          BUNDLE_NAME="autonomy-evidence-${{ needs.gate.outputs.run_id }}.zip"
 
           npx tsx tools/registry/autonomy-viewer/src/bundle.ts \
             --in ${{ github.workspace }} \
@@ -183,15 +183,17 @@ jobs:
             --emit-manifest \
             --verbose
 
+          MANIFEST_PATH="${{ env.VIEWER_DIR }}/${BUNDLE_NAME}.manifest.json"
+
           # Capture manifest SHA256
-          if [ -f "${{ env.VIEWER_DIR }}/MANIFEST.json" ]; then
-            MANIFEST_SHA=$(sha256sum ${{ env.VIEWER_DIR }}/MANIFEST.json | cut -d' ' -f1)
+          if [ -f "$MANIFEST_PATH" ]; then
+            MANIFEST_SHA=$(sha256sum "$MANIFEST_PATH" | cut -d' ' -f1)
             echo "manifest_sha=$MANIFEST_SHA" >> $GITHUB_OUTPUT
-            echo "bundle_name=${BUNDLE_NAME}.zip" >> $GITHUB_OUTPUT
-            echo "bundle_path=${{ env.VIEWER_DIR }}/${BUNDLE_NAME}.zip" >> $GITHUB_OUTPUT
-            echo "✅ Bundle generated: ${BUNDLE_NAME}.zip"
+            echo "bundle_name=${BUNDLE_NAME}" >> $GITHUB_OUTPUT
+            echo "bundle_path=${{ env.VIEWER_DIR }}/${BUNDLE_NAME}" >> $GITHUB_OUTPUT
+            echo "✅ Bundle generated: ${BUNDLE_NAME}"
           else
-            echo "::error::MANIFEST.json not found"
+            echo "::error::Bundle manifest not found at $MANIFEST_PATH"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- fix autonomy evidence publisher manifest detection to match emitted bundle manifest path
- keep scope surgical to workflow gating only

## Root Cause
`autonomy-evidence-publisher.yml` validated `tools/registry/autonomy-viewer/dist/MANIFEST.json`, but the bundle step emits `<bundle>.manifest.json` (e.g. `autonomy-evidence-<run>.zip.manifest.json`).

## Change
- compute `MANIFEST_PATH` as `${VIEWER_DIR}/${BUNDLE_NAME}.manifest.json`
- hash and validate that path
- keep bundle outputs aligned (`bundle_name`/`bundle_path`)

## Evidence
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅
- `pnpm run type-check` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` ✅
- `dotnet test TerraFusion.sln -c Release` ✅

## Commit
- `5e71c0ee1`

## Summary by Sourcery

Align autonomy evidence publisher workflow with the actual bundle manifest file produced by the bundling step and improve its output metadata.

Bug Fixes:
- Fix bundle manifest path detection in the autonomy evidence publisher workflow to match the emitted manifest filename.

Enhancements:
- Standardize bundle name, path, and manifest path handling in the autonomy evidence publisher workflow for clearer outputs and error messages.

CI:
- Update autonomy evidence publisher GitHub Actions workflow to compute and validate the correct manifest path based on the generated bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundle naming convention to include `.zip` extension in filenames.
  * Enhanced manifest path handling for improved file verification accuracy.
  * Improved error messaging when bundle manifest verification fails, providing clearer diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->