### PR TITLE
chore(ui-tokens): B2-28 convert ModuleLoader + UniversalTranslationInterface to HS tokens

### DIFF
--- a/frontend/apps/os-shell/src/components/consciousness/UniversalTranslationInterface.tsx
+++ b/frontend/apps/os-shell/src/components/consciousness/UniversalTranslationInterface.tsx
@@ -55,9 +55,9 @@ interface UniversalMessage {
 type SpeciesType = 'human' | 'ai' | 'quantum' | 'consciousness' | 'dimensional';
 
 const StyledCard = styled(Card)(({ theme }) => ({
-  background: 'rgba(255, 255, 255, 0.05)',
+  background: 'hsl(var(--tf-neutral-hs) 100% / 0.05)',
   backdropFilter: 'blur(20px)',
-  border: '1px solid rgba(200, 150, 255, 0.2)',
+  border: '1px solid hsl(var(--tf-primary-hs) 70% / 0.2)',
   borderRadius: '16px',
   height: '100%',
 }));
@@ -121,7 +121,7 @@ const UniversalTranslationInterface: React.FC = () => {
               variant='outlined'
               sx={{
                 '& .MuiOutlinedInput-root': {
-                  '& fieldset': { borderColor: 'rgba(200, 150, 255, 0.3)' },
+                  '& fieldset': { borderColor: 'hsl(var(--tf-primary-hs) 70% / 0.3)' },
                   '&:hover fieldset': { borderColor: 'var(--tf-accent-quantum)' },
                 },
                 '& .MuiInputLabel-root': { color: 'var(--tf-accent-quantum)' },
@@ -138,7 +138,9 @@ const UniversalTranslationInterface: React.FC = () => {
                 label='Source Species'
                 sx={{
                   color: 'white',
-                  '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(200, 150, 255, 0.3)' },
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'hsl(var(--tf-primary-hs) 70% / 0.3)',
+                  },
                   '& .MuiSvgIcon-root': { color: 'white' },
                 }}
               >
@@ -157,7 +159,9 @@ const UniversalTranslationInterface: React.FC = () => {
                 label='Target Species'
                 sx={{
                   color: 'white',
-                  '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(200, 150, 255, 0.3)' },
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'hsl(var(--tf-primary-hs) 70% / 0.3)',
+                  },
                   '& .MuiSvgIcon-root': { color: 'white' },
                 }}
               >
@@ -177,7 +181,7 @@ const UniversalTranslationInterface: React.FC = () => {
                 py: 1.5,
                 background: 'linear-gradient(135deg, var(--tf-accent-quantum), var(--tf-accent-quantum))',
                 '&:hover': {
-                  boxShadow: '0 8px 25px rgba(102, 126, 234, 0.4)',
+                  boxShadow: '0 8px 25px hsl(var(--tf-primary-hs) 66% / 0.4)',
                 },
               }}
             >
@@ -187,7 +191,7 @@ const UniversalTranslationInterface: React.FC = () => {
         </Grid>
 
         {translatedMessage && (
-          <Paper elevation={3} sx={{ mt: 3, p: 2, background: 'rgba(0,0,0,0.2)' }}>
+          <Paper elevation={3} sx={{ mt: 3, p: 2, background: 'hsl(var(--tf-neutral-hs) 0% / 0.2)' }}>
             <Typography variant='h6' sx={{ color: 'var(--tf-accent-quantum)', mb: 2 }}>
               Translation Output
             </Typography>
@@ -199,7 +203,7 @@ const UniversalTranslationInterface: React.FC = () => {
                   variant='body1'
                   sx={{
                     color: 'white',
-                    background: 'rgba(255,255,255,0.1)',
+                    background: 'hsl(var(--tf-neutral-hs) 100% / 0.1)',
                     p: 1,
                     borderRadius: 1,
                   }}
@@ -211,11 +215,11 @@ const UniversalTranslationInterface: React.FC = () => {
                   color='success'
                   size='small'
                 />
-                <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.7)' }}>
+                <Typography variant='caption' sx={{ color: 'hsl(var(--tf-neutral-hs) 100% / 0.7)' }}>
                   <strong>Cultural Adaptation:</strong>{' '}
                   {translatedMessage.adaptations.culturalReferences.join(', ') || 'None'}
                 </Typography>
-                <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.7)' }}>
+                <Typography variant='caption' sx={{ color: 'hsl(var(--tf-neutral-hs) 100% / 0.7)' }}>
                   <strong>Cognitive Load:</strong>{' '}
                   {translatedMessage.adaptations.cognitiveLoadAdjustment || 'N/A'}
                 </Typography>

--- a/frontend/apps/os-shell/src/shell/desktop/ModuleLoader.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/ModuleLoader.tsx
@@ -34,21 +34,22 @@ const NotFoundState: React.FC<{ moduleId: string }> = ({ moduleId }) => (
     role='alert'
     className='w-full h-full flex flex-col items-center justify-center p-6'
     style={{
-      background: 'linear-gradient(135deg, rgba(10, 14, 26, 0.95) 0%, rgba(20, 24, 36, 0.9) 100%)',
+      background:
+        'linear-gradient(135deg, hsl(var(--tf-neutral-hs) 7% / 0.95) 0%, hsl(var(--tf-neutral-hs) 11% / 0.9) 100%)',
     }}
   >
     {/* Warning icon */}
     <div
       className='w-16 h-16 rounded-full flex items-center justify-center mb-4'
       style={{
-        background: 'rgba(255, 170, 0, 0.15)',
-        border: '1px solid rgba(255, 170, 0, 0.3)',
-        boxShadow: '0 0 30px rgba(255, 170, 0, 0.2)',
+        background: 'hsl(var(--tf-warning-hs) 50% / 0.15)',
+        border: '1px solid hsl(var(--tf-warning-hs) 50% / 0.3)',
+        boxShadow: '0 0 30px hsl(var(--tf-warning-hs) 50% / 0.2)',
       }}
     >
       <svg
         className='w-8 h-8'
-        style={{ color: '#FFAA00' }}
+        style={{ color: 'hsl(var(--tf-warning-hs) 50%)' }}
         fill='none'
         stroke='currentColor'
         viewBox='0 0 24 24'
@@ -64,7 +65,7 @@ const NotFoundState: React.FC<{ moduleId: string }> = ({ moduleId }) => (
     </div>
 
     {/* Title */}
-    <h3 className='text-lg font-light mb-2' style={{ color: '#FFAA00' }}>
+    <h3 className='text-lg font-light mb-2' style={{ color: 'hsl(var(--tf-warning-hs) 50%)' }}>
       Module Not Found
     </h3>
 
@@ -74,9 +75,9 @@ const NotFoundState: React.FC<{ moduleId: string }> = ({ moduleId }) => (
       <code
         className='px-2 py-0.5 rounded'
         style={{
-          color: '#00E5FF',
-          background: 'rgba(0, 229, 255, 0.1)',
-          border: '1px solid rgba(0, 229, 255, 0.2)',
+          color: 'hsl(var(--tf-primary-hs) 50%)',
+          background: 'hsl(var(--tf-primary-hs) 50% / 0.1)',
+          border: '1px solid hsl(var(--tf-primary-hs) 50% / 0.2)',
         }}
       >
         {moduleId || '(empty)'}

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 279,
+  "violationCount": 261,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -276,62 +276,6 @@
       "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\SpeciesDetectionVisualizer.tsx",
       "line": 170,
       "column": 65,
-      "excerpt": "rgba(255,255,255,0.7)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 58,
-      "column": 16,
-      "excerpt": "rgba(255, 255, 255, 0.05)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 60,
-      "column": 22,
-      "excerpt": "rgba(200, 150, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 141,
-      "column": 73,
-      "excerpt": "rgba(200, 150, 255, 0.3)' },"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 160,
-      "column": 73,
-      "excerpt": "rgba(200, 150, 255, 0.3)' },"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 180,
-      "column": 42,
-      "excerpt": "rgba(102, 126, 234, 0.4)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 202,
-      "column": 34,
-      "excerpt": "rgba(255,255,255,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 214,
-      "column": 61,
-      "excerpt": "rgba(255,255,255,0.7)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\UniversalTranslationInterface.tsx",
-      "line": 218,
-      "column": 61,
       "excerpt": "rgba(255,255,255,0.7)' }}>"
     },
     {
@@ -1420,76 +1364,6 @@
       "excerpt": "hsl(0 100% 60%)',"
     },
     {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 51,
-      "column": 26,
-      "excerpt": "#FFAA00' }}"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 67,
-      "column": 62,
-      "excerpt": "#FFAA00' }}>"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 77,
-      "column": 19,
-      "excerpt": "#00E5FF',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 37,
-      "column": 44,
-      "excerpt": "rgba(10, 14, 26, 0.95) 0%, rgba(20, 24, 36, 0.9) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 37,
-      "column": 71,
-      "excerpt": "rgba(20, 24, 36, 0.9) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 44,
-      "column": 22,
-      "excerpt": "rgba(255, 170, 0, 0.15)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 45,
-      "column": 28,
-      "excerpt": "rgba(255, 170, 0, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 46,
-      "column": 30,
-      "excerpt": "rgba(255, 170, 0, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 78,
-      "column": 24,
-      "excerpt": "rgba(0, 229, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\ModuleLoader.tsx",
-      "line": 79,
-      "column": 30,
-      "excerpt": "rgba(0, 229, 255, 0.2)',"
-    },
-    {
       "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\shell\\desktop\\SnapPreview.tsx",
       "line": 79,
@@ -1959,5 +1833,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T18:21:33.012Z"
+  "generatedAtIso": "2026-02-25T18:42:06.588Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -4,7 +4,7 @@
   "ok": true,
   "scopeHash": "e2187676ae870298",
   "baselineViolationCount": 1052,
-  "currentViolationCount": 279,
-  "delta": 773,
-  "generatedAtIso": "2026-02-25T18:21:33.015Z"
+  "currentViolationCount": 261,
+  "delta": 791,
+  "generatedAtIso": "2026-02-25T18:42:06.593Z"
 }


### PR DESCRIPTION
## What this does
- Converts raw color usages in:
  - `frontend/apps/os-shell/src/shell/desktop/ModuleLoader.tsx`
  - `frontend/apps/os-shell/src/components/consciousness/UniversalTranslationInterface.tsx`
- Updates token audit contracts after running `pnpm tdc:ui:tokens`
- Keeps `ui-token-baseline.json` out of commit

## Validation
- `pnpm tdc:ui:tokens`
- `pnpm -w run test:governance:ui`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced color theming consistency across UI components with standardized visual tokens for improved design coherence.
  * Applied consistent theme variables throughout the interface for a more unified visual experience.

* **Chores**
  * Reduced code compliance violations from 279 to 261.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->