### PR TITLE
chore(ui-tokens): B2-38 convert SystemGptConsoleView + LegacyDeprecationBanner

### DIFF
--- a/frontend/apps/os-shell/src/components/legacy/LegacyDeprecationBanner.tsx
+++ b/frontend/apps/os-shell/src/components/legacy/LegacyDeprecationBanner.tsx
@@ -85,9 +85,9 @@ export function LegacyDeprecationBanner({
         alignItems: 'center',
         justifyContent: 'space-between',
         padding: '0.75rem 1rem',
-        backgroundColor: '#fef3c7', // amber-100
-        borderBottom: '1px solid #f59e0b', // amber-500
-        color: '#92400e', // amber-800
+        backgroundColor: 'hsl(var(--tf-warning-hs) 90%)', // warning-tint background
+        borderBottom: '1px solid hsl(var(--tf-warning-hs) 55%)', // warning boundary
+        color: 'hsl(var(--tf-warning-hs) 31%)', // warning text contrast
         fontFamily: 'system-ui, sans-serif',
         fontSize: '0.875rem',
       }}
@@ -99,7 +99,7 @@ export function LegacyDeprecationBanner({
           <code
             style={{
               fontSize: '0.75rem',
-              backgroundColor: 'rgba(0,0,0,0.1)',
+              backgroundColor: 'hsl(var(--tf-tokens-black-hs) 0% / 0.1)',
               padding: '0.125rem 0.25rem',
               borderRadius: '0.25rem',
             }}
@@ -114,7 +114,7 @@ export function LegacyDeprecationBanner({
           href='/os'
           onClick={handleUpgradeClick}
           style={{
-            color: '#92400e',
+            color: 'hsl(var(--tf-warning-hs) 31%)',
             fontWeight: 600,
             textDecoration: 'underline',
           }}
@@ -130,7 +130,7 @@ export function LegacyDeprecationBanner({
             border: 'none',
             cursor: 'pointer',
             padding: '0.25rem',
-            color: '#92400e',
+            color: 'hsl(var(--tf-warning-hs) 31%)',
             fontSize: '1rem',
           }}
         >

--- a/frontend/apps/os-shell/src/features/gpt/SystemGptConsoleView.tsx
+++ b/frontend/apps/os-shell/src/features/gpt/SystemGptConsoleView.tsx
@@ -393,10 +393,10 @@ export const SystemGptConsoleView: React.FC = () => {
       className='flex h-full w-full flex-col bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950/90 p-4 text-sm text-slate-50'
     >
       {/* Header */}
-      <div className='mb-4 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-3 shadow-[0_18px_45px_rgba(0,0,0,0.60)] backdrop-blur-xl'>
+      <div className='mb-4 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-3 shadow-[0_18px_45px_hsl(var(--tf-tokens-black-hs)_0%_/_0.60)] backdrop-blur-xl'>
         <div className='flex items-center gap-3'>
           {/* Control Center icon */}
-          <div className='relative h-8 w-8 rounded-full bg-gradient-to-br from-violet-400 via-fuchsia-400 to-pink-400 shadow-[0_0_25px_rgba(167,139,250,0.8)]'>
+          <div className='relative h-8 w-8 rounded-full bg-gradient-to-br from-violet-400 via-fuchsia-400 to-pink-400 shadow-[0_0_25px_hsl(var(--tf-info-hs)_60%_/_0.8)]'>
             <div className='absolute inset-[2px] rounded-full bg-slate-950/80 backdrop-blur' />
             <div className='absolute inset-[4px] flex items-center justify-center text-lg'>🎛️</div>
           </div>
@@ -453,8 +453,8 @@ export const SystemGptConsoleView: React.FC = () => {
             disabled={safeModeLoading || !diagnostics}
             className={`rounded-full border px-3 py-1 text-xs font-medium transition-all disabled:cursor-not-allowed disabled:opacity-50 ${
               diagnostics?.mode === 'SafeMode'
-                ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 hover:shadow-[0_0_12px_rgba(16,185,129,0.4)]'
-                : 'border-rose-500/50 bg-rose-500/10 text-rose-300 hover:bg-rose-500/20 hover:shadow-[0_0_12px_rgba(244,63,94,0.4)]'
+                ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-success-hs)_52%_/_0.4)]'
+                : 'border-rose-500/50 bg-rose-500/10 text-rose-300 hover:bg-rose-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-error-hs)_60%_/_0.4)]'
             }`}
             title={
               diagnostics?.mode === 'SafeMode'
@@ -473,7 +473,7 @@ export const SystemGptConsoleView: React.FC = () => {
           <button
             onClick={() => void handleDownloadSnapshot()}
             disabled={downloading || !diagnostics}
-            className='rounded-full border border-sky-500/50 bg-sky-500/10 px-3 py-1 text-xs text-sky-300 transition-all hover:bg-sky-500/20 hover:shadow-[0_0_12px_rgba(14,165,233,0.4)] disabled:cursor-not-allowed disabled:opacity-50'
+            className='rounded-full border border-sky-500/50 bg-sky-500/10 px-3 py-1 text-xs text-sky-300 transition-all hover:bg-sky-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-network-blue-hs)_61%_/_0.4)] disabled:cursor-not-allowed disabled:opacity-50'
             title='Download AI Health Snapshot (JSON)'
           >
             {downloading ? '⏳ Downloading…' : '📥 Download Snapshot'}
@@ -482,7 +482,7 @@ export const SystemGptConsoleView: React.FC = () => {
           {/* Explain This button */}
           <button
             onClick={() => void handleExplainThis()}
-            className='rounded-full border border-fuchsia-500/50 bg-fuchsia-500/10 px-3 py-1 text-xs text-fuchsia-300 transition-all hover:bg-fuchsia-500/20 hover:shadow-[0_0_12px_rgba(217,70,239,0.4)]'
+            className='rounded-full border border-fuchsia-500/50 bg-fuchsia-500/10 px-3 py-1 text-xs text-fuchsia-300 transition-all hover:bg-fuchsia-500/20 hover:shadow-[0_0_12px_hsl(var(--tf-info-hs)_60%_/_0.4)]'
             title='Explain this view'
           >
             ❓ Explain
@@ -1030,7 +1030,7 @@ export const SystemGptConsoleView: React.FC = () => {
       {/* Safe Mode Confirmation Dialog - Phase 17 */}
       {showSafeModeDialog && (
         <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm'>
-          <div className='w-full max-w-md rounded-2xl border border-rose-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-rose-950/30 p-6 shadow-[0_25px_60px_rgba(0,0,0,0.8)]'>
+          <div className='w-full max-w-md rounded-2xl border border-rose-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-rose-950/30 p-6 shadow-[0_25px_60px_hsl(var(--tf-tokens-black-hs)_0%_/_0.8)]'>
             <div className='mb-4 flex items-center gap-3'>
               <div className='flex h-12 w-12 items-center justify-center rounded-full bg-rose-500/20 text-2xl'>
                 🛑

--- a/ui-token-compliance.contract.json
+++ b/ui-token-compliance.contract.json
@@ -3,7 +3,7 @@
   "version": "v1",
   "ok": false,
   "scannedFileCount": 875,
-  "violationCount": 261,
+  "violationCount": 172,
   "violations": [
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -18,55 +18,6 @@
       "line": 124,
       "column": 29,
       "excerpt": "rgba(6, 182, 212, 0.2)'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 175,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 197,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 283,
-      "column": 31,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 297,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 353,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 410,
-      "column": 25,
-      "excerpt": "rgba(255, 255, 255, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ABTestingFramework.tsx",
-      "line": 552,
-      "column": 26,
-      "excerpt": "rgba(0, 0, 0, 0.3)',"
     },
     {
       "kind": "RAW_HEX",
@@ -154,94 +105,10 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 19,
-      "column": 31,
-      "excerpt": "rgba(0, 210, 255, 0.6)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 24,
-      "column": 18,
-      "excerpt": "rgba(255, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 26,
-      "column": 24,
-      "excerpt": "rgba(0, 210, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 29,
-      "column": 20,
-      "excerpt": "rgba(0, 210, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 30,
-      "column": 26,
-      "excerpt": "rgba(0, 210, 255, 0.4)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 119,
-      "column": 28,
-      "excerpt": "rgba(0, 0, 0, 0.8)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\common\\FloatingActionMenu.tsx",
-      "line": 122,
-      "column": 34,
-      "excerpt": "rgba(0, 210, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\common\\SystemDiagnostics.tsx",
       "line": 99,
       "column": 19,
       "excerpt": "rgba(255, 255, 255, 0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\QuantumConsciousnessManager.tsx",
-      "line": 28,
-      "column": 40,
-      "excerpt": "rgba(40, 0, 80, 0.1), rgba(20, 0, 40, 0.2))',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\QuantumConsciousnessManager.tsx",
-      "line": 28,
-      "column": 62,
-      "excerpt": "rgba(20, 0, 40, 0.2))',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\QuantumConsciousnessManager.tsx",
-      "line": 39,
-      "column": 35,
-      "excerpt": "rgba(197, 166, 255, 0.16)`,"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\QuantumConsciousnessManager.tsx",
-      "line": 131,
-      "column": 50,
-      "excerpt": "rgba(255,255,255,0.7)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\consciousness\\QuantumConsciousnessManager.tsx",
-      "line": 145,
-      "column": 50,
-      "excerpt": "rgba(255,255,255,0.7)', mb: 2 }}>"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -294,108 +161,10 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\costforge\\EnhancedDataVisualization.tsx",
-      "line": 444,
-      "column": 47,
-      "excerpt": "rgba(15, 23, 42, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\costforge\\EnhancedDataVisualization.tsx",
-      "line": 680,
-      "column": 47,
-      "excerpt": "rgba(15, 23, 42, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\DatabaseStatus.tsx",
-      "line": 153,
-      "column": 23,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\DatabaseStatus.tsx",
-      "line": 174,
-      "column": 23,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\DatabaseStatus.tsx",
-      "line": 195,
-      "column": 23,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\DatabaseStatus.tsx",
-      "line": 216,
-      "column": 23,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\DatabaseStatus.tsx",
-      "line": 248,
-      "column": 21,
-      "excerpt": "rgba(255, 255, 255, 0.7)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\components\\elite\\EliteExperimentalResearchInterface.tsx",
       "line": 618,
       "column": 47,
       "excerpt": "rgba(0, 255, 255, ${node.consciousnessLevel || 0.5})`,"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 48,
-      "column": 33,
-      "excerpt": "rgba(0, 255, 255, 0.5)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 62,
-      "column": 24,
-      "excerpt": "rgba(0, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 89,
-      "column": 34,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 94,
-      "column": 57,
-      "excerpt": "rgba(0, 255, 255, 0.5)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 98,
-      "column": 57,
-      "excerpt": "rgba(0, 255, 255, 0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 109,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\emergency\\EmergencyTerraFusionTest.tsx",
-      "line": 111,
-      "column": 24,
-      "excerpt": "rgba(0, 255, 255, 0.05)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -431,48 +200,6 @@
       "line": 85,
       "column": 57,
       "excerpt": "rgba(0, 255, 255, 0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 338,
-      "column": 28,
-      "excerpt": "rgba(10, 14, 39, 0.9)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 535,
-      "column": 44,
-      "excerpt": "rgba(79, 195, 247, 0.3)' : 'rgba(79, 195, 247, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 535,
-      "column": 72,
-      "excerpt": "rgba(79, 195, 247, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 537,
-      "column": 54,
-      "excerpt": "rgba(79, 195, 247, 0.5)' : 'none',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 742,
-      "column": 35,
-      "excerpt": "rgba(0, 230, 118, 0.3);"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\GovernmentArchitecture.tsx",
-      "line": 752,
-      "column": 59,
-      "excerpt": "rgba(79, 195, 247, 0.3), transparent);"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -515,48 +242,6 @@
       "line": 465,
       "column": 61,
       "excerpt": "rgba(0,255,255,0.6)]')}"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 88,
-      "column": 27,
-      "excerpt": "#fef3c7', // amber-100"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 89,
-      "column": 34,
-      "excerpt": "#f59e0b', // amber-500"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 90,
-      "column": 17,
-      "excerpt": "#92400e', // amber-800"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 117,
-      "column": 21,
-      "excerpt": "#92400e',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 133,
-      "column": 21,
-      "excerpt": "#92400e',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\legacy\\LegacyDeprecationBanner.tsx",
-      "line": 102,
-      "column": 33,
-      "excerpt": "rgba(0,0,0,0.1)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -739,55 +424,6 @@
       "line": 646,
       "column": 32,
       "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 142,
-      "column": 27,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 311,
-      "column": 27,
-      "excerpt": "#0a0a0a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 1428,
-      "column": 31,
-      "excerpt": "#1a1a1a',"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 1434,
-      "column": 32,
-      "excerpt": "#2a2a2a',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 322,
-      "column": 57,
-      "excerpt": "rgba(0, 153, 255, 0.15)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 361,
-      "column": 57,
-      "excerpt": "rgba(0, 153, 255, 0.15)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\components\\ui\\Card.stories.tsx",
-      "line": 399,
-      "column": 57,
-      "excerpt": "rgba(0, 153, 255, 0.15)';"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1162,55 +798,6 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 396,
-      "column": 147,
-      "excerpt": "rgba(0,0,0,0.60)] backdrop-blur-xl'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 399,
-      "column": 136,
-      "excerpt": "rgba(167,139,250,0.8)]'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 456,
-      "column": 124,
-      "excerpt": "rgba(16,185,129,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 457,
-      "column": 112,
-      "excerpt": "rgba(244,63,94,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 476,
-      "column": 165,
-      "excerpt": "rgba(14,165,233,0.4)] disabled:cursor-not-allowed disabled:opacity-50'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 485,
-      "column": 181,
-      "excerpt": "rgba(217,70,239,0.4)]'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\features\\gpt\\SystemGptConsoleView.tsx",
-      "line": 1033,
-      "column": 167,
-      "excerpt": "rgba(0,0,0,0.8)]'>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\globals.css",
       "line": 101,
       "column": 19,
@@ -1229,104 +816,6 @@
       "line": 99,
       "column": 198,
       "excerpt": "rgba(0,255,238,0.1)]'>"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 31,
-      "column": 26,
-      "excerpt": "#00E5FF',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 23,
-      "column": 44,
-      "excerpt": "rgba(10, 14, 26, 0.98) 0%, rgba(20, 24, 36, 0.95) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 23,
-      "column": 71,
-      "excerpt": "rgba(20, 24, 36, 0.95) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 30,
-      "column": 28,
-      "excerpt": "rgba(0, 229, 255, 0.15)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 32,
-      "column": 30,
-      "excerpt": "rgba(0, 229, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 35,
-      "column": 50,
-      "excerpt": "rgba(0, 229, 255, 0.8)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraDossierGen2.tsx",
-      "line": 38,
-      "column": 50,
-      "excerpt": "rgba(255, 255, 255, 0.5)' }}>"
-    },
-    {
-      "kind": "RAW_HEX",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 29,
-      "column": 26,
-      "excerpt": "#00E5FF',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 21,
-      "column": 44,
-      "excerpt": "rgba(10, 14, 26, 0.98) 0%, rgba(20, 24, 36, 0.95) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 21,
-      "column": 71,
-      "excerpt": "rgba(20, 24, 36, 0.95) 100%)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 28,
-      "column": 28,
-      "excerpt": "rgba(0, 229, 255, 0.15)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 30,
-      "column": 30,
-      "excerpt": "rgba(0, 229, 255, 0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 33,
-      "column": 50,
-      "excerpt": "rgba(0, 229, 255, 0.8)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\pages\\gen2\\TerraForgeGen2.tsx",
-      "line": 36,
-      "column": 50,
-      "excerpt": "rgba(255, 255, 255, 0.5)' }}>"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1442,62 +931,6 @@
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 104,
-      "column": 24,
-      "excerpt": "rgba(255,255,255,0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 106,
-      "column": 30,
-      "excerpt": "rgba(255,255,255,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 110,
-      "column": 26,
-      "excerpt": "rgba(255,255,255,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 112,
-      "column": 36,
-      "excerpt": "rgba(0,0,0,0.3)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 121,
-      "column": 27,
-      "excerpt": "rgba(255,255,255,0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 124,
-      "column": 40,
-      "excerpt": "rgba(255,255,255,0.3)' },"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 137,
-      "column": 55,
-      "excerpt": "rgba(255,255,255,0.7)', mb: 1 }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\ModuleLauncher.tsx",
-      "line": 148,
-      "column": 55,
-      "excerpt": "rgba(255,255,255,0.5)' }}>"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
       "file": "frontend\\apps\\os-shell\\src\\shell\\QuantumDesktopShell.tsx",
       "line": 193,
       "column": 26,
@@ -1516,62 +949,6 @@
       "line": 197,
       "column": 26,
       "excerpt": "rgba(255, 170, 0, 0.3)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 33,
-      "column": 24,
-      "excerpt": "rgba(10, 14, 26, 0.95)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 35,
-      "column": 36,
-      "excerpt": "rgba(0, 255, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 181,
-      "column": 30,
-      "excerpt": "rgba(0, 255, 255, 0.05)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 184,
-      "column": 34,
-      "excerpt": "rgba(0, 255, 255, 0.5)'"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 185,
-      "column": 34,
-      "excerpt": "rgba(0, 255, 255, 0.2)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 194,
-      "column": 64,
-      "excerpt": "rgba(0, 255, 255, 0.2)';"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 242,
-      "column": 28,
-      "excerpt": "rgba(0, 255, 255, 0.1)',"
-    },
-    {
-      "kind": "DISALLOWED_COLOR_FUNCTION",
-      "file": "frontend\\apps\\os-shell\\src\\shell\\SimplifiedQuantumDesktopShell.tsx",
-      "line": 243,
-      "column": 34,
-      "excerpt": "rgba(0, 255, 255, 0.3)',"
     },
     {
       "kind": "DISALLOWED_COLOR_FUNCTION",
@@ -1833,5 +1210,5 @@
       "excerpt": "rgba(255, 255, 255, 0.1)'};"
     }
   ],
-  "generatedAtIso": "2026-02-25T18:42:06.588Z"
+  "generatedAtIso": "2026-02-25T22:35:17.771Z"
 }

--- a/ui-token-ratchet.contract.json
+++ b/ui-token-ratchet.contract.json
@@ -3,8 +3,8 @@
   "version": "v1",
   "ok": true,
   "scopeHash": "e2187676ae870298",
-  "baselineViolationCount": 1052,
-  "currentViolationCount": 261,
-  "delta": 791,
-  "generatedAtIso": "2026-02-25T18:42:06.593Z"
+  "baselineViolationCount": 185,
+  "currentViolationCount": 172,
+  "delta": 13,
+  "generatedAtIso": "2026-02-25T22:35:17.774Z"
 }


### PR DESCRIPTION
## Summary
- convert 7 disallowed raw color function literals in `SystemGptConsoleView.tsx` to tokenized `hsl(var(--tf-...))` values
- convert 6 raw color literals in `LegacyDeprecationBanner.tsx` to tokenized `hsl(var(--tf-...))` values
- regenerate UI token compliance + ratchet contracts after conversion

## Validation
- `pnpm tdc:ui:tokens` (185 -> 172, delta -13)
- `pnpm exec vitest tests/governance/noNewRawColors.contract.test.ts --run`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- pre-push gate pack (unit/security/perf/build) via git hook

## Guardrails
- `ui-token-baseline.json` intentionally excluded from commit
- scope limited to os-shell lane files and contract artifacts