### PR TITLE
feat(terracanon): Phase 31 — workspace bootstrap skeleton + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspaceBootstrapContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspaceBootstrapContract.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Phase 31 — TerraCanon Workspace Bootstrap Contract
+ *
+ * Contract: navigating to /canon renders a consistent IDE layout skeleton
+ * with workspace shell, file tree pane, and editor pane — even when no
+ * workspace is loaded.
+ *
+ * Phase 30 proved: TerraCanon has a desktop icon, route, and root landmark.
+ * Phase 31 proves: TerraCanon opens into a stable IDE interior layout.
+ *
+ * Success criteria:
+ *   1) /canon renders data-testid="terracanon-root" (Phase 30 baseline)
+ *   2) /canon renders data-testid="terracanon-workspace" (workspace shell)
+ *   3) /canon renders data-testid="terracanon-filetree" (file tree pane)
+ *   4) /canon renders data-testid="terracanon-editor" (editor pane)
+ *   5) /canon renders data-testid="terracanon-no-workspace" (no-workspace state)
+ *   6) No crash ("Reset Application" never appears)
+ *
+ * Prevents:
+ * - Blank IDE interior after launch (shell opens but nothing inside)
+ * - Missing layout panes that downstream features depend on
+ * - Crash on cold start with no workspace loaded
+ * - Regression if layout components are refactored
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–30
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - Assert all landmark testids after Suspense resolves
+ *
+ * Production change:
+ * - Workspace skeleton placeholders + testids in CanonHome.tsx
+ *
+ * Scope: Mechanical layout landmark only; no persistence, no real files.
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 31 contract: TerraCanon workspace bootstrap — IDE interior renders on cold start', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   * Returns nothing — assertions use screen queries.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    // Wait for Suspense fallback to clear
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    // Must not crash
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Phase 30 baseline — root landmark still present
+  // --------------------------------------------------------------------------
+  it('/canon renders terracanon-root landmark (Phase 30 baseline)', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-root')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Workspace shell landmark
+  // --------------------------------------------------------------------------
+  it('/canon renders terracanon-workspace shell', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: File tree pane landmark
+  // --------------------------------------------------------------------------
+  it('/canon renders terracanon-filetree pane', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Editor pane landmark
+  // --------------------------------------------------------------------------
+  it('/canon renders terracanon-editor pane', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: No-workspace state landmark (explicit empty state)
+  // --------------------------------------------------------------------------
+  it('/canon renders terracanon-no-workspace when no workspace is loaded', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: All landmarks co-exist in one render
+  // --------------------------------------------------------------------------
+  it('/canon renders all workspace landmarks simultaneously', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-root')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-workspace')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S7: Layout hierarchy — workspace contains filetree and editor
+  // --------------------------------------------------------------------------
+  it('terracanon-workspace contains filetree and editor panes', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        const workspace = screen.getByTestId('terracanon-workspace');
+        expect(workspace).toBeInTheDocument();
+
+        // File tree and editor should be nested inside workspace
+        const filetree = screen.getByTestId('terracanon-filetree');
+        const editor = screen.getByTestId('terracanon-editor');
+        expect(workspace.contains(filetree)).toBe(true);
+        expect(workspace.contains(editor)).toBe(true);
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S8: No crash guard — standard regression sentinel
+  // --------------------------------------------------------------------------
+  it('/canon deep-link does not crash (no Reset Application)', async () => {
+    await renderCanonAndWait();
+
+    // Redundant but explicit: the crash sentinel must never appear
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -2,22 +2,93 @@
  * TerraFusion Canon Home
  *
  * Standalone home page for TerraCanon (IDE) using the shared StandaloneHomeShell.
- * Skeleton entry point — editor features will be added in future phases.
+ * Phase 30: Launch spine — route + root landmark.
+ * Phase 31: Workspace bootstrap — IDE interior layout skeleton.
+ *
+ * Layout:
+ *   terracanon-root
+ *     └─ terracanon-workspace
+ *          ├─ terracanon-filetree (sidebar)
+ *          └─ terracanon-editor (main pane)
+ *               └─ terracanon-no-workspace (empty state)
+ *
+ * No persistence, no real files, no LSP. Skeleton only.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
+ * @see Phase 31: TerraCanon Workspace Bootstrap Contract
  */
 
 import React from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
+// ============================================================================
+// File Tree Pane (sidebar placeholder)
+// ============================================================================
+
+function FileTreePane(): React.ReactElement {
+  return (
+    <aside
+      className='canon-filetree border-r border-gray-700/50 w-60 min-h-[200px] p-3'
+      data-testid='terracanon-filetree'
+    >
+      <h3 className='text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2'>
+        Explorer
+      </h3>
+      <p className='text-gray-500 text-xs italic'>No files open</p>
+    </aside>
+  );
+}
+
+// ============================================================================
+// Editor Pane (main content area)
+// ============================================================================
+
+function EditorPane(): React.ReactElement {
+  return (
+    <section
+      className='canon-editor flex-1 min-h-[200px] p-4 flex items-center justify-center'
+      data-testid='terracanon-editor'
+    >
+      <div
+        className='text-center text-gray-500'
+        data-testid='terracanon-no-workspace'
+      >
+        <p className='text-lg mb-1'>No workspace loaded</p>
+        <p className='text-sm'>Open a file or create a new workspace to get started.</p>
+      </div>
+    </section>
+  );
+}
+
+// ============================================================================
+// Workspace Shell (IDE layout container)
+// ============================================================================
+
+function CanonWorkspace(): React.ReactElement {
+  return (
+    <div
+      className='canon-workspace flex border border-gray-700/30 rounded-lg overflow-hidden bg-gray-900/50'
+      data-testid='terracanon-workspace'
+    >
+      <FileTreePane />
+      <EditorPane />
+    </div>
+  );
+}
+
+// ============================================================================
+// Canon Content (root landmark + workspace)
+// ============================================================================
+
 function CanonContent(): React.ReactElement {
   return (
     <div className='canon-console' data-testid='terracanon-root'>
-      <section className='canon-console__overview'>
+      <section className='canon-console__overview mb-4'>
         <h2>TerraCanon IDE</h2>
         <p>Integrated development environment for TerraFusion OS.</p>
       </section>
+      <CanonWorkspace />
     </div>
   );
 }


### PR DESCRIPTION
## Phase 31 — TerraCanon Workspace Bootstrap Contract

Phase 30 proved the door opens. Phase 31 proves there's a room inside.

### Production Changes (1 file)
- **CanonHome.tsx**: Add IDE interior layout skeleton
  - `data-testid="terracanon-workspace"` — workspace shell container
  - `data-testid="terracanon-filetree"` — file tree sidebar pane
  - `data-testid="terracanon-editor"` — editor main pane
  - `data-testid="terracanon-no-workspace"` — explicit empty state

### Test Contract (1 new file, 8 tests)
- **TerraCanonWorkspaceBootstrapContract.test.tsx**
  - S1: Root landmark baseline (Phase 30)
  - S2: Workspace shell renders
  - S3: File tree pane renders
  - S4: Editor pane renders
  - S5: No-workspace state renders
  - S6: All landmarks co-exist simultaneously
  - S7: Workspace contains filetree and editor (hierarchy)
  - S8: No crash guard

### What's NOT here (by design)
- No persistence, no real file system
- No LSP, no Monaco editor
- No workspace storage or indexing
- No changes to Router, registry, or desktop manifest

### Regression
- **204/204 suites GREEN**
- **3,673 tests passing** (+8 from workspace bootstrap)
- **0 failures, 0 type errors**

### Chain
22→23→24→25→26→27→28→29→30→**31**

🐝 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workspace interface for TerraCanon with file tree navigation and editor panes, providing the foundation for an IDE-like development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->