### PR TITLE
fix(tests): add 3 missing leak-guard tests for Phase 203 strict coverage

### DIFF
--- a/os-platform/core/tests/audit-envelope-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/audit-envelope-tsx-leak-guard.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
+
+/**
+ * Leak guard for AuditEnvelope.tsx (Phase 203).
+ */
+describe('AuditEnvelope.tsx leak guard', () => {
+  it('contains no raw color values', () => {
+    const filePath = path.join(
+      process.cwd(),
+      'frontend/apps/os-shell/src/components/AuditEnvelope.tsx'
+    );
+    expect(fs.existsSync(filePath), `Expected file to exist: ${filePath}`).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf8');
+    assertNoRawColorLeaks(content, { label: 'AuditEnvelope.tsx' });
+  });
+});

--- a/os-platform/core/tests/command-palette-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/command-palette-tsx-leak-guard.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
+
+/**
+ * Leak guard for CommandPalette.tsx (Phase 203).
+ */
+describe('CommandPalette.tsx leak guard', () => {
+  it('contains no raw color values', () => {
+    const filePath = path.join(
+      process.cwd(),
+      'frontend/apps/os-shell/src/components/CommandPalette.tsx'
+    );
+    expect(fs.existsSync(filePath), `Expected file to exist: ${filePath}`).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf8');
+    assertNoRawColorLeaks(content, { label: 'CommandPalette.tsx' });
+  });
+});

--- a/os-platform/core/tests/reality-board-tsx-leak-guard.test.ts
+++ b/os-platform/core/tests/reality-board-tsx-leak-guard.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertNoRawColorLeaks } from '../../../tools/ui-tokens/leak-guard';
+
+/**
+ * Leak guard for RealityBoard.tsx (Phase 203).
+ */
+describe('RealityBoard.tsx leak guard', () => {
+  it('contains no raw color values', () => {
+    const filePath = path.join(
+      process.cwd(),
+      'frontend/apps/os-shell/src/components/RealityBoard.tsx'
+    );
+    expect(fs.existsSync(filePath), `Expected file to exist: ${filePath}`).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf8');
+    assertNoRawColorLeaks(content, { label: 'RealityBoard.tsx' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 3 missing leak-guard tests that caused `leak-guard-strict-components-coverage.test.ts` to fail
- New tests for: `AuditEnvelope.tsx`, `CommandPalette.tsx`, `RealityBoard.tsx`
- All 4 tests pass locally (3 new guards + strict coverage enforcement)

## Files Added
- `os-platform/core/tests/audit-envelope-tsx-leak-guard.test.ts`
- `os-platform/core/tests/command-palette-tsx-leak-guard.test.ts`
- `os-platform/core/tests/reality-board-tsx-leak-guard.test.ts`

## Test plan
- [x] 3 new leak-guard tests pass
- [x] Strict coverage test passes (0 unguarded components)
- [x] No vitest imports (jest globals: true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add missing leak-guard tests to ensure strict component coverage for specific TSX components.

Tests:
- Add leak-guard test coverage for AuditEnvelope.tsx.
- Add leak-guard test coverage for CommandPalette.tsx.
- Add leak-guard test coverage for RealityBoard.tsx.
- Ensure strict leak-guard coverage checks pass with no unguarded components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated leak-guard tests to verify there are no raw color values in multiple UI components, ensuring consistent color styling across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->