### PR TITLE
fix(ci): align pnpm action pins with packageManager version

### DIFF
--- a/.github/workflows/autonomy-incident-triage.yml
+++ b/.github/workflows/autonomy-incident-triage.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         if: steps.changes.outputs.contract == 'true'
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.0.0
 
       - name: Setup Node
         if: steps.changes.outputs.contract == 'true'

--- a/.github/workflows/governance-proof.yml
+++ b/.github/workflows/governance-proof.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.governance == 'true'
         with:
-          version: 9
+          version: 9.0.0
 
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.governance == 'true'

--- a/.github/workflows/manifest-contract-guard.yml
+++ b/.github/workflows/manifest-contract-guard.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.0.0
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- fix post-merge governance-proof failure caused by pnpm version mismatch
- align all workflow pnpm/action-setup pins from 9 to 9.0.0 to match package.json packageManager: pnpm@9.0.0

## Files
- .github/workflows/governance-proof.yml
- .github/workflows/ci.yml
- .github/workflows/manifest-contract-guard.yml
- .github/workflows/autonomy-incident-triage.yml

## Why
pnpm/action-setup@v4 fails when both action pin and packageManager are set but not exactly equal. Using the exact semantic version removes ERR_PNPM_BAD_PM_VERSION risk.

## Summary by Sourcery

CI:
- Update all GitHub Actions workflows to pin pnpm/action-setup to version 9.0.0 instead of 9 to match the packageManager configuration and avoid ERR_PNPM_BAD_PM_VERSION.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration across multiple automation pipelines to use a specific pinned version of the pnpm package manager, ensuring consistent build environments and tooling across all automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->