### PR TITLE
chore(ui-tokens): B2-22 convert App + GIS core styles to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/plugins/gis-core/index.module.css
+++ b/frontend/apps/os-shell/src/plugins/gis-core/index.module.css
@@ -1,9 +1,9 @@
 .root {
   padding: 16px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid hsl(var(--tf-text-secondary-hs) 88%);
   border-radius: 8px;
   margin: 12px 0;
-  background: #f8f9fa;
+  background: hsl(var(--tf-text-primary-hs) 98%);
 }
 
 .header {
@@ -15,13 +15,13 @@
 .title {
   font-size: 18px;
   font-weight: 700;
-  color: #2c3e50;
+  color: hsl(var(--tf-surface-dark-hs) 25%);
   margin-bottom: 4px;
 }
 
 .subtitle {
   font-size: 14px;
-  color: #7f8c8d;
+  color: hsl(var(--tf-text-secondary-hs) 53%);
   font-style: italic;
 }
 
@@ -31,7 +31,7 @@
   gap: 8px;
   margin-bottom: 16px;
   font-size: 13px;
-  color: #555;
+  color: hsl(var(--tf-text-secondary-hs) 33%);
 }
 
 .controls {
@@ -57,7 +57,7 @@
 
 .button {
   padding: 8px 16px;
-  background: #3498db;
+  background: hsl(var(--tf-network-blue-hs) 53%);
   color: white;
   border: none;
   border-radius: 4px;
@@ -67,17 +67,17 @@
 }
 
 .button:hover:not(:disabled) {
-  background: #2980b9;
+  background: hsl(var(--tf-network-blue-hs) 44%);
 }
 
 .button:disabled {
-  background: #95a5a6;
+  background: hsl(var(--tf-text-secondary-hs) 62%);
   cursor: not-allowed;
 }
 
 .results {
-  background: #ecf0f1;
-  border: 1px solid #bdc3c7;
+  background: hsl(var(--tf-text-primary-hs) 94%);
+  border: 1px solid hsl(var(--tf-text-secondary-hs) 77%);
   border-radius: 4px;
   padding: 12px;
 }
@@ -85,11 +85,11 @@
 .resultsTitle {
   font-weight: 600;
   margin-bottom: 8px;
-  color: #2c3e50;
+  color: hsl(var(--tf-surface-dark-hs) 25%);
 }
 
 .mapPlaceholder {
-  background: #34495e;
+  background: hsl(var(--tf-surface-dark-hs) 29%);
   color: white;
   padding: 40px;
   text-align: center;
@@ -110,7 +110,7 @@
   background: white;
   padding: 8px;
   border-radius: 3px;
-  border: 1px solid #d5dbdb;
+  border: 1px solid hsl(var(--tf-text-secondary-hs) 85%);
   overflow-x: auto;
   max-height: 200px;
   overflow-y: auto;

--- a/frontend/apps/terraforge/src/App.css
+++ b/frontend/apps/terraforge/src/App.css
@@ -1,17 +1,11 @@
 :root {
   color-scheme: dark;
-  --tf-terraforme-slate-900-hs: 222 47%;
-  --tf-terraforme-slate-200-hs: 215 32%;
-  --tf-terraforme-indigo-500-hs: 239 84%;
-  --tf-terraforme-indigo-200-hs: 226 92%;
-  --tf-terraforme-indigo-100-hs: 225 100%;
-  --tf-terraforme-emerald-200-hs: 152 76%;
 }
 
 .tf-root {
   min-height: 100vh;
-  background: hsl(var(--tf-terraforme-slate-900-hs) 12%); /* slate-900 */
-  color: hsl(var(--tf-terraforme-slate-200-hs) 91%); /* slate-200 */
+  background: #0f172a; /* slate-900 */
+  color: #e2e8f0; /* slate-200 */
   padding: 32px;
   font-family:
     system-ui,
@@ -27,7 +21,7 @@
   gap: 16px;
   margin-bottom: 28px;
   padding-bottom: 18px;
-  border-bottom: 1px solid hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .tf-logo {
@@ -36,9 +30,9 @@
   width: 52px;
   height: 52px;
   border-radius: 16px;
-  background: hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.1);
-  border: 1px solid hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.22);
-  color: hsl(var(--tf-terraforme-indigo-200-hs) 81%); /* indigo-200 */
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  color: #a5b4fc; /* indigo-200 */
 }
 
 .tf-title {
@@ -46,12 +40,12 @@
   font-size: 30px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: hsl(var(--tf-terraforme-slate-200-hs) 100%);
+  color: #fff;
 }
 
 .tf-subtitle {
   margin: 4px 0 0;
-  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.65);
+  color: rgba(226, 232, 240, 0.65);
   font-size: 14px;
 }
 
@@ -70,8 +64,8 @@
 .tf-card {
   border-radius: 18px;
   padding: 18px;
-  background: hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.04);
-  border: 1px solid hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.06);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   transition:
     border-color 120ms ease,
     transform 120ms ease;
@@ -80,7 +74,7 @@
 
 .tf-card:hover {
   transform: translateY(-1px);
-  border-color: hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.3);
+  border-color: rgba(99, 102, 241, 0.3);
 }
 
 .tf-cardTag {
@@ -96,28 +90,28 @@
 }
 
 .tf-indigo {
-  color: hsl(var(--tf-terraforme-indigo-100-hs) 89%);
+  color: #c7d2fe;
 }
 .tf-emerald {
-  color: hsl(var(--tf-terraforme-emerald-200-hs) 81%);
+  color: #a7f3d0;
 }
 
 .tf-cardBig {
   font-size: 22px;
   font-weight: 800;
-  color: hsl(var(--tf-terraforme-slate-200-hs) 100%);
+  color: #fff;
 }
 
 .tf-cardSmall {
   margin-top: 4px;
   font-size: 13px;
-  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.55);
+  color: rgba(226, 232, 240, 0.55);
 }
 
 .tf-footer {
   margin-top: 26px;
   text-align: center;
   font-size: 11px;
-  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.45);
+  color: rgba(226, 232, 240, 0.45);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }

--- a/frontend/apps/terraforge/src/App.css
+++ b/frontend/apps/terraforge/src/App.css
@@ -1,11 +1,17 @@
 :root {
   color-scheme: dark;
+  --tf-terraforme-slate-900-hs: 222 47%;
+  --tf-terraforme-slate-200-hs: 215 32%;
+  --tf-terraforme-indigo-500-hs: 239 84%;
+  --tf-terraforme-indigo-200-hs: 226 92%;
+  --tf-terraforme-indigo-100-hs: 225 100%;
+  --tf-terraforme-emerald-200-hs: 152 76%;
 }
 
 .tf-root {
   min-height: 100vh;
-  background: #0f172a; /* slate-900 */
-  color: #e2e8f0; /* slate-200 */
+  background: hsl(var(--tf-terraforme-slate-900-hs) 12%); /* slate-900 */
+  color: hsl(var(--tf-terraforme-slate-200-hs) 91%); /* slate-200 */
   padding: 32px;
   font-family:
     system-ui,
@@ -21,7 +27,7 @@
   gap: 16px;
   margin-bottom: 28px;
   padding-bottom: 18px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.08);
 }
 
 .tf-logo {
@@ -30,9 +36,9 @@
   width: 52px;
   height: 52px;
   border-radius: 16px;
-  background: rgba(99, 102, 241, 0.1);
-  border: 1px solid rgba(99, 102, 241, 0.22);
-  color: #a5b4fc; /* indigo-200 */
+  background: hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.1);
+  border: 1px solid hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.22);
+  color: hsl(var(--tf-terraforme-indigo-200-hs) 81%); /* indigo-200 */
 }
 
 .tf-title {
@@ -40,12 +46,12 @@
   font-size: 30px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: #fff;
+  color: hsl(var(--tf-terraforme-slate-200-hs) 100%);
 }
 
 .tf-subtitle {
   margin: 4px 0 0;
-  color: rgba(226, 232, 240, 0.65);
+  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.65);
   font-size: 14px;
 }
 
@@ -64,8 +70,8 @@
 .tf-card {
   border-radius: 18px;
   padding: 18px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.04);
+  border: 1px solid hsl(var(--tf-terraforme-slate-200-hs) 100% / 0.06);
   transition:
     border-color 120ms ease,
     transform 120ms ease;
@@ -74,7 +80,7 @@
 
 .tf-card:hover {
   transform: translateY(-1px);
-  border-color: rgba(99, 102, 241, 0.3);
+  border-color: hsl(var(--tf-terraforme-indigo-500-hs) 66% / 0.3);
 }
 
 .tf-cardTag {
@@ -90,28 +96,28 @@
 }
 
 .tf-indigo {
-  color: #c7d2fe;
+  color: hsl(var(--tf-terraforme-indigo-100-hs) 89%);
 }
 .tf-emerald {
-  color: #a7f3d0;
+  color: hsl(var(--tf-terraforme-emerald-200-hs) 81%);
 }
 
 .tf-cardBig {
   font-size: 22px;
   font-weight: 800;
-  color: #fff;
+  color: hsl(var(--tf-terraforme-slate-200-hs) 100%);
 }
 
 .tf-cardSmall {
   margin-top: 4px;
   font-size: 13px;
-  color: rgba(226, 232, 240, 0.55);
+  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.55);
 }
 
 .tf-footer {
   margin-top: 26px;
   text-align: center;
   font-size: 11px;
-  color: rgba(226, 232, 240, 0.45);
+  color: hsl(var(--tf-terraforme-slate-200-hs) 91% / 0.45);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 399,
+  "violationCount": 386,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -2008,97 +2008,6 @@
       "excerpt": "rgba(255, 255, 255, 0.5)' }}>"
     },
     {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 3,
-      "column": 21,
-      "excerpt": "#e0e0e0;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 6,
-      "column": 15,
-      "excerpt": "#f8f9fa;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 18,
-      "column": 10,
-      "excerpt": "#2c3e50;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 24,
-      "column": 10,
-      "excerpt": "#7f8c8d;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 34,
-      "column": 10,
-      "excerpt": "#555;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 60,
-      "column": 15,
-      "excerpt": "#3498db;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 70,
-      "column": 15,
-      "excerpt": "#2980b9;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 74,
-      "column": 15,
-      "excerpt": "#95a5a6;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 79,
-      "column": 15,
-      "excerpt": "#ecf0f1;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 80,
-      "column": 21,
-      "excerpt": "#bdc3c7;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 88,
-      "column": 10,
-      "excerpt": "#2c3e50;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 92,
-      "column": 15,
-      "excerpt": "#34495e;"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\plugins\\gis-core\\index.module.css",
-      "line": 113,
-      "column": 21,
-      "excerpt": "#d5dbdb;"
-    },
-    {
       "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\providers\\TerraFusionExcellenceProvider.tsx",
       "line": 65,
@@ -2799,5 +2708,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T04:45:32.264Z"
+  "generatedAtIso": "2026-02-25T05:21:35.335Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 399,
-  "delta": 653,
-  "generatedAtIso": "2026-02-25T04:45:32.285Z"
+  "currentViolationCount": 386,
+  "delta": 666,
+  "generatedAtIso": "2026-02-25T05:21:35.340Z"
 }


### PR DESCRIPTION
## Summary
- promote B2-22 prep into execution branch on latest main
- convert raw colors in frontend/apps/terraforge/src/App.css
- convert raw colors in frontend/apps/os-shell/src/plugins/gis-core/index.module.css
- update ui-token compliance/ratchet contracts from this sweep
- keep ui-token-baseline.json unchanged

## Gates
- pnpm tdc:ui:tokens
- pnpm -w run test:governance:ui
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified color theming by replacing hard-coded colors with CSS variables across multiple applications for improved consistency and maintainability.

* **Chores**
  * Updated design token compliance metrics, reducing violations from 399 to 386.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->