### PR TITLE
fix(dx): normalize Gate 0 lane-check paths across Windows shells

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,12 +4,53 @@
 echo "🔒 TERRAFUSION OS: Pre-commit Quality Gate"
 
 # Gate 0: Lane check — refuse commits from wrong worktree
-TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-EXPECTED="$(cd "$(dirname -- "$0")/.." && pwd -P)"
-if [ -n "$TOPLEVEL" ] && [ "$TOPLEVEL" != "$EXPECTED" ]; then
+# Normalize path format so C:/... and /c/... compare equivalently on Windows shells.
+canon_path() {
+  _p="$1"
+
+  if command -v python >/dev/null 2>&1; then
+    python - "$_p" <<'PY'
+import os
+import sys
+
+p = sys.argv[1]
+if len(p) >= 3 and p[0] == "/" and p[1].isalpha() and p[2] == "/":
+    p = f"{p[1]}:{p[2:]}"
+print(os.path.normcase(os.path.abspath(p)))
+PY
+    return
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$_p" <<'PY'
+import os
+import sys
+
+p = sys.argv[1]
+if len(p) >= 3 and p[0] == "/" and p[1].isalpha() and p[2] == "/":
+    p = f"{p[1]}:{p[2:]}"
+print(os.path.normcase(os.path.abspath(p)))
+PY
+    return
+  fi
+
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$_p" 2>/dev/null || printf "%s\n" "$_p"
+    return
+  fi
+
+  printf "%s\n" "$_p"
+}
+
+TOPLEVEL_RAW="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+EXPECTED_RAW="$(cd "$(dirname -- "$0")/.." && pwd -P)"
+TOPLEVEL_CANON="$(canon_path "$TOPLEVEL_RAW")"
+EXPECTED_CANON="$(canon_path "$EXPECTED_RAW")"
+
+if [ -n "$TOPLEVEL_RAW" ] && [ "$TOPLEVEL_CANON" != "$EXPECTED_CANON" ]; then
   echo "❌ Lane violation: committing from wrong worktree."
-  echo "   git toplevel: $TOPLEVEL"
-  echo "   expected:     $EXPECTED"
+  echo "   git toplevel: $TOPLEVEL_RAW"
+  echo "   expected:     $EXPECTED_RAW"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- normalize Gate 0 lane-check path comparison in `.husky/pre-commit`
- compare canonicalized paths so `C:/...` and `/c/...` are treated as equivalent on Windows shells
- preserve existing lane guard behavior (still blocks true wrong-worktree commits)

## Validation
- reproduced prior mismatch: `git rev-parse --show-toplevel` -> `C:/...`, `pwd -P` -> `/c/...`
- verified canonical normalization resolves both to the same path
- verified commit now passes Gate 0 without `--no-verify`

## Context
- follow-up to B1a/B1b execution where pre-commit required temporary `--no-verify` due shell path-format mismatch

## Summary by Sourcery

Bug Fixes:
- Resolve false Gate 0 lane-check failures on Windows by canonicalizing and comparing equivalent path formats (e.g., `C:/...` vs `/c/...`) in the pre-commit hook.