### PR TITLE
chore(husky): restore bootstrap so hooks run without no-verify

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+HOOK_DIR="$(dirname -- "$0")"
+if [ -f "$HOOK_DIR/_/husky.sh" ]; then
+  . "$HOOK_DIR/_/husky.sh"
+fi
 
 echo "🔒 TERRAFUSION OS: Pre-commit Quality Gate"
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+HOOK_DIR="$(dirname -- "$0")"
+if [ -f "$HOOK_DIR/_/husky.sh" ]; then
+  . "$HOOK_DIR/_/husky.sh"
+fi
 
 # ============================================================================
 # SPECLOCK: TerraFusion Pre-Push Quality Gate (pnpm-first, deterministic)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "scripts": {
+    "prepare": "husky install",
     "tf": "node tools/tf.js",
     "tf:ship": "node tools/dev/tf-ship.mjs",
     "tf:slice": "node tools/dev/tf-slice.mjs",


### PR DESCRIPTION
## Summary
- makes Husky hook entrypoints resilient when `.husky/_/husky.sh` is not present
- adds root `prepare` script (`husky install`) so bootstrap files are created on install

## Files
- `.husky/pre-commit`
- `.husky/pre-push`
- `package.json`

## Validation
- `pnpm -w install` runs root `prepare` and installs hooks
- normal `git commit` succeeded without `--no-verify`
- normal `git push` succeeded without `--no-verify`

## Summary by Sourcery

Ensure Husky git hooks are automatically installed and resilient to missing bootstrap files.

Build:
- Add a root prepare script to run `husky install` during installation so Husky hooks are bootstrapped correctly.

Chores:
- Adjust Husky hook entrypoints to work even when the shared `husky.sh` bootstrap file is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment setup reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->