### PR TITLE
fix(test): stabilize Phase 25/26 landmark assertions for full-suite runs

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopIntentContract.test.tsx
@@ -19,8 +19,8 @@
  * Scope: Mechanical intent only; not asserting business data.
  */
 
-import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { getDesktopIcons, type DesktopIconEntry } from '../../config/desktopManifest';
 
@@ -197,14 +197,16 @@ describe('Phase 26 intent contract: click desktop icon → navigate → landmark
         { timeout: 5000 }
       );
 
-      // Let async effects settle
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
       // Phase 24 crash guard (redundant but cheap)
       expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
 
-      // Phase 25 landmark assertion
-      assertLandmark(icon.route);
+      // Phase 25 landmark assertion — use waitFor to handle lazy tab rendering under load.
+      await waitFor(
+        () => {
+          assertLandmark(icon.route);
+        },
+        { timeout: 5000 }
+      );
     }
   );
 });

--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopRouteLandmarkContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopRouteLandmarkContract.test.tsx
@@ -155,29 +155,28 @@ describe('Phase 25 contract: desktop routes render stable content landmarks', ()
     }
   });
 
-  it.each(testableIcons)(
-    '$name ($id) at $route has a content landmark',
-    async (icon) => {
-      memoryRouterEntries = [icon.route];
+  it.each(testableIcons)('$name ($id) at $route has a content landmark', async (icon) => {
+    memoryRouterEntries = [icon.route];
 
-      render(<Router />);
+    render(<Router />);
 
-      // Wait for Suspense to resolve (same as Phase 24).
-      await waitFor(
-        () => {
-          expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
-        },
-        { timeout: 5000 }
-      );
+    // Wait for Suspense to resolve (same as Phase 24).
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
 
-      // Let async effects settle.
-      await new Promise((resolve) => setTimeout(resolve, 50));
+    // Phase 24 crash guard (redundant but cheap).
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
 
-      // Phase 24 crash guard (redundant but cheap).
-      expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
-
-      // Phase 25 landmark assertion.
-      assertLandmark(icon.route);
-    }
-  );
+    // Phase 25 landmark assertion — use waitFor to handle lazy tab rendering under load.
+    await waitFor(
+      () => {
+        assertLandmark(icon.route);
+      },
+      { timeout: 5000 }
+    );
+  });
 });


### PR DESCRIPTION
## Fix: Flaky TerraAtlas landmark assertion under full-suite load

### Problem
Phase 25 (DesktopRouteLandmarkContract) and Phase 26 (DesktopIntentContract) both used a fixed 50ms setTimeout after Suspense resolved, then synchronously checked for landmarks. Under full-suite load (200 suites), the lazy-loaded PropertyAtlas tab sometimes hadn't rendered yet, causing TerraAtlas to fail intermittently.

Both tests pass 100% when run in isolation.

### Fix
Replace static delay + synchronous assertLandmark() with waitFor(() => assertLandmark(icon.route), { timeout: 5000 }).

waitFor polls repeatedly until the landmark appears or times out, making the assertion deterministic regardless of worker load.

### Evidence
- 200/200 suites GREEN (2 consecutive full runs, 0 flaky failures)
- 3611 tests passed
- No production code changes