### PR TITLE
ci(governance): use slash-free autonomy evidence release tag

### DIFF
--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -67,9 +67,9 @@ jobs:
           LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
           echo "PR Labels: $LABELS"
 
-          # Generate release tag (monthly rollup format)
+          # Generate release tag (slash-free monthly rollup format)
           YEAR_MONTH=$(date +%Y-%m)
-          RELEASE_TAG="autonomy-evidence/${YEAR_MONTH}"
+          RELEASE_TAG="autonomy-evidence-${YEAR_MONTH}"
           RUN_ID="${{ github.run_id }}"
 
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- switch evidence release tag format from `autonomy-evidence/YYYY-MM` to `autonomy-evidence-YYYY-MM`
- keep workflow scope surgical (single file)

## Root Cause
`evidence-index.ts` immutable URL validation rejects encoded path characters. A release tag containing `/` becomes `%2F` in release URL and fails validation.

## Change
- in `autonomy-evidence-publisher.yml`, generate slash-free monthly tag:
  - before: `autonomy-evidence/${YEAR_MONTH}`
  - after:  `autonomy-evidence-${YEAR_MONTH}`

## Evidence
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅
- `pnpm run type-check` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` ✅
- `dotnet test TerraFusion.sln -c Release` ✅

## Commit
- `02485488b`

## Summary by Sourcery

CI:
- Change the generated autonomy evidence release tag from `autonomy-evidence/YYYY-MM` to `autonomy-evidence-YYYY-MM` in the GitHub Actions workflow.