### PR TITLE
feat(terracanon): Phase 34 — rename workspace intent (session-only) + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonRenameWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonRenameWorkspaceIntentContract.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Phase 34 — TerraCanon Rename Workspace Intent Contract
+ *
+ * Contract: a loaded workspace can be renamed via a text input + commit button.
+ * The rename is session-only — no persistence, no filesystem.
+ *
+ * Phase 33 proved: loaded workspace exposes stable session identity.
+ * Phase 34 proves: the identity name can be updated via user intent.
+ *
+ * Success criteria:
+ *   1) Cold start: no identity, no rename controls
+ *   2) After open: rename input + commit button appear
+ *   3) Typing + committing updates workspace-name landmark
+ *   4) Rename does not change workspace-id
+ *   5) Empty/whitespace rename is rejected (name unchanged)
+ *   6) No crash ("Reset Application" never appears)
+ *
+ * Prevents:
+ * - Rename controls leaking into cold-start state
+ * - Identity ID mutation on rename
+ * - Empty/whitespace name acceptance
+ * - Crash during rename flow
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–33
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent for user intent simulation
+ * - Assert landmark value changes after rename commit
+ *
+ * Production change:
+ * - renameDraft state + commitRename handler + rename controls in EditorPane
+ *
+ * Scope: Session rename only; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 34 contract: loaded workspace can be renamed (session-only, no persistence)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + click the open-empty-workspace button.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start — no identity, no rename controls
+  // --------------------------------------------------------------------------
+  it('S1: cold start has no identity and no rename controls', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-rename-workspace-input')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-rename-workspace-commit')).not.toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Loaded workspace exposes rename controls
+  // --------------------------------------------------------------------------
+  it('S2: loaded workspace exposes rename controls', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-workspace-name')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-workspace-id')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-rename-workspace-input')).toBeInTheDocument();
+        expect(screen.getByTestId('terracanon-rename-workspace-commit')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Renaming updates the workspace name landmark
+  // --------------------------------------------------------------------------
+  it('S3: renaming updates the workspace name landmark', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-rename-workspace-input')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    const commit = screen.getByTestId('terracanon-rename-workspace-commit');
+
+    fireEvent.change(input, { target: { value: 'My First Workspace' } });
+    fireEvent.click(commit);
+
+    expect(screen.getByTestId('terracanon-workspace-name').textContent).toContain('My First Workspace');
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Renaming does not change the workspace id
+  // --------------------------------------------------------------------------
+  it('S4: renaming does not change the workspace id', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-id')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    const commit = screen.getByTestId('terracanon-rename-workspace-commit');
+
+    fireEvent.change(input, { target: { value: 'Renamed Workspace' } });
+    fireEvent.click(commit);
+
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idAfter).toBe(idBefore);
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Empty/whitespace rename is rejected (name stays the same)
+  // --------------------------------------------------------------------------
+  it('S5: empty/whitespace rename is rejected (name stays the same)', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-name')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const nameBefore = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    const commit = screen.getByTestId('terracanon-rename-workspace-commit');
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.click(commit);
+
+    const nameAfter = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameAfter).toBe(nameBefore);
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: No crash guard throughout rename flow
+  // --------------------------------------------------------------------------
+  it('S6: no crash guard throughout rename flow', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-rename-workspace-input')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    const commit = screen.getByTestId('terracanon-rename-workspace-commit');
+
+    fireEvent.change(input, { target: { value: 'Safe Rename' } });
+    fireEvent.click(commit);
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonRenameWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonRenameWorkspaceIntentContract.test.tsx
@@ -163,7 +163,9 @@ describe('Phase 34 contract: loaded workspace can be renamed (session-only, no p
     fireEvent.change(input, { target: { value: 'My First Workspace' } });
     fireEvent.click(commit);
 
-    expect(screen.getByTestId('terracanon-workspace-name').textContent).toContain('My First Workspace');
+    expect(screen.getByTestId('terracanon-workspace-name').textContent).toContain(
+      'My First Workspace'
+    );
   });
 
   // --------------------------------------------------------------------------

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -6,6 +6,7 @@
  * Phase 31: Workspace bootstrap — IDE interior layout skeleton.
  * Phase 32: Open empty workspace intent — state toggle + loaded landmark.
  * Phase 33: Workspace identity — session-stable name + id (no persistence).
+ * Phase 34: Rename workspace intent — editable name (session-only, no persistence).
  *
  * Layout:
  *   terracanon-root
@@ -14,16 +15,19 @@
  *          └─ terracanon-editor (main pane)
  *               ├─ terracanon-no-workspace (empty state, hidden when loaded)
  *               └─ terracanon-workspace-loaded (loaded state, shown after open)
- *                    ├─ terracanon-workspace-name (session identity)
- *                    └─ terracanon-workspace-id (session identity)
+ *                    ├─ terracanon-workspace-name (session identity, editable)
+ *                    ├─ terracanon-workspace-id (session identity)
+ *                    ├─ terracanon-rename-workspace-input (rename draft)
+ *                    └─ terracanon-rename-workspace-commit (commit rename)
  *
- * State: local boolean `hasWorkspace` + useRef identity. No persistence, no filesystem, no LSP.
+ * State: local boolean `hasWorkspace` + useRef identity + renameDraft. No persistence, no filesystem, no LSP.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
  * @see Phase 31: TerraCanon Workspace Bootstrap Contract
  * @see Phase 32: TerraCanon Open Empty Workspace Intent Contract
  * @see Phase 33: TerraCanon Workspace Identity Contract
+ * @see Phase 34: TerraCanon Rename Workspace Intent Contract
  */
 
 import React, { useRef, useState } from 'react';
@@ -55,9 +59,12 @@ interface EditorPaneProps {
   hasWorkspace: boolean;
   workspaceName: string | null;
   workspaceId: string | null;
+  renameDraft: string;
+  onRenameDraftChange: (value: string) => void;
+  onCommitRename: () => void;
 }
 
-function EditorPane({ hasWorkspace, workspaceName, workspaceId }: EditorPaneProps): React.ReactElement {
+function EditorPane({ hasWorkspace, workspaceName, workspaceId, renameDraft, onRenameDraftChange, onCommitRename }: EditorPaneProps): React.ReactElement {
   return (
     <section
       className='canon-editor flex-1 min-h-[200px] p-4 flex items-center justify-center'
@@ -70,6 +77,22 @@ function EditorPane({ hasWorkspace, workspaceName, workspaceId }: EditorPaneProp
           <div className='mt-2 text-xs text-gray-500'>
             <span data-testid='terracanon-workspace-name'>{workspaceName}</span>
             <span className='ml-2' data-testid='terracanon-workspace-id'>{workspaceId}</span>
+          </div>
+          <div className='mt-2 flex items-center gap-2'>
+            <input
+              className='px-2 py-1 text-xs rounded bg-gray-800 border border-gray-600 text-gray-300'
+              data-testid='terracanon-rename-workspace-input'
+              value={renameDraft}
+              onChange={(e) => onRenameDraftChange(e.target.value)}
+              placeholder='Rename workspace'
+            />
+            <button
+              className='px-2 py-1 text-xs rounded bg-cyan-700 hover:bg-cyan-600 text-white'
+              data-testid='terracanon-rename-workspace-commit'
+              onClick={onCommitRename}
+            >
+              Rename
+            </button>
           </div>
         </div>
       ) : (
@@ -90,16 +113,19 @@ interface CanonWorkspaceProps {
   hasWorkspace: boolean;
   workspaceName: string | null;
   workspaceId: string | null;
+  renameDraft: string;
+  onRenameDraftChange: (value: string) => void;
+  onCommitRename: () => void;
 }
 
-function CanonWorkspace({ hasWorkspace, workspaceName, workspaceId }: CanonWorkspaceProps): React.ReactElement {
+function CanonWorkspace({ hasWorkspace, workspaceName, workspaceId, renameDraft, onRenameDraftChange, onCommitRename }: CanonWorkspaceProps): React.ReactElement {
   return (
     <div
       className='canon-workspace flex border border-gray-700/30 rounded-lg overflow-hidden bg-gray-900/50'
       data-testid='terracanon-workspace'
     >
       <FileTreePane />
-      <EditorPane hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceId} />
+      <EditorPane hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceId} renameDraft={renameDraft} onRenameDraftChange={onRenameDraftChange} onCommitRename={onCommitRename} />
     </div>
   );
 }
@@ -114,6 +140,7 @@ function CanonContent(): React.ReactElement {
   const [hasWorkspace, setHasWorkspace] = useState(false);
   const workspaceIdRef = useRef<string | null>(null);
   const [workspaceName, setWorkspaceName] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
 
   const openEmptyWorkspace = () => {
     if (!workspaceIdRef.current) {
@@ -124,6 +151,12 @@ function CanonContent(): React.ReactElement {
       setWorkspaceName('Untitled Workspace');
     }
     setHasWorkspace(true);
+  };
+
+  const commitRename = () => {
+    const next = renameDraft.trim();
+    if (!next) return;
+    setWorkspaceName(next);
   };
 
   return (
@@ -139,7 +172,7 @@ function CanonContent(): React.ReactElement {
           Open Empty Workspace
         </button>
       </section>
-      <CanonWorkspace hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceIdRef.current} />
+      <CanonWorkspace hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceIdRef.current} renameDraft={renameDraft} onRenameDraftChange={setRenameDraft} onCommitRename={commitRename} />
     </div>
   );
 }

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -64,7 +64,14 @@ interface EditorPaneProps {
   onCommitRename: () => void;
 }
 
-function EditorPane({ hasWorkspace, workspaceName, workspaceId, renameDraft, onRenameDraftChange, onCommitRename }: EditorPaneProps): React.ReactElement {
+function EditorPane({
+  hasWorkspace,
+  workspaceName,
+  workspaceId,
+  renameDraft,
+  onRenameDraftChange,
+  onCommitRename,
+}: EditorPaneProps): React.ReactElement {
   return (
     <section
       className='canon-editor flex-1 min-h-[200px] p-4 flex items-center justify-center'
@@ -76,7 +83,9 @@ function EditorPane({ hasWorkspace, workspaceName, workspaceId, renameDraft, onR
           <p className='text-sm text-gray-500'>Ready to edit.</p>
           <div className='mt-2 text-xs text-gray-500'>
             <span data-testid='terracanon-workspace-name'>{workspaceName}</span>
-            <span className='ml-2' data-testid='terracanon-workspace-id'>{workspaceId}</span>
+            <span className='ml-2' data-testid='terracanon-workspace-id'>
+              {workspaceId}
+            </span>
           </div>
           <div className='mt-2 flex items-center gap-2'>
             <input
@@ -118,14 +127,28 @@ interface CanonWorkspaceProps {
   onCommitRename: () => void;
 }
 
-function CanonWorkspace({ hasWorkspace, workspaceName, workspaceId, renameDraft, onRenameDraftChange, onCommitRename }: CanonWorkspaceProps): React.ReactElement {
+function CanonWorkspace({
+  hasWorkspace,
+  workspaceName,
+  workspaceId,
+  renameDraft,
+  onRenameDraftChange,
+  onCommitRename,
+}: CanonWorkspaceProps): React.ReactElement {
   return (
     <div
       className='canon-workspace flex border border-gray-700/30 rounded-lg overflow-hidden bg-gray-900/50'
       data-testid='terracanon-workspace'
     >
       <FileTreePane />
-      <EditorPane hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceId} renameDraft={renameDraft} onRenameDraftChange={onRenameDraftChange} onCommitRename={onCommitRename} />
+      <EditorPane
+        hasWorkspace={hasWorkspace}
+        workspaceName={workspaceName}
+        workspaceId={workspaceId}
+        renameDraft={renameDraft}
+        onRenameDraftChange={onRenameDraftChange}
+        onCommitRename={onCommitRename}
+      />
     </div>
   );
 }
@@ -172,7 +195,14 @@ function CanonContent(): React.ReactElement {
           Open Empty Workspace
         </button>
       </section>
-      <CanonWorkspace hasWorkspace={hasWorkspace} workspaceName={workspaceName} workspaceId={workspaceIdRef.current} renameDraft={renameDraft} onRenameDraftChange={setRenameDraft} onCommitRename={commitRename} />
+      <CanonWorkspace
+        hasWorkspace={hasWorkspace}
+        workspaceName={workspaceName}
+        workspaceId={workspaceIdRef.current}
+        renameDraft={renameDraft}
+        onRenameDraftChange={setRenameDraft}
+        onCommitRename={commitRename}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Phase 34 - TerraCanon Rename Workspace Intent Contract. Chain: 22-34. 207/207 suites, 3691 tests, 0 failures.

## Summary by Sourcery

Add a session-only workspace rename capability to the TerraCanon shell workspace view and validate it with a new contract test suite.

New Features:
- Allow users to rename the current workspace within the TerraCanon shell session via an inline rename control in the editor pane.

Tests:
- Introduce a TerraCanon rename-workspace intent contract test suite to cover the session-only rename behavior and UI wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace rename functionality with text input and commit button; renames are session-only and update the workspace name without changing its ID.

* **Tests**
  * Added comprehensive test suite covering rename workspace scenarios, including validation, UI updates, and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->