### PR TITLE
ci(governance): align evidence-index --out contract in publisher

### DIFF
--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -277,7 +277,7 @@ jobs:
 
           # Phase 4N20: Include SHA for identity pinning
           npx tsx tools/registry/autonomy-viewer/src/evidence-index.ts \
-            --out ${{ env.VIEWER_DIR }}/autonomy-evidence-index.json \
+            --out ${{ env.VIEWER_DIR }} \
             --artifacts ${{ env.OUT_DIR }} \
             --bundle "${{ steps.bundle.outputs.bundle_name }}" \
             --manifest-sha "${{ steps.bundle.outputs.manifest_sha }}" \


### PR DESCRIPTION
## Summary
- fix `autonomy-evidence-publisher` evidence-index invocation contract
- pass `--out` as directory (as required by `evidence-index.ts`) instead of a file path

## Root Cause
`evidence-index.ts` expects `--out <dir>` and always writes `autonomy-evidence-index.json` inside that directory. Passing a file path caused the index file to be emitted to an unintended nested path, so `custody-attest.ts` could not find `autonomy-evidence-index.json`.

## Change
- `.github/workflows/autonomy-evidence-publisher.yml`
  - before: `--out ${{ env.VIEWER_DIR }}/autonomy-evidence-index.json`
  - after:  `--out ${{ env.VIEWER_DIR }}`

## Evidence
- `node scripts/repo-shape-guard.mjs` ✅
- `node --test scripts/quarantine/__tests__/guard.test.mjs` ✅
- `pnpm run type-check` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` ✅
- `dotnet test TerraFusion.sln -c Release` ✅

## Commit
- `486923655`

## Summary by Sourcery

Align the autonomy evidence publisher workflow with the evidence-index output directory contract so downstream steps can locate the generated index file.

Bug Fixes:
- Fix the autonomy evidence publisher to pass an output directory instead of a file path to evidence-index so the index file is written where consumers expect it.

CI:
- Update the autonomy-evidence-publisher GitHub Actions workflow to use VIEWER_DIR as the evidence-index output directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for evidence index generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->