### PR TITLE
feat(terracanon): Phase 36 — close workspace intent (session-only) + contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonCloseWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonCloseWorkspaceIntentContract.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Phase 36 — TerraCanon Close Workspace Intent Contract
+ *
+ * Contract: a loaded workspace can be closed. If multiple workspaces exist,
+ * closing the active one falls back to a remaining workspace. If it's the
+ * last workspace, the UI returns to the explicit empty state.
+ *
+ * Phase 35 proved: multiple workspaces + switcher + per-workspace rename.
+ * Phase 36 proves: close intent is safe across all edge cases.
+ *
+ * Success criteria:
+ *   1) Loaded state exposes close-workspace control
+ *   2) Closing with 2 workspaces removes active and falls back
+ *   3) Closing last workspace returns to empty state
+ *   4) Rename draft does not leak across close/switch
+ *   5) filetree + editor remain mounted; no crash
+ *
+ * Prevents:
+ * - Close control leaking into cold-start state
+ * - Crash on closing last workspace (empty state must restore cleanly)
+ * - Rename draft leaking to the next active workspace after close
+ * - Layout unmount during close
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–35
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent for user intent simulation
+ *
+ * Scope: Session-only close; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 36 contract: TerraCanon can close the active workspace safely (session-only)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + open the first workspace.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Loaded state exposes close-workspace control
+  // --------------------------------------------------------------------------
+  it('S1: loaded state exposes close-workspace control', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.getByTestId('terracanon-close-workspace')).toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Closing with 2 workspaces removes active, falls back to remaining
+  // --------------------------------------------------------------------------
+  it('S2: closing with 2 workspaces removes active and falls back to remaining workspace', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const id0 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+    const id1 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(id1).not.toBe(id0);
+
+    // Close active (workspace 1) → should return to workspace 0
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idAfter).toBe(id0);
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Closing last workspace returns to explicit empty state
+  // --------------------------------------------------------------------------
+  it('S3: closing the last workspace returns to explicit empty state and hides identity/switcher', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-switcher')).not.toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Rename draft does not leak across close/switch
+  // --------------------------------------------------------------------------
+  it('S4: rename draft does not leak across close/switch (safety)', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Make a second workspace active
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Leaky Draft' } });
+
+    // Close active workspace (the one where we typed)
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    // Now we're back on workspace 0; input should be cleared
+    const inputAfter = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    expect((inputAfter.value ?? '').trim()).toBe('');
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: filetree + editor remain mounted; no crash
+  // --------------------------------------------------------------------------
+  it('S5: filetree + editor remain mounted; no crash', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    // Even in empty state, the panes must still exist (layout stability).
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -8,6 +8,7 @@
  * Phase 33: Workspace identity — session-stable name + id (no persistence).
  * Phase 34: Rename workspace intent — editable name (session-only, no persistence).
  * Phase 35: Multi-workspace switcher — in-memory array, active index, per-workspace rename.
+ * Phase 36: Close workspace intent — remove active, fallback or return to empty.
  *
  * Layout:
  *   terracanon-root
@@ -21,6 +22,7 @@
  *                    ├─ terracanon-rename-workspace-input (rename draft)
  *                    ├─ terracanon-rename-workspace-commit (commit rename)
  *                    ├─ terracanon-new-workspace (create additional workspace)
+ *                    ├─ terracanon-close-workspace (close active workspace)
  *                    └─ terracanon-workspace-switcher (switch active workspace)
  *                         ├─ terracanon-workspace-item-0
  *                         └─ terracanon-workspace-item-N
@@ -34,6 +36,7 @@
  * @see Phase 33: TerraCanon Workspace Identity Contract
  * @see Phase 34: TerraCanon Rename Workspace Intent Contract
  * @see Phase 35: TerraCanon Multi-Workspace Switcher Contract
+ * @see Phase 36: TerraCanon Close Workspace Intent Contract
  */
 
 import React, { useState } from 'react';
@@ -76,6 +79,7 @@ interface EditorPaneProps {
   workspaces: Workspace[];
   activeIndex: number;
   onNewWorkspace: () => void;
+  onCloseWorkspace: () => void;
   onSwitchWorkspace: (index: number) => void;
 }
 
@@ -89,6 +93,7 @@ function EditorPane({
   workspaces,
   activeIndex,
   onNewWorkspace,
+  onCloseWorkspace,
   onSwitchWorkspace,
 }: EditorPaneProps): React.ReactElement {
   return (
@@ -127,6 +132,13 @@ function EditorPane({
               onClick={onNewWorkspace}
             >
               New Workspace
+            </button>
+            <button
+              className='px-2 py-1 text-xs rounded bg-red-700 hover:bg-red-600 text-white'
+              data-testid='terracanon-close-workspace'
+              onClick={onCloseWorkspace}
+            >
+              Close
             </button>
           </div>
           <div className='mt-2 flex items-center gap-1' data-testid='terracanon-workspace-switcher'>
@@ -170,6 +182,7 @@ interface CanonWorkspaceProps {
   workspaces: Workspace[];
   activeIndex: number;
   onNewWorkspace: () => void;
+  onCloseWorkspace: () => void;
   onSwitchWorkspace: (index: number) => void;
 }
 
@@ -183,6 +196,7 @@ function CanonWorkspace({
   workspaces,
   activeIndex,
   onNewWorkspace,
+  onCloseWorkspace,
   onSwitchWorkspace,
 }: CanonWorkspaceProps): React.ReactElement {
   return (
@@ -201,6 +215,7 @@ function CanonWorkspace({
         workspaces={workspaces}
         activeIndex={activeIndex}
         onNewWorkspace={onNewWorkspace}
+        onCloseWorkspace={onCloseWorkspace}
         onSwitchWorkspace={onSwitchWorkspace}
       />
     </div>
@@ -252,6 +267,14 @@ function CanonContent(): React.ReactElement {
     }
   };
 
+  const closeWorkspace = () => {
+    if (workspaces.length === 0) return;
+    const next = workspaces.filter((_, i) => i !== activeIndex);
+    setWorkspaces(next);
+    setActiveIndex(next.length === 0 ? 0 : Math.min(activeIndex, next.length - 1));
+    setRenameDraft('');
+  };
+
   const commitRename = () => {
     const next = renameDraft.trim();
     if (!next) return;
@@ -281,6 +304,7 @@ function CanonContent(): React.ReactElement {
         workspaces={workspaces}
         activeIndex={activeIndex}
         onNewWorkspace={newWorkspace}
+        onCloseWorkspace={closeWorkspace}
         onSwitchWorkspace={switchWorkspace}
       />
     </div>


### PR DESCRIPTION
## Summary
- Add `terracanon-close-workspace` button and `closeWorkspace()` handler
- Close with 2+ workspaces: removes active, falls back to remaining
- Close last workspace: returns to explicit empty state (`terracanon-no-workspace`)
- `renameDraft` cleared on close (no cross-workspace leak)
- Layout stable: filetree + editor stay mounted through close

## Contract (5 tests)
| Test | Assertion |
|------|-----------|
| S1 | Loaded state exposes close-workspace control |
| S2 | Closing with 2 workspaces falls back to remaining |
| S3 | Closing last workspace restores empty state |
| S4 | Rename draft does not leak across close |
| S5 | filetree + editor remain mounted; no crash |

## Regression
- 209/209 suites GREEN, 3,702 tests passing
- TypeScript clean (`tsc --noEmit`)
- Chain: 22→…→35→**36**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a session-scoped close-workspace action to TerraCanon that removes the active workspace, falls back to remaining workspaces, or returns to an empty state while keeping the layout stable.

New Features:
- Expose a close-workspace control in the TerraCanon editor pane to close the active workspace within the current session.

Tests:
- Add a close-workspace contract test suite covering control visibility, multi-workspace fallback behavior, last-workspace empty-state restoration, rename-draft clearing, and layout stability during close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to close workspaces. Closing the active workspace automatically switches to another available workspace; closing the last workspace returns to an empty state.

* **Tests**
  * New test suite validates workspace closing behavior across multiple scenarios, including edge cases and UI stability during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->