### PR TITLE
feat(pilot): Governed Tool Invocation UI (PR-UI1)

### DIFF
--- a/frontend/apps/os-shell/src/components/pilot/ExecutionConsole.tsx
+++ b/frontend/apps/os-shell/src/components/pilot/ExecutionConsole.tsx
@@ -1,0 +1,267 @@
+/**
+ * ExecutionConsole.tsx
+ *
+ * PR-UI1: Governed Tool Invocation Console
+ *
+ * Renders the full tool invocation lifecycle with correlationId at every stage.
+ * Composes with RiskConfirmationModal for Gate 5 enforcement.
+ *
+ * Lifecycle: idle → preflight → confirming → executing → succeeded → failed
+ *
+ * Uses real pilotApi — no mock data, no demo tools.
+ */
+
+import React, { useCallback, useState } from 'react';
+import type { ApprovalToken, PilotTool, Risk } from '../../api/pilotApi';
+import { requestApprovalToken } from '../../api/pilotApi';
+import { LiquidPanel } from '../../ui/materials/LiquidPanel';
+import { TactileButton } from '../../ui/materials/TactileButton';
+import type { InvocationPhase, UseToolInvocationResult } from '../../hooks/useToolInvocation';
+import { RiskConfirmationModal } from './RiskConfirmationModal';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ExecutionConsoleProps {
+  /** Hook return from useToolInvocation */
+  invocation: UseToolInvocationResult;
+  /** Tool metadata (for display) */
+  tool?: PilotTool | null;
+  /** Whether to show reset button after completion */
+  showReset?: boolean;
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+const PhaseIndicator: React.FC<{ phase: InvocationPhase }> = ({ phase }) => {
+  const config: Record<InvocationPhase, { icon: string; label: string; color: string }> = {
+    idle: { icon: '⏸', label: 'Ready', color: 'text-white/50' },
+    preflight: { icon: '🔍', label: 'Preflight Check', color: 'text-amber-400' },
+    confirming: { icon: '🔐', label: 'Awaiting Confirmation', color: 'text-amber-400' },
+    executing: { icon: '⚡', label: 'Executing', color: 'text-cyan-400' },
+    succeeded: { icon: '✅', label: 'Succeeded', color: 'text-emerald-400' },
+    failed: { icon: '❌', label: 'Failed', color: 'text-red-400' },
+  };
+
+  const { icon, label, color } = config[phase];
+
+  return (
+    <div className='flex items-center gap-2' data-testid='phase-indicator'>
+      <span role='img' aria-label={label}>{icon}</span>
+      <span className={`text-sm font-medium ${color}`}>{label}</span>
+      {(phase === 'preflight' || phase === 'executing') && (
+        <span className='inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin' />
+      )}
+    </div>
+  );
+};
+
+const CorrelationBadge: React.FC<{ correlationId: string }> = ({ correlationId }) => {
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(correlationId).catch(console.error);
+  }, [correlationId]);
+
+  return (
+    <div className='flex items-center gap-2' data-testid='correlation-badge'>
+      <code className='text-xs text-white/60 bg-black/30 px-2 py-1 rounded font-mono'>
+        {correlationId.length > 20 ? `${correlationId.substring(0, 20)}…` : correlationId}
+      </code>
+      <button
+        onClick={handleCopy}
+        className='text-xs text-white/40 hover:text-white/70 transition-colors'
+        title='Copy full correlationId'
+        aria-label='Copy correlation ID'
+      >
+        📋
+      </button>
+    </div>
+  );
+};
+
+const RiskBadge: React.FC<{ risk: Risk }> = ({ risk }) => {
+  const styles: Record<Risk, string> = {
+    read_only: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
+    write_low: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+    write_high: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
+    irreversible: 'bg-red-500/20 text-red-400 border-red-500/30',
+  };
+
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded border ${styles[risk]}`}>
+      {risk.replace('_', ' ')}
+    </span>
+  );
+};
+
+const ResultDisplay: React.FC<{ result: unknown }> = ({ result }) => {
+  if (result === null || result === undefined) return null;
+
+  const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+
+  return (
+    <div className='mt-3' data-testid='result-display'>
+      <pre className='text-xs text-white/70 bg-black/30 rounded p-3 overflow-auto max-h-60 whitespace-pre-wrap font-mono'>
+        {text}
+      </pre>
+    </div>
+  );
+};
+
+const ErrorDisplay: React.FC<{ error: string; errorCode?: string | null }> = ({ error, errorCode }) => (
+  <div className='mt-3 border border-red-500/30 bg-red-500/10 rounded p-3' data-testid='error-display'>
+    {errorCode && (
+      <code className='text-xs text-red-300 bg-red-500/20 px-2 py-0.5 rounded mb-2 inline-block'>
+        {errorCode}
+      </code>
+    )}
+    <p className='text-sm text-red-300'>{error}</p>
+  </div>
+);
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export const ExecutionConsole: React.FC<ExecutionConsoleProps> = ({
+  invocation,
+  tool,
+  showReset = true,
+}) => {
+  const { state, confirm, cancel, reset } = invocation;
+  const { phase, correlationId, error, errorCode, response, confirmation } = state;
+
+  // Approval token state for irreversible tools
+  const [approvalToken, setApprovalToken] = useState<ApprovalToken | null>(null);
+  const [approvalTokenError, setApprovalTokenError] = useState<string | undefined>();
+  const [isGeneratingToken, setIsGeneratingToken] = useState(false);
+
+  const handleRequestApprovalToken = useCallback(
+    async (reasonCode: string) => {
+      if (!state.toolId || !state.params) return;
+      setIsGeneratingToken(true);
+      setApprovalTokenError(undefined);
+      try {
+        const tokenResponse = await requestApprovalToken({
+          toolId: state.toolId,
+          params: state.params,
+          reasonCode,
+        });
+        if (tokenResponse.success && tokenResponse.token) {
+          setApprovalToken(tokenResponse.token);
+        } else {
+          setApprovalTokenError(tokenResponse.error ?? 'Failed to generate approval token');
+        }
+      } catch (err) {
+        setApprovalTokenError(err instanceof Error ? err.message : 'Token generation failed');
+      } finally {
+        setIsGeneratingToken(false);
+      }
+    },
+    [state.toolId, state.params]
+  );
+
+  const handleConfirm = useCallback(
+    async (options?: { reasonCode?: string; approvalToken?: string }) => {
+      await confirm({
+        confirmation: true,
+        reasonCode: options?.reasonCode,
+      });
+    },
+    [confirm]
+  );
+
+  const handleCancel = useCallback(() => {
+    setApprovalToken(null);
+    setApprovalTokenError(undefined);
+    cancel();
+  }, [cancel]);
+
+  const handleReset = useCallback(() => {
+    setApprovalToken(null);
+    setApprovalTokenError(undefined);
+    reset();
+  }, [reset]);
+
+  // Idle state — nothing to show yet
+  if (phase === 'idle') {
+    return null;
+  }
+
+  return (
+    <LiquidPanel variant='infrastructure' radius='xl' className='p-4 space-y-3'>
+      {/* Header: Phase + Tool Info */}
+      <div className='flex items-center justify-between'>
+        <PhaseIndicator phase={phase} />
+        <div className='flex items-center gap-2'>
+          {tool && <RiskBadge risk={tool.risk} />}
+          {tool?.suite && (
+            <span className='text-xs text-white/40 bg-white/5 px-2 py-0.5 rounded'>
+              {tool.suite}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Tool ID */}
+      {state.toolId && (
+        <div className='flex items-center gap-2'>
+          <code className='text-sm text-white/80 font-mono'>{state.toolId}</code>
+        </div>
+      )}
+
+      {/* Correlation ID (shown when available) */}
+      {correlationId && <CorrelationBadge correlationId={correlationId} />}
+
+      {/* Confirmation Modal (Gate 5) */}
+      {phase === 'confirming' && confirmation && (
+        <RiskConfirmationModal
+          isOpen={true}
+          toolId={confirmation.toolId}
+          toolDescription={confirmation.toolDescription}
+          risk={confirmation.risk}
+          reasonCodes={confirmation.reasonCodes}
+          requiresReasonCode={confirmation.reasonCodeRequired}
+          requiresSupervisorApproval={confirmation.supervisorRequired}
+          supervisorRoles={confirmation.supervisorRoles}
+          approvalToken={approvalToken}
+          approvalTokenError={approvalTokenError}
+          isGeneratingToken={isGeneratingToken}
+          onRequestApprovalToken={handleRequestApprovalToken}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+
+      {/* Success result */}
+      {phase === 'succeeded' && response && (
+        <>
+          <ResultDisplay result={response.result} />
+          {response.traceEventId && (
+            <p className='text-xs text-white/40'>
+              Trace: <code className='font-mono'>{response.traceEventId}</code>
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Error result */}
+      {phase === 'failed' && error && (
+        <ErrorDisplay error={error} errorCode={errorCode} />
+      )}
+
+      {/* Reset button (after terminal states) */}
+      {showReset && (phase === 'succeeded' || phase === 'failed') && (
+        <div className='pt-2'>
+          <TactileButton variant='ghost' size='sm' onClick={handleReset}>
+            Dismiss
+          </TactileButton>
+        </div>
+      )}
+    </LiquidPanel>
+  );
+};
+
+export default ExecutionConsole;

--- a/frontend/apps/os-shell/src/hooks/useToolInvocation.ts
+++ b/frontend/apps/os-shell/src/hooks/useToolInvocation.ts
@@ -1,0 +1,281 @@
+/**
+ * useToolInvocation Hook
+ *
+ * PR-UI1: Governed tool invocation lifecycle state machine.
+ * Manages the full invoke → preflight → confirm → execute → trace flow.
+ *
+ * States: idle → preflight → confirming → executing → succeeded → failed
+ * correlationId is surfaced at every post-execute stage.
+ *
+ * @module hooks/useToolInvocation
+ */
+
+import { useCallback, useReducer } from 'react';
+import {
+  invokePilotTool,
+  validatePilotTool,
+  type PilotInvokeResponse,
+  type PilotValidateResponse,
+  type Risk,
+} from '../api/pilotApi';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type InvocationPhase =
+  | 'idle'
+  | 'preflight'
+  | 'confirming'
+  | 'executing'
+  | 'succeeded'
+  | 'failed';
+
+export interface ConfirmationRequirements {
+  confirmationRequired: boolean;
+  reasonCodeRequired: boolean;
+  reasonCodes: string[];
+  supervisorRequired: boolean;
+  supervisorRoles: string[];
+  risk: Risk;
+  toolId: string;
+  toolDescription?: string;
+}
+
+export interface InvocationState {
+  phase: InvocationPhase;
+  toolId: string | null;
+  params: Record<string, unknown> | null;
+  /** Preflight validation result */
+  validation: PilotValidateResponse | null;
+  /** Confirmation requirements extracted from preflight */
+  confirmation: ConfirmationRequirements | null;
+  /** Invoke response (success or failure) */
+  response: PilotInvokeResponse | null;
+  /** correlationId from response */
+  correlationId: string | null;
+  /** Human-readable error message */
+  error: string | null;
+  /** Machine-readable error code */
+  errorCode: string | null;
+}
+
+// ============================================================================
+// Reducer
+// ============================================================================
+
+type Action =
+  | { type: 'START_PREFLIGHT'; toolId: string; params: Record<string, unknown> }
+  | { type: 'PREFLIGHT_PASS'; validation: PilotValidateResponse }
+  | { type: 'PREFLIGHT_NEEDS_CONFIRMATION'; validation: PilotValidateResponse; requirements: ConfirmationRequirements }
+  | { type: 'PREFLIGHT_FAIL'; error: string }
+  | { type: 'START_EXECUTE' }
+  | { type: 'EXECUTE_SUCCESS'; response: PilotInvokeResponse }
+  | { type: 'EXECUTE_FAIL'; response?: PilotInvokeResponse; error: string; errorCode?: string }
+  | { type: 'RESET' };
+
+const initialState: InvocationState = {
+  phase: 'idle',
+  toolId: null,
+  params: null,
+  validation: null,
+  confirmation: null,
+  response: null,
+  correlationId: null,
+  error: null,
+  errorCode: null,
+};
+
+function reducer(state: InvocationState, action: Action): InvocationState {
+  switch (action.type) {
+    case 'START_PREFLIGHT':
+      return {
+        ...initialState,
+        phase: 'preflight',
+        toolId: action.toolId,
+        params: action.params,
+      };
+    case 'PREFLIGHT_PASS':
+      return {
+        ...state,
+        phase: 'executing',
+        validation: action.validation,
+      };
+    case 'PREFLIGHT_NEEDS_CONFIRMATION':
+      return {
+        ...state,
+        phase: 'confirming',
+        validation: action.validation,
+        confirmation: action.requirements,
+      };
+    case 'PREFLIGHT_FAIL':
+      return {
+        ...state,
+        phase: 'failed',
+        error: action.error,
+        errorCode: 'PREFLIGHT_FAILED',
+      };
+    case 'START_EXECUTE':
+      return {
+        ...state,
+        phase: 'executing',
+      };
+    case 'EXECUTE_SUCCESS':
+      return {
+        ...state,
+        phase: 'succeeded',
+        response: action.response,
+        correlationId: action.response.correlationId,
+      };
+    case 'EXECUTE_FAIL':
+      return {
+        ...state,
+        phase: 'failed',
+        response: action.response ?? null,
+        correlationId: action.response?.correlationId ?? null,
+        error: action.error,
+        errorCode: action.errorCode ?? action.response?.errorCode ?? 'EXECUTION_FAILED',
+      };
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export interface UseToolInvocationResult {
+  state: InvocationState;
+  /** Start a tool invocation (preflight → confirm? → execute) */
+  invoke: (toolId: string, params: Record<string, unknown>) => Promise<void>;
+  /** Confirm and execute after confirmation gate (with reason code, supervisor, etc.) */
+  confirm: (options: {
+    confirmation: boolean;
+    reasonCode?: string;
+    supervisorApproval?: { approvedBy: string; role: string };
+  }) => Promise<void>;
+  /** Cancel a pending confirmation */
+  cancel: () => void;
+  /** Reset to idle */
+  reset: () => void;
+}
+
+export function useToolInvocation(): UseToolInvocationResult {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const invoke = useCallback(async (toolId: string, params: Record<string, unknown>) => {
+    dispatch({ type: 'START_PREFLIGHT', toolId, params });
+
+    try {
+      const validation = await validatePilotTool({ toolId, params });
+
+      // Check if confirmation is needed
+      const pf = validation.preflight;
+      const needsConfirmation = pf?.confirmationRequired && !pf?.confirmationProvided;
+      const needsReason = pf?.reasonCodeRequired && !pf?.reasonCodeProvided;
+      const needsSupervisor = pf?.supervisorRequired && !pf?.supervisorProvided;
+
+      if (needsConfirmation || needsReason || needsSupervisor) {
+        dispatch({
+          type: 'PREFLIGHT_NEEDS_CONFIRMATION',
+          validation,
+          requirements: {
+            confirmationRequired: pf?.confirmationRequired ?? false,
+            reasonCodeRequired: pf?.reasonCodeRequired ?? false,
+            reasonCodes: validation.tool?.reasonCodes ?? [],
+            supervisorRequired: pf?.supervisorRequired ?? false,
+            supervisorRoles: validation.tool?.supervisorRoles ?? [],
+            risk: (validation.tool?.risk as Risk) ?? 'read_only',
+            toolId,
+            toolDescription: undefined,
+          },
+        });
+        return;
+      }
+
+      // No confirmation needed — execute directly
+      if (!validation.valid) {
+        dispatch({
+          type: 'PREFLIGHT_FAIL',
+          error: validation.violations.join('; '),
+        });
+        return;
+      }
+
+      // Execute
+      dispatch({ type: 'PREFLIGHT_PASS', validation });
+
+      const response = await invokePilotTool({ toolId, params });
+
+      if (response.ok) {
+        dispatch({ type: 'EXECUTE_SUCCESS', response });
+      } else {
+        dispatch({
+          type: 'EXECUTE_FAIL',
+          response,
+          error: response.error ?? 'Tool execution failed',
+          errorCode: response.errorCode,
+        });
+      }
+    } catch (err) {
+      dispatch({
+        type: 'EXECUTE_FAIL',
+        error: err instanceof Error ? err.message : 'Network error',
+        errorCode: 'NETWORK_ERROR',
+      });
+    }
+  }, []);
+
+  const confirm = useCallback(
+    async (options: {
+      confirmation: boolean;
+      reasonCode?: string;
+      supervisorApproval?: { approvedBy: string; role: string };
+    }) => {
+      if (state.phase !== 'confirming' || !state.toolId || !state.params) return;
+
+      dispatch({ type: 'START_EXECUTE' });
+
+      try {
+        const response = await invokePilotTool({
+          toolId: state.toolId,
+          params: state.params,
+          confirmation: options.confirmation,
+          reasonCode: options.reasonCode,
+          supervisorApproval: options.supervisorApproval,
+        });
+
+        if (response.ok) {
+          dispatch({ type: 'EXECUTE_SUCCESS', response });
+        } else {
+          dispatch({
+            type: 'EXECUTE_FAIL',
+            response,
+            error: response.error ?? 'Tool execution failed',
+            errorCode: response.errorCode,
+          });
+        }
+      } catch (err) {
+        dispatch({
+          type: 'EXECUTE_FAIL',
+          error: err instanceof Error ? err.message : 'Network error',
+          errorCode: 'NETWORK_ERROR',
+        });
+      }
+    },
+    [state.phase, state.toolId, state.params]
+  );
+
+  const cancel = useCallback(() => {
+    dispatch({ type: 'RESET' });
+  }, []);
+
+  const reset = useCallback(() => {
+    dispatch({ type: 'RESET' });
+  }, []);
+
+  return { state, invoke, confirm, cancel, reset };
+}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
@@ -1,134 +1,132 @@
 /**
  * PropertyPilot.tsx
  *
- * Phase 5: Property Workbench Pilot Tab - Real MWUX Slice
- * First tab to go fully real with parcel-context tool invocation.
+ * PR-UI1: Property Workbench Pilot Tab — Governed Tool Invocation
  *
- * Architecture: UI → pilotApi.invokeTool(parcelId) → correlationId-first UX
- * Uses ToolInvokePanel pattern with parcel context.
+ * Dynamically loads tools from the Pilot manifest via listPilotTools().
+ * All invocations go through useToolInvocation → preflight → confirm → execute.
+ * Write-risk tools enforce Gate 5 (confirmation + reason code) via RiskConfirmationModal.
  *
- * Phase 6.2: Migrated to shared workbench primitives
+ * No mock data. No hardcoded tools. No demo mode.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useWorkbenchTab } from '../../../context/workbenchTabContext';
-import { invokeTool } from '../../../api/pilotApi';
-import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
+import { listPilotTools, type PilotTool, type Risk } from '../../../api/pilotApi';
 import {
-    InvocationHistory,
-    ParcelContextHeader,
-    type InvocationRecord,
+  InvocationHistory,
+  ParcelContextHeader,
+  type InvocationRecord,
 } from '../../../components/workbench';
-import type { ErrorInfo } from '../../../hooks/useErrorHandler';
-import { getEnv } from '../../../runtime/env';
+import { ExecutionConsole } from '../../../components/pilot/ExecutionConsole';
+import { useToolInvocation } from '../../../hooks/useToolInvocation';
 
-/** Available parcel-context tools for quick invocation */
-const PARCEL_TOOLS = [
-  {
-    toolId: 'registry.list_tools',
-    label: 'List Tools',
-    description: 'List all available tools (read-only)',
-    icon: '📋',
-  },
-  {
-    toolId: 'dossier.summarize',
-    label: 'Summarize Dossier',
-    description: 'Generate parcel dossier summary',
-    icon: '📄',
-  },
-] as const;
+// ============================================================================
+// Risk level display helpers
+// ============================================================================
 
-interface InvocationState {
-  status: 'idle' | 'loading' | 'success' | 'error';
-  currentTool?: string;
-  result?: { toolId: string; output: string };
-  correlationId?: string;
-  error?: ErrorInfo;
-}
+const RISK_ICON: Record<Risk, string> = {
+  read_only: '📋',
+  write_low: '✏️',
+  write_high: '🔶',
+  irreversible: '🛑',
+};
+
+const RISK_LABEL: Record<Risk, string> = {
+  read_only: 'Read-Only',
+  write_low: 'Write (Low)',
+  write_high: 'Write (High)',
+  irreversible: 'Irreversible',
+};
+
+const RISK_BADGE_CLASS: Record<Risk, string> = {
+  read_only: 'tf-status-success',
+  write_low: 'tf-status-info',
+  write_high: 'tf-status-warning',
+  irreversible: 'tf-status-error',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
 
 export const PropertyPilot: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
+  const invocation = useToolInvocation();
 
-  const [invocationState, setInvocationState] = useState<InvocationState>({
-    status: 'idle',
-  });
+  // Dynamic tool list from manifest
+  const [tools, setTools] = useState<PilotTool[]>([]);
+  const [toolsLoading, setToolsLoading] = useState(true);
+  const [toolsError, setToolsError] = useState<string | null>(null);
+
+  // Invocation history (accumulated across tool runs)
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
-  const handleInvokeTool = useCallback(
-    async (toolId: string) => {
-      setInvocationState({ status: 'loading', currentTool: toolId });
+  // Track the selected tool for ExecutionConsole metadata display
+  const [activeTool, setActiveTool] = useState<PilotTool | null>(null);
 
-      try {
-        const response = await invokeTool({
-          toolId,
-          params: {},
-          parcelId, // Pass parcel context
-        });
+  // Load tools from the Pilot manifest on mount
+  useEffect(() => {
+    let cancelled = false;
+    setToolsLoading(true);
+    setToolsError(null);
 
-        const record: InvocationRecord = {
-          id: `inv-${Date.now()}`,
-          toolId,
-          status: response.success ? 'success' : 'error',
-          correlationId: response.correlationId,
-          timestamp: new Date(),
-          errorCode: response.error?.code,
-        };
-
-        setInvocationHistory((prev) => [record, ...prev]);
-
-        if (response.success && response.result) {
-          setInvocationState({
-            status: 'success',
-            currentTool: toolId,
-            result: response.result,
-            correlationId: response.correlationId,
-          });
-        } else if (response.error) {
-          setInvocationState({
-            status: 'error',
-            currentTool: toolId,
-            correlationId: response.correlationId,
-            error: {
-              message: response.error.message,
-              code: response.error.code,
-              correlationId: response.correlationId,
-              severity: response.error.severity || 'error',
-            },
-          });
+    listPilotTools()
+      .then((response) => {
+        if (!cancelled) {
+          setTools(response.tools);
+          setToolsLoading(false);
         }
-      } catch (err) {
-        const correlationId = `net-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
-        const errorInfo: ErrorInfo = {
-          message: err instanceof Error ? err.message : 'Network error occurred',
-          code: 'NETWORK_ERROR',
-          correlationId,
-          severity: 'error',
-        };
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setToolsError(err instanceof Error ? err.message : 'Failed to load tools');
+          setToolsLoading(false);
+        }
+      });
 
+    return () => { cancelled = true; };
+  }, []);
+
+  // Record completed invocations into history
+  useEffect(() => {
+    const { phase, toolId, correlationId, errorCode } = invocation.state;
+    if ((phase === 'succeeded' || phase === 'failed') && toolId && correlationId) {
+      setInvocationHistory((prev) => {
+        // Avoid duplicate entries for the same correlationId
+        if (prev.some((r) => r.correlationId === correlationId)) return prev;
         const record: InvocationRecord = {
           id: `inv-${Date.now()}`,
           toolId,
-          status: 'error',
+          status: phase === 'succeeded' ? 'success' : 'error',
           correlationId,
           timestamp: new Date(),
-          errorCode: 'NETWORK_ERROR',
+          errorCode: errorCode ?? undefined,
         };
+        return [record, ...prev];
+      });
+    }
+  }, [invocation.state.phase, invocation.state.toolId, invocation.state.correlationId, invocation.state.errorCode]);
 
-        setInvocationHistory((prev) => [record, ...prev]);
-        setInvocationState({
-          status: 'error',
-          currentTool: toolId,
-          correlationId,
-          error: errorInfo,
-        });
-      }
+  // Invoke a tool through the governed lifecycle
+  const handleInvokeTool = useCallback(
+    (tool: PilotTool) => {
+      setActiveTool(tool);
+      invocation.invoke(tool.toolId, { parcelId });
     },
-    [parcelId]
+    [invocation, parcelId]
   );
 
-  const clearState = useCallback(() => {
-    setInvocationState({ status: 'idle' });
-  }, []);
+  // Memoize the tool currently being invoked (for ExecutionConsole display)
+  const activeToolMeta = useMemo(() => {
+    if (activeTool) return activeTool;
+    if (invocation.state.toolId) {
+      return tools.find((t) => t.toolId === invocation.state.toolId) ?? null;
+    }
+    return null;
+  }, [activeTool, invocation.state.toolId, tools]);
+
+  const isInvoking = invocation.state.phase !== 'idle';
 
   return (
     <div className='tf-suite-pilot space-y-6' data-testid='property-pilot-tab'>
@@ -148,116 +146,87 @@ export const PropertyPilot: React.FC = () => {
         }
       />
 
-      {/* Tool Cards */}
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-        {PARCEL_TOOLS.map((tool) => (
-          <div
-            key={tool.toolId}
-            className='tf-suite-card rounded-xl p-5'
-          >
-            <div className='flex items-start justify-between mb-3'>
-              <div className='flex items-center gap-2'>
-                <span className='text-2xl'>{tool.icon}</span>
-                <div>
-                  <h3 className='tf-text font-semibold'>{tool.label}</h3>
-                  <code className='text-xs tf-text-muted'>{tool.toolId}</code>
-                </div>
-              </div>
-              <span className='px-2 py-0.5 text-xs tf-status-success rounded'>
-                Read-Only
-              </span>
-            </div>
-            <p className='tf-text-secondary text-sm mb-4'>{tool.description}</p>
-            <button
-              onClick={() => handleInvokeTool(tool.toolId)}
-              disabled={invocationState.status === 'loading'}
-              className='tf-suite-pilot-cta w-full px-4 py-2 rounded-lg transition-colors'
-            >
-              {invocationState.status === 'loading' && invocationState.currentTool === tool.toolId
-                ? 'Running...'
-                : 'Run Tool'}
-            </button>
-          </div>
-        ))}
-      </div>
-
-      {/* Current Invocation Result */}
-      {invocationState.status === 'loading' && (
+      {/* Tool loading states */}
+      {toolsLoading && (
         <div className='tf-status-info rounded-xl p-4' role='status'>
           <div className='flex items-center gap-3'>
             <div className='w-5 h-5 border-2 rounded-full animate-spin' style={{ borderColor: 'hsl(var(--tf-text) / 0.3)', borderTopColor: 'hsl(var(--tf-text))' }} />
-            <span className='tf-text'>Invoking {invocationState.currentTool}...</span>
+            <span className='tf-text'>Loading tools from manifest…</span>
           </div>
         </div>
       )}
 
-      {invocationState.status === 'success' && invocationState.result && (
-        <div className='tf-status-success rounded-xl p-5'>
-          <div className='flex items-center justify-between mb-4'>
-            <h3 className='font-semibold flex items-center gap-2' style={{ color: 'hsl(var(--tf-success))' }}>
-              <span>✅</span> Tool Execution Successful
-            </h3>
-            <div className='flex items-center gap-2'>
-              <span className='tf-text-muted text-sm'>Correlation ID:</span>
-              <code className='tf-overlay px-2 py-1 rounded text-sm tf-text-secondary'>
-                {invocationState.correlationId}
-              </code>
+      {toolsError && (
+        <div className='tf-status-error rounded-xl p-4'>
+          <p className='tf-text'>Failed to load tools: {toolsError}</p>
+          <button
+            onClick={() => {
+              setToolsLoading(true);
+              setToolsError(null);
+              listPilotTools()
+                .then((r) => { setTools(r.tools); setToolsLoading(false); })
+                .catch((e) => { setToolsError(e instanceof Error ? e.message : 'Retry failed'); setToolsLoading(false); });
+            }}
+            className='mt-2 px-3 py-1 text-sm tf-hover-surface rounded'
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Tool Cards — dynamically loaded from manifest */}
+      {!toolsLoading && !toolsError && tools.length > 0 && (
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+          {tools.map((tool) => (
+            <div
+              key={tool.toolId}
+              className='tf-suite-card rounded-xl p-5'
+            >
+              <div className='flex items-start justify-between mb-3'>
+                <div className='flex items-center gap-2'>
+                  <span className='text-2xl'>{RISK_ICON[tool.risk]}</span>
+                  <div>
+                    <h3 className='tf-text font-semibold'>
+                      {tool.displayName ?? tool.toolId}
+                    </h3>
+                    <code className='text-xs tf-text-muted'>{tool.toolId}</code>
+                  </div>
+                </div>
+                <span className={`px-2 py-0.5 text-xs ${RISK_BADGE_CLASS[tool.risk]} rounded`}>
+                  {RISK_LABEL[tool.risk]}
+                </span>
+              </div>
+              {tool.description && (
+                <p className='tf-text-secondary text-sm mb-4'>{tool.description}</p>
+              )}
+              {tool.suite && (
+                <p className='tf-text-muted text-xs mb-3'>Suite: {tool.suite}</p>
+              )}
               <button
-                onClick={() => navigator.clipboard.writeText(invocationState.correlationId || '')}
-                className='px-2 py-1 text-xs tf-hover-surface rounded'
-                title='Copy correlation ID'
+                onClick={() => handleInvokeTool(tool)}
+                disabled={isInvoking}
+                className='tf-suite-pilot-cta w-full px-4 py-2 rounded-lg transition-colors disabled:opacity-50'
               >
-                Copy
-              </button>
-              <button
-                onClick={clearState}
-                className='px-2 py-1 text-xs tf-hover-surface rounded'
-              >
-                Dismiss
+                {isInvoking && invocation.state.toolId === tool.toolId
+                  ? 'Running…'
+                  : 'Run Tool'}
               </button>
             </div>
-          </div>
-
-          <div className='tf-overlay rounded-lg p-4 overflow-x-auto'>
-            <pre className='text-sm tf-text-secondary font-mono whitespace-pre-wrap'>
-              {(() => {
-                try {
-                  return JSON.stringify(JSON.parse(invocationState.result.output), null, 2);
-                } catch {
-                  return invocationState.result.output;
-                }
-              })()}
-            </pre>
-          </div>
-
-          {getEnv().DEV && (
-            <details className='mt-4'>
-              <summary className='tf-text-muted text-sm cursor-pointer hover:text-[hsl(var(--tf-text)/0.7)]'>
-                🔍 Developer Info
-              </summary>
-              <div className='mt-2 tf-overlay rounded p-3'>
-                <code className='text-xs tf-text-tertiary block'>
-                  pnpm run trace:query --correlation {invocationState.correlationId}
-                </code>
-              </div>
-            </details>
-          )}
+          ))}
         </div>
       )}
 
-      {invocationState.status === 'error' && invocationState.error && (
-        <div className='tf-status-error rounded-xl p-5'>
-          <div className='flex justify-end mb-2'>
-            <button
-              onClick={clearState}
-              className='px-2 py-1 text-xs tf-hover-surface rounded'
-            >
-              Dismiss
-            </button>
-          </div>
-          <ErrorDisplay error={invocationState.error} />
+      {!toolsLoading && !toolsError && tools.length === 0 && (
+        <div className='tf-status-info rounded-xl p-4'>
+          <p className='tf-text-muted text-center'>No tools available in the manifest.</p>
         </div>
       )}
+
+      {/* Execution Console — lifecycle + confirmation gate + correlationId */}
+      <ExecutionConsole
+        invocation={invocation}
+        tool={activeToolMeta}
+      />
 
       {/* Invocation History */}
       <InvocationHistory

--- a/tools/registry/security-scan-runner.mjs
+++ b/tools/registry/security-scan-runner.mjs
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const configPath = path.resolve(process.cwd(), "mcp-security-config.js");
+
+if (!fs.existsSync(configPath)) {
+  console.log("SKIP: mcp-security-config.js not present (optional)");
+  process.exit(0);
+}
+
+const configModule = await import(pathToFileURL(configPath).href);
+const SecurityValidator = configModule?.SecurityValidator;
+const securityConfig = configModule?.securityConfig;
+
+if (!SecurityValidator || !securityConfig) {
+  console.error("ERROR: mcp-security-config.js missing SecurityValidator or securityConfig exports");
+  process.exit(1);
+}
+
+const validator = new SecurityValidator(securityConfig);
+await validator.validateSecurityPosture();


### PR DESCRIPTION
## PR-UI1: Governed Tool Invocation UI (Console + Confirmation Gate)

### What
Wire real UI behavior to the governed spine. From any tool surface, invoke a tool via Pilot with:
- Lifecycle visibility: idle -> preflight -> confirming -> executing -> succeeded -> failed
- correlationId displayed at every post-execute stage
- Gate 5 enforcement: confirmation + reason code via RiskConfirmationModal for write-risk tools
- No mock data, no hardcoded tools, no demo mode

### Files Changed
- **NEW** hooks/useToolInvocation.ts - Lifecycle state machine hook (useReducer)
- **NEW** components/pilot/ExecutionConsole.tsx - Renders lifecycle + correlationId + composes with RiskConfirmationModal
- **MODIFIED** pages/workbench/tabs/PropertyPilot.tsx - Rewired from hardcoded PARCEL_TOOLS to dynamic listPilotTools() + useToolInvocation
- **INCLUDED** tools/registry/security-scan-runner.mjs - Pre-existing untracked file (governance hook requirement)

### Architecture
PropertyPilot -> listPilotTools() (load manifest) -> useToolInvocation.invoke(toolId, params) -> validatePilotTool() (preflight) -> RiskConfirmationModal (if Gate 5 requires) -> invokePilotTool() (execute) -> correlationId at every stage -> ExecutionConsole (renders lifecycle) -> InvocationHistory (accumulated records)

### Evidence
- Tests: 59/59 core tests pass
- Gates: type-check 0 errors
- Build: vite build green

Government: FISMA compliance
AI-Collaboration: GitHub Copilot