### PR TITLE
chore(ui-tokens): B2-21 token sweep for tokens + valuation CSS

### DIFF
--- a/frontend/apps/os-shell/src/components/styles/terrafusion-tokens.css
+++ b/frontend/apps/os-shell/src/components/styles/terrafusion-tokens.css
@@ -8,15 +8,15 @@
   --terra-cyan: var(--tf-quantum-cyan);
   --terra-midnight: var(--tf-void-black);
   --terra-blue: var(--tf-network-blue);
-  --terra-slate: #1e293b;
-  --terra-accent: #00ffaa;
+  --terra-slate: hsl(var(--tf-bg-surface-hs) var(--tf-l-20));
+  --terra-accent: hsl(var(--tf-success-hs) var(--tf-l-50));
   --terra-transcend: var(--tf-transcend-highlight);
 
   /* Semantic Colors */
-  --success-green: #00ff88;
-  --warning-amber: #ffaa00;
-  --error-red: #ff4444;
-  --info-purple: #8844ff;
+  --success-green: hsl(var(--tf-success-hs) var(--tf-l-50));
+  --warning-amber: hsl(var(--tf-warning-hs) var(--tf-l-50));
+  --error-red: hsl(var(--tf-error-hs) var(--tf-l-60));
+  --info-purple: hsl(var(--tf-info-hs) var(--tf-l-60));
 
   /* Gradient Definitions */
   --gradient-primary: linear-gradient(135deg, var(--terra-cyan) 0%, var(--terra-blue) 100%);
@@ -61,16 +61,16 @@
   --duration-slow: 500ms;
 
   /* Elevation & Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 10px 30px rgba(0, 255, 255, 0.2);
-  --shadow-glow: 0 0 40px rgba(0, 255, 255, 0.4);
-  --shadow-quantum: 0 0 20px rgba(0, 255, 255, 0.3);
+  --shadow-sm: 0 1px 2px hsl(var(--tf-tokens-black-hs) 0% / 0.05);
+  --shadow-md: 0 4px 6px hsl(var(--tf-tokens-black-hs) 0% / 0.1);
+  --shadow-lg: 0 10px 30px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2);
+  --shadow-glow: 0 0 40px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.4);
+  --shadow-quantum: 0 0 20px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3);
 
   /* Glass Morphism */
-  --glass-bg: rgba(30, 41, 59, 0.3);
-  --glass-border: rgba(0, 255, 255, 0.2);
-  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.37);
+  --glass-bg: hsl(var(--tf-bg-surface-hs) var(--tf-l-20) / 0.3);
+  --glass-border: hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2);
+  --glass-shadow: 0 8px 32px hsl(var(--tf-tokens-black-hs) 0% / 0.37);
   --blur-amount: blur(16px);
 
   /* Border Radius */

--- a/frontend/apps/os-shell/src/plugins/valuation-tools/index.module.css
+++ b/frontend/apps/os-shell/src/plugins/valuation-tools/index.module.css
@@ -1,9 +1,9 @@
 .root {
   padding: 16px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid hsl(var(--tf-neutral-hs) 88%);
   border-radius: 8px;
   margin: 12px 0;
-  background: #f9f9f9;
+  background: hsl(var(--tf-neutral-hs) 98%);
 }
 
 .header {
@@ -15,13 +15,13 @@
 .title {
   font-size: 18px;
   font-weight: 700;
-  color: #2c3e50;
+  color: hsl(var(--tf-surface-dark-hs) 25%);
   margin-bottom: 4px;
 }
 
 .subtitle {
   font-size: 14px;
-  color: #7f8c8d;
+  color: hsl(var(--tf-neutral-hs) 55%);
   font-style: italic;
 }
 
@@ -31,7 +31,7 @@
   gap: 8px;
   margin-bottom: 16px;
   font-size: 13px;
-  color: #555;
+  color: hsl(var(--tf-neutral-hs) 35%);
 }
 
 .controls {
@@ -50,7 +50,7 @@
 .label {
   font-weight: 600;
   font-size: 13px;
-  color: #2c3e50;
+  color: hsl(var(--tf-surface-dark-hs) 25%);
 }
 
 .input,
@@ -79,12 +79,12 @@
 }
 
 .button:hover:not(:disabled) {
-  background: #c0392b;
+  background: hsl(var(--tf-error-hs) 47%);
 }
 
 .buttonSecondary {
   padding: 8px 16px;
-  background: #9b59b6;
+  background: hsl(var(--tf-info-hs) 53%);
   color: white;
   border: none;
   border-radius: 4px;
@@ -94,18 +94,18 @@
 }
 
 .buttonSecondary:hover:not(:disabled) {
-  background: #8e44ad;
+  background: hsl(var(--tf-info-hs) 47%);
 }
 
 .button:disabled,
 .buttonSecondary:disabled {
-  background: #95a5a6;
+  background: hsl(var(--tf-neutral-hs) 68%);
   cursor: not-allowed;
 }
 
 .results {
-  background: #ecf0f1;
-  border: 1px solid #bdc3c7;
+  background: hsl(var(--tf-neutral-hs) 94%);
+  border: 1px solid hsl(var(--tf-neutral-hs) 80%);
   border-radius: 4px;
   padding: 12px;
 }
@@ -113,7 +113,7 @@
 .resultsTitle {
   font-weight: 600;
   margin-bottom: 8px;
-  color: #2c3e50;
+  color: hsl(var(--tf-surface-dark-hs) 25%);
 }
 
 .resultsData {
@@ -122,7 +122,7 @@
   background: white;
   padding: 8px;
   border-radius: 3px;
-  border: 1px solid #d5dbdb;
+  border: 1px solid hsl(var(--tf-neutral-hs) 86%);
   overflow-x: auto;
   max-height: 200px;
   overflow-y: auto;

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 427,
+  "violationCount": 399,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1154,104 +1154,6 @@
       "excerpt": "hsl(${180 + Math.random() * 30}, 100%, ${50 + Math.random() * 20}%)`,"
     },
     {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 11,
-      "column": 18,
-      "excerpt": "#1e293b;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 12,
-      "column": 19,
-      "excerpt": "#00ffaa;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 16,
-      "column": 20,
-      "excerpt": "#00ff88;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 17,
-      "column": 20,
-      "excerpt": "#ffaa00;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 18,
-      "column": 16,
-      "excerpt": "#ff4444;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 19,
-      "column": 18,
-      "excerpt": "#8844ff;"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 64,
-      "column": 26,
-      "excerpt": "rgba(0, 0, 0, 0.05);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 65,
-      "column": 26,
-      "excerpt": "rgba(0, 0, 0, 0.1);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 66,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.2);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 67,
-      "column": 27,
-      "excerpt": "rgba(0, 255, 255, 0.4);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 68,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 71,
-      "column": 15,
-      "excerpt": "rgba(30, 41, 59, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 72,
-      "column": 19,
-      "excerpt": "rgba(0, 255, 255, 0.2);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\styles\\terrafusion-tokens.css",
-      "line": 73,
-      "column": 30,
-      "excerpt": "rgba(0, 0, 0, 0.37);"
-    },
-    {
       "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\terra-flow\\SwarmVisualization3D.tsx",
       "line": 118,
@@ -2197,104 +2099,6 @@
       "excerpt": "#d5dbdb;"
     },
     {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 3,
-      "column": 21,
-      "excerpt": "#e0e0e0;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 6,
-      "column": 15,
-      "excerpt": "#f9f9f9;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 18,
-      "column": 10,
-      "excerpt": "#2c3e50;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 24,
-      "column": 10,
-      "excerpt": "#7f8c8d;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 34,
-      "column": 10,
-      "excerpt": "#555;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 53,
-      "column": 10,
-      "excerpt": "#2c3e50;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 82,
-      "column": 15,
-      "excerpt": "#c0392b;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 87,
-      "column": 15,
-      "excerpt": "#9b59b6;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 97,
-      "column": 15,
-      "excerpt": "#8e44ad;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 102,
-      "column": 15,
-      "excerpt": "#95a5a6;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 107,
-      "column": 15,
-      "excerpt": "#ecf0f1;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 108,
-      "column": 21,
-      "excerpt": "#bdc3c7;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 116,
-      "column": 10,
-      "excerpt": "#2c3e50;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\valuation-tools\\index.module.css",
-      "line": 125,
-      "column": 21,
-      "excerpt": "#d5dbdb;"
-    },
-    {
       "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\providers\\TerraFusionExcellenceProvider.tsx",
       "line": 65,
@@ -2995,5 +2799,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T04:23:57.021Z"
+  "generatedAtIso": "2026-02-25T04:45:32.264Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 427,
-  "delta": 625,
-  "generatedAtIso": "2026-02-25T04:23:57.028Z"
+  "currentViolationCount": 399,
+  "delta": 653,
+  "generatedAtIso": "2026-02-25T04:45:32.285Z"
 }


### PR DESCRIPTION
Summary
- convert raw color literals in terrafusion-tokens.css and valuation-tools/index.module.css to HS tokenized forms
- update UI token compliance and ratchet contracts from current sweep
- keep ui-token-baseline.json unchanged

Validation
- pnpm tdc:ui:tokens
- pnpm -w run test:governance:ui
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refactored design token color definitions for improved consistency and maintainability across the application.
  * Updated component styling to use centralized theme variables instead of hardcoded values.

* **Chores**
  * Enhanced design system compliance by reducing token violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->