### PR TITLE
feat(terracanon): Phase 39 — persisted reopen-after-refresh

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPersistedReopenContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPersistedReopenContract.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Phase 39 — TerraCanon Persisted Reopen Contract
+ *
+ * Contract: lastClosed persists to localStorage and enables reopen-after-refresh.
+ * Single-undo, deterministic, schema-safe.
+ *
+ * Phase 38 proved: workspaces + activeIndex persist across refresh.
+ * Phase 39 proves: lastClosed survives refresh via tf.canon.lastClosed.v1.
+ *
+ * Success criteria:
+ *   1) Cold start with no lastClosed → no reopen control
+ *   2) Closing a workspace persists lastClosed (schema-valid JSON)
+ *   3) Remount restores reopen control; clicking it restores + consumes history
+ *   4) Malformed lastClosed → cleared, no crash, no reopen control
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–38
+ * - unmount() + re-render() for remount simulation
+ *
+ * Scope: localStorage persistence for lastClosed only. No backend, no IndexedDB.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Storage keys (must match production)
+// ============================================================================
+
+const KEY_LAST_CLOSED = 'tf.canon.lastClosed.v1';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 39 contract: persisted lastClosed enables reopen-after-refresh (schema-safe)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    const result = render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+    return result;
+  }
+
+  async function renderCanonAndOpenWorkspace() {
+    const result = await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    return result;
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: Cold start — no lastClosed → no reopen control
+  // --------------------------------------------------------------------------
+  it('S1: cold start with no lastClosed has no reopen control', async () => {
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: Closing a workspace persists lastClosed (schema-valid)
+  // --------------------------------------------------------------------------
+  it('S2: closing a workspace persists lastClosed to localStorage', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Rename to make identity distinctive
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Persist Me' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    // Close
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+
+    const raw = localStorage.getItem(KEY_LAST_CLOSED);
+    expect(raw).not.toBeNull();
+
+    const parsed = JSON.parse(raw!);
+    expect(typeof parsed).toBe('object');
+    expect(typeof parsed.id).toBe('string');
+    expect(parsed.id).toBe(idBefore);
+    expect(typeof parsed.name).toBe('string');
+    expect(parsed.name).toBe('Persist Me');
+  });
+
+  // --------------------------------------------------------------------------
+  // S3+S4: Remount restores reopen; clicking consumes history
+  // --------------------------------------------------------------------------
+  it('S3+S4: remount restores reopen control; reopen restores and consumes persisted history', async () => {
+    const { unmount } = await renderCanonAndOpenWorkspace();
+
+    // Rename for identity
+    const input = screen.getByTestId('terracanon-rename-workspace-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Persisted Undo' } });
+    fireEvent.click(screen.getByTestId('terracanon-rename-workspace-commit'));
+
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameBefore = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(nameBefore).toBe('Persisted Undo');
+
+    // Close → persists lastClosed
+    fireEvent.click(screen.getByTestId('terracanon-close-workspace'));
+    expect(localStorage.getItem(KEY_LAST_CLOSED)).not.toBeNull();
+
+    // Unmount (simulate leaving)
+    unmount();
+
+    // Remount (simulate refresh)
+    await renderCanonAndWait();
+
+    // Empty state with reopen visible
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    expect(screen.getByTestId('terracanon-reopen-workspace')).toBeInTheDocument();
+
+    // Click reopen
+    fireEvent.click(screen.getByTestId('terracanon-reopen-workspace'));
+
+    // Workspace restored with same identity
+    expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    const nameAfter = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(idAfter).toBe(idBefore);
+    expect(nameAfter).toBe(nameBefore);
+
+    // History consumed: storage cleared, control gone
+    expect(localStorage.getItem(KEY_LAST_CLOSED)).toBeNull();
+    expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Malformed lastClosed → cleared, no crash
+  // --------------------------------------------------------------------------
+  it('S5: malformed lastClosed fails closed with no crash', async () => {
+    localStorage.setItem(KEY_LAST_CLOSED, '{not-json');
+
+    await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Malformed data cleared
+    expect(localStorage.getItem(KEY_LAST_CLOSED)).toBeNull();
+    expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -11,6 +11,7 @@
  * Phase 36: Close workspace intent — remove active, fallback or return to empty.
  * Phase 37: Reopen last closed workspace — undo-close via lastClosedRef.
  * Phase 38: Persistence spine — localStorage v1, schema-safe restore.
+ * Phase 39: Persist lastClosed — reopen-after-refresh via localStorage.
  *
  * Layout:
  *   terracanon-root
@@ -44,6 +45,7 @@
  * @see Phase 36: TerraCanon Close Workspace Intent Contract
  * @see Phase 37: TerraCanon Reopen Last Closed Workspace Contract
  * @see Phase 38: TerraCanon Persistence Spine Contract
+ * @see Phase 39: TerraCanon Persisted Reopen Contract
  */
 
 import React, { useEffect, useRef, useState } from 'react';
@@ -263,6 +265,7 @@ function CanonWorkspace({
 
 const STORAGE_KEY_WORKSPACES = 'tf.canon.workspaces.v1';
 const STORAGE_KEY_ACTIVE = 'tf.canon.activeIndex.v1';
+const STORAGE_KEY_LAST_CLOSED = 'tf.canon.lastClosed.v1';
 
 function isValidWorkspaceArray(data: unknown): data is Workspace[] {
   if (!Array.isArray(data)) return false;
@@ -273,7 +276,7 @@ function isValidWorkspaceArray(data: unknown): data is Workspace[] {
       typeof (item as Workspace).id === 'string' &&
       (item as Workspace).id.length > 0 &&
       typeof (item as Workspace).name === 'string' &&
-      (item as Workspace).name.length > 0,
+      (item as Workspace).name.length > 0
   );
 }
 
@@ -297,6 +300,33 @@ function persistState(workspaces: Workspace[], activeIndex: number): void {
   localStorage.setItem(STORAGE_KEY_ACTIVE, String(activeIndex));
 }
 
+function isValidWorkspace(data: unknown): data is Workspace {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as Workspace).id === 'string' &&
+    (data as Workspace).id.length > 0 &&
+    typeof (data as Workspace).name === 'string' &&
+    (data as Workspace).name.length > 0
+  );
+}
+
+function loadLastClosed(): Workspace | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_LAST_CLOSED);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw);
+    if (!isValidWorkspace(parsed)) {
+      localStorage.removeItem(STORAGE_KEY_LAST_CLOSED);
+      return null;
+    }
+    return parsed;
+  } catch {
+    localStorage.removeItem(STORAGE_KEY_LAST_CLOSED);
+    return null;
+  }
+}
+
 let workspaceCounter = 0;
 
 function CanonContent(): React.ReactElement {
@@ -316,7 +346,7 @@ function CanonContent(): React.ReactElement {
     return persisted ? persisted.activeIndex : 0;
   });
   const [renameDraft, setRenameDraft] = useState('');
-  const lastClosedRef = useRef<Workspace | null>(null);
+  const lastClosedRef = useRef<Workspace | null>(loadLastClosed());
   const mountedRef = useRef(false);
 
   // Persist on state change (skip initial mount to avoid double-write)
@@ -364,7 +394,9 @@ function CanonContent(): React.ReactElement {
 
   const closeWorkspace = () => {
     if (workspaces.length === 0) return;
-    lastClosedRef.current = workspaces[activeIndex];
+    const closed = workspaces[activeIndex];
+    lastClosedRef.current = closed;
+    localStorage.setItem(STORAGE_KEY_LAST_CLOSED, JSON.stringify(closed));
     const next = workspaces.filter((_, i) => i !== activeIndex);
     setWorkspaces(next);
     setActiveIndex(next.length === 0 ? 0 : Math.min(activeIndex, next.length - 1));
@@ -375,6 +407,7 @@ function CanonContent(): React.ReactElement {
     const ws = lastClosedRef.current;
     if (!ws) return;
     lastClosedRef.current = null;
+    localStorage.removeItem(STORAGE_KEY_LAST_CLOSED);
     setWorkspaces((prev) => [...prev, ws]);
     setActiveIndex(workspaces.length); // new last index
     setRenameDraft('');


### PR DESCRIPTION
## Summary
- Adds `tf.canon.lastClosed.v1` localStorage key so the single-undo reopen control survives page refresh
- `isValidWorkspace()` type guard + `loadLastClosed()` with try/catch for schema-safe restore
- Closing persists to localStorage; reopening clears it (single-undo semantics)
- Malformed data is silently cleared — fail closed, no crash

## Test plan
- [x] S1: Cold start with no lastClosed → no reopen control
- [x] S2: Closing a workspace persists lastClosed (schema-valid JSON)
- [x] S3+S4: Remount restores reopen; clicking consumes persisted history
- [x] S5: Malformed lastClosed → cleared, no crash, no reopen control
- [x] 4/4 Phase 39 tests GREEN
- [x] 212/212 suites, 3,715 tests — full regression GREEN

## Governance chain
Phase 30→31→32→33→34→35→36→37→38→**39** (10 links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Last closed workspace is now automatically saved and can be reopened when the page is refreshed, improving workflow continuity.

* **Tests**
  * Added comprehensive phase-based contract tests validating workspace persistence and recovery behavior.

* **Bug Fixes**
  * Enhanced data validation to safely handle corrupted workspace information without causing application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->