### PR TITLE
fix(shell): port governance wave 13 — 8 more components

### DIFF
--- a/frontend/apps/os-shell/src/applications/terra-levy/components/analytics/DataScienceLaboratory.tsx
+++ b/frontend/apps/os-shell/src/applications/terra-levy/components/analytics/DataScienceLaboratory.tsx
@@ -16,6 +16,7 @@ import {
   Zap,
 } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 // Mock UI components
 const Card = ({ children, className }: { children: React.ReactNode; className?: string }) => (
@@ -354,7 +355,7 @@ export const DataScienceLaboratory: React.FC<DataScienceLabProps> = ({
         setCollaborativeSession(session);
 
         // Setup WebSocket for real-time collaboration
-        wsRef.current = new WebSocket('ws://localhost:8080/jupyter-collaboration');
+        wsRef.current = new WebSocket(`${getViteEnv().VITE_WS_URL || 'ws://localhost:8080'}/jupyter-collaboration`);
 
         wsRef.current.onopen = () => {
           console.log('Collaborative session started');

--- a/frontend/apps/os-shell/src/components/OSShellWindow.SIMPLE.tsx
+++ b/frontend/apps/os-shell/src/components/OSShellWindow.SIMPLE.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 interface OSShellWindowProps {
   children: React.ReactNode;
@@ -48,10 +49,10 @@ const OSShellWindow: React.FC<OSShellWindowProps> = ({ children }) => {
           },
         },
         api: {
-          port: 5000,
-          baseUrl: 'http://localhost:5000',
-          getPort: async () => 5000,
-          getBaseUrl: async () => 'http://localhost:5000',
+          port: parseInt(getViteEnv().TF_API_PORT || '5000', 10),
+          baseUrl: getViteEnv().VITE_API_URL || '/api',
+          getPort: async () => parseInt(getViteEnv().TF_API_PORT || '5000', 10),
+          getBaseUrl: async () => getViteEnv().VITE_API_URL || '/api',
         },
         isDesktop: false,
       };

--- a/frontend/apps/os-shell/src/components/deployment/TerraFusionAutomatedDeploymentOrchestrator.tsx
+++ b/frontend/apps/os-shell/src/components/deployment/TerraFusionAutomatedDeploymentOrchestrator.tsx
@@ -74,7 +74,7 @@ export const TerraFusionAutomatedDeploymentOrchestrator: React.FC = () => {
       status: 'running',
       uptime: '02:34:12',
       restartCount: 0,
-      healthCheckUrl: `http://localhost:${process.env.TF_FRONTEND_PORT || 5175}/`,
+      healthCheckUrl: '/',
     },
   ]);
 

--- a/frontend/apps/os-shell/src/components/nexus/TerraFusionEliteIntegrationNexus.tsx
+++ b/frontend/apps/os-shell/src/components/nexus/TerraFusionEliteIntegrationNexus.tsx
@@ -16,6 +16,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent as CardBody, CardHeader } from '@/components/ui/card';
 import React, { useEffect, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 type IntegrationView =
   | 'NEXUS_OVERVIEW'
@@ -87,7 +88,7 @@ export const TerraFusionEliteIntegrationNexus: React.FC = () => {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 2000);
 
-        const consciousnessResponse = await fetch('http://localhost:3004/health', {
+        const consciousnessResponse = await fetch(`${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/health`, {
           method: 'GET',
           signal: controller.signal,
           headers: { Accept: 'application/json' },

--- a/frontend/apps/os-shell/src/components/orchestrator/TerraFusionEliteServiceOrchestrator.tsx
+++ b/frontend/apps/os-shell/src/components/orchestrator/TerraFusionEliteServiceOrchestrator.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent as CardBody, CardHeader } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import React, { useEffect, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 interface ServiceStatus {
   name: string;
@@ -118,16 +119,16 @@ export const TerraFusionEliteServiceOrchestrator: React.FC = () => {
     setLastMonitoringCheck(new Date().toLocaleTimeString());
   };
 
-  const getHealthCheckUrl = (serviceName: string, port: number): string => {
+  const getHealthCheckUrl = (serviceName: string, _port: number): string => {
     switch (serviceName) {
       case 'Elite Experiments API':
-        return `http://localhost:${port}/health`;
+        return `${getViteEnv().VITE_API_URL || '/api'}/health`;
       case 'Consciousness Engine':
-        return `http://localhost:${port}/`;
+        return `${getViteEnv().VITE_CONSCIOUSNESS_URL || ''}/`;
       case 'Frontend PWA':
-        return `http://localhost:${port}/`;
+        return '/';
       default:
-        return `http://localhost:${port}/health`;
+        return `${getViteEnv().VITE_API_URL || '/api'}/health`;
     }
   };
 

--- a/frontend/apps/os-shell/src/components/terra-flow/HypothesisTestingLab.tsx
+++ b/frontend/apps/os-shell/src/components/terra-flow/HypothesisTestingLab.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -92,7 +93,7 @@ export function HypothesisTestingLab({ isConnected }: HypothesisTestingLabProps)
       };
 
       // Call API
-      const response = await fetch('http://localhost:3005/api/v2/analytics/hypothesis-test', {
+      const response = await fetch(`${getViteEnv().VITE_QUANTUM_ANALYTICS_URL || ''}/api/v2/analytics/hypothesis-test`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/apps/os-shell/src/components/terra-flow/QuantumCommandCenter.tsx
+++ b/frontend/apps/os-shell/src/components/terra-flow/QuantumCommandCenter.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
@@ -63,7 +64,7 @@ export function QuantumCommandCenter() {
   useEffect(() => {
     const checkConnection = async () => {
       try {
-        const response = await fetch('http://localhost:3005', { method: 'GET' });
+        const response = await fetch(`${getViteEnv().VITE_QUANTUM_ANALYTICS_URL || ''}/`, { method: 'GET' });
         if (response.ok) {
           setConnectionStatus('connected');
         } else {
@@ -260,7 +261,7 @@ export function QuantumCommandCenter() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => window.open('http://localhost:3005/swagger', '_blank')}
+                onClick={() => window.open(`${getViteEnv().VITE_QUANTUM_ANALYTICS_URL || ''}/swagger`, '_blank')}
               >
                 View API Docs
               </Button>

--- a/frontend/apps/os-shell/src/components/test/APIConnectionTest.tsx
+++ b/frontend/apps/os-shell/src/components/test/APIConnectionTest.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { getViteEnv } from '@/shared/viteEnv';
 
 interface APITestResult {
   endpoint: string;
@@ -57,10 +58,11 @@ export const APIConnectionTest: React.FC = () => {
   };
 
   const testAllEndpoints = async () => {
+    const apiBase = getViteEnv().VITE_API_URL || '/api';
     const endpoints = [
-      { url: 'http://localhost:5000/health', name: 'Backend Health' },
-      { url: 'http://localhost:5000/api/ai/consciousness', name: 'AI Consciousness' },
-      { url: 'http://localhost:5000/api/government/excellence', name: 'Government Excellence' },
+      { url: `${apiBase}/health`, name: 'Backend Health' },
+      { url: `${apiBase}/ai/consciousness`, name: 'AI Consciousness' },
+      { url: `${apiBase}/government/excellence`, name: 'Government Excellence' },
     ];
 
     setResults(endpoints.map((ep) => ({ endpoint: ep.name, status: 'loading' })));


### PR DESCRIPTION
## Port Governance Wave 13

Replaced hardcoded localhost URLs with \getViteEnv()\ lookups in 8 files.

| File | Change |
|------|--------|
| DataScienceLaboratory | ws://localhost:8080 -> VITE_WS_URL |
| QuantumCommandCenter | localhost:3005 -> VITE_QUANTUM_ANALYTICS_URL (2 URLs) |
| HypothesisTestingLab | localhost:3005/api -> VITE_QUANTUM_ANALYTICS_URL |
| TerraFusionEliteIntegrationNexus | localhost:3004/health -> VITE_CONSCIOUSNESS_URL |
| APIConnectionTest | 3 hardcoded test endpoints -> VITE_API_URL |
| TerraFusionEliteServiceOrchestrator | getHealthCheckUrl -> env-var backed |
| OSShellWindow.SIMPLE | mock bridge port 5000 -> VITE_API_URL |
| TerraFusionAutomatedDeploymentOrchestrator | Frontend PWA healthcheck -> / |

### Evidence
- \pnpm run type-check\: clean
- \phase83-tools\: 32/32
- \	sc --noEmit\: clean
- Jest: 270/270 suites, 3988/3988 passed
- Token ratchet: 197 <= 199 baseline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transitioned service and API endpoint configuration from hard-coded values to environment-based settings. Updated components now read configuration for API URLs, WebSocket connections, service health checks, and analytics endpoints from environment variables with sensible defaults. This enables flexible multi-environment deployments and simplified configuration management without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->