### PR TITLE
feat(canon): Phase 37 - Reopen Last Closed Workspace Intent Contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonReopenWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonReopenWorkspaceIntentContract.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Phase 37 — TerraCanon Reopen Last Closed Workspace Intent Contract
+ *
+ * Contract: after closing a workspace, a "reopen" control appears that
+ * restores the most recently closed workspace with the same id + name.
+ *
+ * Phase 36 proved: close intent is safe across all edge cases.
+ * Phase 37 proves: the most recently closed workspace can be reopened
+ * with identity fully restored, from any state (multi or empty).
+ *
+ * Success criteria:
+ *   1) Cold start has no reopen control (no close history)
+ *   2) Close then reopen restores same id + name
+ *   3) With 2 workspaces, close active then reopen restores it as active
+ *   4) Reopen works from empty state (after closing last workspace)
+ *   5) Rename draft cleared on reopen; layout stable; no crash
+ *
+ * Prevents:
+ * - Reopen control leaking into cold-start state (no history)
+ * - Reopened workspace getting a new id (must restore exact identity)
+ * - Rename draft leaking into reopened workspace
+ * - Layout unmount during reopen
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–36
+ * - Deep-link entry to /canon (cold start, no prior navigation)
+ * - fireEvent for user intent simulation
+ *
+ * Scope: Session-only reopen; no persistence, no filesystem, no Monaco.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 37 contract: TerraCanon can reopen the last closed workspace (session-only)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+  }
+
+  /**
+   * Helper: render + open the first workspace.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start has no reopen control
+  // --------------------------------------------------------------------------
+  it('S1: cold start has no reopen control', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Close then reopen restores same id + name
+  // --------------------------------------------------------------------------
+  it('S2: close then reopen restores same id + name', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Rename to ensure name restoration is real
+    const renameInput = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(renameInput, { target: { value: 'Reopen Me' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameBefore = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameBefore).toBe('Reopen Me');
+
+    // Close
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    // Reopen control must appear
+    expect(screen.getByTestId('terracanon-reopen-workspace')).toBeInTheDocument();
+
+    // Reopen
+    fireEvent.click(screen.getByTestId('terracanon-reopen-workspace'));
+
+    expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameAfter = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+
+    expect(idAfter).toBe(idBefore);
+    expect(nameAfter).toBe(nameBefore);
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: With 2 workspaces, closing active then reopening restores it as active
+  // --------------------------------------------------------------------------
+  it('S3: with 2 workspaces, closing active then reopening restores it and makes it active', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const id0 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+    const id1 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(id1).not.toBe(id0);
+
+    // Close active (workspace 1)
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+    const activeAfterClose = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(activeAfterClose).toBe(id0);
+
+    // Reopen → id1 returns as active
+    fireEvent.click(screen.getByTestId('terracanon-reopen-workspace'));
+    const activeAfterReopen = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(activeAfterReopen).toBe(id1);
+
+    // Switcher shows both
+    expect(screen.getByTestId('terracanon-workspace-switcher')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace-item-0')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace-item-1')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Reopen works from empty state after closing last workspace
+  // --------------------------------------------------------------------------
+  it('S4: reopen works from empty state after closing last workspace', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    // Close last workspace → empty state
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+    expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+
+    // Reopen must be visible even in empty state
+    expect(screen.getByTestId('terracanon-reopen-workspace')).toBeInTheDocument();
+
+    // Reopen
+    fireEvent.click(screen.getByTestId('terracanon-reopen-workspace'));
+    expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(idAfter).toBe(idBefore);
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Rename draft cleared on reopen; layout stable; no crash
+  // --------------------------------------------------------------------------
+  it('S5: rename draft is cleared on reopen; layout stable; no crash', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Create second workspace
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+
+    // Type into rename draft
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Draft Text' } });
+
+    // Close active
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    // Reopen
+    fireEvent.click(screen.getByTestId('terracanon-reopen-workspace'));
+
+    // Draft must be cleared
+    const inputAfter = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    expect((inputAfter.value ?? '').trim()).toBe('');
+
+    // Layout stable
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -9,6 +9,7 @@
  * Phase 34: Rename workspace intent — editable name (session-only, no persistence).
  * Phase 35: Multi-workspace switcher — in-memory array, active index, per-workspace rename.
  * Phase 36: Close workspace intent — remove active, fallback or return to empty.
+ * Phase 37: Reopen last closed workspace — undo-close via lastClosedRef.
  *
  * Layout:
  *   terracanon-root
@@ -16,6 +17,7 @@
  *          ├─ terracanon-filetree (sidebar)
  *          └─ terracanon-editor (main pane)
  *               ├─ terracanon-no-workspace (empty state, hidden when loaded)
+ *               │    └─ terracanon-reopen-workspace (reopen, if history)
  *               └─ terracanon-workspace-loaded (loaded state, shown after open)
  *                    ├─ terracanon-workspace-name (active workspace name)
  *                    ├─ terracanon-workspace-id (active workspace id)
@@ -23,6 +25,7 @@
  *                    ├─ terracanon-rename-workspace-commit (commit rename)
  *                    ├─ terracanon-new-workspace (create additional workspace)
  *                    ├─ terracanon-close-workspace (close active workspace)
+ *                    ├─ terracanon-reopen-workspace (reopen last closed)
  *                    └─ terracanon-workspace-switcher (switch active workspace)
  *                         ├─ terracanon-workspace-item-0
  *                         └─ terracanon-workspace-item-N
@@ -37,9 +40,10 @@
  * @see Phase 34: TerraCanon Rename Workspace Intent Contract
  * @see Phase 35: TerraCanon Multi-Workspace Switcher Contract
  * @see Phase 36: TerraCanon Close Workspace Intent Contract
+ * @see Phase 37: TerraCanon Reopen Last Closed Workspace Contract
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
 // ============================================================================
@@ -80,6 +84,8 @@ interface EditorPaneProps {
   activeIndex: number;
   onNewWorkspace: () => void;
   onCloseWorkspace: () => void;
+  onReopenWorkspace: () => void;
+  hasClosedHistory: boolean;
   onSwitchWorkspace: (index: number) => void;
 }
 
@@ -94,6 +100,8 @@ function EditorPane({
   activeIndex,
   onNewWorkspace,
   onCloseWorkspace,
+  onReopenWorkspace,
+  hasClosedHistory,
   onSwitchWorkspace,
 }: EditorPaneProps): React.ReactElement {
   return (
@@ -140,6 +148,15 @@ function EditorPane({
             >
               Close
             </button>
+            {hasClosedHistory && (
+              <button
+                className='px-2 py-1 text-xs rounded bg-yellow-700 hover:bg-yellow-600 text-white'
+                data-testid='terracanon-reopen-workspace'
+                onClick={onReopenWorkspace}
+              >
+                Reopen
+              </button>
+            )}
           </div>
           <div className='mt-2 flex items-center gap-1' data-testid='terracanon-workspace-switcher'>
             {workspaces.map((ws, i) => (
@@ -162,6 +179,15 @@ function EditorPane({
         <div className='text-center text-gray-500' data-testid='terracanon-no-workspace'>
           <p className='text-lg mb-1'>No workspace loaded</p>
           <p className='text-sm'>Open a file or create a new workspace to get started.</p>
+          {hasClosedHistory && (
+            <button
+              className='mt-2 px-2 py-1 text-xs rounded bg-yellow-700 hover:bg-yellow-600 text-white'
+              data-testid='terracanon-reopen-workspace'
+              onClick={onReopenWorkspace}
+            >
+              Reopen Last Closed
+            </button>
+          )}
         </div>
       )}
     </section>
@@ -183,6 +209,8 @@ interface CanonWorkspaceProps {
   activeIndex: number;
   onNewWorkspace: () => void;
   onCloseWorkspace: () => void;
+  onReopenWorkspace: () => void;
+  hasClosedHistory: boolean;
   onSwitchWorkspace: (index: number) => void;
 }
 
@@ -197,6 +225,8 @@ function CanonWorkspace({
   activeIndex,
   onNewWorkspace,
   onCloseWorkspace,
+  onReopenWorkspace,
+  hasClosedHistory,
   onSwitchWorkspace,
 }: CanonWorkspaceProps): React.ReactElement {
   return (
@@ -216,6 +246,8 @@ function CanonWorkspace({
         activeIndex={activeIndex}
         onNewWorkspace={onNewWorkspace}
         onCloseWorkspace={onCloseWorkspace}
+        onReopenWorkspace={onReopenWorkspace}
+        hasClosedHistory={hasClosedHistory}
         onSwitchWorkspace={onSwitchWorkspace}
       />
     </div>
@@ -232,6 +264,7 @@ function CanonContent(): React.ReactElement {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
   const [renameDraft, setRenameDraft] = useState('');
+  const lastClosedRef = useRef<Workspace | null>(null);
 
   const hasWorkspace = workspaces.length > 0;
   const active = hasWorkspace ? workspaces[activeIndex] : null;
@@ -269,11 +302,23 @@ function CanonContent(): React.ReactElement {
 
   const closeWorkspace = () => {
     if (workspaces.length === 0) return;
+    lastClosedRef.current = workspaces[activeIndex];
     const next = workspaces.filter((_, i) => i !== activeIndex);
     setWorkspaces(next);
     setActiveIndex(next.length === 0 ? 0 : Math.min(activeIndex, next.length - 1));
     setRenameDraft('');
   };
+
+  const reopenLastClosed = () => {
+    const ws = lastClosedRef.current;
+    if (!ws) return;
+    lastClosedRef.current = null;
+    setWorkspaces((prev) => [...prev, ws]);
+    setActiveIndex(workspaces.length); // new last index
+    setRenameDraft('');
+  };
+
+  const hasClosedHistory = lastClosedRef.current !== null;
 
   const commitRename = () => {
     const next = renameDraft.trim();
@@ -305,6 +350,8 @@ function CanonContent(): React.ReactElement {
         activeIndex={activeIndex}
         onNewWorkspace={newWorkspace}
         onCloseWorkspace={closeWorkspace}
+        onReopenWorkspace={reopenLastClosed}
+        hasClosedHistory={hasClosedHistory}
         onSwitchWorkspace={switchWorkspace}
       />
     </div>


### PR DESCRIPTION
Phase 37: TerraCanon Reopen Last Closed Workspace Intent Contract. Adds lastClosedRef to store workspace on close, reopenLastClosed handler restores identity, reopen button in loaded and empty states. 5 contract tests, 210/210 suites, 3707 tests. Chain 22-37.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now quickly restore their most recently closed workspace with a Reopen button.
  * Closed workspace is restored with its original identity and properties intact.

* **Tests**
  * Added comprehensive test suite validating the workspace reopen functionality across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->