### PR TITLE
chore(ui-tokens): B2-19 convert QuantumNavigation + GptStudioView to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/components/navigation/QuantumNavigation.css
+++ b/frontend/apps/os-shell/src/components/navigation/QuantumNavigation.css
@@ -11,7 +11,11 @@
 /* Navigation header effects */
 .quantum-nav-header {
   position: relative;
-  background: linear-gradient(135deg, rgba(0, 255, 255, 0.05) 0%, rgba(0, 128, 255, 0.05) 100%);
+  background: linear-gradient(
+    135deg,
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.05) 0%,
+    hsl(var(--tf-network-blue-hs) var(--tf-l-50) / 0.05) 100%
+  );
 }
 
 .quantum-nav-header::before {
@@ -21,7 +25,12 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(90deg, transparent 0%, rgba(0, 255, 255, 0.1) 50%, transparent 100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1) 50%,
+    transparent 100%
+  );
   animation: quantum-header-sweep 4s linear infinite;
   pointer-events: none;
 }
@@ -39,7 +48,12 @@
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent 0%, rgba(0, 255, 255, 0.2) 50%, transparent 100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2) 50%,
+    transparent 100%
+  );
   transition: left 0.5s ease;
   pointer-events: none;
 }
@@ -51,11 +65,11 @@
 /* Active item glow effect */
 .quantum-nav-item.terra-glow {
   position: relative;
-  background: rgba(0, 255, 255, 0.1);
-  border: 1px solid rgba(0, 255, 255, 0.3);
+  background: hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1);
+  border: 1px solid hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3);
   box-shadow:
-    0 0 20px rgba(0, 255, 255, 0.2),
-    inset 0 0 20px rgba(0, 255, 255, 0.1);
+    0 0 20px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2),
+    inset 0 0 20px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1);
 }
 
 .quantum-nav-item.terra-glow::after {
@@ -67,9 +81,9 @@
   bottom: 0;
   background: linear-gradient(
     45deg,
-    rgba(0, 255, 255, 0.1) 0%,
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1) 0%,
     transparent 50%,
-    rgba(0, 255, 255, 0.1) 100%
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1) 100%
   );
   animation: quantum-active-pulse 2s ease-in-out infinite;
   pointer-events: none;
@@ -120,25 +134,29 @@
 }
 
 .quantum-nav-content::-webkit-scrollbar-thumb {
-  background: rgba(0, 255, 255, 0.3);
+  background: hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3);
   border-radius: 2px;
 }
 
 .quantum-nav-content::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 255, 255, 0.5);
+  background: hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.5);
 }
 
 /* Navigation footer status indicator */
 .quantum-nav-footer {
   position: relative;
-  background: linear-gradient(135deg, rgba(0, 255, 255, 0.02) 0%, rgba(0, 128, 255, 0.02) 100%);
+  background: linear-gradient(
+    135deg,
+    hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.02) 0%,
+    hsl(var(--tf-network-blue-hs) var(--tf-l-50) / 0.02) 100%
+  );
 }
 
 /* Breadcrumb styling */
 .quantum-breadcrumb {
   padding: 1rem;
-  background: rgba(30, 41, 59, 0.3);
-  border-bottom: 1px solid rgba(0, 255, 255, 0.1);
+  background: hsl(var(--tf-bg-surface-hs) var(--tf-l-20) / 0.3);
+  border-bottom: 1px solid hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
@@ -205,11 +223,11 @@
 /* High contrast mode */
 @media (prefers-contrast: high) {
   .quantum-nav-item {
-    border: 1px solid rgba(0, 255, 255, 0.5);
+    border: 1px solid hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.5);
   }
 
   .quantum-nav-item:hover {
-    background: rgba(0, 255, 255, 0.2);
+    background: hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2);
   }
 
   .quantum-nav-item.terra-glow {

--- a/frontend/apps/os-shell/src/features/gpt/GptStudioView.tsx
+++ b/frontend/apps/os-shell/src/features/gpt/GptStudioView.tsx
@@ -228,10 +228,10 @@ export const GptStudioView: React.FC = () => {
       className='flex h-full w-full flex-col bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950/90 p-4 text-sm text-slate-50'
     >
       {/* Header / title bar */}
-      <div className='mb-3 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-2 shadow-[0_18px_45px_rgba(0,0,0,0.60)] backdrop-blur-xl'>
+      <div className='mb-3 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-2 shadow-[0_18px_45px_hsl(var(--tf-tokens-black-hs)_0%_/_0.6)] backdrop-blur-xl'>
         <div className='flex items-center gap-3'>
           {/* TerraSphere-style indicator */}
-          <div className='relative h-7 w-7 rounded-full bg-gradient-to-br from-sky-400 via-cyan-300 to-emerald-300 shadow-[0_0_25px_rgba(56,189,248,0.9)]'>
+          <div className='relative h-7 w-7 rounded-full bg-gradient-to-br from-sky-400 via-cyan-300 to-emerald-300 shadow-[0_0_25px_hsl(var(--tf-network-blue-hs)_61%_/_0.9)]'>
             <div className='absolute inset-[2px] rounded-full bg-slate-950/80 backdrop-blur' />
             <div className='absolute inset-[4px] rounded-full border border-cyan-300/40' />
           </div>
@@ -264,7 +264,7 @@ export const GptStudioView: React.FC = () => {
                   ragStatus &&
                   ragStatus.indexed &&
                   ragStatus.embeddingCount > 0 && (
-                    <span className='rounded-full border border-emerald-400/60 bg-emerald-500/10 px-2 py-0.5 text-[0.6rem] text-emerald-300 shadow-[0_0_18px_rgba(52,211,153,0.6)]'>
+                    <span className='rounded-full border border-emerald-400/60 bg-emerald-500/10 px-2 py-0.5 text-[0.6rem] text-emerald-300 shadow-[0_0_18px_hsl(var(--tf-success-hs)_52%_/_0.6)]'>
                       RAG: Benton CAMA Online · {ragStatus.documentCount} docs
                     </span>
                   )}
@@ -278,7 +278,7 @@ export const GptStudioView: React.FC = () => {
                       </span>
                       <button
                         onClick={() => void handleIndexRag()}
-                        className='rounded-full border border-cyan-400/60 bg-cyan-500/10 px-2 py-0.5 text-[0.6rem] text-cyan-300 transition-all hover:bg-cyan-500/20 hover:shadow-[0_0_12px_rgba(34,211,238,0.4)]'
+                        className='rounded-full border border-cyan-400/60 bg-cyan-500/10 px-2 py-0.5 text-[0.6rem] text-cyan-300 transition-all hover:bg-cyan-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-transcend-cyan-hs)_53%_/_0.4)]'
                       >
                         Index Now
                       </button>
@@ -305,7 +305,7 @@ export const GptStudioView: React.FC = () => {
             {/* Explain This button (Phase 13) */}
             <button
               onClick={() => void handleExplainThis()}
-              className='rounded-full border border-fuchsia-500/50 bg-fuchsia-500/10 px-2 py-0.5 text-[0.6rem] text-fuchsia-300 transition-all hover:bg-fuchsia-500/20 hover:shadow-[0_0_12px_rgba(217,70,239,0.4)]'
+              className='rounded-full border border-fuchsia-500/50 bg-fuchsia-500/10 px-2 py-0.5 text-[0.6rem] text-fuchsia-300 transition-all hover:bg-fuchsia-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-info-hs)_60%_/_0.4)]'
               title='Explain this view'
             >
               ❓ Explain
@@ -317,7 +317,7 @@ export const GptStudioView: React.FC = () => {
       {/* Main content area */}
       <div className='flex min-h-0 flex-1 gap-4'>
         {/* Left column: GPT list */}
-        <div className='flex w-72 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_18px_55px_rgba(0,0,0,0.65)] backdrop-blur-xl'>
+        <div className='flex w-72 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_18px_55px_hsl(var(--tf-tokens-black-hs)_0%_/_0.65)] backdrop-blur-xl'>
           <div className='mb-2 flex items-center justify-between'>
             <div className='text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-slate-400'>
               System GPTs
@@ -343,15 +343,15 @@ export const GptStudioView: React.FC = () => {
                   className={[
                     'group w-full rounded-xl px-3 py-2 text-left text-xs transition-all',
                     'border border-transparent bg-slate-900/70 backdrop-blur-sm',
-                    'hover:border-sky-500/70 hover:bg-slate-900/90 hover:shadow-[0_10px_30px_rgba(56,189,248,0.35)]',
+                    'hover:border-sky-500/70 hover:bg-slate-900/90 hover:shadow-[0_10px_30px_hsl(var(--tf-network-blue-hs)_61%_/_0.35)]',
                     isActive
-                      ? 'border-sky-400/80 bg-slate-900/95 shadow-[0_0_30px_rgba(56,189,248,0.85)]'
+                      ? 'border-sky-400/80 bg-slate-900/95 shadow-[0_0_30px_hsl(var(--tf-network-blue-hs)_61%_/_0.85)]'
                       : '',
                   ].join(' ')}
                 >
                   <div className='flex items-center justify-between'>
                     <div className='font-semibold text-slate-50'>{gpt.name}</div>
-                    <div className='h-1.5 w-1.5 rounded-full bg-emerald-400/80 shadow-[0_0_10px_rgba(52,211,153,0.9)] group-hover:bg-sky-400/90' />
+                    <div className='h-1.5 w-1.5 rounded-full bg-emerald-400/80 shadow-[0_0_10px_hsl(var(--tf-success-hs)_52%_/_0.9)] group-hover:bg-sky-400/90' />
                   </div>
                   <div className='mt-0.5 text-[0.7rem] leading-snug text-slate-300/90 line-clamp-2'>
                     {gpt.description}
@@ -364,13 +364,13 @@ export const GptStudioView: React.FC = () => {
 
         {/* Middle column: Assessor Flows (only for PropertyAssessmentGPT) */}
         {showAssessorFlows && (
-          <div className='flex w-64 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_18px_55px_rgba(0,0,0,0.65)] backdrop-blur-xl'>
+          <div className='flex w-64 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_18px_55px_hsl(var(--tf-tokens-black-hs)_0%_/_0.65)] backdrop-blur-xl'>
             <PropertyAssessmentFlows onSelectFlow={handleSelectFlow} isDisabled={sending} />
           </div>
         )}
 
         {/* Right column: conversation */}
-        <div className='flex min-w-0 flex-1 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_20px_60px_rgba(0,0,0,0.75)] backdrop-blur-2xl'>
+        <div className='flex min-w-0 flex-1 flex-col rounded-2xl border border-slate-800/70 bg-slate-950/70 p-3 shadow-[0_20px_60px_hsl(var(--tf-tokens-black-hs)_0%_/_0.75)] backdrop-blur-2xl'>
           <div className='mb-2 flex items-center justify-between'>
             <div className='flex flex-col'>
               <div className='text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-slate-400'>
@@ -390,7 +390,7 @@ export const GptStudioView: React.FC = () => {
                 className={[
                   'flex items-center gap-1.5 rounded-xl px-2.5 py-1 text-[0.65rem] font-medium transition-all',
                   showSources
-                    ? 'border border-emerald-400/60 bg-emerald-500/20 text-emerald-200 shadow-[0_0_15px_rgba(52,211,153,0.4)]'
+                    ? 'border border-emerald-400/60 bg-emerald-500/20 text-emerald-200 shadow-[0_0_15px_hsl(var(--tf-success-hs)_52%_/_0.4)]'
                     : 'border border-slate-700/50 bg-slate-900/60 text-slate-400 hover:border-emerald-400/40 hover:text-emerald-300',
                 ].join(' ')}
                 title='Toggle RAG source visibility for audit traceability'
@@ -423,8 +423,8 @@ export const GptStudioView: React.FC = () => {
                         'max-w-[80%] rounded-2xl px-3 py-2 text-xs leading-relaxed backdrop-blur',
                         'border border-slate-700/60',
                         isUser
-                          ? 'bg-gradient-to-br from-sky-500/90 via-sky-400/90 to-cyan-400/90 text-white shadow-[0_14px_40px_rgba(56,189,248,0.65)]'
-                          : 'bg-slate-900/90 text-slate-50 shadow-[0_8px_30px_rgba(15,23,42,0.80)]',
+                          ? 'bg-gradient-to-br from-sky-500/90 via-sky-400/90 to-cyan-400/90 text-white shadow-[0_14px_40px_hsl(var(--tf-network-blue-hs)_61%_/_0.65)]'
+                          : 'bg-slate-900/90 text-slate-50 shadow-[0_8px_30px_hsl(var(--tf-surface-dark-hs)_11%_/_0.8)]',
                       ].join(' ')}
                     >
                       <div className='mb-1 flex items-center gap-2'>
@@ -477,7 +477,7 @@ export const GptStudioView: React.FC = () => {
             {sendError && <div className='mb-1 text-xs text-red-400'>{sendError}</div>}
             <div className='flex items-end gap-2'>
               <textarea
-                className='h-18 flex-1 resize-none rounded-2xl border border-slate-800/70 bg-slate-950/80 px-3 py-2 text-xs text-slate-100 shadow-[0_10px_32px_rgba(0,0,0,0.75)] outline-none backdrop-blur-xl transition focus:border-sky-500 focus:ring-1 focus:ring-sky-500/60 disabled:opacity-60'
+                className='h-18 flex-1 resize-none rounded-2xl border border-slate-800/70 bg-slate-950/80 px-3 py-2 text-xs text-slate-100 shadow-[0_10px_32px_hsl(var(--tf-tokens-black-hs)_0%_/_0.75)] outline-none backdrop-blur-xl transition focus:border-sky-500 focus:ring-1 focus:ring-sky-500/60 disabled:opacity-60'
                 placeholder={
                   selectedGpt
                     ? `Ask ${selectedGpt.name} a question…`
@@ -492,7 +492,7 @@ export const GptStudioView: React.FC = () => {
                 type='button'
                 onClick={() => void handleSend()}
                 disabled={!selectedGpt || sending || !input.trim()}
-                className='mb-0.5 rounded-2xl bg-gradient-to-br from-sky-500 via-sky-400 to-cyan-400 px-4 py-2 text-xs font-semibold text-slate-950 shadow-[0_12px_40px_rgba(56,189,248,0.8)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50'
+                className='mb-0.5 rounded-2xl bg-gradient-to-br from-sky-500 via-sky-400 to-cyan-400 px-4 py-2 text-xs font-semibold text-slate-950 shadow-[0_12px_40px_hsl(var(--tf-network-blue-hs)_61%_/_0.8)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50'
               >
                 {sending ? 'Sending…' : 'Send'}
               </button>

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 488,
+  "violationCount": 456,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1022,118 +1022,6 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 14,
-      "column": 39,
-      "excerpt": "rgba(0, 255, 255, 0.05) 0%, rgba(0, 128, 255, 0.05) 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 14,
-      "column": 67,
-      "excerpt": "rgba(0, 128, 255, 0.05) 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 24,
-      "column": 54,
-      "excerpt": "rgba(0, 255, 255, 0.1) 50%, transparent 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 42,
-      "column": 54,
-      "excerpt": "rgba(0, 255, 255, 0.2) 50%, transparent 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 54,
-      "column": 15,
-      "excerpt": "rgba(0, 255, 255, 0.1);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 55,
-      "column": 21,
-      "excerpt": "rgba(0, 255, 255, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 57,
-      "column": 14,
-      "excerpt": "rgba(0, 255, 255, 0.2),"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 58,
-      "column": 20,
-      "excerpt": "rgba(0, 255, 255, 0.1);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 70,
-      "column": 5,
-      "excerpt": "rgba(0, 255, 255, 0.1) 0%,"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 72,
-      "column": 5,
-      "excerpt": "rgba(0, 255, 255, 0.1) 100%"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 123,
-      "column": 15,
-      "excerpt": "rgba(0, 255, 255, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 128,
-      "column": 15,
-      "excerpt": "rgba(0, 255, 255, 0.5);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 134,
-      "column": 39,
-      "excerpt": "rgba(0, 255, 255, 0.02) 0%, rgba(0, 128, 255, 0.02) 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 134,
-      "column": 67,
-      "excerpt": "rgba(0, 128, 255, 0.02) 100%);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 140,
-      "column": 15,
-      "excerpt": "rgba(30, 41, 59, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\navigation\\QuantumNavigation.css",
-      "line": 141,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.1);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\playground\\PlaygroundTester.tsx",
       "line": 187,
       "column": 75,
@@ -2048,118 +1936,6 @@
       "line": 127,
       "column": 44,
       "excerpt": "rgba(251,113,133,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 231,
-      "column": 147,
-      "excerpt": "rgba(0,0,0,0.60)] backdrop-blur-xl'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 234,
-      "column": 133,
-      "excerpt": "rgba(56,189,248,0.9)]'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 267,
-      "column": 158,
-      "excerpt": "rgba(52,211,153,0.6)]'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 281,
-      "column": 189,
-      "excerpt": "rgba(34,211,238,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 308,
-      "column": 191,
-      "excerpt": "rgba(217,70,239,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 320,
-      "column": 123,
-      "excerpt": "rgba(0,0,0,0.65)] backdrop-blur-xl'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 346,
-      "column": 94,
-      "excerpt": "rgba(56,189,248,0.35)]',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 348,
-      "column": 77,
-      "excerpt": "rgba(56,189,248,0.85)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 354,
-      "column": 97,
-      "excerpt": "rgba(52,211,153,0.9)] group-hover:bg-sky-400/90' />"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 367,
-      "column": 125,
-      "excerpt": "rgba(0,0,0,0.65)] backdrop-blur-xl'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 373,
-      "column": 133,
-      "excerpt": "rgba(0,0,0,0.75)] backdrop-blur-2xl'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 393,
-      "column": 105,
-      "excerpt": "rgba(52,211,153,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 426,
-      "column": 125,
-      "excerpt": "rgba(56,189,248,0.65)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 427,
-      "column": 79,
-      "excerpt": "rgba(15,23,42,0.80)]',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 480,
-      "column": 160,
-      "excerpt": "rgba(0,0,0,0.75)] outline-none backdrop-blur-xl transition focus:border-sky-500 focus:ring-1 focus:ring-sky-500/60 disabled:opacity-60'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\GptStudioView.tsx",
-      "line": 495,
-      "column": 169,
-      "excerpt": "rgba(56,189,248,0.8)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50'"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -3422,5 +3198,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T03:26:04.118Z"
+  "generatedAtIso": "2026-02-25T03:57:00.862Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 488,
-  "delta": 564,
-  "generatedAtIso": "2026-02-25T03:26:04.126Z"
+  "currentViolationCount": 456,
+  "delta": 596,
+  "generatedAtIso": "2026-02-25T03:57:00.867Z"
 }


### PR DESCRIPTION
## Summary
- convert raw color usage in `QuantumNavigation.css` to tokenized `hsl(var(--tf-*-hs) ... / alpha)`
- convert raw `rgba(...)` arbitrary Tailwind shadow values in `GptStudioView.tsx` to tokenized `hsl(var(--tf-*-hs)_..._/_...)`
- refresh `ui-token-compliance.contract.json` and `ui-token-ratchet.contract.json`
- keep `ui-token-baseline.json` out of commit

## Validation
- `pnpm tdc:ui:tokens` (Ratchet OK: `456 <= baseline 1052`)
- `pnpm -w run test:governance:ui`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized color theming across UI components by transitioning to variable-based color system for improved visual consistency and theme support.

* **Refactor**
  * Consolidated color definitions to CSS variables, reducing hardcoded color values and enhancing maintainability of the theme system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->