### PR TITLE
chore(ui-tokens): B2-26 convert MinimalTerraFusionTest + Marketplace to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/components/Marketplace.tsx
+++ b/frontend/apps/os-shell/src/components/Marketplace.tsx
@@ -212,7 +212,7 @@ const Marketplace: React.FC = () => {
         </h1>
         <p
           style={{
-            color: 'rgba(255,255,255,0.7)',
+            color: 'hsl(var(--tf-neutral-hs) 100% / 0.7)',
             fontSize: '1.1rem',
           }}
         >
@@ -232,8 +232,8 @@ const Marketplace: React.FC = () => {
             minWidth: '300px',
             maxWidth: '500px',
             padding: '0.8rem 1rem',
-            background: 'rgba(255,255,255,0.1)',
-            border: '1px solid rgba(0,255,238,0.3)',
+            background: 'hsl(var(--tf-neutral-hs) 100% / 0.1)',
+            border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
             borderRadius: '25px',
             color: 'var(--tf-text-primary)',
             fontSize: '0.9rem',
@@ -252,7 +252,7 @@ const Marketplace: React.FC = () => {
               background:
                 selectedCategory === category.id
                   ? 'linear-gradient(135deg, var(--tf-network-blue), var(--tf-transcend-highlight))'
-                  : 'rgba(0,153,255,0.1)',
+                  : 'hsl(var(--tf-primary-hs) 50% / 0.1)',
               color: selectedCategory === category.id ? 'var(--tf-void-black)' : 'var(--tf-transcend-highlight)',
             }}
             className='font-semibold flex items-center gap-2'
@@ -284,7 +284,7 @@ const Marketplace: React.FC = () => {
               <div
                 key={item.id}
                 style={{
-                  background: 'rgba(0,0,0,0.6)',
+                  background: 'hsl(var(--tf-neutral-hs) 0% / 0.6)',
                   backdropFilter: 'blur(20px)',
                   border: '2px solid var(--tf-accent-success)',
                   borderRadius: '20px',
@@ -295,7 +295,7 @@ const Marketplace: React.FC = () => {
                 }}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.transform = 'translateY(-5px)';
-                  e.currentTarget.style.boxShadow = '0 20px 40px rgba(0,255,170,0.3)';
+                  e.currentTarget.style.boxShadow = '0 20px 40px hsl(var(--tf-success-hs) 45% / 0.3)';
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.transform = 'translateY(0)';
@@ -333,7 +333,7 @@ const Marketplace: React.FC = () => {
                     </h3>
                     <p
                       style={{
-                        color: 'rgba(255,255,255,0.6)',
+                        color: 'hsl(var(--tf-neutral-hs) 100% / 0.6)',
                         fontSize: '0.85rem',
                         margin: 0,
                       }}
@@ -345,7 +345,7 @@ const Marketplace: React.FC = () => {
 
                 <p
                   style={{
-                    color: 'rgba(255,255,255,0.8)',
+                    color: 'hsl(var(--tf-neutral-hs) 100% / 0.8)',
                     fontSize: '0.9rem',
                     lineHeight: 1.4,
                     marginBottom: '1rem',
@@ -394,7 +394,7 @@ const Marketplace: React.FC = () => {
                   <button
                     onClick={() => viewDetails(item.id)}
                     onMouseEnter={(e) => {
-                      e.currentTarget.style.background = 'rgba(0,255,238,0.1)';
+                      e.currentTarget.style.background = 'hsl(var(--tf-primary-hs) 50% / 0.1)';
                     }}
                     onMouseLeave={(e) => {
                       e.currentTarget.style.background = 'transparent';
@@ -430,9 +430,9 @@ const Marketplace: React.FC = () => {
             <div
               key={item.id}
               style={{
-                background: 'rgba(0,0,0,0.5)',
+                background: 'hsl(var(--tf-neutral-hs) 0% / 0.5)',
                 backdropFilter: 'blur(20px)',
-                border: '1px solid rgba(0,255,238,0.2)',
+                border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.2)',
                 borderRadius: '15px',
                 padding: '1.5rem',
                 transition: 'all 0.3s ease',
@@ -442,13 +442,13 @@ const Marketplace: React.FC = () => {
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.transform = 'translateY(-3px)';
-                e.currentTarget.style.boxShadow = '0 15px 30px rgba(0,255,238,0.2)';
+                e.currentTarget.style.boxShadow = '0 15px 30px hsl(var(--tf-primary-hs) 50% / 0.2)';
                 e.currentTarget.style.borderColor = 'var(--tf-transcend-highlight)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = 'translateY(0)';
                 e.currentTarget.style.boxShadow = 'none';
-                e.currentTarget.style.borderColor = 'rgba(0,255,238,0.2)';
+                e.currentTarget.style.borderColor = 'hsl(var(--tf-primary-hs) 50% / 0.2)';
               }}
             >
               {item.featured && (
@@ -484,7 +484,7 @@ const Marketplace: React.FC = () => {
                   </h3>
                   <p
                     style={{
-                      color: 'rgba(255,255,255,0.6)',
+                      color: 'hsl(var(--tf-neutral-hs) 100% / 0.6)',
                       fontSize: '0.8rem',
                       margin: 0,
                     }}
@@ -496,7 +496,7 @@ const Marketplace: React.FC = () => {
 
               <p
                 style={{
-                  color: 'rgba(255,255,255,0.7)',
+                  color: 'hsl(var(--tf-neutral-hs) 100% / 0.7)',
                   fontSize: '0.85rem',
                   lineHeight: 1.4,
                   marginBottom: '1rem',
@@ -579,7 +579,7 @@ const Marketplace: React.FC = () => {
               </div>
               <div
                 style={{
-                  color: 'rgba(255,255,255,0.7)',
+                  color: 'hsl(var(--tf-neutral-hs) 100% / 0.7)',
                   fontSize: '0.9rem',
                 }}
               >

--- a/frontend/apps/os-shell/src/components/emergency/MinimalTerraFusionTest.tsx
+++ b/frontend/apps/os-shell/src/components/emergency/MinimalTerraFusionTest.tsx
@@ -29,9 +29,9 @@ export function MinimalTerraFusionTest() {
           left: 0,
           right: 0,
           height: '64px',
-          background: 'rgba(10, 14, 26, 0.95)',
+          background: 'hsl(var(--tf-neutral-hs) 7% / 0.95)',
           backdropFilter: 'blur(20px)',
-          borderBottom: '1px solid rgba(0, 255, 255, 0.2)',
+          borderBottom: '1px solid hsl(var(--tf-primary-hs) 50% / 0.2)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
@@ -107,8 +107,8 @@ export function MinimalTerraFusionTest() {
           >
             <div
               style={{
-                background: 'rgba(0, 255, 255, 0.1)',
-                border: '1px solid rgba(0, 255, 255, 0.3)',
+                background: 'hsl(var(--tf-primary-hs) 50% / 0.1)',
+                border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
                 borderRadius: '12px',
                 padding: '24px',
                 textAlign: 'center',
@@ -121,8 +121,8 @@ export function MinimalTerraFusionTest() {
 
             <div
               style={{
-                background: 'rgba(0, 255, 255, 0.1)',
-                border: '1px solid rgba(0, 255, 255, 0.3)',
+                background: 'hsl(var(--tf-primary-hs) 50% / 0.1)',
+                border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
                 borderRadius: '12px',
                 padding: '24px',
                 textAlign: 'center',
@@ -135,8 +135,8 @@ export function MinimalTerraFusionTest() {
 
             <div
               style={{
-                background: 'rgba(0, 255, 255, 0.1)',
-                border: '1px solid rgba(0, 255, 255, 0.3)',
+                background: 'hsl(var(--tf-primary-hs) 50% / 0.1)',
+                border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
                 borderRadius: '12px',
                 padding: '24px',
                 textAlign: 'center',
@@ -159,8 +159,8 @@ export function MinimalTerraFusionTest() {
           width: '60px',
           height: '60px',
           borderRadius: '50%',
-          background: 'linear-gradient(135deg, rgba(0, 255, 255, 0.1), rgba(0, 128, 255, 0.05))',
-          border: '2px solid rgba(0, 255, 255, 0.3)',
+          background: 'linear-gradient(135deg, hsl(var(--tf-primary-hs) 50% / 0.1), hsl(var(--tf-primary-hs) 45% / 0.05))',
+          border: '2px solid hsl(var(--tf-primary-hs) 50% / 0.3)',
           backdropFilter: 'blur(16px)',
           display: 'flex',
           alignItems: 'center',

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 321,
+  "violationCount": 299,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -525,83 +525,6 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 32,
-      "column": 24,
-      "excerpt": "rgba(10, 14, 26, 0.95)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 34,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 110,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 111,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 124,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 125,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 138,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 139,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 162,
-      "column": 48,
-      "excerpt": "rgba(0, 255, 255, 0.1), rgba(0, 128, 255, 0.05))',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 162,
-      "column": 72,
-      "excerpt": "rgba(0, 128, 255, 0.05))',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\MinimalTerraFusionTest.tsx",
-      "line": 163,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\TerraFusionEmergencyTest.tsx",
       "line": 43,
       "column": 33,
@@ -760,83 +683,6 @@
       "line": 102,
       "column": 33,
       "excerpt": "rgba(0,0,0,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 215,
-      "column": 21,
-      "excerpt": "rgba(255,255,255,0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 298,
-      "column": 66,
-      "excerpt": "rgba(0,255,170,0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 336,
-      "column": 33,
-      "excerpt": "rgba(255,255,255,0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 348,
-      "column": 29,
-      "excerpt": "rgba(255,255,255,0.8)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 397,
-      "column": 59,
-      "excerpt": "rgba(0,255,238,0.1)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 433,
-      "column": 30,
-      "excerpt": "rgba(0,0,0,0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 435,
-      "column": 36,
-      "excerpt": "rgba(0,255,238,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 451,
-      "column": 54,
-      "excerpt": "rgba(0,255,238,0.2)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 487,
-      "column": 31,
-      "excerpt": "rgba(255,255,255,0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 499,
-      "column": 27,
-      "excerpt": "rgba(255,255,255,0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\Marketplace.tsx",
-      "line": 582,
-      "column": 27,
-      "excerpt": "rgba(255,255,255,0.7)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -2253,5 +2099,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T17:42:12.457Z"
+  "generatedAtIso": "2026-02-25T17:59:48.980Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 321,
-  "delta": 731,
-  "generatedAtIso": "2026-02-25T17:42:12.460Z"
+  "currentViolationCount": 299,
+  "delta": 753,
+  "generatedAtIso": "2026-02-25T17:59:48.983Z"
 }


### PR DESCRIPTION
## What this does\n- Promotes B2-26 prep to full execution lane\n- Converts remaining raw/disallowed color literals in:\n  - frontend/apps/os-shell/src/components/emergency/MinimalTerraFusionTest.tsx\n  - frontend/apps/os-shell/src/components/Marketplace.tsx\n- Regenerates token compliance and ratchet contracts\n\n## Validation\n- pnpm tdc:ui:tokens\n- pnpm -w run test:governance:ui\n- pnpm run type-check\n- node --test os-platform/core/tests/phase83-tools.test.mjs\n\n## Lane safety\n- ui-token-baseline.json restored and excluded from commit\n