### PR TITLE
chore(ui-tokens): B2-25 convert Alert stories + DesktopShell to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/components/ui/Alert.stories.tsx
+++ b/frontend/apps/os-shell/src/components/ui/Alert.stories.tsx
@@ -158,8 +158,8 @@ export const WithIcons: Story = {
       {/* Warning Alert */}
       <Alert
         style={{
-          borderColor: '#f59e0b',
-          color: '#f59e0b',
+          borderColor: 'hsl(var(--tf-warning-hs) 56%)',
+          color: 'hsl(var(--tf-warning-hs) 56%)',
         }}
       >
         <svg
@@ -270,7 +270,7 @@ export const WithActions: Story = {
                 padding: '6px 12px',
                 fontSize: '14px',
                 backgroundColor: 'transparent',
-                border: '1px solid #2a2a2a',
+                border: '1px solid hsl(var(--tf-neutral-hs) 16%)',
                 borderRadius: '6px',
                 color: 'var(--tf-text-primary)',
                 cursor: 'pointer',
@@ -333,7 +333,7 @@ export const RealWorldExample: Story = {
       style={{
         maxWidth: '800px',
         padding: '24px',
-        backgroundColor: '#0a0a0a',
+        backgroundColor: 'hsl(var(--tf-neutral-hs) 4%)',
         borderRadius: '12px',
       }}
     >
@@ -344,7 +344,7 @@ export const RealWorldExample: Story = {
         style={{
           marginBottom: '24px',
           borderColor: 'var(--tf-success-green)',
-          backgroundColor: 'rgba(34, 197, 94, 0.05)',
+          backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.05)',
         }}
       >
         <svg
@@ -415,8 +415,8 @@ export const RealWorldExample: Story = {
       <Alert
         style={{
           marginBottom: '24px',
-          borderColor: '#f59e0b',
-          backgroundColor: 'rgba(245, 158, 11, 0.05)',
+          borderColor: 'hsl(var(--tf-warning-hs) 56%)',
+          backgroundColor: 'hsl(var(--tf-warning-hs) 56% / 0.05)',
         }}
       >
         <svg
@@ -425,7 +425,7 @@ export const RealWorldExample: Story = {
           height='16'
           viewBox='0 0 24 24'
           fill='none'
-          stroke='#f59e0b'
+          stroke='hsl(var(--tf-warning-hs) 56%)'
           strokeWidth='2'
         >
           <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z' />
@@ -433,14 +433,14 @@ export const RealWorldExample: Story = {
         </svg>
         <AlertTitle
           style={{
-            color: '#f59e0b',
+            color: 'hsl(var(--tf-warning-hs) 56%)',
           }}
         >
           Careful!
         </AlertTitle>
         <AlertDescription
           style={{
-            color: '#f59e0b',
+            color: 'hsl(var(--tf-warning-hs) 56%)',
           }}
         >
           Changing your email address will require verification.
@@ -454,7 +454,7 @@ export const RealWorldExample: Story = {
             padding: '10px 16px',
             fontSize: '14px',
             backgroundColor: 'transparent',
-            border: '1px solid #2a2a2a',
+            border: '1px solid hsl(var(--tf-neutral-hs) 16%)',
             borderRadius: '6px',
             color: 'var(--tf-text-primary)',
             cursor: 'pointer',
@@ -517,7 +517,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -545,7 +545,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -573,7 +573,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -601,7 +601,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -644,7 +644,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-danger-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -672,7 +672,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-danger-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -700,7 +700,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-danger-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -728,7 +728,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-danger-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -765,13 +765,13 @@ export const UsageGuidelines: Story = {
         <h4 className='font-semibold'>Code Examples</h4>
         <div
           style={{
-            backgroundColor: '#1a1a1a',
+            backgroundColor: 'hsl(var(--tf-neutral-hs) 10%)',
             padding: '20px',
             borderRadius: '8px',
             fontFamily: '"Fira Code", monospace',
             fontSize: '13px',
             overflow: 'auto',
-            border: '1px solid #2a2a2a',
+            border: '1px solid hsl(var(--tf-neutral-hs) 16%)',
           }}
         >
           <pre

--- a/frontend/apps/os-shell/src/shell/DesktopShell.tsx
+++ b/frontend/apps/os-shell/src/shell/DesktopShell.tsx
@@ -74,9 +74,9 @@ export const DesktopShell: React.FC = () => {
       <AppBar
         position='static'
         sx={{
-          background: 'rgba(11, 16, 32, 0.9)',
+          background: 'hsl(var(--tf-neutral-hs) 9% / 0.9)',
           backdropFilter: 'blur(20px)',
-          borderBottom: '1px solid rgba(0, 255, 238, 0.2)',
+          borderBottom: '1px solid hsl(var(--tf-primary-hs) 50% / 0.2)',
         }}
       >
         <Toolbar>
@@ -90,7 +90,7 @@ export const DesktopShell: React.FC = () => {
               background: 'linear-gradient(135deg, var(--tf-network-blue), var(--tf-transcend-highlight))',
               color: 'var(--tf-bg-surface)',
               fontWeight: 'bold',
-              boxShadow: '0 0 20px rgba(0, 255, 238, 0.4)',
+              boxShadow: '0 0 20px hsl(var(--tf-primary-hs) 50% / 0.4)',
             }}
           >
             TF
@@ -164,16 +164,16 @@ export const DesktopShell: React.FC = () => {
               <Card
                 className='tf-card'
                 sx={{
-                  background: 'rgba(11, 16, 32, 0.8)',
+                  background: 'hsl(var(--tf-neutral-hs) 9% / 0.8)',
                   backdropFilter: 'blur(20px)',
-                  border: '1px solid rgba(0, 255, 238, 0.3)',
-                  boxShadow: '0 20px 40px rgba(10, 15, 28, 0.8), 0 0 60px rgba(0, 255, 238, 0.2)',
+                  border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
+                  boxShadow: '0 20px 40px hsl(var(--tf-neutral-hs) 7% / 0.8), 0 0 60px hsl(var(--tf-primary-hs) 50% / 0.2)',
                   transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
                   '&:hover': {
                     transform: 'translateY(-8px)',
                     borderColor: 'var(--tf-transcend-highlight)',
                     boxShadow:
-                      '0 25px 50px rgba(0, 229, 255, 0.15), 0 0 80px rgba(0, 255, 238, 0.4)',
+                      '0 25px 50px hsl(var(--tf-primary-hs) 50% / 0.15), 0 0 80px hsl(var(--tf-primary-hs) 50% / 0.4)',
                   },
                 }}
               >
@@ -194,7 +194,7 @@ export const DesktopShell: React.FC = () => {
                   <Typography
                     variant='body1'
                     sx={{
-                      color: 'rgba(255,255,255,0.9)',
+                      color: 'hsl(var(--tf-neutral-hs) 100% / 0.9)',
                       fontWeight: 500,
                     }}
                   >
@@ -214,9 +214,9 @@ export const DesktopShell: React.FC = () => {
             <Grid item xs={12} md={4}>
               <Card
                 sx={{
-                  background: 'rgba(255,255,255,0.1)',
+                  background: 'hsl(var(--tf-neutral-hs) 100% / 0.1)',
                   backdropFilter: 'blur(10px)',
-                  border: '1px solid rgba(255,255,255,0.2)',
+                  border: '1px solid hsl(var(--tf-neutral-hs) 100% / 0.2)',
                 }}
               >
                 <CardContent>
@@ -261,7 +261,7 @@ export const DesktopShell: React.FC = () => {
         PaperProps={{
           sx: {
             width: 300,
-            background: 'rgba(0,0,0,0.9)',
+            background: 'hsl(var(--tf-neutral-hs) 0% / 0.9)',
             backdropFilter: 'blur(10px)',
           },
         }}

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 347,
+  "violationCount": 321,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1049,97 +1049,6 @@
       "excerpt": "#ccc', padding: '12px', borderRadius: '4px' }}>"
     },
     {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 161,
-      "column": 25,
-      "excerpt": "#f59e0b',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 162,
-      "column": 19,
-      "excerpt": "#f59e0b',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 273,
-      "column": 36,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 336,
-      "column": 27,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 418,
-      "column": 25,
-      "excerpt": "#f59e0b',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 428,
-      "column": 19,
-      "excerpt": "#f59e0b'"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 436,
-      "column": 21,
-      "excerpt": "#f59e0b',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 443,
-      "column": 21,
-      "excerpt": "#f59e0b',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 457,
-      "column": 32,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 768,
-      "column": 31,
-      "excerpt": "#1a1a1a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 774,
-      "column": 32,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 347,
-      "column": 29,
-      "excerpt": "rgba(34, 197, 94, 0.05)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Alert.stories.tsx",
-      "line": 419,
-      "column": 29,
-      "excerpt": "rgba(245, 158, 11, 0.05)',"
-    },
-    {
       "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\ui\\avatar.tsx",
       "line": 22,
@@ -1953,97 +1862,6 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 77,
-      "column": 24,
-      "excerpt": "rgba(11, 16, 32, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 79,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 238, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 93,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 238, 0.4)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 167,
-      "column": 32,
-      "excerpt": "rgba(11, 16, 32, 0.8)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 169,
-      "column": 38,
-      "excerpt": "rgba(0, 255, 238, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 170,
-      "column": 43,
-      "excerpt": "rgba(10, 15, 28, 0.8), 0 0 60px rgba(0, 255, 238, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 170,
-      "column": 75,
-      "excerpt": "rgba(0, 255, 238, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 176,
-      "column": 36,
-      "excerpt": "rgba(0, 229, 255, 0.15), 0 0 80px rgba(0, 255, 238, 0.4)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 176,
-      "column": 70,
-      "excerpt": "rgba(0, 255, 238, 0.4)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 197,
-      "column": 31,
-      "excerpt": "rgba(255,255,255,0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 217,
-      "column": 32,
-      "excerpt": "rgba(255,255,255,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 219,
-      "column": 38,
-      "excerpt": "rgba(255,255,255,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\DesktopShell.tsx",
-      "line": 264,
-      "column": 26,
-      "excerpt": "rgba(0,0,0,0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
       "line": 104,
       "column": 24,
@@ -2435,5 +2253,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T17:27:43.073Z"
+  "generatedAtIso": "2026-02-25T17:42:12.457Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 347,
-  "delta": 705,
-  "generatedAtIso": "2026-02-25T17:27:43.077Z"
+  "currentViolationCount": 321,
+  "delta": 731,
+  "generatedAtIso": "2026-02-25T17:42:12.460Z"
 }


### PR DESCRIPTION
## What this does\n- Promotes B2-25 prep to full execution\n- Converts remaining raw/disallowed color literals in:\n  - frontend/apps/os-shell/src/components/ui/Alert.stories.tsx\n  - frontend/apps/os-shell/src/shell/DesktopShell.tsx\n- Regenerates token compliance and ratchet contracts\n\n## Validation\n- pnpm tdc:ui:tokens\n- pnpm -w run test:governance:ui\n- pnpm run type-check\n- node --test os-platform/core/tests/phase83-tools.test.mjs\n\n## Lane safety\n- ui-token-baseline.json intentionally restored and excluded from commit\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized color definitions across the application using design tokens for improved visual consistency.
  * Reduced styling violations by 26 instances, bringing the system further into alignment with design standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->