### PR TITLE
feat(terracanon): Phase 35 — session multi-workspace switcher + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
@@ -83,7 +83,7 @@ describe('Phase 35 contract: TerraCanon supports multiple session workspaces and
       () => {
         expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 5000 }
     );
 
     expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
@@ -99,7 +99,7 @@ describe('Phase 35 contract: TerraCanon supports multiple session workspaces and
       () => {
         expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 5000 }
     );
 
     fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
@@ -108,7 +108,7 @@ describe('Phase 35 contract: TerraCanon supports multiple session workspaces and
       () => {
         expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 5000 }
     );
   }
 
@@ -122,7 +122,7 @@ describe('Phase 35 contract: TerraCanon supports multiple session workspaces and
       () => {
         expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
       },
-      { timeout: 5000 },
+      { timeout: 5000 }
     );
 
     expect(screen.queryByTestId('terracanon-workspace-switcher')).not.toBeInTheDocument();
@@ -207,9 +207,7 @@ describe('Phase 35 contract: TerraCanon supports multiple session workspaces and
 
     // Create workspace 1 (active)
     fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
-    const nameBInitial = (
-      screen.getByTestId('terracanon-workspace-name').textContent ?? ''
-    ).trim();
+    const nameBInitial = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
     expect(nameBInitial.length).toBeGreaterThan(0);
     expect(nameBInitial).not.toBe('Workspace Alpha');
 

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Phase 35 — TerraCanon Multi-Workspace Switcher Contract
+ *
+ * Contract: TerraCanon supports multiple in-session workspaces and a
+ * deterministic switcher that swaps active context safely.
+ *
+ * Phase 34 proved: rename is session-only per loaded workspace.
+ * Phase 35 proves: multiple workspaces can coexist in memory with
+ * independent identities, per-workspace rename, and a switcher UI.
+ *
+ * Success criteria:
+ *   1) Cold start: no switcher, no identity
+ *   2) After open: identity + new-workspace + switcher controls appear
+ *   3) Creating second workspace yields new id and makes it active
+ *   4) Switcher items exist; switching changes active identity
+ *   5) Rename is per-workspace (switch restores each name)
+ *   6) filetree + editor remain mounted; no crash
+ *
+ * Prevents:
+ * - Switcher leaking into cold-start state
+ * - Second workspace reusing the same id
+ * - Switch not updating active identity
+ * - Rename cross-contaminating workspaces
+ * - Layout crash during multi-workspace operations
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–34
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent for user intent simulation
+ *
+ * Scope: Session-only multi-workspace; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 35 contract: TerraCanon supports multiple session workspaces and a safe switcher', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + open the first workspace.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start — no switcher, no identity
+  // --------------------------------------------------------------------------
+  it('S1: cold start has no switcher and no identity', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByTestId('terracanon-workspace-switcher')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: After open, identity landmarks + controls appear
+  // --------------------------------------------------------------------------
+  it('S2: after open, identity landmarks exist and controls appear', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.getByTestId('terracanon-workspace-name')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace-id')).toBeInTheDocument();
+
+    expect(screen.getByTestId('terracanon-new-workspace')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace-switcher')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Creating second workspace yields new id, makes it active
+  // --------------------------------------------------------------------------
+  it('S3: creating a second workspace yields a new id and makes it active', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const id1 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+
+    const id2 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    expect(id1.length).toBeGreaterThan(0);
+    expect(id2.length).toBeGreaterThan(0);
+    expect(id2).not.toBe(id1);
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Switcher items exist; switching changes active identity
+  // --------------------------------------------------------------------------
+  it('S4: switcher items exist and switching changes the active identity', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const idA = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+
+    const idB = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idB).not.toBe(idA);
+
+    // Items must exist
+    expect(screen.getByTestId('terracanon-workspace-item-0')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace-item-1')).toBeInTheDocument();
+
+    // Switch back to item 0 → id becomes idA
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-0'));
+    const idBack = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idBack).toBe(idA);
+
+    // Switch to item 1 → id becomes idB
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-1'));
+    const idForward = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idForward).toBe(idB);
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Rename is per-workspace (switch away and back restores each name)
+  // --------------------------------------------------------------------------
+  it('S5: rename is per-workspace (switch away and back restores each name)', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    const commit = screen.getByTestId('terracanon-rename-workspace-commit');
+
+    // Rename workspace 0
+    fireEvent.change(input, { target: { value: 'Workspace Alpha' } });
+    fireEvent.click(commit);
+
+    const nameA = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameA).toBe('Workspace Alpha');
+
+    // Create workspace 1 (active)
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+    const nameBInitial = (
+      screen.getByTestId('terracanon-workspace-name').textContent ?? ''
+    ).trim();
+    expect(nameBInitial.length).toBeGreaterThan(0);
+    expect(nameBInitial).not.toBe('Workspace Alpha');
+
+    // Rename workspace 1
+    const input2 = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input2, { target: { value: 'Workspace Beta' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    const nameB = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameB).toBe('Workspace Beta');
+
+    // Switch back to workspace 0 → name must restore to Alpha
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-0'));
+    const nameBackA = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameBackA).toBe('Workspace Alpha');
+
+    // Switch to workspace 1 → name must restore to Beta
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-1'));
+    const nameBackB = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameBackB).toBe('Workspace Beta');
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: filetree + editor remain mounted; no crash
+  // --------------------------------------------------------------------------
+  it('S6: filetree + editor remain mounted; no crash', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -7,6 +7,7 @@
  * Phase 32: Open empty workspace intent — state toggle + loaded landmark.
  * Phase 33: Workspace identity — session-stable name + id (no persistence).
  * Phase 34: Rename workspace intent — editable name (session-only, no persistence).
+ * Phase 35: Multi-workspace switcher — in-memory array, active index, per-workspace rename.
  *
  * Layout:
  *   terracanon-root
@@ -15,12 +16,16 @@
  *          └─ terracanon-editor (main pane)
  *               ├─ terracanon-no-workspace (empty state, hidden when loaded)
  *               └─ terracanon-workspace-loaded (loaded state, shown after open)
- *                    ├─ terracanon-workspace-name (session identity, editable)
- *                    ├─ terracanon-workspace-id (session identity)
+ *                    ├─ terracanon-workspace-name (active workspace name)
+ *                    ├─ terracanon-workspace-id (active workspace id)
  *                    ├─ terracanon-rename-workspace-input (rename draft)
- *                    └─ terracanon-rename-workspace-commit (commit rename)
+ *                    ├─ terracanon-rename-workspace-commit (commit rename)
+ *                    ├─ terracanon-new-workspace (create additional workspace)
+ *                    └─ terracanon-workspace-switcher (switch active workspace)
+ *                         ├─ terracanon-workspace-item-0
+ *                         └─ terracanon-workspace-item-N
  *
- * State: local boolean `hasWorkspace` + useRef identity + renameDraft. No persistence, no filesystem, no LSP.
+ * State: workspaces[] array + activeIndex. No persistence, no filesystem, no LSP.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
@@ -28,9 +33,10 @@
  * @see Phase 32: TerraCanon Open Empty Workspace Intent Contract
  * @see Phase 33: TerraCanon Workspace Identity Contract
  * @see Phase 34: TerraCanon Rename Workspace Intent Contract
+ * @see Phase 35: TerraCanon Multi-Workspace Switcher Contract
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
 // ============================================================================
@@ -55,6 +61,11 @@ function FileTreePane(): React.ReactElement {
 // Editor Pane (main content area)
 // ============================================================================
 
+interface Workspace {
+  id: string;
+  name: string;
+}
+
 interface EditorPaneProps {
   hasWorkspace: boolean;
   workspaceName: string | null;
@@ -62,6 +73,10 @@ interface EditorPaneProps {
   renameDraft: string;
   onRenameDraftChange: (value: string) => void;
   onCommitRename: () => void;
+  workspaces: Workspace[];
+  activeIndex: number;
+  onNewWorkspace: () => void;
+  onSwitchWorkspace: (index: number) => void;
 }
 
 function EditorPane({
@@ -71,6 +86,10 @@ function EditorPane({
   renameDraft,
   onRenameDraftChange,
   onCommitRename,
+  workspaces,
+  activeIndex,
+  onNewWorkspace,
+  onSwitchWorkspace,
 }: EditorPaneProps): React.ReactElement {
   return (
     <section
@@ -102,6 +121,29 @@ function EditorPane({
             >
               Rename
             </button>
+            <button
+              className='px-2 py-1 text-xs rounded bg-cyan-700 hover:bg-cyan-600 text-white'
+              data-testid='terracanon-new-workspace'
+              onClick={onNewWorkspace}
+            >
+              New Workspace
+            </button>
+          </div>
+          <div className='mt-2 flex items-center gap-1' data-testid='terracanon-workspace-switcher'>
+            {workspaces.map((ws, i) => (
+              <button
+                key={ws.id}
+                className={`px-2 py-0.5 text-xs rounded ${
+                  i === activeIndex
+                    ? 'bg-cyan-700 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                }`}
+                data-testid={`terracanon-workspace-item-${i}`}
+                onClick={() => onSwitchWorkspace(i)}
+              >
+                {ws.name}
+              </button>
+            ))}
           </div>
         </div>
       ) : (
@@ -125,6 +167,10 @@ interface CanonWorkspaceProps {
   renameDraft: string;
   onRenameDraftChange: (value: string) => void;
   onCommitRename: () => void;
+  workspaces: Workspace[];
+  activeIndex: number;
+  onNewWorkspace: () => void;
+  onSwitchWorkspace: (index: number) => void;
 }
 
 function CanonWorkspace({
@@ -134,6 +180,10 @@ function CanonWorkspace({
   renameDraft,
   onRenameDraftChange,
   onCommitRename,
+  workspaces,
+  activeIndex,
+  onNewWorkspace,
+  onSwitchWorkspace,
 }: CanonWorkspaceProps): React.ReactElement {
   return (
     <div
@@ -148,6 +198,10 @@ function CanonWorkspace({
         renameDraft={renameDraft}
         onRenameDraftChange={onRenameDraftChange}
         onCommitRename={onCommitRename}
+        workspaces={workspaces}
+        activeIndex={activeIndex}
+        onNewWorkspace={onNewWorkspace}
+        onSwitchWorkspace={onSwitchWorkspace}
       />
     </div>
   );
@@ -160,26 +214,48 @@ function CanonWorkspace({
 let workspaceCounter = 0;
 
 function CanonContent(): React.ReactElement {
-  const [hasWorkspace, setHasWorkspace] = useState(false);
-  const workspaceIdRef = useRef<string | null>(null);
-  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [renameDraft, setRenameDraft] = useState('');
 
+  const hasWorkspace = workspaces.length > 0;
+  const active = hasWorkspace ? workspaces[activeIndex] : null;
+
   const openEmptyWorkspace = () => {
-    if (!workspaceIdRef.current) {
+    if (workspaces.length === 0) {
       workspaceCounter += 1;
-      workspaceIdRef.current = `canon-workspace-${workspaceCounter}`;
+      const ws: Workspace = {
+        id: `canon-workspace-${workspaceCounter}`,
+        name: 'Untitled Workspace',
+      };
+      setWorkspaces([ws]);
+      setActiveIndex(0);
+      setRenameDraft('');
     }
-    if (!workspaceName) {
-      setWorkspaceName('Untitled Workspace');
+  };
+
+  const newWorkspace = () => {
+    workspaceCounter += 1;
+    const ws: Workspace = {
+      id: `canon-workspace-${workspaceCounter}`,
+      name: 'Untitled Workspace',
+    };
+    setWorkspaces((prev) => [...prev, ws]);
+    setActiveIndex(workspaces.length); // will be the new last index
+    setRenameDraft('');
+  };
+
+  const switchWorkspace = (index: number) => {
+    if (index >= 0 && index < workspaces.length) {
+      setActiveIndex(index);
+      setRenameDraft('');
     }
-    setHasWorkspace(true);
   };
 
   const commitRename = () => {
     const next = renameDraft.trim();
     if (!next) return;
-    setWorkspaceName(next);
+    setWorkspaces((prev) => prev.map((ws, i) => (i === activeIndex ? { ...ws, name: next } : ws)));
   };
 
   return (
@@ -197,11 +273,15 @@ function CanonContent(): React.ReactElement {
       </section>
       <CanonWorkspace
         hasWorkspace={hasWorkspace}
-        workspaceName={workspaceName}
-        workspaceId={workspaceIdRef.current}
+        workspaceName={active?.name ?? null}
+        workspaceId={active?.id ?? null}
         renameDraft={renameDraft}
         onRenameDraftChange={setRenameDraft}
         onCommitRename={commitRename}
+        workspaces={workspaces}
+        activeIndex={activeIndex}
+        onNewWorkspace={newWorkspace}
+        onSwitchWorkspace={switchWorkspace}
       />
     </div>
   );


### PR DESCRIPTION
Phase 35 - TerraCanon Multi-Workspace Switcher Contract. Chain: 22-35. 208/208 suites, 3697 tests, 0 failures.

## Summary by Sourcery

Introduce in-memory multi-workspace management and switching for TerraCanon sessions.

New Features:
- Add support for multiple in-memory workspaces per session with an active workspace index.
- Expose a workspace switcher UI with per-workspace buttons and a control to create additional workspaces.
- Allow each workspace in the session to have its own editable, session-scoped name and id shown in the editor pane.

Tests:
- Add a TerraCanon multi-workspace switcher contract test suite to validate creation, switching, and renaming behavior across workspaces.