### PR TITLE
chore(governance): Phase 43 — import hygiene sweep + non-blocking report

### DIFF
--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -263,7 +263,7 @@ function CanonWorkspace({
 
 const STORAGE_KEY_WORKSPACES = 'tf.canon.workspaces.v1';
 const STORAGE_KEY_ACTIVE = 'tf.canon.activeIndex.v1';
-// STORAGE_KEY_LAST_CLOSED imported from @/canon/reopenPersistence
+// STORAGE_KEY_LAST_CLOSED imported from @/canon/governance (Phase 42 barrel)
 
 function isValidWorkspaceArray(data: unknown): data is Workspace[] {
   if (!Array.isArray(data)) return false;
@@ -290,7 +290,7 @@ function persistState(workspaces: Workspace[], activeIndex: number): void {
   localStorage.setItem(STORAGE_KEY_ACTIVE, String(activeIndex));
 }
 
-// isValidWorkspace imported from @/canon/reopenPersistence (Phase 41 dedup)
+// isValidWorkspace imported from @/canon/governance (Phase 42 barrel)
 
 function loadLastClosed(): Workspace | null {
   try {

--- a/os-platform/core/tests/governance-import-hygiene.report.test.mjs
+++ b/os-platform/core/tests/governance-import-hygiene.report.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * TerraCanon – Governance Import Hygiene Report (Non-Blocking)
+ *
+ * Surfaces any non-barrel governance imports in CI logs.
+ * Always passes — informational only, not enforcement.
+ *
+ * Run with: node --test os-platform/core/tests/governance-import-hygiene.report.test.mjs
+ *
+ * @see Phase 43: Import Hygiene
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { reportNonBarrelGovernanceImports } from '../../../scripts/governance/report-non-barrel-governance-imports.mjs';
+
+describe('Governance Import Hygiene Report (informational)', () => {
+  it('reports non-barrel governance imports (always passes)', () => {
+    const offenders = reportNonBarrelGovernanceImports({ rootDir: process.cwd() });
+
+    if (offenders.length > 0) {
+      console.log(
+        'ℹ️ Non-barrel governance imports detected (migrate to canon/governance.ts):\n' +
+          offenders.map(f => ` - ${f}`).join('\n')
+      );
+    } else {
+      console.log('✅ No non-barrel governance imports detected.');
+    }
+
+    // Always pass — informational only
+    assert.ok(true);
+  });
+});
+
+console.log('Governance Import Hygiene Report Suite');
+console.log('=======================================');
+console.log(
+  'Run with: node --test os-platform/core/tests/governance-import-hygiene.report.test.mjs'
+);

--- a/scripts/governance/report-non-barrel-governance-imports.mjs
+++ b/scripts/governance/report-non-barrel-governance-imports.mjs
@@ -1,0 +1,88 @@
+/**
+ * Informational governance report (non-blocking):
+ * Finds UI files importing governance symbols from non-barrel paths
+ * (e.g. reopenPersistence directly instead of canon/governance).
+ *
+ * Exit code ALWAYS 0. This is a visibility tool, not enforcement.
+ *
+ * @module scripts/governance/report-non-barrel-governance-imports
+ * @see Phase 43: Import Hygiene
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ROOT = process.cwd();
+
+const UI_ROOTS = ['frontend', 'apps', 'src'];
+
+const FILE_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.next', 'QUARANTINE', 'ARCHIVE']);
+
+const NON_BARREL_IMPORT_PATTERNS = [/from\s+['"][^'"]*reopenPersistence['"]/];
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(full);
+    else if (e.isFile() && FILE_EXTS.has(path.extname(e.name))) yield full;
+  }
+}
+
+function scanFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const norm = filePath.replaceAll('\\', '/');
+
+  // Allow the barrel itself and the canonical source to import reopenPersistence
+  if (norm.endsWith('/canon/governance.ts') || norm.endsWith('/canon/governance.js')) return false;
+  if (norm.endsWith('/canon/reopenPersistence.ts') || norm.endsWith('/canon/reopenPersistence.js'))
+    return false;
+
+  // Allow test files that explicitly test reopenPersistence
+  if (norm.includes('/tests/') && norm.includes('canon-reopen')) return false;
+  if (norm.includes('/tests/') && norm.includes('canon-governance-barrel')) return false;
+
+  return NON_BARREL_IMPORT_PATTERNS.some(re => re.test(raw));
+}
+
+export function reportNonBarrelGovernanceImports({ rootDir = DEFAULT_ROOT } = {}) {
+  const offenders = [];
+  const root = path.resolve(rootDir);
+
+  for (const uiRoot of UI_ROOTS) {
+    const abs = path.resolve(root, uiRoot);
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) continue;
+
+    for (const f of walk(abs)) {
+      if (scanFile(f)) offenders.push(path.relative(root, f));
+    }
+  }
+
+  return offenders;
+}
+
+// CLI entry: always exit 0
+const isMain =
+  import.meta.url === `file:///${process.argv[1].replaceAll('\\', '/')}` ||
+  import.meta.url === `file://${process.argv[1].replaceAll('\\', '/')}`;
+
+if (isMain) {
+  const offenders = reportNonBarrelGovernanceImports();
+  if (offenders.length === 0) {
+    console.log('✅ Governance import hygiene: no non-barrel imports detected.');
+  } else {
+    console.log(
+      'ℹ️ Governance import hygiene report: non-barrel imports detected (please migrate to canon/governance.ts):'
+    );
+    for (const f of offenders) console.log(` - ${f}`);
+  }
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary
- Sweep remaining UI governance imports to `canon/governance.ts` barrel (already clean from Phase 42)
- Add non-blocking import hygiene report script (`scripts/governance/report-non-barrel-governance-imports.mjs`)
- Add informational test harness (`governance-import-hygiene.report.test.mjs`) — always passes, surfaces drift in CI logs
- Update stale comments in `CanonHome.tsx` referencing `reopenPersistence` → `governance` barrel

## Test plan
- [x] Import hygiene report: ✅ zero non-barrel imports detected
- [x] Import hygiene test: 1/1 GREEN (informational, always passes)
- [x] Validator dedup tripwire: 1/1 GREEN
- [x] Barrel contract tripwire: 5/5 GREEN
- [x] TerraCanon: 10/10 suites, 56/56 tests GREEN
- [x] Full regression: 213/213 suites, 3,721/3,721 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added governance import hygiene test to validate code organization standards.

* **Chores**
  * Consolidated import paths to improve code structure and maintainability.
  * Implemented validation tooling to enforce consistent import organization practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->