### PR TITLE
feat(pilot): Lane A — trace list endpoint + parcel-scoped EvidenceRail feed

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/hooks/usePilotTraceList.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/hooks/usePilotTraceList.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * usePilotTraceList.test.tsx
+ *
+ * Lane A: Tests for the parcel-scoped trace list hook.
+ *
+ * Verifies:
+ *   - idle when no parcelId
+ *   - loading → ready on initial fetch
+ *   - incremental poll merges + dedupes
+ *   - error state on fetch failure
+ *   - refresh resets and re-fetches
+ *   - newest-first ordering maintained
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { usePilotTraceList } from '../../hooks/usePilotTraceList';
+import type { PilotTraceEvent, PilotTraceListResponse } from '../../api/pilotApi';
+
+// ============================================================================
+// Mock the API
+// ============================================================================
+
+const mockListPilotTraces = jest.fn<Promise<PilotTraceListResponse>, [unknown]>();
+
+jest.mock('../../api/pilotApi', () => ({
+  ...jest.requireActual('../../api/pilotApi'),
+  listPilotTraces: (...args: unknown[]) => mockListPilotTraces(args[0]),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeEvent(overrides: Partial<PilotTraceEvent> & { eventId: string; timestamp: string }): PilotTraceEvent {
+  return {
+    type: 'tool_invoked',
+    toolId: 'test-tool',
+    correlationId: 'corr-1',
+    summary: 'test',
+    context: { countyId: 'benton', userId: 'u-1', mode: 'pilot' as const },
+    ...overrides,
+  };
+}
+
+const evt1: PilotTraceEvent = makeEvent({ eventId: 'e1', timestamp: '2026-03-01T10:00:00.000Z', correlationId: 'c1' });
+const evt2: PilotTraceEvent = makeEvent({ eventId: 'e2', timestamp: '2026-03-01T11:00:00.000Z', correlationId: 'c2' });
+const evt3: PilotTraceEvent = makeEvent({ eventId: 'e3', timestamp: '2026-03-01T12:00:00.000Z', correlationId: 'c3' });
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('usePilotTraceList', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockListPilotTraces.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stays idle when parcelId is null', () => {
+    const { result } = renderHook(() =>
+      usePilotTraceList({ parcelId: null, pollMs: 0 }),
+    );
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.events).toEqual([]);
+    expect(mockListPilotTraces).not.toHaveBeenCalled();
+  });
+
+  it('transitions loading → ready on initial fetch', async () => {
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt2, evt1], // newest first
+      pagination: { offset: 0, limit: 50, returned: 2 },
+    });
+
+    const { result } = renderHook(() =>
+      usePilotTraceList({ parcelId: 'P-001', pollMs: 0 }),
+    );
+
+    // Should be loading initially
+    expect(result.current.phase).toBe('loading');
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('ready');
+    });
+
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[0].eventId).toBe('e2'); // newest first
+    expect(mockListPilotTraces).toHaveBeenCalledWith(
+      expect.objectContaining({ parcelId: 'P-001', limit: 50 }),
+    );
+  });
+
+  it('shows error on fetch failure', async () => {
+    mockListPilotTraces.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      usePilotTraceList({ parcelId: 'P-001', pollMs: 0 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('error');
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.events).toEqual([]);
+  });
+
+  it('merges new events on incremental poll (dedupes by eventId)', async () => {
+    // Initial fetch returns evt2, evt1
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt2, evt1],
+      pagination: { offset: 0, limit: 50, returned: 2 },
+    });
+
+    const { result } = renderHook(() =>
+      usePilotTraceList({ parcelId: 'P-001', pollMs: 5000 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('ready');
+    });
+    expect(result.current.events).toHaveLength(2);
+
+    // Set up incremental response: evt3 is new, evt2 is duplicate
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt3, evt2], // evt2 is duplicate
+      pagination: { offset: 0, limit: 50, returned: 2 },
+    });
+
+    // Advance timer to trigger poll
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toHaveLength(3); // e3 + e2 + e1, no dupe
+    });
+
+    // Verify newest-first ordering
+    expect(result.current.events[0].eventId).toBe('e3');
+    expect(result.current.events[1].eventId).toBe('e2');
+    expect(result.current.events[2].eventId).toBe('e1');
+
+    // Verify incremental poll used from= parameter
+    expect(mockListPilotTraces).toHaveBeenCalledTimes(2);
+    const secondCall = mockListPilotTraces.mock.calls[1][0] as Record<string, unknown>;
+    expect(secondCall).toHaveProperty('from', evt2.timestamp);
+  });
+
+  it('refresh does full re-fetch', async () => {
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt1],
+      pagination: { offset: 0, limit: 50, returned: 1 },
+    });
+
+    const { result } = renderHook(() =>
+      usePilotTraceList({ parcelId: 'P-001', pollMs: 0 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('ready');
+    });
+
+    // Set up next response
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt3, evt2, evt1],
+      pagination: { offset: 0, limit: 50, returned: 3 },
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toHaveLength(3);
+    });
+
+    // Refresh should NOT use from= (full re-fetch)
+    const refreshCall = mockListPilotTraces.mock.calls[1][0] as Record<string, unknown>;
+    expect(refreshCall).not.toHaveProperty('from');
+  });
+
+  it('resets on parcelId change', async () => {
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt1],
+      pagination: { offset: 0, limit: 50, returned: 1 },
+    });
+
+    const { result, rerender } = renderHook(
+      ({ pid }: { pid: string }) => usePilotTraceList({ parcelId: pid, pollMs: 0 }),
+      { initialProps: { pid: 'P-001' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('ready');
+    });
+    expect(result.current.events).toHaveLength(1);
+
+    // Change parcelId
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [evt3],
+      pagination: { offset: 0, limit: 50, returned: 1 },
+    });
+
+    rerender({ pid: 'P-002' });
+
+    // Should reset to loading
+    await waitFor(() => {
+      expect(result.current.phase).toBe('ready');
+    });
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0].eventId).toBe('e3');
+  });
+
+  it('passes toolId to API when provided', async () => {
+    mockListPilotTraces.mockResolvedValueOnce({
+      events: [],
+      pagination: { offset: 0, limit: 50, returned: 0 },
+    });
+
+    renderHook(() =>
+      usePilotTraceList({ parcelId: 'P-001', toolId: 'run_valuation_model', pollMs: 0 }),
+    );
+
+    await waitFor(() => {
+      expect(mockListPilotTraces).toHaveBeenCalled();
+    });
+
+    expect(mockListPilotTraces).toHaveBeenCalledWith(
+      expect.objectContaining({ parcelId: 'P-001', toolId: 'run_valuation_model' }),
+    );
+  });
+});

--- a/frontend/apps/os-shell/src/api/pilotApi.ts
+++ b/frontend/apps/os-shell/src/api/pilotApi.ts
@@ -230,6 +230,26 @@ export interface PilotTraceResponse {
   events: PilotTraceEvent[];
 }
 
+/** Trace list query params */
+export interface PilotTraceListParams {
+  parcelId: string;
+  toolId?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Trace list response (with pagination metadata) */
+export interface PilotTraceListResponse {
+  events: PilotTraceEvent[];
+  pagination: {
+    offset: number;
+    limit: number;
+    returned: number;
+  };
+}
+
 /** Health check response */
 export interface PilotHealthResponse {
   status: string;
@@ -420,6 +440,36 @@ export async function getPilotTrace(correlationId: string): Promise<PilotTraceRe
   }
 
   return (await response.json()) as PilotTraceResponse;
+}
+
+/**
+ * List trace events with parcel-scoped filtering and date range.
+ * Newest-first ordering with offset/limit pagination.
+ *
+ * @param params - Query parameters (parcelId required, rest optional)
+ */
+export async function listPilotTraces(params: PilotTraceListParams): Promise<PilotTraceListResponse> {
+  const qs = new URLSearchParams();
+  qs.set('parcelId', params.parcelId);
+  if (params.toolId) qs.set('toolId', params.toolId);
+  if (params.from) qs.set('from', params.from);
+  if (params.to) qs.set('to', params.to);
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+  if (params.offset !== undefined) qs.set('offset', String(params.offset));
+
+  const url = `${API_BASE_URL}/pilot/traces?${qs.toString()}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: buildPilotHeaders(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(`Failed to list traces (${response.status}): ${errorText}`);
+  }
+
+  return (await response.json()) as PilotTraceListResponse;
 }
 
 /**

--- a/frontend/apps/os-shell/src/components/pilot/EvidenceRail.tsx
+++ b/frontend/apps/os-shell/src/components/pilot/EvidenceRail.tsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import type { PilotTraceEvent } from '../../api/pilotApi';
 import type { TracePhase } from '../../hooks/useTraceByCorrelationId';
+import type { TraceListPhase } from '../../hooks/usePilotTraceList';
 import { LiquidPanel } from '../../ui/materials/LiquidPanel';
 import { TactileButton } from '../../ui/materials/TactileButton';
 
@@ -21,7 +22,7 @@ import { TactileButton } from '../../ui/materials/TactileButton';
 // ============================================================================
 
 export interface EvidenceRailProps {
-  phase: TracePhase;
+  phase: TracePhase | TraceListPhase;
   events: PilotTraceEvent[];
   error: string | null;
   onRetry: () => void;
@@ -74,14 +75,21 @@ function formatTimestamp(value: string): string {
 function CorrelationHeader({ events }: { events: PilotTraceEvent[] }) {
   if (events.length === 0) return null;
 
-  const cid = events[0].correlationId;
+  // Detect if showing multiple correlations (list mode) or single (detail mode)
+  const uniqueCorrelations = new Set(events.map(e => e.correlationId));
+  const isList = uniqueCorrelations.size > 1;
+
   const timestamps = events.map((e) => new Date(e.timestamp).getTime()).filter((t) => !Number.isNaN(t));
   const earliest = timestamps.length > 0 ? new Date(Math.min(...timestamps)) : null;
   const latest = timestamps.length > 1 ? new Date(Math.max(...timestamps)) : null;
 
   return (
     <div className="flex items-center justify-between text-[11px] text-white/50 px-1" data-testid="evidence-header">
-      <code className="bg-black/30 px-2 py-0.5 rounded truncate max-w-[60%]">{cid}</code>
+      {isList ? (
+        <span className="bg-black/30 px-2 py-0.5 rounded">{uniqueCorrelations.size} invocations</span>
+      ) : (
+        <code className="bg-black/30 px-2 py-0.5 rounded truncate max-w-[60%]">{events[0].correlationId}</code>
+      )}
       <span>
         {earliest ? formatTimestamp(earliest.toISOString()) : ''}
         {latest ? ` → ${formatTimestamp(latest.toISOString())}` : ''}

--- a/frontend/apps/os-shell/src/hooks/usePilotTraceList.ts
+++ b/frontend/apps/os-shell/src/hooks/usePilotTraceList.ts
@@ -1,0 +1,163 @@
+/**
+ * usePilotTraceList.ts
+ *
+ * Lane A: Parcel-scoped trace list feed with incremental polling.
+ *
+ * States: idle | loading | ready | error
+ *
+ * Behavior:
+ *   - Initial fetch: GET /pilot/traces?parcelId=&limit=50&offset=0
+ *   - Poll refresh: from=lastSeenTimestamp (newest event) to fetch only new events
+ *   - Merges new events at front, dedupes by eventId
+ *   - Newest-first ordering maintained
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PilotTraceEvent, PilotTraceListParams } from '../api/pilotApi';
+import { listPilotTraces } from '../api/pilotApi';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TraceListPhase = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UsePilotTraceListOptions {
+  parcelId: string | null | undefined;
+  toolId?: string;
+  limit?: number;
+  /** Polling interval in ms. Default 5000. Set 0 to disable polling. */
+  pollMs?: number;
+}
+
+export interface UsePilotTraceListResult {
+  phase: TraceListPhase;
+  events: PilotTraceEvent[];
+  error: string | null;
+  refresh: () => void;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_POLL_MS = 5000;
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function usePilotTraceList(options: UsePilotTraceListOptions): UsePilotTraceListResult {
+  const { parcelId, toolId, limit = DEFAULT_LIMIT, pollMs = DEFAULT_POLL_MS } = options;
+
+  const [phase, setPhase] = useState<TraceListPhase>('idle');
+  const [events, setEvents] = useState<PilotTraceEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track latest seen timestamp for incremental poll
+  const newestTimestampRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeParcelRef = useRef<string | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Merge new events into the existing list, deduping by eventId, newest-first
+  const mergeEvents = useCallback(
+    (existing: PilotTraceEvent[], incoming: PilotTraceEvent[]): PilotTraceEvent[] => {
+      const seen = new Set(existing.map(e => e.eventId));
+      const novel = incoming.filter(e => !seen.has(e.eventId));
+      if (novel.length === 0) return existing;
+
+      // Prepend new events (they're already newest-first from the API)
+      const merged = [...novel, ...existing];
+      // Re-sort newest first in case of any ordering edge
+      merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      return merged;
+    },
+    [],
+  );
+
+  const fetchList = useCallback(
+    async (pid: string, isIncremental: boolean) => {
+      if (activeParcelRef.current !== pid) return;
+
+      try {
+        const params: PilotTraceListParams = {
+          parcelId: pid,
+          limit,
+        };
+        if (toolId) params.toolId = toolId;
+
+        // Incremental: only fetch events newer than what we have
+        if (isIncremental && newestTimestampRef.current) {
+          params.from = newestTimestampRef.current;
+        }
+
+        const response = await listPilotTraces(params);
+
+        if (activeParcelRef.current !== pid) return;
+
+        setEvents(prev => {
+          const merged = isIncremental ? mergeEvents(prev, response.events) : response.events;
+          // Update newest timestamp
+          if (merged.length > 0) {
+            newestTimestampRef.current = merged[0].timestamp;
+          }
+          return merged;
+        });
+        setPhase('ready');
+        setError(null);
+      } catch (err) {
+        if (activeParcelRef.current !== pid) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setPhase('error');
+      }
+
+      // Schedule next poll
+      if (pollMs > 0 && activeParcelRef.current === pid) {
+        timerRef.current = setTimeout(() => fetchList(pid, true), pollMs);
+      }
+    },
+    [limit, toolId, pollMs, mergeEvents],
+  );
+
+  // Manual refresh (full re-fetch, not incremental)
+  const refresh = useCallback(() => {
+    if (!parcelId) return;
+    cleanup();
+    newestTimestampRef.current = null;
+    setPhase('loading');
+    fetchList(parcelId, false);
+  }, [parcelId, cleanup, fetchList]);
+
+  // Start/restart when parcelId or toolId changes
+  useEffect(() => {
+    cleanup();
+
+    if (!parcelId) {
+      activeParcelRef.current = null;
+      setPhase('idle');
+      setEvents([]);
+      setError(null);
+      return;
+    }
+
+    activeParcelRef.current = parcelId;
+    newestTimestampRef.current = null;
+    setPhase('loading');
+    setEvents([]);
+    setError(null);
+
+    fetchList(parcelId, false);
+
+    return cleanup;
+  }, [parcelId, toolId, cleanup, fetchList]);
+
+  return { phase, events, error, refresh };
+}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
@@ -21,7 +21,7 @@ import {
 import { ExecutionConsole } from '../../../components/pilot/ExecutionConsole';
 import { EvidenceRail } from '../../../components/pilot/EvidenceRail';
 import { useToolInvocation } from '../../../hooks/useToolInvocation';
-import { useTraceByCorrelationId } from '../../../hooks/useTraceByCorrelationId';
+import { usePilotTraceList } from '../../../hooks/usePilotTraceList';
 
 // ============================================================================
 // Risk level display helpers
@@ -130,12 +130,8 @@ export const PropertyPilot: React.FC = () => {
 
   const isInvoking = invocation.state.phase !== 'idle';
 
-  // Evidence Rail — show trace for most-recent invocation
-  const latestCorrelationId = useMemo(
-    () => (invocationHistory.length > 0 ? invocationHistory[0].correlationId : null),
-    [invocationHistory],
-  );
-  const trace = useTraceByCorrelationId(latestCorrelationId);
+  // Evidence Rail — parcel-scoped trace list feed
+  const traceList = usePilotTraceList({ parcelId });
 
   return (
     <div className='tf-suite-pilot space-y-6' data-testid='property-pilot-tab'>
@@ -247,7 +243,7 @@ export const PropertyPilot: React.FC = () => {
           />
         </div>
 
-        <EvidenceRail phase={trace.phase} events={trace.events} error={trace.error} onRetry={trace.refresh} />
+        <EvidenceRail phase={traceList.phase} events={traceList.events} error={traceList.error} onRetry={traceList.refresh} />
       </div>
     </div>
   );

--- a/os-platform/core/api/PilotController.ts
+++ b/os-platform/core/api/PilotController.ts
@@ -557,6 +557,102 @@ export function createPilotRouter(runner?: ToolRunner): Router {
   });
 
   /**
+   * GET /pilot/traces
+   *
+   * List trace events with parcel-scoped filtering and date range.
+   * Newest-first ordering with offset/limit pagination.
+   *
+   * Query params:
+   *   - parcelId (required) — scope to a single parcel
+   *   - toolId (optional)   — filter by tool
+   *   - from (optional)     — ISO 8601 lower bound (inclusive)
+   *   - to (optional)       — ISO 8601 upper bound (inclusive)
+   *   - limit (optional)    — page size, default 50, max 200
+   *   - offset (optional)   — pagination offset, default 0
+   *
+   * ACCESS RULES: same county isolation as /trace/:correlationId.
+   */
+  router.get('/traces', async (req: AuthenticatedRequest, res: Response) => {
+    const parcelId = req.query.parcelId as string | undefined;
+    if (!parcelId) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST',
+        message: 'parcelId query parameter is required',
+      });
+    }
+
+    // Parse and validate limit
+    const rawLimit = req.query.limit as string | undefined;
+    const limit = rawLimit ? Math.min(Math.max(1, parseInt(rawLimit, 10) || 50), 200) : 50;
+
+    // Parse and validate offset
+    const rawOffset = req.query.offset as string | undefined;
+    const offset = rawOffset ? Math.max(0, parseInt(rawOffset, 10) || 0) : 0;
+
+    // Parse date bounds
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+
+    if (from && isNaN(new Date(from).getTime())) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST',
+        message: 'from must be a valid ISO 8601 timestamp',
+      });
+    }
+    if (to && isNaN(new Date(to).getTime())) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST',
+        message: 'to must be a valid ISO 8601 timestamp',
+      });
+    }
+    if (from && to && new Date(from).getTime() > new Date(to).getTime()) {
+      return res.status(400).json({
+        error: 'INVALID_REQUEST',
+        message: 'from must not be after to',
+      });
+    }
+
+    const toolId = req.query.toolId as string | undefined;
+
+    // Build access principal from auth context
+    const user = req.user ?? {
+      userId: 'anonymous',
+      roles: ['viewer'],
+      countyId: 'benton',
+    };
+
+    const principal: TraceAccessPrincipal = {
+      userId: user.userId,
+      roles: user.roles,
+      countyId: user.countyId,
+    };
+
+    // Query trace events (async path for persistent store)
+    const events = await traceService.queryAsync({
+      parcelId,
+      toolId,
+      from: from || undefined,
+      to: to || undefined,
+      limit,
+      offset,
+    });
+
+    // Filter by county isolation + access control
+    const visibleEvents = events.filter(e => {
+      // Always deny cross-county
+      if (e.context.countyId.toLowerCase() !== principal.countyId.toLowerCase()) return false;
+      // Elevated roles see all in-county; others only own
+      if (hasElevatedTraceRole(principal)) return true;
+      return e.context.userId === principal.userId;
+    });
+
+    return res.json({
+      events: visibleEvents,
+      pagination: { offset, limit, returned: visibleEvents.length },
+    });
+  });
+
+  /**
    * GET /pilot/trace/:correlationId
    *
    * Get trace events for a tool invocation.

--- a/os-platform/core/tests/trace-list-query.test.mjs
+++ b/os-platform/core/tests/trace-list-query.test.mjs
@@ -1,0 +1,242 @@
+/**
+ * TerraFusion OS - Trace List Query Tests
+ *
+ * Tests for:
+ *   - TraceQueryOptions from/to date filtering
+ *   - TraceService.query() with date bounds
+ *   - InMemoryTraceStore date filtering
+ *   - Newest-first ordering
+ *   - Offset/limit pagination
+ *
+ * Run: node --test os-platform/core/tests/trace-list-query.test.mjs
+ */
+
+import assert from 'node:assert';
+import { before, beforeEach, describe, it } from 'node:test';
+
+// ============================================================================
+// Dynamic imports for ESM compatibility
+// ============================================================================
+
+let InMemoryTraceStore;
+let TraceService;
+
+before(async () => {
+  const traceModule = await import('../trace/index.js');
+  const trace = traceModule.default || traceModule;
+  InMemoryTraceStore = trace.InMemoryTraceStore;
+  TraceService = trace.TraceService;
+});
+
+// ============================================================================
+// Helper: create a TraceEvent with controlled timestamp
+// ============================================================================
+
+function makeEvent(overrides = {}) {
+  return {
+    eventId: `evt-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'tool_invoked',
+    toolId: overrides.toolId ?? 'test-tool',
+    correlationId: overrides.correlationId ?? `corr-${Math.random().toString(36).slice(2, 10)}`,
+    summary: overrides.summary ?? 'test event',
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    schemaVersion: '1.0.0',
+    context: {
+      countyId: overrides.countyId ?? 'benton',
+      userId: overrides.userId ?? 'user-1',
+      mode: overrides.mode ?? 'pilot',
+      parcelId: overrides.parcelId ?? undefined,
+      dossierId: overrides.dossierId ?? undefined,
+    },
+    ...(overrides.payloadRef ? { payloadRef: overrides.payloadRef } : {}),
+    ...(overrides.redactedFields ? { redactedFields: overrides.redactedFields } : {}),
+  };
+}
+
+// ============================================================================
+// TraceService.query() with from/to
+// ============================================================================
+
+describe('TraceService.query() with date filters', () => {
+  let service;
+  const t1 = '2026-03-01T10:00:00.000Z';
+  const t2 = '2026-03-01T11:00:00.000Z';
+  const t3 = '2026-03-01T12:00:00.000Z';
+  const t4 = '2026-03-01T13:00:00.000Z';
+
+  beforeEach(() => {
+    service = new TraceService({ ringBufferSize: 1000 });
+    // Emit events with controlled timestamps (emit overrides timestamp,
+    // so we inject directly into the ring buffer via emit + override)
+    // Actually TraceService.emit() sets timestamp = now, so we need to
+    // modify the events after emission. For testing, we bypass via direct access.
+    // Better: use the store approach.
+  });
+
+  it('returns all events when no from/to specified', () => {
+    // Emit 3 events - they'll have ~same timestamp
+    service.emit({ type: 'tool_invoked', toolId: 't1', correlationId: 'c1', summary: 'e1', context: { countyId: 'benton', userId: 'u1', mode: 'pilot' } });
+    service.emit({ type: 'tool_completed', toolId: 't1', correlationId: 'c1', summary: 'e2', context: { countyId: 'benton', userId: 'u1', mode: 'pilot' } });
+
+    const results = service.query({});
+    assert.strictEqual(results.length, 2);
+  });
+
+  it('respects limit', () => {
+    for (let i = 0; i < 10; i++) {
+      service.emit({ type: 'tool_invoked', toolId: 't1', correlationId: `c${i}`, summary: `e${i}`, context: { countyId: 'benton', userId: 'u1', mode: 'pilot' } });
+    }
+    const results = service.query({ limit: 3 });
+    assert.strictEqual(results.length, 3);
+  });
+
+  it('respects offset + limit', () => {
+    for (let i = 0; i < 10; i++) {
+      service.emit({ type: 'tool_invoked', toolId: 't1', correlationId: `c${i}`, summary: `e${i}`, context: { countyId: 'benton', userId: 'u1', mode: 'pilot' } });
+    }
+    const page1 = service.query({ limit: 3, offset: 0 });
+    const page2 = service.query({ limit: 3, offset: 3 });
+    assert.strictEqual(page1.length, 3);
+    assert.strictEqual(page2.length, 3);
+    // No overlap
+    const ids1 = new Set(page1.map(e => e.eventId));
+    assert.ok(page2.every(e => !ids1.has(e.eventId)));
+  });
+
+  it('filters by parcelId', () => {
+    service.emit({ type: 'tool_invoked', toolId: 't1', correlationId: 'c1', summary: 'e1', context: { countyId: 'benton', userId: 'u1', mode: 'pilot', parcelId: 'P-001' } });
+    service.emit({ type: 'tool_invoked', toolId: 't1', correlationId: 'c2', summary: 'e2', context: { countyId: 'benton', userId: 'u1', mode: 'pilot', parcelId: 'P-002' } });
+
+    const results = service.query({ parcelId: 'P-001' });
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].context.parcelId, 'P-001');
+  });
+});
+
+// ============================================================================
+// InMemoryTraceStore.query() with from/to
+// ============================================================================
+
+describe('InMemoryTraceStore.query() with date filters', () => {
+  let store;
+  const t1 = '2026-03-01T10:00:00.000Z';
+  const t2 = '2026-03-01T11:00:00.000Z';
+  const t3 = '2026-03-01T12:00:00.000Z';
+  const t4 = '2026-03-01T13:00:00.000Z';
+
+  beforeEach(async () => {
+    store = new InMemoryTraceStore();
+    // Seed events with known timestamps
+    await store.append(makeEvent({ timestamp: t1, toolId: 'tool-a', parcelId: 'P-001', correlationId: 'c1' }));
+    await store.append(makeEvent({ timestamp: t2, toolId: 'tool-b', parcelId: 'P-001', correlationId: 'c2' }));
+    await store.append(makeEvent({ timestamp: t3, toolId: 'tool-a', parcelId: 'P-001', correlationId: 'c3' }));
+    await store.append(makeEvent({ timestamp: t4, toolId: 'tool-b', parcelId: 'P-002', correlationId: 'c4' }));
+  });
+
+  it('returns all events when no filters applied', async () => {
+    const results = await store.query({});
+    assert.strictEqual(results.length, 4);
+  });
+
+  it('orders newest-first', async () => {
+    const results = await store.query({});
+    assert.strictEqual(results[0].timestamp, t4);
+    assert.strictEqual(results[3].timestamp, t1);
+  });
+
+  it('filters by from (inclusive)', async () => {
+    const results = await store.query({ from: t2 });
+    assert.strictEqual(results.length, 3);
+    // Should include t2, t3, t4 but not t1
+    assert.ok(results.every(e => new Date(e.timestamp).getTime() >= new Date(t2).getTime()));
+  });
+
+  it('filters by to (inclusive)', async () => {
+    const results = await store.query({ to: t2 });
+    assert.strictEqual(results.length, 2);
+    // Should include t1, t2 but not t3, t4
+    assert.ok(results.every(e => new Date(e.timestamp).getTime() <= new Date(t2).getTime()));
+  });
+
+  it('filters by from AND to', async () => {
+    const results = await store.query({ from: t2, to: t3 });
+    assert.strictEqual(results.length, 2);
+    assert.ok(results.every(e => {
+      const ts = new Date(e.timestamp).getTime();
+      return ts >= new Date(t2).getTime() && ts <= new Date(t3).getTime();
+    }));
+  });
+
+  it('filters by parcelId', async () => {
+    const results = await store.query({ parcelId: 'P-001' });
+    assert.strictEqual(results.length, 3);
+  });
+
+  it('filters by toolId', async () => {
+    const results = await store.query({ toolId: 'tool-a' });
+    assert.strictEqual(results.length, 2);
+  });
+
+  it('combines parcelId + toolId + from/to', async () => {
+    const results = await store.query({ parcelId: 'P-001', toolId: 'tool-a', from: t1, to: t2 });
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].timestamp, t1);
+  });
+
+  it('respects limit', async () => {
+    const results = await store.query({ limit: 2 });
+    assert.strictEqual(results.length, 2);
+    // Newest first
+    assert.strictEqual(results[0].timestamp, t4);
+    assert.strictEqual(results[1].timestamp, t3);
+  });
+
+  it('respects offset + limit', async () => {
+    const results = await store.query({ offset: 1, limit: 2 });
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(results[0].timestamp, t3);
+    assert.strictEqual(results[1].timestamp, t2);
+  });
+
+  it('returns empty array when from is after all events', async () => {
+    const results = await store.query({ from: '2026-12-01T00:00:00.000Z' });
+    assert.strictEqual(results.length, 0);
+  });
+
+  it('returns empty array when to is before all events', async () => {
+    const results = await store.query({ to: '2025-01-01T00:00:00.000Z' });
+    assert.strictEqual(results.length, 0);
+  });
+});
+
+// ============================================================================
+// TraceService with persistent store — date filtering threads through
+// ============================================================================
+
+describe('TraceService.queryAsync() delegates to store with from/to', () => {
+  let service;
+  let store;
+  const t1 = '2026-03-01T10:00:00.000Z';
+  const t2 = '2026-03-01T11:00:00.000Z';
+  const t3 = '2026-03-01T12:00:00.000Z';
+
+  beforeEach(async () => {
+    store = new InMemoryTraceStore();
+    service = new TraceService({ store });
+    await store.append(makeEvent({ timestamp: t1, parcelId: 'P-001' }));
+    await store.append(makeEvent({ timestamp: t2, parcelId: 'P-001' }));
+    await store.append(makeEvent({ timestamp: t3, parcelId: 'P-001' }));
+  });
+
+  it('queryAsync passes from/to to store', async () => {
+    const results = await service.queryAsync({ parcelId: 'P-001', from: t2 });
+    assert.strictEqual(results.length, 2);
+    assert.ok(results.every(e => new Date(e.timestamp).getTime() >= new Date(t2).getTime()));
+  });
+
+  it('queryAsync with to boundary', async () => {
+    const results = await service.queryAsync({ parcelId: 'P-001', to: t1 });
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].timestamp, t1);
+  });
+});

--- a/os-platform/core/trace/TraceService.js
+++ b/os-platform/core/trace/TraceService.js
@@ -149,6 +149,16 @@ class TraceService {
         if (options.dossierId) {
             results = results.filter(e => e.context.dossierId === options.dossierId);
         }
+        if (options.from) {
+            const fromMs = new Date(options.from).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+        }
+        if (options.to) {
+            const toMs = new Date(options.to).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
+        }
+        // Sort newest first
+        results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
         // Apply pagination
         const offset = options.offset ?? 0;
         const limit = options.limit ?? 100;

--- a/os-platform/core/trace/TraceService.ts
+++ b/os-platform/core/trace/TraceService.ts
@@ -200,6 +200,17 @@ export class TraceService {
     if (options.dossierId) {
       results = results.filter(e => e.context.dossierId === options.dossierId);
     }
+    if (options.from) {
+      const fromMs = new Date(options.from).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+    }
+    if (options.to) {
+      const toMs = new Date(options.to).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
+    }
+
+    // Sort newest first
+    results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
     // Apply pagination
     const offset = options.offset ?? 0;

--- a/os-platform/core/trace/TraceStore.js
+++ b/os-platform/core/trace/TraceStore.js
@@ -46,6 +46,14 @@ class InMemoryTraceStore {
         if (options.dossierId) {
             results = results.filter(e => e.context.dossierId === options.dossierId);
         }
+        if (options.from) {
+            const fromMs = new Date(options.from).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+        }
+        if (options.to) {
+            const toMs = new Date(options.to).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
+        }
         // Sort newest first
         results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
         // Apply pagination
@@ -160,6 +168,14 @@ class FileTraceStore {
         }
         if (options.dossierId) {
             results = results.filter(e => e.context.dossierId === options.dossierId);
+        }
+        if (options.from) {
+            const fromMs = new Date(options.from).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+        }
+        if (options.to) {
+            const toMs = new Date(options.to).getTime();
+            results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
         }
         results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
         const offset = options.offset ?? 0;

--- a/os-platform/core/trace/TraceStore.ts
+++ b/os-platform/core/trace/TraceStore.ts
@@ -111,6 +111,14 @@ export class InMemoryTraceStore implements TraceStore {
     if (options.dossierId) {
       results = results.filter(e => e.context.dossierId === options.dossierId);
     }
+    if (options.from) {
+      const fromMs = new Date(options.from).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+    }
+    if (options.to) {
+      const toMs = new Date(options.to).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
+    }
 
     // Sort newest first
     results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
@@ -260,6 +268,14 @@ export class FileTraceStore implements TraceStore {
     }
     if (options.dossierId) {
       results = results.filter(e => e.context.dossierId === options.dossierId);
+    }
+    if (options.from) {
+      const fromMs = new Date(options.from).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() >= fromMs);
+    }
+    if (options.to) {
+      const toMs = new Date(options.to).getTime();
+      results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
     }
 
     results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());

--- a/os-platform/core/types/index.d.ts
+++ b/os-platform/core/types/index.d.ts
@@ -118,6 +118,10 @@ export interface TraceQueryOptions {
     toolId?: string;
     correlationId?: string;
     type?: TraceEventType;
+    /** ISO 8601 lower bound (inclusive). Events with timestamp >= from. */
+    from?: string;
+    /** ISO 8601 upper bound (inclusive). Events with timestamp <= to. */
+    to?: string;
     limit?: number;
     offset?: number;
 }

--- a/os-platform/core/types/index.ts
+++ b/os-platform/core/types/index.ts
@@ -172,6 +172,10 @@ export interface TraceQueryOptions {
   toolId?: string;
   correlationId?: string;
   type?: TraceEventType;
+  /** ISO 8601 lower bound (inclusive). Events with timestamp >= from. */
+  from?: string;
+  /** ISO 8601 upper bound (inclusive). Events with timestamp <= to. */
+  to?: string;
   limit?: number;
   offset?: number;
 }


### PR DESCRIPTION
## Lane A: Trace Persistence / List Query

Parcel-scoped EvidenceRail feed via `GET /pilot/traces` with date filtering + paging. Frontend switches from correlation-scoped polling to list query.

### Backend Changes

| File | Change |
|------|--------|
| `os-platform/core/types/index.ts` + `.d.ts` | `TraceQueryOptions` gains `from?: string`, `to?: string` (ISO 8601) |
| `os-platform/core/trace/TraceStore.ts` | `InMemoryTraceStore.query()` + `FileTraceStore.query()` filter by from/to (inclusive), newest-first sort |
| `os-platform/core/trace/TraceService.ts` | `query()` filters by from/to + newest-first sort before pagination |
| `os-platform/core/api/PilotController.ts` | New `GET /pilot/traces` endpoint: parcelId required, limit cap 200, ISO date validation, county isolation |

### Frontend Changes

| File | Change |
|------|--------|
| `pilotApi.ts` | `PilotTraceListParams/Response` + `listPilotTraces()` |
| `usePilotTraceList.ts` | **NEW** — parcel-scoped hook: initial fetch + incremental poll (`from=newest`), merge/dedupe by eventId |
| `EvidenceRail.tsx` | Accepts `TraceListPhase`, auto-detects list vs detail header |
| `PropertyPilot.tsx` | Switched from `useTraceByCorrelationId` to `usePilotTraceList` |

### Tests

- `trace-list-query.test.mjs`: 18 backend tests (date filters, pagination, store delegation)
- `usePilotTraceList.test.tsx`: 7 frontend hook tests (polling, merge/dedupe, reset, toolId passthrough)

### Evidence

| Gate | Result |
|------|--------|
| `pnpm run type-check` | 0 errors |
| Frontend `tsc --noEmit` | 0 errors |
| Core tests (phase83/85/86 + trace-list) | 77/77 pass |
| Frontend Jest (full suite) | 283/283 suites, 4166 tests pass |
| Vite production build | exit 0 (14808 modules) |
| EvidenceRail regression | 5/5 pass |
| UI token ratchet | 192 ≤ 195 baseline (improved by 3) |

### Design Decisions
- **Offset/limit** (not cursor) — per plan, cursor is a follow-on optimization
- **from/to date filters** — enables incremental polling without re-fetching full list
- **Single atomic commit** — pre-commit hook enforces all governed-path files tracked together

AI-Collaboration: GitHub Copilot (Lane A)

## Summary by Sourcery

Add parcel-scoped trace listing with date-based filtering and pagination, and wire the Property Pilot EvidenceRail to consume it via a new frontend hook.

New Features:
- Expose a GET /pilot/traces API for parcel-scoped trace events with optional tool filter, date range, and offset/limit pagination.
- Add frontend API types and a listPilotTraces helper plus a usePilotTraceList hook to consume the trace list with incremental polling and deduplication.
- Update EvidenceRail and the Property Pilot tab to display a parcel-scoped trace feed, including a header that adapts between list and single-correlation views.

Enhancements:
- Extend trace query options and TraceService/TraceStore implementations to support from/to timestamp filtering and consistent newest-first ordering across in-memory and file-backed stores.

Tests:
- Add core tests validating trace list querying behavior, including date filters, ordering, pagination, and store delegation.
- Add React hook tests covering usePilotTraceList lifecycle, polling, merge/dedupe behavior, parcelId changes, and toolId passthrough.