### PR TITLE
feat(canon): Phase 49 — preflight→invoke wiring for /canon; surface denial reason + correlationId with deny/allow contracts

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightAllowContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightAllowContract.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+let memoryRouterEntries: string[] = ['/'];
+
+const mockValidatePilotTool = jest.fn();
+const mockInvokeTool = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+jest.mock('../../api/pilotApi', () => ({
+  validatePilotTool: (...args: unknown[]) => mockValidatePilotTool(...args),
+  invokeTool: (...args: unknown[]) => mockInvokeTool(...args),
+}));
+
+import Router from '../../Router';
+
+describe('Phase 49 contract: TerraCanon preflight allow invokes exactly once', () => {
+  beforeEach(() => {
+    mockValidatePilotTool.mockReset();
+    mockInvokeTool.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  }
+
+  it('allow invokes once and correlationId is displayed', async () => {
+    mockValidatePilotTool.mockResolvedValue({
+      valid: true,
+      violations: [],
+      tool: { toolId: 'summarize_dossier', suite: 'dossier', risk: 'read_only' },
+    });
+
+    mockInvokeTool.mockImplementation(async (request: any) => ({
+      success: true,
+      correlationId: request.params.correlationId,
+      result: {
+        toolId: request.toolId,
+        output: 'ok',
+      },
+    }));
+
+    await renderCanonAndWait();
+
+    fireEvent.click(screen.getByTestId('terracanon-run-governed-command'));
+
+    await waitFor(() => {
+      expect(mockInvokeTool).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('terracanon-command-correlation')).toBeInTheDocument();
+    });
+
+    const calledCorrelation = mockInvokeTool.mock.calls[0][0].params.correlationId;
+    const shownCorrelation = (screen.getByTestId('terracanon-command-correlation').textContent ?? '').trim();
+
+    expect(calledCorrelation).toBe(shownCorrelation);
+    expect(shownCorrelation.startsWith('canon-')).toBe(true);
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightDenyContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightDenyContract.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+let memoryRouterEntries: string[] = ['/'];
+
+const mockValidatePilotTool = jest.fn();
+const mockInvokeTool = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
+      <actual.MemoryRouter initialEntries={memoryRouterEntries}>{children}</actual.MemoryRouter>
+    ),
+  };
+});
+
+jest.mock('../../auth/authStorage', () => ({
+  getToken: () => 'smoke-test-token',
+  setToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+
+jest.mock('../../auth/authBridge', () => ({
+  registerLogoutHandler: jest.fn(),
+  unregisterLogoutHandler: jest.fn(),
+}));
+
+jest.mock('../../api/pilotApi', () => ({
+  validatePilotTool: (...args: unknown[]) => mockValidatePilotTool(...args),
+  invokeTool: (...args: unknown[]) => mockInvokeTool(...args),
+}));
+
+import Router from '../../Router';
+
+describe('Phase 49 contract: TerraCanon preflight deny blocks invocation', () => {
+  beforeEach(() => {
+    mockValidatePilotTool.mockReset();
+    mockInvokeTool.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  async function renderCanonAndWait() {
+    memoryRouterEntries = ['/canon'];
+    render(<Router />);
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Loading TerraFusion OS/i)).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+  }
+
+  it('deny shows reason + correlationId and does not invoke tool', async () => {
+    mockValidatePilotTool.mockResolvedValue({
+      valid: false,
+      violations: ['Denied by policy'],
+      tool: { toolId: 'summarize_dossier', suite: 'dossier', risk: 'read_only' },
+    });
+
+    await renderCanonAndWait();
+
+    fireEvent.click(screen.getByTestId('terracanon-run-governed-command'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terracanon-command-deny-reason')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('terracanon-command-deny-reason')).toHaveTextContent('Denied by policy');
+
+    const correlationText = (screen.getByTestId('terracanon-command-correlation').textContent ?? '').trim();
+    expect(correlationText.length).toBeGreaterThan(0);
+    expect(correlationText.startsWith('canon-')).toBe(true);
+
+    expect(mockInvokeTool).toHaveBeenCalledTimes(0);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/invokeWithPreflight.ts
+++ b/frontend/apps/os-shell/src/canon/invokeWithPreflight.ts
@@ -1,0 +1,97 @@
+import {
+  invokeTool,
+  validatePilotTool,
+  type Mode,
+  type PilotInvokeRequest,
+  type PilotValidateResponse,
+} from '../api/pilotApi';
+
+export interface CanonInvokeRequest {
+  toolId: string;
+  params: Record<string, unknown>;
+  mode?: Mode;
+}
+
+export type CanonInvokeResult =
+  | { status: 'denied'; reason: string; correlationId: string }
+  | { status: 'ok'; correlationId: string; result?: { toolId: string; output: string } };
+
+interface InvokeDeps {
+  validate: (request: {
+    toolId: string;
+    params?: Record<string, unknown>;
+    mode?: Mode;
+  }) => Promise<PilotValidateResponse>;
+  invoke: (request: PilotInvokeRequest) => Promise<{
+    success: boolean;
+    correlationId: string;
+    result?: { toolId: string; output: string };
+    error?: { code: string; message: string };
+  }>;
+  createCorrelationId: () => string;
+}
+
+const defaultDeps: InvokeDeps = {
+  validate: validatePilotTool,
+  invoke: invokeTool,
+  createCorrelationId: () =>
+    `canon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`,
+};
+
+function normalizeReason(reason: unknown): string {
+  if (typeof reason === 'string' && reason.trim().length > 0) return reason.trim();
+  return 'Policy denied';
+}
+
+export async function invokeWithPreflight(
+  request: CanonInvokeRequest,
+  deps: InvokeDeps = defaultDeps
+): Promise<CanonInvokeResult> {
+  const clientCorrelationId = deps.createCorrelationId();
+
+  try {
+    const validation = await deps.validate({
+      toolId: request.toolId,
+      params: request.params,
+      mode: request.mode,
+    });
+
+    if (!validation.valid) {
+      return {
+        status: 'denied',
+        reason: normalizeReason(validation.violations?.[0]),
+        correlationId: clientCorrelationId,
+      };
+    }
+
+    const invokeResponse = await deps.invoke({
+      toolId: request.toolId,
+      params: {
+        ...request.params,
+        correlationId: clientCorrelationId,
+      },
+      mode: request.mode,
+    });
+
+    if (!invokeResponse.success) {
+      return {
+        status: 'denied',
+        reason: normalizeReason(invokeResponse.error?.message),
+        correlationId: invokeResponse.correlationId || clientCorrelationId,
+      };
+    }
+
+    return {
+      status: 'ok',
+      correlationId: invokeResponse.correlationId || clientCorrelationId,
+      result: invokeResponse.result,
+    };
+  } catch (error) {
+    return {
+      status: 'denied',
+      reason: normalizeReason(error instanceof Error ? error.message : error),
+      correlationId: clientCorrelationId,
+    };
+  }
+}
+

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -53,6 +53,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { invokeWithPreflight, type CanonInvokeResult } from '../canon/invokeWithPreflight';
 import {
   isValidWorkspace,
   parseLastClosedV2,
@@ -347,6 +348,8 @@ function CanonContent(): React.ReactElement {
     return persisted ? persisted.activeIndex : 0;
   });
   const [renameDraft, setRenameDraft] = useState('');
+  const [commandResult, setCommandResult] = useState<CanonInvokeResult | null>(null);
+  const [commandRunning, setCommandRunning] = useState(false);
   const [, forceUpdate] = useState(0);
   const lastClosedRef = useRef<Workspace | null>(loadLastClosed());
   const mountedRef = useRef(false);
@@ -474,6 +477,22 @@ function CanonContent(): React.ReactElement {
     setWorkspaces((prev) => prev.map((ws, i) => (i === activeIndex ? { ...ws, name: next } : ws)));
   };
 
+  const runGovernedCommand = async () => {
+    setCommandRunning(true);
+    try {
+      const outcome = await invokeWithPreflight({
+        toolId: 'summarize_dossier',
+        mode: 'muse',
+        params: {
+          dossierId: active?.id ?? 'canon-workspace',
+        },
+      });
+      setCommandResult(outcome);
+    } finally {
+      setCommandRunning(false);
+    }
+  };
+
   return (
     <div className='canon-console' data-testid='terracanon-root'>
       <section className='canon-console__overview mb-4'>
@@ -486,6 +505,22 @@ function CanonContent(): React.ReactElement {
         >
           Open Empty Workspace
         </button>
+        <button
+          className='mt-2 ml-2 px-3 py-1 text-sm rounded bg-indigo-700 hover:bg-indigo-600 text-white disabled:opacity-50'
+          data-testid='terracanon-run-governed-command'
+          onClick={runGovernedCommand}
+          disabled={commandRunning}
+        >
+          {commandRunning ? 'Running...' : 'Run Governed Command'}
+        </button>
+        {commandResult && (
+          <div className='mt-3 text-xs text-gray-300' data-testid='terracanon-command-result'>
+            <div data-testid='terracanon-command-correlation'>{commandResult.correlationId}</div>
+            {commandResult.status === 'denied' && (
+              <div data-testid='terracanon-command-deny-reason'>{commandResult.reason}</div>
+            )}
+          </div>
+        )}
       </section>
       <CanonWorkspace
         hasWorkspace={hasWorkspace}


### PR DESCRIPTION
Phase 49 frontend integration for TerraCanon /canon.

## What changed
- Added governed invoke wrapper: rontend/apps/os-shell/src/canon/invokeWithPreflight.ts
- Wired CanonHome to preflight before invoke and surface deny reason + correlationId
- Added desktop contract tests:
  - rontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightDenyContract.test.tsx
  - rontend/apps/os-shell/src/__tests__/desktop/TerraCanonPreflightAllowContract.test.tsx

## Contract behavior verified
- Deny path shows normalized reason + correlationId and performs zero invokes
- Allow path invokes exactly once and shows correlationId

## Scope discipline
- No new surfaces
- No naming changes
- Focused to /canon governed command path only