### PR TITLE
chore(dx): add lane check to pre-commit hook (Gate 0: worktree guard)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,16 @@
 
 echo "🔒 TERRAFUSION OS: Pre-commit Quality Gate"
 
+# Gate 0: Lane check — refuse commits from wrong worktree
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+EXPECTED="$(cd "$(dirname -- "$0")/.." && pwd -P)"
+if [ -n "$TOPLEVEL" ] && [ "$TOPLEVEL" != "$EXPECTED" ]; then
+  echo "❌ Lane violation: committing from wrong worktree."
+  echo "   git toplevel: $TOPLEVEL"
+  echo "   expected:     $EXPECTED"
+  exit 1
+fi
+
 # Gate 1: UI Token Contract (Lumin design system — scoped Gen2 + ratchet)
 if command -v pnpm >/dev/null 2>&1; then
   echo "🎨 Running UI token contract audit (scoped + ratchet)..."


### PR DESCRIPTION
Adds a worktree lane check as Gate 0 in the Husky pre-commit hook. Refuses commits if git toplevel doesn't match the expected repo root — prevents accidental cross-worktree commits when Claude Code worktrees are active.

Also updated local VS Code settings (gitignored, not in this PR):
- formatOnSave: false (prevent reformatting Claude's files)
- codeActionsOnSave: never (prevent auto-fix/organize-imports)
- git.autofetch: false, git.confirmSync: true

One file changed: .husky/pre-commit (10 lines added).

## Summary by Sourcery

Chores:
- Introduce a pre-commit worktree lane check that blocks commits when the Git toplevel differs from the expected repository root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the commit validation process with a check to ensure commits originate from the intended repository location, reducing the risk of accidentally committing from incorrect paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->