### PR TITLE
feat(ui-tokens): add HS anchor foundation + harden anchor test

### DIFF
--- a/.github/workflows/ui-governance.yml
+++ b/.github/workflows/ui-governance.yml
@@ -10,6 +10,8 @@ on:
       - 'tools/tdc/src/contracts/**'
       - 'tools/tdc/src/commands/ui.ts'
       - 'tools/registry/ratchet_guard.mjs'
+      - 'tests/governance/**'
+      - 'package.json'
       - 'configs/eslint/**'
       - 'tdc.config.json'
       - 'ui-token-baseline.json'
@@ -24,6 +26,8 @@ on:
       - 'tools/tdc/src/contracts/**'
       - 'tools/tdc/src/commands/ui.ts'
       - 'tools/registry/ratchet_guard.mjs'
+      - 'tests/governance/**'
+      - 'package.json'
       - 'configs/eslint/**'
       - 'tdc.config.json'
       - 'ui-token-baseline.json'
@@ -61,6 +65,9 @@ jobs:
       - name: UI Token Contract (Gen2 scope + ratchet)
         run: pnpm tdc:ui:tokens
 
+      - name: UI Governance Tripwires
+        run: pnpm -w run test:governance:ui
+
       - name: Strict ratchet guard (Gen2 scope)
         if: github.event_name == 'pull_request'
         run: node tools/registry/ratchet_guard.mjs --minDelta 1 --baseRef "origin/${{ github.base_ref }}"
@@ -74,12 +81,21 @@ jobs:
             echo "ui-token-baseline.json changed in this PR."
             HASH_BEFORE=$(git show origin/${{ github.base_ref }}:ui-token-baseline.json 2>/dev/null | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{console.log(JSON.parse(d).scopeHash||"")}catch{console.log("")}})' || echo "")
             HASH_AFTER=$(node -e 'try{console.log(JSON.parse(require("fs").readFileSync("ui-token-baseline.json","utf8")).scopeHash||"")}catch{console.log("")}')
+            COUNT_BEFORE=$(git show origin/${{ github.base_ref }}:ui-token-baseline.json 2>/dev/null | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const j=JSON.parse(d);console.log(Number.isFinite(j.violationCount)?j.violationCount:"")}catch{console.log("")}})' || echo "")
+            COUNT_AFTER=$(node -e 'try{const j=JSON.parse(require("fs").readFileSync("ui-token-baseline.json","utf8"));console.log(Number.isFinite(j.violationCount)?j.violationCount:"")}catch{console.log("")}')
             if [ -n "$HASH_BEFORE" ] && [ "$HASH_BEFORE" = "$HASH_AFTER" ]; then
-              echo "::error::Baseline changed without scopeHash change — likely ratchet bypass."
-              echo "If intentional, update scope in tdc.config.json or explain in PR."
-              exit 1
+              if [ "$COUNT_BEFORE" = "0" ] && [ -n "$COUNT_AFTER" ] && [ "$COUNT_AFTER" -gt 0 ]; then
+                echo "Bootstrap baseline repair detected (0 -> $COUNT_AFTER) with unchanged scopeHash; allowing one-time fix."
+              else
+                echo "::error::Baseline changed without scopeHash change — likely ratchet bypass."
+                echo "If intentional, update scope in tdc.config.json or explain in PR."
+                exit 1
+              fi
+            elif [ -n "$HASH_BEFORE" ] && [ -n "$HASH_AFTER" ]; then
+              echo "✅ Baseline changed with scopeHash change (expected rebaseline)."
+            else
+              echo "⚠️ Could not validate baseline scopeHash transition; check baseline JSON schema."
             fi
-            echo "✅ Baseline changed with scopeHash change (expected rebaseline)."
           else
             echo "Baseline unchanged."
           fi

--- a/frontend/apps/os-shell/src/styles/terrafusion-tokens.css
+++ b/frontend/apps/os-shell/src/styles/terrafusion-tokens.css
@@ -108,6 +108,35 @@
   /* HS Channel Anchor (file-local, pure-black for ambient shadows) */
   --tf-tokens-black-hs: 0 0%;
 
+  /* HS anchor foundation for tokenized color migration (additive only). */
+  --tf-hs-neutral: 220 12%;
+  --tf-hs-primary: 215 90%;
+  --tf-hs-success: 145 55%;
+  --tf-hs-warning: 38 92%;
+  --tf-hs-danger: 0 84%;
+  --tf-hs-info: 200 85%;
+  --tf-hs-accent: 285 70%;
+  --tf-hs-muted: 220 10%;
+  --tf-hs-surface: 220 14%;
+  --tf-hs-border: 220 12%;
+  --tf-hs-overlay: 220 16%;
+
+  --tf-l-0: 0%;
+  --tf-l-5: 5%;
+  --tf-l-10: 10%;
+  --tf-l-15: 15%;
+  --tf-l-20: 20%;
+  --tf-l-25: 25%;
+  --tf-l-30: 30%;
+  --tf-l-40: 40%;
+  --tf-l-50: 50%;
+  --tf-l-60: 60%;
+  --tf-l-70: 70%;
+  --tf-l-80: 80%;
+  --tf-l-90: 90%;
+  --tf-l-95: 95%;
+  --tf-l-98: 98%;
+
   /* ═══ ELEVATION & SHADOWS ═══ */
   --shadow-sm: 0 1px 2px hsl(var(--tf-tokens-black-hs) 0% / 0.05);
   --shadow-md: 0 4px 6px hsl(var(--tf-tokens-black-hs) 0% / 0.1);

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "type-check": "tsc -p tsconfig.core.json",
     "typecheck:core": "tsc -p tsconfig.core.json",
     "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs",
+    "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts",
     "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",
     "canon": "node tools/canon/canon.mjs",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "type-check": "tsc -p tsconfig.core.json",
     "typecheck:core": "tsc -p tsconfig.core.json",
     "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs",
-    "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts",
+    "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts tests/governance/tfHsAnchorsDefined.contract.test.ts",
     "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",
     "canon": "node tools/canon/canon.mjs",

--- a/tests/governance/noNewRawColors.contract.test.ts
+++ b/tests/governance/noNewRawColors.contract.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const UI_SCOPE_DIR = path.join(ROOT_DIR, 'frontend', 'apps', 'os-shell');
+const BASELINE_RGBA_RGB = 1335;
+const BASELINE_HEX = 798;
+
+const INCLUDED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.css', '.scss', '.html']);
+const EXCLUDED_DIRECTORIES = new Set(['node_modules', 'dist', '__tests__', '__mocks__', 'ARCHIVE', 'QUARANTINE']);
+
+function collectScopedFiles(dir: string): string[] {
+  const files: string[] = [];
+  if (!fs.existsSync(dir)) return files;
+
+  const walk = (currentDir: string) => {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRECTORIES.has(entry.name)) continue;
+        walk(entryPath);
+      } else if (entry.isFile() && INCLUDED_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(entryPath);
+      }
+    }
+  };
+
+  walk(dir);
+  return files;
+}
+
+function stripComments(input: string): string {
+  let output = input.replace(/\/\*[\s\S]*?\*\//g, '');
+  output = output.replace(/(^|[^:])\/\/.*$/gm, '$1');
+  return output;
+}
+
+function countRawColors(sourceText: string) {
+  const sanitized = stripComments(sourceText);
+  const rgbaRgbCount =
+    (sanitized.match(/\brgba\s*\(/gi) ?? []).length +
+    (sanitized.match(/\brgb\s*\(/gi) ?? []).length;
+  const hexCount = (sanitized.match(/#[0-9a-fA-F]{3,8}\b/g) ?? []).length;
+
+  return { rgbaRgbCount, hexCount };
+}
+
+describe('Governance Contract: no new raw colors in UI scope', () => {
+  it('keeps raw color usage at or below baseline', () => {
+    const files = collectScopedFiles(UI_SCOPE_DIR);
+    expect(files.length, `Expected UI scope at ${UI_SCOPE_DIR} to contain source files.`).toBeGreaterThan(0);
+
+    let rgbaRgbCount = 0;
+    let hexCount = 0;
+
+    for (const file of files) {
+      const sourceText = fs.readFileSync(file, 'utf-8');
+      const counts = countRawColors(sourceText);
+      rgbaRgbCount += counts.rgbaRgbCount;
+      hexCount += counts.hexCount;
+    }
+
+    expect(
+      rgbaRgbCount,
+      `rgba/rgb raw colors increased above baseline (${BASELINE_RGBA_RGB}); current=${rgbaRgbCount}`
+    ).toBeLessThanOrEqual(BASELINE_RGBA_RGB);
+    expect(hexCount, `hex raw colors increased above baseline (${BASELINE_HEX}); current=${hexCount}`).toBeLessThanOrEqual(
+      BASELINE_HEX
+    );
+  });
+});

--- a/tests/governance/ratchetGuardScope.contract.test.ts
+++ b/tests/governance/ratchetGuardScope.contract.test.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const RATCHET_GUARD_PATH = path.join(ROOT_DIR, 'tools', 'registry', 'ratchet_guard.mjs');
+const TDC_CONFIG_PATH = path.join(ROOT_DIR, 'tdc.config.json');
+const REQUIRED_SCOPE = 'frontend/apps/os-shell/**';
+
+describe('Governance Contract: ratchet scope alignment', () => {
+  it('ratchet guard default scope includes frontend/apps/os-shell', () => {
+    const content = fs.readFileSync(RATCHET_GUARD_PATH, 'utf-8');
+    expect(content).toContain(REQUIRED_SCOPE);
+  });
+
+  it('tdc UI token scope includes frontend/apps/os-shell', () => {
+    const config = JSON.parse(fs.readFileSync(TDC_CONFIG_PATH, 'utf-8'));
+    const includeScope = config?.ui?.tokens?.include;
+
+    expect(Array.isArray(includeScope)).toBe(true);
+    expect(includeScope).toContain(REQUIRED_SCOPE);
+  });
+});

--- a/tests/governance/tfHsAnchorsDefined.contract.test.ts
+++ b/tests/governance/tfHsAnchorsDefined.contract.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const TOKENS_PATH = path.join(ROOT_DIR, 'frontend', 'apps', 'os-shell', 'src', 'styles', 'terrafusion-tokens.css');
+
+const REQUIRED_HS_ANCHORS = [
+  '--tf-hs-neutral:',
+  '--tf-hs-primary:',
+  '--tf-hs-success:',
+  '--tf-hs-warning:',
+  '--tf-hs-danger:',
+  '--tf-hs-info:',
+  '--tf-hs-accent:',
+  '--tf-hs-muted:',
+  '--tf-hs-surface:',
+  '--tf-hs-border:',
+  '--tf-hs-overlay:',
+];
+
+const REQUIRED_LIGHTNESS_STEPS = [
+  '--tf-l-0:',
+  '--tf-l-5:',
+  '--tf-l-10:',
+  '--tf-l-15:',
+  '--tf-l-20:',
+  '--tf-l-25:',
+  '--tf-l-30:',
+  '--tf-l-40:',
+  '--tf-l-50:',
+  '--tf-l-60:',
+  '--tf-l-70:',
+  '--tf-l-80:',
+  '--tf-l-90:',
+  '--tf-l-95:',
+  '--tf-l-98:',
+];
+
+describe('Governance Contract: HS anchor foundation', () => {
+  it('tokens file must exist', () => {
+    expect(fs.existsSync(TOKENS_PATH), `Missing tokens file at ${TOKENS_PATH}`).toBe(true);
+  });
+
+  it('must include required HS anchor tokens', () => {
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
+    const missing = REQUIRED_HS_ANCHORS.filter((anchor) => !css.includes(anchor));
+    expect(missing, `Missing HS anchors: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('must include required lightness steps', () => {
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
+    const missing = REQUIRED_LIGHTNESS_STEPS.filter((step) => !css.includes(step));
+    expect(missing, `Missing lightness steps: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/tests/governance/uiTokenBaseline.contract.test.ts
+++ b/tests/governance/uiTokenBaseline.contract.test.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const BASELINE_PATH = path.join(ROOT_DIR, 'ui-token-baseline.json');
+
+describe('Governance Contract: UI token baseline schema', () => {
+  it('ui-token-baseline.json exists and contains a valid Gen2 ratchet payload', () => {
+    expect(fs.existsSync(BASELINE_PATH), `Missing baseline file at ${BASELINE_PATH}`).toBe(true);
+
+    const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf-8'));
+
+    expect(baseline.contract).toBe('ui-token-baseline.json');
+    expect(baseline.version).toBe('v1');
+    expect(typeof baseline.scopeHash).toBe('string');
+    expect(baseline.scopeHash.length).toBeGreaterThan(0);
+    expect(typeof baseline.violationCount).toBe('number');
+    expect(Number.isFinite(baseline.violationCount)).toBe(true);
+    expect(baseline.violationCount).toBeGreaterThan(0);
+  });
+});

--- a/tools/registry/ratchet_guard.mjs
+++ b/tools/registry/ratchet_guard.mjs
@@ -19,13 +19,20 @@
  * Environment:
  *   RATCHET_BASE_REF      - base ref (default: origin/main, or GITHUB_BASE_REF)
  *   RATCHET_MIN_DELTA     - minimum improvement required (default: 1)
- *   RATCHET_SCOPE         - comma-separated scope patterns (default: apps/os-shell/**,packages/ui/**)
+ *   RATCHET_SCOPE         - comma-separated scope patterns
+ *                          (default: frontend/apps/os-shell/**,apps/os-shell/**,packages/ui/**)
  *   RATCHET_BASELINE_FILE - baseline JSON file path (default: ui-token-baseline.json)
  *   DEBUG_RATCHET_GUARD   - set to "1" for verbose output
  */
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+
+const DEFAULT_SCOPE = [
+  "frontend/apps/os-shell/**",
+  "apps/os-shell/**",
+  "packages/ui/**",
+];
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -40,7 +47,10 @@ function parseArgs(argv) {
   const out = {
     baseRef: process.env.RATCHET_BASE_REF || process.env.GITHUB_BASE_REF || "origin/main",
     minDelta: Number(process.env.RATCHET_MIN_DELTA || "1"),
-    scope: (process.env.RATCHET_SCOPE || "apps/os-shell/**,packages/ui/**").split(",").map(s => s.trim()).filter(Boolean),
+    scope: (process.env.RATCHET_SCOPE || DEFAULT_SCOPE.join(","))
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
     baselineFile: process.env.RATCHET_BASELINE_FILE || "ui-token-baseline.json",
     debug: process.env.DEBUG_RATCHET_GUARD === "1",
   };


### PR DESCRIPTION
## Summary
- add 11 HS anchors and 15 lightness tokens to `frontend/apps/os-shell/src/styles/terrafusion-tokens.css` (additive only)
- add governance contract `tests/governance/tfHsAnchorsDefined.contract.test.ts`
  - asserts token file exists before read
  - asserts required HS anchors exist
  - asserts required lightness steps exist
- include anchor contract in `test:governance:ui`

## Validation
- `pnpm -w run test:governance:ui`
- `pnpm tdc:ui:tokens`
- `pnpm -w run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

## Notes
- stacked on top of `fix/ui-governance-b1a1` (PR #407)
- no token sweep/replacements in this PR

## Summary by Sourcery

Introduce HS anchor and lightness tokens for UI color governance and enforce their presence via a new governance contract test.

New Features:
- Add HS anchor and lightness CSS custom properties to the terrafusion token stylesheet for future color tokenization.
- Add a governance contract test to verify required HS anchors and lightness steps exist in the token file and that the file is present.

Tests:
- Include the new HS anchor governance contract in the ui governance test suite command.