### PR TITLE
feat(terracanon): Phase 32 — open-empty-workspace intent + loaded landmark + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonOpenEmptyWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonOpenEmptyWorkspaceIntentContract.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Phase 32 — TerraCanon Open Empty Workspace Intent Contract
+ *
+ * Contract: a user action on /canon transitions from "no workspace loaded"
+ * to "workspace loaded" deterministically, without crash, with stable landmarks.
+ *
+ * Phase 31 proved: TerraCanon opens into a stable IDE interior layout.
+ * Phase 32 proves: TerraCanon can transition from empty → loaded state.
+ *
+ * Success criteria:
+ *   1) Cold start renders terracanon-no-workspace (baseline)
+ *   2) Button terracanon-open-empty-workspace exists
+ *   3) Click → terracanon-workspace-loaded appears
+ *   4) Click → terracanon-no-workspace disappears
+ *   5) Loaded state still contains filetree + editor
+ *   6) No crash ("Reset Application" never appears)
+ *
+ * Prevents:
+ * - State transition that crashes or blanks the IDE
+ * - Missing loaded landmark after intent fires
+ * - Empty state lingering after open-workspace action
+ * - Layout panes disappearing after state change
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–31
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent.click for user intent simulation
+ * - Assert landmark transitions after click
+ *
+ * Production change:
+ * - Local boolean state + button + conditional landmarks in CanonHome.tsx
+ *
+ * Scope: State transition only; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 32 contract: TerraCanon open empty workspace intent — state transition with stable landmarks', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + click the open-empty-workspace button.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start — no-workspace landmark present
+  // --------------------------------------------------------------------------
+  it('cold start renders terracanon-no-workspace', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Open-empty-workspace button exists on cold start
+  // --------------------------------------------------------------------------
+  it('button terracanon-open-empty-workspace exists', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Click → workspace-loaded appears
+  // --------------------------------------------------------------------------
+  it('click open-empty-workspace → terracanon-workspace-loaded appears', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Click → no-workspace disappears
+  // --------------------------------------------------------------------------
+  it('click open-empty-workspace → terracanon-no-workspace disappears', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('terracanon-no-workspace')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Loaded state still contains filetree + editor
+  // --------------------------------------------------------------------------
+  it('loaded state keeps filetree + editor panes', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: No crash guard — standard regression sentinel
+  // --------------------------------------------------------------------------
+  it('state transition does not crash (no Reset Application)', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -4,22 +4,25 @@
  * Standalone home page for TerraCanon (IDE) using the shared StandaloneHomeShell.
  * Phase 30: Launch spine — route + root landmark.
  * Phase 31: Workspace bootstrap — IDE interior layout skeleton.
+ * Phase 32: Open empty workspace intent — state toggle + loaded landmark.
  *
  * Layout:
  *   terracanon-root
  *     └─ terracanon-workspace
  *          ├─ terracanon-filetree (sidebar)
  *          └─ terracanon-editor (main pane)
- *               └─ terracanon-no-workspace (empty state)
+ *               ├─ terracanon-no-workspace (empty state, hidden when loaded)
+ *               └─ terracanon-workspace-loaded (loaded state, shown after open)
  *
- * No persistence, no real files, no LSP. Skeleton only.
+ * State: local boolean `hasWorkspace`. No persistence, no filesystem, no LSP.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
  * @see Phase 31: TerraCanon Workspace Bootstrap Contract
+ * @see Phase 32: TerraCanon Open Empty Workspace Intent Contract
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
 // ============================================================================
@@ -44,19 +47,26 @@ function FileTreePane(): React.ReactElement {
 // Editor Pane (main content area)
 // ============================================================================
 
-function EditorPane(): React.ReactElement {
+function EditorPane({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactElement {
   return (
     <section
       className='canon-editor flex-1 min-h-[200px] p-4 flex items-center justify-center'
       data-testid='terracanon-editor'
     >
-      <div
-        className='text-center text-gray-500'
-        data-testid='terracanon-no-workspace'
-      >
-        <p className='text-lg mb-1'>No workspace loaded</p>
-        <p className='text-sm'>Open a file or create a new workspace to get started.</p>
-      </div>
+      {hasWorkspace ? (
+        <div data-testid='terracanon-workspace-loaded'>
+          <p className='text-lg mb-1 text-gray-300'>Workspace loaded</p>
+          <p className='text-sm text-gray-500'>Ready to edit.</p>
+        </div>
+      ) : (
+        <div
+          className='text-center text-gray-500'
+          data-testid='terracanon-no-workspace'
+        >
+          <p className='text-lg mb-1'>No workspace loaded</p>
+          <p className='text-sm'>Open a file or create a new workspace to get started.</p>
+        </div>
+      )}
     </section>
   );
 }
@@ -65,14 +75,14 @@ function EditorPane(): React.ReactElement {
 // Workspace Shell (IDE layout container)
 // ============================================================================
 
-function CanonWorkspace(): React.ReactElement {
+function CanonWorkspace({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactElement {
   return (
     <div
       className='canon-workspace flex border border-gray-700/30 rounded-lg overflow-hidden bg-gray-900/50'
       data-testid='terracanon-workspace'
     >
       <FileTreePane />
-      <EditorPane />
+      <EditorPane hasWorkspace={hasWorkspace} />
     </div>
   );
 }
@@ -82,13 +92,24 @@ function CanonWorkspace(): React.ReactElement {
 // ============================================================================
 
 function CanonContent(): React.ReactElement {
+  const [hasWorkspace, setHasWorkspace] = useState(false);
+
   return (
     <div className='canon-console' data-testid='terracanon-root'>
       <section className='canon-console__overview mb-4'>
         <h2>TerraCanon IDE</h2>
         <p>Integrated development environment for TerraFusion OS.</p>
+        {!hasWorkspace && (
+          <button
+            className='mt-2 px-3 py-1 text-sm rounded bg-cyan-700 hover:bg-cyan-600 text-white'
+            data-testid='terracanon-open-empty-workspace'
+            onClick={() => setHasWorkspace(true)}
+          >
+            Open Empty Workspace
+          </button>
+        )}
       </section>
-      <CanonWorkspace />
+      <CanonWorkspace hasWorkspace={hasWorkspace} />
     </div>
   );
 }


### PR DESCRIPTION
## Phase 32 — TerraCanon Open Empty Workspace Intent Contract

**Chain:** 22→23→24→25→26→27→28→29→30→31→**32**

### What
- Add local boolean state \hasWorkspace\ to CanonHome
- Render \	erracanon-open-empty-workspace\ button on cold start
- Click transitions: \	erracanon-no-workspace\ → \	erracanon-workspace-loaded\
- Filetree + editor survive the state transition

### Files changed (tight lane)
- \rontend/apps/os-shell/src/pages/CanonHome.tsx\ (state toggle + button + conditional landmarks)
- \rontend/apps/os-shell/src/__tests__/desktop/TerraCanonOpenEmptyWorkspaceIntentContract.test.tsx\ (new, 6 tests)

### Test evidence
- **Isolated:** 6/6 PASS
- **Full regression:** 205/205 suites, 3679 tests, 0 failures

### Non-goals
- No persistence, no filesystem, no Monaco/LSP
- No router/registry/manifest changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now open an empty workspace from the initial state. The interface smoothly transitions between the empty state and the loaded workspace state.

* **Tests**
  * Added comprehensive test coverage for the workspace opening workflow, including UI transitions and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->