### PR TITLE
fix(governance): make autonomy evidence ledger ESM-compatible

### DIFF
--- a/tools/registry/autonomy-viewer/src/evidence-ledger-viewer.ts
+++ b/tools/registry/autonomy-viewer/src/evidence-ledger-viewer.ts
@@ -23,7 +23,7 @@
  *   --verbose             Verbose output
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { EvidenceIndex, EvidenceRecord } from './evidence-index.js';
@@ -247,7 +247,7 @@ export function loadIndices(inputPath: string, verbose = false): EvidenceIndex[]
   }
 
   // Check if it's a file or directory
-  const stat = require('node:fs').statSync(inputPath);
+  const stat = statSync(inputPath);
 
   if (stat.isFile()) {
     // Single file


### PR DESCRIPTION
## Summary
- fix ESM runtime failure in `evidence-ledger-viewer.ts`
- replace CommonJS `require('node:fs').statSync(...)` with imported `statSync(...)`

## Root Cause
`autonomy-evidence-publisher` runs via `tsx` in ESM mode. `require` is undefined in ESM scope, causing `Generate Evidence Ledger` to fail.

## Change
- `tools/registry/autonomy-viewer/src/evidence-ledger-viewer.ts`
  - import `statSync` from `node:fs`
  - use `statSync(inputPath)`

## Evidence
- `npx tsx tools/registry/autonomy-viewer/src/evidence-ledger-viewer.ts --in tools/registry/autonomy-viewer/dist --out tools/registry/autonomy-viewer/dist/autonomy-ledger.html --title "TerraFusion Evidence Ledger - local" --verbose` ✅
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅
- `pnpm run type-check` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` ✅
- `dotnet test TerraFusion.sln -c Release` ✅

## Commit
- `e2758b7c6`

## Summary by Sourcery

Bug Fixes:
- Resolve ESM runtime failure in the evidence ledger viewer by replacing CommonJS require-based fs access with an imported statSync call.