### PR TITLE
chore(ui-tokens): B2-30 prep tokenize ABTestingFramework + Card stories (no contract regen)

### DIFF
--- a/frontend/apps/os-shell/src/components/ABTestingFramework.tsx
+++ b/frontend/apps/os-shell/src/components/ABTestingFramework.tsx
@@ -172,7 +172,7 @@ const ABTestingFramework: React.FC = () => {
               style={{
                 fontSize: 'clamp(18px, 3vw, 24px)',
                 fontWeight: 300,
-                color: 'rgba(255, 255, 255, 0.9)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.9)',
                 marginBottom: '24px',
                 maxWidth: '800px',
                 margin: '0 auto 24px',
@@ -194,7 +194,7 @@ const ABTestingFramework: React.FC = () => {
               style={{
                 fontSize: 'clamp(18px, 3vw, 24px)',
                 fontWeight: 300,
-                color: 'rgba(255, 255, 255, 0.9)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.9)',
                 marginBottom: '48px',
                 maxWidth: '800px',
                 margin: '0 auto 48px',
@@ -262,7 +262,7 @@ const ABTestingFramework: React.FC = () => {
                 <div
                   key={index}
                   style={{
-                    background: 'rgba(0, 255, 238, 0.1)',
+                    background: 'hsl(var(--tf-transcend-cyan-hs) 50% / 0.1)',
                     padding: '20px',
                     borderRadius: '12px',
                     border: '1px solid var(--tf-transcend-highlight)',
@@ -280,7 +280,7 @@ const ABTestingFramework: React.FC = () => {
                   <div
                     style={{
                       fontSize: '14px',
-                      color: 'rgba(255, 255, 255, 0.7)',
+                      color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)',
                       marginTop: '5px',
                     }}
                   >
@@ -294,7 +294,7 @@ const ABTestingFramework: React.FC = () => {
               style={{
                 fontSize: 'clamp(18px, 3vw, 24px)',
                 fontWeight: 300,
-                color: 'rgba(255, 255, 255, 0.9)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.9)',
                 marginBottom: '48px',
                 maxWidth: '800px',
                 margin: '0 auto 48px',
@@ -331,7 +331,7 @@ const ABTestingFramework: React.FC = () => {
 
             <div
               style={{
-                background: 'rgba(255, 0, 0, 0.1)',
+                background: 'hsl(var(--tf-error-hs) 50% / 0.1)',
                 border: '2px solid var(--tf-error-red)',
                 padding: '15px 30px',
                 borderRadius: '50px',
@@ -350,7 +350,7 @@ const ABTestingFramework: React.FC = () => {
               style={{
                 fontSize: 'clamp(18px, 3vw, 24px)',
                 fontWeight: 300,
-                color: 'rgba(255, 255, 255, 0.9)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.9)',
                 marginBottom: '24px',
                 maxWidth: '800px',
                 margin: '0 auto 24px',
@@ -407,7 +407,7 @@ const ABTestingFramework: React.FC = () => {
               style={{
                 fontSize: 'clamp(18px, 3vw, 24px)',
                 fontWeight: 300,
-                color: 'rgba(255, 255, 255, 0.9)',
+                color: 'hsl(var(--tf-text-primary-hs) 100% / 0.9)',
                 marginBottom: '48px',
                 maxWidth: '800px',
                 margin: '0 auto 48px',
@@ -481,7 +481,7 @@ const ABTestingFramework: React.FC = () => {
           position: 'fixed',
           top: '20px',
           right: '20px',
-          background: 'rgba(26, 31, 58, 0.95)',
+          background: 'hsl(var(--tf-surface-dark-hs) 17% / 0.95)',
           padding: '20px',
           borderRadius: '12px',
           border: '1px solid var(--tf-transcend-highlight)',
@@ -549,7 +549,7 @@ const ABTestingFramework: React.FC = () => {
 
         <div
           style={{
-            background: 'rgba(0, 0, 0, 0.3)',
+            background: 'hsl(var(--tf-text-primary-hs) 0% / 0.3)',
             padding: '10px',
             borderRadius: '6px',
             fontSize: '12px',

--- a/frontend/apps/os-shell/src/components/ui/Card.stories.tsx
+++ b/frontend/apps/os-shell/src/components/ui/Card.stories.tsx
@@ -139,7 +139,7 @@ export const CardGrid: Story = {
         gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
         gap: '24px',
         padding: '24px',
-        backgroundColor: '#0a0a0a',
+        backgroundColor: 'hsl(var(--tf-neutral-hs) 4%)',
         borderRadius: '12px',
       }}
     >
@@ -308,7 +308,7 @@ export const InteractiveCard: Story = {
         gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
         gap: '16px',
         padding: '24px',
-        backgroundColor: '#0a0a0a',
+        backgroundColor: 'hsl(var(--tf-neutral-hs) 4%)',
         borderRadius: '12px',
       }}
     >
@@ -319,7 +319,7 @@ export const InteractiveCard: Story = {
         }}
         onMouseEnter={(e) => {
           e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 153, 255, 0.15)';
+          e.currentTarget.style.boxShadow = '0 8px 24px hsl(var(--tf-network-blue-hs) 50% / 0.15)';
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.transform = 'translateY(0)';
@@ -358,7 +358,7 @@ export const InteractiveCard: Story = {
         }}
         onMouseEnter={(e) => {
           e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 153, 255, 0.15)';
+          e.currentTarget.style.boxShadow = '0 8px 24px hsl(var(--tf-network-blue-hs) 50% / 0.15)';
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.transform = 'translateY(0)';
@@ -396,7 +396,7 @@ export const InteractiveCard: Story = {
         }}
         onMouseEnter={(e) => {
           e.currentTarget.style.transform = 'translateY(-4px)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 153, 255, 0.15)';
+          e.currentTarget.style.boxShadow = '0 8px 24px hsl(var(--tf-network-blue-hs) 50% / 0.15)';
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.transform = 'translateY(0)';
@@ -1177,7 +1177,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -1205,7 +1205,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -1233,7 +1233,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -1261,7 +1261,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                backgroundColor: 'hsl(var(--tf-success-hs) 45% / 0.1)',
                 borderLeft: '3px solid var(--tf-success-green)',
                 borderRadius: '6px',
               }}
@@ -1304,7 +1304,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -1332,7 +1332,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -1360,7 +1360,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -1388,7 +1388,7 @@ export const UsageGuidelines: Story = {
             <li
               style={{
                 padding: '16px',
-                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                backgroundColor: 'hsl(var(--tf-error-hs) 60% / 0.1)',
                 borderLeft: '3px solid var(--tf-accent-error)',
                 borderRadius: '6px',
               }}
@@ -1425,13 +1425,13 @@ export const UsageGuidelines: Story = {
         <h4 className='font-semibold'>Code Examples</h4>
         <div
           style={{
-            backgroundColor: '#1a1a1a',
+            backgroundColor: 'hsl(var(--tf-neutral-hs) 10%)',
             padding: '20px',
             borderRadius: '8px',
             fontFamily: '"Fira Code", monospace',
             fontSize: '13px',
             overflow: 'auto',
-            border: '1px solid #2a2a2a',
+            border: '1px solid hsl(var(--tf-neutral-hs) 16%)',
           }}
         >
           <pre


### PR DESCRIPTION
## Summary
- prep lane only (no contract regen)
- tokenized raw color literals in:
  - frontend/apps/os-shell/src/components/ABTestingFramework.tsx
  - frontend/apps/os-shell/src/components/ui/Card.stories.tsx

## Validation
- pnpm -w run test:governance:ui
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

## Notes
- pre-push hook generated local token contract artifacts; reverted after push to keep diff scoped.
