### PR TITLE
feat(ui-tokens): harden HS anchor governance test on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "type-check": "tsc -p tsconfig.core.json",
     "typecheck:core": "tsc -p tsconfig.core.json",
     "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs",
-    "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts",
+    "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts tests/governance/tfHsAnchorsDefined.contract.test.ts",
     "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",
     "canon": "node tools/canon/canon.mjs",

--- a/tests/governance/tfHsAnchorsDefined.contract.test.ts
+++ b/tests/governance/tfHsAnchorsDefined.contract.test.ts
@@ -3,24 +3,20 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const ROOT_DIR = path.resolve(__dirname, '../..');
-const TOKENS_PATH = path.join(
-  ROOT_DIR,
-  'frontend/apps/os-shell/src/styles/terrafusion-tokens.css'
-);
+const TOKENS_PATH = path.join(ROOT_DIR, 'frontend/apps/os-shell/src/styles/terrafusion-tokens.css');
 
 /**
  * Governance contract: HS anchors must be centrally defined in terrafusion-tokens.css.
  * Without these anchors, any component using hsl(var(--tf-*-hs) L% / alpha)
- * will render as transparent — an invisible-UI regression.
+ * will render as transparent.
  */
 describe('Governance: HS Anchors Defined', () => {
-  const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
-
   it('tokens file must exist', () => {
     expect(fs.existsSync(TOKENS_PATH), `Missing: ${TOKENS_PATH}`).toBe(true);
   });
 
   it('must include all required --tf-*-hs semantic anchors', () => {
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
     const required = [
       '--tf-bg-surface-hs:',
       '--tf-surface-dark-hs:',
@@ -37,13 +33,11 @@ describe('Governance: HS Anchors Defined', () => {
     ];
 
     const missing = required.filter((anchor) => !css.includes(anchor));
-    expect(
-      missing,
-      `Missing HS anchors in terrafusion-tokens.css:\n  ${missing.join('\n  ')}`
-    ).toEqual([]);
+    expect(missing, `Missing HS anchors in terrafusion-tokens.css:\n  ${missing.join('\n  ')}`).toEqual([]);
   });
 
   it('must define lightness step variables (--tf-l-*)', () => {
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
     const requiredSteps = [
       '--tf-l-0:',
       '--tf-l-10:',
@@ -54,36 +48,32 @@ describe('Governance: HS Anchors Defined', () => {
     ];
 
     const missing = requiredSteps.filter((step) => !css.includes(step));
-    expect(
-      missing,
-      `Missing lightness steps:\n  ${missing.join('\n  ')}`
-    ).toEqual([]);
+    expect(missing, `Missing lightness steps:\n  ${missing.join('\n  ')}`).toEqual([]);
   });
 
   it('must define at least one derived token referencing HS anchors', () => {
-    // Lumin Bridge tokens use the pattern: hsl(var(--tf-*) / alpha)
-    // HS anchor consumers use: hsl(var(--tf-*-hs) L%)
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
     const hasLuminBridge = /hsl\(var\(--tf-[a-z-]+\)\s*\//.test(css);
     const hasHsConsumer = /hsl\(var\(--tf-[a-z-]+-hs\)/.test(css);
-    expect(
-      hasLuminBridge || hasHsConsumer,
-      'No derived tokens found that reference HS anchors or Lumin Bridge'
-    ).toBe(true);
+    expect(hasLuminBridge || hasHsConsumer).toBe(true);
   });
 
   it('HS anchor values must follow H S% format', () => {
+    const css = fs.readFileSync(TOKENS_PATH, 'utf-8');
     const hsPattern = /--tf-[a-z-]+-hs:\s*(\d+)\s+(\d+)%/g;
-    let match;
+    let match: RegExpExecArray | null;
     let count = 0;
+
     while ((match = hsPattern.exec(css)) !== null) {
       const hue = parseInt(match[1], 10);
-      const sat = parseInt(match[2], 10);
+      const saturation = parseInt(match[2], 10);
       expect(hue, `Hue out of range: ${match[0]}`).toBeGreaterThanOrEqual(0);
       expect(hue, `Hue out of range: ${match[0]}`).toBeLessThanOrEqual(360);
-      expect(sat, `Saturation out of range: ${match[0]}`).toBeGreaterThanOrEqual(0);
-      expect(sat, `Saturation out of range: ${match[0]}`).toBeLessThanOrEqual(100);
-      count++;
+      expect(saturation, `Saturation out of range: ${match[0]}`).toBeGreaterThanOrEqual(0);
+      expect(saturation, `Saturation out of range: ${match[0]}`).toBeLessThanOrEqual(100);
+      count += 1;
     }
+
     expect(count, 'No HS anchor declarations found').toBeGreaterThanOrEqual(5);
   });
 });


### PR DESCRIPTION
## Summary
- include `tfHsAnchorsDefined.contract.test.ts` in `test:governance:ui`
- harden anchor contract behavior by asserting tokens file existence before reading it
- keep HS anchor expectations aligned with current `main` token schema (`--tf-*-hs` set from PR #405)

## Validation
- `pnpm -w run test:governance:ui`
- `pnpm tdc:ui:tokens`
- `pnpm -w run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

## Notes
- rebased from stacked history after #407 merged
- PR #408 auto-closed when base branch was deleted; this PR replaces it

## Summary by Sourcery

Strengthen UI token governance around HS anchor definitions and ensure the corresponding contract test runs as part of the standard UI governance test suite.

Enhancements:
- Improve the HS anchor governance contract test to validate file existence and clarify HS anchor value expectations.

Tests:
- Include the HS anchor governance contract test in the `test:governance:ui` script so it runs with other UI governance checks.