### PR TITLE
fix(ci): pin governance-proof to Node 20

### DIFF
--- a/.github/workflows/governance-proof.yml
+++ b/.github/workflows/governance-proof.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.governance == 'true'
         with:
-          node-version-file: '.nvmrc'
+          node-version: '20'
           cache: pnpm
 
       - name: Install


### PR DESCRIPTION
## Summary
- fix governance-proof install failure caused by Node 18 from .nvmrc
- pin ctions/setup-node in governance-proof.yml to Node 20, matching current dependency engine requirements

## Error addressed
- ERR_PNPM_UNSUPPORTED_ENGINE
- minimatch@10.1.1 requires 20 || >=22

## Summary by Sourcery

CI:
- Update the governance-proof workflow to use Node.js 20 explicitly via actions/setup-node instead of reading the version from .nvmrc.