### PR TITLE
chore(ui-tokens): B2-24 convert ApplicationLauncher + CountiesHub to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/components/ApplicationLauncher.tsx
+++ b/frontend/apps/os-shell/src/components/ApplicationLauncher.tsx
@@ -211,11 +211,11 @@ const ApplicationLauncher: React.FC = () => {
       {/* Package Info */}
       <div
         style={{
-          background: 'rgba(255, 255, 255, 0.05)',
+          background: 'hsl(var(--tf-text) / 0.05)',
           padding: '20px',
           borderRadius: '8px',
           marginBottom: '30px',
-          border: '1px solid rgba(0, 210, 255, 0.3)',
+          border: '1px solid hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3)',
         }}
       >
         <div
@@ -293,26 +293,26 @@ const ApplicationLauncher: React.FC = () => {
           <div
             key={app.id}
             style={{
-              background: 'rgba(255, 255, 255, 0.05)',
-              border: `1px solid ${launchedApps.has(app.id) ? 'var(--tf-accent-success)' : 'rgba(0, 210, 255, 0.3)'}`,
+              background: 'hsl(var(--tf-text) / 0.05)',
+              border: `1px solid ${launchedApps.has(app.id) ? 'var(--tf-accent-success)' : 'hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3)'}`,
               borderRadius: '12px',
               padding: '20px',
               transition: 'all 0.3s ease',
               cursor: 'pointer',
               transform: launchedApps.has(app.id) ? 'translateY(-2px)' : 'translateY(0)',
-              boxShadow: launchedApps.has(app.id) ? '0 10px 30px rgba(0, 255, 170, 0.3)' : 'none',
+              boxShadow: launchedApps.has(app.id) ? '0 10px 30px hsl(var(--tf-success-hs) var(--tf-l-50) / 0.3)' : 'none',
             }}
             onMouseEnter={(e) => {
               if (!launchedApps.has(app.id)) {
                 e.currentTarget.style.transform = 'translateY(-5px)';
                 e.currentTarget.style.borderColor = 'var(--tf-transcend-cyan)';
-                e.currentTarget.style.boxShadow = '0 10px 30px rgba(0, 210, 255, 0.3)';
+                e.currentTarget.style.boxShadow = '0 10px 30px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3)';
               }
             }}
             onMouseLeave={(e) => {
               if (!launchedApps.has(app.id)) {
                 e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.borderColor = 'rgba(0, 210, 255, 0.3)';
+                e.currentTarget.style.borderColor = 'hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.3)';
                 e.currentTarget.style.boxShadow = 'none';
               }
             }}
@@ -345,7 +345,7 @@ const ApplicationLauncher: React.FC = () => {
             <div
               style={{
                 fontSize: '0.9rem',
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text) / 0.7)',
                 marginBottom: '15px',
                 lineHeight: 1.4,
               }}
@@ -357,10 +357,10 @@ const ApplicationLauncher: React.FC = () => {
             <div
               style={{
                 fontSize: '0.85rem',
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: 'hsl(var(--tf-text) / 0.5)',
                 marginBottom: '15px',
                 fontFamily: 'monospace',
-                background: 'rgba(0, 0, 0, 0.3)',
+                background: 'hsl(var(--tf-tokens-black-hs) 0% / 0.3)',
                 padding: '8px',
                 borderRadius: '4px',
               }}
@@ -418,7 +418,7 @@ const ApplicationLauncher: React.FC = () => {
             </div>
             <div
               style={{
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text) / 0.7)',
               }}
             >
               Government Modules
@@ -437,7 +437,7 @@ const ApplicationLauncher: React.FC = () => {
             </div>
             <div
               style={{
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text) / 0.7)',
               }}
             >
               Active AI Agents
@@ -456,7 +456,7 @@ const ApplicationLauncher: React.FC = () => {
             </div>
             <div
               style={{
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text) / 0.7)',
               }}
             >
               Harris PACS Parcels
@@ -475,7 +475,7 @@ const ApplicationLauncher: React.FC = () => {
             </div>
             <div
               style={{
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: 'hsl(var(--tf-text) / 0.7)',
               }}
             >
               Modules Launched
@@ -487,3 +487,4 @@ const ApplicationLauncher: React.FC = () => {
   );
 };
 export default ApplicationLauncher;
+

--- a/frontend/apps/os-shell/src/components/CountiesHub.tsx
+++ b/frontend/apps/os-shell/src/components/CountiesHub.tsx
@@ -184,7 +184,7 @@ const CountiesHub: React.FC = () => {
         </h1>
         <p
           style={{
-            color: 'rgba(255,255,255,0.7)',
+            color: 'hsl(var(--tf-text) / 0.7)',
             fontSize: '1.1rem',
           }}
         >
@@ -227,7 +227,7 @@ const CountiesHub: React.FC = () => {
             </div>
             <div
               style={{
-                color: 'rgba(255,255,255,0.6)',
+                color: 'hsl(var(--tf-text) / 0.6)',
                 fontSize: '0.9rem',
                 marginTop: '0.5rem',
               }}
@@ -265,7 +265,7 @@ const CountiesHub: React.FC = () => {
               background:
                 filter === filterOption.key
                   ? 'linear-gradient(135deg, var(--tf-network-blue), var(--tf-transcend-highlight))'
-                  : 'rgba(0,153,255,0.1)',
+                  : 'hsl(var(--tf-network-blue-hs) var(--tf-l-50) / 0.1)',
               color: filter === filterOption.key ? 'var(--tf-void-black)' : 'var(--tf-transcend-highlight)',
               transform: filter === filterOption.key ? 'scale(1.05)' : 'scale(1)',
             }}
@@ -290,9 +290,9 @@ const CountiesHub: React.FC = () => {
           <div
             key={county.id}
             style={{
-              background: 'rgba(0,0,0,0.6)',
+              background: 'hsl(var(--tf-tokens-black-hs) 0% / 0.6)',
               backdropFilter: 'blur(20px)',
-              border: '1px solid rgba(0,255,238,0.2)',
+              border: '1px solid hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2)',
               borderRadius: '20px',
               padding: '1.5rem',
               transition: 'all 0.3s ease',
@@ -308,7 +308,7 @@ const CountiesHub: React.FC = () => {
             onMouseLeave={(e) => {
               e.currentTarget.style.transform = 'translateY(0)';
               e.currentTarget.style.boxShadow = 'none';
-              e.currentTarget.style.borderColor = 'rgba(0,255,238,0.2)';
+              e.currentTarget.style.borderColor = 'hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2)';
             }}
           >
             <div
@@ -336,12 +336,12 @@ const CountiesHub: React.FC = () => {
               <div
                 style={{
                   background:
-                    county.status === 'ready' ? 'rgba(0,255,136,0.1)' : 'rgba(255,170,0,0.1)',
+                    county.status === 'ready' ? 'hsl(var(--tf-success-hs) var(--tf-l-50) / 0.1)' : 'hsl(var(--tf-warning-hs) var(--tf-l-50) / 0.1)',
                   color: county.status === 'ready' ? 'var(--success-green)' : 'var(--warning-amber)',
                   border:
                     county.status === 'ready'
-                      ? '1px solid rgba(0,255,136,0.3)'
-                      : '1px solid rgba(255,170,0,0.3)',
+                      ? '1px solid hsl(var(--tf-success-hs) var(--tf-l-50) / 0.3)'
+                      : '1px solid hsl(var(--tf-warning-hs) var(--tf-l-50) / 0.3)',
                   animation:
                     county.status === 'analyzing' ? 'pulse 2s ease-in-out infinite' : 'none',
                 }}
@@ -374,7 +374,7 @@ const CountiesHub: React.FC = () => {
                 <div key={index} className='flex justify-between'>
                   <span
                     style={{
-                      color: 'rgba(255,255,255,0.6)',
+                      color: 'hsl(var(--tf-text) / 0.6)',
                     }}
                   >
                     {info.label}
@@ -392,7 +392,7 @@ const CountiesHub: React.FC = () => {
                   style={{
                     display: 'inline-block',
                     padding: '0.2rem 0.5rem',
-                    background: 'rgba(0,255,238,0.2)',
+                    background: 'hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.2)',
                     borderRadius: '10px',
                     fontSize: '0.75rem',
                     color: 'var(--tf-transcend-highlight)',
@@ -424,7 +424,7 @@ const CountiesHub: React.FC = () => {
                 onClick={() => initiateMigration(county.id)}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.transform = 'scale(1.05)';
-                  e.currentTarget.style.boxShadow = '0 10px 30px rgba(0,255,238,0.4)';
+                  e.currentTarget.style.boxShadow = '0 10px 30px hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.4)';
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.transform = 'scale(1)';
@@ -437,7 +437,7 @@ const CountiesHub: React.FC = () => {
               <button
                 onClick={() => viewDetails(county.id)}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'rgba(0,255,238,0.1)';
+                  e.currentTarget.style.background = 'hsl(var(--tf-transcend-cyan-hs) var(--tf-l-50) / 0.1)';
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.background = 'transparent';
@@ -505,7 +505,7 @@ const CountiesHub: React.FC = () => {
               </div>
               <div
                 style={{
-                  color: 'rgba(255,255,255,0.7)',
+                  color: 'hsl(var(--tf-text) / 0.7)',
                   fontSize: '0.9rem',
                 }}
               >
@@ -526,3 +526,4 @@ const CountiesHub: React.FC = () => {
   );
 };
 export default CountiesHub;
+

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 373,
+  "violationCount": 347,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -186,97 +186,6 @@
       "line": 273,
       "column": 23,
       "excerpt": "rgba(0, 255, 255, 1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 214,
-      "column": 24,
-      "excerpt": "rgba(255, 255, 255, 0.05)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 218,
-      "column": 30,
-      "excerpt": "rgba(0, 210, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 297,
-      "column": 93,
-      "excerpt": "rgba(0, 210, 255, 0.3)'}`,"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 303,
-      "column": 66,
-      "excerpt": "rgba(0, 255, 170, 0.3)' : 'none',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 309,
-      "column": 64,
-      "excerpt": "rgba(0, 210, 255, 0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 315,
-      "column": 54,
-      "excerpt": "rgba(0, 210, 255, 0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 348,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 360,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 363,
-      "column": 30,
-      "excerpt": "rgba(0, 0, 0, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 421,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 440,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 459,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ApplicationLauncher.tsx",
-      "line": 478,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -522,97 +431,6 @@
       "line": 680,
       "column": 47,
       "excerpt": "rgba(15, 23, 42, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 187,
-      "column": 21,
-      "excerpt": "rgba(255,255,255,0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 230,
-      "column": 25,
-      "excerpt": "rgba(255,255,255,0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 293,
-      "column": 28,
-      "excerpt": "rgba(0,0,0,0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 295,
-      "column": 34,
-      "excerpt": "rgba(0,255,238,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 311,
-      "column": 52,
-      "excerpt": "rgba(0,255,238,0.2)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 339,
-      "column": 50,
-      "excerpt": "rgba(0,255,136,0.1)' : 'rgba(255,170,0,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 339,
-      "column": 74,
-      "excerpt": "rgba(255,170,0,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 343,
-      "column": 36,
-      "excerpt": "rgba(0,255,136,0.3)'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 344,
-      "column": 36,
-      "excerpt": "rgba(255,170,0,0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 377,
-      "column": 31,
-      "excerpt": "rgba(255,255,255,0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 427,
-      "column": 66,
-      "excerpt": "rgba(0,255,238,0.4)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 440,
-      "column": 55,
-      "excerpt": "rgba(0,255,238,0.1)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\CountiesHub.tsx",
-      "line": 508,
-      "column": 27,
-      "excerpt": "rgba(255,255,255,0.7)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -2617,5 +2435,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T17:05:38.096Z"
+  "generatedAtIso": "2026-02-25T17:27:43.073Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 373,
-  "delta": 679,
-  "generatedAtIso": "2026-02-25T17:05:38.102Z"
+  "currentViolationCount": 347,
+  "delta": 705,
+  "generatedAtIso": "2026-02-25T17:27:43.077Z"
 }


### PR DESCRIPTION
## What this does\n- Promotes B2-24 prep to full execution lane\n- Converts remaining raw/disallowed color literals in:\n  - frontend/apps/os-shell/src/components/ApplicationLauncher.tsx\n  - frontend/apps/os-shell/src/components/CountiesHub.tsx\n- Regenerates token compliance and ratchet contracts\n\n## Validation\n- pnpm tdc:ui:tokens\n- pnpm -w run test:governance:ui\n- pnpm run type-check\n- node --test os-platform/core/tests/phase83-tools.test.mjs\n\n## Lane safety\n- ui-token-baseline.json intentionally restored and excluded from commit\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color styling across multiple UI components to use improved design tokens and CSS variable-based color references.

* **Chores**
  * Enhanced design token compliance by reducing styling-related violations in the codebase. No functional changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->