### PR TITLE
fix(tests): remove vitest imports from Jest-lane governance tests (Phase 1)

### DIFF
--- a/os-platform/core/tests/ab-testing-framework-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ab-testing-framework-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/accessibility-compliance-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/accessibility-compliance-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AccessibilityCompliance.test.tsx leak guard', () => {

--- a/os-platform/core/tests/accordion-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/accordion-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/action-stream-module-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/action-stream-module-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/advanced-codex-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/advanced-codex-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AdvancedCodexDashboard.tsx leak guard', () => {

--- a/os-platform/core/tests/advanced-design-system-css-leak-guard.test.ts
+++ b/os-platform/core/tests/advanced-design-system-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('advanced-design-system.css leak guard', () => {

--- a/os-platform/core/tests/advanced-monitoring-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/advanced-monitoring-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-agent-monitoring-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-agent-monitoring-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-agent-showcase-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-agent-showcase-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-analytics-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-analytics-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-assistant-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-assistant-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AIAssistantPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/ai-code-completion-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-code-completion-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-debugging-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-debugging-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-health-status-chip-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-health-status-chip-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-insights-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-insights-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AIInsightsPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/ai-marketplace-hero-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-marketplace-hero-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-orchestration-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-orchestration-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-superiority-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-superiority-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-superiority-launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-superiority-launcher-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-swarm-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-swarm-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-swarm-intelligence-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-swarm-intelligence-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-swarm-management-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-swarm-management-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/ai-workflow-automation-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/ai-workflow-automation-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/alert-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/alert-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/analytics-analytics-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/analytics-analytics-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/analytics-workbench-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/analytics-workbench-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/api-connection-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/api-connection-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/application-launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/application-launcher-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/aspect-ratio-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/aspect-ratio-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/assert-unique-keys.test.ts
+++ b/os-platform/core/tests/assert-unique-keys.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { assertUniqueKeys } from '../../../frontend/apps/os-shell/src/utils/assertUniqueKeys';
 
 describe('assertUniqueKeys', () => {

--- a/os-platform/core/tests/atlas-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/atlas-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/autonomous-operations-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/autonomous-operations-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/avatar-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/avatar-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('avatar.tsx leak guard', () => {

--- a/os-platform/core/tests/axiom-metric-card-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/axiom-metric-card-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AxiomMetricCard.tsx leak guard', () => {

--- a/os-platform/core/tests/axiomfs-window-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/axiomfs-window-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('AxiomFSWindow.tsx leak guard', () => {

--- a/os-platform/core/tests/badge-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/badge-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('badge.tsx leak guard', () => {

--- a/os-platform/core/tests/brand-kit-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/brand-kit-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/button-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/button-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/button-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/button-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/calendar-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/calendar-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/cama-core-index-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/cama-core-index-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('index.module.css (cama-core) leak guard', () => {

--- a/os-platform/core/tests/card-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/card-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/card-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/card-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/championship-deployment-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/championship-deployment-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/checkbox-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/checkbox-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/code-optimization-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/code-optimization-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/codex-admin-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/codex-admin-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/codex-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/codex-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/codex-email-notification-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/codex-email-notification-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/codex-mobile-widget-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/codex-mobile-widget-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/codex-trend-analysis-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/codex-trend-analysis-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/collaboration-provider-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/collaboration-provider-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/collaboration-sidebar-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/collaboration-sidebar-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/collaborative-editor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/collaborative-editor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/colors-stories-css-leak-guard.test.ts
+++ b/os-platform/core/tests/colors-stories-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('colors.stories.css leak guard', () => {

--- a/os-platform/core/tests/colors-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/colors-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('colors.ts leak guard', () => {

--- a/os-platform/core/tests/command-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/command-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/comment-thread-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/comment-thread-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/common-error-boundary-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/common-error-boundary-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/common-module-error-boundary-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/common-module-error-boundary-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/conflict-resolution-dialog-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/conflict-resolution-dialog-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/consciousness-engine-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/consciousness-engine-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('ConsciousnessEngine.tsx leak guard', () => {

--- a/os-platform/core/tests/consciousness-parameter-tuning-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/consciousness-parameter-tuning-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/container-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/container-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/core-module-launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/core-module-launcher-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/core-system-tray-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/core-system-tray-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/cost-forge-collaboration-tools-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/cost-forge-collaboration-tools-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/cost-forge-export-suite-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/cost-forge-export-suite-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/cost-forge-integration-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/cost-forge-integration-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/cost-forge-quantum-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/cost-forge-quantum-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/counties-hub-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/counties-hub-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/county-employee-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/county-employee-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/county-modules-card-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/county-modules-card-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/county-modules-card-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/county-modules-card-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/css-ambient-layer-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/css-ambient-layer-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/css-conditional-fix-js-leak-guard.test.ts
+++ b/os-platform/core/tests/css-conditional-fix-js-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/css-conditional-fix-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/css-conditional-fix-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/css-in-js-bridge-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/css-in-js-bridge-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('css-in-js-bridge.ts leak guard', () => {

--- a/os-platform/core/tests/cursor-presence-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/cursor-presence-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/dashboard-widgets-css-leak-guard.test.ts
+++ b/os-platform/core/tests/dashboard-widgets-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('DashboardWidgets.css leak guard', () => {

--- a/os-platform/core/tests/dashboard-widgets-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/dashboard-widgets-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/data-science-laboratory-css-leak-guard.test.ts
+++ b/os-platform/core/tests/data-science-laboratory-css-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';

--- a/os-platform/core/tests/database-status-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/database-status-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/desktop-shell-backup-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/desktop-shell-backup-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { assertNoRawColorLeaks } from "../../../tools/ui-tokens/leak-guard";

--- a/os-platform/core/tests/development-mode-indicator-css-leak-guard.test.ts
+++ b/os-platform/core/tests/development-mode-indicator-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('DevelopmentModeIndicator.css leak guard', () => {

--- a/os-platform/core/tests/development-mode-indicator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/development-mode-indicator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/dialog-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/dialog-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/divider-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/divider-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('divider.tsx leak guard', () => {

--- a/os-platform/core/tests/documentation-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/documentation-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/dropdown-menu-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/dropdown-menu-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-ai-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-ai-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-analytics-toolset-css-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-analytics-toolset-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-analytics-toolset-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-analytics-toolset-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-api-test-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-api-test-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-backend-connectivity-monitor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-backend-connectivity-monitor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-consciousness-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-consciousness-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-experimental-interface-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-experimental-interface-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-experimental-research-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-experimental-research-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('EliteExperimentalResearchInterface.tsx leak guard', () => {

--- a/os-platform/core/tests/elite-icons-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-icons-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-live-development-status-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-live-development-status-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-performance-analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-performance-analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-performance-indicator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-performance-indicator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-performance-verification-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-performance-verification-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-production-config-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-production-config-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('elite-production-config.ts leak guard', () => {

--- a/os-platform/core/tests/elite-progress-css-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-progress-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('EliteProgress.css leak guard', () => {

--- a/os-platform/core/tests/elite-progress-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-progress-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('EliteProgress.tsx leak guard', () => {

--- a/os-platform/core/tests/elite-quantum-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-quantum-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-success-celebration-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-success-celebration-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-system-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-system-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-system-status-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-system-status-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-system-validator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-system-validator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-todo-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-todo-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/elite-widget-performance-monitor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/elite-widget-performance-monitor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/emergency-mount-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/emergency-mount-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/emergency-terrafusion-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/emergency-terrafusion-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/enhanced-cost-calculator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/enhanced-cost-calculator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('EnhancedCostCalculator.tsx leak guard', () => {

--- a/os-platform/core/tests/enhanced-data-visualization-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/enhanced-data-visualization-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('EnhancedDataVisualization.tsx leak guard', () => {

--- a/os-platform/core/tests/enhanced-government-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/enhanced-government-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/enhanced-presence-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/enhanced-presence-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/error-display-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/error-display-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/error-prediction-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/error-prediction-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/errors-error-boundary-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/errors-error-boundary-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/excellence-analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/excellence-analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/excellence-verification-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/excellence-verification-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/explain-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/explain-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('ExplainPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/federation-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/federation-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('FederationDashboard.tsx leak guard', () => {

--- a/os-platform/core/tests/floating-action-menu-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/floating-action-menu-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/form-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/form-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-ai-status-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-ai-status-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-architecture-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-architecture-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { assertNoRawColorLeaks } from "../../../tools/ui-tokens/leak-guard";

--- a/os-platform/core/tests/government-compliance-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-compliance-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-excellence-status-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-excellence-status-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-module-hub-css-leak-guard.test.ts
+++ b/os-platform/core/tests/government-module-hub-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-module-hub-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-module-hub-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/government-security-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/government-security-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gpt-chat-interface-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/gpt-chat-interface-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gpt-management-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/gpt-management-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gpt-marketplace-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/gpt-marketplace-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gpt-studio-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/gpt-studio-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gpt-studio-view-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/gpt-studio-view-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/gradients-stories-css-leak-guard.test.ts
+++ b/os-platform/core/tests/gradients-stories-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('gradients.stories.css leak guard', () => {

--- a/os-platform/core/tests/grid-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/grid-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/hero-sections-css-leak-guard.test.ts
+++ b/os-platform/core/tests/hero-sections-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('HeroSections.css leak guard', () => {

--- a/os-platform/core/tests/hero-sections-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/hero-sections-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/hypothesis-testing-lab-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/hypothesis-testing-lab-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/immersive-analytics-suite-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/immersive-analytics-suite-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/index-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/index-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('index.tsx leak guard', () => {

--- a/os-platform/core/tests/infinite-precision-analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/infinite-precision-analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('InfinitePrecisionAnalyticsPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/input-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/input-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('input.tsx leak guard', () => {

--- a/os-platform/core/tests/integration-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/integration-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/intelligent-cell-suggestions-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/intelligent-cell-suggestions-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/invocation-history-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/invocation-history-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/label-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/label-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/launcher-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/launcher-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/launcher-model-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/launcher-model-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/launcher-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/layout-validator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/layout-validator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/leak-guard-coverage-mapping.test.ts
+++ b/os-platform/core/tests/leak-guard-coverage-mapping.test.ts
@@ -1,7 +1,6 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 
 /**
  * Phase 202: Coverage mapping test

--- a/os-platform/core/tests/leak-guard-meta-integrity.test.ts
+++ b/os-platform/core/tests/leak-guard-meta-integrity.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 
 /**
  * Phase 200 — Guard the guards.

--- a/os-platform/core/tests/leak-guard-mutation-resistance.test.ts
+++ b/os-platform/core/tests/leak-guard-mutation-resistance.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 
 type GuardParse = {
   guardAbsPath: string;

--- a/os-platform/core/tests/leak-guard-strict-components-coverage.test.ts
+++ b/os-platform/core/tests/leak-guard-strict-components-coverage.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 
 /**
  * Phase 203: Strict coverage (narrow root)

--- a/os-platform/core/tests/legacy-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/legacy-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/legacy-redirect-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/legacy-redirect-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/levy-core-index-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/levy-core-index-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('levy-core/index.module.css leak guard', () => {

--- a/os-platform/core/tests/live-analytics-chart-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/live-analytics-chart-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/loading-states-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/loading-states-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/main-navigation-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/main-navigation-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/marketplace-app-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/marketplace-app-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/marketplace-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/marketplace-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';

--- a/os-platform/core/tests/material-quality-gate-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/material-quality-gate-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('materialQualityGate.ts leak guard', () => {

--- a/os-platform/core/tests/menubar-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/menubar-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/minimal-terra-fusion-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/minimal-terra-fusion-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/module-ecosystem-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/module-ecosystem-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/module-host-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/module-host-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/module-launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/module-launcher-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { assertNoRawColorLeaks } from "../../../tools/ui-tokens/leak-guard";

--- a/os-platform/core/tests/module-loader-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/module-loader-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { assertNoRawColorLeaks } from "../../../tools/ui-tokens/leak-guard";

--- a/os-platform/core/tests/modules-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/modules-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/modules-module-error-boundary-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/modules-module-error-boundary-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/motion-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/motion-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/motion-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/motion-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('motion.ts leak guard', () => {

--- a/os-platform/core/tests/multi-county-deployment-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/multi-county-deployment-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/multi-user-cursor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/multi-user-cursor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('MultiUserCursor.tsx leak guard', () => {

--- a/os-platform/core/tests/navigation-menu-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/navigation-menu-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/no-untracked-leak-guards.test.ts
+++ b/os-platform/core/tests/no-untracked-leak-guards.test.ts
@@ -1,5 +1,4 @@
 import { execFileSync } from 'node:child_process';
-import { describe, it } from 'vitest';
 
 function getRepoRoot(): string {
   const out = execFileSync('git', ['rev-parse', '--show-toplevel'], {

--- a/os-platform/core/tests/notification-preferences-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/notification-preferences-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/notification-system-css-leak-guard.test.ts
+++ b/os-platform/core/tests/notification-system-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/notification-system-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/notification-system-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/os-messages-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/os-messages-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/os-shell-window-simple-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/os-shell-window-simple-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/os-shell-window-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/os-shell-window-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/os-status-badge-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/os-status-badge-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/os-status-badge-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/os-status-badge-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/overview-mdx-leak-guard.test.ts
+++ b/os-platform/core/tests/overview-mdx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/parcel-context-header-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/parcel-context-header-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/parcel-context-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/parcel-context-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/parcel-context-indicator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/parcel-context-indicator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('ParcelContextIndicator.tsx leak guard', () => {

--- a/os-platform/core/tests/performance-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/performance-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/performance-optimized-css-leak-guard.test.ts
+++ b/os-platform/core/tests/performance-optimized-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('performance-optimized.css leak guard', () => {

--- a/os-platform/core/tests/performance-profile-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/performance-profile-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/pins-store-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/pins-store-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/playground-tester-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/playground-tester-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('PlaygroundTester.tsx leak guard', () => {

--- a/os-platform/core/tests/plugins-host-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/plugins-host-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('PluginsHost.module.css leak guard', () => {

--- a/os-platform/core/tests/plugins-host-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/plugins-host-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/policy-panel-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/policy-panel-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/policy-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/policy-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/popover-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/popover-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/production-deployment-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/production-deployment-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/professional-dashboard-css-leak-guard.test.ts
+++ b/os-platform/core/tests/professional-dashboard-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/professional-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/professional-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/professional-header-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/professional-header-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';

--- a/os-platform/core/tests/progress-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/progress-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('progress.tsx leak guard', () => {

--- a/os-platform/core/tests/progressive-terra-fusion-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/progressive-terra-fusion-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/progressive-terrafusion-test-css-leak-guard.test.ts
+++ b/os-platform/core/tests/progressive-terrafusion-test-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('ProgressiveTerraFusionTest.css leak guard', () => {

--- a/os-platform/core/tests/property-assessment-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/property-assessment-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/property-assessment-flows-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/property-assessment-flows-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('PropertyAssessmentFlows.tsx leak guard', () => {

--- a/os-platform/core/tests/property-assessment-workflow-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/property-assessment-workflow-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('PropertyAssessmentWorkflow.tsx leak guard', () => {

--- a/os-platform/core/tests/property-details-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/property-details-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/pwa-shell-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/pwa-shell-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { assertNoRawColorLeaks } from "../../../tools/ui-tokens/leak-guard";

--- a/os-platform/core/tests/quantum-command-center-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-command-center-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-consciousness-manager-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-consciousness-manager-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-consciousness-research-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-consciousness-research-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-data-table-css-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-data-table-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-data-table-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-data-table-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-desktop-shell-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-desktop-shell-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('QuantumDesktopShell.tsx leak guard', () => {

--- a/os-platform/core/tests/quantum-form-components-css-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-form-components-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-form-components-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-form-components-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-modal-css-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-modal-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-modal-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-modal-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-module-manager-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-module-manager-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('QuantumModuleManager.ts leak guard', () => {

--- a/os-platform/core/tests/quantum-navigation-css-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-navigation-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-navigation-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-navigation-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/quantum-research-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/quantum-research-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('QuantumResearchDashboard.tsx leak guard', () => {

--- a/os-platform/core/tests/radio-group-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/radio-group-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/rag-dataset-manager-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/rag-dataset-manager-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/rag-sources-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/rag-sources-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('RAGSourcesPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/ranking-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/ranking-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/real-data-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/real-data-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/realtime-notebook-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/realtime-notebook-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/recents-store-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/recents-store-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/research-portal-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/research-portal-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/result-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/result-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/risk-confirmation-modal-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/risk-confirmation-modal-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/risk-policy-gate-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/risk-policy-gate-tsx-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';

--- a/os-platform/core/tests/scroll-area-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/scroll-area-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/security-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/security-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/select-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/select-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/separator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/separator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/service-worker-manager-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/service-worker-manager-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/sheet-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/sheet-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/simplified-quantum-desktop-shell-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/simplified-quantum-desktop-shell-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/skeleton-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/skeleton-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/slider-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/slider-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/slider-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/slider-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/smart-property-card-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/smart-property-card-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/snap-preview-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/snap-preview-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('SnapPreview.tsx leak guard', () => {

--- a/os-platform/core/tests/sonner-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/sonner-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/spacing-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/spacing-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/species-detection-visualizer-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/species-detection-visualizer-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/stack-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/stack-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/standalone-home-contracts-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/standalone-home-contracts-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/standalone-home-shell-css-leak-guard.test.ts
+++ b/os-platform/core/tests/standalone-home-shell-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/standalone-home-shell-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/standalone-home-shell-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/standalone-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/standalone-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/statistical-validation-workbench-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/statistical-validation-workbench-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/storage-adapter-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/storage-adapter-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/strategy-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/strategy-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/streaming-cell-output-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/streaming-cell-output-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/styles-terrafusion-tokens-css-leak-guard.test.ts
+++ b/os-platform/core/tests/styles-terrafusion-tokens-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/suite-launcher-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/suite-launcher-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/suite-registry-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/suite-registry-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/swarm-visualization-3d-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/swarm-visualization-3d-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('SwarmVisualization3D.tsx leak guard', () => {

--- a/os-platform/core/tests/switch-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/switch-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-diagnostics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-diagnostics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('SystemDiagnostics.tsx leak guard', () => {

--- a/os-platform/core/tests/system-gpt-atlas-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-gpt-atlas-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('SystemGptAtlasPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/system-gpt-console-view-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-gpt-console-view-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-gpt-policy-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-gpt-policy-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('SystemGptPolicyPanel.tsx leak guard', () => {

--- a/os-platform/core/tests/system-health-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-health-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-health-monitor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-health-monitor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-health-sentinel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-health-sentinel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-monitor-module-css-leak-guard.test.ts
+++ b/os-platform/core/tests/system-monitor-module-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-monitor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-monitor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-orchestration-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-orchestration-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/system-tray-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/system-tray-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/table-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/table-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/tabs-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/tabs-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/tdc-zero-baseline-contract.test.ts
+++ b/os-platform/core/tests/tdc-zero-baseline-contract.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 
 /**
  * CI-level TDC zero-baseline contract enforcement.

--- a/os-platform/core/tests/terra-dossier-gen2-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-dossier-gen2-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-flow-design-engine-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-flow-design-engine-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('TerraFlowDesignEngine.tsx leak guard', () => {

--- a/os-platform/core/tests/terra-forge-gen2-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-forge-gen2-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-advanced-analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-advanced-analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-ai-consciousness-network-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-ai-consciousness-network-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-automated-deployment-orchestrator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-automated-deployment-orchestrator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-blockchain-ledger-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-blockchain-ledger-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-brand-enhancement-system-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-brand-enhancement-system-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-cross-service-coordination-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-cross-service-coordination-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-css-index-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-css-index-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-edge-coordination-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-edge-coordination-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-elite-command-center-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-elite-command-center-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-elite-integration-nexus-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-elite-integration-nexus-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-elite-performance-analytics-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-elite-performance-analytics-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-elite-realtime-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-elite-realtime-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-elite-service-orchestrator-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-elite-service-orchestrator-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-emergency-test-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-emergency-test-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-logo-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-logo-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-marketplace-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-marketplace-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-ml-intelligence-hub-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-ml-intelligence-hub-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-quantum-computing-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-quantum-computing-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-showcase-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-showcase-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-fusion-system-integration-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-fusion-system-integration-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-gaia-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-gaia-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terra-sphere-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terra-sphere-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terraforge-components-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terraforge-components-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('TerraForgeComponents.tsx leak guard', () => {

--- a/os-platform/core/tests/terrafusion-brand-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-brand-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('terrafusion-brand.css leak guard', () => {

--- a/os-platform/core/tests/terrafusion-celebration-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-celebration-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('terrafusion-celebration.css leak guard', () => {

--- a/os-platform/core/tests/terrafusion-css-engine-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-css-engine-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('TerraFusionCSSEngine.ts leak guard', () => {

--- a/os-platform/core/tests/terrafusion-design-system-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-design-system-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('terrafusion-design-system.ts leak guard', () => {

--- a/os-platform/core/tests/terrafusion-excellence-provider-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-excellence-provider-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('TerraFusionExcellenceProvider.tsx leak guard', () => {

--- a/os-platform/core/tests/terrafusion-intelligent-architecture-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-intelligent-architecture-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('terrafusion-intelligent-architecture.css leak guard', () => {

--- a/os-platform/core/tests/terrafusion-layout-fixes-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-layout-fixes-css-leak-guard.test.ts
@@ -1,4 +1,3 @@
-import { describe, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';

--- a/os-platform/core/tests/terrafusion-system-check-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-system-check-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('TerraFusionSystemCheck.tsx leak guard', () => {

--- a/os-platform/core/tests/terrafusion-tokens-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-tokens-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('terrafusion-tokens.css leak guard', () => {

--- a/os-platform/core/tests/terrafusion-ui-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-ui-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terrafusion-ui-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-ui-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terrafusion-ultimate-architecture-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrafusion-ultimate-architecture-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/terrasphere-css-leak-guard.test.ts
+++ b/os-platform/core/tests/terrasphere-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/textarea-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/textarea-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/tier-preflight.test.ts
+++ b/os-platform/core/tests/tier-preflight.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/os-platform/core/tests/toast-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/toast-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('Toast.stories.tsx leak guard', () => {

--- a/os-platform/core/tests/toggle-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/toggle-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/tool-invoke-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/tool-invoke-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/tooltip-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/tooltip-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/trace-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/trace-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/trace-to-os-action-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/trace-to-os-action-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/typography-stories-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/typography-stories-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('Typography.stories.tsx leak guard', () => {

--- a/os-platform/core/tests/universal-translation-interface-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/universal-translation-interface-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/valuation-chart-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/valuation-chart-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/version-history-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/version-history-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/visual-workflow-designer-css-leak-guard.test.ts
+++ b/os-platform/core/tests/visual-workflow-designer-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/visualization-dashboard-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/visualization-dashboard-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/web-gl-transcendence-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/web-gl-transcendence-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/webgl-background-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/webgl-background-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/webgl-effects-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/webgl-effects-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 describe('WebGLEffects.tsx leak guard', () => {

--- a/os-platform/core/tests/widget-manager-panel-css-leak-guard.test.ts
+++ b/os-platform/core/tests/widget-manager-panel-css-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/widget-manager-panel-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/widget-manager-panel-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/window-animations-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/window-animations-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/window-manager-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/window-manager-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/workbench-index-ts-leak-guard.test.ts
+++ b/os-platform/core/tests/workbench-index-ts-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/workflow-designer-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/workflow-designer-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**

--- a/os-platform/core/tests/workflow-execution-monitor-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/workflow-execution-monitor-tsx-leak-guard.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
 import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
 
 /**


### PR DESCRIPTION
## Summary
- removes \\import ... from 'vitest'\\ from Jest-lane governance/leak-guard tests under \\os-platform/core/tests\\
- keeps test logic unchanged (globals already provided by test runner setup)
- resolves \\	ests/governance/no-vitest-imports-in-jest-lane.contract.test.ts\\ failures

## Scope
- mechanical import cleanup only
- no token/baseline/workflow/governance config changes

## Validation
- \\pnpm exec vitest run tests/governance/no-vitest-imports-in-jest-lane.contract.test.ts\\ ✅
- \\pnpm run test:unit\\ ✅ (164/164)
- \\pnpm run type-check\\ ✅
- \\
ode --test os-platform/core/tests/phase83-tools.test.mjs\\ ✅
- \\pnpm run governance:check\\ ✅