### PR TITLE
chore: update stale Last Updated dates (Aug/Oct 2025 -> Feb 2026)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -368,5 +368,5 @@ docker ps                             # ✅ Container status
 - **System Operations**: Full development environment control
 
 **Status**: Production Development Configuration  
-**Last Updated**: August 27, 2025  
+**Last Updated**: February 24, 2026  
 **Authority**: TerraFusion Development Operations Division  

--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -438,5 +438,5 @@ lsof -i :5000                         # Port usage analysis
 ---
 
 **Classification**: Development Environment Configuration  
-**Last Updated**: August 27, 2025  
+**Last Updated**: February 24, 2026  
 **Version**: TerraFusion OS 1.0 Development Configuration  

--- a/.claude/index.md
+++ b/.claude/index.md
@@ -280,6 +280,6 @@ sudo systemctl status nginx  # ✅ Service status checking
 
 ---
 
-**Last Updated**: August 27, 2025  
+**Last Updated**: February 24, 2026  
 **Version**: TerraFusion OS 1.0 Development Configuration  
 **Authority**: TerraFusion Development Operations Division  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,7 +488,7 @@ npm run ai-agent-briefing
 
 ---
 
-**Last Updated**: October 2025
+**Last Updated**: February 2026
 **Version**: TerraFusion OS 1.0
 **Classification**: Government Operating System Platform
 **Compliance**: FISMA-HIGH, NIST 800-53, WCAG 2.1 AA


### PR DESCRIPTION
Four files still showed August 2025 or October 2025 dates. Updated to February 2026.

### Files changed
- CLAUDE.md (Oct 2025 -> Feb 2026)
- .claude/README.md (Aug 2025 -> Feb 2026)
- .claude/claude.md (Aug 2025 -> Feb 2026)
- .claude/index.md (Aug 2025 -> Feb 2026)

Docs-only change. No code modified.

## Summary by Sourcery

Documentation:
- Refresh "Last Updated" dates in Claude-related documentation files from 2025 to February 2026 to reflect current information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation metadata timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->