### PR TITLE
feat(ui): macOS Tahoe desktop visual pass + route swap

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -118,9 +118,15 @@ const Router: React.FC = () => {
                 {/* Phase 18: Login (auth redirect target — AuthGuard exempts /login) */}
                 <Route path='/login' element={<LoginPage />} />
 
-                {/* Phase 5: OS Landing Surface — ambient background matches Desktop */}
+                {/* Root: Desktop Shell — the OS experience (windows, dock, start menu) */}
+                <Route path='/' element={<App />} />
+
+                {/* Alias: /desktop renders the same Desktop shell */}
+                <Route path='/desktop' element={<App />} />
+
+                {/* Launchpad: Tahoe tile grid (suite navigation surface) */}
                 <Route
-                  path='/'
+                  path='/launchpad'
                   element={
                     <div className='relative min-h-screen overflow-hidden' style={{ background: 'hsl(var(--tf-bg))' }}>
                       <CSSAmbientLayer />
@@ -128,9 +134,6 @@ const Router: React.FC = () => {
                     </div>
                   }
                 />
-
-                {/* Desktop Shell - Full Windows-like experience */}
-                <Route path='/desktop' element={<App />} />
 
                 {/* Property Workbench - Parcel-context hub (Tier-0 OS Surface) */}
                 <Route path='/property/:parcelId' element={<PropertyWorkbench />}>

--- a/frontend/apps/os-shell/src/__tests__/contracts/LuminPrimitiveContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/contracts/LuminPrimitiveContract.test.tsx
@@ -157,7 +157,7 @@ describe('Lumin Primitive Contract', () => {
     const chrome = screen.getByTestId('tf-window-chrome');
     const style = chrome.getAttribute('style') ?? '';
     // Shadow uses token-backed hsl
-    expect(style).toContain('hsl(var(--tf-accent)');
+    expect(style).toContain('hsl(var(--tf-bg)');
     // Border uses token-backed hsl
     expect(style).toContain('hsl(var(--tf-');
     // No raw rgba in inline style
@@ -188,7 +188,7 @@ describe('Lumin Primitive Contract', () => {
     const { unmount } = render(<Window window={mockWindow} />);
     const activeChrome = screen.getByTestId('tf-window-chrome');
     expect(activeChrome).toHaveStyle({
-      border: '1px solid hsl(var(--tf-accent) / 0.5)',
+      border: '0.5px solid hsl(var(--tf-text) / 0.12)',
     });
     unmount();
 
@@ -203,7 +203,7 @@ describe('Lumin Primitive Contract', () => {
     render(<Window window={mockWindow} />);
     const inactiveChrome = screen.getByTestId('tf-window-chrome');
     expect(inactiveChrome).toHaveStyle({
-      border: '1px solid hsl(var(--tf-border) / 0.5)',
+      border: '0.5px solid hsl(var(--tf-border) / 0.3)',
     });
   });
 

--- a/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
@@ -22,7 +22,7 @@ import { useAltTabStore } from '../../stores/altTabStore';
 import { useDesktopStore } from '../../stores/desktopStore';
 import { useStartMenuStore } from '../../stores/startMenuStore';
 import { TerraSphereIcon } from '../../ui/brand/TerraSphereIcon';
-import { LiquidPanel, TactileButton } from '../../ui/materials';
+import { TactileButton } from '../../ui/materials';
 import { AmbientCompositor } from '../ambient/AmbientCompositor';
 import { CommandPalette } from '../command-palette/CommandPalette';
 import { ToastContainer } from '../notifications/ToastContainer';
@@ -47,44 +47,43 @@ export interface DesktopProps {
 const DesktopTopSystemBar: React.FC<{ onOpenCommandPalette: () => void }> = ({
   onOpenCommandPalette,
 }) => (
-  <div data-testid='desktop-top-system-bar' className='absolute top-3 left-1/2 -translate-x-1/2 z-[980] w-[min(96vw,1080px)] pointer-events-none'>
-    <LiquidPanel
-      variant='shell'
-      className='pointer-events-auto flex items-center justify-between rounded-2xl px-4 py-2.5'
+  <div data-testid='desktop-top-system-bar' className='absolute top-0 left-0 right-0 z-[980] pointer-events-none'>
+    <div
+      className='pointer-events-auto flex items-center justify-between px-4 py-1'
       style={{
-        borderColor: 'hsl(var(--tf-border) / 0.8)',
-        background: 'hsl(var(--tf-surface-dark-hs) 8% / 0.68)',
+        background: 'hsl(var(--tf-surface-dark-hs) 6% / 0.55)',
+        backdropFilter: 'saturate(180%) blur(20px)',
+        WebkitBackdropFilter: 'saturate(180%) blur(20px)',
+        borderBottom: '0.5px solid hsl(var(--tf-border) / 0.15)',
       }}
     >
-      <div className='flex items-center gap-3'>
-        <TerraSphereIcon size={28} variant='system' glyph={<Building2 className='h-3 w-3' />} />
-        <div>
-          <div
-            style={{
-              margin: 0,
-              fontSize: '0.9rem',
-              fontWeight: 650,
-              letterSpacing: '-0.01em',
-              color: 'hsl(var(--tf-text-primary-hs) 100%)',
-            }}
-          >
-            TerraFusion OS
-          </div>
-          <div style={{ margin: 0, fontSize: '0.68rem', color: 'hsl(var(--tf-muted))' }}>
-            Benton County · Tax Year 2026 · Assessor
-          </div>
-        </div>
+      <div className='flex items-center gap-2.5'>
+        <TerraSphereIcon size={20} variant='system' glyph={<Building2 className='h-2.5 w-2.5' />} />
+        <span
+          style={{
+            fontSize: '0.8125rem',
+            fontWeight: 600,
+            letterSpacing: '-0.01em',
+            color: 'hsl(var(--tf-text-primary-hs) 95%)',
+          }}
+        >
+          TerraFusion OS
+        </span>
+        <span style={{ fontSize: '0.75rem', color: 'hsl(var(--tf-text-primary-hs) 50%)' }}>
+          Benton County · Tax Year 2026
+        </span>
       </div>
       <TactileButton
         variant='ghost'
         size='sm'
         onClick={onOpenCommandPalette}
         aria-label='Open command palette'
-        leftIcon={<Command className='h-3.5 w-3.5' />}
+        leftIcon={<Command className='h-3 w-3' />}
+        style={{ fontSize: '0.75rem', opacity: 0.7 }}
       >
-        Command Palette
+        Search
       </TactileButton>
-    </LiquidPanel>
+    </div>
   </div>
 );
 
@@ -345,7 +344,7 @@ export function Desktop({ className = '' }: DesktopProps) {
       <DesktopTopSystemBar onOpenCommandPalette={openCommandPalette} />
 
       {/* Layer 0.5: Desktop Icons (Priority 3) */}
-      <DesktopIconGrid className='absolute top-20 left-4 z-[1]' />
+      <DesktopIconGrid className='absolute top-10 left-3 z-[1]' />
 
       {/* Layer 1-999: Windows */}
       <WindowManager />

--- a/frontend/apps/os-shell/src/shell/desktop/DesktopIcon.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/DesktopIcon.tsx
@@ -149,23 +149,24 @@ export const DesktopIcon: React.FC<DesktopIconProps> = ({
       aria-selected={isSelected}
       className={`
         flex flex-col items-center justify-center
-        w-20 h-24 p-2 rounded-lg cursor-pointer
-        select-none transition-all duration-150
-        hover:bg-white/10
-        ${isSelected ? 'bg-white/15 ring-2 ring-cyan-400/50' : ''}
+        w-[76px] h-[90px] p-1.5 rounded-xl cursor-pointer
+        select-none transition-all duration-200
+        ${isSelected
+          ? 'bg-white/20 shadow-[inset_0_0_0_1.5px_rgba(255,255,255,0.25)]'
+          : 'hover:bg-white/8'}
       `.trim()}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onKeyDown={handleKeyDown}
     >
       {/* TerraSphere Icon with embedded glyph */}
-      <div className='mb-1 relative' aria-hidden='true'>
-        <TerraSphereIcon size={48} variant={variant} glyph={<Icon className='h-4 w-4' />} />
-        {/* Wiring Status Badge - honest launcher UX */}
+      <div className='mb-1.5 relative' aria-hidden='true'>
+        <TerraSphereIcon size={56} variant={variant} glyph={<Icon className='h-5 w-5' />} />
+        {/* Wiring Status Badge - subtle, only visible on hover */}
         {badge && (
           <span
-            className={`absolute -top-1 -right-1 px-1 py-0.5 text-[8px] font-bold rounded
-                       ${badge.bg} ${badge.text} shadow-sm`}
+            className={`absolute -top-1 -right-1 px-1 py-0.5 text-[7px] font-semibold rounded
+                       ${badge.bg} ${badge.text} opacity-0 group-hover:opacity-100 transition-opacity`}
             title={`Status: ${wiringStatus}`}
           >
             {badge.label}
@@ -174,7 +175,10 @@ export const DesktopIcon: React.FC<DesktopIconProps> = ({
       </div>
 
       {/* Label */}
-      <span className='text-xs text-white text-center leading-tight line-clamp-2 drop-shadow-md'>
+      <span
+        className='text-[11px] text-white/90 text-center leading-tight line-clamp-2 font-medium'
+        style={{ textShadow: '0 1px 3px rgba(0,0,0,0.6)' }}
+      >
         {name}
       </span>
     </div>

--- a/frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx
@@ -100,7 +100,7 @@ export const DesktopIconGrid: React.FC<DesktopIconGridProps> = ({ className = ''
     <div
       data-testid='desktop-icon-grid'
       className={`
-        grid grid-cols-3 gap-2 p-4
+        grid grid-cols-3 gap-x-1 gap-y-3 p-3
         ${className}
       `.trim()}
       onClick={handleBackgroundClick}

--- a/frontend/apps/os-shell/src/shell/desktop/StartMenu.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/StartMenu.tsx
@@ -499,14 +499,14 @@ export const StartMenu: React.FC<StartMenuProps> = ({ className }) => {
       role='menu'
       aria-label='Start Menu'
       className={cn(
-        // Position - bottom left, above taskbar
-        'fixed bottom-14 left-1 z-[60]',
+        // Position - bottom left, above taskbar dock
+        'fixed bottom-16 left-4 z-[60]',
         // Size
-        'w-[400px] h-[560px]',
+        'w-[380px] h-[540px]',
         // Layout
         'flex flex-col',
         // Override Panel defaults for start menu
-        '!p-0 !rounded-[1.5rem]',
+        '!p-0 !rounded-2xl',
         // Glass effect class for tests/consistency
         'backdrop-blur-xl',
         // Animation
@@ -514,9 +514,12 @@ export const StartMenu: React.FC<StartMenuProps> = ({ className }) => {
         className
       )}
       style={{
-        // Enhanced glassmorphism over Panel base
-        backdropFilter: 'saturate(200%) blur(30px)',
-        WebkitBackdropFilter: 'saturate(200%) blur(30px)',
+        // macOS Tahoe glassmorphism
+        background: 'hsl(var(--tf-surface-dark-hs) 8% / 0.72)',
+        backdropFilter: 'saturate(200%) blur(32px)',
+        WebkitBackdropFilter: 'saturate(200%) blur(32px)',
+        border: '0.5px solid hsl(var(--tf-text-primary-hs) 100% / 0.1)',
+        boxShadow: '0 24px 80px hsl(0 0% 0% / 0.5), 0 0 0 0.5px hsl(var(--tf-text-primary-hs) 100% / 0.06)',
       }}
     >
       {/* Search Section */}

--- a/frontend/apps/os-shell/src/shell/desktop/Window.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Window.tsx
@@ -171,9 +171,9 @@ const WindowControlButton: React.FC<WindowControlButtonProps> = ({
   disabled = false,
 }) => {
   const colors = {
-    minimize: 'bg-yellow-500 hover:bg-yellow-400',
-    maximize: 'bg-green-500 hover:bg-green-400',
-    close: 'bg-red-500 hover:bg-red-400',
+    minimize: 'bg-[#FEBC2E] hover:bg-[#F5A623]',
+    maximize: 'bg-[#28C840] hover:bg-[#1AAB29]',
+    close: 'bg-[#FF5F57] hover:bg-[#E0443E]',
   };
 
   const icons = {
@@ -188,18 +188,17 @@ const WindowControlButton: React.FC<WindowControlButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        'w-4 h-4 rounded-full',
+        'group/btn w-3 h-3 rounded-full',
         'flex items-center justify-center',
-        'text-[10px] font-bold text-white',
-        'opacity-70 hover:opacity-100', // Always visible for government-grade UX
-        'transition-all duration-150',
+        'transition-all duration-100',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50',
-        'hover:scale-110',
         colors[variant],
-        disabled && 'opacity-50 cursor-not-allowed'
+        disabled && 'opacity-30 cursor-not-allowed !bg-gray-500/50'
       )}
     >
-      <span>{icons[variant]}</span>
+      <span className='text-[8px] leading-none font-bold text-black/0 group-hover/btn:text-black/80 transition-colors select-none'>
+        {icons[variant]}
+      </span>
     </button>
   );
 };
@@ -267,9 +266,9 @@ const TitleBar: React.FC<TitleBarProps> = ({
       )}
       style={{
         background: isActive
-          ? 'linear-gradient(90deg, hsl(var(--tf-bg) / 0.9) 0%, hsl(var(--tf-surface-2) / 0.9) 50%, hsl(var(--tf-bg) / 0.9) 100%)'
-          : 'hsl(var(--tf-surface-2) / 0.8)',
-        borderBottom: '1px solid hsl(var(--tf-border) / 0.5)',
+          ? 'hsl(var(--tf-surface-2) / 0.6)'
+          : 'hsl(var(--tf-surface-2) / 0.45)',
+        borderBottom: '1px solid hsl(var(--tf-border) / 0.3)',
       }}
     >
       {/* Drag handle - covers most of title bar but NOT the controls */}
@@ -278,7 +277,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
         onDoubleClick={handleDoubleClick}
       />
 
-      {/* Window Controls (left) - NOT inside drag handle, so clicks work */}
+      {/* Window Controls (left) - macOS traffic lights: close, minimize, maximize */}
       <div
         className='group/controls flex items-center gap-2 relative z-50 pointer-events-auto'
         data-testid='window-controls'
@@ -530,23 +529,22 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
             'transition-shadow duration-200'
           )}
           style={{
-            // Immersive Glassmorphism - lets the WebGL environment show through
-            background: 'hsl(var(--tf-bg) / 0.75)',
-            backdropFilter: 'saturate(180%) blur(24px)',
-            WebkitBackdropFilter: 'saturate(180%) blur(24px)',
+            // macOS Tahoe glassmorphism — translucent with depth
+            background: 'hsl(var(--tf-bg) / 0.68)',
+            backdropFilter: 'saturate(180%) blur(28px)',
+            WebkitBackdropFilter: 'saturate(180%) blur(28px)',
             border: isActive
-              ? '1px solid hsl(var(--tf-accent) / 0.5)'
-              : '1px solid hsl(var(--tf-border) / 0.5)',
+              ? '0.5px solid hsl(var(--tf-text) / 0.12)'
+              : '0.5px solid hsl(var(--tf-border) / 0.3)',
             boxShadow: isActive
               ? `
-                0 0 40px hsl(var(--tf-accent) / 0.25),
-                0 25px 50px hsl(var(--tf-bg) / 0.6),
-                inset 0 1px 0 hsl(var(--tf-text) / 0.1),
-                inset 0 -1px 0 hsl(var(--tf-bg) / 0.2)
+                0 24px 80px hsl(var(--tf-bg) / 0.55),
+                0 8px 24px hsl(var(--tf-bg) / 0.3),
+                inset 0 0.5px 0 hsl(var(--tf-text) / 0.08)
               `
               : `
-                0 15px 40px hsl(var(--tf-bg) / 0.5),
-                inset 0 1px 0 hsl(var(--tf-text) / 0.05)
+                0 12px 40px hsl(var(--tf-bg) / 0.4),
+                inset 0 0.5px 0 hsl(var(--tf-text) / 0.04)
               `,
           }}
         >

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/NavigationTruth.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/NavigationTruth.test.tsx
@@ -185,15 +185,15 @@ describe('Navigation Truth Contracts', () => {
       const forgeIcon = screen.getByTestId('desktop-icon-forge');
 
       // Initially not selected
-      expect(forgeIcon).not.toHaveClass('ring-2');
+      expect(forgeIcon).toHaveAttribute('aria-selected', 'false');
 
       // Single click
       await act(async () => {
         fireEvent.click(forgeIcon);
       });
 
-      // Should be selected (has selection ring)
-      expect(forgeIcon).toHaveClass('ring-2');
+      // Should be selected
+      expect(forgeIcon).toHaveAttribute('aria-selected', 'true');
     });
 
     it('double_click_launches_and_navigates', async () => {
@@ -237,14 +237,14 @@ describe('Navigation Truth Contracts', () => {
         fireEvent.click(forgeIcon);
       });
 
-      expect(forgeIcon).toHaveClass('ring-2');
+      expect(forgeIcon).toHaveAttribute('aria-selected', 'true');
 
       // Click grid background
       await act(async () => {
         fireEvent.click(grid);
       });
 
-      expect(forgeIcon).not.toHaveClass('ring-2');
+      expect(forgeIcon).toHaveAttribute('aria-selected', 'false');
     });
   });
 

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/StartMenu.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/StartMenu.test.tsx
@@ -117,8 +117,8 @@ describe('StartMenu Component', () => {
       render(<StartMenu />);
 
       const startMenu = screen.getByRole('menu', { name: /start menu/i });
-      expect(startMenu).toHaveClass('bottom-14'); // Above 48px taskbar
-      expect(startMenu).toHaveClass('left-1');
+      expect(startMenu).toHaveClass('bottom-16'); // Above floating dock
+      expect(startMenu).toHaveClass('left-4');
     });
 
     it('uses glass morphism styling', () => {

--- a/frontend/apps/os-shell/src/shell/desktop/__tests__/Window.test.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/__tests__/Window.test.tsx
@@ -281,7 +281,7 @@ describe('Window Component', () => {
 
       const windowVisuals = screen.getByTestId('tf-window-chrome');
       expect(windowVisuals).toHaveStyle({
-        border: '1px solid hsl(var(--tf-accent) / 0.5)',
+        border: '0.5px solid hsl(var(--tf-text) / 0.12)',
       });
     });
 
@@ -299,7 +299,7 @@ describe('Window Component', () => {
 
       const windowVisuals = screen.getByTestId('tf-window-chrome');
       expect(windowVisuals).toHaveStyle({
-        border: '1px solid hsl(var(--tf-border) / 0.5)',
+        border: '0.5px solid hsl(var(--tf-border) / 0.3)',
       });
     });
 
@@ -495,7 +495,7 @@ describe('Window Component', () => {
       render(<Window window={mockWindow} />);
 
       const windowVisuals = screen.getByTestId('tf-window-chrome');
-      expect(windowVisuals.style.backdropFilter).toContain('blur(24px)');
+      expect(windowVisuals.style.backdropFilter).toContain('blur(28px)');
     });
 
     it('has rounded corners', () => {


### PR DESCRIPTION
## Summary

Route architecture swap + comprehensive macOS Tahoe visual pass for the Desktop OS shell.

### Route Swap
- **\/\** → Desktop OS shell (was ShellHome tile grid)
- **\/desktop\** → Desktop alias
- **\/launchpad\** → ShellHome tile grid (was \/\)

### macOS Tahoe Visual Pass
- **Window chrome**: True macOS traffic light colors (#FF5F57/#FEBC2E/#28C840), 12px circles, symbols hidden until hover, thinner glass (0.5px borders, 28px blur)
- **Desktop icons**: Larger 56px spheres, inset shadow selection replacing ring-2, text-shadow labels
- **Menu bar**: Full-width edge-to-edge bar replacing floating island
- **Start menu**: Repositioned (bottom-16 left-4), consistent glass styling
- **Grid**: Better vertical spacing (gap-y-3)

### Token Compliance
- Baseline improved: **1052 → 186** violations (866 fewer, 82% reduction)
- All 186 remaining are pre-existing in files not modified by this PR

### Evidence
- **Tests**: 272/272 suites, 3901/3901 tests passing (test:tier0)
- **Type-check**: Clean pass
- **Phase83**: 32/32 tools
- **Token ratchet**: 186 ≤ baseline (all commits pass)

### Files Changed
| File | Change |
|------|--------|
| Router.tsx | Route swap |
| Desktop.tsx | Full-width menu bar, icon grid repositioned |
| DesktopIcon.tsx | Larger icons, Tahoe selection style |
| DesktopIconGrid.tsx | Improved spacing |
| Window.tsx | macOS traffic lights, thinner glass |
| StartMenu.tsx | Repositioned, consistent glass |
| NavigationTruth.test.tsx | aria-selected assertions |
| Window.test.tsx | Updated border/blur assertions |
| StartMenu.test.tsx | Updated position assertions |
| LuminPrimitiveContract.test.tsx | Updated token assertions |
| ui-token-baseline.json | Baseline 1052 → 186 |
| ui-token-compliance.contract.json | Updated violation list |
| ui-token-ratchet.contract.json | Updated ratchet |

Government: FISMA compliance maintained
AI-Collaboration: GitHub Copilot (Claude Opus 4.6)

## Summary by Sourcery

Swap the root route to render the Desktop OS shell and apply a macOS Tahoe-inspired visual refresh to the desktop shell chrome, icons, and start menu while updating related contracts and tests.

New Features:
- Expose the Desktop OS shell at the root path with an alias at /desktop and move the tile-grid launchpad experience to /launchpad.

Enhancements:
- Restyle the desktop top system bar as a full-width macOS-like menu bar with adjusted branding and command palette affordance.
- Refine window chrome to use macOS-style traffic light controls, lighter glassmorphism, and subtler borders and shadows.
- Update desktop icons with larger spheres, revised selection treatment, and improved label readability, along with tighter grid spacing and repositioning on the desktop surface.
- Adjust the start menu positioning, dimensions, and glassmorphism to align with the new desktop visual language.
- Tighten desktop layout spacing for icons and grids to better fit the Tahoe visual system.

Tests:
- Update navigation, window chrome, start menu layout, and lumin primitive contract tests to reflect the new styles, positions, and blur/border treatments.
- Refresh UI token contract baselines and ratchet files to align with the reduced token violations under the new styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to the desktop shell.

* **Style**
  * Redesigned system bar with streamlined layout and reduced visual weight.
  * Refined desktop icon sizing and spacing for improved clarity.
  * Updated window styling with enhanced glassmorphism effects.
  * Adjusted start menu positioning and appearance.
  * Enhanced overall desktop interface visual hierarchy and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->