### PR TITLE
feat(terracanon): Phase 33 — workspace identity (session-only) + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspaceIdentityContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspaceIdentityContract.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Phase 33 — TerraCanon Workspace Identity Contract
+ *
+ * Contract: when TerraCanon enters loaded workspace state, it exposes a
+ * stable workspace identity (name + id) via testable landmarks. The identity
+ * is session-only — no persistence, no filesystem.
+ *
+ * Phase 32 proved: TerraCanon can transition from empty → loaded state.
+ * Phase 33 proves: The loaded state carries a stable session identity.
+ *
+ * Success criteria:
+ *   1) Cold start: no-workspace present, identity landmarks absent
+ *   2) After open: workspace-loaded + name + id landmarks with non-empty values
+ *   3) After open: no-workspace disappears
+ *   4) Re-click is idempotent: identity does not change
+ *   5) Filetree + editor survive alongside identity
+ *   6) No crash ("Reset Application" never appears)
+ *
+ * Prevents:
+ * - Loaded workspace with no identity (downstream features need something to hang off)
+ * - Identity that changes on every re-render or re-click
+ * - Identity leaking into cold-start state
+ * - Layout panes disappearing after identity renders
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–32
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent.click for user intent simulation
+ * - Assert identity landmarks after state transition
+ *
+ * Production change:
+ * - useRef + useState identity in CanonHome.tsx (idempotent, session-only)
+ *
+ * Scope: Session identity only; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 33 contract: TerraCanon loaded workspace exposes stable session identity (no persistence)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + click the open-empty-workspace button.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start — no-workspace present, identity landmarks absent
+  // --------------------------------------------------------------------------
+  it('S1: cold start shows no-workspace and does not expose workspace identity', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-root')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: After opening empty workspace, identity landmarks render with non-empty values
+  // --------------------------------------------------------------------------
+  it('S2: after opening empty workspace, identity landmarks render with non-empty values', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const name = screen.getByTestId('terracanon-workspace-name');
+    const id = screen.getByTestId('terracanon-workspace-id');
+
+    expect((name.textContent ?? '').trim().length).toBeGreaterThan(0);
+    expect((id.textContent ?? '').trim().length).toBeGreaterThan(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Opening workspace hides no-workspace state
+  // --------------------------------------------------------------------------
+  it('S3: opening workspace hides no-workspace state', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('terracanon-no-workspace')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Identity stable across repeated clicks (idempotent)
+  // --------------------------------------------------------------------------
+  it('S4: identity is stable across repeated open-empty-workspace clicks', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-id')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const id1 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const name1 = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+
+    // Click button again (still visible, idempotent)
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    const id2 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const name2 = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+
+    expect(id1).toBe(id2);
+    expect(name1).toBe(name2);
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Filetree + editor survive in loaded state alongside identity
+  // --------------------------------------------------------------------------
+  it('S5: filetree + editor survive in loaded state alongside identity', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-workspace-name')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-workspace-id')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: No crash guard — standard regression sentinel
+  // --------------------------------------------------------------------------
+  it('S6: no crash guard after identity renders', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -5,6 +5,7 @@
  * Phase 30: Launch spine — route + root landmark.
  * Phase 31: Workspace bootstrap — IDE interior layout skeleton.
  * Phase 32: Open empty workspace intent — state toggle + loaded landmark.
+ * Phase 33: Workspace identity — session-stable name + id (no persistence).
  *
  * Layout:
  *   terracanon-root
@@ -13,16 +14,19 @@
  *          └─ terracanon-editor (main pane)
  *               ├─ terracanon-no-workspace (empty state, hidden when loaded)
  *               └─ terracanon-workspace-loaded (loaded state, shown after open)
+ *                    ├─ terracanon-workspace-name (session identity)
+ *                    └─ terracanon-workspace-id (session identity)
  *
- * State: local boolean `hasWorkspace`. No persistence, no filesystem, no LSP.
+ * State: local boolean `hasWorkspace` + useRef identity. No persistence, no filesystem, no LSP.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
  * @see Phase 31: TerraCanon Workspace Bootstrap Contract
  * @see Phase 32: TerraCanon Open Empty Workspace Intent Contract
+ * @see Phase 33: TerraCanon Workspace Identity Contract
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
 // ============================================================================
@@ -47,7 +51,13 @@ function FileTreePane(): React.ReactElement {
 // Editor Pane (main content area)
 // ============================================================================
 
-function EditorPane({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactElement {
+interface EditorPaneProps {
+  hasWorkspace: boolean;
+  workspaceName: string | null;
+  workspaceId: string | null;
+}
+
+function EditorPane({ hasWorkspace, workspaceName, workspaceId }: EditorPaneProps): React.ReactElement {
   return (
     <section
       className='canon-editor flex-1 min-h-[200px] p-4 flex items-center justify-center'
@@ -57,12 +67,13 @@ function EditorPane({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactEle
         <div data-testid='terracanon-workspace-loaded'>
           <p className='text-lg mb-1 text-gray-300'>Workspace loaded</p>
           <p className='text-sm text-gray-500'>Ready to edit.</p>
+          <div className='mt-2 text-xs text-gray-500'>
+            <span data-testid='terracanon-workspace-name'>{workspaceName}</span>
+            <span className='ml-2' data-testid='terracanon-workspace-id'>{workspaceId}</span>
+          </div>
         </div>
       ) : (
-        <div
-          className='text-center text-gray-500'
-          data-testid='terracanon-no-workspace'
-        >
+        <div className='text-center text-gray-500' data-testid='terracanon-no-workspace'>
           <p className='text-lg mb-1'>No workspace loaded</p>
           <p className='text-sm'>Open a file or create a new workspace to get started.</p>
         </div>
@@ -75,14 +86,20 @@ function EditorPane({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactEle
 // Workspace Shell (IDE layout container)
 // ============================================================================
 
-function CanonWorkspace({ hasWorkspace }: { hasWorkspace: boolean }): React.ReactElement {
+interface CanonWorkspaceProps {
+  hasWorkspace: boolean;
+  workspaceName: string | null;
+  workspaceId: string | null;
+}
+
+function CanonWorkspace({ hasWorkspace, workspaceName, workspaceId }: CanonWorkspaceProps): React.ReactElement {
   return (
     <div
       className='canon-workspace flex border border-gray-700/30 rounded-lg overflow-hidden bg-gray-900/50'
       data-testid='terracanon-workspace'
     >
       <FileTreePane />
-      <EditorPane hasWorkspace={hasWorkspace} />
+      <EditorPane hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceId} />
     </div>
   );
 }
@@ -91,25 +108,38 @@ function CanonWorkspace({ hasWorkspace }: { hasWorkspace: boolean }): React.Reac
 // Canon Content (root landmark + workspace)
 // ============================================================================
 
+let workspaceCounter = 0;
+
 function CanonContent(): React.ReactElement {
   const [hasWorkspace, setHasWorkspace] = useState(false);
+  const workspaceIdRef = useRef<string | null>(null);
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
+
+  const openEmptyWorkspace = () => {
+    if (!workspaceIdRef.current) {
+      workspaceCounter += 1;
+      workspaceIdRef.current = `canon-workspace-${workspaceCounter}`;
+    }
+    if (!workspaceName) {
+      setWorkspaceName('Untitled Workspace');
+    }
+    setHasWorkspace(true);
+  };
 
   return (
     <div className='canon-console' data-testid='terracanon-root'>
       <section className='canon-console__overview mb-4'>
         <h2>TerraCanon IDE</h2>
         <p>Integrated development environment for TerraFusion OS.</p>
-        {!hasWorkspace && (
-          <button
-            className='mt-2 px-3 py-1 text-sm rounded bg-cyan-700 hover:bg-cyan-600 text-white'
-            data-testid='terracanon-open-empty-workspace'
-            onClick={() => setHasWorkspace(true)}
-          >
-            Open Empty Workspace
-          </button>
-        )}
+        <button
+          className='mt-2 px-3 py-1 text-sm rounded bg-cyan-700 hover:bg-cyan-600 text-white'
+          data-testid='terracanon-open-empty-workspace'
+          onClick={openEmptyWorkspace}
+        >
+          Open Empty Workspace
+        </button>
       </section>
-      <CanonWorkspace hasWorkspace={hasWorkspace} />
+      <CanonWorkspace hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceIdRef.current} />
     </div>
   );
 }


### PR DESCRIPTION
Phase 33 - TerraCanon Workspace Identity Contract. Chain: 22-33. Adds session-stable workspace identity (name + id) via useRef/useState. Two new landmarks: terracanon-workspace-name, terracanon-workspace-id. Identity only in loaded state, absent on cold start. Idempotent on re-click. 6/6 isolated PASS, 206/206 full regression, 3685 tests, 0 failures. No persistence, no filesystem, no router changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspaces now display session-scoped identity information, including a unique workspace ID and assigned name.
  * Opening a new workspace automatically generates a unique identifier and default name displayed in the editor area.

* **Tests**
  * Added comprehensive test suite validating workspace identity functionality and stability across workspace state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->