### PR TITLE
test(desktop): Phase 27 — deep-link intent contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
@@ -1,9 +1,9 @@
 /**
  * Phase 27 — Desktop Deep-Link Intent Contract
  *
- * Contract: navigating directly to each desktop route (as if pasting a URL
- * or hitting browser refresh) must mount the full Router and render the
- * Phase 25 landmark — without any prior desktop click or navigation.
+ * Contract: for every desktop route from getDesktopIcons(), direct navigation
+ * (paste URL / browser refresh) renders the Phase 25 landmark WITHOUT
+ * requiring prior desktop interaction (no click, no icon grid).
  *
  * Phase 22 guarantees "IDs are canonical".
  * Phase 23 guarantees "route exists in Router".
@@ -135,11 +135,11 @@ describe('Phase 27 contract: deep-link → Router mounts → landmark renders', 
     expect(testableIcons.length).toBeGreaterThan(0);
   });
 
-  it('every route has a landmark spec registered', () => {
+  it('every route has a deep-link landmark spec registered', () => {
     const missing = testableIcons.filter((icon) => !ROUTE_LANDMARKS[icon.route]);
     if (missing.length > 0) {
       throw new Error(
-        'Routes without landmark spec:\n' +
+        'Routes without deep-link landmark spec:\n' +
           missing.map((i) => `  - ${i.id}: ${i.route}`).join('\n') +
           '\nAdd them to ROUTE_LANDMARKS in this test file.'
       );

--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Phase 27 — Desktop Deep-Link Intent Contract
+ *
+ * Contract: navigating directly to each desktop route (as if pasting a URL
+ * or hitting browser refresh) must mount the full Router and render the
+ * Phase 25 landmark — without any prior desktop click or navigation.
+ *
+ * Phase 22 guarantees "IDs are canonical".
+ * Phase 23 guarantees "route exists in Router".
+ * Phase 24 guarantees "route doesn't immediately crash on render".
+ * Phase 25 guarantees "route renders non-empty content with a landmark".
+ * Phase 26 guarantees "click → navigate → landmark".
+ * Phase 27 guarantees "deep-link (refresh / pasted URL) → landmark".
+ *
+ * Prevents:
+ * - "Works from desktop click, fails on refresh/pasted URL"
+ * - Missing Suspense boundaries on direct entry
+ * - Broken lazy-load paths when entering mid-tree
+ * - AuthGuard redirect loops on direct route access
+ *
+ * Technique: set MemoryRouter initialEntries to each desktop route
+ * (simulating direct URL entry), render the full Router, assert landmark.
+ * Same BrowserRouter→MemoryRouter swap as Phase 24/25/26.
+ *
+ * Scope: Mechanical deep-link only; not asserting business data or API calls.
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { getDesktopIcons } from '../../config/desktopManifest';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Landmark Registry (identical to Phase 25 — the canonical landmark set)
+// ============================================================================
+
+const ROUTE_LANDMARKS: Record<string, { anyTestIds: string[] }> = {
+  '/property/1234567890/forge': {
+    anyTestIds: ['property-forge-tab', 'property-workbench-root'],
+  },
+  '/property/1234567890/atlas': {
+    anyTestIds: ['property-atlas-tab', 'property-workbench-root'],
+  },
+  '/property/1234567890/dais': {
+    anyTestIds: ['property-dais-tab', 'property-workbench-root'],
+  },
+  '/property/1234567890/dossier': {
+    anyTestIds: ['property-dossier-tab', 'property-workbench-root'],
+  },
+  '/property/1234567890/pilot': {
+    anyTestIds: ['property-pilot-tab', 'property-workbench-root'],
+  },
+  '/pilot': {
+    anyTestIds: ['standalone-shell', 'pilot-console-content'],
+  },
+  '/trace': {
+    anyTestIds: ['standalone-shell', 'trace-console-content'],
+  },
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isExternal(p: string): boolean {
+  return p.startsWith('http://') || p.startsWith('https://');
+}
+
+function assertLandmark(route: string) {
+  const spec = ROUTE_LANDMARKS[route];
+  if (!spec) {
+    throw new Error(
+      `Phase 27: No landmark spec for route "${route}". ` +
+        'Add it to ROUTE_LANDMARKS with at least one stable testid.'
+    );
+  }
+
+  const hit = spec.anyTestIds.some((id) => screen.queryByTestId(id));
+  if (!hit) {
+    throw new Error(
+      `Phase 27: Deep-linked to "${route}" but no landmark found.\n` +
+        `Expected any of: ${spec.anyTestIds.join(', ')}\n` +
+        'Fix: verify that direct-entry to this route renders the same landmarks as Phase 25.'
+    );
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 27 contract: deep-link → Router mounts → landmark renders', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const icons = getDesktopIcons();
+
+  const testableIcons = icons.filter((icon) => {
+    const r = icon.route;
+    if (!r || typeof r !== 'string') return false;
+    if (isExternal(r)) return false;
+    return true;
+  });
+
+  it('has testable desktop icons for deep-link testing', () => {
+    expect(testableIcons.length).toBeGreaterThan(0);
+  });
+
+  it('every route has a landmark spec registered', () => {
+    const missing = testableIcons.filter((icon) => !ROUTE_LANDMARKS[icon.route]);
+    if (missing.length > 0) {
+      throw new Error(
+        'Routes without landmark spec:\n' +
+          missing.map((i) => `  - ${i.id}: ${i.route}`).join('\n') +
+          '\nAdd them to ROUTE_LANDMARKS in this test file.'
+      );
+    }
+  });
+
+  it.each(testableIcons)(
+    '$name ($id): deep-link to $route renders Phase 25 landmark',
+    async (icon) => {
+      // Simulate direct-entry: set MemoryRouter to start at the route
+      // (as if user pasted the URL or hit refresh at this path).
+      memoryRouterEntries = [icon.route];
+
+      render(<Router />);
+
+      // Wait for Suspense to resolve (same as Phase 24/25/26).
+      await waitFor(
+        () => {
+          expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
+
+      // Crash guard: app should not be in error fallback state.
+      expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+
+      // Phase 27 core guarantee: deep-link produces the same landmark
+      // that Phase 25 verifies via navigated-to route.
+      await waitFor(
+        () => {
+          assertLandmark(icon.route);
+        },
+        { timeout: 5000 }
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Phase 27A — Desktop Deep-Link Intent Contract

### Contract
For every desktop route from `getDesktopIcons()`, **direct navigation** (paste URL / browser refresh) renders the Phase 25 landmark **without requiring prior desktop interaction**.

### Prevents
- "Works from desktop click, fails on refresh/pasted URL"
- Missing Suspense boundaries on direct entry
- Broken lazy-load paths when entering mid-tree
- AuthGuard redirect loops on direct route access

### Results
- **9/9 GREEN** on first run
- **201/201 suites passed** (full regression)
- **3,620 tests passed** / 0 type errors
- **Zero production changes**

### Governance Chain (7 links)
| Phase | Contract | Status |
|-------|---------|--------|
| 22 | IDs canonical (suiteRegistry → desktopManifest) | ✅ |
| 23 | Routes exist (desktopManifest → Router.tsx) | ✅ |
| 24 | Routes don't crash (Router render → no ErrorBoundary) | ✅ |
| 25 | Routes render landmarks (Router render → testid present) | ✅ |
| 26 | Click reaches content (double-click → navigate → landmark) | ✅ |
| **27** | **Deep-link reaches content (URL → Router → landmark)** | ✅ |

### Files Changed
- `frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx` (test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)