### PR TITLE
feat(modules): Phase 4 — TactileButton for commitment actions

### DIFF
--- a/frontend/apps/os-shell/src/pages/suites/modules/AppealForgeModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/AppealForgeModule.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -438,12 +439,11 @@ export default function AppealForgeModule() {
                   />
                 </div>
                 <div className='flex gap-2'>
-                  <Button
+                  <TactileButton
                     onClick={handleCreateAppeal}
-                    style={{ background: 'hsl(var(--tf-suite-forge))', color: '#fff' }}
                   >
                     Create Appeal
-                  </Button>
+                  </TactileButton>
                   <Button
                     variant='outline'
                     onClick={() => setShowCreateForm(false)}
@@ -481,13 +481,12 @@ export default function AppealForgeModule() {
                     </div>
                     <div className='flex gap-2'>
                       {!['DECIDED', 'WITHDRAWN'].includes(activeAppeal.status) && (
-                        <Button
+                        <TactileButton
                           size='sm'
                           onClick={() => handleAdvanceStatus(activeAppeal.id)}
-                          style={{ background: 'hsl(var(--tf-suite-forge))', color: '#fff' }}
                         >
                           Advance Status
-                        </Button>
+                        </TactileButton>
                       )}
                       {!activeAppeal.id.startsWith('demo-') && (
                         <Button
@@ -645,15 +644,14 @@ export default function AppealForgeModule() {
                           className='text-xs'
                           style={{ background: 'hsl(var(--tf-bg))', borderColor: 'hsl(var(--tf-border))', color: 'hsl(var(--tf-fg))' }}
                         />
-                        <Button
+                        <TactileButton
                           size='sm'
                           onClick={handleAddEvidence}
                           disabled={!newEvidenceTitle}
-                          className='gap-1'
-                          style={{ background: 'hsl(var(--tf-suite-forge))', color: '#fff' }}
+                          leftIcon={<Plus size={14} />}
                         >
-                          <Plus size={14} /> Add Evidence
-                        </Button>
+                          Add Evidence
+                        </TactileButton>
                       </div>
                     </>
                   )}

--- a/frontend/apps/os-shell/src/pages/suites/modules/CostForgeModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/CostForgeModule.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -554,15 +555,15 @@ export default function CostForgeModule() {
                     color: 'hsl(var(--tf-fg))',
                   }}
                 />
-                <Button
+                <TactileButton
                   onClick={handleSaveScenario}
                   disabled={!scenarioName.trim()}
                   size='sm'
                   className='shrink-0'
+                  leftIcon={<Save size={14} />}
                 >
-                  <Save size={14} className='mr-1.5' />
                   Save
-                </Button>
+                </TactileButton>
               </div>
               {scenarios.length > 0 && (
                 <div className='mt-3 space-y-2'>
@@ -864,20 +865,16 @@ export default function CostForgeModule() {
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-3'>
-              <Button
+              <TactileButton
                 onClick={verifyViaApi}
                 disabled={apiLoading}
                 size='sm'
-                className='w-full'
-                variant='outline'
+                fullWidth
+                loading={apiLoading}
+                leftIcon={<ShieldCheck size={14} />}
               >
-                {apiLoading ? (
-                  <Loader2 size={14} className='mr-1.5 animate-spin' />
-                ) : (
-                  <ShieldCheck size={14} className='mr-1.5' />
-                )}
                 {apiLoading ? 'Verifying…' : 'Verify via API'}
-              </Button>
+              </TactileButton>
               {apiResult && (
                 <div className='space-y-1 text-sm'>
                   <div className='flex justify-between'>

--- a/frontend/apps/os-shell/src/pages/suites/modules/DocumentsModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/DocumentsModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -107,9 +108,9 @@ export default function DocumentsModule() {
             Government evidence repository -- Chain-of-custody tracking
           </p>
         </div>
-        <Button style={{ background: 'hsl(var(--tf-suite-dossier))' }}>
-          <Upload size={16} className='mr-2' /> Upload Document
-        </Button>
+        <TactileButton leftIcon={<Upload size={16} />}>
+          Upload Document
+        </TactileButton>
       </div>
 
       {/* Summary */}

--- a/frontend/apps/os-shell/src/pages/suites/modules/GPTBuilderModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/GPTBuilderModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -330,9 +331,9 @@ export default function GPTBuilderModule() {
           <Button variant='outline' style={{ borderColor: 'hsl(var(--tf-border))' }}>
             <Clock size={14} className='mr-1' /> Save Draft
           </Button>
-          <Button style={{ background: 'hsl(var(--tf-suite-gpt))', color: 'hsl(var(--tf-bg))' }}>
-            <Save size={14} className='mr-1' /> Publish GPT
-          </Button>
+          <TactileButton leftIcon={<Save size={14} />}>
+            Publish GPT
+          </TactileButton>
         </div>
       </div>
     </div>

--- a/frontend/apps/os-shell/src/pages/suites/modules/LayerWorksModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/LayerWorksModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import {
@@ -275,10 +276,9 @@ export default function LayerWorksModule() {
                     </p>
                   )}
                   {analysis.status === 'ready' && (
-                    <Button variant='outline' size='sm' onClick={() => runAnalysis(analysis.id)} className='w-full' style={{ borderColor: 'hsl(var(--tf-border))' }}>
-                      <Activity size={14} className='mr-1' />
+                    <TactileButton size='sm' onClick={() => runAnalysis(analysis.id)} fullWidth leftIcon={<Activity size={14} />}>
                       Run Analysis
-                    </Button>
+                    </TactileButton>
                   )}
                   {analysis.status === 'running' && (
                     <div className='flex items-center gap-2'>

--- a/frontend/apps/os-shell/src/pages/suites/modules/RAGDatasetsModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/RAGDatasetsModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useRef, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -259,10 +260,9 @@ export default function RAGDatasetsModule() {
             Knowledge bases powering RAG-enabled GPTs
           </p>
         </div>
-        <Button onClick={handleUpload} disabled={uploading} style={{ background: 'hsl(var(--tf-suite-gpt))', color: 'white' }}>
-          {uploading ? <RefreshCw size={16} className="mr-2 animate-spin" /> : <Upload size={16} className="mr-2" />}
+        <TactileButton onClick={handleUpload} disabled={uploading} loading={uploading} leftIcon={uploading ? undefined : <Upload size={16} />}>
           {uploading ? 'Ingesting…' : 'Ingest Documents'}
-        </Button>
+        </TactileButton>
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/apps/os-shell/src/pages/suites/modules/ReconciliationModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/ReconciliationModule.tsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   ChevronUp,
 } from 'lucide-react';
+import { TactileButton } from '@/ui/materials';
 import {
   type ApproachValue,
   type ReconciliationMethod,
@@ -446,13 +447,12 @@ export default function ReconciliationModule() {
               </div>
 
               {/* Save Button */}
-              <button
+              <TactileButton
                 onClick={handleSaveToAudit}
-                className='w-full py-2.5 rounded-lg text-sm font-medium transition-colors hover:opacity-90'
-                style={{ background: 'hsl(var(--tf-suite-forge))', color: '#000' }}
+                fullWidth
               >
                 Save to Audit Trail
-              </button>
+              </TactileButton>
             </>
           ) : (
             <div className='flex items-center justify-center min-h-[300px]'>

--- a/frontend/apps/os-shell/src/pages/suites/modules/TerraExportModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/TerraExportModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -281,15 +282,14 @@ export default function TerraExportModule() {
                 </div>
               </div>
 
-              <Button
+              <TactileButton
                 onClick={handleExport}
                 disabled={selectedLayers.length === 0}
-                className='w-full'
-                style={{ background: 'hsl(var(--tf-suite-atlas))', color: 'hsl(var(--tf-bg))' }}
+                fullWidth
+                leftIcon={<Download size={14} />}
               >
-                <Download size={14} className='mr-2' />
                 Export Data
-              </Button>
+              </TactileButton>
             </CardContent>
           </Card>
         </div>

--- a/frontend/apps/os-shell/src/pages/suites/modules/TerraPrintModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/TerraPrintModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -288,15 +289,14 @@ export default function TerraPrintModule() {
                 </div>
               )}
 
-              <Button
+              <TactileButton
                 onClick={handlePrint}
                 disabled={!selectedTemplate}
-                className='w-full'
-                style={{ background: 'hsl(var(--tf-suite-atlas))', color: 'hsl(var(--tf-bg))' }}
+                fullWidth
+                leftIcon={<Printer size={14} />}
               >
-                <Printer size={14} className='mr-2' />
                 Generate Print
-              </Button>
+              </TactileButton>
             </CardContent>
           </Card>
         </div>

--- a/frontend/apps/os-shell/src/pages/suites/modules/TerraQueryModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/TerraQueryModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import {
   Table,
   TableBody,
@@ -219,15 +220,15 @@ export default function TerraQueryModule() {
                   <Button variant='outline' size='sm' style={{ borderColor: 'hsl(var(--tf-border))' }}>
                     <Save size={14} className='mr-1' /> Save
                   </Button>
-                  <Button
+                  <TactileButton
                     size='sm'
                     onClick={() => runQuery()}
                     disabled={running || (!query.trim() && !activeQuery)}
-                    style={{ background: 'hsl(var(--tf-suite-atlas))', color: 'hsl(var(--tf-bg))' }}
+                    loading={running}
+                    leftIcon={<Play size={14} />}
                   >
-                    <Play size={14} className='mr-1' />
                     {running ? 'Running...' : 'Execute'}
-                  </Button>
+                  </TactileButton>
                 </div>
               </div>
             </CardHeader>

--- a/frontend/apps/os-shell/src/pages/suites/modules/TerraSketchModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/TerraSketchModule.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { TactileButton } from '@/ui/materials';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import {
@@ -188,12 +189,12 @@ export default function TerraSketchModule() {
                   )}
                 </div>
                 <div className='flex items-center gap-2'>
-                  <Button variant='outline' size='sm' style={{ borderColor: 'hsl(var(--tf-border))' }}>
-                    <Save size={14} className='mr-1' /> Save
-                  </Button>
-                  <Button variant='outline' size='sm' style={{ borderColor: 'hsl(var(--tf-border))' }}>
-                    <Download size={14} className='mr-1' /> Export
-                  </Button>
+                  <TactileButton size='sm' leftIcon={<Save size={14} />}>
+                    Save
+                  </TactileButton>
+                  <TactileButton variant='secondary' size='sm' leftIcon={<Download size={14} />}>
+                    Export
+                  </TactileButton>
                 </div>
               </div>
               {/* Canvas area */}

--- a/frontend/apps/os-shell/src/pages/suites/modules/ValueAuditModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/ValueAuditModule.tsx
@@ -26,6 +26,7 @@ import {
   RefreshCw,
   FileText,
 } from 'lucide-react';
+import { TactileButton } from '@/ui/materials';
 import {
   type AuditAction,
   type ValuationAuditEntry,
@@ -207,9 +208,9 @@ export default function ValueAuditModule() {
           <button onClick={handleAddTestEntry} className='px-3 py-1.5 rounded text-xs hover:bg-white/10 transition-colors' style={{ border: '1px solid hsl(var(--tf-border))', color: 'hsl(var(--tf-muted))' }}>
             + Test Entry
           </button>
-          <button onClick={handleExportCSV} className='flex items-center gap-1.5 px-3 py-1.5 rounded text-xs hover:bg-white/10 transition-colors' style={{ border: '1px solid hsl(var(--tf-border))', color: 'hsl(var(--tf-muted))' }}>
-            <Download size={12} /> Export CSV
-          </button>
+          <TactileButton size='sm' onClick={handleExportCSV} leftIcon={<Download size={12} />}>
+            Export CSV
+          </TactileButton>
           <button onClick={handleClearUserEntries} className='flex items-center gap-1.5 px-3 py-1.5 rounded text-xs hover:bg-white/10 transition-colors' style={{ border: '1px solid hsl(var(--tf-border))', color: 'hsl(var(--tf-muted))' }}>
             <Trash2 size={12} /> Clear User Entries
           </button>


### PR DESCRIPTION
# Phase 4: TactileButton for Commitment Actions\n\nDesign Manifesto Phase 4 — replaces 16 commitment buttons across 12 suite modules with `TactileButton` (spring physics).\n\n## Changes (12 files)\n\n| Module | Buttons Replaced | Actions |\n|--------|-----------------|--------|\n| CostForge | 2 | Verify via API, Save Scenario |\n| TerraExport | 1 | Export Data |\n| TerraPrint | 1 | Generate Print |\n| TerraQuery | 1 | Execute query |\n| AppealForge | 3 | Create Appeal, Advance Status, Add Evidence |\n| GPTBuilder | 1 | Publish GPT |\n| RAGDatasets | 1 | Ingest Documents |\n| LayerWorks | 1 | Run Analysis |\n| Reconciliation | 1 | Save to Audit Trail |\n| Documents | 1 | Upload Document |\n| TerraSketch | 2 | Save, Export |\n| ValueAudit | 1 | Export CSV |\n\n## Design Philosophy\n- Only **commitment actions** get TactileButton (Run, Calculate, Export, Publish, Save to Audit, etc.)\n- Regular navigation/filter/cancel buttons stay as standard `<Button>`\n- \"If everything is squishy, nothing is important\"\n\n## Evidence\n- `pnpm run type-check`: PASS\n- `npx tsc --noEmit`: PASS\n- `npx jest --ci`: 271/271 suites, 4031 tests\n- `phase83-tools.test.mjs`: 32/32\n- Token ratchet: 193 <= 199 (improved by 6 — removed inline hsl() styles)\n\n## Design Manifesto Progress\n- [x] Phase 1: Liquid Glass on OS Chrome (PR #482)\n- [x] Phase 2: BentoGrid & BentoCard (PR #483)\n- [x] Phase 3: TerraForge Stage Tabs (PR #484)\n- [x] **Phase 4: TactileButton for commitment actions** (this PR)\n- [ ] Phase 5: Neon-as-Signal system\n- [ ] Phase 6: Control Center drawer\n- [ ] Phase 7: Remaining suite refactors\n- [ ] Phase 8: Context Mode / Canonical Scenes

## Summary by Sourcery

Replace primary commitment action buttons across multiple suite modules with the spring-physics `TactileButton` component to emphasize high-importance actions and align with the Phase 4 design system.

New Features:
- Introduce `TactileButton` as the default control for commitment actions such as save, export, run, publish, and ingest across CostForge, TerraExport, TerraPrint, TerraQuery, AppealForge, GPTBuilder, RAGDatasets, LayerWorks, Reconciliation, Documents, TerraSketch, and ValueAudit modules.

Enhancements:
- Standardize commitment action buttons with consistent icons, loading states, and full-width variants where appropriate, replacing ad-hoc styles and inline HSL color usage.