### PR TITLE
feat(canon): Phase 50 — module host + layout persistence contracts for /canon

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonLayoutPersistenceContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonLayoutPersistenceContract.test.tsx
@@ -1,0 +1,50 @@
+import {
+  CANON_LAYOUT_STORAGE_KEY,
+  defaultCanonLayoutV1,
+  loadCanonLayout,
+  saveCanonLayout,
+} from '../../canon/layoutPersistence';
+
+describe('Phase 50 contract: TerraCanon layout persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves valid v1 envelope and round-trips layout', () => {
+    const layout = {
+      leftPaneWidth: 320,
+      rightPaneWidth: 280,
+      inspectorOpen: false,
+    };
+
+    saveCanonLayout(layout);
+
+    const raw = localStorage.getItem(CANON_LAYOUT_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(raw).toContain('"version":1');
+
+    expect(loadCanonLayout()).toEqual(layout);
+  });
+
+  it('malformed or unknown envelope fails closed and clears storage key', () => {
+    const fallback = defaultCanonLayoutV1();
+
+    localStorage.setItem(CANON_LAYOUT_STORAGE_KEY, '{not-json');
+    expect(loadCanonLayout()).toEqual(fallback);
+    expect(localStorage.getItem(CANON_LAYOUT_STORAGE_KEY)).toBeNull();
+
+    localStorage.setItem(
+      CANON_LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        layout: {
+          leftPaneWidth: 111,
+          rightPaneWidth: 222,
+          inspectorOpen: true,
+        },
+      })
+    );
+    expect(loadCanonLayout()).toEqual(fallback);
+    expect(localStorage.getItem(CANON_LAYOUT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonModuleMountContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/desktop/TerraCanonModuleMountContract.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { CanonModuleHost, type WorkspaceModule } from '../../canon/CanonModuleHost';
+
+function Harness({ module }: { module: WorkspaceModule }) {
+  const [workspaceId, setWorkspaceId] = React.useState('canon-workspace-1');
+  return (
+    <div>
+      <button
+        data-testid='switch-workspace'
+        onClick={() => setWorkspaceId('canon-workspace-2')}
+      >
+        switch
+      </button>
+      <CanonModuleHost module={module} workspaceId={workspaceId} />
+    </div>
+  );
+}
+
+describe('Phase 50 contract: TerraCanon module host mount/unmount determinism', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('mounts once per workspace and unmounts on switch + host unmount', async () => {
+    const unmountA = jest.fn();
+    const unmountB = jest.fn();
+    const mount = jest
+      .fn()
+      .mockResolvedValueOnce(unmountA)
+      .mockResolvedValueOnce(unmountB);
+
+    const module: WorkspaceModule = {
+      id: 'builtin-noop',
+      title: () => 'Noop',
+      mount,
+    };
+
+    const view = render(<Harness module={module} />);
+
+    await waitFor(() => {
+      expect(mount).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mount).toHaveBeenNthCalledWith(1, { workspaceId: 'canon-workspace-1' });
+
+    fireEvent.click(screen.getByTestId('switch-workspace'));
+
+    await waitFor(() => {
+      expect(mount).toHaveBeenCalledTimes(2);
+    });
+
+    expect(unmountA).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenNthCalledWith(2, { workspaceId: 'canon-workspace-2' });
+
+    view.unmount();
+
+    expect(unmountB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/CanonModuleHost.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonModuleHost.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef } from 'react';
+
+export type UnmountFn = () => void;
+
+export interface ModuleContext {
+  workspaceId: string;
+}
+
+export interface WorkspaceModule {
+  id: string;
+  title(workspaceId: string): string;
+  mount(ctx: ModuleContext): Promise<UnmountFn | void>;
+}
+
+interface CanonModuleHostProps {
+  module: WorkspaceModule;
+  workspaceId: string | null;
+}
+
+export function CanonModuleHost({ module, workspaceId }: CanonModuleHostProps): React.ReactElement | null {
+  const cleanupRef = useRef<UnmountFn | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    let disposed = false;
+    const priorCleanup = cleanupRef.current;
+    cleanupRef.current = null;
+    if (priorCleanup) priorCleanup();
+
+    (async () => {
+      const unmount = await module.mount({ workspaceId });
+      if (disposed) {
+        if (typeof unmount === 'function') unmount();
+        return;
+      }
+      cleanupRef.current = typeof unmount === 'function' ? unmount : null;
+    })();
+
+    return () => {
+      disposed = true;
+      const mountedCleanup = cleanupRef.current;
+      cleanupRef.current = null;
+      if (mountedCleanup) mountedCleanup();
+    };
+  }, [module, workspaceId]);
+
+  return null;
+}

--- a/frontend/apps/os-shell/src/canon/layoutPersistence.ts
+++ b/frontend/apps/os-shell/src/canon/layoutPersistence.ts
@@ -1,0 +1,70 @@
+export const CANON_LAYOUT_STORAGE_KEY = 'tf.canon.layout.v1';
+
+export interface CanonLayoutV1 {
+  leftPaneWidth: number;
+  rightPaneWidth: number;
+  inspectorOpen: boolean;
+}
+
+interface LayoutEnvelopeV1 {
+  version: 1;
+  layout: CanonLayoutV1;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isCanonLayoutV1(v: unknown): v is CanonLayoutV1 {
+  if (!isObject(v)) return false;
+  return (
+    typeof v.leftPaneWidth === 'number' &&
+    Number.isFinite(v.leftPaneWidth) &&
+    typeof v.rightPaneWidth === 'number' &&
+    Number.isFinite(v.rightPaneWidth) &&
+    typeof v.inspectorOpen === 'boolean'
+  );
+}
+
+function isLayoutEnvelopeV1(v: unknown): v is LayoutEnvelopeV1 {
+  if (!isObject(v)) return false;
+  if (v.version !== 1) return false;
+  if (!isCanonLayoutV1(v.layout)) return false;
+  return true;
+}
+
+export function defaultCanonLayoutV1(): CanonLayoutV1 {
+  return {
+    leftPaneWidth: 240,
+    rightPaneWidth: 320,
+    inspectorOpen: true,
+  };
+}
+
+export function serializeLayoutEnvelopeV1(layout: CanonLayoutV1): string {
+  return JSON.stringify({
+    version: 1,
+    layout,
+  } satisfies LayoutEnvelopeV1);
+}
+
+export function loadCanonLayout(): CanonLayoutV1 {
+  const fallback = defaultCanonLayoutV1();
+  try {
+    const raw = localStorage.getItem(CANON_LAYOUT_STORAGE_KEY);
+    if (raw === null) return fallback;
+    const parsed = JSON.parse(raw);
+    if (!isLayoutEnvelopeV1(parsed)) {
+      localStorage.removeItem(CANON_LAYOUT_STORAGE_KEY);
+      return fallback;
+    }
+    return parsed.layout;
+  } catch {
+    localStorage.removeItem(CANON_LAYOUT_STORAGE_KEY);
+    return fallback;
+  }
+}
+
+export function saveCanonLayout(layout: CanonLayoutV1): void {
+  localStorage.setItem(CANON_LAYOUT_STORAGE_KEY, serializeLayoutEnvelopeV1(layout));
+}

--- a/frontend/apps/os-shell/src/canon/modules/BuiltinNoopModule.ts
+++ b/frontend/apps/os-shell/src/canon/modules/BuiltinNoopModule.ts
@@ -1,0 +1,9 @@
+import type { WorkspaceModule } from '../CanonModuleHost';
+
+export const BuiltinNoopModule: WorkspaceModule = {
+  id: 'builtin-noop',
+  title: () => 'Noop',
+  async mount() {
+    return () => {};
+  },
+};

--- a/frontend/apps/os-shell/src/canon/useCanonLayout.ts
+++ b/frontend/apps/os-shell/src/canon/useCanonLayout.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+import { loadCanonLayout, saveCanonLayout, type CanonLayoutV1 } from './layoutPersistence';
+
+export function useCanonLayout(): [CanonLayoutV1, (next: CanonLayoutV1) => void] {
+  const [layout, setLayout] = useState<CanonLayoutV1>(() => loadCanonLayout());
+
+  useEffect(() => {
+    saveCanonLayout(layout);
+  }, [layout]);
+
+  return [layout, setLayout];
+}

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -53,7 +53,10 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { CanonModuleHost } from '../canon/CanonModuleHost';
 import { invokeWithPreflight, type CanonInvokeResult } from '../canon/invokeWithPreflight';
+import { BuiltinNoopModule } from '../canon/modules/BuiltinNoopModule';
+import { useCanonLayout } from '../canon/useCanonLayout';
 import {
   isValidWorkspace,
   parseLastClosedV2,
@@ -332,6 +335,7 @@ function loadLastClosed(): Workspace | null {
 let workspaceCounter = 0;
 
 function CanonContent(): React.ReactElement {
+  const [layout] = useCanonLayout();
   const [workspaces, setWorkspaces] = useState<Workspace[]>(() => {
     const persisted = loadPersistedState();
     if (persisted) {
@@ -495,6 +499,9 @@ function CanonContent(): React.ReactElement {
 
   return (
     <div className='canon-console' data-testid='terracanon-root'>
+      <div className='hidden' data-testid='terracanon-layout-version'>
+        v1:{layout.leftPaneWidth}:{layout.rightPaneWidth}:{layout.inspectorOpen ? '1' : '0'}
+      </div>
       <section className='canon-console__overview mb-4'>
         <h2>TerraCanon IDE</h2>
         <p>Integrated development environment for TerraFusion OS.</p>
@@ -537,6 +544,7 @@ function CanonContent(): React.ReactElement {
         hasClosedHistory={hasClosedHistory}
         onSwitchWorkspace={switchWorkspace}
       />
+      <CanonModuleHost module={BuiltinNoopModule} workspaceId={active?.id ?? null} />
     </div>
   );
 }


### PR DESCRIPTION
Phase 50 TDD-first scaffolding for TerraCanon /canon.

## What changed
- Added module host runtime:
  - rontend/apps/os-shell/src/canon/CanonModuleHost.tsx
  - rontend/apps/os-shell/src/canon/modules/BuiltinNoopModule.ts
- Added layout persistence runtime (v1 envelope, fail-closed):
  - rontend/apps/os-shell/src/canon/layoutPersistence.ts
  - rontend/apps/os-shell/src/canon/useCanonLayout.ts
- Minimal CanonHome wiring to load/persist layout and mount module host:
  - rontend/apps/os-shell/src/pages/CanonHome.tsx
- Added contract tests:
  - rontend/apps/os-shell/src/__tests__/desktop/TerraCanonModuleMountContract.test.tsx
  - rontend/apps/os-shell/src/__tests__/desktop/TerraCanonLayoutPersistenceContract.test.tsx

## Contracts verified
- Module host mounts exactly once per workspace and unmounts on workspace switch and host unmount
- Layout persistence writes v1 envelope and fail-closes on malformed/unknown envelope by clearing storage and defaulting
- Existing Phase 49 preflight deny/allow contracts continue to pass

## Scope discipline
- No new routes/surfaces
- No naming changes
- Phase 49 invokeWithPreflight logic untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent layout preferences for the Canon interface (pane widths and inspector state)
  * Introduced workspace module system with lifecycle management for dynamic module loading
  * Implemented command governance framework enabling policy-driven preflight checks for tool execution
  * Added versioned layout envelope with strict validation and fail-safe fallbacks

* **Tests**
  * Added comprehensive contract tests for layout persistence, command governance, and module lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->