### PR TITLE
feat(suites): Phase 7 — Stage Tabs for Atlas, Dossier, GPT, Dais

### DIFF
--- a/frontend/apps/os-shell/src/pages/suites/AtlasSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/AtlasSuiteHome.tsx
@@ -4,7 +4,8 @@
  * Constitutional Suite: atlas (Article I)
  * Standalone route: /atlas
  *
- * Modules (ALL 7 ACTIVE):
+ * Layout: Stage Tabs (horizontal) + content area
+ * Phase 7 Design Manifesto: replaces sidebar navigation with Stage Tabs
  *   - TerraGIS: Parcel boundaries, aerial, zoning overlays
  *   - ParcelLens: Detailed parcel inspection with measurement tools
  *   - LayerWorks: Advanced layer management & spatial analysis
@@ -58,9 +59,15 @@ export default function AtlasSuiteHome() {
 
   return (
     <div data-testid="suite-atlas-root" className='h-full flex flex-col' style={{ background: 'hsl(var(--tf-bg))' }}>
-      {/* Header */}
-      <header style={{ borderBottom: '1px solid hsl(var(--tf-border))', background: 'hsl(var(--tf-card-bg) / 0.5)' }} className='backdrop-blur-xl'>
-        <div className='max-w-[1600px] mx-auto px-6 py-4 flex items-center gap-4'>
+      {/* Header + Stage Tabs */}
+      <header
+        style={{
+          borderBottom: '1px solid hsl(var(--tf-border))',
+          background: 'hsl(var(--tf-card-bg) / 0.5)',
+        }}
+        className='backdrop-blur-xl shrink-0'
+      >
+        <div className='max-w-[1600px] mx-auto px-6 pt-4 pb-0 flex items-center gap-4'>
           <button
             onClick={() => navigate('/')}
             className='p-2 rounded-lg hover:bg-white/5 transition-colors'
@@ -75,14 +82,13 @@ export default function AtlasSuiteHome() {
             <p className='text-sm' style={{ color: 'hsl(var(--tf-muted))' }}>Geographic Intelligence & Parcel Mapping</p>
           </div>
         </div>
-      </header>
 
-      <div className='flex flex-1 min-h-0'>
-        {/* Module Sidebar */}
-        <nav className='w-64 shrink-0 p-4 space-y-1 overflow-y-auto' style={{ borderRight: '1px solid hsl(var(--tf-border))' }}>
-          <p className='text-xs font-medium uppercase tracking-wider px-3 py-2' style={{ color: 'hsl(var(--tf-muted))' }}>
-            Modules
-          </p>
+        {/* Stage Tabs */}
+        <nav
+          role='tablist'
+          aria-label='TerraAtlas modules'
+          className='max-w-[1600px] mx-auto px-6 flex gap-1 mt-3 overflow-x-auto'
+        >
           {ATLAS_MODULES.map((mod) => {
             const Icon = mod.icon;
             const isActive = mod.id === activeModule;
@@ -90,51 +96,68 @@ export default function AtlasSuiteHome() {
             return (
               <button
                 key={mod.id}
+                role='tab'
+                aria-selected={isActive}
+                aria-controls={`atlas-panel-${mod.id}`}
                 onClick={() => !isPlanned && setActiveModule(mod.id)}
                 disabled={isPlanned}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${
+                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap ${
                   isActive
                     ? 'bg-white/10'
                     : isPlanned
-                    ? 'opacity-40 cursor-not-allowed'
-                    : 'hover:bg-white/5'
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'hover:bg-white/5'
                 }`}
+                style={{
+                  color: isActive
+                    ? 'hsl(var(--tf-fg))'
+                    : 'hsl(var(--tf-muted))',
+                  borderBottom: isActive
+                    ? '2px solid hsl(var(--tf-suite-atlas))'
+                    : '2px solid transparent',
+                }}
               >
                 <Icon
-                  size={18}
-                  style={{ color: isActive ? 'hsl(var(--tf-suite-atlas))' : 'hsl(var(--tf-muted))' }}
+                  size={16}
+                  style={{
+                    color: isActive
+                      ? 'hsl(var(--tf-suite-atlas))'
+                      : 'hsl(var(--tf-muted))',
+                  }}
                 />
-                <div>
-                  <span
-                    className='text-sm font-medium'
-                    style={{ color: isActive ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))' }}
-                  >
-                    {mod.label}
-                  </span>
-                  {isPlanned && (
-                    <span className='ml-2 text-xs px-1.5 py-0.5 rounded' style={{ background: 'hsl(var(--tf-muted) / 0.15)', color: 'hsl(var(--tf-muted))' }}>
-                      Planned
-                    </span>
-                  )}
-                </div>
+                {mod.label}
               </button>
             );
           })}
         </nav>
+      </header>
 
-        {/* Module Content */}
-        <main className='flex-1 min-w-0'>
-          <Suspense fallback={<ModuleLoading />}>
-            {activeModule === 'gis' && <GISModule />}
-            {activeModule === 'parcel-lens' && <ParcelLensModule />}
-            {activeModule === 'layer-works' && <LayerWorksModule />}
-            {activeModule === 'terra-sketch' && <TerraSketchModule />}
-            {activeModule === 'terra-print' && <TerraPrintModule />}
-            {activeModule === 'terra-export' && <TerraExportModule />}
-            {activeModule === 'terra-query' && <TerraQueryModule />}
-          </Suspense>
-        </main>
-      </div>
+      {/* Module Content */}
+      <main className='flex-1 min-h-0 overflow-y-auto'>
+        <Suspense fallback={<ModuleLoading />}>
+          {activeModule === 'gis' && (
+            <div role='tabpanel' id='atlas-panel-gis'><GISModule /></div>
+          )}
+          {activeModule === 'parcel-lens' && (
+            <div role='tabpanel' id='atlas-panel-parcel-lens'><ParcelLensModule /></div>
+          )}
+          {activeModule === 'layer-works' && (
+            <div role='tabpanel' id='atlas-panel-layer-works'><LayerWorksModule /></div>
+          )}
+          {activeModule === 'terra-sketch' && (
+            <div role='tabpanel' id='atlas-panel-terra-sketch'><TerraSketchModule /></div>
+          )}
+          {activeModule === 'terra-print' && (
+            <div role='tabpanel' id='atlas-panel-terra-print'><TerraPrintModule /></div>
+          )}
+          {activeModule === 'terra-export' && (
+            <div role='tabpanel' id='atlas-panel-terra-export'><TerraExportModule /></div>
+          )}
+          {activeModule === 'terra-query' && (
+            <div role='tabpanel' id='atlas-panel-terra-query'><TerraQueryModule /></div>
+          )}
+        </Suspense>
+      </main>
     </div>
   );
 }

--- a/frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx
@@ -3,6 +3,8 @@
  * ===================================================================
  * Constitutional Suite: dais (Article I)
  * Standalone route: /dais
+ * Layout: Stage Tabs (horizontal) + content area
+ * Phase 7 Design Manifesto: replaces sidebar navigation with Stage Tabs
  *
  * Modules (ALL 6 ACTIVE):
  *   - Levy: Property tax levy calculation & analysis (API-wired)
@@ -1205,15 +1207,15 @@ export default function DaisSuiteHome() {
 
   return (
     <div data-testid="suite-dais-root" className='h-full flex flex-col' style={{ background: 'hsl(var(--tf-bg))' }}>
-      {/* Header */}
+      {/* Header + Stage Tabs */}
       <header
         style={{
           borderBottom: '1px solid hsl(var(--tf-border))',
           background: 'hsl(var(--tf-card-bg) / 0.5)',
         }}
-        className='backdrop-blur-xl'
+        className='backdrop-blur-xl shrink-0'
       >
-        <div className='max-w-[1600px] mx-auto px-6 py-4 flex items-center gap-4'>
+        <div className='max-w-[1600px] mx-auto px-6 pt-4 pb-0 flex items-center gap-4'>
           <button
             onClick={() => navigate('/')}
             className='p-2 rounded-lg hover:bg-white/5 transition-colors'
@@ -1235,20 +1237,13 @@ export default function DaisSuiteHome() {
             </p>
           </div>
         </div>
-      </header>
 
-      <div className='flex flex-1 min-h-0'>
-        {/* Module Sidebar */}
+        {/* Stage Tabs */}
         <nav
-          className='w-64 shrink-0 p-4 space-y-1 overflow-y-auto'
-          style={{ borderRight: '1px solid hsl(var(--tf-border))' }}
+          role='tablist'
+          aria-label='TerraDais modules'
+          className='max-w-[1600px] mx-auto px-6 flex gap-1 mt-3 overflow-x-auto'
         >
-          <p
-            className='text-xs font-medium uppercase tracking-wider px-3 py-2'
-            style={{ color: 'hsl(var(--tf-muted))' }}
-          >
-            Modules
-          </p>
           {DAIS_MODULES.map((mod) => {
             const Icon = mod.icon;
             const isActive = mod.id === activeModule;
@@ -1256,50 +1251,44 @@ export default function DaisSuiteHome() {
             return (
               <button
                 key={mod.id}
+                role='tab'
+                aria-selected={isActive}
+                aria-controls={`dais-panel-${mod.id}`}
                 onClick={() => !isPlanned && setActiveModule(mod.id)}
                 disabled={isPlanned}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${
+                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap ${
                   isActive
                     ? 'bg-white/10'
                     : isPlanned
                       ? 'opacity-40 cursor-not-allowed'
                       : 'hover:bg-white/5'
                 }`}
+                style={{
+                  color: isActive
+                    ? 'hsl(var(--tf-fg))'
+                    : 'hsl(var(--tf-muted))',
+                  borderBottom: isActive
+                    ? '2px solid hsl(var(--tf-suite-dais))'
+                    : '2px solid transparent',
+                }}
               >
                 <Icon
-                  size={18}
+                  size={16}
                   style={{
                     color: isActive
                       ? 'hsl(var(--tf-suite-dais))'
                       : 'hsl(var(--tf-muted))',
                   }}
                 />
-                <div>
-                  <span
-                    className='text-sm font-medium'
-                    style={{
-                      color: isActive ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))',
-                    }}
-                  >
-                    {mod.label}
-                  </span>
-                  {isPlanned && (
-                    <span
-                      className='block text-xs'
-                      style={{ color: 'hsl(var(--tf-muted))' }}
-                    >
-                      Coming soon
-                    </span>
-                  )}
-                </div>
+                {mod.label}
               </button>
             );
           })}
         </nav>
+      </header>
 
-        {/* Module Content */}
-        <main className='flex-1 min-w-0'>{renderModule()}</main>
-      </div>
+      {/* Module Content */}
+      <main className='flex-1 min-h-0 overflow-y-auto'>{renderModule()}</main>
     </div>
   );
 }

--- a/frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx
@@ -3,6 +3,8 @@
  * ===================================================================
  * Constitutional Suite: dossier (Article I)
  * Standalone route: /dossier
+ * Layout: Stage Tabs (horizontal) + content area
+ * Phase 7 Design Manifesto: replaces sidebar navigation with Stage Tabs
  *
  * Modules (ALL 6 ACTIVE):
  *   - Documents: File repository with search & type filtering
@@ -55,9 +57,15 @@ export default function DossierSuiteHome() {
 
   return (
     <div data-testid="suite-dossier-root" className='h-full flex flex-col' style={{ background: 'hsl(var(--tf-bg))' }}>
-      {/* Header */}
-      <header style={{ borderBottom: '1px solid hsl(var(--tf-border))', background: 'hsl(var(--tf-card-bg) / 0.5)' }} className='backdrop-blur-xl'>
-        <div className='max-w-[1600px] mx-auto px-6 py-4 flex items-center gap-4'>
+      {/* Header + Stage Tabs */}
+      <header
+        style={{
+          borderBottom: '1px solid hsl(var(--tf-border))',
+          background: 'hsl(var(--tf-card-bg) / 0.5)',
+        }}
+        className='backdrop-blur-xl shrink-0'
+      >
+        <div className='max-w-[1600px] mx-auto px-6 pt-4 pb-0 flex items-center gap-4'>
           <button
             onClick={() => navigate('/')}
             className='p-2 rounded-lg hover:bg-white/5 transition-colors'
@@ -72,14 +80,13 @@ export default function DossierSuiteHome() {
             <p className='text-sm' style={{ color: 'hsl(var(--tf-muted))' }}>Document Management & Evidence Archive</p>
           </div>
         </div>
-      </header>
 
-      <div className='flex flex-1 min-h-0'>
-        {/* Module Sidebar */}
-        <nav className='w-64 shrink-0 p-4 space-y-1 overflow-y-auto' style={{ borderRight: '1px solid hsl(var(--tf-border))' }}>
-          <p className='text-xs font-medium uppercase tracking-wider px-3 py-2' style={{ color: 'hsl(var(--tf-muted))' }}>
-            Modules
-          </p>
+        {/* Stage Tabs */}
+        <nav
+          role='tablist'
+          aria-label='TerraDossier modules'
+          className='max-w-[1600px] mx-auto px-6 flex gap-1 mt-3 overflow-x-auto'
+        >
           {DOSSIER_MODULES.map((mod) => {
             const Icon = mod.icon;
             const isActive = mod.id === activeModule;
@@ -87,57 +94,72 @@ export default function DossierSuiteHome() {
             return (
               <button
                 key={mod.id}
+                role='tab'
+                aria-selected={isActive}
+                aria-controls={`dossier-panel-${mod.id}`}
                 onClick={() => !isPlanned && setActiveModule(mod.id)}
                 disabled={isPlanned}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${
+                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap ${
                   isActive
                     ? 'bg-white/10'
                     : isPlanned
-                    ? 'opacity-40 cursor-not-allowed'
-                    : 'hover:bg-white/5'
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'hover:bg-white/5'
                 }`}
+                style={{
+                  color: isActive
+                    ? 'hsl(var(--tf-fg))'
+                    : 'hsl(var(--tf-muted))',
+                  borderBottom: isActive
+                    ? '2px solid hsl(var(--tf-suite-dossier))'
+                    : '2px solid transparent',
+                }}
               >
                 <Icon
-                  size={18}
-                  style={{ color: isActive ? 'hsl(var(--tf-suite-dossier))' : 'hsl(var(--tf-muted))' }}
+                  size={16}
+                  style={{
+                    color: isActive
+                      ? 'hsl(var(--tf-suite-dossier))'
+                      : 'hsl(var(--tf-muted))',
+                  }}
                 />
-                <div>
-                  <span
-                    className='text-sm font-medium'
-                    style={{ color: isActive ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))' }}
-                  >
-                    {mod.label}
-                  </span>
-                  {isPlanned && (
-                    <span className='ml-2 text-xs px-1.5 py-0.5 rounded' style={{ background: 'hsl(var(--tf-muted) / 0.15)', color: 'hsl(var(--tf-muted))' }}>
-                      Planned
-                    </span>
-                  )}
-                </div>
+                {mod.label}
               </button>
             );
           })}
         </nav>
+      </header>
 
-        {/* Module Content */}
-        <main className='flex-1 min-w-0'>
-          <Suspense fallback={<ModuleLoading />}>
-            {activeModule === 'documents' && <DocumentsModule />}
-            {activeModule === 'evidence' && <EvidenceModule />}
-            {activeModule === 'defense' && <DefensePacketsModule />}
-            {activeModule === 'chain' && <ChainOfCustodyModule />}
-            {activeModule === 'photos' && <PhotoManagerModule />}
-            {activeModule === 'search' && <DeepSearchModule />}
-            {!['documents', 'evidence', 'defense', 'chain', 'photos', 'search'].includes(activeModule) && (
-              <div className='p-6 flex items-center justify-center min-h-[400px]'>
-                <p style={{ color: 'hsl(var(--tf-muted))' }}>
-                  Module under development
-                </p>
-              </div>
-            )}
-          </Suspense>
-        </main>
-      </div>
+      {/* Module Content */}
+      <main className='flex-1 min-h-0 overflow-y-auto'>
+        <Suspense fallback={<ModuleLoading />}>
+          {activeModule === 'documents' && (
+            <div role='tabpanel' id='dossier-panel-documents'><DocumentsModule /></div>
+          )}
+          {activeModule === 'evidence' && (
+            <div role='tabpanel' id='dossier-panel-evidence'><EvidenceModule /></div>
+          )}
+          {activeModule === 'defense' && (
+            <div role='tabpanel' id='dossier-panel-defense'><DefensePacketsModule /></div>
+          )}
+          {activeModule === 'chain' && (
+            <div role='tabpanel' id='dossier-panel-chain'><ChainOfCustodyModule /></div>
+          )}
+          {activeModule === 'photos' && (
+            <div role='tabpanel' id='dossier-panel-photos'><PhotoManagerModule /></div>
+          )}
+          {activeModule === 'search' && (
+            <div role='tabpanel' id='dossier-panel-search'><DeepSearchModule /></div>
+          )}
+          {!['documents', 'evidence', 'defense', 'chain', 'photos', 'search'].includes(activeModule) && (
+            <div className='p-6 flex items-center justify-center min-h-[400px]'>
+              <p style={{ color: 'hsl(var(--tf-muted))' }}>
+                Module under development
+              </p>
+            </div>
+          )}
+        </Suspense>
+      </main>
     </div>
   );
 }

--- a/frontend/apps/os-shell/src/pages/suites/GptSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/GptSuiteHome.tsx
@@ -3,6 +3,8 @@
  * ===================================================================
  * Constitutional Suite: gpt (Article I)
  * Standalone route: /gpt
+ * Layout: Stage Tabs (horizontal) + content area
+ * Phase 7 Design Manifesto: replaces sidebar navigation with Stage Tabs
  *
  * Modules:
  *   - GPT Studio: Interactive chat with AI assistants
@@ -87,10 +89,16 @@ export default function GptSuiteHome() {
   const [activeModule, setActiveModule] = useState('studio');
 
   return (
-    <div className='h-full flex flex-col' style={{ background: 'hsl(var(--tf-bg))' }}>
-      {/* Header */}
-      <header style={{ borderBottom: '1px solid hsl(var(--tf-border))', background: 'hsl(var(--tf-card-bg) / 0.5)' }} className='backdrop-blur-xl'>
-        <div className='max-w-[1600px] mx-auto px-6 py-4 flex items-center gap-4'>
+    <div data-testid="suite-gpt-root" className='h-full flex flex-col' style={{ background: 'hsl(var(--tf-bg))' }}>
+      {/* Header + Stage Tabs */}
+      <header
+        style={{
+          borderBottom: '1px solid hsl(var(--tf-border))',
+          background: 'hsl(var(--tf-card-bg) / 0.5)',
+        }}
+        className='backdrop-blur-xl shrink-0'
+      >
+        <div className='max-w-[1600px] mx-auto px-6 pt-4 pb-0 flex items-center gap-4'>
           <button
             onClick={() => navigate('/')}
             className='p-2 rounded-lg hover:bg-white/5 transition-colors'
@@ -105,14 +113,13 @@ export default function GptSuiteHome() {
             <p className='text-sm' style={{ color: 'hsl(var(--tf-muted))' }}>AI Assistant & Natural Language Interface</p>
           </div>
         </div>
-      </header>
 
-      <div className='flex flex-1 min-h-0'>
-        {/* Module Sidebar */}
-        <nav className='w-64 shrink-0 p-4 space-y-1 overflow-y-auto' style={{ borderRight: '1px solid hsl(var(--tf-border))' }}>
-          <p className='text-xs font-medium uppercase tracking-wider px-3 py-2' style={{ color: 'hsl(var(--tf-muted))' }}>
-            Modules
-          </p>
+        {/* Stage Tabs */}
+        <nav
+          role='tablist'
+          aria-label='TerraGPT modules'
+          className='max-w-[1600px] mx-auto px-6 flex gap-1 mt-3 overflow-x-auto'
+        >
           {GPT_MODULES.map((mod) => {
             const Icon = mod.icon;
             const isActive = mod.id === activeModule;
@@ -120,50 +127,65 @@ export default function GptSuiteHome() {
             return (
               <button
                 key={mod.id}
+                role='tab'
+                aria-selected={isActive}
+                aria-controls={`gpt-panel-${mod.id}`}
                 onClick={() => !isPlanned && setActiveModule(mod.id)}
                 disabled={isPlanned}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${
+                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap ${
                   isActive
                     ? 'bg-white/10'
                     : isPlanned
-                    ? 'opacity-40 cursor-not-allowed'
-                    : 'hover:bg-white/5'
+                      ? 'opacity-40 cursor-not-allowed'
+                      : 'hover:bg-white/5'
                 }`}
+                style={{
+                  color: isActive
+                    ? 'hsl(var(--tf-fg))'
+                    : 'hsl(var(--tf-muted))',
+                  borderBottom: isActive
+                    ? '2px solid hsl(var(--tf-suite-gpt))'
+                    : '2px solid transparent',
+                }}
               >
                 <Icon
-                  size={18}
-                  style={{ color: isActive ? 'hsl(var(--tf-suite-gpt))' : 'hsl(var(--tf-muted))' }}
+                  size={16}
+                  style={{
+                    color: isActive
+                      ? 'hsl(var(--tf-suite-gpt))'
+                      : 'hsl(var(--tf-muted))',
+                  }}
                 />
-                <div>
-                  <span
-                    className='text-sm font-medium'
-                    style={{ color: isActive ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))' }}
-                  >
-                    {mod.label}
-                  </span>
-                  {isPlanned && (
-                    <span className='ml-2 text-xs px-1.5 py-0.5 rounded' style={{ background: 'hsl(var(--tf-muted) / 0.15)', color: 'hsl(var(--tf-muted))' }}>
-                      Planned
-                    </span>
-                  )}
-                </div>
+                {mod.label}
               </button>
             );
           })}
         </nav>
+      </header>
 
-        {/* Module Content */}
-        <main className='flex-1 min-w-0'>
-          <Suspense fallback={<ModuleLoading />}>
-            {activeModule === 'studio' && <GptStudioView />}
-            {activeModule === 'marketplace' && <GPTMarketplace />}
-            {activeModule === 'management' && <GPTManagementDashboard />}
-            {activeModule === 'builder' && <GPTBuilderModule />}
-            {activeModule === 'analytics' && <GPTAnalyticsModule />}
-            {activeModule === 'rag' && <RAGDatasetsModule />}
-          </Suspense>
-        </main>
-      </div>
+      {/* Module Content */}
+      <main className='flex-1 min-h-0 overflow-y-auto'>
+        <Suspense fallback={<ModuleLoading />}>
+          {activeModule === 'studio' && (
+            <div role='tabpanel' id='gpt-panel-studio'><GptStudioView /></div>
+          )}
+          {activeModule === 'marketplace' && (
+            <div role='tabpanel' id='gpt-panel-marketplace'><GPTMarketplace /></div>
+          )}
+          {activeModule === 'management' && (
+            <div role='tabpanel' id='gpt-panel-management'><GPTManagementDashboard /></div>
+          )}
+          {activeModule === 'builder' && (
+            <div role='tabpanel' id='gpt-panel-builder'><GPTBuilderModule /></div>
+          )}
+          {activeModule === 'analytics' && (
+            <div role='tabpanel' id='gpt-panel-analytics'><GPTAnalyticsModule /></div>
+          )}
+          {activeModule === 'rag' && (
+            <div role='tabpanel' id='gpt-panel-rag'><RAGDatasetsModule /></div>
+          )}
+        </Suspense>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Phase 7 — Suite Stage Tabs (Wave 2)

All 4 remaining suites refactored from sidebar navigation to horizontal Stage Tabs, matching the ForgeSuiteHome pattern from Phase 3.

### Changes
- **AtlasSuiteHome**: sidebar -> Stage Tabs, 7 modules with tabpanel roles
- **DossierSuiteHome**: sidebar -> Stage Tabs, 6 modules with tabpanel roles  
- **GptSuiteHome**: sidebar -> Stage Tabs, 6 modules with tabpanel roles, added data-testid
- **DaisSuiteHome**: sidebar -> Stage Tabs, 6 inline modules (API wiring preserved)

### ARIA
- role=tab, aria-selected, aria-controls per tab button
- role=tabpanel with id per module content panel
- aria-label on tablist nav

### Evidence
- Tests: 274/274 suites, 4069 tests (0 regressions)
- Gates: tsc clean, type-check OK, phase83 32/32
- Ratchet: 194 = 194 (no new violations)

### Design Manifesto Progress
Phase 7 of 8 complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized navigation from left sidebar to horizontal tabs positioned in the header across all suite pages.
  * Tab-based module selection now includes active state indicators and disabled styling for planned modules.

* **Style**
  * Enhanced header and tab styling with refined padding, rounded corners, and dynamic color adjustments reflecting active/inactive tab states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->