### PR TITLE
fix(tdc): allowlist token definition files in TDC scope excludes

### DIFF
--- a/tdc.config.json
+++ b/tdc.config.json
@@ -1,17 +1,15 @@
 {
   "ui": {
     "tokens": {
-      "include": [
-        "frontend/apps/os-shell/**",
-        "packages/ui/**"
-      ],
+      "include": ["frontend/apps/os-shell/**", "packages/ui/**"],
       "exclude": [
         "**/node_modules/**",
         "**/dist/**",
         "**/__tests__/**",
         "**/__mocks__/**",
         "**/ARCHIVE/**",
-        "**/QUARANTINE/**"
+        "**/QUARANTINE/**",
+        "**/tokens/**"
       ]
     }
   }

--- a/ui-token-baseline.json
+++ b/ui-token-baseline.json
@@ -1,7 +1,7 @@
 {
   "contract": "ui-token-baseline.json",
   "version": "v1",
-  "scopeHash": "856cd3514f4e254a",
-  "violationCount": 2138,
-  "generatedAtIso": "2026-02-24T18:30:44.396Z"
+  "scopeHash": "e2187676ae870298",
+  "violationCount": 1052,
+  "generatedAtIso": "2026-02-25T00:12:40.775Z"
 }


### PR DESCRIPTION
## Summary
- Adds `**/tokens/**` to `tdc.config.json` excludes array to exclude token definition files (e.g., `color-tokens.css`, `colors.ts`) from violation counting
- Regenerates `ui-token-baseline.json` with new scopeHash reflecting the updated scope
- Violation count drops from 2,138 → 1,052 (51% reduction) by correctly excluding files that **define** design tokens rather than **consume** them

## Why
Token definition files like `packages/ui/design-system/tokens/color-tokens.css` contain raw hex values **by design** — they are the source of truth for the token system. Counting them as violations inflates the ratchet baseline and masks real consumer-side violations.

The `parseExcludeDirNames()` regex only matches single directory names, so `**/tokens/**` is the correct pattern (not `**/design-system/tokens/**`).

## Test plan
- [x] `pnpm tdc:ui:tokens` exits 0 with new scopeHash + violationCount: 1052
- [x] scopeHash change triggers "scope changed → re-baselining" path (avoids tampering guard)
- [x] 164/164 unit tests passing
- [x] Pre-push quality gates all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update TDC configuration to exclude token definition files from violation counting and refresh the UI token baseline to reflect the new analysis scope.

Enhancements:
- Adjust TDC scope excludes to ignore token definition files under tokens directories so only consumer usage contributes to violations.

Tests:
- Regenerate the UI token baseline snapshot with updated scope hash and reduced violation count.