### PR TITLE
test(terracanon): Phase 40 cross-tab sync contract (6/6 GREEN)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonCrossTabSyncContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonCrossTabSyncContract.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * Phase 40 — TerraCanon Cross-Tab Sync Contract
+ *
+ * Contract: when another tab changes TerraCanon workspace state in
+ * localStorage, this tab reloads deterministically without crash.
+ *
+ * Phase 39 proved: lastClosed persists to localStorage.
+ * Phase 40 proves: storage events from other tabs trigger safe reload
+ * of workspaces, activeIndex, and lastClosed — schema-guarded, fail-closed.
+ *
+ * Success criteria:
+ *   1) External workspace write → this tab reflects new state
+ *   2) External activeIndex write → this tab reflects new active
+ *   3) External lastClosed write → reopen control appears
+ *   4) External lastClosed clear → reopen control disappears
+ *   5) Malformed external data → ignored, current state preserved, no crash
+ *   6) Layout stable throughout all sync events
+ *
+ * Technique:
+ * - Same BrowserRouter → MemoryRouter swap as Phase 24–39
+ * - window.dispatchEvent(new StorageEvent('storage', {...})) simulates
+ *   cross-tab writes (JSDOM supports StorageEvent construction)
+ * - Direct localStorage mutation before event dispatch (simulating
+ *   what the browser does when another tab writes)
+ *
+ * Scope: Cross-tab sync via storage events. No BroadcastChannel, no SharedWorker.
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ============================================================================
+// Mocks (hoisted before imports by Jest)
+// ============================================================================
+
+let memoryRouterEntries: string[] = ['/'];
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+import Router from '../../Router';
+
+// ============================================================================
+// Storage keys (must match production)
+// ============================================================================
+
+const KEY_WORKSPACES = 'tf.canon.workspaces.v1';
+const KEY_ACTIVE = 'tf.canon.activeIndex.v1';
+const KEY_LAST_CLOSED = 'tf.canon.lastClosed.v1';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Simulate a cross-tab storage write by:
+ *   1. Writing the new value to localStorage (as if another tab wrote it)
+ *   2. Dispatching a StorageEvent (which the browser fires on OTHER tabs)
+ *
+ * Note: JSDOM does NOT auto-fire storage events on setItem, so we must
+ * dispatch manually. The `oldValue` param mirrors the browser behavior.
+ */
+function simulateCrossTabWrite(key: string, newValue: string | null, oldValue: string | null = null) {
+  if (newValue !== null) {
+    localStorage.setItem(key, newValue);
+  } else {
+    localStorage.removeItem(key);
+  }
+  act(() => {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key,
+        newValue,
+        oldValue,
+        storageArea: localStorage,
+        url: window.location.href,
+      }),
+    );
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Phase 40 contract: cross-tab sync reloads workspace state from storage events', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    const result = render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.queryByText(/Reset Application/i)).not.toBeInTheDocument();
+    return result;
+  }
+
+  async function renderCanonAndOpenWorkspace() {
+    const result = await renderCanonAndWait();
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-open-empty-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByTestId('terracanon-open-empty-workspace'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    return result;
+  }
+
+  // --------------------------------------------------------------------------
+  // S1: External workspace write → this tab reflects new state
+  // --------------------------------------------------------------------------
+  it('S1: external workspace write updates this tab to loaded state', async () => {
+    await renderCanonAndWait();
+
+    // Start in empty state
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-no-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Flush all pending React effects (including lazy-load useEffects)
+    // before dispatching storage events
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Another tab creates a workspace — write BOTH keys before dispatching
+    // (simulates atomic write by other tab; our handler reads both on either event)
+    const externalWorkspaces = [{ id: 'canon-workspace-99', name: 'External WS' }];
+    localStorage.setItem(KEY_WORKSPACES, JSON.stringify(externalWorkspaces));
+    localStorage.setItem(KEY_ACTIVE, '0');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY_WORKSPACES,
+          newValue: JSON.stringify(externalWorkspaces),
+          oldValue: null,
+          storageArea: localStorage,
+          url: window.location.href,
+        }),
+      );
+    });
+
+    // This tab should now show the workspace
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    const name = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    expect(name).toBe('External WS');
+  });
+
+  // --------------------------------------------------------------------------
+  // S2: External activeIndex write → this tab reflects new active
+  // --------------------------------------------------------------------------
+  it('S2: external activeIndex change switches the active workspace', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Create a second workspace locally
+    fireEvent.click(screen.getByTestId('terracanon-new-workspace'));
+    const id1 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    // Switch back to 0 locally
+    fireEvent.click(screen.getByTestId('terracanon-workspace-item-0'));
+    const id0 = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(id0).not.toBe(id1);
+
+    // Another tab switches to index 1 — update localStorage then dispatch
+    localStorage.setItem(KEY_ACTIVE, '1');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY_ACTIVE,
+          newValue: '1',
+          oldValue: '0',
+          storageArea: localStorage,
+          url: window.location.href,
+        }),
+      );
+    });
+
+    // This tab should reflect index 1
+    await waitFor(
+      () => {
+        const currentId = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+        expect(currentId).toBe(id1);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S3: External lastClosed write → reopen control appears
+  // --------------------------------------------------------------------------
+  it('S3: external lastClosed write makes reopen control appear', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // No reopen control initially (nothing closed)
+    expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+
+    // Another tab closes a workspace (writes lastClosed)
+    const closedWs = { id: 'canon-workspace-77', name: 'Closed Elsewhere' };
+    simulateCrossTabWrite(KEY_LAST_CLOSED, JSON.stringify(closedWs));
+
+    // Reopen control should appear
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-reopen-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S4: External lastClosed clear → reopen control disappears
+  // --------------------------------------------------------------------------
+  it('S4: external lastClosed clear removes reopen control', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    // Set lastClosed from another tab
+    const closedWs = { id: 'canon-workspace-88', name: 'Will Clear' };
+    simulateCrossTabWrite(KEY_LAST_CLOSED, JSON.stringify(closedWs));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('terracanon-reopen-workspace')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Another tab clears lastClosed
+    simulateCrossTabWrite(KEY_LAST_CLOSED, null, JSON.stringify(closedWs));
+
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('terracanon-reopen-workspace')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // S5: Malformed external data → ignored, no crash
+  // --------------------------------------------------------------------------
+  it('S5: malformed external storage data is ignored without crash', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    const nameBefore = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    const idBefore = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+
+    // Fire malformed workspace data from another tab
+    simulateCrossTabWrite(KEY_WORKSPACES, '{{{not-json');
+    simulateCrossTabWrite(KEY_ACTIVE, 'garbage');
+    simulateCrossTabWrite(KEY_LAST_CLOSED, '!!!invalid');
+
+    // Current state must be preserved — no crash, no change
+    expect(screen.getByTestId('terracanon-workspace-loaded')).toBeInTheDocument();
+    const nameAfter = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+    const idAfter = (screen.getByTestId('terracanon-workspace-id').textContent ?? '').trim();
+    expect(nameAfter).toBe(nameBefore);
+    expect(idAfter).toBe(idBefore);
+
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // S6: Layout stable throughout sync events
+  // --------------------------------------------------------------------------
+  it('S6: layout remains stable through cross-tab sync events', async () => {
+    await renderCanonAndOpenWorkspace();
+
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+
+    // Fire valid external update — write both keys atomically, then dispatch
+    const externalWorkspaces = [
+      { id: 'canon-workspace-50', name: 'Synced A' },
+      { id: 'canon-workspace-51', name: 'Synced B' },
+    ];
+    localStorage.setItem(KEY_WORKSPACES, JSON.stringify(externalWorkspaces));
+    localStorage.setItem(KEY_ACTIVE, '1');
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY_WORKSPACES,
+          newValue: JSON.stringify(externalWorkspaces),
+          oldValue: null,
+          storageArea: localStorage,
+          url: window.location.href,
+        }),
+      );
+    });
+
+    await waitFor(
+      () => {
+        const name = (screen.getByTestId('terracanon-workspace-name').textContent ?? '').trim();
+        expect(name).toBe('Synced B');
+      },
+      { timeout: 5000 },
+    );
+
+    // Layout still intact
+    expect(screen.getByTestId('terracanon-filetree')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('terracanon-workspace')).toBeInTheDocument();
+    expect(screen.queryByText(/reset application/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `TerraCanonCrossTabSyncContract.test.tsx` — 6 tests proving cross-tab sync via `StorageEvent` works deterministically
- S1: External workspace write → this tab reflects new state
- S2: External activeIndex change → switches active workspace
- S3: External lastClosed write → reopen control appears
- S4: External lastClosed clear → reopen control disappears
- S5: Malformed external data → ignored, no crash
- S6: Layout stable through sync events

## Technique
- `window.dispatchEvent(new StorageEvent('storage', {...}))` simulates cross-tab writes
- Atomic key writes ensure `loadPersistedState()` sees both WORKSPACES + ACTIVE
- `act(async () => setTimeout(r, 50))` flushes lazy-load component effects before event dispatch

## Regression
- **213/213** suites, **3,721** tests, **0** failures

## Test plan
- [x] Phase 40 contract: 6/6 GREEN
- [x] Full regression gate: 213/213 suites GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cross-tab workspace state synchronization, including external workspace updates, active workspace changes, reopen controls, malformed data handling, and UI layout stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->