### PR TITLE
chore(governance): Phase 43 -- non-barrel governance import report + hygiene test harness

### DIFF
--- a/os-platform/core/tests/governance-import-hygiene.report.test.mjs
+++ b/os-platform/core/tests/governance-import-hygiene.report.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * TerraCanon – Governance Import Hygiene Report (Non-Blocking)
+ *
+ * Surfaces any non-barrel governance imports in CI logs.
+ * Always passes — informational only, not enforcement.
+ *
+ * Run with: node --test os-platform/core/tests/governance-import-hygiene.report.test.mjs
+ *
+ * @see Phase 43: Import Hygiene
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { reportNonBarrelGovernanceImports } from '../../../scripts/governance/report-non-barrel-governance-imports.mjs';
+
+describe('Governance Import Hygiene Report (informational)', () => {
+  it('reports non-barrel governance imports (always passes)', () => {
+    const offenders = reportNonBarrelGovernanceImports({ rootDir: process.cwd() });
+
+    if (offenders.length > 0) {
+      console.log(
+        'ℹ️ Non-barrel governance imports detected (migrate to canon/governance.ts):\n' +
+          offenders.map(f => ` - ${f}`).join('\n')
+      );
+    } else {
+      console.log('✅ No non-barrel governance imports detected.');
+    }
+
+    // Always pass — informational only
+    assert.ok(true);
+  });
+});
+
+console.log('Governance Import Hygiene Report Suite');
+console.log('=======================================');
+console.log(
+  'Run with: node --test os-platform/core/tests/governance-import-hygiene.report.test.mjs'
+);

--- a/scripts/governance/report-non-barrel-governance-imports.mjs
+++ b/scripts/governance/report-non-barrel-governance-imports.mjs
@@ -1,0 +1,88 @@
+/**
+ * Informational governance report (non-blocking):
+ * Finds UI files importing governance symbols from non-barrel paths
+ * (e.g. reopenPersistence directly instead of canon/governance).
+ *
+ * Exit code ALWAYS 0. This is a visibility tool, not enforcement.
+ *
+ * @module scripts/governance/report-non-barrel-governance-imports
+ * @see Phase 43: Import Hygiene
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ROOT = process.cwd();
+
+const UI_ROOTS = ['frontend', 'apps', 'src'];
+
+const FILE_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'QUARANTINE', 'ARCHIVE']);
+
+const NON_BARREL_IMPORT_PATTERNS = [/from\s+['"][^'"]*reopenPersistence['"]/];
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(full);
+    else if (e.isFile() && FILE_EXTS.has(path.extname(e.name))) yield full;
+  }
+}
+
+function scanFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const norm = filePath.replaceAll('\\', '/');
+
+  // Allow the barrel itself and the canonical source to import reopenPersistence
+  if (norm.endsWith('/canon/governance.ts') || norm.endsWith('/canon/governance.js')) return false;
+  if (norm.endsWith('/canon/reopenPersistence.ts') || norm.endsWith('/canon/reopenPersistence.js'))
+    return false;
+
+  // Allow test files that explicitly test reopenPersistence
+  if (norm.includes('/tests/') && norm.includes('canon-reopen')) return false;
+  if (norm.includes('/tests/') && norm.includes('canon-governance-barrel')) return false;
+
+  return NON_BARREL_IMPORT_PATTERNS.some(re => re.test(raw));
+}
+
+export function reportNonBarrelGovernanceImports({ rootDir = DEFAULT_ROOT } = {}) {
+  const offenders = [];
+  const root = path.resolve(rootDir);
+
+  for (const uiRoot of UI_ROOTS) {
+    const abs = path.resolve(root, uiRoot);
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) continue;
+
+    for (const f of walk(abs)) {
+      if (scanFile(f)) offenders.push(path.relative(root, f));
+    }
+  }
+
+  return offenders;
+}
+
+// CLI entry: always exit 0
+const isMain =
+  import.meta.url === `file:///${process.argv[1].replaceAll('\\', '/')}` ||
+  import.meta.url === `file://${process.argv[1].replaceAll('\\', '/')}`;
+
+if (isMain) {
+  const offenders = reportNonBarrelGovernanceImports();
+  if (offenders.length === 0) {
+    console.log('✅ Governance import hygiene: no non-barrel imports detected.');
+  } else {
+    console.log(
+      'ℹ️ Governance import hygiene report: non-barrel imports detected (please migrate to canon/governance.ts):'
+    );
+    for (const f of offenders) console.log(` - ${f}`);
+  }
+  process.exit(0);
+}


### PR DESCRIPTION
Phase 43: Add informational (non-blocking) report script that detects non-barrel governance imports + core-lane report test harness. Scan confirms zero offenders -- all governance imports already flow through canon/governance.ts barrel. Gates: hygiene report 1/1, barrel 5/5, dedup 1/1, canon-reopen 17/17, phase83 32/32, frontend 213/213 (3721 tests). Chain: 22-42-43.

## Summary by Sourcery

Add an informational governance import hygiene report script and wire it into the core governance import hygiene test harness.

New Features:
- Introduce a script that scans UI code for non-barrel governance imports and reports offenders without failing the build.

Tests:
- Add a governance import hygiene report test harness under core tests to exercise the new reporting script.