### PR TITLE
feat(security): FISMA lockout + password history persistent stores

### DIFF
--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -247,6 +247,23 @@ else
 // Detects discrepancies between Harris PACS and TerraFusion, auto-corrects data issues, maintains 99.9% accuracy
 builder.Services.AddScoped<TerraFusion.Core.Services.IPropertyDataValidationService, TerraFusion.Core.Services.PropertyDataValidationService>();
 
+// ====================================================================
+// 🔐 Phase 4 Sprint 1: NIST 800-63B Storage Infrastructure
+// ====================================================================
+
+// Feature flags configuration (all OFF by default - Sprint 1 storage only)
+builder.Services.Configure<TerraFusion.Core.Configuration.FeatureFlagsOptions>(
+    builder.Configuration.GetSection("FeatureFlags"));
+
+// Redis lockout store (uses existing IDistributedCache from line 70-71)
+builder.Services.AddScoped<TerraFusion.Core.Security.Lockout.ILockoutStore, TerraFusion.Core.Security.Lockout.RedisLockoutStore>();
+
+// SQL password history store (uses TerraFusionDbContext)
+builder.Services.AddScoped<TerraFusion.Core.Security.PasswordHistory.IPasswordHistoryStore, TerraFusion.Data.Security.SqlPasswordHistoryStore>();
+
+// Note: Enforcement logic wired in Sprint 2 (flags OFF for Sprint 1)
+// ====================================================================
+
 // 📊 Register TerraFusion Elite Metrics Exporter - Championship-level observability for 7 AI services
 // Exports Prometheus metrics for: Consciousness (swarm), CostForge AI, TerraGaia, TerraFusionGPT, TerraLevy, TerraFlow, TerraSync, Harris PACS integration
 builder.Services.AddSingleton<TerraFusion.Core.Metrics.TerraFusionMetricsExporter>();

--- a/backend/src/TerraFusion.API/appsettings.Development.json
+++ b/backend/src/TerraFusion.API/appsettings.Development.json
@@ -37,6 +37,12 @@
     "SecretKey": "Terrafusion-OS-1.0-Development-JWT-Secret-Key-For-Local-Development-Only",
     "ExpirationMinutes": 120
   },
+  "FeatureFlags": {
+    "UseAccountLockout": false,
+    "UsePasswordHistory": false,
+    "UseCommonPasswordCheck": false,
+    "EnforceFipsCompliance": false
+  },
   "AllowedOrigins": [
     "http://localhost:3000",
     "http://localhost:3001",

--- a/backend/src/TerraFusion.API/appsettings.Production.json
+++ b/backend/src/TerraFusion.API/appsettings.Production.json
@@ -91,6 +91,12 @@
       "https://benton.terrafusionmarket.com"
     ]
   },
+  "FeatureFlags": {
+    "UseAccountLockout": false,
+    "UsePasswordHistory": false,
+    "UseCommonPasswordCheck": false,
+    "EnforceFipsCompliance": false
+  },
   "Performance": {
     "MaxWorkerThreads": 32,
     "MaxIOThreads": 32,

--- a/backend/src/TerraFusion.API/appsettings.json
+++ b/backend/src/TerraFusion.API/appsettings.json
@@ -19,6 +19,12 @@
     "ExpirationMinutes": 60,
     "RefreshTokenExpirationDays": 7
   },
+  "FeatureFlags": {
+    "UseAccountLockout": false,
+    "UsePasswordHistory": false,
+    "UseCommonPasswordCheck": false,
+    "EnforceFipsCompliance": false
+  },
   "AllowedOrigins": [
     "http://localhost:3000",
     "https://localhost:3001",

--- a/backend/src/TerraFusion.Core/Configuration/FeatureFlagsOptions.cs
+++ b/backend/src/TerraFusion.Core/Configuration/FeatureFlagsOptions.cs
@@ -1,0 +1,32 @@
+namespace TerraFusion.Core.Configuration;
+
+/// <summary>
+/// Phase 4 Sprint 1: Feature flags for NIST 800-63B hardening
+/// All flags default OFF (no behavior change until explicitly enabled)
+/// </summary>
+public class FeatureFlagsOptions
+{
+    /// <summary>
+    /// Enable progressive account lockout (NIST 800-63B AC-2(4))
+    /// Default: false (Sprint 1 no behavior change)
+    /// </summary>
+    public bool UseAccountLockout { get; set; } = false;
+    
+    /// <summary>
+    /// Enable password history validation (NIST 800-63B AC-2(7))
+    /// Default: false (Sprint 1 no behavior change)
+    /// </summary>
+    public bool UsePasswordHistory { get; set; } = false;
+    
+    /// <summary>
+    /// Enable common password deny list check
+    /// Default: false (Sprint 1 no behavior change)
+    /// </summary>
+    public bool UseCommonPasswordCheck { get; set; } = false;
+    
+    /// <summary>
+    /// Enforce FIPS 140-2 crypto validation at startup
+    /// Default: false (dev), true (prod after validation)
+    /// </summary>
+    public bool EnforceFipsCompliance { get; set; } = false;
+}

--- a/backend/src/TerraFusion.Core/Entities/CoreEntities.cs
+++ b/backend/src/TerraFusion.Core/Entities/CoreEntities.cs
@@ -52,6 +52,32 @@ public class GovernmentUser
     public string? Permissions { get; set; } // JSON string
 }
 
+public class PasswordHistory
+{
+    public Guid Id { get; set; }
+    
+    /// <summary>
+    /// Foreign key to GovernmentUser
+    /// </summary>
+    public Guid UserId { get; set; }
+    
+    /// <summary>
+    /// Hashed password (PBKDF2/Argon2 format)
+    /// Phase 4 Sprint 1: Storage only, no enforcement
+    /// </summary>
+    public required string PasswordHash { get; set; }
+    
+    /// <summary>
+    /// When this password was set
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+    
+    /// <summary>
+    /// Navigation property (optional)
+    /// </summary>
+    public GovernmentUser? User { get; set; }
+}
+
 public class AuditLog
 {
     public Guid Id { get; set; }

--- a/backend/src/TerraFusion.Core/Security/Lockout/ILockoutStore.cs
+++ b/backend/src/TerraFusion.Core/Security/Lockout/ILockoutStore.cs
@@ -1,0 +1,39 @@
+namespace TerraFusion.Core.Security.Lockout;
+
+/// <summary>
+/// Phase 4 Sprint 1: Account lockout state storage interface
+/// Implements NIST 800-63B AC-2(4) progressive lockout tracking
+/// </summary>
+public interface ILockoutStore
+{
+    /// <summary>
+    /// Get current failed login attempt count for user
+    /// </summary>
+    Task<int> GetFailedAttemptsAsync(Guid userId);
+    
+    /// <summary>
+    /// Increment failed login attempt counter
+    /// </summary>
+    /// <returns>New attempt count after increment</returns>
+    Task<int> IncrementFailedAttemptsAsync(Guid userId);
+    
+    /// <summary>
+    /// Reset failed attempts (after successful login)
+    /// </summary>
+    Task ResetFailedAttemptsAsync(Guid userId);
+    
+    /// <summary>
+    /// Get lockout expiry timestamp (null if not locked)
+    /// </summary>
+    Task<DateTime?> GetLockoutExpiryAsync(Guid userId);
+    
+    /// <summary>
+    /// Set account lockout until specified time
+    /// </summary>
+    Task SetLockoutAsync(Guid userId, DateTime expiresAt);
+    
+    /// <summary>
+    /// Check if user is currently locked out
+    /// </summary>
+    Task<bool> IsLockedOutAsync(Guid userId);
+}

--- a/backend/src/TerraFusion.Core/Security/Lockout/RedisLockoutStore.cs
+++ b/backend/src/TerraFusion.Core/Security/Lockout/RedisLockoutStore.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Caching.Distributed;
+using System.Text.Json;
+
+namespace TerraFusion.Core.Security.Lockout;
+
+/// <summary>
+/// Phase 4 Sprint 1: Redis-backed account lockout store
+/// Implements ILockoutStore using IDistributedCache (Redis)
+/// NIST 800-63B AC-2(4) progressive lockout tracking
+/// </summary>
+public class RedisLockoutStore : ILockoutStore
+{
+    private readonly IDistributedCache _cache;
+    private const string LOCKOUT_PREFIX = "auth:lockout:";
+    private const int LOCKOUT_TTL_HOURS = 2; // Max TTL for lockout keys
+
+    public RedisLockoutStore(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task<int> GetFailedAttemptsAsync(Guid userId)
+    {
+        var state = await GetLockoutStateAsync(userId);
+        return state?.FailedAttempts ?? 0;
+    }
+
+    public async Task<int> IncrementFailedAttemptsAsync(Guid userId)
+    {
+        var state = await GetLockoutStateAsync(userId) ?? new LockoutState();
+        state.FailedAttempts++;
+        state.LastAttemptAt = DateTime.UtcNow;
+        
+        await SetLockoutStateAsync(userId, state);
+        return state.FailedAttempts;
+    }
+
+    public async Task ResetFailedAttemptsAsync(Guid userId)
+    {
+        var key = GetKey(userId);
+        await _cache.RemoveAsync(key);
+    }
+
+    public async Task<DateTime?> GetLockoutExpiryAsync(Guid userId)
+    {
+        var state = await GetLockoutStateAsync(userId);
+        return state?.LockedUntil;
+    }
+
+    public async Task SetLockoutAsync(Guid userId, DateTime expiresAt)
+    {
+        var state = await GetLockoutStateAsync(userId) ?? new LockoutState();
+        state.LockedUntil = expiresAt;
+        
+        await SetLockoutStateAsync(userId, state);
+    }
+
+    public async Task<bool> IsLockedOutAsync(Guid userId)
+    {
+        var expiry = await GetLockoutExpiryAsync(userId);
+        return expiry.HasValue && expiry.Value > DateTime.UtcNow;
+    }
+
+    // Private helpers
+    private string GetKey(Guid userId) => $"{LOCKOUT_PREFIX}{userId}";
+
+    private async Task<LockoutState?> GetLockoutStateAsync(Guid userId)
+    {
+        var key = GetKey(userId);
+        var json = await _cache.GetStringAsync(key);
+        
+        if (string.IsNullOrEmpty(json))
+            return null;
+        
+        return JsonSerializer.Deserialize<LockoutState>(json);
+    }
+
+    private async Task SetLockoutStateAsync(Guid userId, LockoutState state)
+    {
+        var key = GetKey(userId);
+        var json = JsonSerializer.Serialize(state);
+        
+        var options = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(LOCKOUT_TTL_HOURS)
+        };
+        
+        await _cache.SetStringAsync(key, json, options);
+    }
+
+    private class LockoutState
+    {
+        public int FailedAttempts { get; set; }
+        public DateTime? LockedUntil { get; set; }
+        public DateTime? LastAttemptAt { get; set; }
+    }
+}

--- a/backend/src/TerraFusion.Core/Security/PasswordHistory/IPasswordHistoryStore.cs
+++ b/backend/src/TerraFusion.Core/Security/PasswordHistory/IPasswordHistoryStore.cs
@@ -1,0 +1,30 @@
+namespace TerraFusion.Core.Security.PasswordHistory;
+
+/// <summary>
+/// Phase 4 Sprint 1: Password history storage interface
+/// Implements NIST 800-63B AC-2(7) password reuse prevention
+/// </summary>
+public interface IPasswordHistoryStore
+{
+    /// <summary>
+    /// Add a password hash to user's history
+    /// </summary>
+    Task AddPasswordHashAsync(Guid userId, string passwordHash);
+    
+    /// <summary>
+    /// Get user's recent password hashes (ordered by CreatedAt DESC)
+    /// </summary>
+    /// <param name="count">Number of recent hashes to retrieve (default: 5)</param>
+    Task<List<string>> GetRecentPasswordHashesAsync(Guid userId, int count = 5);
+    
+    /// <summary>
+    /// Check if a password hash exists in user's recent history
+    /// Note: This does NOT verify the password, just checks hash presence
+    /// </summary>
+    Task<bool> IsHashInHistoryAsync(Guid userId, string passwordHash);
+    
+    /// <summary>
+    /// Delete password history older than retention period (90 days)
+    /// </summary>
+    Task PruneOldHistoryAsync(int retentionDays = 90);
+}

--- a/backend/src/TerraFusion.Data/Migrations/TerraFusionDbContextModelSnapshot.cs
+++ b/backend/src/TerraFusion.Data/Migrations/TerraFusionDbContextModelSnapshot.cs
@@ -1358,6 +1358,31 @@ namespace TerraFusion.Data.Migrations
                     b.ToTable("NotificationPreferences", (string)null);
                 });
 
+            modelBuilder.Entity("TerraFusion.Core.Entities.PasswordHistory", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("PasswordHash")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId", "CreatedAt")
+                        .HasDatabaseName("IX_PasswordHistory_UserId_CreatedAt");
+
+                    b.ToTable("PasswordHistories");
+                });
+
             modelBuilder.Entity("TerraFusion.Core.Entities.PerformanceMetric", b =>
                 {
                     b.Property<Guid>("Id")
@@ -2923,6 +2948,17 @@ namespace TerraFusion.Data.Migrations
                         .IsRequired();
 
                     b.Navigation("Project");
+                });
+
+            modelBuilder.Entity("TerraFusion.Core.Entities.PasswordHistory", b =>
+                {
+                    b.HasOne("TerraFusion.Core.Entities.GovernmentUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("TerraFusion.Core.Entities.Project", b =>

--- a/backend/src/TerraFusion.Data/Security/SqlPasswordHistoryStore.cs
+++ b/backend/src/TerraFusion.Data/Security/SqlPasswordHistoryStore.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities;
+using TerraFusion.Core.Security.PasswordHistory;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Data.Security;
+
+/// <summary>
+/// Phase 4 Sprint 1: SQL-backed password history store
+/// Implements IPasswordHistoryStore using TerraFusionDbContext
+/// NIST 800-63B AC-2(7) password reuse prevention
+/// </summary>
+public class SqlPasswordHistoryStore : IPasswordHistoryStore
+{
+    private readonly TerraFusionDbContext _context;
+
+    public SqlPasswordHistoryStore(TerraFusionDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddPasswordHashAsync(Guid userId, string passwordHash)
+    {
+        var entry = new Core.Entities.PasswordHistory
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PasswordHash = passwordHash,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.PasswordHistories.Add(entry);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<List<string>> GetRecentPasswordHashesAsync(Guid userId, int count = 5)
+    {
+        return await _context.PasswordHistories
+            .Where(ph => ph.UserId == userId)
+            .OrderByDescending(ph => ph.CreatedAt)
+            .Take(count)
+            .Select(ph => ph.PasswordHash)
+            .ToListAsync();
+    }
+
+    public async Task<bool> IsHashInHistoryAsync(Guid userId, string passwordHash)
+    {
+        // Note: This checks for exact hash match (for deduplication)
+        // Password verification against hashes is done at service layer
+        return await _context.PasswordHistories
+            .Where(ph => ph.UserId == userId)
+            .OrderByDescending(ph => ph.CreatedAt)
+            .Take(5) // Only check last 5
+            .AnyAsync(ph => ph.PasswordHash == passwordHash);
+    }
+
+    public async Task PruneOldHistoryAsync(int retentionDays = 90)
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+        
+        var oldEntries = await _context.PasswordHistories
+            .Where(ph => ph.CreatedAt < cutoff)
+            .ToListAsync();
+        
+        _context.PasswordHistories.RemoveRange(oldEntries);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -58,6 +58,7 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // Security Entities
     public DbSet<SecurityEvent> SecurityEvents { get; set; }
     public DbSet<UserSession> UserSessions { get; set; }
+    public DbSet<PasswordHistory> PasswordHistories { get; set; }
 
     // Collaboration Entities
     public DbSet<CollaborationUser> CollaborationUsers { get; set; }
@@ -232,6 +233,21 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
             entity.Property(e => e.Metadata).HasColumnType("jsonb");
             entity.HasIndex(e => e.Timestamp);
             entity.HasIndex(e => e.EventType);
+        });
+
+        // Configure PasswordHistory entity (Phase 4 Sprint 1)
+        modelBuilder.Entity<PasswordHistory>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.Property(e => e.PasswordHash).IsRequired().HasMaxLength(500);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.HasIndex(e => new { e.UserId, e.CreatedAt })
+                .HasDatabaseName("IX_PasswordHistory_UserId_CreatedAt");
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<Plugin>(entity =>

--- a/backend/tests/TerraFusion.Tests.Unit/Security/Lockout/RedisLockoutStoreTests.cs
+++ b/backend/tests/TerraFusion.Tests.Unit/Security/Lockout/RedisLockoutStoreTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Moq;
+using TerraFusion.Core.Security.Lockout;
+using Xunit;
+
+namespace TerraFusion.Tests.Unit.Security.Lockout;
+
+/// <summary>
+/// Phase 4 Sprint 1: Redis lockout store tests (TDD - tests first)
+/// Tests account lockout state management using IDistributedCache
+/// </summary>
+public class RedisLockoutStoreTests
+{
+    private readonly Mock<IDistributedCache> _cacheMock;
+    private readonly RedisLockoutStore _store;
+
+    public RedisLockoutStoreTests()
+    {
+        _cacheMock = new Mock<IDistributedCache>();
+        _store = new RedisLockoutStore(_cacheMock.Object);
+    }
+
+    [Fact]
+    public async Task GetFailedAttemptsAsync_ReturnsZero_WhenNoState()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((byte[]?)null);
+
+        // Act
+        var attempts = await _store.GetFailedAttemptsAsync(userId);
+
+        // Assert
+        Assert.Equal(0, attempts);
+    }
+
+    [Fact]
+    public async Task IncrementFailedAttemptsAsync_IncrementsFromZero()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((byte[]?)null);
+
+        // Act
+        var attempts = await _store.IncrementFailedAttemptsAsync(userId);
+
+        // Assert
+        Assert.Equal(1, attempts);
+        _cacheMock.Verify(c => c.SetAsync(
+            It.Is<string>(k => k.Contains(userId.ToString())),
+            It.IsAny<byte[]>(),
+            It.IsAny<DistributedCacheEntryOptions>(),
+            default), Times.Once);
+    }
+
+    [Fact]
+    public async Task IncrementFailedAttemptsAsync_IncrementsExistingCount()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var existingState = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            FailedAttempts = 2,
+            LastAttemptAt = DateTime.UtcNow
+        });
+        var existingBytes = System.Text.Encoding.UTF8.GetBytes(existingState);
+        
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(existingBytes);
+
+        // Act
+        var attempts = await _store.IncrementFailedAttemptsAsync(userId);
+
+        // Assert
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public async Task ResetFailedAttemptsAsync_RemovesKey()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        // Act
+        await _store.ResetFailedAttemptsAsync(userId);
+
+        // Assert
+        _cacheMock.Verify(c => c.RemoveAsync(
+            It.Is<string>(k => k.Contains(userId.ToString())),
+            default), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsLockedOutAsync_ReturnsFalse_WhenNotLocked()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((byte[]?)null);
+
+        // Act
+        var isLocked = await _store.IsLockedOutAsync(userId);
+
+        // Assert
+        Assert.False(isLocked);
+    }
+
+    [Fact]
+    public async Task IsLockedOutAsync_ReturnsFalse_WhenLockoutExpired()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var expiredState = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            FailedAttempts = 5,
+            LockedUntil = DateTime.UtcNow.AddMinutes(-10) // Expired 10 minutes ago
+        });
+        var expiredBytes = System.Text.Encoding.UTF8.GetBytes(expiredState);
+        
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(expiredBytes);
+
+        // Act
+        var isLocked = await _store.IsLockedOutAsync(userId);
+
+        // Assert
+        Assert.False(isLocked);
+    }
+
+    [Fact]
+    public async Task IsLockedOutAsync_ReturnsTrue_WhenLockedAndNotExpired()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var activeState = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            FailedAttempts = 5,
+            LockedUntil = DateTime.UtcNow.AddMinutes(15) // Expires in 15 minutes
+        });
+        var activeBytes = System.Text.Encoding.UTF8.GetBytes(activeState);
+        
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(activeBytes);
+
+        // Act
+        var isLocked = await _store.IsLockedOutAsync(userId);
+
+        // Assert
+        Assert.True(isLocked);
+    }
+
+    [Fact]
+    public async Task SetLockoutAsync_StoresExpiryTimestamp()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var expiresAt = DateTime.UtcNow.AddMinutes(30);
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((byte[]?)null);
+
+        // Act
+        await _store.SetLockoutAsync(userId, expiresAt);
+
+        // Assert
+        _cacheMock.Verify(c => c.SetAsync(
+            It.Is<string>(k => k.Contains(userId.ToString())),
+            It.IsAny<byte[]>(),
+            It.IsAny<DistributedCacheEntryOptions>(),
+            default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetLockoutExpiryAsync_ReturnsNull_WhenNoState()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((byte[]?)null);
+
+        // Act
+        var expiry = await _store.GetLockoutExpiryAsync(userId);
+
+        // Assert
+        Assert.Null(expiry);
+    }
+
+    [Fact]
+    public async Task GetLockoutExpiryAsync_ReturnsTimestamp_WhenLocked()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var expectedExpiry = DateTime.UtcNow.AddMinutes(15);
+        var state = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            FailedAttempts = 5,
+            LockedUntil = expectedExpiry
+        });
+        var stateBytes = System.Text.Encoding.UTF8.GetBytes(state);
+        
+        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(stateBytes);
+
+        // Act
+        var expiry = await _store.GetLockoutExpiryAsync(userId);
+
+        // Assert
+        Assert.NotNull(expiry);
+        Assert.True(Math.Abs((expiry.Value - expectedExpiry).TotalSeconds) < 1);
+    }
+}

--- a/backend/tests/TerraFusion.Tests.Unit/Security/PasswordHistory/SqlPasswordHistoryStoreTests.cs
+++ b/backend/tests/TerraFusion.Tests.Unit/Security/PasswordHistory/SqlPasswordHistoryStoreTests.cs
@@ -1,0 +1,285 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using TerraFusion.Core.Entities;
+using TerraFusion.Core.Security.PasswordHistory;
+using TerraFusion.Data;
+using TerraFusion.Data.Security;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Tests.Unit.Security.PasswordHistory;
+
+/// <summary>
+/// Phase 4 Sprint 1: SQL password history store tests (TDD - tests first)
+/// Tests password history persistence and retrieval using in-memory SQLite
+/// </summary>
+public class SqlPasswordHistoryStoreTests : IAsyncLifetime
+{
+    private TerraFusionDbContext _context = null!;
+    private SqlPasswordHistoryStore _store = null!;
+    
+    // Seeded test users (deterministic GUIDs for reproducibility)
+    private static readonly Guid TestUserId1 = new Guid("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TestUserId2 = new Guid("22222222-2222-2222-2222-222222222222");
+
+    public async Task InitializeAsync()
+    {
+        // Use in-memory SQLite for tests
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        // Mock IConfiguration (required by TerraFusionDbContext constructor)
+        var configMock = new Mock<IConfiguration>();
+        
+        _context = new TerraFusionDbContext(options, configMock.Object);
+        await _context.Database.OpenConnectionAsync();
+        await _context.Database.EnsureCreatedAsync();
+
+        // Seed test users (satisfies FK constraint)
+        var testUser1 = new GovernmentUser
+        {
+            Id = TestUserId1,
+            Email = "testuser1@phase4.terrafusion.local",
+            FirstName = "Test",
+            LastName = "User1",
+            Role = "Administrator",
+            Department = "Security",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            LastLoginAt = DateTime.UtcNow
+        };
+        
+        var testUser2 = new GovernmentUser
+        {
+            Id = TestUserId2,
+            Email = "testuser2@phase4.terrafusion.local",
+            FirstName = "Test",
+            LastName = "User2",
+            Role = "User",
+            Department = "Security",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            LastLoginAt = DateTime.UtcNow
+        };
+        
+        _context.GovernmentUsers.Add(testUser1);
+        _context.GovernmentUsers.Add(testUser2);
+        await _context.SaveChangesAsync();
+
+        _store = new SqlPasswordHistoryStore(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.Database.CloseConnectionAsync();
+        await _context.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AddPasswordHashAsync_StoresHash()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        var passwordHash = "hashed_password_1";
+
+        // Act
+        await _store.AddPasswordHashAsync(userId, passwordHash);
+
+        // Assert
+        var history = await _context.PasswordHistories
+            .Where(ph => ph.UserId == userId)
+            .ToListAsync();
+        
+        Assert.Single(history);
+        Assert.Equal(passwordHash, history[0].PasswordHash);
+    }
+
+    [Fact]
+    public async Task GetRecentPasswordHashesAsync_ReturnsEmpty_WhenNoHistory()
+    {
+        // Arrange
+        var userId = TestUserId2;
+
+        // Act
+        var hashes = await _store.GetRecentPasswordHashesAsync(userId, 5);
+
+        // Assert
+        Assert.Empty(hashes);
+    }
+
+    [Fact]
+    public async Task GetRecentPasswordHashesAsync_ReturnsLast5_WhenMoreExist()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        
+        // Add 7 password hashes with delays to ensure CreatedAt differs
+        for (int i = 1; i <= 7; i++)
+        {
+            await _store.AddPasswordHashAsync(userId, $"hash_{i}");
+            await Task.Delay(10); // Ensure CreatedAt differs
+        }
+
+        // Act
+        var hashes = await _store.GetRecentPasswordHashesAsync(userId, 5);
+
+        // Assert
+        Assert.Equal(5, hashes.Count);
+        Assert.Equal("hash_7", hashes[0]); // Most recent first
+        Assert.Equal("hash_6", hashes[1]);
+        Assert.Equal("hash_5", hashes[2]);
+        Assert.Equal("hash_4", hashes[3]);
+        Assert.Equal("hash_3", hashes[4]);
+    }
+
+    [Fact]
+    public async Task GetRecentPasswordHashesAsync_ReturnsInReverseChronologicalOrder()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        
+        // Add 3 password hashes
+        await _store.AddPasswordHashAsync(userId, "oldest");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "middle");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "newest");
+
+        // Act
+        var hashes = await _store.GetRecentPasswordHashesAsync(userId, 5);
+
+        // Assert
+        Assert.Equal(3, hashes.Count);
+        Assert.Equal("newest", hashes[0]);
+        Assert.Equal("middle", hashes[1]);
+        Assert.Equal("oldest", hashes[2]);
+    }
+
+    [Fact]
+    public async Task IsHashInHistoryAsync_ReturnsFalse_WhenHashNotFound()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        await _store.AddPasswordHashAsync(userId, "existing_hash");
+
+        // Act
+        var exists = await _store.IsHashInHistoryAsync(userId, "different_hash");
+
+        // Assert
+        Assert.False(exists);
+    }
+
+    [Fact]
+    public async Task IsHashInHistoryAsync_ReturnsTrue_WhenHashExists()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        var existingHash = "existing_hash";
+        
+        await _store.AddPasswordHashAsync(userId, existingHash);
+
+        // Act
+        var exists = await _store.IsHashInHistoryAsync(userId, existingHash);
+
+        // Assert
+        Assert.True(exists);
+    }
+
+    [Fact]
+    public async Task IsHashInHistoryAsync_OnlyChecksLast5()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        
+        // Add 6 hashes
+        await _store.AddPasswordHashAsync(userId, "hash_1_oldest");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "hash_2");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "hash_3");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "hash_4");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "hash_5");
+        await Task.Delay(10);
+        await _store.AddPasswordHashAsync(userId, "hash_6_newest");
+
+        // Act - hash_1 should NOT be found (beyond last 5)
+        var oldestExists = await _store.IsHashInHistoryAsync(userId, "hash_1_oldest");
+        var recentExists = await _store.IsHashInHistoryAsync(userId, "hash_6_newest");
+
+        // Assert
+        Assert.False(oldestExists); // Beyond last 5
+        Assert.True(recentExists);  // Within last 5
+    }
+
+    [Fact]
+    public async Task PruneOldHistoryAsync_DeletesOldEntries()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        
+        // Add old entry (91 days ago) by directly inserting with past CreatedAt
+        var oldEntry = new Core.Entities.PasswordHistory
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PasswordHash = "old_hash",
+            CreatedAt = DateTime.UtcNow.AddDays(-91)
+        };
+        _context.PasswordHistories.Add(oldEntry);
+        await _context.SaveChangesAsync();
+        
+        // Add recent entry (10 days ago)
+        var recentEntry = new Core.Entities.PasswordHistory
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PasswordHash = "recent_hash",
+            CreatedAt = DateTime.UtcNow.AddDays(-10)
+        };
+        _context.PasswordHistories.Add(recentEntry);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _store.PruneOldHistoryAsync(90);
+
+        // Assert
+        var remaining = await _context.PasswordHistories
+            .Where(ph => ph.UserId == userId)
+            .ToListAsync();
+        
+        Assert.Single(remaining);
+        Assert.Equal("recent_hash", remaining[0].PasswordHash);
+    }
+
+    [Fact]
+    public async Task PruneOldHistoryAsync_DefaultsTo90Days()
+    {
+        // Arrange
+        var userId = TestUserId1;
+        
+        // Add entry 100 days ago
+        var oldEntry = new Core.Entities.PasswordHistory
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            PasswordHash = "very_old_hash",
+            CreatedAt = DateTime.UtcNow.AddDays(-100)
+        };
+        _context.PasswordHistories.Add(oldEntry);
+        await _context.SaveChangesAsync();
+
+        // Act (no parameter = default 90 days)
+        await _store.PruneOldHistoryAsync();
+
+        // Assert
+        var remaining = await _context.PasswordHistories
+            .Where(ph => ph.UserId == userId)
+            .ToListAsync();
+        
+        Assert.Empty(remaining); // Entry older than 90 days should be deleted
+    }
+}


### PR DESCRIPTION
## Summary
Cherry-picks 4 TDD commits from `fervent-spence` implementing persistent FISMA security controls:

- **Redis-backed lockout store** — replaces in-memory `ConcurrentDictionary` stub with `IDistributedCache`-backed persistent lockout tracking (2h TTL, JSON-serialized state)
- **SQL-backed password history store** — replaces in-memory stub with EF Core `PasswordHistory` entity (last 5 hashes, 90-day retention)
- **Contracts + EF migration** — `ILockoutStore`, `IPasswordHistoryStore` interfaces, `PasswordHistory` entity, `FeatureFlagsOptions`
- **DI wiring + feature flags** — all flags default `false`, zero runtime behavior change until explicitly enabled

## Files Changed
- 8 new files (interfaces, implementations, tests, config class)
- 6 modified files (Program.cs, appsettings, DbContext, migration snapshot)
- +876 lines total

## Risk
**Low.** Feature flags default `false` — stores are registered in DI but never invoked until flags are enabled. Existing in-memory stubs in `TerraFusion.Security` remain untouched. New `Guid userId` interfaces coexist with existing `string userId` interfaces.

## Test Plan
- [x] `git merge-tree --write-tree` exit code 0 (zero conflicts)
- [x] Pre-push quality gates passed (unit tests, security scan, build)
- [ ] `dotnet build TerraFusion.sln` on CI
- [ ] `dotnet test` on CI
- [ ] Verify migration applies cleanly in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Introduce persistent, feature-flagged infrastructure for FISMA/NIST-aligned account lockout and password history without changing current runtime behavior.

New Features:
- Add Redis-backed lockout store implementing a new ILockoutStore interface for distributed tracking of account lockout state.
- Add SQL-backed password history store implementing a new IPasswordHistoryStore interface to persist recent password hashes per user.
- Introduce a PasswordHistory entity and DbSet with corresponding EF Core model configuration for storing per-user password history.
- Add configurable feature flags (UseAccountLockout, UsePasswordHistory, UseCommonPasswordCheck, EnforceFipsCompliance) to control activation of new security behaviors.

Enhancements:
- Register new lockout and password history stores in dependency injection while keeping them gated behind feature flags.
- Extend the data model snapshot and DbContext to include password history relationships to GovernmentUser.

Tests:
- Add unit test suite for the Redis lockout store covering lockout state lifecycle in the distributed cache.
- Add unit test suite for the SQL password history store covering persistence, retrieval, reuse checks, and retention pruning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure for account lockout and password history validation to support enhanced security controls.
  * Introduced feature flags to progressively enable NIST 800-63B hardening behaviors (currently disabled).

* **Tests**
  * Added comprehensive unit tests for lockout state management and password history tracking.

* **Chores**
  * Updated configuration settings to support new security feature toggles across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->