### PR TITLE
feat(wave9): Flip USE_MOCK_DATA default, wire CostForge API, fix ShellHome empty state

### DIFF
--- a/frontend/apps/os-shell/src/config/features.ts
+++ b/frontend/apps/os-shell/src/config/features.ts
@@ -32,5 +32,5 @@ export const FEATURES: FeatureFlags = {
   ENABLE_SIMULATION_ENGINE: getEnvBool('VITE_ENABLE_SIMULATION_ENGINE', true),
   ENABLE_REDUCED_MOTION: getEnvBool('VITE_ENABLE_REDUCED_MOTION', false),
   ENABLE_DEBUG_OVERLAYS: getEnvBool('VITE_ENABLE_DEBUG_OVERLAYS', false),
-  USE_MOCK_DATA: getEnvBool('VITE_USE_MOCK_DATA', true), // Default to true for Demo Mode
+  USE_MOCK_DATA: getEnvBool('VITE_USE_MOCK_DATA', false), // Explicitly enable via VITE_USE_MOCK_DATA=true for demos
 };

--- a/frontend/apps/os-shell/src/modules/dashboard/__tests__/CostforgeSimulation.test.tsx
+++ b/frontend/apps/os-shell/src/modules/dashboard/__tests__/CostforgeSimulation.test.tsx
@@ -13,7 +13,7 @@ import { act, renderHook } from '@testing-library/react';
 import { useCostforgeStore } from '../store/costforgeStore';
 
 // Tests run with mock data so initial metrics use GOLDEN_METRICS
-vi.mock('../../../config/features', () => ({
+jest.mock('../../../config/features', () => ({
   FEATURES: { USE_MOCK_DATA: true },
 }));
 
@@ -68,11 +68,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('state transitions', () => {
     beforeEach(() => {
-      vi.useFakeTimers();
+      jest.useFakeTimers();
     });
 
     afterEach(() => {
-      vi.useRealTimers();
+      jest.useRealTimers();
     });
 
     it('transitions from idle to analyzing on runAnalysis', async () => {
@@ -95,7 +95,7 @@ describe('CostForge Simulation - Phase C4', () => {
 
       // Fast-forward past the analysis delay (phi-based: 1618ms)
       await act(async () => {
-        vi.advanceTimersByTime(1618);
+        jest.advanceTimersByTime(1618);
       });
 
       expect(result.current.status).toBe('ready');
@@ -109,7 +109,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        vi.advanceTimersByTime(1618);
+        jest.advanceTimersByTime(1618);
       });
 
       expect(result.current.status).toBe('ready');
@@ -129,7 +129,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        vi.advanceTimersByTime(1618);
+        jest.advanceTimersByTime(1618);
       });
       act(() => {
         result.current.applyOptimization();
@@ -151,11 +151,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('optimization commit', () => {
     beforeEach(() => {
-      vi.useFakeTimers();
+      jest.useFakeTimers();
     });
 
     afterEach(() => {
-      vi.useRealTimers();
+      jest.useRealTimers();
     });
 
     it('applyOptimization commits projected to current', async () => {
@@ -166,7 +166,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        vi.advanceTimersByTime(1618);
+        jest.advanceTimersByTime(1618);
       });
 
       const projectedBefore = result.current.metrics.assessedValue.projected;
@@ -186,7 +186,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        vi.advanceTimersByTime(1618);
+        jest.advanceTimersByTime(1618);
       });
 
       act(() => {
@@ -220,11 +220,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('idempotency', () => {
     beforeEach(() => {
-      vi.useFakeTimers();
+      jest.useFakeTimers();
     });
 
     afterEach(() => {
-      vi.useRealTimers();
+      jest.useRealTimers();
     });
 
     it('runAnalysis is idempotent (only runs if idle)', async () => {

--- a/frontend/apps/os-shell/src/modules/dashboard/__tests__/CostforgeSimulation.test.tsx
+++ b/frontend/apps/os-shell/src/modules/dashboard/__tests__/CostforgeSimulation.test.tsx
@@ -12,6 +12,11 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useCostforgeStore } from '../store/costforgeStore';
 
+// Tests run with mock data so initial metrics use GOLDEN_METRICS
+vi.mock('../../../config/features', () => ({
+  FEATURES: { USE_MOCK_DATA: true },
+}));
+
 // ============================================================================
 // Test Setup
 // ============================================================================
@@ -63,11 +68,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('state transitions', () => {
     beforeEach(() => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
     });
 
     afterEach(() => {
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
 
     it('transitions from idle to analyzing on runAnalysis', async () => {
@@ -90,7 +95,7 @@ describe('CostForge Simulation - Phase C4', () => {
 
       // Fast-forward past the analysis delay (phi-based: 1618ms)
       await act(async () => {
-        jest.advanceTimersByTime(1618);
+        vi.advanceTimersByTime(1618);
       });
 
       expect(result.current.status).toBe('ready');
@@ -104,7 +109,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        jest.advanceTimersByTime(1618);
+        vi.advanceTimersByTime(1618);
       });
 
       expect(result.current.status).toBe('ready');
@@ -124,7 +129,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        jest.advanceTimersByTime(1618);
+        vi.advanceTimersByTime(1618);
       });
       act(() => {
         result.current.applyOptimization();
@@ -146,11 +151,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('optimization commit', () => {
     beforeEach(() => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
     });
 
     afterEach(() => {
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
 
     it('applyOptimization commits projected to current', async () => {
@@ -161,7 +166,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        jest.advanceTimersByTime(1618);
+        vi.advanceTimersByTime(1618);
       });
 
       const projectedBefore = result.current.metrics.assessedValue.projected;
@@ -181,7 +186,7 @@ describe('CostForge Simulation - Phase C4', () => {
         result.current.runAnalysis();
       });
       await act(async () => {
-        jest.advanceTimersByTime(1618);
+        vi.advanceTimersByTime(1618);
       });
 
       act(() => {
@@ -215,11 +220,11 @@ describe('CostForge Simulation - Phase C4', () => {
 
   describe('idempotency', () => {
     beforeEach(() => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
     });
 
     afterEach(() => {
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
 
     it('runAnalysis is idempotent (only runs if idle)', async () => {

--- a/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
+++ b/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
@@ -2,7 +2,6 @@ import { TF_TOKENS } from '@/ui/theme/tokens';
 import { create } from 'zustand';
 import { FEATURES } from '../../../config/features';
 import { GOLDEN_METRICS } from '../../../data/goldenParcel';
-import api from '../../../services/api';
 
 export type OptimizationStatus = 'idle' | 'analyzing' | 'ready' | 'optimized';
 
@@ -77,6 +76,7 @@ export const useCostforgeStore = create<CostforgeState>((set, get) => {
       set({ status: 'analyzing' });
 
       try {
+        const { default: api } = await import('../../../services/api');
         const res = await api.post('/costforge/calculate', {
           region: 'benton-wa',
           buildingType: 'residential',
@@ -89,6 +89,7 @@ export const useCostforgeStore = create<CostforgeState>((set, get) => {
         if (data?.totalCost) {
           const projected = data.totalCost;
           const current = state.metrics.assessedValue.current || projected;
+          const landVal = data.landValue || 0;
           set({
             status: 'ready',
             metrics: {
@@ -100,9 +101,9 @@ export const useCostforgeStore = create<CostforgeState>((set, get) => {
               },
               taxLiability: {
                 ...state.metrics.taxLiability,
-                current: state.metrics.taxLiability.current || data.landValue ?? 0,
-                projected: data.landValue ?? state.metrics.taxLiability.projected,
-                delta: (data.landValue ?? state.metrics.taxLiability.projected) - (state.metrics.taxLiability.current || data.landValue ?? 0),
+                current: state.metrics.taxLiability.current || landVal,
+                projected: landVal || state.metrics.taxLiability.projected,
+                delta: (landVal || state.metrics.taxLiability.projected) - (state.metrics.taxLiability.current || landVal),
               },
               grm: state.metrics.grm,
             },

--- a/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
+++ b/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
@@ -75,46 +75,51 @@ export const useCostforgeStore = create<CostforgeState>((set, get) => {
 
       set({ status: 'analyzing' });
 
-      try {
-        const { default: api } = await import('../../../services/api');
-        const res = await api.post('/costforge/calculate', {
-          region: 'benton-wa',
-          buildingType: 'residential',
-        });
-
-        // If someone reset during the request, don't resurrect
-        if (get().status !== 'analyzing') return;
-
-        const data = res.data;
-        if (data?.totalCost) {
-          const projected = data.totalCost;
-          const current = state.metrics.assessedValue.current || projected;
-          const landVal = data.landValue || 0;
-          set({
-            status: 'ready',
-            metrics: {
-              assessedValue: {
-                ...state.metrics.assessedValue,
-                current,
-                projected,
-                delta: projected - current,
-              },
-              taxLiability: {
-                ...state.metrics.taxLiability,
-                current: state.metrics.taxLiability.current || landVal,
-                projected: landVal || state.metrics.taxLiability.projected,
-                delta: (landVal || state.metrics.taxLiability.projected) - (state.metrics.taxLiability.current || landVal),
-              },
-              grm: state.metrics.grm,
-            },
+      // Live mode: call CostForge API
+      if (!FEATURES.USE_MOCK_DATA) {
+        try {
+          const { default: api } = await import('../../../services/api');
+          const res = await api.post('/costforge/calculate', {
+            region: 'benton-wa',
+            buildingType: 'residential',
           });
-          return;
+
+          // If someone reset during the request, don't resurrect
+          if (get().status !== 'analyzing') return;
+
+          const data = res.data;
+          if (data?.totalCost) {
+            const projected = data.totalCost;
+            const current = state.metrics.assessedValue.current || projected;
+            const landVal = data.landValue || 0;
+            set({
+              status: 'ready',
+              metrics: {
+                assessedValue: {
+                  ...state.metrics.assessedValue,
+                  current,
+                  projected,
+                  delta: projected - current,
+                },
+                taxLiability: {
+                  ...state.metrics.taxLiability,
+                  current: state.metrics.taxLiability.current || landVal,
+                  projected: landVal || state.metrics.taxLiability.projected,
+                  delta:
+                    (landVal || state.metrics.taxLiability.projected) -
+                    (state.metrics.taxLiability.current || landVal),
+                },
+                grm: state.metrics.grm,
+              },
+            });
+            return;
+          }
+        } catch {
+          // API unavailable — fall through to token-driven delay fallback
         }
-      } catch {
-        // API unavailable — fall through to token-driven delay fallback
       }
 
-      // Fallback: token-driven delay when API is offline
+      // Token-driven delay (mock mode or API fallback)
       if (get().status !== 'analyzing') return;
       const delayMs = (TF_TOKENS as any).motion?.analysisDelayMs ?? 1618;
       await new Promise<void>((resolve) => setTimeout(resolve, delayMs));

--- a/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
+++ b/frontend/apps/os-shell/src/modules/dashboard/store/costforgeStore.ts
@@ -2,6 +2,7 @@ import { TF_TOKENS } from '@/ui/theme/tokens';
 import { create } from 'zustand';
 import { FEATURES } from '../../../config/features';
 import { GOLDEN_METRICS } from '../../../data/goldenParcel';
+import api from '../../../services/api';
 
 export type OptimizationStatus = 'idle' | 'analyzing' | 'ready' | 'optimized';
 
@@ -75,12 +76,47 @@ export const useCostforgeStore = create<CostforgeState>((set, get) => {
 
       set({ status: 'analyzing' });
 
-      // Token-driven delay (no magic numbers)
+      try {
+        const res = await api.post('/costforge/calculate', {
+          region: 'benton-wa',
+          buildingType: 'residential',
+        });
+
+        // If someone reset during the request, don't resurrect
+        if (get().status !== 'analyzing') return;
+
+        const data = res.data;
+        if (data?.totalCost) {
+          const projected = data.totalCost;
+          const current = state.metrics.assessedValue.current || projected;
+          set({
+            status: 'ready',
+            metrics: {
+              assessedValue: {
+                ...state.metrics.assessedValue,
+                current,
+                projected,
+                delta: projected - current,
+              },
+              taxLiability: {
+                ...state.metrics.taxLiability,
+                current: state.metrics.taxLiability.current || data.landValue ?? 0,
+                projected: data.landValue ?? state.metrics.taxLiability.projected,
+                delta: (data.landValue ?? state.metrics.taxLiability.projected) - (state.metrics.taxLiability.current || data.landValue ?? 0),
+              },
+              grm: state.metrics.grm,
+            },
+          });
+          return;
+        }
+      } catch {
+        // API unavailable — fall through to token-driven delay fallback
+      }
+
+      // Fallback: token-driven delay when API is offline
+      if (get().status !== 'analyzing') return;
       const delayMs = (TF_TOKENS as any).motion?.analysisDelayMs ?? 1618;
-
       await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
-
-      // If someone reset during delay, don’t resurrect
       if (get().status !== 'analyzing') return;
 
       set({ status: 'ready' });

--- a/frontend/apps/os-shell/src/shell/home/ShellHome.tsx
+++ b/frontend/apps/os-shell/src/shell/home/ShellHome.tsx
@@ -410,11 +410,8 @@ export const ShellHome: React.FC<ShellHomeProps> = ({ className = '' }) => {
         route: `/modules/${app.id}`,
       }));
     }
-    // Fallback for empty state
-    return [
-      { id: 'rec-1', title: '12345-001', subtitle: 'Benton County parcel', route: '/property/12345-001' },
-      { id: 'rec-2', title: '67890-002', subtitle: 'Benton County parcel', route: '/property/67890-002' },
-    ];
+    // Empty state — no hardcoded parcels; user should search
+    return [];
   }, [storedRecentParcels, recentApps]);
 
   const actionContext: OsActionContext = useMemo(
@@ -599,31 +596,37 @@ export const ShellHome: React.FC<ShellHomeProps> = ({ className = '' }) => {
               >
                 Recent
               </h2>
-              <div className='grid grid-cols-1 md:grid-cols-3 gap-2'>
-                {recentItems.map((item) => (
-                  <button
-                    key={item.id}
-                    onClick={() => openRecent(item)}
-                    className='text-left'
-                    style={{
-                      width: '100%',
-                      border: '1px solid hsl(var(--tf-border) / 0.4)',
-                      background: 'hsl(var(--tf-surface-dark-hs) 10% / 0.4)',
-                      color: 'hsl(var(--tf-text))',
-                      borderRadius: '0.75rem',
-                      padding: '0.65rem 0.75rem',
-                      backdropFilter: 'blur(10px)',
-                      WebkitBackdropFilter: 'blur(10px)',
-                      cursor: 'pointer',
-                    }}
-                  >
-                    <div style={{ fontWeight: 600, fontSize: '0.82rem' }}>{item.title}</div>
-                    <div style={{ marginTop: '0.15rem', fontSize: '0.68rem', color: 'hsl(var(--tf-muted))' }}>
-                      {item.subtitle}
-                    </div>
-                  </button>
-                ))}
-              </div>
+              {recentItems.length > 0 ? (
+                <div className='grid grid-cols-1 md:grid-cols-3 gap-2'>
+                  {recentItems.map((item) => (
+                    <button
+                      key={item.id}
+                      onClick={() => openRecent(item)}
+                      className='text-left'
+                      style={{
+                        width: '100%',
+                        border: '1px solid hsl(var(--tf-border) / 0.4)',
+                        background: 'hsl(var(--tf-surface-dark-hs) 10% / 0.4)',
+                        color: 'hsl(var(--tf-text))',
+                        borderRadius: '0.75rem',
+                        padding: '0.65rem 0.75rem',
+                        backdropFilter: 'blur(10px)',
+                        WebkitBackdropFilter: 'blur(10px)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <div style={{ fontWeight: 600, fontSize: '0.82rem' }}>{item.title}</div>
+                      <div style={{ marginTop: '0.15rem', fontSize: '0.68rem', color: 'hsl(var(--tf-muted))' }}>
+                        {item.subtitle}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p style={{ fontSize: '0.78rem', color: 'hsl(var(--tf-muted))', padding: '0.5rem 0' }}>
+                  Search for a parcel to start building your history.
+                </p>
+              )}
             </section>
           </LiquidPanel>
         </main>


### PR DESCRIPTION
## Wave 9: Production Mode + CostForge API + Shell Empty State

### Changes
- **features.ts**: \USE_MOCK_DATA\ defaults to \alse\ (production mode). Enable via \VITE_USE_MOCK_DATA=true\ for demos.
- **costforgeStore.ts**: \unAnalysis\ now calls \/api/costforge/calculate\ with graceful fallback to token-driven delay when API is offline.
- **ShellHome.tsx**: Remove hardcoded fallback parcel IDs (\12345-001\, \67890-002\). Empty state shows helpful hint to search for parcels.

### Evidence
- type-check: 0 errors
- phase83: 32/32 pass

AI-Collaboration: GitHub Copilot

## Summary by Sourcery

Flip the application into production mode by default, integrate the CostForge backend API for cost analysis with a graceful offline fallback, and improve the Shell home recent-items empty state.

New Features:
- Wire the CostForge analysis flow to call the backend /costforge/calculate API and populate cost metrics from the response when available.

Enhancements:
- Default USE_MOCK_DATA feature flag to false so real data is used unless mock mode is explicitly enabled.
- Improve the Shell home "Recent" section to show an instructional empty state message instead of hardcoded example parcels when no history exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cost calculations can now use live API-driven data for more accurate, up-to-date analysis when available.

* **Improvements**
  * Demo/mock data disabled by default; explicit enablement required for demo mode.
  * Recent section only shows the items grid when there are items and otherwise displays a prompt: "Search for a parcel to start building your history."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->