### PR TITLE
phase52.1: guard branch-protection check when read token is unavailable

### DIFF
--- a/.github/workflows/core-governance-gates.yml
+++ b/.github/workflows/core-governance-gates.yml
@@ -39,6 +39,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.core == 'true'
     runs-on: ${{ vars.BENTON_RUNNER == 'true' && fromJSON('["self-hosted", "benton", "linux-x64"]') || 'ubuntu-latest' }}
+    env:
+      BRANCH_PROTECTION_READ_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -49,10 +51,10 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Verify branch protection matches canon snapshot
-        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1' && github.event_name == 'push' && github.ref_name == 'main' && secrets.BRANCH_PROTECTION_READ_TOKEN != ''
+        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1' && github.event_name == 'push' && github.ref_name == 'main' && env.BRANCH_PROTECTION_READ_TOKEN != ''
         env:
           TF_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}
+          GH_TOKEN: ${{ env.BRANCH_PROTECTION_READ_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
         run: bash scripts/ci/verify-branch-protection-against-canon.sh
       - name: Verify AGENTS.md matches protection canon

--- a/.github/workflows/core-governance-gates.yml
+++ b/.github/workflows/core-governance-gates.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Verify branch protection matches canon snapshot
-        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1' && github.event_name == 'push' && github.ref_name == 'main'
+        if: env.TF_ENFORCE_BRANCH_PROTECTION == '1' && github.event_name == 'push' && github.ref_name == 'main' && secrets.BRANCH_PROTECTION_READ_TOKEN != ''
         env:
           TF_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN }}


### PR DESCRIPTION
## Summary\n- prevent false mainline governance outages when BRANCH_PROTECTION_READ_TOKEN is unset\n- keep branch-protection drift verification enabled when token is configured\n\n## Change\n- update core-governance-gates step condition to require non-empty secrets.BRANCH_PROTECTION_READ_TOKEN before calling GitHub branch protection API\n\n## Why\n- post-merge main run for commit 4f25a9351 failed with curl: (22) 403 due missing token secret, not canon drift\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced branch protection verification process by adding stricter validation requirements for GitHub Actions security configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->