### PR TITLE
Phase 51 canon reconciliation + release-lane safety fixes (clean lane)

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -5,7 +5,7 @@
 #   - Frontend: pnpm --frozen-lockfile (HARD FAIL if lockfile drifts)
 #   - Backend: dotnet with NuGet cache (retry on transient failures)
 #   - Security: CodeQL analysis (continue-on-error to not block release)
-#   - Deployment: main branch only
+#   - Deployment: manual dispatch only (production gated)
 # ============================================================================
 name: 🏛️ TerraFusion OS - Main CI/CD Pipeline
 
@@ -307,7 +307,7 @@ jobs:
     name: 🚀 Deployment Pipeline
     runs-on: ubuntu-latest
     needs: build-package
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch'
 
     environment: production
 

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -505,7 +505,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to Production
     needs: deploy-staging
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.deployment_environment == 'production'
     environment: production
 
     steps:
@@ -573,7 +573,7 @@ jobs:
   rollback:
     runs-on: ubuntu-latest
     name: Emergency Rollback
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.deployment_environment == 'production'
     needs: deploy-production
     environment: production
 

--- a/.github/workflows/ci-verified.yml
+++ b/.github/workflows/ci-verified.yml
@@ -157,7 +157,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [code-quality, container-build]
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch'
     environment: production
 
     steps:

--- a/.github/workflows/core-governance-gates.yml
+++ b/.github/workflows/core-governance-gates.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [main]
 
+env:
+  TF_ENFORCE_BRANCH_PROTECTION: '1'
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -45,6 +48,17 @@ jobs:
           cache: 'pnpm'
       - name: Install
         run: pnpm install --frozen-lockfile
+      - name: Verify branch protection matches canon snapshot
+        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1'
+        env:
+          TF_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash scripts/ci/verify-branch-protection-against-canon.sh
+      - name: Verify AGENTS.md matches protection canon
+        run: bash scripts/ci/verify-agents-doc-against-protection-canon.sh
+      - name: Release lane safety lint (no auto-approve / no direct-to-prod)
+        run: bash scripts/ci/release-lane-safety-lint.sh
       - name: Governed Spine (type-check + phase83-tools)
         run: pnpm test:governed
 

--- a/.github/workflows/core-governance-gates.yml
+++ b/.github/workflows/core-governance-gates.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Verify branch protection matches canon snapshot
-        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1'
+        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1' && github.event_name == 'push' && github.ref_name == 'main'
         env:
           TF_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -112,7 +112,7 @@ jobs:
   deploy-staging:
     needs: [build-and-test, backend-tests]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'staging'
+    if: github.event.inputs.environment == 'staging'
     environment: staging
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/infrastructure-cicd.yml
+++ b/.github/workflows/infrastructure-cicd.yml
@@ -2,7 +2,16 @@
 name: TerraFusion Infrastructure CI/CD
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
 env:
   TF_VERSION: '1.5.0'
   TF_VAR_region: 'us-east-1'
@@ -145,7 +154,7 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [validate-terraform, validate-helm, security-scan]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
     environment:
       name: staging
 
@@ -179,7 +188,7 @@ jobs:
           terraform init -backend-config="bucket=${{ secrets.TF_STATE_BUCKET_STAGING }}"
           terraform workspace select staging || terraform workspace new staging
           terraform plan -out=tfplan
-          terraform apply -auto-approve tfplan
+          terraform apply tfplan
 
       - name: Get EKS cluster credentials
         run: |
@@ -205,7 +214,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [deploy-staging]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
     environment:
       name: production
 
@@ -239,7 +248,7 @@ jobs:
           terraform init -backend-config="bucket=${{ secrets.TF_STATE_BUCKET_PROD }}"
           terraform workspace select production || terraform workspace new production
           terraform plan -out=tfplan
-          terraform apply -auto-approve tfplan
+          terraform apply tfplan
 
       - name: Get EKS cluster credentials
         run: |
@@ -276,7 +285,7 @@ jobs:
     name: Rollback on Failure
     runs-on: ubuntu-latest
     needs: [deploy-production]
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/kubernetes-infrastructure-ci.yml
+++ b/.github/workflows/kubernetes-infrastructure-ci.yml
@@ -745,7 +745,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [build-and-package, integration-tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
     timeout-minutes: 20
     environment:
       name: production

--- a/.github/workflows/observability-ci.yml
+++ b/.github/workflows/observability-ci.yml
@@ -880,7 +880,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [package-configs, integration-tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
     timeout-minutes: 20
     environment:
       name: production-monitoring

--- a/.github/workflows/security-compliance-ci.yml
+++ b/.github/workflows/security-compliance-ci.yml
@@ -910,8 +910,8 @@ jobs:
     name: Deploy Security Policies & Baselines
     runs-on: ubuntu-latest
     needs: [compliance-scan, vulnerability-scan, policy-validation, compliance-reporting]
-    # Only run on main branch when Azure credentials are configured
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Production security deployment is manual-only and environment-gated
+    if: github.event_name == 'workflow_dispatch'
     timeout-minutes: 15
     environment:
       name: production-security

--- a/.github/workflows/terrafusion-ci-cd-production.yml
+++ b/.github/workflows/terrafusion-ci-cd-production.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, production]
+    branches: [production]
     tags: ['v*']
     paths:
       - 'backend/**'
@@ -423,7 +423,7 @@ jobs:
     name: Infrastructure Deployment (Terraform)
     runs-on: ubuntu-latest
     needs: [container-build]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production' || github.event.inputs.deploy_environment != ''
+    if: github.ref == 'refs/heads/production' || github.event_name == 'workflow_dispatch'
     environment:
       name: ${{ github.event.inputs.deploy_environment || (github.ref == 'refs/heads/production' && 'production' || 'staging') }}
     permissions:
@@ -455,17 +455,17 @@ jobs:
           terraform plan -var="environment=${{ github.event.inputs.deploy_environment || 'staging' }}"
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production' || github.event.inputs.force_deploy == 'true'
+        if: github.ref == 'refs/heads/production' || github.event_name == 'workflow_dispatch'
         run: |
           cd infrastructure/terraform
-          terraform apply -auto-approve -var="environment=${{ github.event.inputs.deploy_environment || 'staging' }}"
+          terraform apply -var="environment=${{ github.event.inputs.deploy_environment || 'staging' }}"
 
   # ArgoCD Deployment
   argocd-deployment:
     name: ArgoCD Application Deployment
     runs-on: ubuntu-latest
     needs: [infrastructure-deployment, container-build]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/production' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/terrafusion-pipeline.yml
+++ b/.github/workflows/terrafusion-pipeline.yml
@@ -157,7 +157,7 @@ jobs:
             bash ops/scripts/deploy-team-packages.sh
           fi
       - name: Perfect-Power soak guard
-        if: ${{ env.TF_ENV == 'stage' || github.ref == 'refs/heads/main' }}
+        if: ${{ env.TF_ENV == 'stage' }}
         run: |
           if [[ -f "ops/scripts/soak-guard.sh" ]]; then
             bash ops/scripts/soak-guard.sh

--- a/.governance/main.protection.json
+++ b/.governance/main.protection.json
@@ -1,36 +1,11 @@
 {
-  "url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection",
-  "required_status_checks": {
-    "url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection/required_status_checks",
-    "strict": true,
-    "contexts": ["typecheck-core", "phase83-tools", "≡ƒöÆ SEAL"],
-    "contexts_url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection/required_status_checks/contexts",
-    "checks": [
-      { "context": "typecheck-core", "app_id": 15368 },
-      { "context": "phase83-tools", "app_id": 15368 },
-      { "context": "≡ƒöÆ SEAL", "app_id": 15368 }
-    ]
-  },
-  "required_pull_request_reviews": {
-    "url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection/required_pull_request_reviews",
-    "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
-    "require_last_push_approval": false,
-    "required_approving_review_count": 0
-  },
-  "required_signatures": {
-    "url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection/required_signatures",
-    "enabled": false
-  },
-  "enforce_admins": {
-    "url": "https://api.github.com/repos/bsvalues/terrafusion_os_1.0/branches/main/protection/enforce_admins",
-    "enabled": false
-  },
-  "required_linear_history": { "enabled": false },
-  "allow_force_pushes": { "enabled": false },
-  "allow_deletions": { "enabled": false },
-  "block_creations": { "enabled": false },
-  "required_conversation_resolution": { "enabled": false },
-  "lock_branch": { "enabled": false },
-  "allow_fork_syncing": { "enabled": false }
+  "branch": "main",
+  "enforce_admins": true,
+  "required_checks": [
+    "governed-spine",
+    "phase85-tools",
+    "phase86-toolrunner",
+    "🔒 TerraFusion Seal Gate",
+    "🧪 Tier-1 UI Harness Validation"
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,15 +36,11 @@ The following status checks are **required** on `main` branch:
 
 | Check | Scope | Enforcement |
 |-------|-------|-------------|
-| `🔒 SEAL` | All PRs | Required, admins enforced |
-| `typecheck-core` | All PRs | Required |
-| `phase83-tools` | All PRs | Required |
-| `SEAL Gate 8 (workflow)` | Triggering paths | Required (part of SEAL) |
-| `SEAL Gate 9 (truth)` | All PRs | Required (part of SEAL) |
-| `Accreditation Compat Check` | Accreditation paths only | Required when triggered |
-| `Accreditation Oracle Health` | Scheduled weekly | Non-blocking (monitoring) |
-
-**NOTE:** Gate 8 and Gate 9 are sub-gates of 🔒 SEAL. If SEAL passes, they passed.
+| `governed-spine` | Core-governance surface PRs | Required |
+| `phase85-tools` | Core-governance surface PRs | Required |
+| `phase86-toolrunner` | Core-governance surface PRs | Required |
+| `🔒 TerraFusion Seal Gate` | All PRs | Required |
+| `🧪 Tier-1 UI Harness Validation` | All PRs | Required |
 
 ### Two-Tier Oracle Model
 
@@ -65,16 +61,28 @@ main:
   required_status_checks:
     strict: true
     contexts:
-      - "🔒 SEAL"              # Includes Gate 8 (workflow) + Gate 9 (truth)
-      - "typecheck-core"
-      - "phase83-tools"
-      - "Accreditation Compat Check (ubuntu-latest)"
-      - "Accreditation Compat Check (windows-latest)"
+      - "governed-spine"
+      - "phase85-tools"
+      - "phase86-toolrunner"
+      - "🔒 TerraFusion Seal Gate"
+      - "🧪 Tier-1 UI Harness Validation"
   enforce_admins: true
   require_pull_request: true
   required_pull_request_reviews:
     required_approving_review_count: 0  # Solo dev: CI = Constitutional Review
   restrictions: null
+```
+
+### Branch Protection Canon (Machine Readable)
+
+```yaml
+enforce_admins: true
+required_checks:
+  - governed-spine
+  - phase85-tools
+  - phase86-toolrunner
+  - 🔒 TerraFusion Seal Gate
+  - 🧪 Tier-1 UI Harness Validation
 ```
 
 **Solo Dev Governance:**
@@ -96,7 +104,7 @@ These are the **enforced invariants** for `main` branch. Any deviation is a gove
 
 | Invariant | Value | Rationale |
 |-----------|-------|-----------|
-| Required checks | `🔒 SEAL`, `typecheck-core`, `phase83-tools` | Constitutional review |
+| Required checks | `governed-spine`, `phase85-tools`, `phase86-toolrunner`, `🔒 TerraFusion Seal Gate`, `🧪 Tier-1 UI Harness Validation` | Constitutional review |
 | Approving reviews | **0** | Solo dev: CI = approval |
 | Require PR | **true** | Evidence trail |
 | Require up-to-date | **true** | No merge race conditions |
@@ -113,7 +121,8 @@ gh api repos/bsvalues/terrafusion_os_1.0/branches/main/protection > .tmp/main.pr
 
 # Verify invariants
 jq '.required_pull_request_reviews.required_approving_review_count == 0' .tmp/main.protection.current.json
-jq '.required_status_checks.contexts | contains(["🔒 SEAL"])' .tmp/main.protection.current.json
+jq '.enforce_admins.enabled == true' .tmp/main.protection.current.json
+jq '.required_status_checks.contexts | contains(["governed-spine","phase85-tools","phase86-toolrunner","🔒 TerraFusion Seal Gate","🧪 Tier-1 UI Harness Validation"])' .tmp/main.protection.current.json
 
 # Raw diff (no dependencies)
 git diff --no-index .governance/main.protection.json .tmp/main.protection.current.json
@@ -130,7 +139,7 @@ git diff --no-index .tmp/main.protection.canon.norm.json .tmp/main.protection.cu
 - Link to the PR that authorized the change
 - Update "Last verified" date below
 
-**Last verified:** 2026-02-04 (PR #242 merged without `--admin`)
+**Last verified:** 2026-02-18 (Phase 51.0 canonical reconciliation)
 
 ## TOOL GOVERNANCE RULES
 - ToolRegistry must resolve the manifest path canonically (relative to ToolRegistry) and allow env override only:

--- a/scripts/ci/__tests__/governance-canon-scripts.test.sh
+++ b/scripts/ci/__tests__/governance-canon-scripts.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/.governance" "$tmp/.github/workflows" "$tmp/.tf-ci-diagnostics"
+
+cat > "$tmp/.governance/main.protection.json" <<'JSON'
+{
+  "branch": "main",
+  "enforce_admins": true,
+  "required_checks": ["governed-spine", "phase85-tools"]
+}
+JSON
+
+cat > "$tmp/AGENTS.md" <<'MD'
+enforce_admins: true
+required_checks:
+  - governed-spine
+  - phase85-tools
+MD
+
+mkdir -p "$tmp/scripts/ci"
+cp "$ROOT/scripts/ci/verify-agents-doc-against-protection-canon.sh" "$tmp/scripts/ci/"
+chmod +x "$tmp/scripts/ci/verify-agents-doc-against-protection-canon.sh"
+
+(
+  cd "$tmp"
+  bash scripts/ci/verify-agents-doc-against-protection-canon.sh >/dev/null
+)
+
+cat > "$tmp/AGENTS.md" <<'MD'
+enforce_admins: false
+required_checks:
+  - governed-spine
+MD
+
+(
+  cd "$tmp"
+  set +e
+  bash scripts/ci/verify-agents-doc-against-protection-canon.sh >/dev/null 2>&1
+  code=$?
+  set -e
+  if [[ "$code" -eq 0 ]]; then
+    echo "TEST FAIL: expected drift to fail"
+    exit 1
+  fi
+)
+
+echo "governance-canon-scripts.test: PASS"

--- a/scripts/ci/release-lane-safety-lint.sh
+++ b/scripts/ci/release-lane-safety-lint.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fails on dangerous release-lane patterns:
+#  - terraform apply -auto-approve
+#  - production deploy patterns triggered directly from main (heuristic)
+
+DIAG_DIR="${TF_DIAG_DIR:-.tf-ci-diagnostics}"
+ALLOW="${TF_RELEASE_LINT_ALLOWLIST_REGEX:-$^}"
+PYTHON_BIN="${TF_PYTHON_BIN:-python3}"
+
+mkdir -p "${DIAG_DIR}"
+
+if [[ ! -d ".github/workflows" ]]; then
+  echo "release-lane-lint: no workflows found; PASS"
+  exit 0
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "ERROR: python3/python not found in PATH."
+    exit 1
+  fi
+fi
+
+echo "release-lane-lint: scanning .github/workflows for dangerous patterns"
+
+AUTO_APPROVE_HITS="$(rg -n --no-heading -S "terraform[[:space:]]+apply\\b.*-auto-approve" .github/workflows -g "*.yml" -g "*.yaml" || true)"
+AUTO_APPROVE_HITS="$(echo "${AUTO_APPROVE_HITS}" | rg -v "${ALLOW}" || true)"
+
+DIRECT_MAIN_PROD_RAW="$("${PYTHON_BIN}" <<'PY'
+import glob
+import os
+import re
+
+files = sorted(glob.glob(".github/workflows/*.yml")) + sorted(glob.glob(".github/workflows/*.yaml"))
+results = []
+
+job_header = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+prod_env_inline = re.compile(r"^\s+environment:\s*production(?:\b|-)", re.IGNORECASE)
+prod_env_block = re.compile(r"^\s+environment:\s*$", re.IGNORECASE)
+prod_env_name = re.compile(r"^\s+name:\s*production(?:\b|-)", re.IGNORECASE)
+main_ref = re.compile(
+    r"refs/heads/main|github\.ref_name\s*==\s*['\"]main['\"]|github\.ref\s*==\s*['\"]refs/heads/main['\"]"
+)
+prod_name = re.compile(r"deploy[-_]?prod|deploy[-_]?production", re.IGNORECASE)
+prod_step = re.compile(r"^\s+name:\s*.*deploy to production", re.IGNORECASE | re.MULTILINE)
+
+for path in files:
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    in_jobs = False
+    current_job = None
+    current_start = 0
+    current_lines = []
+
+    def analyze(job_name, start_line, block):
+        if not job_name:
+            return
+        text = "\n".join(block)
+        is_prod = False
+        prod_line = None
+        in_env = False
+
+        for idx, line in enumerate(block, start=start_line):
+            if prod_env_inline.search(line):
+                is_prod = True
+                prod_line = idx
+                break
+            if prod_env_block.search(line):
+                in_env = True
+                continue
+            if in_env:
+                if re.match(r"^\s{2}[A-Za-z0-9_-]+:\s*$", line):
+                    in_env = False
+                elif prod_env_name.search(line):
+                    is_prod = True
+                    prod_line = idx
+                    break
+                elif re.match(r"^\s+\w+:\s*", line):
+                    in_env = False
+
+        if not is_prod and (prod_name.search(job_name) or prod_step.search(text)):
+            is_prod = True
+            prod_line = start_line
+
+        if not is_prod:
+            return
+
+        main_line = None
+        for idx, line in enumerate(block, start=start_line):
+            if main_ref.search(line):
+                main_line = idx
+                break
+
+        if main_line is not None:
+            results.append(f"{path}:{main_line}: main-triggered production job '{job_name}'")
+            if prod_line is not None and prod_line != main_line:
+                results.append(f"{path}:{prod_line}: production marker for job '{job_name}'")
+
+    for i, line in enumerate(lines, start=1):
+        if not in_jobs:
+            if line.strip() == "jobs:":
+                in_jobs = True
+            continue
+
+        m = job_header.match(line)
+        if m:
+            analyze(current_job, current_start, current_lines)
+            current_job = m.group(1)
+            current_start = i
+            current_lines = [line]
+            continue
+
+        if current_job is not None:
+            current_lines.append(line)
+
+    analyze(current_job, current_start, current_lines)
+
+print("\n".join(results))
+PY
+)"
+
+DIRECT_MAIN_PROD_HITS="$(echo "${DIRECT_MAIN_PROD_RAW}" | rg -v "${ALLOW}" || true)"
+
+FAIL=0
+
+{
+  echo "Release Lane Safety Lint"
+  echo ""
+
+  if [[ -n "${AUTO_APPROVE_HITS}" ]]; then
+    echo "FAIL: terraform apply uses -auto-approve:"
+    echo "${AUTO_APPROVE_HITS}"
+    echo ""
+    FAIL=1
+  fi
+
+  if [[ -n "${DIRECT_MAIN_PROD_HITS}" ]]; then
+    echo "FAIL: Direct main-to-production deployment risk detected:"
+    echo "${DIRECT_MAIN_PROD_HITS}"
+    echo ""
+    echo "Fix: production jobs must be workflow_dispatch/tag/release gated and environment-approved."
+    FAIL=1
+  fi
+} > "${DIAG_DIR}/release-lane-lint.txt"
+
+cat "${DIAG_DIR}/release-lane-lint.txt"
+
+if [[ "${FAIL}" -eq 1 ]]; then
+  exit 1
+fi
+
+echo "release-lane-lint: PASS"

--- a/scripts/ci/verify-agents-doc-against-protection-canon.sh
+++ b/scripts/ci/verify-agents-doc-against-protection-canon.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONIOENCODING=UTF-8
+
+CANON_PATH="${TF_PROTECTION_CANON_PATH:-.governance/main.protection.json}"
+AGENTS_PATH="${TF_AGENTS_PATH:-AGENTS.md}"
+DIAG_DIR="${TF_DIAG_DIR:-.tf-ci-diagnostics}"
+PYTHON_BIN="${TF_PYTHON_BIN:-python3}"
+
+mkdir -p "${DIAG_DIR}"
+
+if [[ ! -f "${CANON_PATH}" ]]; then
+  echo "ERROR: missing canon file: ${CANON_PATH}"
+  exit 1
+fi
+
+if [[ ! -f "${AGENTS_PATH}" ]]; then
+  echo "ERROR: missing AGENTS.md at: ${AGENTS_PATH}"
+  exit 1
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "ERROR: python3/python not found in PATH."
+    exit 1
+  fi
+fi
+
+"${PYTHON_BIN}" - "${CANON_PATH}" "${AGENTS_PATH}" > "${DIAG_DIR}/agents-vs-canon-diff.txt" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    canon = json.load(f)
+with open(sys.argv[2], "r", encoding="utf-8") as f:
+    agents = f.read()
+
+expected_enforce = str(bool(canon.get("enforce_admins"))).lower()
+expected_checks = canon.get("required_checks", [])
+
+m_enf = re.search(r"enforce_admins\s*:\s*(true|false)", agents, re.IGNORECASE)
+found_enf = m_enf.group(1).lower() if m_enf else None
+
+checks = []
+sec = re.search(r"required_checks\s*:\s*\n(?P<body>(?:\s*-\s*.+\n)+)", agents, re.IGNORECASE)
+if sec:
+    body = sec.group("body")
+    for line in body.splitlines():
+        mm = re.match(r"\s*-\s*(.+?)\s*$", line)
+        if mm:
+            checks.append(mm.group(1))
+
+diffs = []
+if found_enf is None:
+    diffs.append("AGENTS.md missing explicit 'enforce_admins: true|false' line.")
+elif found_enf != expected_enforce:
+    diffs.append(f"enforce_admins mismatch: canon={expected_enforce} AGENTS.md={found_enf}")
+
+if not checks:
+    diffs.append("AGENTS.md missing explicit required_checks block (required_checks: \\n  - ...).")
+else:
+    cset = set(expected_checks)
+    aset = set(checks)
+    missing = sorted(list(cset - aset))
+    extra = sorted(list(aset - cset))
+    if missing:
+        diffs.append("required_checks missing in AGENTS.md:\n  - " + "\n  - ".join(missing))
+    if extra:
+        diffs.append("required_checks extra in AGENTS.md:\n  - " + "\n  - ".join(extra))
+
+if not diffs:
+    print("OK: AGENTS.md matches protection canon.")
+else:
+    print("FAIL: AGENTS.md drift detected.\n")
+    print("\n\n".join(diffs))
+PY
+
+if grep -q '^FAIL:' "${DIAG_DIR}/agents-vs-canon-diff.txt"; then
+  echo ""
+  cat "${DIAG_DIR}/agents-vs-canon-diff.txt"
+  echo ""
+  exit 1
+fi
+
+cat "${DIAG_DIR}/agents-vs-canon-diff.txt"
+echo "agents-doc-canon: PASS"

--- a/scripts/ci/verify-branch-protection-against-canon.sh
+++ b/scripts/ci/verify-branch-protection-against-canon.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONIOENCODING=UTF-8
+
+# Verifies GitHub branch protection for the configured branch matches
+# .governance/main.protection.json. CI-only, read-only, deterministic output.
+
+REPO="${TF_REPO:-${GITHUB_REPOSITORY:-}}"
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+CANON_PATH="${TF_PROTECTION_CANON_PATH:-.governance/main.protection.json}"
+DIAG_DIR="${TF_DIAG_DIR:-.tf-ci-diagnostics}"
+PYTHON_BIN="${TF_PYTHON_BIN:-python3}"
+
+mkdir -p "${DIAG_DIR}"
+
+if [[ -z "${REPO}" ]]; then
+  echo "ERROR: repo not set (TF_REPO or GITHUB_REPOSITORY)."
+  exit 1
+fi
+
+if [[ -z "${TOKEN}" ]]; then
+  echo "ERROR: missing token (GH_TOKEN or GITHUB_TOKEN) for branch protection read."
+  exit 1
+fi
+
+if [[ ! -f "${CANON_PATH}" ]]; then
+  echo "ERROR: missing canon file: ${CANON_PATH}"
+  exit 1
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "ERROR: python3/python not found in PATH."
+    exit 1
+  fi
+fi
+
+"${PYTHON_BIN}" - "${CANON_PATH}" > "${DIAG_DIR}/branch-protection-canon.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    canon = json.load(f)
+
+out = {
+    "branch": canon.get("branch", "main"),
+    "enforce_admins": bool(canon.get("enforce_admins")),
+    "required_checks": sorted(list(dict.fromkeys(canon.get("required_checks", [])))),
+}
+print(json.dumps(out, indent=2, ensure_ascii=False))
+PY
+
+BRANCH="$("${PYTHON_BIN}" - "${DIAG_DIR}/branch-protection-canon.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+print(data.get("branch", "main"))
+PY
+)"
+
+URL="https://api.github.com/repos/${REPO}/branches/${BRANCH}/protection"
+echo "branch-protect-canon: fetching live protection for ${REPO}@${BRANCH}"
+
+LIVE_JSON="$(curl -fsSL \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "${URL}")"
+
+RAW_LIVE_PATH="${DIAG_DIR}/branch-protection-live-raw.json"
+printf '%s' "${LIVE_JSON}" > "${RAW_LIVE_PATH}"
+
+"${PYTHON_BIN}" - "${BRANCH}" "${RAW_LIVE_PATH}" > "${DIAG_DIR}/branch-protection-live.json" <<'PY'
+import json
+import sys
+
+branch = sys.argv[1] if len(sys.argv) > 1 else "main"
+live_path = sys.argv[2]
+with open(live_path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+ea = data.get("enforce_admins")
+if isinstance(ea, dict):
+    enforce_admins = bool(ea.get("enabled", False))
+else:
+    enforce_admins = bool(ea)
+
+req = data.get("required_status_checks") or {}
+contexts = list(req.get("contexts") or [])
+for chk in (req.get("checks") or []):
+    ctx = chk.get("context")
+    if ctx:
+        contexts.append(ctx)
+
+contexts = sorted(
+    list(
+        dict.fromkeys(
+            [c for c in contexts if isinstance(c, str) and c.strip()]
+        )
+    )
+)
+
+out = {
+    "branch": branch,
+    "enforce_admins": enforce_admins,
+    "required_checks": contexts,
+}
+print(json.dumps(out, indent=2, ensure_ascii=False))
+PY
+
+"${PYTHON_BIN}" - "${DIAG_DIR}/branch-protection-canon.json" "${DIAG_DIR}/branch-protection-live.json" > "${DIAG_DIR}/branch-protection-diff.txt" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    canon = json.load(f)
+with open(sys.argv[2], "r", encoding="utf-8") as f:
+    live = json.load(f)
+
+diffs = []
+
+if canon.get("enforce_admins") != live.get("enforce_admins"):
+    diffs.append(
+        f"enforce_admins: canon={canon.get('enforce_admins')} live={live.get('enforce_admins')}"
+    )
+
+cset = set(canon.get("required_checks", []))
+lset = set(live.get("required_checks", []))
+
+missing = sorted(list(cset - lset))
+extra = sorted(list(lset - cset))
+
+if missing:
+    diffs.append("required_checks missing in live:\n  - " + "\n  - ".join(missing))
+if extra:
+    diffs.append("required_checks extra in live:\n  - " + "\n  - ".join(extra))
+
+if not diffs:
+    print("OK: live branch protection matches canon.")
+else:
+    print("FAIL: branch protection drift detected.\n")
+    print("\n\n".join(diffs))
+PY
+
+if grep -q '^FAIL:' "${DIAG_DIR}/branch-protection-diff.txt"; then
+  echo ""
+  cat "${DIAG_DIR}/branch-protection-diff.txt"
+  echo ""
+  exit 1
+fi
+
+cat "${DIAG_DIR}/branch-protection-diff.txt"
+echo "branch-protect-canon: PASS"


### PR DESCRIPTION
- Includes Phase 51.0 branch protection canon + AGENTS.md alignment + CI verification wiring
- Includes Phase 51.1 removal of terraform -auto-approve, production deploy/apply gating away from main push, and job-level safety lint refinement

Validation: safety lint PASS, governance canon tests PASS, AGENTS vs canon PASS, phase83 tools PASS.

Note: This PR isolates the validated Phase 51 changes on a clean branch to avoid unrelated historical drift in PR #390.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governance verification and release-safety lint tools to validate branch protection, agents doc, and detect unsafe release patterns.

* **Refactor**
  * Production deployments now require manual workflow dispatch instead of automatic runs on main.
  * Simplified branch protection representation and updated core required status checks.

* **Tests**
  * Added an automated test to exercise governance verification and detect drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->