### PR TITLE
ci(seal): run backend fast gate on seal workflow edits

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -88,10 +88,17 @@ jobs:
           # Classify
           # Treat SEAL backend-gate wiring changes as backend-impacting so security
           # regression checks cannot be skipped by workflow-only diffs.
-          HAS_BACKEND=$(echo "$CHANGED" | grep -E '^(backend/|\.github/workflows/seal-gate-fast\.yml$)' | head -1 || true)
+          HAS_SEAL_BACKEND_WIRING=$(echo "$CHANGED" | grep -E '^\.github/workflows/seal-gate-fast\.yml$' | head -1 || true)
+          HAS_BACKEND=$(echo "$CHANGED" | grep -E '^backend/' | head -1 || true)
+          if [ -n "$HAS_SEAL_BACKEND_WIRING" ]; then
+            HAS_BACKEND="$HAS_SEAL_BACKEND_WIRING"
+          fi
           HAS_FRONTEND=$(echo "$CHANGED" | grep -E '^(src/|frontend/|package\.json|pnpm-lock\.yaml)' | head -1 || true)
           # NON_DOC: anything that isn't docs, markdown, config, or meta files
           NON_DOC=$(echo "$CHANGED" | grep -Ev '^(docs/|.*\.md$|README(\..*)?$|\.github/|\.editorconfig$|\.gitignore$|LICENSE$)' | head -1 || true)
+          if [ -n "$HAS_SEAL_BACKEND_WIRING" ]; then
+            NON_DOC="$HAS_SEAL_BACKEND_WIRING"
+          fi
 
           # Set outputs
           if [ -z "$HAS_BACKEND" ]; then

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -86,7 +86,9 @@ jobs:
           echo "$CHANGED"
 
           # Classify
-          HAS_BACKEND=$(echo "$CHANGED" | grep -E '^backend/' | head -1 || true)
+          # Treat SEAL backend-gate wiring changes as backend-impacting so security
+          # regression checks cannot be skipped by workflow-only diffs.
+          HAS_BACKEND=$(echo "$CHANGED" | grep -E '^(backend/|\.github/workflows/seal-gate-fast\.yml$)' | head -1 || true)
           HAS_FRONTEND=$(echo "$CHANGED" | grep -E '^(src/|frontend/|package\.json|pnpm-lock\.yaml)' | head -1 || true)
           # NON_DOC: anything that isn't docs, markdown, config, or meta files
           NON_DOC=$(echo "$CHANGED" | grep -Ev '^(docs/|.*\.md$|README(\..*)?$|\.github/|\.editorconfig$|\.gitignore$|LICENSE$)' | head -1 || true)


### PR DESCRIPTION
## Summary
- update SEAL classify logic to treat .github/workflows/seal-gate-fast.yml as backend-impacting
- prevent backend fast gate (including Phase 4 security regression visibility step) from being skipped on SEAL workflow-only changes

## Why
Workflow-only changes to seal-gate-fast.yml can affect backend/security enforcement behavior. This keeps fast-gate coverage deterministic for SEAL wiring changes.

## Validation
- pnpm run type-check
- 
ode --test os-platform/core/tests/phase83-tools.test.mjs
- 
ode scripts/repo-shape-guard.mjs
- 
ode --test scripts/quarantine/__tests__/guard.test.mjs
- dotnet test TerraFusion.sln -c Release

## Summary by Sourcery

CI:
- Update SEAL fast gate workflow change detection to treat seal-gate-fast.yml edits as backend-impacting to ensure the backend fast gate runs.