### PR TITLE
chore(ui-tokens): salvage swarm conversions for dashboard/plugin/tsx offender set

### DIFF
--- a/frontend/apps/os-shell/src/components/brand/TerraFusionBrandEnhancementSystem.tsx
+++ b/frontend/apps/os-shell/src/components/brand/TerraFusionBrandEnhancementSystem.tsx
@@ -114,13 +114,13 @@ export function TerraFusionBrandEnhancementSystem({
     root.style.setProperty('--space-golden', '1.618rem');
 
     // Shadow System
-    root.style.setProperty('--shadow-glow', '0 0 40px rgba(0, 255, 255, 0.4)');
-    root.style.setProperty('--shadow-quantum', '0 0 20px rgba(0, 255, 255, 0.3)');
-    root.style.setProperty('--shadow-elevation', '0 10px 30px rgba(0, 0, 0, 0.3)');
+    root.style.setProperty('--shadow-glow', '0 0 40px color-mix(in srgb, var(--tf-transcend-cyan) 40%, transparent)');
+    root.style.setProperty('--shadow-quantum', '0 0 20px color-mix(in srgb, var(--tf-transcend-cyan) 30%, transparent)');
+    root.style.setProperty('--shadow-elevation', '0 10px 30px color-mix(in srgb, hsl(var(--tf-text-primary-hs) 0%) 30%, transparent)');
 
     // Glassmorphic System
-    root.style.setProperty('--glass-bg', 'rgba(30, 41, 59, 0.3)');
-    root.style.setProperty('--glass-border', 'rgba(0, 255, 255, 0.2)');
+    root.style.setProperty('--glass-bg', 'color-mix(in srgb, hsl(var(--tf-surface-dark-hs) 17%) 30%, transparent)');
+    root.style.setProperty('--glass-border', 'color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent)');
     root.style.setProperty('--glass-blur', 'blur(10px)');
 
     // Border Radius System
@@ -145,12 +145,12 @@ export function TerraFusionBrandEnhancementSystem({
         0%, 100% {
           opacity: 1;
           transform: scale(1);
-          box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+          box-shadow: 0 0 20px color-mix(in srgb, var(--tf-transcend-cyan) 30%, transparent);
         }
         50% {
           opacity: 0.8;
           transform: scale(1.05);
-          box-shadow: 0 0 40px rgba(0, 255, 255, 0.6);
+          box-shadow: 0 0 40px color-mix(in srgb, var(--tf-transcend-cyan) 60%, transparent);
         }
       }
 
@@ -197,7 +197,7 @@ export function TerraFusionBrandEnhancementSystem({
         left: 0;
         right: 0;
         bottom: 0;
-        background: linear-gradient(90deg, transparent, rgba(0, 255, 255, 0.2), transparent);
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent), transparent);
         animation: terraQuantumFlow 3s ease-in-out infinite;
       }
 
@@ -205,9 +205,9 @@ export function TerraFusionBrandEnhancementSystem({
         background: linear-gradient(
           90deg,
           transparent 0%,
-          rgba(0, 255, 255, 0.1) 25%,
-          rgba(0, 255, 255, 0.2) 50%,
-          rgba(0, 255, 255, 0.1) 75%,
+          color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent) 25%,
+          color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent) 50%,
+          color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent) 75%,
           transparent 100%
         );
         background-size: 200% 100%;
@@ -239,36 +239,36 @@ export function TerraFusionBrandEnhancementSystem({
         left: 0;
         right: 0;
         height: 1px;
-        background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, hsl(var(--tf-text-primary-hs) 100%) 10%, transparent), transparent);
       }
 
       .terra-glass-card {
-        background: rgba(15, 23, 42, 0.6);
+        background: color-mix(in srgb, hsl(var(--tf-surface-dark-hs) 11%) 60%, transparent);
         backdrop-filter: blur(20px);
         -webkit-backdrop-filter: blur(20px);
-        border: 1px solid rgba(0, 255, 255, 0.2);
+        border: 1px solid color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent);
         border-radius: var(--radius-xl);
         transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       }
 
       .terra-glass-card:hover {
-        border-color: rgba(0, 255, 255, 0.4);
+        border-color: color-mix(in srgb, var(--tf-transcend-cyan) 40%, transparent);
         box-shadow: var(--shadow-quantum);
         transform: translateY(-2px);
       }
 
       .terra-glass-button {
-        background: rgba(0, 255, 255, 0.1);
+        background: color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent);
         backdrop-filter: blur(10px);
         -webkit-backdrop-filter: blur(10px);
-        border: 1px solid rgba(0, 255, 255, 0.3);
+        border: 1px solid color-mix(in srgb, var(--tf-transcend-cyan) 30%, transparent);
         color: var(--terra-cyan);
         transition: all 0.3s ease;
       }
 
       .terra-glass-button:hover {
-        background: rgba(0, 255, 255, 0.2);
-        box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+        background: color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent);
+        box-shadow: 0 0 20px color-mix(in srgb, var(--tf-transcend-cyan) 40%, transparent);
         transform: translateY(-1px);
       }
     `;
@@ -351,7 +351,7 @@ export function TerraFusionBrandEnhancementSystem({
       }
 
       .btn-secondary:hover {
-        background: rgba(0, 255, 255, 0.1);
+        background: color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent);
         box-shadow: var(--shadow-quantum);
         transform: translateY(-1px);
       }
@@ -372,8 +372,8 @@ export function TerraFusionBrandEnhancementSystem({
       .terra-input:focus {
         outline: none;
         border-color: var(--terra-cyan);
-        box-shadow: 0 0 0 3px rgba(0, 255, 255, 0.1);
-        background: rgba(0, 255, 255, 0.05);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent);
+        background: color-mix(in srgb, var(--tf-transcend-cyan) 5%, transparent);
       }
 
       /* TerraFusion Typography */
@@ -398,7 +398,7 @@ export function TerraFusionBrandEnhancementSystem({
       .terra-text {
         font-size: var(--text-base);
         line-height: 1.6;
-        color: rgba(255, 255, 255, 0.8);
+        color: color-mix(in srgb, hsl(var(--tf-text-primary-hs) 100%) 80%, transparent);
       }
 
       /* TerraFusion Status Indicators */
@@ -431,15 +431,15 @@ export function TerraFusionBrandEnhancementSystem({
       }
 
       .terra-badge-primary {
-        background: rgba(0, 255, 255, 0.2);
+        background: color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent);
         color: var(--terra-cyan);
-        border: 1px solid rgba(0, 255, 255, 0.3);
+        border: 1px solid color-mix(in srgb, var(--tf-transcend-cyan) 30%, transparent);
       }
 
       .terra-badge-success {
-        background: rgba(0, 255, 136, 0.2);
+        background: color-mix(in srgb, var(--tf-accent-success) 20%, transparent);
         color: var(--success-green);
-        border: 1px solid rgba(0, 255, 136, 0.3);
+        border: 1px solid color-mix(in srgb, var(--tf-accent-success) 30%, transparent);
       }
     `;
 
@@ -494,7 +494,7 @@ export function TerraFusionBrandEnhancementSystem({
             height: '8px',
             borderRadius: '50%',
             background: 'var(--success-green)',
-            boxShadow: '0 0 10px rgba(0, 255, 136, 0.5)',
+            boxShadow: '0 0 10px color-mix(in srgb, var(--tf-accent-success) 50%, transparent)',
           }}
           className='terra-quantum-pulse'
         />

--- a/frontend/apps/os-shell/src/components/pilot/ToolInvokePanel.tsx
+++ b/frontend/apps/os-shell/src/components/pilot/ToolInvokePanel.tsx
@@ -156,9 +156,9 @@ export const ToolInvokePanel: React.FC = () => {
           max-width: 800px;
           margin: 2rem auto;
           padding: 2rem;
-          background: var(--surface-color, #ffffff);
+          background: var(--surface-color, hsl(var(--tf-text-primary-hs) 100%));
           border-radius: 8px;
-          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 2px 8px color-mix(in srgb, hsl(var(--tf-text-primary-hs) 0%) 10%, transparent);
         }
 
         .panel-header {
@@ -167,32 +167,32 @@ export const ToolInvokePanel: React.FC = () => {
 
         .panel-header h2 {
           margin: 0 0 0.5rem 0;
-          color: var(--text-primary, #1a1a1a);
+          color: var(--text-primary, hsl(var(--tf-text-primary-hs) 10%));
         }
 
         .subtitle {
           margin: 0;
-          color: var(--text-secondary, #666);
+          color: var(--text-secondary, hsl(var(--tf-neutral-hs) 40%));
           font-size: 0.9rem;
         }
 
         .tool-card {
           padding: 1.5rem;
-          background: var(--surface-secondary, #f5f5f5);
+          background: var(--surface-secondary, hsl(var(--tf-neutral-hs) 96%));
           border-radius: 6px;
-          border: 1px solid var(--border-color, #e0e0e0);
+          border: 1px solid var(--border-color, hsl(var(--tf-neutral-hs) 88%));
           margin-bottom: 1.5rem;
         }
 
         .tool-card h3 {
           margin: 0 0 0.5rem 0;
           font-family: 'Courier New', monospace;
-          color: var(--text-primary, #1a1a1a);
+          color: var(--text-primary, hsl(var(--tf-text-primary-hs) 10%));
         }
 
         .tool-description {
           margin: 0.5rem 0;
-          color: var(--text-secondary, #666);
+          color: var(--text-secondary, hsl(var(--tf-neutral-hs) 40%));
         }
 
         .badge {
@@ -205,8 +205,8 @@ export const ToolInvokePanel: React.FC = () => {
         }
 
         .badge.read-only {
-          background: var(--success-light, #d4edda);
-          color: var(--success-dark, #155724);
+          background: var(--success-light, hsl(var(--tf-success-hs) 90%));
+          color: var(--success-dark, hsl(var(--tf-success-hs) 20%));
         }
 
         .invocation-controls {
@@ -215,7 +215,7 @@ export const ToolInvokePanel: React.FC = () => {
 
         .btn-primary {
           padding: 0.75rem 2rem;
-          background: var(--primary-color, #007bff);
+          background: var(--primary-color, hsl(var(--tf-network-blue-hs) 50%));
           color: white;
           border: none;
           border-radius: 4px;
@@ -226,11 +226,11 @@ export const ToolInvokePanel: React.FC = () => {
         }
 
         .btn-primary:hover:not(:disabled) {
-          background: var(--primary-hover, #0056b3);
+          background: var(--primary-hover, hsl(var(--tf-network-blue-hs) 35%));
         }
 
         .btn-primary:disabled {
-          background: var(--disabled-color, #cccccc);
+          background: var(--disabled-color, hsl(var(--tf-neutral-hs) 80%));
           cursor: not-allowed;
         }
 
@@ -239,7 +239,7 @@ export const ToolInvokePanel: React.FC = () => {
           align-items: center;
           gap: 1rem;
           padding: 1.5rem;
-          background: var(--info-light, #d1ecf1);
+          background: var(--info-light, hsl(var(--tf-network-blue-hs) 90%));
           border-radius: 6px;
           margin-top: 1rem;
         }
@@ -247,8 +247,8 @@ export const ToolInvokePanel: React.FC = () => {
         .spinner {
           width: 20px;
           height: 20px;
-          border: 3px solid var(--border-color, #e0e0e0);
-          border-top-color: var(--primary-color, #007bff);
+          border: 3px solid var(--border-color, hsl(var(--tf-neutral-hs) 88%));
+          border-top-color: var(--primary-color, hsl(var(--tf-network-blue-hs) 50%));
           border-radius: 50%;
           animation: spin 0.8s linear infinite;
         }
@@ -260,9 +260,9 @@ export const ToolInvokePanel: React.FC = () => {
         .success-state {
           margin-top: 1.5rem;
           padding: 1.5rem;
-          background: var(--success-light, #d4edda);
+          background: var(--success-light, hsl(var(--tf-success-hs) 90%));
           border-radius: 6px;
-          border: 1px solid var(--success-border, #c3e6cb);
+          border: 1px solid var(--success-border, hsl(var(--tf-success-hs) 78%));
         }
 
         .result-header {
@@ -274,7 +274,7 @@ export const ToolInvokePanel: React.FC = () => {
 
         .result-header h3 {
           margin: 0;
-          color: var(--success-dark, #155724);
+          color: var(--success-dark, hsl(var(--tf-success-hs) 20%));
         }
 
         .correlation-id-badge {
@@ -284,23 +284,23 @@ export const ToolInvokePanel: React.FC = () => {
           padding: 0.5rem 1rem;
           background: white;
           border-radius: 4px;
-          border: 1px solid var(--border-color, #e0e0e0);
+          border: 1px solid var(--border-color, hsl(var(--tf-neutral-hs) 88%));
         }
 
         .correlation-id-badge .label {
           font-size: 0.85rem;
-          color: var(--text-secondary, #666);
+          color: var(--text-secondary, hsl(var(--tf-neutral-hs) 40%));
         }
 
         .correlation-id-badge code {
           font-family: 'Courier New', monospace;
-          color: var(--text-primary, #1a1a1a);
+          color: var(--text-primary, hsl(var(--tf-text-primary-hs) 10%));
           font-size: 0.9rem;
         }
 
         .btn-copy {
           padding: 0.25rem 0.75rem;
-          background: var(--primary-color, #007bff);
+          background: var(--primary-color, hsl(var(--tf-network-blue-hs) 50%));
           color: white;
           border: none;
           border-radius: 4px;
@@ -310,19 +310,19 @@ export const ToolInvokePanel: React.FC = () => {
         }
 
         .btn-copy:hover {
-          background: var(--primary-hover, #0056b3);
+          background: var(--primary-hover, hsl(var(--tf-network-blue-hs) 35%));
         }
 
         .result-content h4 {
           margin: 1rem 0 0.5rem 0;
-          color: var(--success-dark, #155724);
+          color: var(--success-dark, hsl(var(--tf-success-hs) 20%));
         }
 
         .result-output {
           background: white;
           padding: 1rem;
           border-radius: 4px;
-          border: 1px solid var(--border-color, #e0e0e0);
+          border: 1px solid var(--border-color, hsl(var(--tf-neutral-hs) 88%));
           overflow-x: auto;
           font-family: 'Courier New', monospace;
           font-size: 0.9rem;
@@ -331,14 +331,14 @@ export const ToolInvokePanel: React.FC = () => {
         .dev-trace-hint {
           margin-top: 1rem;
           padding: 1rem;
-          background: var(--info-light, #d1ecf1);
+          background: var(--info-light, hsl(var(--tf-network-blue-hs) 90%));
           border-radius: 4px;
         }
 
         .dev-trace-hint summary {
           cursor: pointer;
           font-weight: 600;
-          color: var(--info-dark, #0c5460);
+          color: var(--info-dark, hsl(var(--tf-transcend-cyan-hs) 18%));
         }
 
         .hint-content {
@@ -347,7 +347,7 @@ export const ToolInvokePanel: React.FC = () => {
 
         .hint-content p {
           margin: 0.5rem 0;
-          color: var(--text-secondary, #666);
+          color: var(--text-secondary, hsl(var(--tf-neutral-hs) 40%));
         }
 
         .trace-command {

--- a/frontend/apps/os-shell/src/components/research/AISwarmManagementPanel.tsx
+++ b/frontend/apps/os-shell/src/components/research/AISwarmManagementPanel.tsx
@@ -414,7 +414,7 @@ export const AISwarmManagementPanel: React.FC = () => {
         width: '100%',
         height: '100%',
         background: 'linear-gradient(135deg, var(--terra-midnight) 0%, var(--terra-slate) 100%)',
-        color: 'white',
+        color: 'hsl(var(--tf-text-primary-hs) 100%)',
         fontFamily: "'Inter', system-ui, sans-serif",
         overflow: 'auto',
         padding: '2rem',
@@ -441,7 +441,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             fontWeight: 700,
             color: 'var(--terra-cyan)',
             marginBottom: '0.5rem',
-            textShadow: '0 0 20px rgba(0, 255, 255, 0.5)',
+            textShadow: '0 0 20px hsl(var(--tf-transcend-cyan-hs) 50% / 0.5)',
           }}
         >
           AI Swarm Management & Coordination
@@ -449,7 +449,7 @@ export const AISwarmManagementPanel: React.FC = () => {
         <p
           style={{
             fontSize: '1rem',
-            color: 'rgba(255, 255, 255, 0.7)',
+            color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)',
             margin: 0,
           }}
         >
@@ -483,7 +483,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -506,7 +506,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -529,7 +529,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -558,7 +558,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -581,7 +581,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -610,7 +610,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -633,7 +633,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 fontSize: '0.75rem',
-                color: 'rgba(255, 255, 255, 0.6)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                 marginBottom: '0.25rem',
               }}
             >
@@ -676,7 +676,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <label
               style={{
                 fontSize: '0.875rem',
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)',
                 display: 'block',
                 marginBottom: '0.5rem',
               }}
@@ -689,10 +689,10 @@ export const AISwarmManagementPanel: React.FC = () => {
               style={{
                 width: '100%',
                 padding: '0.75rem',
-                background: 'rgba(10, 14, 26, 0.8)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.8)',
                 border: '1px solid var(--glass-border)',
                 borderRadius: '0.5rem',
-                color: 'white',
+                color: 'hsl(var(--tf-text-primary-hs) 100%)',
                 fontSize: '0.875rem',
                 cursor: 'pointer',
               }}
@@ -709,7 +709,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <label
               style={{
                 fontSize: '0.875rem',
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)',
                 display: 'block',
                 marginBottom: '0.5rem',
               }}
@@ -722,10 +722,10 @@ export const AISwarmManagementPanel: React.FC = () => {
               style={{
                 width: '100%',
                 padding: '0.75rem',
-                background: 'rgba(10, 14, 26, 0.8)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.8)',
                 border: '1px solid var(--glass-border)',
                 borderRadius: '0.5rem',
-                color: 'white',
+                color: 'hsl(var(--tf-text-primary-hs) 100%)',
                 fontSize: '0.875rem',
                 cursor: 'pointer',
               }}
@@ -744,7 +744,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <label
               style={{
                 fontSize: '0.875rem',
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)',
                 display: 'block',
                 marginBottom: '0.5rem',
               }}
@@ -776,8 +776,8 @@ export const AISwarmManagementPanel: React.FC = () => {
               gap: '0.5rem',
               cursor: 'pointer',
               padding: '0.5rem 1rem',
-              background: showConnections ? 'var(--glass-border)' : 'rgba(30, 41, 59, 0.5)',
-              border: showConnections ? '1px solid var(--terra-cyan)' : '1px solid rgba(255, 255, 255, 0.1)',
+              background: showConnections ? 'var(--glass-border)' : 'hsl(var(--tf-bg-surface-hs) 17% / 0.5)',
+              border: showConnections ? '1px solid var(--terra-cyan)' : '1px solid hsl(var(--tf-text-primary-hs) 100% / 0.1)',
               borderRadius: '0.5rem',
               transition: 'all 0.3s ease',
             }}
@@ -789,7 +789,7 @@ export const AISwarmManagementPanel: React.FC = () => {
               style={{ accentColor: 'var(--terra-cyan)' }}
               aria-label='Toggle agent connections visibility'
             />
-            <span style={{ color: 'white', fontSize: '0.875rem' }}>Show Connections</span>
+            <span style={{ color: 'hsl(var(--tf-text-primary-hs) 100%)', fontSize: '0.875rem' }}>Show Connections</span>
           </label>
 
           <button
@@ -799,7 +799,7 @@ export const AISwarmManagementPanel: React.FC = () => {
               background: 'linear-gradient(135deg, var(--terra-cyan) 0%, var(--terra-blue) 100%)',
               border: 'none',
               borderRadius: '0.5rem',
-              color: 'white',
+              color: 'hsl(var(--tf-text-primary-hs) 100%)',
               fontSize: '0.875rem',
               fontWeight: 600,
               cursor: 'pointer',
@@ -817,11 +817,11 @@ export const AISwarmManagementPanel: React.FC = () => {
               background: 'linear-gradient(135deg, var(--terra-blue) 0%, var(--terra-cyan) 100%)',
               border: 'none',
               borderRadius: '0.5rem',
-              color: 'white',
+              color: 'hsl(var(--tf-text-primary-hs) 100%)',
               fontSize: '0.875rem',
               fontWeight: 600,
               cursor: 'pointer',
-              boxShadow: '0 0 20px rgba(0, 128, 255, 0.3)',
+              boxShadow: '0 0 20px hsl(var(--tf-network-blue-hs) 50% / 0.3)',
               transition: 'all 0.3s ease',
             }}
           >
@@ -858,7 +858,7 @@ export const AISwarmManagementPanel: React.FC = () => {
         <div
           style={{
             height: '500px',
-            background: 'rgba(10, 14, 26, 0.5)',
+            background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
             borderRadius: '0.5rem',
             overflow: 'hidden',
             position: 'relative',
@@ -936,7 +936,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 padding: '1rem',
-                background: 'rgba(10, 14, 26, 0.5)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
                 borderRadius: '0.5rem',
                 border: '1px solid var(--glass-border)',
               }}
@@ -955,7 +955,7 @@ export const AISwarmManagementPanel: React.FC = () => {
                 style={{ margin: 0, paddingLeft: '1.5rem', fontSize: '0.875rem', lineHeight: 1.6 }}
               >
                 {intelligenceAnalysis.emergentBehaviors.map((behavior, index) => (
-                  <li key={index} style={{ color: 'white', marginBottom: '0.25rem' }}>
+                  <li key={index} style={{ color: 'hsl(var(--tf-text-primary-hs) 100%)', marginBottom: '0.25rem' }}>
                     {behavior}
                   </li>
                 ))}
@@ -966,7 +966,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 padding: '1rem',
-                background: 'rgba(10, 14, 26, 0.5)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
                 borderRadius: '0.5rem',
                 border: '1px solid var(--glass-border)',
               }}
@@ -983,13 +983,13 @@ export const AISwarmManagementPanel: React.FC = () => {
               </h4>
               {intelligenceAnalysis.coordinationPatterns.map((pattern, index) => (
                 <div key={index} style={{ marginBottom: '0.5rem' }}>
-                  <div style={{ fontSize: '0.875rem', color: 'white' }}>{pattern.pattern}</div>
+                  <div style={{ fontSize: '0.875rem', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>{pattern.pattern}</div>
                   <div
                     style={{
                       display: 'flex',
                       justifyContent: 'space-between',
                       fontSize: '0.75rem',
-                      color: 'rgba(255, 255, 255, 0.6)',
+                      color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                     }}
                   >
                     <span>Frequency: {pattern.frequency}</span>
@@ -1003,9 +1003,9 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 padding: '1rem',
-                background: 'rgba(10, 14, 26, 0.5)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
                 borderRadius: '0.5rem',
-                border: '1px solid rgba(255, 165, 0, 0.2)',
+                border: '1px solid hsl(var(--tf-warning-hs) 50% / 0.2)',
               }}
             >
               <h4
@@ -1020,13 +1020,13 @@ export const AISwarmManagementPanel: React.FC = () => {
               </h4>
               {intelligenceAnalysis.bottlenecks.map((bottleneck, index) => (
                 <div key={index} style={{ marginBottom: '0.75rem' }}>
-                  <div style={{ fontSize: '0.875rem', color: 'white' }}>
+                  <div style={{ fontSize: '0.875rem', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>
                     {bottleneck.location}
                   </div>
                   <div
                     style={{
                       fontSize: '0.75rem',
-                      color: 'rgba(255, 255, 255, 0.6)',
+                      color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                       marginTop: '0.25rem',
                     }}
                   >
@@ -1043,9 +1043,9 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 padding: '1rem',
-                background: 'rgba(10, 14, 26, 0.5)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
                 borderRadius: '0.5rem',
-                border: '1px solid rgba(0, 255, 0, 0.2)',
+                border: '1px solid hsl(var(--tf-success-hs) 50% / 0.2)',
               }}
             >
               <h4
@@ -1060,14 +1060,14 @@ export const AISwarmManagementPanel: React.FC = () => {
               </h4>
               {intelligenceAnalysis.optimizationOpportunities.map((opportunity, index) => (
                 <div key={index} style={{ marginBottom: '0.75rem' }}>
-                  <div style={{ fontSize: '0.875rem', color: 'white' }}>{opportunity.area}</div>
+                  <div style={{ fontSize: '0.875rem', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>{opportunity.area}</div>
                   <div style={{ fontSize: '0.75rem', color: 'var(--success-green)', marginTop: '0.25rem' }}>
                     Potential Gain: +{(opportunity.potentialGain * 100).toFixed(1)}%
                   </div>
                   <div
                     style={{
                       fontSize: '0.75rem',
-                      color: 'rgba(255, 255, 255, 0.6)',
+                      color: 'hsl(var(--tf-text-primary-hs) 100% / 0.6)',
                       marginTop: '0.25rem',
                     }}
                   >
@@ -1081,7 +1081,7 @@ export const AISwarmManagementPanel: React.FC = () => {
             <div
               style={{
                 padding: '1rem',
-                background: 'rgba(10, 14, 26, 0.5)',
+                background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.5)',
                 borderRadius: '0.5rem',
                 border: '1px solid var(--glass-border)',
               }}
@@ -1097,19 +1097,19 @@ export const AISwarmManagementPanel: React.FC = () => {
                 Predicted Performance
               </h4>
               <div style={{ fontSize: '0.875rem', lineHeight: 1.8 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'white' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>
                   <span>Next 5 min:</span>
                   <span style={{ color: 'var(--terra-cyan)', fontWeight: 600 }}>
                     {(intelligenceAnalysis.predictedPerformance.next5Minutes * 100).toFixed(1)}%
                   </span>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'white' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>
                   <span>Next 15 min:</span>
                   <span style={{ color: 'var(--terra-cyan)', fontWeight: 600 }}>
                     {(intelligenceAnalysis.predictedPerformance.next15Minutes * 100).toFixed(1)}%
                   </span>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'white' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', color: 'hsl(var(--tf-text-primary-hs) 100%)' }}>
                   <span>Next 60 min:</span>
                   <span style={{ color: 'var(--terra-cyan)', fontWeight: 600 }}>
                     {(intelligenceAnalysis.predictedPerformance.next60Minutes * 100).toFixed(1)}%
@@ -1125,4 +1125,3 @@ export const AISwarmManagementPanel: React.FC = () => {
 };
 
 export default AISwarmManagementPanel;
-

--- a/frontend/apps/os-shell/src/plugins/harris-pacs/index.module.css
+++ b/frontend/apps/os-shell/src/plugins/harris-pacs/index.module.css
@@ -2,7 +2,7 @@
   padding: 24px;
   background: linear-gradient(135deg, var(--tf-surface-darker) 0%, var(--tf-surface-darker) 100%);
   border-radius: 12px;
-  color: #ffffff;
+  color: hsl(var(--tf-text-primary-hs) 100%);
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
@@ -15,20 +15,20 @@
   margin: 0 0 8px 0;
   font-size: 28px;
   font-weight: 600;
-  color: #4fc3f7;
+  color: hsl(var(--tf-network-blue-hs) 64%);
 }
 
 .header p {
   margin: 0;
   font-size: 16px;
-  color: #b0bec5;
+  color: hsl(var(--tf-neutral-hs) 73%);
 }
 
 .loading {
   text-align: center;
   padding: 40px;
   font-size: 18px;
-  color: #4fc3f7;
+  color: hsl(var(--tf-network-blue-hs) 64%);
 }
 
 .statusGrid {
@@ -39,8 +39,8 @@
 }
 
 .statusCard {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(79, 195, 247, 0.2);
+  background: hsl(var(--tf-text-primary-hs) 100% / 0.05);
+  border: 1px solid hsl(var(--tf-network-blue-hs) 64% / 0.2);
   border-radius: 8px;
   padding: 20px;
   backdrop-filter: blur(10px);
@@ -50,13 +50,13 @@
   margin: 0 0 16px 0;
   font-size: 18px;
   font-weight: 500;
-  color: #4fc3f7;
+  color: hsl(var(--tf-network-blue-hs) 64%);
 }
 
 .progressBar {
   width: 100%;
   height: 8px;
-  background: rgba(255, 255, 255, 0.1);
+  background: hsl(var(--tf-text-primary-hs) 100% / 0.1);
   border-radius: 4px;
   overflow: hidden;
   margin-bottom: 8px;
@@ -64,14 +64,14 @@
 
 .progressFill {
   height: 100%;
-  background: linear-gradient(90deg, #4fc3f7, #29b6f6);
+  background: linear-gradient(90deg, hsl(var(--tf-network-blue-hs) 64%), hsl(var(--tf-network-blue-hs) 56%));
   transition: width 0.3s ease;
 }
 
 .progressText {
   font-size: 14px;
   font-weight: 600;
-  color: #4fc3f7;
+  color: hsl(var(--tf-network-blue-hs) 64%);
   text-align: center;
 }
 
@@ -89,7 +89,7 @@
 
 .statLabel {
   font-size: 14px;
-  color: #b0bec5;
+  color: hsl(var(--tf-neutral-hs) 73%);
 }
 
 .statValue {
@@ -98,15 +98,15 @@
 }
 
 .statValue.valid {
-  color: #4caf50;
+  color: hsl(var(--tf-success-hs) 49%);
 }
 
 .statValue.invalid {
-  color: #f44336;
+  color: hsl(var(--tf-error-hs) 58%);
 }
 
 .statValue.pending {
-  color: #ff9800;
+  color: hsl(var(--tf-warning-hs) 50%);
 }
 
 .mappingInfo {
@@ -117,9 +117,9 @@
 
 .mappingRow {
   font-size: 14px;
-  color: #e0e0e0;
+  color: hsl(var(--tf-text-primary-hs) 88%);
   padding: 8px;
-  background: rgba(255, 255, 255, 0.05);
+  background: hsl(var(--tf-text-primary-hs) 100% / 0.05);
   border-radius: 4px;
 }
 
@@ -131,11 +131,11 @@
 }
 
 .mappingStats span:first-child {
-  color: #4caf50;
+  color: hsl(var(--tf-success-hs) 49%);
 }
 
 .mappingStats span:last-child {
-  color: #f44336;
+  color: hsl(var(--tf-error-hs) 58%);
 }
 
 .actions {
@@ -146,8 +146,8 @@
 }
 
 .primaryButton {
-  background: linear-gradient(135deg, #4fc3f7, #29b6f6);
-  color: white;
+  background: linear-gradient(135deg, hsl(var(--tf-network-blue-hs) 64%), hsl(var(--tf-network-blue-hs) 56%));
+  color: hsl(var(--tf-text-primary-hs) 100%);
   border: none;
   padding: 12px 24px;
   border-radius: 6px;
@@ -159,7 +159,7 @@
 }
 
 .primaryButton:hover:not(:disabled) {
-  background: linear-gradient(135deg, #29b6f6, var(--tf-info-light));
+  background: linear-gradient(135deg, hsl(var(--tf-network-blue-hs) 56%), var(--tf-info-light));
   transform: translateY(-1px);
 }
 
@@ -171,8 +171,8 @@
 
 .secondaryButton {
   background: transparent;
-  color: #4fc3f7;
-  border: 1px solid #4fc3f7;
+  color: hsl(var(--tf-network-blue-hs) 64%);
+  border: 1px solid hsl(var(--tf-network-blue-hs) 64%);
   padding: 12px 24px;
   border-radius: 6px;
   font-size: 16px;
@@ -183,7 +183,7 @@
 }
 
 .secondaryButton:hover:not(:disabled) {
-  background: rgba(79, 195, 247, 0.1);
+  background: hsl(var(--tf-network-blue-hs) 64% / 0.1);
   transform: translateY(-1px);
 }
 
@@ -194,10 +194,10 @@
 }
 
 .timeline {
-  background: rgba(255, 255, 255, 0.05);
+  background: hsl(var(--tf-text-primary-hs) 100% / 0.05);
   border-radius: 8px;
   padding: 20px;
-  border: 1px solid rgba(79, 195, 247, 0.2);
+  border: 1px solid hsl(var(--tf-network-blue-hs) 64% / 0.2);
 }
 
 .timelineItem {
@@ -208,19 +208,19 @@
 }
 
 .timelineItem:not(:last-child) {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid hsl(var(--tf-text-primary-hs) 100% / 0.1);
   margin-bottom: 8px;
   padding-bottom: 16px;
 }
 
 .timelineLabel {
   font-size: 14px;
-  color: #b0bec5;
+  color: hsl(var(--tf-neutral-hs) 73%);
   font-weight: 500;
 }
 
 .timelineValue {
   font-size: 14px;
-  color: #e0e0e0;
+  color: hsl(var(--tf-text-primary-hs) 88%);
   font-weight: 600;
 }

--- a/frontend/apps/os-shell/src/styles/elite-quantum-dashboard.css
+++ b/frontend/apps/os-shell/src/styles/elite-quantum-dashboard.css
@@ -23,36 +23,36 @@
 .excellence-header {
   padding: 2rem;
   border-radius: 1rem;
-  border: 1px solid rgba(0, 255, 255, 0.2);
+  border: 1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2);
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
-  background: linear-gradient(135deg, rgba(0, 255, 255, 0.05), rgba(0, 128, 255, 0.03));
+  background: linear-gradient(135deg, hsl(var(--tf-transcend-cyan-hs) 50% / 0.05), hsl(var(--tf-network-blue-hs) 50% / 0.03));
 }
 
 .quantum-metric-card {
   padding: 1.5rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(0, 255, 255, 0.2);
+  border: 1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2);
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
-  background: linear-gradient(135deg, rgba(30, 41, 59, 0.4), rgba(0, 255, 255, 0.02));
+  background: linear-gradient(135deg, hsl(var(--tf-surface-dark-hs) 17% / 0.4), hsl(var(--tf-transcend-cyan-hs) 50% / 0.02));
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .quantum-metric-card:hover {
   transform: translateY(-0.25rem);
-  border-color: rgba(0, 255, 255, 0.4);
-  box-shadow: 0 20px 40px rgba(0, 255, 255, 0.1);
+  border-color: hsl(var(--tf-transcend-cyan-hs) 50% / 0.4);
+  box-shadow: 0 20px 40px hsl(var(--tf-transcend-cyan-hs) 50% / 0.1);
 }
 
 .terra-glass {
-  background: rgba(255, 255, 255, 0.1);
+  background: hsl(var(--tf-text-primary-hs) 100% / 0.1);
   -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(0, 255, 255, 0.2);
+  border: 1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2);
   border-radius: 1rem;
   padding: 1.5rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 8px 32px hsl(var(--tf-text-primary-hs) 0% / 0.3);
 }
 
 .quantum-progress-bar[data-width='100'] {
@@ -105,31 +105,31 @@
 
 /* Elite status indicators */
 .status-transcendent {
-  color: #4ade80;
-  border-color: rgba(74, 222, 128, 0.3);
-  background-color: rgba(74, 222, 128, 0.1);
-  box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
+  color: hsl(var(--tf-success-hs) 63%);
+  border-color: hsl(var(--tf-success-hs) 58% / 0.3);
+  background-color: hsl(var(--tf-success-hs) 58% / 0.1);
+  box-shadow: 0 0 20px hsl(var(--tf-success-hs) 45% / 0.3);
 }
 
 .status-championship {
   color: var(--tf-status-blue-light);
-  border-color: rgba(96, 165, 250, 0.3);
-  background-color: rgba(96, 165, 250, 0.1);
-  box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
+  border-color: hsl(var(--tf-network-blue-hs) 68% / 0.3);
+  background-color: hsl(var(--tf-network-blue-hs) 68% / 0.1);
+  box-shadow: 0 0 20px hsl(var(--tf-network-blue-hs) 60% / 0.3);
 }
 
 .status-elite {
-  color: #a78bfa;
-  border-color: rgba(167, 139, 250, 0.3);
-  background-color: rgba(167, 139, 250, 0.1);
-  box-shadow: 0 0 20px rgba(168, 85, 247, 0.3);
+  color: hsl(var(--tf-info-hs) 76%);
+  border-color: hsl(var(--tf-info-hs) 76% / 0.3);
+  background-color: hsl(var(--tf-info-hs) 76% / 0.1);
+  box-shadow: 0 0 20px hsl(var(--tf-info-hs) 65% / 0.3);
 }
 
 .status-optimal {
-  color: #22d3ee;
-  border-color: rgba(34, 211, 238, 0.3);
-  background-color: rgba(34, 211, 238, 0.1);
-  box-shadow: 0 0 20px rgba(34, 211, 238, 0.3);
+  color: hsl(var(--tf-transcend-cyan-hs) 53%);
+  border-color: hsl(var(--tf-transcend-cyan-hs) 53% / 0.3);
+  background-color: hsl(var(--tf-transcend-cyan-hs) 53% / 0.1);
+  box-shadow: 0 0 20px hsl(var(--tf-transcend-cyan-hs) 53% / 0.3);
 }
 
 /* Government excellence animations */
@@ -163,15 +163,15 @@
 .elite-system-card {
   padding: 0.75rem;
   border-radius: 0.5rem;
-  border: 1px solid rgba(0, 255, 255, 0.2);
+  border: 1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  background: linear-gradient(135deg, rgba(10, 14, 26, 0.8), rgba(30, 41, 59, 0.3));
+  background: linear-gradient(135deg, hsl(var(--tf-surface-dark-hs) 7% / 0.8), hsl(var(--tf-surface-dark-hs) 17% / 0.3));
 }
 
 .elite-system-card:hover {
-  border-color: rgba(0, 255, 255, 0.4);
+  border-color: hsl(var(--tf-transcend-cyan-hs) 50% / 0.4);
   transform: scale(1.05);
-  box-shadow: 0 10px 25px rgba(0, 255, 255, 0.1);
+  box-shadow: 0 10px 25px hsl(var(--tf-transcend-cyan-hs) 50% / 0.1);
 }
 
 /* Transcendent mode notification */
@@ -181,9 +181,9 @@
 
 @keyframes transcendent-glow {
   0% {
-    box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
+    box-shadow: 0 0 20px hsl(var(--tf-success-hs) 45% / 0.3);
   }
   100% {
-    box-shadow: 0 0 30px rgba(34, 197, 94, 0.6);
+    box-shadow: 0 0 30px hsl(var(--tf-success-hs) 45% / 0.6);
   }
 }


### PR DESCRIPTION
## Summary
- Salvaged completed conversion work from paused swarm output into a clean branch
- Converted raw color literals to tokenized forms in:
  - frontend/apps/os-shell/src/plugins/harris-pacs/index.module.css
  - frontend/apps/os-shell/src/styles/elite-quantum-dashboard.css
  - frontend/apps/os-shell/src/components/pilot/ToolInvokePanel.tsx
  - frontend/apps/os-shell/src/components/research/AISwarmManagementPanel.tsx
  - frontend/apps/os-shell/src/components/brand/TerraFusionBrandEnhancementSystem.tsx
- Kept ui-token-baseline.json and ui-token-* contract artifacts out of commit to minimize cross-PR contract conflicts

## Local Validation
- pnpm tdc:ui:tokens => Ratchet OK: 729 <= baseline 1052 (delta -323)
- pnpm -w run test:governance:ui
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs