### PR TITLE
chore(ui-tokens): B2-18 convert LoadingStates + AspectRatio stories

### DIFF
--- a/frontend/apps/os-shell/src/components/common/LoadingStates.tsx
+++ b/frontend/apps/os-shell/src/components/common/LoadingStates.tsx
@@ -120,7 +120,7 @@ export const QuantumLoader: React.FC = () => (
         width: '100%',
         height: '100%',
         borderRadius: '50%',
-        border: '3px solid rgba(0, 255, 255, 0.3)',
+        border: '3px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.3)',
         animation: 'quantum-pulse 1.5s ease-in-out infinite',
       }}
     />
@@ -130,7 +130,7 @@ export const QuantumLoader: React.FC = () => (
         width: '100%',
         height: '100%',
         borderRadius: '50%',
-        border: '3px solid rgba(0, 255, 255, 0.5)',
+        border: '3px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.5)',
         animation: 'quantum-pulse 1.5s ease-in-out 0.5s infinite',
       }}
     />
@@ -140,7 +140,7 @@ export const QuantumLoader: React.FC = () => (
         width: '100%',
         height: '100%',
         borderRadius: '50%',
-        border: '3px solid rgba(0, 255, 255, 0.7)',
+        border: '3px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.7)',
         animation: 'quantum-pulse 1.5s ease-in-out 1s infinite',
       }}
     />
@@ -176,7 +176,7 @@ export const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({
       style={{
         width: '100%',
         height,
-        background: 'rgba(30, 41, 59, 0.5)',
+        background: 'hsl(var(--tf-bg-surface-hs) 18% / 0.5)',
         borderRadius: '3px',
         overflow: 'hidden',
       }}
@@ -188,7 +188,7 @@ export const ProgressIndicator: React.FC<ProgressIndicatorProps> = ({
           background: color,
           borderRadius: '3px',
           transition: 'width 0.3s ease',
-          boxShadow: '0 0 10px rgba(0, 255, 255, 0.5)',
+          boxShadow: '0 0 10px hsl(var(--tf-transcend-cyan-hs) 50% / 0.5)',
         }}
       />
     </div>
@@ -234,7 +234,7 @@ export const CircularProgress: React.FC<CircularProgressProps> = ({
         cy={size / 2}
         r={radius}
         fill='none'
-        stroke='rgba(30, 41, 59, 0.3)'
+        stroke='hsl(var(--tf-bg-surface-hs) 18% / 0.3)'
         strokeWidth={strokeWidth}
       />
       <circle
@@ -279,7 +279,7 @@ export const SkeletonPanel: React.FC<{ height?: string }> = ({ height = '400px' 
       width: '100%',
       height,
       background:
-        'linear-gradient(90deg, rgba(30, 41, 59, 0.3) 0%, rgba(30, 41, 59, 0.5) 50%, rgba(30, 41, 59, 0.3) 100%)',
+        'linear-gradient(90deg, hsl(var(--tf-bg-surface-hs) 18% / 0.3) 0%, hsl(var(--tf-bg-surface-hs) 18% / 0.5) 50%, hsl(var(--tf-bg-surface-hs) 18% / 0.3) 100%)',
       backgroundSize: '200% 100%',
       animation: 'skeleton-shimmer 1.5s ease-in-out infinite',
       borderRadius: '12px',
@@ -301,17 +301,17 @@ export const SkeletonCard: React.FC = () => (
   <div
     style={{
       padding: '1.5rem',
-      background: 'rgba(30, 41, 59, 0.3)',
+      background: 'hsl(var(--tf-bg-surface-hs) 18% / 0.3)',
       borderRadius: '12px',
       backdropFilter: 'blur(10px)',
-      border: '1px solid rgba(148, 163, 184, 0.2)',
+      border: '1px solid hsl(var(--tf-neutral-hs) 70% / 0.2)',
     }}
   >
     <div
       style={{
         width: '60%',
         height: '24px',
-        background: 'rgba(148, 163, 184, 0.2)',
+        background: 'hsl(var(--tf-neutral-hs) 70% / 0.2)',
         borderRadius: '4px',
         marginBottom: '1rem',
         animation: 'skeleton-pulse 1.5s ease-in-out infinite',
@@ -321,7 +321,7 @@ export const SkeletonCard: React.FC = () => (
       style={{
         width: '100%',
         height: '16px',
-        background: 'rgba(148, 163, 184, 0.2)',
+        background: 'hsl(var(--tf-neutral-hs) 70% / 0.2)',
         borderRadius: '4px',
         marginBottom: '0.5rem',
         animation: 'skeleton-pulse 1.5s ease-in-out 0.2s infinite',
@@ -331,7 +331,7 @@ export const SkeletonCard: React.FC = () => (
       style={{
         width: '80%',
         height: '16px',
-        background: 'rgba(148, 163, 184, 0.2)',
+        background: 'hsl(var(--tf-neutral-hs) 70% / 0.2)',
         borderRadius: '4px',
         animation: 'skeleton-pulse 1.5s ease-in-out 0.4s infinite',
       }}
@@ -353,7 +353,7 @@ export const SkeletonTable: React.FC<{ rows?: number; columns?: number }> = ({
 }) => (
   <div
     style={{
-      background: 'rgba(30, 41, 59, 0.3)',
+      background: 'hsl(var(--tf-bg-surface-hs) 18% / 0.3)',
       borderRadius: '12px',
       overflow: 'hidden',
       backdropFilter: 'blur(10px)',
@@ -366,7 +366,7 @@ export const SkeletonTable: React.FC<{ rows?: number; columns?: number }> = ({
         gridTemplateColumns: `repeat(${columns}, 1fr)`,
         gap: '1rem',
         padding: '1rem',
-        borderBottom: '1px solid rgba(148, 163, 184, 0.2)',
+        borderBottom: '1px solid hsl(var(--tf-neutral-hs) 70% / 0.2)',
       }}
     >
       {Array.from({ length: columns }).map((_, i) => (
@@ -374,7 +374,7 @@ export const SkeletonTable: React.FC<{ rows?: number; columns?: number }> = ({
           key={i}
           style={{
             height: '20px',
-            background: 'rgba(148, 163, 184, 0.2)',
+            background: 'hsl(var(--tf-neutral-hs) 70% / 0.2)',
             borderRadius: '4px',
             animation: `skeleton-pulse 1.5s ease-in-out ${i * 0.1}s infinite`,
           }}
@@ -391,7 +391,7 @@ export const SkeletonTable: React.FC<{ rows?: number; columns?: number }> = ({
           gridTemplateColumns: `repeat(${columns}, 1fr)`,
           gap: '1rem',
           padding: '1rem',
-          borderBottom: rowIndex < rows - 1 ? '1px solid rgba(148, 163, 184, 0.1)' : 'none',
+          borderBottom: rowIndex < rows - 1 ? '1px solid hsl(var(--tf-neutral-hs) 70% / 0.1)' : 'none',
         }}
       >
         {Array.from({ length: columns }).map((_, colIndex) => (
@@ -399,7 +399,7 @@ export const SkeletonTable: React.FC<{ rows?: number; columns?: number }> = ({
             key={colIndex}
             style={{
               height: '16px',
-              background: 'rgba(148, 163, 184, 0.15)',
+              background: 'hsl(var(--tf-neutral-hs) 70% / 0.15)',
               borderRadius: '4px',
               animation: `skeleton-pulse 1.5s ease-in-out ${(rowIndex * columns + colIndex) * 0.05}s infinite`,
             }}

--- a/frontend/apps/os-shell/src/components/ui/AspectRatio.stories.tsx
+++ b/frontend/apps/os-shell/src/components/ui/AspectRatio.stories.tsx
@@ -375,8 +375,8 @@ export const WithOverlay: Story = {
               <button
                 style={{
                   padding: '8px 16px',
-                  backgroundColor: 'rgba(255,255,255,0.2)',
-                  border: '1px solid rgba(255,255,255,0.3)',
+                  backgroundColor: 'hsl(var(--tf-neutral-hs) 100% / 0.2)',
+                  border: '1px solid hsl(var(--tf-neutral-hs) 100% / 0.3)',
                   borderRadius: '6px',
                   color: 'var(--tf-text-primary)',
                   fontWeight: 500,
@@ -403,7 +403,7 @@ export const RealWorldGallery: Story = {
       style={{
         maxWidth: '1200px',
         padding: '32px',
-        backgroundColor: '#0a0a0a',
+        backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
         borderRadius: '12px',
       }}
     >
@@ -534,7 +534,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -563,7 +563,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -591,7 +591,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -619,7 +619,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -662,7 +662,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -690,7 +690,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -718,7 +718,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -746,7 +746,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -783,13 +783,13 @@ export const UsageGuidelines: Story = {
         <h4 className='font-semibold'>Code Examples</h4>
         <div
           style={{
-            backgroundColor: '#1a1a1a',
+            backgroundColor: 'hsl(var(--tf-bg-surface-hs) 12%)',
             padding: '20px',
             borderRadius: '8px',
             fontFamily: '"Fira Code", monospace',
             fontSize: '13px',
             overflow: 'auto',
-            border: '1px solid #2a2a2a',
+            border: '1px solid hsl(var(--tf-neutral-hs) 18%)',
           }}
         >
           <pre
@@ -853,17 +853,17 @@ export const UsageGuidelines: Story = {
         <h4 className='font-semibold'>Common Aspect Ratios Reference</h4>
         <div
           style={{
-            backgroundColor: '#1a1a1a',
+            backgroundColor: 'hsl(var(--tf-bg-surface-hs) 12%)',
             padding: '20px',
             borderRadius: '8px',
-            border: '1px solid #2a2a2a',
+            border: '1px solid hsl(var(--tf-neutral-hs) 18%)',
           }}
         >
           <table className='w-full border-collapse'>
             <thead>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <th className='text-left font-semibold'>Ratio</th>
@@ -874,7 +874,7 @@ export const UsageGuidelines: Story = {
             <tbody>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <td
@@ -885,7 +885,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >
@@ -910,7 +910,7 @@ export const UsageGuidelines: Story = {
               </tr>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <td
@@ -921,7 +921,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >
@@ -946,7 +946,7 @@ export const UsageGuidelines: Story = {
               </tr>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <td
@@ -957,7 +957,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >
@@ -982,7 +982,7 @@ export const UsageGuidelines: Story = {
               </tr>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <td
@@ -993,7 +993,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >
@@ -1018,7 +1018,7 @@ export const UsageGuidelines: Story = {
               </tr>
               <tr
                 style={{
-                  borderBottom: '1px solid #2a2a2a',
+                  borderBottom: '1px solid hsl(var(--tf-neutral-hs) 18%)',
                 }}
               >
                 <td
@@ -1029,7 +1029,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >
@@ -1061,7 +1061,7 @@ export const UsageGuidelines: Story = {
                   <code
                     style={{
                       padding: '4px 8px',
-                      backgroundColor: '#0a0a0a',
+                      backgroundColor: 'hsl(var(--tf-bg-surface-hs) 6%)',
                       borderRadius: '4px',
                     }}
                   >

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 523,
+  "violationCount": 488,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -361,132 +361,6 @@
       "line": 122,
       "column": 34,
       "excerpt": "rgba(0, 210, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 123,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 133,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 143,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 179,
-      "column": 22,
-      "excerpt": "rgba(30, 41, 59, 0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 237,
-      "column": 17,
-      "excerpt": "rgba(30, 41, 59, 0.3)'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 282,
-      "column": 33,
-      "excerpt": "rgba(30, 41, 59, 0.3) 0%, rgba(30, 41, 59, 0.5) 50%, rgba(30, 41, 59, 0.3) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 282,
-      "column": 59,
-      "excerpt": "rgba(30, 41, 59, 0.5) 50%, rgba(30, 41, 59, 0.3) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 282,
-      "column": 86,
-      "excerpt": "rgba(30, 41, 59, 0.3) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 304,
-      "column": 20,
-      "excerpt": "rgba(30, 41, 59, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 307,
-      "column": 26,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 314,
-      "column": 22,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 324,
-      "column": 22,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 334,
-      "column": 22,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 356,
-      "column": 20,
-      "excerpt": "rgba(30, 41, 59, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 369,
-      "column": 34,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 377,
-      "column": 26,
-      "excerpt": "rgba(148, 163, 184, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 394,
-      "column": 58,
-      "excerpt": "rgba(148, 163, 184, 0.1)' : 'none',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\LoadingStates.tsx",
-      "line": 402,
-      "column": 28,
-      "excerpt": "rgba(148, 163, 184, 0.15)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1656,125 +1530,6 @@
       "line": 419,
       "column": 29,
       "excerpt": "rgba(245, 158, 11, 0.05)',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 406,
-      "column": 27,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 786,
-      "column": 31,
-      "excerpt": "#1a1a1a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 792,
-      "column": 32,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 856,
-      "column": 31,
-      "excerpt": "#1a1a1a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 859,
-      "column": 32,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 866,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 877,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 888,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 913,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 924,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 949,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 960,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 985,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 996,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 1021,
-      "column": 44,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 1032,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\AspectRatio.stories.tsx",
-      "line": 1064,
-      "column": 41,
-      "excerpt": "#0a0a0a',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -3667,5 +3422,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T02:59:53.133Z"
+  "generatedAtIso": "2026-02-25T03:26:04.118Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 523,
-  "delta": 529,
-  "generatedAtIso": "2026-02-25T02:59:53.137Z"
+  "currentViolationCount": 488,
+  "delta": 564,
+  "generatedAtIso": "2026-02-25T03:26:04.126Z"
 }


### PR DESCRIPTION
## Summary
- selected next top pair (excluding files in open PR #433)
- converted raw color literals in:
  - `frontend/apps/os-shell/src/components/common/LoadingStates.tsx`
  - `frontend/apps/os-shell/src/components/ui/AspectRatio.stories.tsx`
- updated token compliance contracts
- kept `ui-token-baseline.json` out of commit

## Validation
- `pnpm tdc:ui:tokens`
- `pnpm -w run test:governance:ui`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
