### PR TITLE
fix(shell): port governance wave 12 — 16 components + hooks

### DIFF
--- a/frontend/apps/os-shell/.env.example
+++ b/frontend/apps/os-shell/.env.example
@@ -24,8 +24,8 @@ VITE_USE_MOCK_DATA=true
 # - In conjunction with VITE_USE_MOCK_DATA=true, this prevents 401-driven redirect loops to /login
 VITE_DEV_PREVIEW_BYPASS_AUTH=true
 
-# Suggested defaults for dev-preview
-VITE_API_URL=http://localhost:5001
+# Suggested defaults for dev-preview (use /api to leverage Vite proxy)
+VITE_API_URL=/api
 
 # [Performance]
 # Force reduced motion for low-end hardware

--- a/frontend/apps/os-shell/src/applications/terra-levy/hooks/useBudgetData.ts
+++ b/frontend/apps/os-shell/src/applications/terra-levy/hooks/useBudgetData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import { BudgetCategory } from '../types/BudgetTypes';
 
 // Custom hook for managing budget data with real-time updates
@@ -150,7 +151,7 @@ export const useBudgetData = () => {
     const connectWebSocket = () => {
       try {
         // In a real implementation, this would connect to TerraLevy's real-time service
-        wsRef.current = new WebSocket('ws://localhost:8080/budget-updates');
+        wsRef.current = new WebSocket(`${getViteEnv().VITE_WS_URL || 'ws://localhost:8080'}/budget-updates`);
 
         wsRef.current.onopen = () => {
           console.log('Connected to budget data stream');

--- a/frontend/apps/os-shell/src/applications/terra-levy/hooks/useCollaboration.ts
+++ b/frontend/apps/os-shell/src/applications/terra-levy/hooks/useCollaboration.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import {
   CollaborativeSession,
   ConflictResolution,
@@ -37,7 +38,7 @@ export const useCollaboration = ({
       setConnectionStatus('connecting');
 
       // Initialize WebSocket connection for real-time collaboration
-      const wsUrl = `ws://localhost:8080/collaboration/${sessionId}`;
+      const wsUrl = `${getViteEnv().VITE_WS_URL || 'ws://localhost:8080'}/collaboration/${sessionId}`;
       wsRef.current = new WebSocket(wsUrl);
 
       wsRef.current.onopen = () => {

--- a/frontend/apps/os-shell/src/applications/terra-levy/hooks/useQuantumResearch.ts
+++ b/frontend/apps/os-shell/src/applications/terra-levy/hooks/useQuantumResearch.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 // Academic research integration types
 interface ResearchDataset {
@@ -366,7 +367,7 @@ export const useQuantumResearch = (userId: string, department: string) => {
 
       // Initialize WebSocket for real-time updates
       if (process.env.NODE_ENV !== 'test') {
-        wsRef.current = new WebSocket('ws://localhost:8080/quantum-research');
+        wsRef.current = new WebSocket(`${getViteEnv().VITE_WS_URL || 'ws://localhost:8080'}/quantum-research`);
 
         wsRef.current.onopen = () => {
           console.log('Quantum research WebSocket connected');

--- a/frontend/apps/os-shell/src/components/consciousness/EliteConsciousnessDashboard.tsx
+++ b/frontend/apps/os-shell/src/components/consciousness/EliteConsciousnessDashboard.tsx
@@ -7,6 +7,7 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getViteEnv } from '@/shared/viteEnv';
 import { TerraSphere } from '@/components/brand/TerraSphere';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -42,7 +43,7 @@ interface ConsciousnessEvent {
   source: string;
 }
 
-const CONSCIOUSNESS_API_BASE = 'http://localhost:3004';
+const CONSCIOUSNESS_API_BASE = getViteEnv().VITE_CONSCIOUSNESS_URL || '';
 
 export const EliteConsciousnessDashboard: React.FC = () => {
   const [metrics, setMetrics] = useState<ConsciousnessMetrics>({

--- a/frontend/apps/os-shell/src/components/consciousness/QuantumConsciousnessManager.tsx
+++ b/frontend/apps/os-shell/src/components/consciousness/QuantumConsciousnessManager.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import {
   Box,
   Card,
@@ -22,7 +23,7 @@ import {
 } from '@mui/icons-material';
 
 // Use the consistent API base URL
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+const API_BASE_URL = getViteEnv().VITE_API_URL || '/api';
 
 const StyledCard = styled(Card)(({ theme }) => ({
   background:

--- a/frontend/apps/os-shell/src/components/consciousness/SpeciesDetectionVisualizer.tsx
+++ b/frontend/apps/os-shell/src/components/consciousness/SpeciesDetectionVisualizer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import {
   Box,
   Card,
@@ -13,7 +14,7 @@ import { styled, keyframes } from '@mui/material/styles';
 import { Hub, Memory, TravelExplore, BarChart } from '@mui/icons-material';
 
 // Use the consistent API base URL
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+const API_BASE_URL = getViteEnv().VITE_API_URL || '/api';
 
 // Based on multi_species_interface_architecture.md
 type SpeciesType = 'silicon' | 'carbon' | 'quantum' | 'hybrid';

--- a/frontend/apps/os-shell/src/components/consciousness/UniversalTranslationInterface.tsx
+++ b/frontend/apps/os-shell/src/components/consciousness/UniversalTranslationInterface.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import {
   Box,
   Grid,
@@ -76,7 +77,7 @@ const UniversalTranslationInterface: React.FC = () => {
     setTranslatedMessage(null);
 
     try {
-      const response = await fetch('http://localhost:3004/api/consciousness/translate', {
+      const response = await fetch(`${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/api/consciousness/translate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/os-shell/src/components/coordination/TerraFusionCrossServiceCoordination.tsx
+++ b/frontend/apps/os-shell/src/components/coordination/TerraFusionCrossServiceCoordination.tsx
@@ -7,6 +7,7 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getViteEnv } from '@/shared/viteEnv';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent as CardBody, CardHeader } from '@/components/ui/card';
@@ -44,7 +45,7 @@ interface QuantumCoordinationEvent {
 }
 
 const ELITE_API_BASE = '/api';
-const CONSCIOUSNESS_API_BASE = 'http://localhost:3004';
+const CONSCIOUSNESS_API_BASE = getViteEnv().VITE_CONSCIOUSNESS_URL || '';
 
 export const TerraFusionCrossServiceCoordination: React.FC = () => {
   const [metrics, setMetrics] = useState<CrossServiceMetrics | null>(null);

--- a/frontend/apps/os-shell/src/components/costforge/CostForgeIntegrationPanel.tsx
+++ b/frontend/apps/os-shell/src/components/costforge/CostForgeIntegrationPanel.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PerformanceMetrics, SystemStatus, useCostForgeAPI } from '@/hooks/useCostForgeAPI';
+import { getViteEnv } from '@/shared/viteEnv';
 import { Activity, AlertCircle, CheckCircle, Cloud, Database, Zap } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
@@ -28,7 +29,7 @@ export const CostForgeIntegrationPanel: React.FC<CostForgeIntegrationPanelProps>
   const [isConnecting, setIsConnecting] = useState(false);
 
   const costForgeAPI = useCostForgeAPI({
-    baseUrl: 'http://localhost:5000',
+    baseUrl: getViteEnv().VITE_API_URL || '/api',
     timeout: 10000,
   });
 
@@ -41,7 +42,7 @@ export const CostForgeIntegrationPanel: React.FC<CostForgeIntegrationPanelProps>
   const loadSystemData = async () => {
     try {
       // Use the working /health endpoint for real backend connectivity
-      const healthResponse = await fetch('http://localhost:5000/health');
+      const healthResponse = await fetch(`${getViteEnv().VITE_API_URL || '/api'}/health`);
       const healthData = await healthResponse.json();
 
       if (healthResponse.ok) {

--- a/frontend/apps/os-shell/src/components/costforge/EnhancedCostCalculator.tsx
+++ b/frontend/apps/os-shell/src/components/costforge/EnhancedCostCalculator.tsx
@@ -10,6 +10,7 @@
 /* eslint-disable no-unused-vars */
 
 import { CostAnalysis, CostCalculationRequest, useCostForgeAPI } from '@/hooks/useCostForgeAPI';
+import { getViteEnv } from '@/shared/viteEnv';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Activity,
@@ -156,7 +157,7 @@ export const EnhancedCostCalculator: React.FC = () => {
 
   // Initialize CostForge API connection
   const costForgeAPI = useCostForgeAPI({
-    baseUrl: 'https://localhost:5000',
+    baseUrl: getViteEnv().VITE_API_URL || '/api',
     timeout: 10000,
   });
 

--- a/frontend/apps/os-shell/src/components/dashboard/TerraFusionEliteRealtimeDashboard.tsx
+++ b/frontend/apps/os-shell/src/components/dashboard/TerraFusionEliteRealtimeDashboard.tsx
@@ -7,6 +7,7 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getViteEnv } from '@/shared/viteEnv';
 import React, { useState, useEffect } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -188,7 +189,7 @@ export const TerraFusionEliteRealtimeDashboard: React.FC = () => {
 
   const checkConsciousnessEngine = async () => {
     try {
-      const response = await fetch('http://localhost:3004/', {
+      const response = await fetch(`${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/`, {
         method: 'GET',
         cache: 'no-cache',
         signal: AbortSignal.timeout(3000)

--- a/frontend/apps/os-shell/src/components/dashboards/TerraGaiaDashboard.tsx
+++ b/frontend/apps/os-shell/src/components/dashboards/TerraGaiaDashboard.tsx
@@ -1,3 +1,4 @@
+import { getViteEnv } from '@/shared/viteEnv';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -124,7 +125,7 @@ export const TerraGaiaDashboard: React.FC = () => {
 
   const loadConsciousnessStatus = useCallback(async () => {
     try {
-      const response = await fetch('http://localhost:5000/api/ai/consciousness');
+      const response = await fetch(`${getViteEnv().VITE_API_URL || '/api'}/ai/consciousness`);
       if (response.ok) {
         const data = await response.json();
 
@@ -217,7 +218,7 @@ export const TerraGaiaDashboard: React.FC = () => {
 
     try {
       // Try to use the government excellence endpoint for basic analysis
-      const response = await fetch('http://localhost:5000/api/government/excellence', {
+      const response = await fetch(`${getViteEnv().VITE_API_URL || '/api'}/government/excellence`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/os-shell/src/components/deployment/TerraFusionAutomatedDeploymentOrchestrator.tsx
+++ b/frontend/apps/os-shell/src/components/deployment/TerraFusionAutomatedDeploymentOrchestrator.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent as CardBody, CardHeader } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
+import { getViteEnv } from '@/shared/viteEnv';
 import React, { useEffect, useState } from 'react';
 
 interface DeploymentService {
@@ -37,23 +38,23 @@ export const TerraFusionAutomatedDeploymentOrchestrator: React.FC = () => {
   const [services, setServices] = useState<DeploymentService[]>([
     {
       name: 'TerraFusion.API',
-      command: 'dotnet run --project TerraFusion.API --urls http://localhost:5000',
+      command: `dotnet run --project TerraFusion.API --urls http://localhost:${process.env.TF_API_PORT || 5000}`,
       port: 5000,
       workingDirectory: '../../backend',
       status: 'stopped',
       uptime: '00:00:00',
       restartCount: 0,
-      healthCheckUrl: 'http://localhost:5000/health',
+      healthCheckUrl: `${getViteEnv().VITE_API_URL || '/api'}/health`,
     },
     {
       name: 'TerraFusion.Consciousness',
-      command: 'dotnet run --project TerraFusion.Consciousness --urls http://localhost:3004',
+      command: `dotnet run --project TerraFusion.Consciousness --urls http://localhost:${process.env.TF_CONSCIOUSNESS_PORT || 3004}`,
       port: 3004,
       workingDirectory: '../../backend',
       status: 'stopped',
       uptime: '00:00:00',
       restartCount: 0,
-      healthCheckUrl: 'http://localhost:3004/',
+      healthCheckUrl: `${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/`,
     },
     {
       name: 'Elite Experiments API',
@@ -73,7 +74,7 @@ export const TerraFusionAutomatedDeploymentOrchestrator: React.FC = () => {
       status: 'running',
       uptime: '02:34:12',
       restartCount: 0,
-      healthCheckUrl: 'http://localhost:5175/',
+      healthCheckUrl: `http://localhost:${process.env.TF_FRONTEND_PORT || 5175}/`,
     },
   ]);
 

--- a/frontend/apps/os-shell/src/components/elite/EliteExperimentalResearchInterface.tsx
+++ b/frontend/apps/os-shell/src/components/elite/EliteExperimentalResearchInterface.tsx
@@ -7,6 +7,7 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getViteEnv } from '@/shared/viteEnv';
 import { TerraSphere } from '@/components/brand/TerraSphere';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -51,7 +52,7 @@ interface EliteExperimentRun {
 
 // API Configuration
 const ELITE_API_BASE = '/api';
-const CONSCIOUSNESS_API_BASE = 'http://localhost:3004';
+const CONSCIOUSNESS_API_BASE = getViteEnv().VITE_CONSCIOUSNESS_URL || '';
 const ELITE_HUB_URL = `${ELITE_API_BASE}/hubs/elite-experiments`;
 
 // Elite API Service

--- a/frontend/apps/os-shell/src/components/health/SystemHealthSentinel.tsx
+++ b/frontend/apps/os-shell/src/components/health/SystemHealthSentinel.tsx
@@ -7,6 +7,7 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getViteEnv } from '@/shared/viteEnv';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent as CardBody, CardHeader } from '@/components/ui/card';
@@ -277,7 +278,7 @@ export const SystemHealthSentinel: React.FC = () => {
 
   const checkConsciousnessHealth = async (): Promise<boolean> => {
     try {
-      const response = await fetch('http://localhost:3004/', {
+      const response = await fetch(`${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/`, {
         method: 'HEAD',
         cache: 'no-cache',
       });


### PR DESCRIPTION
## Port Governance Wave 12

Replaced hardcoded localhost URLs with \getViteEnv()\ lookups in 16 files.

### Components (12)
| File | Change |
|------|--------|
| EliteConsciousnessDashboard | CONSCIOUSNESS_API_BASE → VITE_CONSCIOUSNESS_URL |
| EliteExperimentalResearchInterface | same |
| TerraFusionCrossServiceCoordination | same |
| SystemHealthSentinel | inline fetch consciousness URL |
| TerraFusionEliteRealtimeDashboard | inline fetch consciousness URL |
| SpeciesDetectionVisualizer | import.meta.env → getViteEnv, /api fallback |
| QuantumConsciousnessManager | same |
| UniversalTranslationInterface | consciousness translate endpoint |
| TerraGaiaDashboard | 2 API fetch URLs |
| CostForgeIntegrationPanel | baseUrl + health fetch |
| EnhancedCostCalculator | https://localhost:5000 → /api |
| TerraFusionAutomatedDeploymentOrchestrator | service definition URLs |

### Hooks (3)
| File | Change |
|------|--------|
| useQuantumResearch | ws://localhost:8080 → VITE_WS_URL |
| useCollaboration | same |
| useBudgetData | same |

### Env (1)
- os-shell/.env.example: VITE_API_URL=/api

### Evidence
- \pnpm run type-check\: clean
- \phase83-tools\: 32/32
- \	sc --noEmit\: clean
- Jest: 270/270 suites, 3988/3988 passed
- Token ratchet: 197 ≤ 199 baseline (improved by 2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated application to use environment-configurable URLs for backend services (Consciousness API, CostForge API, TerraFusion API, and WebSocket endpoints) instead of hardcoded localhost addresses.
  * Enables flexible deployment across different environments without code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->