### PR TITLE
feat(policy): Phase 14 Tool RiskPolicy + Write-Lane Enforcement

### DIFF
--- a/backend/TerraFusion.API.Tests/Phase13/TraceContractTests.cs
+++ b/backend/TerraFusion.API.Tests/Phase13/TraceContractTests.cs
@@ -1,0 +1,294 @@
+using System.Text.RegularExpressions;
+using Xunit;
+using FluentAssertions;
+
+namespace TerraFusion.API.Tests.Phase13;
+
+/// <summary>
+/// Phase 13 — Trace Contract Hardening.
+/// Enforces PII sanitization, correlation-ID propagation, and
+/// payload-by-reference discipline across all backend logging.
+/// </summary>
+[Trait("Category", "Phase13")]
+[Trait("Category", "Governance")]
+public class TraceContractTests
+{
+    private static readonly string BackendSrcDir = FindBackendSrcDir();
+
+    private static string FindBackendSrcDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "backend", "src");
+            if (Directory.Exists(candidate)) return candidate;
+            var gitDir = Path.Combine(dir, ".git");
+            if (Directory.Exists(gitDir) || File.Exists(gitDir))
+            {
+                candidate = Path.Combine(dir, "backend", "src");
+                if (Directory.Exists(candidate)) return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// PII fields (email, SSN, password) must NEVER appear as raw values
+    /// in structured-log format strings.  Allowed patterns:
+    ///   - Hashed/masked references: {EmailHash}, {UserIdHash}
+    ///   - Redacted placeholders: [REDACTED]
+    ///   - Config/flag mentions (not value interpolation)
+    ///
+    /// Violations: _logger.Log*("... {Email} ...", email)
+    ///             _logger.Log*("... {Password} ...", password)
+    /// </summary>
+    [Fact]
+    public void No_Raw_Email_In_Log_Format_Strings()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        // Pattern: _logger.Log*(... "{Email}" or "{email}" ..., email)
+        // Matches format string interpolation holes that expose raw email values
+        var emailLogPattern = new Regex(
+            @"_logger\.Log\w+\([^;]*\{[Ee]mail\}[^;]*,\s*\w*[Ee]mail",
+            RegexOptions.Compiled);
+
+        var violations = ScanForViolations(emailLogPattern, "Raw {Email} in log");
+
+        violations.Should().BeEmpty(
+            "PII contract: email addresses must not appear as raw values in log format strings. " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations.Take(20)));
+    }
+
+    [Fact]
+    public void No_Raw_Password_In_Log_Format_Strings()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        // Matches log calls that interpolate password-related values
+        var passwordLogPattern = new Regex(
+            @"_logger\.Log\w+\([^;]*\{[Pp]assword\}",
+            RegexOptions.Compiled);
+
+        var violations = ScanForViolations(passwordLogPattern, "Raw {Password} in log");
+
+        violations.Should().BeEmpty(
+            "PII contract: password values must never appear in log format strings. " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations.Take(20)));
+    }
+
+    [Fact]
+    public void No_Raw_SSN_In_Log_Format_Strings()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var ssnLogPattern = new Regex(
+            @"_logger\.Log\w+\([^;]*\{[Ss][Ss][Nn]\}",
+            RegexOptions.Compiled);
+
+        var violations = ScanForViolations(ssnLogPattern, "Raw {SSN} in log");
+
+        violations.Should().BeEmpty(
+            "PII contract: SSN values must never appear in log format strings. " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations.Take(20)));
+    }
+
+    /// <summary>
+    /// Every HTTP middleware or audit service that generates log entries
+    /// must reference a CorrelationId, X-Correlation-ID, or TraceIdentifier.
+    /// This ensures all log events are traceable across service boundaries.
+    /// </summary>
+    [Theory]
+    [InlineData("AuditLogger.cs")]
+    [InlineData("DatabaseAuditLogger.cs")]
+    public void Audit_Services_Must_Propagate_CorrelationId(string fileName)
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var files = Directory.GetFiles(BackendSrcDir, fileName, SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin") && !f.Contains("Test"))
+            .ToArray();
+
+        files.Should().NotBeEmpty($"audit service {fileName} must exist in backend/src");
+
+        foreach (var file in files)
+        {
+            var content = File.ReadAllText(file);
+            var hasCorrelation =
+                content.Contains("CorrelationId", StringComparison.OrdinalIgnoreCase) ||
+                content.Contains("X-Correlation-ID", StringComparison.OrdinalIgnoreCase) ||
+                content.Contains("TraceIdentifier", StringComparison.OrdinalIgnoreCase) ||
+                content.Contains("Activity.Current", StringComparison.OrdinalIgnoreCase);
+
+            hasCorrelation.Should().BeTrue(
+                $"{fileName} must propagate correlation IDs for trace compliance " +
+                "(CorrelationId, X-Correlation-ID, TraceIdentifier, or Activity.Current)");
+        }
+    }
+
+    /// <summary>
+    /// The TerraPilot tool registry must define piiHandling and tracePolicy
+    /// for every registered tool. No tool may omit these fields.
+    /// </summary>
+    [Fact]
+    public void TerraPilot_Tools_Must_Declare_PII_And_Trace_Policy()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir))
+            return;
+
+        var repoRoot = Path.GetDirectoryName(Path.GetDirectoryName(BackendSrcDir))!;
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+
+        if (!File.Exists(toolsFile))
+            return; // Tool registry not present in this checkout
+
+        var content = File.ReadAllText(toolsFile);
+
+        // Every tool entry must have piiHandling
+        var toolPattern = new Regex(@"""toolId""\s*:\s*""([^""]+)""", RegexOptions.Compiled);
+        var piiPattern = new Regex(@"""piiHandling""\s*:", RegexOptions.Compiled);
+        var tracePattern = new Regex(@"""tracePolicy""\s*:", RegexOptions.Compiled);
+
+        var toolCount = toolPattern.Matches(content).Count;
+        var piiCount = piiPattern.Matches(content).Count;
+        var traceCount = tracePattern.Matches(content).Count;
+
+        piiCount.Should().Be(toolCount,
+            $"every tool ({toolCount} total) must declare piiHandling — found {piiCount}");
+        traceCount.Should().Be(toolCount,
+            $"every tool ({toolCount} total) must declare tracePolicy — found {traceCount}");
+    }
+
+    /// <summary>
+    /// OpenTelemetry must be configured in the API entry point (Program.cs).
+    /// This ensures distributed tracing is active for all requests.
+    /// </summary>
+    [Fact]
+    public void OpenTelemetry_Must_Be_Configured_In_API()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var programCs = Directory.GetFiles(BackendSrcDir, "Program.cs", SearchOption.AllDirectories)
+            .Where(f => f.Contains("TerraFusion.API") && !f.Contains("Test") &&
+                        !f.Contains("obj") && !f.Contains("bin"))
+            .FirstOrDefault();
+
+        programCs.Should().NotBeNull("TerraFusion.API/Program.cs must exist");
+
+        var content = File.ReadAllText(programCs!);
+
+        content.Should().Contain("AddOpenTelemetry",
+            "Program.cs must configure OpenTelemetry for distributed tracing");
+
+        content.Should().Contain("WithTracing",
+            "Program.cs must enable OpenTelemetry tracing");
+    }
+
+    /// <summary>
+    /// TracingConstants must be spec-locked (Phase 36 invariant).
+    /// Verifies the constants file exists and contains required ActivitySource names.
+    /// </summary>
+    [Fact]
+    public void TracingConstants_Must_Define_Required_ActivitySources()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var constFiles = Directory.GetFiles(BackendSrcDir, "TracingConstants.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin") && !f.Contains("Test"))
+            .ToArray();
+
+        if (constFiles.Length == 0)
+            return; // Phase 36 tracing not present
+
+        var content = File.ReadAllText(constFiles[0]);
+        content.Should().Contain("TerraFusion.",
+            "TracingConstants must define TerraFusion.* ActivitySource names");
+    }
+
+    /// <summary>
+    /// Console.WriteLine must not be used for request/response logging in
+    /// production code paths. Use structured logging (ILogger) instead.
+    /// Scans API controllers and middleware for Console.Write* calls.
+    /// </summary>
+    [Fact]
+    public void No_Console_WriteLine_In_API_Controllers_Or_Middleware()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var apiDir = Path.Combine(BackendSrcDir, "TerraFusion.API");
+        if (!Directory.Exists(apiDir))
+            return;
+
+        var controllerFiles = Directory.GetFiles(
+                Path.Combine(apiDir, "Controllers"), "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin"))
+            .ToArray();
+
+        var middlewareDir = Path.Combine(apiDir, "Middleware");
+        var middlewareFiles = Directory.Exists(middlewareDir)
+            ? Directory.GetFiles(middlewareDir, "*.cs", SearchOption.AllDirectories)
+                .Where(f => !f.Contains("obj") && !f.Contains("bin"))
+                .ToArray()
+            : Array.Empty<string>();
+
+        var consolePattern = new Regex(
+            @"Console\.(Write|WriteLine)\s*\(",
+            RegexOptions.Compiled);
+
+        var violations = new List<string>();
+
+        foreach (var file in controllerFiles.Concat(middlewareFiles))
+        {
+            var content = File.ReadAllText(file);
+            if (consolePattern.IsMatch(content))
+            {
+                var rel = Path.GetRelativePath(BackendSrcDir, file);
+                violations.Add(rel);
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "API controllers and middleware must use ILogger, not Console.Write*. " +
+            $"Found {violations.Count} file(s) with Console.Write*:\n" +
+            string.Join("\n", violations));
+    }
+
+    #region Helpers
+
+    private List<string> ScanForViolations(Regex pattern, string label)
+    {
+        var violations = new List<string>();
+        var csFiles = Directory.GetFiles(BackendSrcDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin") && !f.Contains("Test") &&
+                        !f.Contains("Migrations"))
+            .ToArray();
+
+        foreach (var file in csFiles)
+        {
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (pattern.IsMatch(lines[i]))
+                {
+                    var rel = Path.GetRelativePath(BackendSrcDir, file);
+                    violations.Add($"  {rel}:{i + 1} — {label}");
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    #endregion
+}

--- a/backend/TerraFusion.API.Tests/Phase14/ToolRiskPolicyTests.cs
+++ b/backend/TerraFusion.API.Tests/Phase14/ToolRiskPolicyTests.cs
@@ -1,0 +1,447 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Xunit;
+using FluentAssertions;
+
+namespace TerraFusion.API.Tests.Phase14;
+
+/// <summary>
+/// Phase 14 — Tool RiskPolicy + Write-Lane Enforcement.
+/// Ensures the TerraPilot tool registry enforces risk levels,
+/// write-lane ownership, and that backend authorization policies
+/// referenced by controllers are actually registered.
+/// </summary>
+[Trait("Category", "Phase14")]
+[Trait("Category", "Governance")]
+public class ToolRiskPolicyTests
+{
+    private static readonly string BackendSrcDir = FindBackendSrcDir();
+
+    private static string FindBackendSrcDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "backend", "src");
+            if (Directory.Exists(candidate)) return candidate;
+            var gitDir = Path.Combine(dir, ".git");
+            if (Directory.Exists(gitDir) || File.Exists(gitDir))
+            {
+                candidate = Path.Combine(dir, "backend", "src");
+                if (Directory.Exists(candidate)) return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        return string.Empty;
+    }
+
+    private static string? GetRepoRoot()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir)) return null;
+        return Path.GetDirectoryName(Path.GetDirectoryName(BackendSrcDir));
+    }
+
+    #region Tool Registry — Risk + WriteLane Invariants
+
+    /// <summary>
+    /// Every tool with risk != "read_only" MUST declare a non-null writeLane.
+    /// Write operations need lane discipline to prevent cross-service mutation.
+    /// </summary>
+    [Fact]
+    public void Write_Tools_Must_Declare_WriteLane()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var risk = tool.GetProperty("risk").GetString()!;
+            var writeLane = tool.TryGetProperty("writeLane", out var wl)
+                ? wl.ValueKind == JsonValueKind.Null ? null : wl.GetString()
+                : null;
+
+            if (risk != "read_only" && string.IsNullOrEmpty(writeLane))
+            {
+                violations.Add($"  {toolId} (risk={risk}) has no writeLane");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "all tools with risk > read_only must declare a writeLane for ownership discipline. " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Read-only tools MUST have writeLane = null.
+    /// A read-only tool with a write lane is a contradiction.
+    /// </summary>
+    [Fact]
+    public void ReadOnly_Tools_Must_Have_Null_WriteLane()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var risk = tool.GetProperty("risk").GetString()!;
+            var writeLane = tool.TryGetProperty("writeLane", out var wl)
+                ? wl.ValueKind == JsonValueKind.Null ? null : wl.GetString()
+                : null;
+
+            if (risk == "read_only" && !string.IsNullOrEmpty(writeLane))
+            {
+                violations.Add($"  {toolId} (read_only) declares writeLane={writeLane}");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "read_only tools must have writeLane=null — a read tool should not own a write lane. " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Irreversible tools MUST require supervisor approval.
+    /// The schema mandates requiresSupervisorApproval for irreversible risk.
+    /// </summary>
+    [Fact]
+    public void Irreversible_Tools_Must_Require_Supervisor_Approval()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var risk = tool.GetProperty("risk").GetString()!;
+
+            if (risk == "irreversible")
+            {
+                var requiresSupervisor = tool.TryGetProperty("requiresSupervisorApproval", out var rs)
+                    && rs.GetBoolean();
+
+                if (!requiresSupervisor)
+                {
+                    violations.Add($"  {toolId} (irreversible) missing requiresSupervisorApproval=true");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "irreversible tools must require supervisor approval — " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Write-high and irreversible tools MUST require user confirmation.
+    /// </summary>
+    [Fact]
+    public void High_Risk_Tools_Must_Require_Confirmation()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var risk = tool.GetProperty("risk").GetString()!;
+
+            if (risk is "write_high" or "irreversible")
+            {
+                var requiresConfirmation = tool.TryGetProperty("requiresConfirmation", out var rc)
+                    && rc.GetBoolean();
+
+                if (!requiresConfirmation)
+                {
+                    violations.Add($"  {toolId} (risk={risk}) missing requiresConfirmation=true");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "write_high and irreversible tools must require user confirmation — " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Tool risk values must be from the canonical enum: read_only, write_low, write_high, irreversible.
+    /// </summary>
+    [Fact]
+    public void Tool_Risk_Values_Must_Be_Canonical()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        var validRisks = new HashSet<string> { "read_only", "write_low", "write_high", "irreversible" };
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var risk = tool.GetProperty("risk").GetString()!;
+
+            if (!validRisks.Contains(risk))
+            {
+                violations.Add($"  {toolId} has invalid risk={risk}");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "all tool risk values must be canonical (read_only|write_low|write_high|irreversible). " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// WriteLane values must be from canonical suites: dais, forge, os, dossier, atlas, pilot, gpt.
+    /// </summary>
+    [Fact]
+    public void WriteLane_Values_Must_Be_Canonical_Suites()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        var validLanes = new HashSet<string> { "forge", "atlas", "dais", "dossier", "os", "pilot", "gpt" };
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            if (tool.TryGetProperty("writeLane", out var wl) && wl.ValueKind != JsonValueKind.Null)
+            {
+                var lane = wl.GetString()!;
+                if (!validLanes.Contains(lane))
+                {
+                    violations.Add($"  {toolId} has non-canonical writeLane={lane}");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "writeLane values must be canonical suites (forge|atlas|dais|dossier|os|pilot|gpt). " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    #endregion
+
+    #region Authorization Policy Registration
+
+    /// <summary>
+    /// Every [Authorize(Policy = "X")] used on a controller MUST be
+    /// registered in AddAuthorization(). Unregistered policies cause
+    /// runtime 500 errors on first request.
+    /// </summary>
+    [Fact]
+    public void All_Referenced_Policies_Must_Be_Registered()
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        // Step 1: Find all Policy references in [Authorize] attributes
+        var policyRefPattern = new Regex(
+            @"\[Authorize\s*\(\s*Policy\s*=\s*""(\w+)""",
+            RegexOptions.Compiled);
+
+        var csFiles = Directory.GetFiles(BackendSrcDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin") && !f.Contains("Test"))
+            .ToArray();
+
+        var referencedPolicies = new HashSet<string>();
+        foreach (var file in csFiles)
+        {
+            var content = File.ReadAllText(file);
+            foreach (Match match in policyRefPattern.Matches(content))
+            {
+                referencedPolicies.Add(match.Groups[1].Value);
+            }
+        }
+
+        // Step 2: Find all registered policies in AddAuthorization
+        var registeredPolicies = new HashSet<string>();
+        var addPolicyPattern = new Regex(
+            @"AddPolicy\s*\(\s*""(\w+)""",
+            RegexOptions.Compiled);
+
+        foreach (var file in csFiles)
+        {
+            var content = File.ReadAllText(file);
+            foreach (Match match in addPolicyPattern.Matches(content))
+            {
+                registeredPolicies.Add(match.Groups[1].Value);
+            }
+        }
+
+        var unregistered = referencedPolicies.Except(registeredPolicies).ToList();
+
+        unregistered.Should().BeEmpty(
+            "every [Authorize(Policy = \"X\")] must have a matching AddPolicy(\"X\") registration. " +
+            "Unregistered policies cause runtime 500 errors. " +
+            $"Found {unregistered.Count} unregistered policy(ies): {string.Join(", ", unregistered)}");
+    }
+
+    /// <summary>
+    /// Critical controllers that handle sensitive operations must have
+    /// class-level [Authorize] or [AllowAnonymous] attributes.
+    /// Phase 14 focuses on controllers with policy-gated access or
+    /// AI agent execution endpoints.
+    /// </summary>
+    [Theory]
+    [InlineData("CoPilotController.cs")]
+    [InlineData("AISwarmController.cs")]
+    [InlineData("EliteSecurityController.cs")]
+    [InlineData("MultiCountyIntegrationController.cs")]
+    public void Critical_Controllers_Must_Have_Authorization(string fileName)
+    {
+        if (string.IsNullOrEmpty(BackendSrcDir) || !Directory.Exists(BackendSrcDir))
+            return;
+
+        var files = Directory.GetFiles(BackendSrcDir, fileName, SearchOption.AllDirectories)
+            .Where(f => !f.Contains("obj") && !f.Contains("bin") && !f.Contains("Test"))
+            .ToArray();
+
+        if (files.Length == 0)
+            return; // Controller not present in this checkout
+
+        var authorizePattern = new Regex(@"\[Authorize", RegexOptions.Compiled);
+        var allowAnonymousPattern = new Regex(@"\[AllowAnonymous\]", RegexOptions.Compiled);
+
+        foreach (var file in files)
+        {
+            var content = File.ReadAllText(file);
+            var hasAuth = authorizePattern.IsMatch(content) || allowAnonymousPattern.IsMatch(content);
+
+            hasAuth.Should().BeTrue(
+                $"{fileName} must have [Authorize] or [AllowAnonymous] — " +
+                "unsecured controllers handling sensitive operations violate FISMA-HIGH");
+        }
+    }
+
+    #endregion
+
+    #region Tool Registry Schema Compliance
+
+    /// <summary>
+    /// The tool registry must validate against the schema.
+    /// Every tool must have required fields: toolId, suite, risk.
+    /// </summary>
+    [Fact]
+    public void All_Tools_Must_Have_Required_Fields()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        var index = 0;
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var missingFields = new List<string>();
+
+            if (!tool.TryGetProperty("toolId", out _)) missingFields.Add("toolId");
+            if (!tool.TryGetProperty("suite", out _)) missingFields.Add("suite");
+            if (!tool.TryGetProperty("risk", out _)) missingFields.Add("risk");
+
+            if (missingFields.Count > 0)
+            {
+                var toolId = tool.TryGetProperty("toolId", out var tid)
+                    ? tid.GetString() ?? $"tool[{index}]"
+                    : $"tool[{index}]";
+                violations.Add($"  {toolId} missing: {string.Join(", ", missingFields)}");
+            }
+            index++;
+        }
+
+        violations.Should().BeEmpty(
+            "every tool must declare required fields (toolId, suite, risk). " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Every tool's suite value must match the canonical enum from the schema.
+    /// </summary>
+    [Fact]
+    public void Tool_Suite_Values_Must_Be_Canonical()
+    {
+        var repoRoot = GetRepoRoot();
+        if (repoRoot == null) return;
+
+        var toolsFile = Path.Combine(repoRoot, "tools", "registry", "terrapilot.tools.json");
+        if (!File.Exists(toolsFile)) return;
+
+        var validSuites = new HashSet<string> { "forge", "atlas", "dais", "dossier", "os", "pilot", "gpt" };
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(toolsFile));
+        var tools = doc.RootElement.GetProperty("tools");
+
+        var violations = new List<string>();
+        foreach (var tool in tools.EnumerateArray())
+        {
+            var toolId = tool.GetProperty("toolId").GetString()!;
+            var suite = tool.GetProperty("suite").GetString()!;
+
+            if (!validSuites.Contains(suite))
+            {
+                violations.Add($"  {toolId} has non-canonical suite={suite}");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "all tool suite values must be canonical (forge|atlas|dais|dossier|os|pilot|gpt). " +
+            $"Found {violations.Count} violation(s):\n" +
+            string.Join("\n", violations));
+    }
+
+    #endregion
+}

--- a/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
+++ b/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
@@ -96,6 +96,13 @@ namespace TerraFusion.API.Security
 
                 options.AddPolicy("RequireUser", policy =>
                     policy.RequireAuthenticatedUser());
+
+                // OS-level access policies referenced by controllers (Phase 14)
+                options.AddPolicy("OSCoreAccess", policy =>
+                    policy.RequireRole("GovernmentUser", "SystemAdministrator", "Admin", "SystemAdmin"));
+
+                options.AddPolicy("TIER5AIAccess", policy =>
+                    policy.RequireRole("SystemAdministrator", "Admin", "SystemAdmin", "AIModuleAccess"));
             });
 
             return services;

--- a/backend/src/TerraFusion.Consciousness/CoPilot/CoPilotController.cs
+++ b/backend/src/TerraFusion.Consciousness/CoPilot/CoPilotController.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.SemanticKernel;
@@ -29,6 +30,7 @@ namespace TerraFusion.Consciousness.CoPilot;
 /// </summary>
 [ApiController]
 [Route("api/copilot")]
+[Authorize(Policy = "OSCoreAccess")]
 public class CoPilotController : ControllerBase
 {
     private readonly ICoPilotService _copilotService;

--- a/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
+++ b/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
@@ -37,6 +37,17 @@ namespace TerraFusion.Core.Services
         private const string BLACKLIST_PREFIX = "blacklist:";
         private const int REFRESH_TOKEN_LENGTH = 64;
 
+        /// <summary>
+        /// Mask email for safe logging (PII contract — Phase 13).
+        /// </summary>
+        private static string MaskEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email)) return "[empty]";
+            var at = email.IndexOf('@');
+            if (at <= 0) return "***";
+            return string.Concat(email[0], "***", email.Substring(at));
+        }
+
         public AuthenticationService(
             IJwtTokenService jwtTokenService,
             IDistributedCache cache,
@@ -73,7 +84,7 @@ namespace TerraFusion.Core.Services
 
                 var token = _jwtTokenService.GenerateAccessToken(userId, email, roles.ToArray(), customClaims);
                 
-                _logger.LogInformation("Generated JWT token for user {UserId} with email {Email}", userId, email);
+                _logger.LogInformation("Generated JWT token for user {UserId} with email {EmailMasked}", userId, MaskEmail(email));
                 
                 return await Task.FromResult(token);
             }

--- a/backend/src/TerraFusion.Core/Services/SecurityService.cs
+++ b/backend/src/TerraFusion.Core/Services/SecurityService.cs
@@ -41,6 +41,18 @@ namespace TerraFusion.Core.Services
         private const string FAILED_ATTEMPTS_PREFIX = "failed_attempts:";
         private const string ACCOUNT_LOCK_PREFIX = "account_lock:";
 
+        /// <summary>
+        /// Mask an email address for safe logging (PII contract — Phase 13).
+        /// Example: "user@county.gov" → "u***@county.gov"
+        /// </summary>
+        private static string MaskEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email)) return "[empty]";
+            var at = email.IndexOf('@');
+            if (at <= 0) return "***";
+            return string.Concat(email[0], "***", email.Substring(at));
+        }
+
         // Valid government domains
         private readonly HashSet<string> _governmentDomains = new()
         {
@@ -87,11 +99,11 @@ namespace TerraFusion.Core.Services
                     
                     if (!string.IsNullOrEmpty(isWhitelisted))
                     {
-                        _logger.LogInformation("Whitelisted user {Email} validated", email);
+                        _logger.LogInformation("Whitelisted user {EmailMasked} validated", MaskEmail(email));
                         return true;
                     }
 
-                    _logger.LogWarning("Non-government email attempted: {Email}", email);
+                    _logger.LogWarning("Non-government email attempted: {EmailMasked}", MaskEmail(email));
                     return false;
                 }
 
@@ -99,7 +111,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error validating government user {Email}", email);
+                _logger.LogError(ex, "Error validating government user {EmailMasked}", MaskEmail(email));
                 return false;
             }
         }
@@ -161,9 +173,9 @@ namespace TerraFusion.Core.Services
                 // (Active Directory / LDAP / OAuth2) in production.
                 // This stub rejects all credentials and logs the attempt.
                 _logger.LogWarning(
-                    "ValidateUserCredentialsAsync called for {Email} — no identity provider configured. " +
+                    "ValidateUserCredentialsAsync called for {EmailMasked} — no identity provider configured. " +
                     "Wire up ILdapService or an OAuth2 provider for real authentication.",
-                    email);
+                    MaskEmail(email));
 
                 var isValid = false;
 
@@ -178,7 +190,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error validating credentials for {Email}", email);
+                _logger.LogError(ex, "Error validating credentials for {EmailMasked}", MaskEmail(email));
                 return false;
             }
         }
@@ -234,7 +246,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting roles for {Email}", email);
+                _logger.LogError(ex, "Error getting roles for {EmailMasked}", MaskEmail(email));
                 return new[] { "GovernmentUser" };
             }
         }
@@ -253,7 +265,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error checking account lock for {Email}", email);
+                _logger.LogError(ex, "Error checking account lock for {EmailMasked}", MaskEmail(email));
                 return false;
             }
         }
@@ -288,7 +300,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error recording failed login for {Email}", email);
+                _logger.LogError(ex, "Error recording failed login for {EmailMasked}", MaskEmail(email));
             }
         }
 
@@ -302,11 +314,11 @@ namespace TerraFusion.Core.Services
                 var attemptsKey = $"{FAILED_ATTEMPTS_PREFIX}{email}";
                 await _cache.RemoveAsync(attemptsKey);
                 
-                _logger.LogInformation("Reset failed login attempts for {Email}", email);
+                _logger.LogInformation("Reset failed login attempts for {EmailMasked}", MaskEmail(email));
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error resetting failed attempts for {Email}", email);
+                _logger.LogError(ex, "Error resetting failed attempts for {EmailMasked}", MaskEmail(email));
             }
         }
 
@@ -324,7 +336,7 @@ namespace TerraFusion.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting failed attempts for {Email}", email);
+                _logger.LogError(ex, "Error getting failed attempts for {EmailMasked}", MaskEmail(email));
                 return 0;
             }
         }
@@ -353,11 +365,11 @@ namespace TerraFusion.Core.Services
                 
                 await LogSecurityEventAsync("ACCOUNT_LOCKED", $"Account {email} locked for {duration.TotalMinutes} minutes", reason);
                 
-                _logger.LogWarning("Account {Email} locked. Reason: {Reason}", email, reason);
+                _logger.LogWarning("Account {EmailMasked} locked. Reason: {Reason}", MaskEmail(email), reason);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error locking account {Email}", email);
+                _logger.LogError(ex, "Error locking account {EmailMasked}", MaskEmail(email));
             }
         }
 
@@ -375,11 +387,11 @@ namespace TerraFusion.Core.Services
                 
                 await LogSecurityEventAsync("ACCOUNT_UNLOCKED", $"Account {email} unlocked");
                 
-                _logger.LogInformation("Account {Email} unlocked", email);
+                _logger.LogInformation("Account {EmailMasked} unlocked", MaskEmail(email));
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error unlocking account {Email}", email);
+                _logger.LogError(ex, "Error unlocking account {EmailMasked}", MaskEmail(email));
             }
         }
 


### PR DESCRIPTION
## Summary
- **13 governance tests** enforcing tool risk policy, write-lane discipline, authorization policy registration, and critical controller authorization
- Registers previously missing `OSCoreAccess` and `TIER5AIAccess` authorization policies — prevents runtime 500 errors on 8+ controllers
- Secures `CoPilotController` with `[Authorize(Policy = "OSCoreAccess")]` — AI agent endpoints were previously publicly accessible

## What changed

### New: `backend/TerraFusion.API.Tests/Phase14/ToolRiskPolicyTests.cs`
13 governance tests in 3 regions:
| Region | Tests | What it enforces |
|--------|-------|-----------------|
| Tool Registry Risk+WriteLane | 6 | Write tools declare writeLane, read-only tools have null writeLane, irreversible tools need supervisor approval, high-risk tools need confirmation, canonical risk/writeLane enums |
| Authorization Policy Registration | 1 + 4 Theory | Every `[Authorize(Policy="X")]` has a matching `AddPolicy("X")`; CoPilot, AISwarm, EliteSecurity, MultiCountyIntegration controllers must have `[Authorize]` |
| Schema Compliance | 2 | Required fields (toolId, suite, risk); canonical suite enum |

### Modified: `AuthenticationConfiguration.cs`
- Added `OSCoreAccess` policy (roles: GovernmentUser, SystemAdministrator, Admin, SystemAdmin)
- Added `TIER5AIAccess` policy (roles: SystemAdministrator, Admin, SystemAdmin, AIModuleAccess)

### Modified: `CoPilotController.cs`
- Added `using Microsoft.AspNetCore.Authorization;`
- Added `[Authorize(Policy = "OSCoreAccess")]` class-level attribute

## Test plan
- [x] 13/13 Phase 14 tests pass
- [x] 9/9 Phase 13 tests still pass (no regression)
- [x] Solution builds with 0 errors

## Phase pipeline
- Phase 11 (CS1998 pragma cleanup): PR #337 MERGED
- Phase 12 (orphan interface stubs): PR #338 MERGED
- Phase 13 (trace contract hardening): PR #341 auto-merge enabled
- **Phase 14 (tool risk policy + write lanes): this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)