### PR TITLE
feat(terracanon): Phase 30A — TerraCanon launch spine + governance contracts

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -71,6 +71,8 @@ const PilotConsole = lazy(() => import('./pages/PilotConsole'));
 const PilotHome = lazy(() => import('./pages/PilotHome'));
 // Slice 6.1: Standalone Home Shell for Trace
 const TraceHome = lazy(() => import('./pages/TraceHome'));
+// Phase 30: TerraCanon IDE Shell
+const CanonHome = lazy(() => import('./pages/CanonHome'));
 
 // GovernanceLock - Dashboard (role-gated metrics)
 const GovernanceDashboard = lazy(() => import('./pages/GovernanceDashboard'));
@@ -164,6 +166,8 @@ const Router: React.FC = () => {
                 <Route path='/pilot/legacy' element={<PilotConsole />} />
                 {/* Slice 6.1: TerraTrace - Observability & Telemetry */}
                 <Route path='/trace' element={<TraceHome />} />
+                {/* Phase 30: TerraCanon - Integrated Development Environment */}
+                <Route path='/canon' element={<CanonHome />} />
 
                 {/* GovernanceLock - Dashboard (role-gated) */}
                 <Route path='/pilot/dashboard' element={<GovernanceDashboard />} />

--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
+import { AuthGuard, AuthProvider } from './auth/AuthProvider';
 import { ErrorBoundary } from './components/errors/ErrorBoundary';
 import { LegacyRedirect } from './components/legacy/LegacyRedirect';
-import { AuthProvider, AuthGuard } from './auth/AuthProvider';
 import { getViteEnv } from './env/getViteEnv';
 
 // Loading component for Suspense fallback

--- a/frontend/apps/os-shell/src/__tests__/desktop/AuthBoundaryIntent.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/AuthBoundaryIntent.test.tsx
@@ -98,6 +98,9 @@ const ROUTE_LANDMARKS: Record<string, { anyTestIds: string[] }> = {
   '/trace': {
     anyTestIds: ['standalone-shell', 'trace-console-content'],
   },
+  '/canon': {
+    anyTestIds: ['terracanon-root', 'standalone-shell'],
+  },
 };
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopDeepLinkContract.test.tsx
@@ -84,6 +84,9 @@ const ROUTE_LANDMARKS: Record<string, { anyTestIds: string[] }> = {
   '/trace': {
     anyTestIds: ['standalone-shell', 'trace-console-content'],
   },
+  '/canon': {
+    anyTestIds: ['terracanon-root', 'standalone-shell'],
+  },
 };
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopIntentContract.test.tsx
@@ -100,6 +100,9 @@ const ROUTE_LANDMARKS: Record<string, { anyTestIds: string[] }> = {
   '/trace': {
     anyTestIds: ['standalone-shell', 'trace-console-content'],
   },
+  '/canon': {
+    anyTestIds: ['terracanon-root', 'standalone-shell'],
+  },
 };
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/__tests__/desktop/DesktopRouteLandmarkContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/DesktopRouteLandmarkContract.test.tsx
@@ -83,6 +83,9 @@ const ROUTE_LANDMARKS: Record<string, { anyTestIds: string[] }> = {
   '/trace': {
     anyTestIds: ['standalone-shell', 'trace-console-content'],
   },
+  '/canon': {
+    anyTestIds: ['terracanon-root', 'standalone-shell'],
+  },
 };
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/config/desktopManifest.ts
+++ b/frontend/apps/os-shell/src/config/desktopManifest.ts
@@ -11,13 +11,13 @@
  * @see config/suiteRegistry.ts - Canonical source of truth
  */
 
-import type { Category } from './generatedModules';
 import type { WiringStatus } from '../shell/desktop/DesktopIcon';
+import type { Category } from './generatedModules';
 import {
-  CONSTITUTIONAL_SUITES,
-  OS_FEATURES,
-  type SuiteDefinition,
-  type OsFeatureDefinition,
+    CONSTITUTIONAL_SUITES,
+    OS_FEATURES,
+    type OsFeatureDefinition,
+    type SuiteDefinition,
 } from './suiteRegistry';
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/config/desktopManifest.ts
+++ b/frontend/apps/os-shell/src/config/desktopManifest.ts
@@ -62,6 +62,7 @@ const SUITE_CATEGORY: Record<string, Category> = {
 const FEATURE_CATEGORY: Record<string, Category> = {
   pilot: 'system',
   trace: 'system',
+  canon: 'system',
 };
 
 // ============================================================================

--- a/frontend/apps/os-shell/src/config/suiteRegistry.ts
+++ b/frontend/apps/os-shell/src/config/suiteRegistry.ts
@@ -23,7 +23,8 @@ export type SuiteId =
 
 export type OsFeatureId =
   | 'pilot' // TerraPilot - Agentic Task Orchestration
-  | 'trace'; // TerraTrace - Observability & Audit Trail
+  | 'trace' // TerraTrace - Observability & Audit Trail
+  | 'canon'; // TerraCanon - Integrated Development Environment
 
 export type OsSurfaceId = 'workbench'; // Property Workbench - Primary parcel-context UX
 
@@ -298,6 +299,30 @@ export const OS_FEATURES: readonly OsFeatureDefinition[] = [
           icon: '🔍',
         },
       ],
+    },
+  },
+  {
+    id: 'canon',
+    displayName: 'TerraCanon',
+    shortName: 'Canon',
+    description: 'Integrated Development Environment',
+    iconName: 'Code',
+    route: '/canon',
+    status: 'live',
+    label: 'TerraCanon',
+    icon: 'code',
+    homeMeta: {
+      title: 'TerraCanon IDE',
+      description: 'Integrated development environment for TerraFusion OS.',
+      subtitle: 'Standalone',
+      primaryActions: [
+        {
+          id: 'new-file',
+          label: 'New File',
+          intent: 'standalone',
+        },
+      ],
+      showWorkbenchCta: false,
     },
   },
 ] as const;

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -1,0 +1,46 @@
+/**
+ * TerraFusion Canon Home
+ *
+ * Standalone home page for TerraCanon (IDE) using the shared StandaloneHomeShell.
+ * Skeleton entry point — editor features will be added in future phases.
+ *
+ * @module pages/CanonHome
+ * @see Phase 30: TerraCanon Launch Spine Contract
+ */
+
+import React from 'react';
+import { StandaloneHomeShell } from '../components/standalone';
+
+function CanonContent(): React.ReactElement {
+  return (
+    <div className='canon-console' data-testid='terracanon-root'>
+      <section className='canon-console__overview'>
+        <h2>TerraCanon IDE</h2>
+        <p>Integrated development environment for TerraFusion OS.</p>
+      </section>
+    </div>
+  );
+}
+
+export function CanonHome(): React.ReactElement {
+  return (
+    <StandaloneHomeShell
+      featureId='canon'
+      meta={{
+        title: 'TerraCanon IDE',
+        description: 'Integrated development environment for TerraFusion OS.',
+        primaryActions: [
+          {
+            id: 'new-file',
+            label: 'New File',
+            intent: 'standalone',
+          },
+        ],
+      }}
+    >
+      <CanonContent />
+    </StandaloneHomeShell>
+  );
+}
+
+export default CanonHome;


### PR DESCRIPTION
## Phase 30A — TerraCanon Launch Spine Contract

Introduces **TerraCanon** (IDE) as a first-class desktop surface with the same governance protections as existing suites.

### Production Changes (4 files, minimal)
- **suiteRegistry.ts**: Add \canon\ to \OsFeatureId\, add TerraCanon to \OS_FEATURES\ array
- **desktopManifest.ts**: Add \canon: 'system'\ category mapping
- **Router.tsx**: Add \/canon\ route with lazy-loaded \CanonHome\
- **CanonHome.tsx**: New minimal shell page with \data-testid='terracanon-root'\

### Test Contract Extensions (4 files)
- Phase 25 landmark: \/canon\ → \	erracanon-root\
- Phase 26 click-intent: \/canon\ → \	erracanon-root\
- Phase 27 deep-link: \/canon\ → \	erracanon-root\
- Phase 29 auth boundary: \/canon\ → \	erracanon-root\

### Auto-Covered (no changes needed)
- Phase 22: Desktop manifest drift gate (icon derived from registry)
- Phase 23: Suite registry ↔ Router contract (route exists)
- Phase 24: Desktop launch smoke (no crash on render)
- Phase 28: Parcel param robustness (TerraCanon is standalone, not parcel-scoped)

### Regression
- **203/203 suites GREEN**
- **3665 tests passing** (+12 from TerraCanon coverage across existing contracts)
- **0 failures**

### Chain
22→23→24→25→26→27→28→29→**30**