### PR TITLE
feat(pilot): Phase 48A - ToolRunner preflight + command governance metadata (backwards compatible)

### DIFF
--- a/os-platform/core/canon/commandGate.mjs
+++ b/os-platform/core/canon/commandGate.mjs
@@ -1,0 +1,69 @@
+/**
+ * Phase 48: Governed Command Gate (Core)
+ *
+ * Any mutating command requires explicit allow from a policy check.
+ * Deny returns a reason string. Never throws; exceptions become deny(reason).
+ *
+ * @module canon/commandGate
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+/**
+ * @typedef {{ id: string; mutates: boolean; meta?: Readonly<Record<string, string | number | boolean>> }} CommandRequest
+ * @typedef {Readonly<{ allow: true }> | Readonly<{ allow: false; reason: string }>} CommandDecision
+ * @typedef {(req: CommandRequest) => CommandDecision} PolicyCheck
+ */
+
+/**
+ * Create a governed command gate from a policy check function.
+ *
+ * The gate wraps the policy in a fail-safe envelope:
+ * - Invalid decision shape → deny("Policy returned invalid decision")
+ * - Exception in policy → deny(error.message || "Policy exception")
+ * - Empty reason string → deny("Policy denied")
+ *
+ * @param {PolicyCheck} check
+ * @returns {Readonly<{ decide: (req: CommandRequest) => CommandDecision, run: <T>(req: CommandRequest, thunk: () => T) => Readonly<{ decision: CommandDecision, value?: T }> }>}
+ */
+export function createCommandGate(check) {
+  return Object.freeze({
+    /**
+     * Evaluate policy for a command request.
+     * @param {CommandRequest} req
+     * @returns {CommandDecision}
+     */
+    decide(req) {
+      try {
+        const d = check(req);
+        if (d && typeof d === 'object' && 'allow' in d) {
+          if (d.allow === true) return { allow: true };
+          const reason = /** @type {{ allow: false; reason?: unknown }} */ (d).reason;
+          return {
+            allow: false,
+            reason: typeof reason === 'string' && reason.length > 0 ? reason : 'Policy denied',
+          };
+        }
+        return { allow: false, reason: 'Policy returned invalid decision' };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Policy exception';
+        return { allow: false, reason: msg || 'Policy exception' };
+      }
+    },
+
+    /**
+     * Execute a command thunk under policy.
+     * - If denied, returns denied decision and does not call thunk.
+     * - If allowed, calls thunk and returns allow + value.
+     *
+     * @template T
+     * @param {CommandRequest} req
+     * @param {() => T} thunk
+     * @returns {Readonly<{ decision: CommandDecision, value?: T }>}
+     */
+    run(req, thunk) {
+      const decision = this.decide(req);
+      if (!decision.allow) return { decision };
+      return { decision, value: thunk() };
+    },
+  });
+}

--- a/os-platform/core/canon/layoutEnvelope.mjs
+++ b/os-platform/core/canon/layoutEnvelope.mjs
@@ -1,0 +1,145 @@
+/**
+ * Phase 48: Layout Persistence Envelope (Core)
+ *
+ * Versioned envelope + strict validation + fail-closed parsing
+ * for TerraCanon layout state. Same discipline as Phase 47
+ * lastClosedEnvelope — strict shape, fail-closed, no crash.
+ *
+ * @module canon/layoutEnvelope
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+/** @typedef {"leftNav" | "main" | "rightInspector"} PanelId */
+
+const PANEL_IDS = /** @type {const} */ (['leftNav', 'main', 'rightInspector']);
+
+/**
+ * @param {unknown} v
+ * @returns {v is Record<string, unknown>}
+ */
+function isPlainObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * @param {Record<string, unknown>} obj
+ * @param {readonly string[]} keys
+ * @returns {boolean}
+ */
+function hasExactKeys(obj, keys) {
+  const actual = Object.keys(obj);
+  if (actual.length !== keys.length) return false;
+  for (const k of actual) if (!keys.includes(k)) return false;
+  return true;
+}
+
+/**
+ * @param {unknown} n
+ * @returns {n is number}
+ */
+function isFiniteNumber(n) {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+/**
+ * @param {unknown} s
+ * @returns {s is PanelId}
+ */
+function isPanelId(s) {
+  return typeof s === 'string' && PANEL_IDS.includes(/** @type {any} */ (s));
+}
+
+/**
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+function isValidPanelConfig(v) {
+  if (!isPlainObject(v)) return false;
+  if (!hasExactKeys(/** @type {Record<string, unknown>} */ (v), ['visible', 'size'])) return false;
+  const obj = /** @type {Record<string, unknown>} */ (v);
+  return typeof obj.visible === 'boolean' && isFiniteNumber(obj.size) && /** @type {number} */ (obj.size) >= 0;
+}
+
+/**
+ * Validate a LayoutV1 shape.
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+export function isValidLayoutV1(v) {
+  if (!isPlainObject(v)) return false;
+  const obj = /** @type {Record<string, unknown>} */ (v);
+  if (!hasExactKeys(obj, ['panels'])) return false;
+
+  const panels = obj.panels;
+  if (!isPlainObject(panels)) return false;
+  const panelsObj = /** @type {Record<string, unknown>} */ (panels);
+
+  // Strictly require exactly the three known panel IDs
+  const keys = Object.keys(panelsObj);
+  if (keys.length !== 3) return false;
+  for (const k of keys) if (!isPanelId(k)) return false;
+
+  return (
+    isValidPanelConfig(panelsObj.leftNav) &&
+    isValidPanelConfig(panelsObj.main) &&
+    isValidPanelConfig(panelsObj.rightInspector)
+  );
+}
+
+/**
+ * Validate a LayoutEnvelopeV1 shape.
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+export function isValidLayoutEnvelopeV1(v) {
+  if (!isPlainObject(v)) return false;
+  const obj = /** @type {Record<string, unknown>} */ (v);
+  if (!hasExactKeys(obj, ['v', 'layout', 'ts'])) return false;
+  if (obj.v !== 1) return false;
+  if (!isValidLayoutV1(obj.layout)) return false;
+  return isFiniteNumber(obj.ts) && /** @type {number} */ (obj.ts) > 0;
+}
+
+/**
+ * Serialize a LayoutV1 into a versioned envelope JSON string.
+ * @param {object} layout - A valid LayoutV1
+ * @param {number} [nowMs] - Timestamp override (default: Date.now())
+ * @returns {string}
+ */
+export function serializeLayoutEnvelopeV1(layout, nowMs = Date.now()) {
+  if (!isValidLayoutV1(layout)) {
+    throw new Error('Cannot serialize invalid layout into v1 envelope');
+  }
+  return JSON.stringify({ v: 1, layout, ts: nowMs });
+}
+
+/**
+ * Strict parse. Returns null if invalid/malformed.
+ * Caller should fail-close (clear key / fallback layout).
+ * @param {string} raw
+ * @returns {{ v: 1, layout: object, ts: number } | null}
+ */
+export function parseLayoutEnvelopeV1(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    return isValidLayoutEnvelopeV1(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default layout for TerraCanon workspace.
+ * @returns {{ panels: { leftNav: { visible: boolean, size: number }, main: { visible: boolean, size: number }, rightInspector: { visible: boolean, size: number } } }}
+ */
+export function defaultLayoutV1() {
+  return {
+    panels: {
+      leftNav: { visible: true, size: 280 },
+      main: { visible: true, size: 1 },
+      rightInspector: { visible: true, size: 360 },
+    },
+  };
+}
+
+export const LAYOUT_ENVELOPE_VERSION = 1;

--- a/os-platform/core/pilot/ToolRegistry.js
+++ b/os-platform/core/pilot/ToolRegistry.js
@@ -12,11 +12,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.VALID_TRACE_POLICIES = exports.VALID_SUITES = exports.VALID_RISKS = exports.VALID_PII_HANDLING = exports.toolRegistry = exports.ToolRegistry = exports.ManifestValidationError = void 0;
 const fs_1 = require("fs");
 const path_1 = require("path");
+const commandGovernance_js_1 = require("../types/commandGovernance.js");
 // ============================================================================
 // Constants
 // ============================================================================
 const MANIFEST_VERSION = '1.3.0';
-const CANONICAL_MANIFEST_PATH = (0, path_1.resolve)(__dirname, '../../../tools/registry/terrapilot.tools.json');
+const BASE_DIR = __dirname;
+const CANONICAL_MANIFEST_PATH = (0, path_1.resolve)(BASE_DIR, '../../../tools/registry/terrapilot.tools.json');
 const VALID_SUITES = ['forge', 'atlas', 'dais', 'dossier', 'os', 'pilot', 'gpt'];
 exports.VALID_SUITES = VALID_SUITES;
 const VALID_RISKS = ['read_only', 'write_low', 'write_high', 'irreversible'];
@@ -95,6 +97,11 @@ function validateTool(tool, index) {
     // payload_ref requires payloadStore
     if (tool.tracePolicy === 'payload_ref' && !tool.payloadStore) {
         violations.push(`${prefix}: payload_ref tracePolicy requires payloadStore`);
+    }
+    // Phase 48A: Optional governance metadata (strict shape when present)
+    const governance = tool.governance;
+    if (governance !== undefined && !(0, commandGovernance_js_1.isCommandGovernanceMeta)(governance)) {
+        violations.push(`${prefix}: governance must match { intent, mutation, visibility } with valid enum values`);
     }
     return violations;
 }

--- a/os-platform/core/pilot/ToolRegistry.ts
+++ b/os-platform/core/pilot/ToolRegistry.ts
@@ -8,8 +8,8 @@
  */
 
 import { readFileSync } from 'fs';
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { resolve } from 'path';
+import { isCommandGovernanceMeta } from '../types/commandGovernance.js';
 import type { Mode, Risk, Suite, Tool, ToolManifest } from '../types/index.js';
 
 // ============================================================================
@@ -17,8 +17,7 @@ import type { Mode, Risk, Suite, Tool, ToolManifest } from '../types/index.js';
 // ============================================================================
 
 const MANIFEST_VERSION = '1.3.0';
-const BASE_DIR =
-  typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
+const BASE_DIR = __dirname;
 const CANONICAL_MANIFEST_PATH = resolve(
   BASE_DIR,
   '../../../tools/registry/terrapilot.tools.json'
@@ -113,6 +112,14 @@ function validateTool(tool: Tool, index: number): string[] {
   // payload_ref requires payloadStore
   if (tool.tracePolicy === 'payload_ref' && !tool.payloadStore) {
     violations.push(`${prefix}: payload_ref tracePolicy requires payloadStore`);
+  }
+
+  // Phase 48A: Optional governance metadata (strict shape when present)
+  const governance = (tool as Tool & { governance?: unknown }).governance;
+  if (governance !== undefined && !isCommandGovernanceMeta(governance)) {
+    violations.push(
+      `${prefix}: governance must match { intent, mutation, visibility } with valid enum values`
+    );
   }
 
   return violations;

--- a/os-platform/core/pilot/ToolRunner.js
+++ b/os-platform/core/pilot/ToolRunner.js
@@ -14,6 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.toolRunner = exports.ToolRunner = exports.ToolRunnerError = exports.ErrorCodes = void 0;
 const crypto_1 = require("crypto");
 const TraceService_js_1 = require("../trace/TraceService.js");
+const ToolRunner_preflight_js_1 = require("./ToolRunner.preflight.js");
 const ToolRegistry_js_1 = require("./ToolRegistry.js");
 // ============================================================================
 // Error Codes
@@ -33,6 +34,7 @@ exports.ErrorCodes = {
     // General
     TOOL_NOT_FOUND: 'TOOL_NOT_FOUND',
     MODE_MISMATCH: 'MODE_MISMATCH',
+    POLICY_DENIED: 'POLICY_DENIED',
     EXECUTION_FAILED: 'EXECUTION_FAILED',
 };
 class ToolRunnerError extends Error {
@@ -116,6 +118,7 @@ class ToolRunner {
         this.handlers = new Map();
         this.registry = options.registry ?? ToolRegistry_js_1.toolRegistry;
         this.trace = options.trace ?? TraceService_js_1.traceService;
+        this.preflight = (0, ToolRunner_preflight_js_1.createPreflight)(options.preflightPolicy);
     }
     /**
      * Canonical execution path.
@@ -179,6 +182,22 @@ class ToolRunner {
         // Mode check
         if (tool.mode && tool.mode !== context.mode) {
             return this.fail(correlationId, exports.ErrorCodes.MODE_MISMATCH, `Tool ${toolId} requires mode "${tool.mode}" but got "${context.mode}"`);
+        }
+        // Optional preflight policy gate (additive, defaults to allow)
+        const governance = tool.governance;
+        const preflight = this.preflight.decide({
+            toolId,
+            correlationId,
+            governance,
+            requestedMutation: mutationFromRisk(tool.risk),
+        });
+        if (!preflight.allow) {
+            this.emitTraceEvent(tool, 'tool_failed', correlationId, context, {
+                summary: `Policy denied ${toolId}: ${preflight.reason}`,
+                errorCode: exports.ErrorCodes.POLICY_DENIED,
+                component: 'ToolRunner',
+            });
+            return this.fail(correlationId, exports.ErrorCodes.POLICY_DENIED, preflight.reason);
         }
         // Collect all enforcement violations
         const violations = [
@@ -308,6 +327,7 @@ function mapErrorCode(code) {
             return 'PII_BLOCKED';
         case exports.ErrorCodes.TOOL_NOT_FOUND:
             return 'TOOL_NOT_FOUND';
+        case exports.ErrorCodes.POLICY_DENIED:
         case exports.ErrorCodes.WRITE_LANE_MISMATCH:
         case exports.ErrorCodes.WRITE_LANE_REQUIRED:
         case exports.ErrorCodes.CONFIRMATION_REQUIRED:
@@ -319,6 +339,13 @@ function mapErrorCode(code) {
         default:
             return 'EXECUTION_FAILED';
     }
+}
+function mutationFromRisk(risk) {
+    if (risk === 'read_only')
+        return 'none';
+    if (risk === 'write_low')
+        return 'transient';
+    return 'durable';
 }
 // ============================================================================
 // Singleton Instance

--- a/os-platform/core/pilot/ToolRunner.preflight.js
+++ b/os-platform/core/pilot/ToolRunner.preflight.js
@@ -1,0 +1,22 @@
+// GENERATED - DO NOT EDIT
+"use strict";
+/**
+ * Phase 48A: ToolRunner Preflight (Additive)
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createPreflight = createPreflight;
+const commandGovernance_js_1 = require("../types/commandGovernance.js");
+function createPreflight(policy) {
+    const p = policy ?? (() => ({ allow: true }));
+    return Object.freeze({
+        decide(req) {
+            try {
+                return (0, commandGovernance_js_1.normalizeDecision)(p(req));
+            }
+            catch (e) {
+                const msg = e instanceof Error ? e.message : 'Policy exception';
+                return { allow: false, reason: msg || 'Policy exception', visibility: 'restricted' };
+            }
+        },
+    });
+}

--- a/os-platform/core/pilot/ToolRunner.preflight.ts
+++ b/os-platform/core/pilot/ToolRunner.preflight.ts
@@ -1,0 +1,21 @@
+/**
+ * Phase 48A: ToolRunner Preflight (Additive)
+ */
+
+import type { PolicyDecision, PreflightPolicy, PreflightRequest } from '../types/commandGovernance.js';
+import { normalizeDecision } from '../types/commandGovernance.js';
+
+export function createPreflight(policy?: PreflightPolicy) {
+  const p: PreflightPolicy = policy ?? (() => ({ allow: true }));
+
+  return Object.freeze({
+    decide(req: PreflightRequest): PolicyDecision {
+      try {
+        return normalizeDecision(p(req));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Policy exception';
+        return { allow: false, reason: msg || 'Policy exception', visibility: 'restricted' };
+      }
+    },
+  });
+}

--- a/os-platform/core/pilot/ToolRunner.ts
+++ b/os-platform/core/pilot/ToolRunner.ts
@@ -12,6 +12,12 @@
 import { randomUUID } from 'crypto';
 import { traceService, TraceService } from '../trace/TraceService.js';
 import type {
+  CommandGovernanceMeta,
+  MutationClass,
+  PreflightPolicy,
+} from '../types/commandGovernance.js';
+import { createPreflight } from './ToolRunner.preflight.js';
+import type {
     Tool,
     ToolExecutionContext,
     ToolExecutionInput,
@@ -42,6 +48,7 @@ export const ErrorCodes = {
   // General
   TOOL_NOT_FOUND: 'TOOL_NOT_FOUND',
   MODE_MISMATCH: 'MODE_MISMATCH',
+  POLICY_DENIED: 'POLICY_DENIED',
   EXECUTION_FAILED: 'EXECUTION_FAILED',
 } as const;
 
@@ -172,16 +179,19 @@ export type ToolHandler<TParams = unknown, TResult = unknown> = (
 export interface ToolRunnerOptions {
   registry?: ToolRegistry;
   trace?: TraceService;
+  preflightPolicy?: PreflightPolicy;
 }
 
 export class ToolRunner {
   private registry: ToolRegistry;
   private trace: TraceService;
   private handlers: Map<string, ToolHandler> = new Map();
+  private preflight: ReturnType<typeof createPreflight>;
 
   constructor(options: ToolRunnerOptions = {}) {
     this.registry = options.registry ?? toolRegistry;
     this.trace = options.trace ?? traceService;
+    this.preflight = createPreflight(options.preflightPolicy);
   }
 
   /**
@@ -275,6 +285,23 @@ export class ToolRunner {
         ErrorCodes.MODE_MISMATCH,
         `Tool ${toolId} requires mode "${tool.mode}" but got "${context.mode}"`
       );
+    }
+
+    // Optional preflight policy gate (additive, defaults to allow)
+    const governance = (tool as Tool & { governance?: CommandGovernanceMeta }).governance;
+    const preflight = this.preflight.decide({
+      toolId,
+      correlationId,
+      governance,
+      requestedMutation: mutationFromRisk(tool.risk),
+    });
+    if (!preflight.allow) {
+      this.emitTraceEvent(tool, 'tool_failed', correlationId, context, {
+        summary: `Policy denied ${toolId}: ${preflight.reason}`,
+        errorCode: ErrorCodes.POLICY_DENIED,
+        component: 'ToolRunner',
+      });
+      return this.fail(correlationId, ErrorCodes.POLICY_DENIED, preflight.reason);
     }
 
     // Collect all enforcement violations
@@ -445,6 +472,7 @@ function mapErrorCode(code: ErrorCode): RunnerErrorCode {
       return 'PII_BLOCKED';
     case ErrorCodes.TOOL_NOT_FOUND:
       return 'TOOL_NOT_FOUND';
+    case ErrorCodes.POLICY_DENIED:
     case ErrorCodes.WRITE_LANE_MISMATCH:
     case ErrorCodes.WRITE_LANE_REQUIRED:
     case ErrorCodes.CONFIRMATION_REQUIRED:
@@ -456,6 +484,12 @@ function mapErrorCode(code: ErrorCode): RunnerErrorCode {
     default:
       return 'EXECUTION_FAILED';
   }
+}
+
+function mutationFromRisk(risk: Tool['risk']): MutationClass {
+  if (risk === 'read_only') return 'none';
+  if (risk === 'write_low') return 'transient';
+  return 'durable';
 }
 
 // ============================================================================

--- a/os-platform/core/pilot/index.js
+++ b/os-platform/core/pilot/index.js
@@ -6,7 +6,7 @@
  * Re-exports all pilot module components for clean imports.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.summarizeSalesCompsHandler = exports.summarizeParcelCasefileHandler = exports.summarizeLevyRateHandler = exports.summarizeDossierHandler = exports.searchTraceByCorrelationHandler = exports.registerPhase84Handlers = exports.registerPhase83Handlers = exports.registerAllHandlers = exports.phase84Handlers = exports.phase83Handlers = exports.explainSeniorExemptionHandler = exports.explainModelResultsHandler = exports.explainModelInputsHandler = exports.draftValueChangeNoticeHandler = exports.draftBoeAppealResponseHandler = exports.draftAppealResponseHandler = exports.compareAssessedValueHandler = exports.addDossierNoteHandler = exports.toolRunner = exports.ToolRunner = exports.ToolRunnerError = exports.ErrorCodes = exports.toolRegistry = exports.VALID_TRACE_POLICIES = exports.VALID_SUITES = exports.VALID_RISKS = exports.VALID_PII_HANDLING = exports.ToolRegistry = exports.ManifestValidationError = void 0;
+exports.summarizeSalesCompsHandler = exports.summarizeParcelCasefileHandler = exports.summarizeLevyRateHandler = exports.summarizeDossierHandler = exports.searchTraceByCorrelationHandler = exports.registerPhase84Handlers = exports.registerPhase83Handlers = exports.registerAllHandlers = exports.phase84Handlers = exports.phase83Handlers = exports.explainSeniorExemptionHandler = exports.explainModelResultsHandler = exports.explainModelInputsHandler = exports.draftValueChangeNoticeHandler = exports.draftBoeAppealResponseHandler = exports.draftAppealResponseHandler = exports.compareAssessedValueHandler = exports.addDossierNoteHandler = exports.toolRunner = exports.ToolRunner = exports.ToolRunnerError = exports.ErrorCodes = exports.createPreflight = exports.toolRegistry = exports.VALID_TRACE_POLICIES = exports.VALID_SUITES = exports.VALID_RISKS = exports.VALID_PII_HANDLING = exports.ToolRegistry = exports.ManifestValidationError = void 0;
 var ToolRegistry_js_1 = require("./ToolRegistry.js");
 Object.defineProperty(exports, "ManifestValidationError", { enumerable: true, get: function () { return ToolRegistry_js_1.ManifestValidationError; } });
 Object.defineProperty(exports, "ToolRegistry", { enumerable: true, get: function () { return ToolRegistry_js_1.ToolRegistry; } });
@@ -15,6 +15,8 @@ Object.defineProperty(exports, "VALID_RISKS", { enumerable: true, get: function 
 Object.defineProperty(exports, "VALID_SUITES", { enumerable: true, get: function () { return ToolRegistry_js_1.VALID_SUITES; } });
 Object.defineProperty(exports, "VALID_TRACE_POLICIES", { enumerable: true, get: function () { return ToolRegistry_js_1.VALID_TRACE_POLICIES; } });
 Object.defineProperty(exports, "toolRegistry", { enumerable: true, get: function () { return ToolRegistry_js_1.toolRegistry; } });
+var ToolRunner_preflight_js_1 = require("./ToolRunner.preflight.js");
+Object.defineProperty(exports, "createPreflight", { enumerable: true, get: function () { return ToolRunner_preflight_js_1.createPreflight; } });
 var ToolRunner_js_1 = require("./ToolRunner.js");
 Object.defineProperty(exports, "ErrorCodes", { enumerable: true, get: function () { return ToolRunner_js_1.ErrorCodes; } });
 Object.defineProperty(exports, "ToolRunnerError", { enumerable: true, get: function () { return ToolRunner_js_1.ToolRunnerError; } });

--- a/os-platform/core/pilot/index.ts
+++ b/os-platform/core/pilot/index.ts
@@ -15,6 +15,10 @@ export {
 } from './ToolRegistry.js';
 
 export {
+    createPreflight,
+} from './ToolRunner.preflight.js';
+
+export {
     ErrorCodes,
     ToolRunnerError,
     ToolRunner,

--- a/os-platform/core/tests/commandGate.contract.test.mjs
+++ b/os-platform/core/tests/commandGate.contract.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * Phase 48: Command Gate Contract Tests
+ *
+ * Validates the governed command gate:
+ * - Mutating commands require policy allow
+ * - Deny returns a reason string
+ * - Never throws; exceptions become deny(reason)
+ * - run() executes thunk only on allow
+ * - Invalid policy decisions → deny with explanation
+ *
+ * Run with: node --test os-platform/core/tests/commandGate.contract.test.mjs
+ *
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createCommandGate } from '../canon/commandGate.mjs';
+
+describe('Command Gate – Policy Decisions (CG1-CG2)', () => {
+  it('CG1 — mutating command denied with reason', () => {
+    const gate = createCommandGate((req) => {
+      if (req.mutates) return { allow: false, reason: 'No mutations in readonly mode' };
+      return { allow: true };
+    });
+
+    const d = gate.decide({ id: 'canon.workspace.close', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'No mutations in readonly mode' });
+  });
+
+  it('CG2 — non-mutating command allowed', () => {
+    const gate = createCommandGate(() => ({ allow: true }));
+    const d = gate.decide({ id: 'canon.workspace.inspect', mutates: false });
+    assert.deepEqual(d, { allow: true });
+  });
+});
+
+describe('Command Gate – Exception Safety (CG3)', () => {
+  it('CG3a — policy exceptions become deny (never throws)', () => {
+    const gate = createCommandGate(() => {
+      throw new Error('Policy engine offline');
+    });
+    const d = gate.decide({ id: 'canon.any', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'Policy engine offline' });
+  });
+
+  it('CG3b — non-Error throw becomes generic deny', () => {
+    const gate = createCommandGate(() => {
+      throw 'string error'; // eslint-disable-line no-throw-literal
+    });
+    const d = gate.decide({ id: 'canon.any', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'Policy exception' });
+  });
+
+  it('CG3c — Error with empty message becomes generic deny', () => {
+    const gate = createCommandGate(() => {
+      throw new Error('');
+    });
+    const d = gate.decide({ id: 'canon.any', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'Policy exception' });
+  });
+});
+
+describe('Command Gate – Invalid Policy Decisions (CG4)', () => {
+  it('CG4a — null decision becomes deny', () => {
+    const gate = createCommandGate(() => /** @type {any} */ (null));
+    const d = gate.decide({ id: 'canon.any', mutates: false });
+    assert.deepEqual(d, { allow: false, reason: 'Policy returned invalid decision' });
+  });
+
+  it('CG4b — undefined decision becomes deny', () => {
+    const gate = createCommandGate(() => /** @type {any} */ (undefined));
+    const d = gate.decide({ id: 'canon.any', mutates: false });
+    assert.deepEqual(d, { allow: false, reason: 'Policy returned invalid decision' });
+  });
+
+  it('CG4c — deny with empty reason becomes "Policy denied"', () => {
+    const gate = createCommandGate(() => ({ allow: false, reason: '' }));
+    const d = gate.decide({ id: 'canon.any', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'Policy denied' });
+  });
+
+  it('CG4d — deny with non-string reason becomes "Policy denied"', () => {
+    const gate = createCommandGate(() => /** @type {any} */ ({ allow: false, reason: 42 }));
+    const d = gate.decide({ id: 'canon.any', mutates: true });
+    assert.deepEqual(d, { allow: false, reason: 'Policy denied' });
+  });
+});
+
+describe('Command Gate – run() (CG5-CG6)', () => {
+  it('CG5 — run() does not execute thunk on deny', () => {
+    let ran = false;
+    const gate = createCommandGate(() => ({ allow: false, reason: 'Denied' }));
+    const out = gate.run({ id: 'canon.mutate', mutates: true }, () => {
+      ran = true;
+      return 123;
+    });
+    assert.equal(ran, false);
+    assert.deepEqual(out.decision, { allow: false, reason: 'Denied' });
+    assert.equal(out.value, undefined);
+  });
+
+  it('CG6 — run() executes thunk on allow and returns value', () => {
+    const gate = createCommandGate(() => ({ allow: true }));
+    const out = gate.run({ id: 'canon.read', mutates: false }, () => 42);
+    assert.deepEqual(out.decision, { allow: true });
+    assert.equal(out.value, 42);
+  });
+});
+
+describe('Command Gate – Meta Passthrough (CG7)', () => {
+  it('CG7 — policy receives meta from request', () => {
+    let receivedMeta = null;
+    const gate = createCommandGate((req) => {
+      receivedMeta = req.meta;
+      return { allow: true };
+    });
+
+    gate.decide({
+      id: 'canon.workspace.rename',
+      mutates: true,
+      meta: { target: 'workspace-1', dryRun: false },
+    });
+
+    assert.deepEqual(receivedMeta, { target: 'workspace-1', dryRun: false });
+  });
+});
+
+describe('Command Gate – Immutability (CG8)', () => {
+  it('CG8 — gate object is frozen', () => {
+    const gate = createCommandGate(() => ({ allow: true }));
+    assert.ok(Object.isFrozen(gate));
+  });
+});
+
+console.log('Command Gate Contract Suite');
+console.log('==========================');
+console.log(
+  'Run with: node --test os-platform/core/tests/commandGate.contract.test.mjs'
+);

--- a/os-platform/core/tests/commandGovernance.contract.test.mjs
+++ b/os-platform/core/tests/commandGovernance.contract.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isCommandGovernanceMeta,
+  normalizeDecision,
+} from '../types/commandGovernance.js';
+
+test('CGM1 - accepts valid governance meta', () => {
+  const ok = { intent: 'inspect', mutation: 'none', visibility: 'public' };
+  assert.equal(isCommandGovernanceMeta(ok), true);
+});
+
+test('CGM2 - rejects missing/extra keys', () => {
+  const bad1 = { intent: 'inspect', mutation: 'none' };
+  const bad2 = { intent: 'inspect', mutation: 'none', visibility: 'public', extra: 1 };
+  assert.equal(isCommandGovernanceMeta(bad1), false);
+  assert.equal(isCommandGovernanceMeta(bad2), false);
+});
+
+test('CGM3 - rejects invalid enum values', () => {
+  const bad = { intent: 'build', mutation: 'durable', visibility: 'public' };
+  assert.equal(isCommandGovernanceMeta(bad), false);
+});
+
+test('CGM4 - normalizeDecision applies deny defaults', () => {
+  const d = normalizeDecision({ allow: false, reason: '   ' });
+  assert.deepEqual(d, {
+    allow: false,
+    reason: 'Policy denied',
+    visibility: 'restricted',
+  });
+});

--- a/os-platform/core/tests/layoutEnvelope.contract.test.mjs
+++ b/os-platform/core/tests/layoutEnvelope.contract.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * Phase 48: Layout Envelope v1 Contract Tests
+ *
+ * Validates the versioned layout persistence envelope:
+ * - Strict shape validation (panels, version, timestamp)
+ * - Fail-closed parsing (malformed → null)
+ * - Serialization round-trip
+ * - Panel ID strictness (no unknown panels)
+ * - Default layout correctness
+ *
+ * Run with: node --test os-platform/core/tests/layoutEnvelope.contract.test.mjs
+ *
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  LAYOUT_ENVELOPE_VERSION,
+  defaultLayoutV1,
+  isValidLayoutEnvelopeV1,
+  isValidLayoutV1,
+  parseLayoutEnvelopeV1,
+  serializeLayoutEnvelopeV1,
+} from '../canon/layoutEnvelope.mjs';
+
+describe('Layout Envelope v1 – Version Constant', () => {
+  it('LAYOUT_ENVELOPE_VERSION is exactly 1', () => {
+    assert.equal(LAYOUT_ENVELOPE_VERSION, 1);
+  });
+});
+
+describe('Layout Envelope v1 – Valid Parsing (LE1)', () => {
+  it('LE1a — parses a valid layout envelope v1', () => {
+    const layout = defaultLayoutV1();
+    const raw = serializeLayoutEnvelopeV1(layout, 1700000000000);
+    const parsed = parseLayoutEnvelopeV1(raw);
+    assert.ok(parsed);
+    assert.equal(parsed.v, 1);
+    assert.equal(parsed.ts, 1700000000000);
+    assert.deepEqual(parsed.layout, layout);
+  });
+
+  it('LE1b — validates a well-formed envelope object', () => {
+    const env = { v: 1, layout: defaultLayoutV1(), ts: 1700000000000 };
+    assert.ok(isValidLayoutEnvelopeV1(env));
+  });
+
+  it('LE1c — validates default layout shape', () => {
+    assert.ok(isValidLayoutV1(defaultLayoutV1()));
+  });
+});
+
+describe('Layout Envelope v1 – Version Rejection (LE2)', () => {
+  it('LE2a — rejects v:99', () => {
+    const raw = JSON.stringify({ v: 99, layout: defaultLayoutV1(), ts: 1 });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE2b — rejects v:0', () => {
+    const raw = JSON.stringify({ v: 0, layout: defaultLayoutV1(), ts: 1 });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE2c — rejects v:"1" (string)', () => {
+    const raw = JSON.stringify({ v: '1', layout: defaultLayoutV1(), ts: 1 });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+});
+
+describe('Layout Envelope v1 – Timestamp Validation (LE3)', () => {
+  it('LE3a — rejects missing ts', () => {
+    const raw = JSON.stringify({ v: 1, layout: defaultLayoutV1() });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE3b — rejects ts:0', () => {
+    const raw = JSON.stringify({ v: 1, layout: defaultLayoutV1(), ts: 0 });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE3c — rejects ts:-1', () => {
+    const raw = JSON.stringify({ v: 1, layout: defaultLayoutV1(), ts: -1 });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE3d — rejects ts:NaN', () => {
+    assert.equal(isValidLayoutEnvelopeV1({ v: 1, layout: defaultLayoutV1(), ts: NaN }), false);
+  });
+
+  it('LE3e — rejects ts:Infinity', () => {
+    assert.equal(isValidLayoutEnvelopeV1({ v: 1, layout: defaultLayoutV1(), ts: Infinity }), false);
+  });
+});
+
+describe('Layout Envelope v1 – Strict Envelope Shape (LE4)', () => {
+  it('LE4a — rejects extra keys at envelope level', () => {
+    const raw = JSON.stringify({ v: 1, layout: defaultLayoutV1(), ts: 1, extra: true });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+
+  it('LE4b — rejects envelope with only 2 keys', () => {
+    const raw = JSON.stringify({ v: 1, layout: defaultLayoutV1() });
+    assert.equal(parseLayoutEnvelopeV1(raw), null);
+  });
+});
+
+describe('Layout Envelope v1 – Malformed JSON (LE5)', () => {
+  it('LE5a — returns null for malformed JSON', () => {
+    assert.equal(parseLayoutEnvelopeV1('{bad json'), null);
+  });
+
+  it('LE5b — returns null for empty string', () => {
+    assert.equal(parseLayoutEnvelopeV1(''), null);
+  });
+
+  it('LE5c — returns null for bare string', () => {
+    assert.equal(parseLayoutEnvelopeV1('"hello"'), null);
+  });
+
+  it('LE5d — returns null for null literal', () => {
+    assert.equal(parseLayoutEnvelopeV1('null'), null);
+  });
+});
+
+describe('Layout Envelope v1 – Panel Strictness (LE6)', () => {
+  it('LE6a — rejects missing panel id (rightInspector missing)', () => {
+    const bad = {
+      v: 1,
+      ts: 1,
+      layout: {
+        panels: {
+          leftNav: { visible: true, size: 1 },
+          main: { visible: true, size: 1 },
+        },
+      },
+    };
+    assert.equal(parseLayoutEnvelopeV1(JSON.stringify(bad)), null);
+  });
+
+  it('LE6b — rejects unknown panel id', () => {
+    const bad = {
+      v: 1,
+      ts: 1,
+      layout: {
+        panels: {
+          leftNav: { visible: true, size: 1 },
+          main: { visible: true, size: 1 },
+          rightInspector: { visible: true, size: 1 },
+          chaos: { visible: true, size: 1 },
+        },
+      },
+    };
+    assert.equal(parseLayoutEnvelopeV1(JSON.stringify(bad)), null);
+  });
+
+  it('LE6c — rejects panel with extra keys', () => {
+    const bad = {
+      v: 1,
+      ts: 1,
+      layout: {
+        panels: {
+          leftNav: { visible: true, size: 1, extra: 'no' },
+          main: { visible: true, size: 1 },
+          rightInspector: { visible: true, size: 1 },
+        },
+      },
+    };
+    assert.equal(parseLayoutEnvelopeV1(JSON.stringify(bad)), null);
+  });
+
+  it('LE6d — rejects panel with negative size', () => {
+    const bad = {
+      v: 1,
+      ts: 1,
+      layout: {
+        panels: {
+          leftNav: { visible: true, size: -10 },
+          main: { visible: true, size: 1 },
+          rightInspector: { visible: true, size: 1 },
+        },
+      },
+    };
+    assert.equal(parseLayoutEnvelopeV1(JSON.stringify(bad)), null);
+  });
+
+  it('LE6e — accepts panel with size 0', () => {
+    const ok = {
+      v: 1,
+      ts: 1,
+      layout: {
+        panels: {
+          leftNav: { visible: false, size: 0 },
+          main: { visible: true, size: 1 },
+          rightInspector: { visible: false, size: 0 },
+        },
+      },
+    };
+    const parsed = parseLayoutEnvelopeV1(JSON.stringify(ok));
+    assert.ok(parsed);
+    assert.equal(parsed.layout.panels.leftNav.size, 0);
+  });
+});
+
+describe('Layout Envelope v1 – Serialization (LE7)', () => {
+  it('LE7a — serialize produces valid v1 envelope JSON', () => {
+    const layout = defaultLayoutV1();
+    const raw = serializeLayoutEnvelopeV1(layout, 1700000000000);
+    const parsed = JSON.parse(raw);
+    assert.equal(parsed.v, 1);
+    assert.equal(parsed.ts, 1700000000000);
+    assert.deepEqual(parsed.layout, layout);
+  });
+
+  it('LE7b — serialized envelope round-trips through parse', () => {
+    const layout = defaultLayoutV1();
+    const raw = serializeLayoutEnvelopeV1(layout);
+    const parsed = parseLayoutEnvelopeV1(raw);
+    assert.ok(parsed);
+    assert.deepEqual(parsed.layout, layout);
+    assert.equal(parsed.v, 1);
+    assert.equal(typeof parsed.ts, 'number');
+    assert.ok(parsed.ts > 0);
+  });
+
+  it('LE7c — serialize throws on invalid layout', () => {
+    assert.throws(() => serializeLayoutEnvelopeV1({ panels: {} }), /invalid layout/i);
+  });
+
+  it('LE7d — serialize throws on layout with extra keys', () => {
+    const bad = { ...defaultLayoutV1(), extra: true };
+    assert.throws(() => serializeLayoutEnvelopeV1(bad), /invalid layout/i);
+  });
+});
+
+describe('Layout Envelope v1 – Default Layout (LE8)', () => {
+  it('LE8a — default layout has all three panels', () => {
+    const layout = defaultLayoutV1();
+    assert.ok(layout.panels.leftNav);
+    assert.ok(layout.panels.main);
+    assert.ok(layout.panels.rightInspector);
+  });
+
+  it('LE8b — default layout panels are all visible', () => {
+    const layout = defaultLayoutV1();
+    assert.equal(layout.panels.leftNav.visible, true);
+    assert.equal(layout.panels.main.visible, true);
+    assert.equal(layout.panels.rightInspector.visible, true);
+  });
+
+  it('LE8c — default layout validates as LayoutV1', () => {
+    assert.ok(isValidLayoutV1(defaultLayoutV1()));
+  });
+});
+
+console.log('Layout Envelope v1 Contract Suite');
+console.log('=================================');
+console.log(
+  'Run with: node --test os-platform/core/tests/layoutEnvelope.contract.test.mjs'
+);

--- a/os-platform/core/tests/toolrunner.preflight.contract.test.mjs
+++ b/os-platform/core/tests/toolrunner.preflight.contract.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPreflight } from '../pilot/ToolRunner.preflight.js';
+
+test('PF1 - default preflight allows', () => {
+  const pf = createPreflight();
+  const d = pf.decide({ toolId: 't1', correlationId: 'c1' });
+  assert.deepEqual(d, { allow: true });
+});
+
+test('PF2 - deny is normalized', () => {
+  const pf = createPreflight(() => ({ allow: false, reason: '' }));
+  const d = pf.decide({ toolId: 't1', correlationId: 'c1' });
+  assert.deepEqual(d, {
+    allow: false,
+    reason: 'Policy denied',
+    visibility: 'restricted',
+  });
+});
+
+test('PF3 - policy exceptions become deny, never throw', () => {
+  const pf = createPreflight(() => {
+    throw new Error('Policy engine offline');
+  });
+  const d = pf.decide({ toolId: 't1', correlationId: 'c1' });
+  assert.deepEqual(d, {
+    allow: false,
+    reason: 'Policy engine offline',
+    visibility: 'restricted',
+  });
+});

--- a/os-platform/core/tests/workspaceModule.contract.test.mjs
+++ b/os-platform/core/tests/workspaceModule.contract.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * Phase 48: Workspace Module Contract Tests
+ *
+ * Validates the TerraCanon workspace module interface contract:
+ * - Module shape correctness (id, title, mount, routes, permissions)
+ * - Mount returns UnmountFn that is always safe to call
+ * - Guard is callable and returns proper decisions
+ * - Integration with commandGate and layoutEnvelope
+ *
+ * Run with: node --test os-platform/core/tests/workspaceModule.contract.test.mjs
+ *
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createCommandGate } from '../canon/commandGate.mjs';
+import { defaultLayoutV1 } from '../canon/layoutEnvelope.mjs';
+
+describe('Workspace Module – Shape Contract (WM1)', () => {
+  it('WM1a — module object shape is minimally sane', async () => {
+    const gate = createCommandGate(() => ({ allow: true }));
+    const ctx = {
+      workspaceId: 'w1',
+      storageNamespace: 'canon:w1:mod:test',
+      guard: (req) => gate.decide({ id: req.actionId, mutates: req.mutates, meta: req.meta }),
+    };
+
+    /** @type {import("../types/workspaceModule.ts").WorkspaceModule} */
+    const mod = {
+      id: 'test.module',
+      title: () => 'Test Module',
+      mount: async (c) => {
+        // Guard must be callable; layout default must exist (sanity hook)
+        const d = c.guard({ actionId: 'canon.workspace.inspect', mutates: false });
+        assert.deepEqual(d, { allow: true });
+        assert.ok(defaultLayoutV1().panels.main.visible);
+        return () => {};
+      },
+      routes: [{ id: 'home', path: 'home', label: 'Home' }],
+    };
+
+    const unmount = await mod.mount(ctx);
+    assert.equal(typeof unmount, 'function');
+    unmount(); // must not throw
+  });
+
+  it('WM1b — module title is workspace-aware', () => {
+    const mod = {
+      id: 'ws-aware.module',
+      title: (wsId) => `Module for ${wsId}`,
+      mount: async () => () => {},
+    };
+    assert.equal(mod.title('workspace-42'), 'Module for workspace-42');
+  });
+});
+
+describe('Workspace Module – Mount/Unmount Lifecycle (WM2)', () => {
+  it('WM2a — mount resolves to an UnmountFn', async () => {
+    const mod = {
+      id: 'lifecycle.module',
+      title: () => 'Lifecycle',
+      mount: async (ctx) => {
+        // Simulate setup
+        const state = { active: true };
+        return () => {
+          state.active = false;
+        };
+      },
+    };
+
+    const gate = createCommandGate(() => ({ allow: true }));
+    const unmount = await mod.mount({
+      workspaceId: 'w1',
+      storageNamespace: 'canon:w1:mod:lifecycle',
+      guard: (req) => gate.decide({ id: req.actionId, mutates: req.mutates }),
+    });
+
+    assert.equal(typeof unmount, 'function');
+    // Calling unmount twice must not throw
+    unmount();
+    unmount();
+  });
+
+  it('WM2b — mount receives correct context properties', async () => {
+    let receivedCtx = null;
+    const mod = {
+      id: 'ctx.module',
+      title: () => 'Context Check',
+      mount: async (ctx) => {
+        receivedCtx = ctx;
+        return () => {};
+      },
+    };
+
+    const gate = createCommandGate(() => ({ allow: true }));
+    await mod.mount({
+      workspaceId: 'workspace-99',
+      storageNamespace: 'canon:workspace-99:mod:ctx',
+      guard: (req) => gate.decide({ id: req.actionId, mutates: req.mutates }),
+    });
+
+    assert.equal(receivedCtx.workspaceId, 'workspace-99');
+    assert.equal(receivedCtx.storageNamespace, 'canon:workspace-99:mod:ctx');
+    assert.equal(typeof receivedCtx.guard, 'function');
+  });
+});
+
+describe('Workspace Module – Guard Integration (WM3)', () => {
+  it('WM3a — module guard denies mutating actions when policy says no', async () => {
+    const gate = createCommandGate((req) => {
+      if (req.mutates) return { allow: false, reason: 'Read-only workspace' };
+      return { allow: true };
+    });
+
+    const mod = {
+      id: 'guarded.module',
+      title: () => 'Guarded',
+      mount: async (ctx) => {
+        // Read is allowed
+        const readDecision = ctx.guard({ actionId: 'canon.inspect', mutates: false });
+        assert.deepEqual(readDecision, { allow: true });
+
+        // Write is denied
+        const writeDecision = ctx.guard({ actionId: 'canon.workspace.close', mutates: true });
+        assert.equal(writeDecision.allow, false);
+        assert.equal(/** @type {{ reason: string }} */ (writeDecision).reason, 'Read-only workspace');
+
+        return () => {};
+      },
+    };
+
+    await mod.mount({
+      workspaceId: 'w-readonly',
+      storageNamespace: 'canon:w-readonly:mod:guarded',
+      guard: (req) => gate.decide({ id: req.actionId, mutates: req.mutates, meta: req.meta }),
+    });
+  });
+});
+
+describe('Workspace Module – Optional Fields (WM4)', () => {
+  it('WM4a — module without routes is valid', async () => {
+    const mod = {
+      id: 'no-routes.module',
+      title: () => 'No Routes',
+      mount: async () => () => {},
+    };
+    assert.equal(mod.routes, undefined);
+    const unmount = await mod.mount({
+      workspaceId: 'w1',
+      storageNamespace: 'ns',
+      guard: () => ({ allow: true }),
+    });
+    assert.equal(typeof unmount, 'function');
+  });
+
+  it('WM4b — module without permissions is valid', async () => {
+    const mod = {
+      id: 'no-perms.module',
+      title: () => 'No Perms',
+      mount: async () => () => {},
+    };
+    assert.equal(mod.permissions, undefined);
+  });
+
+  it('WM4c — module with routes and permissions has correct shapes', () => {
+    const mod = {
+      id: 'full.module',
+      title: () => 'Full',
+      mount: async () => () => {},
+      routes: [
+        { id: 'home', path: 'home', label: 'Home' },
+        { id: 'settings', path: 'settings', label: 'Settings' },
+      ],
+      permissions: [
+        { id: 'canon.read', description: 'Read workspace data' },
+        { id: 'canon.write', description: 'Write workspace data' },
+      ],
+    };
+
+    assert.equal(mod.routes.length, 2);
+    assert.equal(mod.routes[0].id, 'home');
+    assert.equal(mod.routes[1].path, 'settings');
+    assert.equal(mod.permissions.length, 2);
+    assert.equal(mod.permissions[0].id, 'canon.read');
+  });
+});
+
+console.log('Workspace Module Contract Suite');
+console.log('================================');
+console.log(
+  'Run with: node --test os-platform/core/tests/workspaceModule.contract.test.mjs'
+);

--- a/os-platform/core/types/commandGovernance.js
+++ b/os-platform/core/types/commandGovernance.js
@@ -1,0 +1,44 @@
+// GENERATED - DO NOT EDIT
+"use strict";
+/**
+ * Phase 48A: TerraCanon/TerraPilot Command Governance Types
+ *
+ * Additive, backwards-compatible governance metadata and preflight policy contract.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isCommandGovernanceMeta = isCommandGovernanceMeta;
+exports.normalizeDecision = normalizeDecision;
+function isCommandGovernanceMeta(v) {
+    if (typeof v !== 'object' || v === null || Array.isArray(v))
+        return false;
+    const o = v;
+    const keys = Object.keys(o);
+    if (keys.length !== 3)
+        return false;
+    if (!('intent' in o) || !('mutation' in o) || !('visibility' in o))
+        return false;
+    const intent = o.intent;
+    const mutation = o.mutation;
+    const visibility = o.visibility;
+    const intentOk = intent === 'inspect' ||
+        intent === 'explain' ||
+        intent === 'plan' ||
+        intent === 'simulate' ||
+        intent === 'mutate' ||
+        intent === 'execute';
+    const mutationOk = mutation === 'none' || mutation === 'transient' || mutation === 'durable';
+    const visibilityOk = visibility === 'public' || visibility === 'restricted' || visibility === 'secret';
+    return intentOk && mutationOk && visibilityOk;
+}
+function normalizeDecision(d) {
+    if (d.allow)
+        return { allow: true };
+    const reason = typeof d.reason === 'string' && d.reason.trim().length > 0
+        ? d.reason.trim()
+        : 'Policy denied';
+    return {
+        allow: false,
+        reason,
+        visibility: d.visibility ?? 'restricted',
+    };
+}

--- a/os-platform/core/types/commandGovernance.ts
+++ b/os-platform/core/types/commandGovernance.ts
@@ -1,0 +1,76 @@
+/**
+ * Phase 48A: TerraCanon/TerraPilot Command Governance Types
+ *
+ * Additive, backwards-compatible governance metadata and preflight policy contract.
+ */
+
+export type CommandIntent =
+  | 'inspect'
+  | 'explain'
+  | 'plan'
+  | 'simulate'
+  | 'mutate'
+  | 'execute';
+
+export type MutationClass = 'none' | 'transient' | 'durable';
+
+export type VisibilityClass = 'public' | 'restricted' | 'secret';
+
+export type CommandGovernanceMeta = Readonly<{
+  intent: CommandIntent;
+  mutation: MutationClass;
+  visibility: VisibilityClass;
+}>;
+
+export type PolicyDecision =
+  | Readonly<{ allow: true }>
+  | Readonly<{ allow: false; reason: string; visibility?: VisibilityClass }>;
+
+export type PreflightRequest = Readonly<{
+  toolId: string;
+  correlationId: string;
+  governance?: CommandGovernanceMeta;
+  requestedMutation?: MutationClass;
+}>;
+
+export type PreflightPolicy = (req: PreflightRequest) => PolicyDecision;
+
+export function isCommandGovernanceMeta(v: unknown): v is CommandGovernanceMeta {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return false;
+  const o = v as Record<string, unknown>;
+  const keys = Object.keys(o);
+  if (keys.length !== 3) return false;
+  if (!('intent' in o) || !('mutation' in o) || !('visibility' in o)) return false;
+
+  const intent = o.intent;
+  const mutation = o.mutation;
+  const visibility = o.visibility;
+
+  const intentOk =
+    intent === 'inspect' ||
+    intent === 'explain' ||
+    intent === 'plan' ||
+    intent === 'simulate' ||
+    intent === 'mutate' ||
+    intent === 'execute';
+
+  const mutationOk = mutation === 'none' || mutation === 'transient' || mutation === 'durable';
+  const visibilityOk =
+    visibility === 'public' || visibility === 'restricted' || visibility === 'secret';
+
+  return intentOk && mutationOk && visibilityOk;
+}
+
+export function normalizeDecision(d: PolicyDecision): PolicyDecision {
+  if (d.allow) return { allow: true };
+
+  const reason = typeof d.reason === 'string' && d.reason.trim().length > 0
+    ? d.reason.trim()
+    : 'Policy denied';
+
+  return {
+    allow: false,
+    reason,
+    visibility: d.visibility ?? 'restricted',
+  };
+}

--- a/os-platform/core/types/workspaceModule.ts
+++ b/os-platform/core/types/workspaceModule.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase 48: Workspace Module Interface Contract
+ *
+ * Defines the canonical shape for any TerraCanon workspace module:
+ * - id: unique module identifier
+ * - title: workspace-aware display name
+ * - mount: async lifecycle with UnmountFn return
+ * - routes: optional navigation routes
+ * - permissions: optional permission declarations
+ *
+ * @see Phase 48: TerraCanon Core Contracts
+ */
+
+/** Cleanup function returned by mount(). Must be safe to call multiple times. */
+export type UnmountFn = () => void;
+
+/** A navigable route within a workspace module. */
+export type RouteDef = Readonly<{
+  id: string;
+  path: string;
+  label: string;
+}>;
+
+/** A permission declaration for a workspace module. */
+export type PermissionDef = Readonly<{
+  id: string;
+  description: string;
+}>;
+
+/** A guard request from a module to the workspace policy. */
+export type GuardRequest = Readonly<{
+  actionId: string;
+  mutates: boolean;
+  meta?: Readonly<Record<string, string | number | boolean>>;
+}>;
+
+/** The decision returned by a guard check. */
+export type GuardDecision =
+  | Readonly<{ allow: true }>
+  | Readonly<{ allow: false; reason: string }>;
+
+/** Context provided to a module during mount. */
+export type ModuleContext = Readonly<{
+  workspaceId: string;
+  storageNamespace: string;
+  guard: (req: GuardRequest) => GuardDecision;
+}>;
+
+/**
+ * The canonical workspace module interface.
+ *
+ * Every TerraCanon module must satisfy this shape.
+ * - `id` is globally unique across all modules.
+ * - `title` is a function so it can be workspace-aware.
+ * - `mount` receives a ModuleContext and returns a cleanup function.
+ * - `routes` and `permissions` are optional metadata arrays.
+ */
+export type WorkspaceModule = Readonly<{
+  id: string;
+  title: (workspaceId: string) => string;
+  mount: (ctx: ModuleContext) => Promise<UnmountFn>;
+  routes?: readonly RouteDef[];
+  permissions?: readonly PermissionDef[];
+}>;

--- a/tools/registry/build-core-js.mjs
+++ b/tools/registry/build-core-js.mjs
@@ -6,6 +6,18 @@ const HEADER = '// GENERATED - DO NOT EDIT';
 const ROOT = process.cwd();
 const targets = [
   {
+    source: 'os-platform/core/types/commandGovernance.ts',
+    out: 'os-platform/core/types/commandGovernance.js',
+  },
+  {
+    source: 'os-platform/core/pilot/ToolRegistry.ts',
+    out: 'os-platform/core/pilot/ToolRegistry.js',
+  },
+  {
+    source: 'os-platform/core/pilot/ToolRunner.preflight.ts',
+    out: 'os-platform/core/pilot/ToolRunner.preflight.js',
+  },
+  {
     source: 'os-platform/core/pilot/handlers.ts',
     out: 'os-platform/core/pilot/handlers.js',
   },

--- a/tools/registry/terrapilot.tools.schema.json
+++ b/tools/registry/terrapilot.tools.schema.json
@@ -46,6 +46,28 @@
       "type": "string",
       "enum": ["pilot", "muse"]
     },
+    "CommandIntent": {
+      "type": "string",
+      "enum": ["inspect", "explain", "plan", "simulate", "mutate", "execute"]
+    },
+    "MutationClass": {
+      "type": "string",
+      "enum": ["none", "transient", "durable"]
+    },
+    "VisibilityClass": {
+      "type": "string",
+      "enum": ["public", "restricted", "secret"]
+    },
+    "CommandGovernanceMeta": {
+      "type": "object",
+      "required": ["intent", "mutation", "visibility"],
+      "additionalProperties": false,
+      "properties": {
+        "intent": { "$ref": "#/definitions/CommandIntent" },
+        "mutation": { "$ref": "#/definitions/MutationClass" },
+        "visibility": { "$ref": "#/definitions/VisibilityClass" }
+      }
+    },
     "Tool": {
       "type": "object",
       "required": ["toolId", "suite", "risk"],
@@ -138,6 +160,10 @@
           "type": "string",
           "enum": ["dossier", "secure-blob", "case-store"],
           "description": "Where payload refs are stored (required if tracePolicy is payload_ref)"
+        },
+        "governance": {
+          "$ref": "#/definitions/CommandGovernanceMeta",
+          "description": "Optional command governance metadata for preflight policy checks"
         }
       }
     }


### PR DESCRIPTION
Phase 48A (core-only): resurrection contract lane for TerraCanon -> TerraPilot execution.

What changed:
- Added command governance contract (intent/mutation/visibility) + strict validator
- Added ToolRunner preflight helper and integrated preflight into ToolRunner (non-breaking default allow)
- Added optional governance metadata validation in ToolRegistry
- Extended terrapilot.tools.schema.json to support optional governance metadata
- Updated build-core-js generator targets

Tests:
- node --test os-platform/core/tests/commandGovernance.contract.test.mjs ✅
- node --test os-platform/core/tests/toolrunner.preflight.contract.test.mjs ✅
- node --test os-platform/core/tests/phase83-tools.test.mjs ✅

Notes / Known pre-existing repo issues (NOT introduced here):
- pnpm run type-check fails due missing @types (prismjs, ramda, react-redux, semver, serve-static, three, trusted-types, use-sync-external-store)
- pnpm run check:generated fails due existing workspace mirror artifacts under .claude/worktrees/** and packages/os-core/dist/**

Scope discipline:
- No frontend changes
- No new surfaces
- Additive + backwards compatible only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy-driven preflight gating for tool execution with normalized denial handling and new POLICY_DENIED error classification
  * Command governance types and validation utilities plus optional per-tool governance metadata in the tool schema
  * Versioned layout envelope: strict validation, parsing, serialization, and a default layout

* **Tests**
  * Added extensive contract/unit tests for command gating, preflight, layout envelopes, and workspace module behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->