### PR TITLE
feat(desktop): Phase 22 — derive desktop icons from canonical registry

### DIFF
--- a/frontend/apps/os-shell/src/config/__tests__/DesktopManifestDriftGate.test.ts
+++ b/frontend/apps/os-shell/src/config/__tests__/DesktopManifestDriftGate.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Phase 22 — Desktop Manifest Drift Gate
+ *
+ * Mechanical enforcement: every desktop icon entry must map to a
+ * canonical suite or OS feature ID from suiteRegistry.ts.
+ *
+ * This gate FAILS if:
+ * - A desktop icon references an ID not in CONSTITUTIONAL_SUITES or OS_FEATURES
+ * - A desktop icon ID appears more than once (duplicates)
+ * - getDesktopIcons() returns an empty array (registry disconnected)
+ */
+
+import { CONSTITUTIONAL_SUITES, OS_FEATURES } from '../suiteRegistry';
+import { getDesktopIcons } from '../desktopManifest';
+
+describe('DesktopManifestDriftGate', () => {
+  const canonicalSuiteIds = CONSTITUTIONAL_SUITES.map((s) => s.id);
+  const canonicalFeatureIds = OS_FEATURES.map((f) => f.id);
+  const allCanonicalIds = [...canonicalSuiteIds, ...canonicalFeatureIds];
+
+  const desktopIcons = getDesktopIcons();
+  const desktopIds = desktopIcons.map((d) => d.id);
+
+  it('desktop manifest is non-empty', () => {
+    expect(desktopIcons.length).toBeGreaterThan(0);
+  });
+
+  it('every desktop icon ID exists in canonical suites or OS features', () => {
+    const unknown = desktopIds.filter((id) => !allCanonicalIds.includes(id));
+    expect(unknown).toEqual([]);
+  });
+
+  it('no duplicate desktop icon IDs', () => {
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const id of desktopIds) {
+      if (seen.has(id)) duplicates.push(id);
+      seen.add(id);
+    }
+    expect(duplicates).toEqual([]);
+  });
+
+  it('every desktop icon has required fields', () => {
+    for (const icon of desktopIcons) {
+      expect(icon.id).toBeTruthy();
+      expect(icon.name).toBeTruthy();
+      expect(icon.iconName).toBeTruthy();
+      expect(icon.route).toBeTruthy();
+    }
+  });
+
+  it('all workbench suites appear on desktop', () => {
+    const workbenchSuiteIds = CONSTITUTIONAL_SUITES.filter((s) => s.workbenchTab).map((s) => s.id);
+    const missing = workbenchSuiteIds.filter((id) => !desktopIds.includes(id));
+    expect(missing).toEqual([]);
+  });
+});

--- a/frontend/apps/os-shell/src/config/desktopManifest.ts
+++ b/frontend/apps/os-shell/src/config/desktopManifest.ts
@@ -1,0 +1,115 @@
+/**
+ * TerraFusion OS - Desktop Icon Manifest (Derived)
+ * ═══════════════════════════════════════════════════════════════
+ *
+ * SINGLE DERIVED SOURCE for desktop icons.
+ * Consumes CONSTITUTIONAL_SUITES + OS_FEATURES from suiteRegistry.ts
+ * so desktop icons can never drift from the governance registry.
+ *
+ * Phase 22: Eliminates hardcoded DESKTOP_ICONS in DesktopIconGrid.
+ *
+ * @see config/suiteRegistry.ts - Canonical source of truth
+ */
+
+import type { Category } from './generatedModules';
+import type { WiringStatus } from '../shell/desktop/DesktopIcon';
+import {
+  CONSTITUTIONAL_SUITES,
+  OS_FEATURES,
+  type SuiteDefinition,
+  type OsFeatureDefinition,
+} from './suiteRegistry';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DesktopIconEntry {
+  /** Canonical ID from suiteRegistry (suite or OS feature) */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Lucide icon name */
+  iconName: string;
+  /** Module category for TerraSphere variant */
+  category: Category;
+  /** Navigation route (workbench tab or standalone) */
+  route: string;
+  /** Wiring status badge for honest UX */
+  wiringStatus: WiringStatus;
+}
+
+// ============================================================================
+// Presentation Mapping (keyed by canonical IDs only)
+// ============================================================================
+
+/**
+ * Demo parcel ID for workbench routing.
+ * In production, this would come from user's recent parcels.
+ */
+const DEMO_PARCEL_ID = '1234567890';
+
+/** Category mapping for suites (keyed by canonical suite ID) */
+const SUITE_CATEGORY: Record<string, Category> = {
+  forge: 'assessment',
+  atlas: 'mapping',
+  dais: 'system',
+  dossier: 'records',
+  gpt: 'ai',
+};
+
+/** Category mapping for OS features (keyed by canonical feature ID) */
+const FEATURE_CATEGORY: Record<string, Category> = {
+  pilot: 'system',
+  trace: 'system',
+};
+
+// ============================================================================
+// Derivation Logic
+// ============================================================================
+
+function suiteToDesktopIcon(suite: SuiteDefinition): DesktopIconEntry {
+  const tabId = suite.workbenchTarget?.tabId ?? suite.id;
+  return {
+    id: suite.id,
+    name: suite.displayName,
+    iconName: suite.iconName,
+    category: SUITE_CATEGORY[suite.id] ?? 'system',
+    route: `/property/${DEMO_PARCEL_ID}/${tabId}`,
+    wiringStatus: 'WB',
+  };
+}
+
+function featureToDesktopIcon(feature: OsFeatureDefinition): DesktopIconEntry {
+  return {
+    id: feature.id,
+    name: feature.displayName,
+    iconName: feature.iconName,
+    category: FEATURE_CATEGORY[feature.id] ?? 'system',
+    route: feature.route ?? `/${feature.id}`,
+    wiringStatus: 'OS',
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Returns desktop icon entries derived from canonical suite registry.
+ *
+ * Includes:
+ * - All constitutional suites with workbenchTab=true (route to Workbench)
+ * - OS features with route defined (native OS routes)
+ *
+ * This function is the ONLY source DesktopIconGrid should consume.
+ */
+export function getDesktopIcons(): DesktopIconEntry[] {
+  const suiteIcons = CONSTITUTIONAL_SUITES.filter((s) => s.workbenchTab).map(suiteToDesktopIcon);
+
+  const featureIcons = OS_FEATURES.filter((f) => f.route && f.status === 'live').map(
+    featureToDesktopIcon
+  );
+
+  return [...suiteIcons, ...featureIcons];
+}

--- a/frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx
@@ -1,98 +1,33 @@
 /**
  * TerraFusion OS Desktop Icon Grid Component
  *
- * Grid layout of CONSTITUTIONAL SUITES only.
+ * Grid layout of CONSTITUTIONAL SUITES + OS FEATURES.
  * Legacy modules are accessible via Start Menu with [EXT] badge.
  *
- * Phase 9: Desktop now shows only constitutional suites from suiteRegistry.ts
+ * Phase 22: Desktop icons derived from canonical desktopManifest.ts
+ * (no hardcoded icon list — single source of truth is suiteRegistry.ts)
  *
  * @module shell/desktop/DesktopIconGrid
- * @see config/suiteRegistry.ts - Single source of truth
+ * @see config/desktopManifest.ts - Derived desktop icon entries
+ * @see config/suiteRegistry.ts - Canonical source of truth
  */
 
 import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Category } from '../../config/generatedModules';
-import { DesktopIcon, type WiringStatus } from './DesktopIcon';
+import { getDesktopIcons } from '../../config/desktopManifest';
+import { DesktopIcon } from './DesktopIcon';
 
 // ============================================================================
-// Constants - Constitutional Suites with HONEST Wiring Status
+// Derived Icons from Canonical Registry (Phase 22)
 // ============================================================================
 
 /**
- * Demo parcel ID for workbench routing.
- * In production, this would come from user's recent parcels.
- */
-const DEMO_PARCEL_ID = '1234567890';
-
-/**
- * Desktop icon definitions from Constitutional Suite Registry.
- * Each suite routes to Workbench (real MWUX) instead of WIP suite homes.
+ * Desktop icons derived from the canonical suite registry.
+ * This is the ONLY list DesktopIconGrid should render.
  *
- * Wiring Status Legend:
- * - WB: Opens Workbench tab (BEST - real invokeTool flows)
- * - OS: Native OS route (live)
- * - WIP: Work in progress (placeholder page)
+ * @see getDesktopIcons() — derives from CONSTITUTIONAL_SUITES + OS_FEATURES
  */
-const DESKTOP_ICONS: Array<{
-  id: string;
-  name: string;
-  iconName: string;
-  category: Category;
-  route: string;
-  wiringStatus: WiringStatus;
-}> = [
-  // Constitutional Suites → Route to Workbench tabs (real MWUX)
-  {
-    id: 'forge',
-    name: 'TerraForge',
-    iconName: 'Hammer',
-    category: 'assessment',
-    route: `/property/${DEMO_PARCEL_ID}/forge`, // Real invokeTool: explain_model_results
-    wiringStatus: 'WB',
-  },
-  {
-    id: 'atlas',
-    name: 'TerraAtlas',
-    iconName: 'Globe',
-    category: 'mapping',
-    route: `/property/${DEMO_PARCEL_ID}/atlas`, // Real invokeTool: query_parcel_layers
-    wiringStatus: 'WB',
-  },
-  {
-    id: 'dais',
-    name: 'TerraDais',
-    iconName: 'LayoutDashboard',
-    category: 'system',
-    route: `/property/${DEMO_PARCEL_ID}/dais`, // Real invokeTool: check_cert_status
-    wiringStatus: 'WB',
-  },
-  {
-    id: 'dossier',
-    name: 'TerraDossier',
-    iconName: 'FileStack',
-    category: 'records',
-    route: `/property/${DEMO_PARCEL_ID}/dossier`, // Real invokeTool: summarize_dossier
-    wiringStatus: 'WB',
-  },
-  {
-    id: 'gpt',
-    name: 'TerraGPT',
-    iconName: 'Bot',
-    category: 'ai',
-    route: `/property/${DEMO_PARCEL_ID}/pilot`, // Real invokeTool: registry.list_tools
-    wiringStatus: 'WB',
-  },
-  // OS Feature: Pilot Console (full standalone route)
-  {
-    id: 'pilot',
-    name: 'TerraPilot',
-    iconName: 'Compass',
-    category: 'system',
-    route: '/pilot', // Native OS route (live)
-    wiringStatus: 'OS',
-  },
-];
+const DESKTOP_ICONS = getDesktopIcons();
 
 // ============================================================================
 // Types

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIconGrid.canonical.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIconGrid.canonical.test.tsx
@@ -22,9 +22,7 @@ const { DesktopIconGrid } = require('../DesktopIconGrid');
 
 const DESKTOP_ICONS = getDesktopIcons();
 
-// Skip: Phase 22 test — DesktopIconGrid still uses hardcoded DESKTOP_ICONS,
-// not yet rewired to consume desktopManifest. Enable after Phase 22 implementation.
-describe.skip('DesktopIconGrid canonical behavior (Phase 22)', () => {
+describe('DesktopIconGrid canonical behavior (Phase 22)', () => {
   beforeEach(() => mockNavigate.mockClear());
 
   it('renders the correct number of icons from manifest', () => {

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIconGrid.canonical.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIconGrid.canonical.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Phase 22 — DesktopIconGrid Canonical Behavior Test
+ *
+ * Verifies that the desktop icon grid renders icons derived from
+ * the canonical suite registry (not hardcoded). Tests the component
+ * consumes getDesktopIcons() and navigates correctly on interaction.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { getDesktopIcons } from '../../../config/desktopManifest';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { DesktopIconGrid } = require('../DesktopIconGrid');
+
+const DESKTOP_ICONS = getDesktopIcons();
+
+// Skip: Phase 22 test — DesktopIconGrid still uses hardcoded DESKTOP_ICONS,
+// not yet rewired to consume desktopManifest. Enable after Phase 22 implementation.
+describe.skip('DesktopIconGrid canonical behavior (Phase 22)', () => {
+  beforeEach(() => mockNavigate.mockClear());
+
+  it('renders the correct number of icons from manifest', () => {
+    render(<DesktopIconGrid />, {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    const icons = DESKTOP_ICONS.map((d) => screen.getByTestId(`desktop-icon-${d.id}`));
+    expect(icons).toHaveLength(DESKTOP_ICONS.length);
+  });
+
+  it('renders display names from manifest', () => {
+    render(<DesktopIconGrid />, {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    for (const icon of DESKTOP_ICONS) {
+      expect(screen.getByText(icon.name)).toBeInTheDocument();
+    }
+  });
+
+  it('navigates to manifest route on double-click', () => {
+    render(<DesktopIconGrid />, {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    const first = DESKTOP_ICONS[0];
+    const el = screen.getByTestId(`desktop-icon-${first.id}`);
+    fireEvent.doubleClick(el);
+
+    expect(mockNavigate).toHaveBeenCalledWith(first.route);
+  });
+
+  it('no hardcoded IDs outside desktopManifest', () => {
+    // This test verifies that the number of rendered icons equals
+    // the manifest count — if someone adds a hardcoded icon, this breaks.
+    render(<DesktopIconGrid />, {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    const grid = screen.getByTestId('desktop-icon-grid');
+    const renderedIcons = grid.querySelectorAll('[data-testid^="desktop-icon-"]');
+    expect(renderedIcons).toHaveLength(DESKTOP_ICONS.length);
+  });
+});

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIcons.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/DesktopIcons.test.tsx
@@ -29,17 +29,12 @@ jest.mock('react-router-dom', () => {
 });
 
 // ============================================================================
-// Constants — must match DesktopIconGrid's hardcoded DESKTOP_ICONS
+// Constants — derived from canonical desktopManifest (Phase 22)
 // ============================================================================
 
-const DESKTOP_ICONS = [
-  { id: 'forge', name: 'TerraForge', iconName: 'Hammer', route: '/property/1234567890/forge' },
-  { id: 'atlas', name: 'TerraAtlas', iconName: 'Globe', route: '/property/1234567890/atlas' },
-  { id: 'dais', name: 'TerraDais', iconName: 'LayoutDashboard', route: '/property/1234567890/dais' },
-  { id: 'dossier', name: 'TerraDossier', iconName: 'FileStack', route: '/property/1234567890/dossier' },
-  { id: 'gpt', name: 'TerraGPT', iconName: 'Bot', route: '/property/1234567890/pilot' },
-  { id: 'pilot', name: 'TerraPilot', iconName: 'Compass', route: '/pilot' },
-];
+import { getDesktopIcons } from '../../../config/desktopManifest';
+
+const DESKTOP_ICONS = getDesktopIcons();
 
 // ============================================================================
 // Test Utilities


### PR DESCRIPTION
## Phase 22 — Desktop Icon Canonicalization

### What
Eliminates hardcoded `DESKTOP_ICONS` in DesktopIconGrid. Desktop icons are now derived from the canonical suite registry via `getDesktopIcons()` in `desktopManifest.ts`.

### Changes
1. **desktopManifest.ts** — derives desktop icons from `CONSTITUTIONAL_SUITES` + `OS_FEATURES` in `suiteRegistry.ts`
2. **DesktopIconGrid.tsx** — replaced 65-line hardcoded array with `const DESKTOP_ICONS = getDesktopIcons()`
3. **DesktopIcons.test.tsx** — derives test constants from manifest (no more inline array)
4. **DesktopIconGrid.canonical.test.tsx** — enabled (was `describe.skip`), verifies rendered icons === manifest icons
5. **DesktopManifestDriftGate.test.ts** — validates every desktop icon ID maps to canonical suite/feature

### Why
Desktop icon IDs drifted from the suite registry. This caused test failures in Phase 21 and would have allowed silent breakage if suites were renamed. Now the desktop and registry are mechanically linked — if someone adds/removes a suite, the desktop auto-updates.

### Evidence
- Full regression: **197/197 suites GREEN** (gained 2: canonical test + drift gate)
- Tests: **3585 passed / 0 failed**
- Type-check: **0 errors**
- Drift gate: **5/5 GREEN**
- Canonical test: **4/4 GREEN**