### PR TITLE
chore(ui-tokens): B2-35 prep convert ModuleLauncher + SimplifiedQuantumDesktopShell to token color-mix

### DIFF
--- a/frontend/apps/os-shell/src/shell/ModuleLauncher.tsx
+++ b/frontend/apps/os-shell/src/shell/ModuleLauncher.tsx
@@ -101,15 +101,15 @@ export const ModuleLauncher: React.FC<ModuleLauncherProps> = ({ modules, onModul
     <Grid item xs={12} sm={6} md={4} lg={3}>
       <Card
         sx={{
-          background: 'hsl(var(--tf-text-primary-hs) 100% / 0.1)',
+          background: 'color-mix(in srgb, var(--tf-text-primary) 10%, transparent)',
           backdropFilter: 'blur(10px)',
-          border: '1px solid hsl(var(--tf-text-primary-hs) 100% / 0.2)',
+          border: '1px solid color-mix(in srgb, var(--tf-text-primary) 20%, transparent)',
           cursor: 'pointer',
           transition: 'all 0.3s ease',
           '&:hover': {
-            background: 'hsl(var(--tf-text-primary-hs) 100% / 0.2)',
+            background: 'color-mix(in srgb, var(--tf-text-primary) 20%, transparent)',
             transform: 'translateY(-2px)',
-            boxShadow: '0 8px 32px hsl(var(--tf-text-primary-hs) 0% / 0.3)',
+            boxShadow: '0 8px 32px color-mix(in srgb, var(--tf-text-primary) 30%, transparent)',
           },
         }}
         onClick={() => onModuleLaunch(module.id)}
@@ -118,10 +118,10 @@ export const ModuleLauncher: React.FC<ModuleLauncherProps> = ({ modules, onModul
           <Box sx={{ mb: 2 }}>
             <IconButton
               sx={{
-                bgcolor: 'hsl(var(--tf-text-primary-hs) 100% / 0.2)',
+                bgcolor: 'color-mix(in srgb, var(--tf-text-primary) 20%, transparent)',
                 color: 'white',
                 mb: 1,
-                '&:hover': { bgcolor: 'hsl(var(--tf-text-primary-hs) 100% / 0.3)' },
+                '&:hover': { bgcolor: 'color-mix(in srgb, var(--tf-text-primary) 30%, transparent)' },
               }}
               size='large'
             >
@@ -134,7 +134,7 @@ export const ModuleLauncher: React.FC<ModuleLauncherProps> = ({ modules, onModul
           </Typography>
 
           {module.description && (
-            <Typography variant='body2' sx={{ color: 'hsl(var(--tf-text-primary-hs) 100% / 0.7)', mb: 1 }}>
+            <Typography variant='body2' sx={{ color: 'color-mix(in srgb, var(--tf-text-primary) 70%, transparent)', mb: 1 }}>
               {module.description}
             </Typography>
           )}
@@ -145,7 +145,7 @@ export const ModuleLauncher: React.FC<ModuleLauncherProps> = ({ modules, onModul
             <Chip label={module.status} size='small' color={getStatusColor(module.status)} />
           </Box>
 
-          <Typography variant='caption' sx={{ color: 'hsl(var(--tf-text-primary-hs) 100% / 0.5)' }}>
+          <Typography variant='caption' sx={{ color: 'color-mix(in srgb, var(--tf-text-primary) 50%, transparent)' }}>
             v{module.version}
           </Typography>
         </CardContent>
@@ -199,3 +199,4 @@ export const ModuleLauncher: React.FC<ModuleLauncherProps> = ({ modules, onModul
     </Box>
   );
 };
+

--- a/frontend/apps/os-shell/src/shell/SimplifiedQuantumDesktopShell.tsx
+++ b/frontend/apps/os-shell/src/shell/SimplifiedQuantumDesktopShell.tsx
@@ -30,9 +30,9 @@ export function QuantumDesktopShell() {
           left: 0,
           right: 0,
           height: '64px',
-          background: 'hsl(var(--tf-surface-dark-hs) 7% / 0.95)',
+          background: 'color-mix(in srgb, var(--tf-surface-dark) 95%, transparent)',
           backdropFilter: 'blur(20px)',
-          borderBottom: '1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2)',
+          borderBottom: '1px solid color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
@@ -178,11 +178,11 @@ export function QuantumDesktopShell() {
               key={index}
               onClick={() => setCurrentModule(module.name)}
               style={{
-                background: 'hsl(var(--tf-transcend-cyan-hs) 50% / 0.05)',
+                background: 'color-mix(in srgb, var(--tf-transcend-cyan) 5%, transparent)',
                 border:
                   currentModule === module.name
-                    ? '2px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.5)'
-                    : '1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.2)',
+                    ? '2px solid color-mix(in srgb, var(--tf-transcend-cyan) 50%, transparent)'
+                    : '1px solid color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent)',
                 borderRadius: '16px',
                 padding: '24px',
                 cursor: 'pointer',
@@ -192,7 +192,7 @@ export function QuantumDesktopShell() {
               onMouseEnter={(e) => {
                 e.currentTarget.style.transform = 'translateY(-4px)';
                 e.currentTarget.style.boxShadow =
-                  '0 10px 30px hsl(var(--tf-transcend-cyan-hs) 50% / 0.2)';
+                  '0 10px 30px color-mix(in srgb, var(--tf-transcend-cyan) 20%, transparent)';
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = 'translateY(0)';
@@ -240,8 +240,8 @@ export function QuantumDesktopShell() {
               bottom: '24px',
               left: '50%',
               transform: 'translateX(-50%)',
-              background: 'hsl(var(--tf-transcend-cyan-hs) 50% / 0.1)',
-              border: '1px solid hsl(var(--tf-transcend-cyan-hs) 50% / 0.3)',
+              background: 'color-mix(in srgb, var(--tf-transcend-cyan) 10%, transparent)',
+              border: '1px solid color-mix(in srgb, var(--tf-transcend-cyan) 30%, transparent)',
               borderRadius: '12px',
               padding: '16px 24px',
               backdropFilter: 'blur(16px)',
@@ -258,3 +258,4 @@ export function QuantumDesktopShell() {
 }
 
 export default QuantumDesktopShell;
+


### PR DESCRIPTION
## Summary
- convert inline hsl(var(--tf-*-hs) ...) usages to token ar(--tf-...) + color-mix(...)
- touch only:
  - rontend/apps/os-shell/src/shell/ModuleLauncher.tsx
  - rontend/apps/os-shell/src/shell/SimplifiedQuantumDesktopShell.tsx
- no contract regeneration in this prep lane

## Validation
- raw color scan on touched files reports no #hex or gba() patterns
- narrow diff guard passes (2 files only)
