### PR TITLE
feat(terracanon): Phase 38 - Persistence Spine (localStorage v1, schema-safe)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonMultiWorkspaceSwitcherContract.test.tsx
@@ -68,8 +68,13 @@ import Router from '../../Router';
 // ============================================================================
 
 describe('Phase 35 contract: TerraCanon supports multiple session workspaces and a safe switcher', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     cleanup();
+    localStorage.clear();
   });
 
   /**

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonReopenWorkspaceIntentContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonReopenWorkspaceIntentContract.test.tsx
@@ -66,8 +66,13 @@ import Router from '../../Router';
 // ============================================================================
 
 describe('Phase 37 contract: TerraCanon can reopen the last closed workspace (session-only)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
     cleanup();
+    localStorage.clear();
   });
 
   /**

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspacePersistenceSpineContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonWorkspacePersistenceSpineContract.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Phase 38 — TerraCanon Workspace Persistence Spine Contract
+ *
+ * Contract: workspace state (list + activeIndex) persists to localStorage
+ * and restores correctly on remount. Malformed data fails closed.
+ *
+ * Phase 37 proved: reopen last closed (session-only).
+ * Phase 38 proves: workspace state survives refresh via localStorage.
+ *
+ * Success criteria:
+ *   1) Cold start with no persisted data → empty state, no identity
+ *   2) After workspace changes, localStorage contains serialized state
+ *   3) Unmount + remount restores loaded state with correct identity
+ *   4) Malformed persisted data → fail closed to empty state, no crash
+ *
+ * Prevents:
+ * - Refresh losing all workspace state
+ * - Corrupted localStorage crashing the app
+ * - Stale/phantom workspaces appearing after clear
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–37
+ * - localStorage spy for persistence verification
+ * - unmount() + re-render() for remount simulation
+ *
+ * Scope: localStorage persistence only. No backend, no API, no IndexedDB.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Storage keys (must match production)
+// ============================================================================
+
+const WORKSPACES_KEY = 'tf.canon.workspaces.v1';
+const ACTIVE_INDEX_KEY = 'tf.canon.activeIndex.v1';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 38 contract: TerraCanon persists workspace state to localStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  /**
+   * Helper: render Router at /canon and wait for Suspense to resolve.
+   */
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    const result = render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+    return result;
+  }
+
+  /**
+   * Helper: render + open the first workspace.
+   */
+  async function renderCanonAndOpenWorkspace() {
+    const result = await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    return result;
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start with no persisted data → empty state
+  // --------------------------------------------------------------------------
+  it('S1: cold start with no persisted data shows empty state', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: After workspace changes, localStorage contains serialized state
+  // --------------------------------------------------------------------------
+  it('S2: workspace changes persist to localStorage', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Rename workspace 0
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Alpha' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    // Create workspace 1
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+
+    // Rename workspace 1
+    const input2 = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input2, { target: { value: 'Beta' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    // Switch to workspace 0
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-0'));
+
+    // Verify localStorage was written
+    const rawWorkspaces = localStorage.getItem(WORKSPACES_KEY);
+    const rawIndex = localStorage.getItem(ACTIVE_INDEX_KEY);
+
+    expect(rawWorkspaces).not.toBeNull();
+    expect(rawIndex).not.toBeNull();
+
+    const parsed = JSON.parse(rawWorkspaces!);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(2);
+    expect(parsed[0].name).toBe('Alpha');
+    expect(parsed[1].name).toBe('Beta');
+    expect(parsed[0].id).toBeTruthy();
+    expect(parsed[1].id).toBeTruthy();
+    expect(Number(rawIndex)).toBe(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: Unmount + remount restores loaded state with correct identity
+  // --------------------------------------------------------------------------
+  it('S3: unmount + remount restores workspace state from localStorage', async () => {
+    const { unmount } = await renderCanonAndOpenWorkspace();
+
+    // Rename to make identity distinctive
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Persisted WS' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    // Capture identity before unmount
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameBefore = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameBefore).toBe('Persisted WS');
+
+    // Unmount (simulates leaving page)
+    unmount();
+
+    // Remount (simulates returning / refreshing)
+    await renderCanonAndWait();
+
+    // Should restore to loaded state
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameAfter = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+
+    expect(idAfter).toBe(idBefore);
+    expect(nameAfter).toBe(nameBefore);
+
+    // Layout stable
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: Malformed persisted data → fail closed to empty state
+  // --------------------------------------------------------------------------
+  it('S4: malformed persisted data fails closed to empty state without crash', async () => {
+    // Write garbage to localStorage before mount
+    localStorage.setItem(WORKSPACES_KEY, 'not-valid-json{{{');
+    localStorage.setItem(ACTIVE_INDEX_KEY, 'garbage');
+
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(screen.queryByTestId('terracanon-workspace-name')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('terracanon-workspace-id')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -10,6 +10,7 @@
  * Phase 35: Multi-workspace switcher — in-memory array, active index, per-workspace rename.
  * Phase 36: Close workspace intent — remove active, fallback or return to empty.
  * Phase 37: Reopen last closed workspace — undo-close via lastClosedRef.
+ * Phase 38: Persistence spine — localStorage v1, schema-safe restore.
  *
  * Layout:
  *   terracanon-root
@@ -30,7 +31,8 @@
  *                         ├─ terracanon-workspace-item-0
  *                         └─ terracanon-workspace-item-N
  *
- * State: workspaces[] array + activeIndex. No persistence, no filesystem, no LSP.
+ * State: workspaces[] array + activeIndex. Persisted to localStorage (v1 keys).
+ * No filesystem, no LSP.
  *
  * @module pages/CanonHome
  * @see Phase 30: TerraCanon Launch Spine Contract
@@ -41,9 +43,10 @@
  * @see Phase 35: TerraCanon Multi-Workspace Switcher Contract
  * @see Phase 36: TerraCanon Close Workspace Intent Contract
  * @see Phase 37: TerraCanon Reopen Last Closed Workspace Contract
+ * @see Phase 38: TerraCanon Persistence Spine Contract
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { StandaloneHomeShell } from '../components/standalone';
 
 // ============================================================================
@@ -258,13 +261,72 @@ function CanonWorkspace({
 // Canon Content (root landmark + workspace)
 // ============================================================================
 
+const STORAGE_KEY_WORKSPACES = 'tf.canon.workspaces.v1';
+const STORAGE_KEY_ACTIVE = 'tf.canon.activeIndex.v1';
+
+function isValidWorkspaceArray(data: unknown): data is Workspace[] {
+  if (!Array.isArray(data)) return false;
+  return data.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as Workspace).id === 'string' &&
+      (item as Workspace).id.length > 0 &&
+      typeof (item as Workspace).name === 'string' &&
+      (item as Workspace).name.length > 0,
+  );
+}
+
+function loadPersistedState(): { workspaces: Workspace[]; activeIndex: number } | null {
+  try {
+    const rawWs = localStorage.getItem(STORAGE_KEY_WORKSPACES);
+    const rawIdx = localStorage.getItem(STORAGE_KEY_ACTIVE);
+    if (rawWs === null || rawIdx === null) return null;
+    const parsed = JSON.parse(rawWs);
+    if (!isValidWorkspaceArray(parsed)) return null;
+    const idx = Number(rawIdx);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= parsed.length) return null;
+    return { workspaces: parsed, activeIndex: idx };
+  } catch {
+    return null;
+  }
+}
+
+function persistState(workspaces: Workspace[], activeIndex: number): void {
+  localStorage.setItem(STORAGE_KEY_WORKSPACES, JSON.stringify(workspaces));
+  localStorage.setItem(STORAGE_KEY_ACTIVE, String(activeIndex));
+}
+
 let workspaceCounter = 0;
 
 function CanonContent(): React.ReactElement {
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>(() => {
+    const persisted = loadPersistedState();
+    if (persisted) {
+      const maxId = persisted.workspaces.reduce((max, ws) => {
+        const match = ws.id.match(/^canon-workspace-(\d+)$/);
+        return match ? Math.max(max, Number(match[1])) : max;
+      }, 0);
+      if (maxId > workspaceCounter) workspaceCounter = maxId;
+    }
+    return persisted ? persisted.workspaces : [];
+  });
+  const [activeIndex, setActiveIndex] = useState(() => {
+    const persisted = loadPersistedState();
+    return persisted ? persisted.activeIndex : 0;
+  });
   const [renameDraft, setRenameDraft] = useState('');
   const lastClosedRef = useRef<Workspace | null>(null);
+  const mountedRef = useRef(false);
+
+  // Persist on state change (skip initial mount to avoid double-write)
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    persistState(workspaces, activeIndex);
+  }, [workspaces, activeIndex]);
 
   const hasWorkspace = workspaces.length > 0;
   const active = hasWorkspace ? workspaces[activeIndex] : null;


### PR DESCRIPTION
Phase 38: Persist workspace state to localStorage with schema validation. Adds tf.canon.workspaces.v1 and tf.canon.activeIndex.v1 keys. Restore on mount if valid, fail closed to empty if malformed. Phase 35/37 tests updated with localStorage.clear(). 4 contract tests, 211/211 suites, 3711 tests. Chain 22-38.