### PR TITLE
harden(trace): stable sort tiebreak + default 30d retention window

### DIFF
--- a/os-platform/core/api/PilotController.ts
+++ b/os-platform/core/api/PilotController.ts
@@ -614,6 +614,9 @@ export function createPilotRouter(runner?: ToolRunner): Router {
 
     const toolId = req.query.toolId as string | undefined;
 
+    // Default from=now-30d when no date bounds specified (retention window)
+    const effectiveFrom = from || (to ? undefined : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
     // Build access principal from auth context
     const user = req.user ?? {
       userId: 'anonymous',
@@ -631,7 +634,7 @@ export function createPilotRouter(runner?: ToolRunner): Router {
     const events = await traceService.queryAsync({
       parcelId,
       toolId,
-      from: from || undefined,
+      from: effectiveFrom || undefined,
       to: to || undefined,
       limit,
       offset,

--- a/os-platform/core/tests/trace-list-query.test.mjs
+++ b/os-platform/core/tests/trace-list-query.test.mjs
@@ -207,6 +207,25 @@ describe('InMemoryTraceStore.query() with date filters', () => {
     const results = await store.query({ to: '2025-01-01T00:00:00.000Z' });
     assert.strictEqual(results.length, 0);
   });
+
+  it('tiebreaks equal timestamps by correlationId for stable ordering', async () => {
+    const sameTs = '2026-03-01T15:00:00.000Z';
+    const tieStore = new InMemoryTraceStore();
+    await tieStore.append(makeEvent({ timestamp: sameTs, correlationId: 'corr-zebra' }));
+    await tieStore.append(makeEvent({ timestamp: sameTs, correlationId: 'corr-alpha' }));
+    await tieStore.append(makeEvent({ timestamp: sameTs, correlationId: 'corr-mango' }));
+
+    const results = await tieStore.query({});
+    assert.strictEqual(results.length, 3);
+    // Same timestamp → sorted ascending by correlationId
+    assert.strictEqual(results[0].correlationId, 'corr-alpha');
+    assert.strictEqual(results[1].correlationId, 'corr-mango');
+    assert.strictEqual(results[2].correlationId, 'corr-zebra');
+
+    // Run again — must be deterministic
+    const results2 = await tieStore.query({});
+    assert.deepStrictEqual(results.map(e => e.correlationId), results2.map(e => e.correlationId));
+  });
 });
 
 // ============================================================================

--- a/os-platform/core/trace/TraceService.js
+++ b/os-platform/core/trace/TraceService.js
@@ -157,8 +157,13 @@ class TraceService {
             const toMs = new Date(options.to).getTime();
             results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
         }
-        // Sort newest first
-        results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        // Sort newest first; tiebreak by correlationId for stable ordering
+        results.sort((a, b) => {
+            const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+            if (dt !== 0)
+                return dt;
+            return a.correlationId.localeCompare(b.correlationId);
+        });
         // Apply pagination
         const offset = options.offset ?? 0;
         const limit = options.limit ?? 100;

--- a/os-platform/core/trace/TraceService.ts
+++ b/os-platform/core/trace/TraceService.ts
@@ -209,8 +209,12 @@ export class TraceService {
       results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
     }
 
-    // Sort newest first
-    results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    // Sort newest first; tiebreak by correlationId for stable ordering
+    results.sort((a, b) => {
+      const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+      if (dt !== 0) return dt;
+      return a.correlationId.localeCompare(b.correlationId);
+    });
 
     // Apply pagination
     const offset = options.offset ?? 0;

--- a/os-platform/core/trace/TraceStore.js
+++ b/os-platform/core/trace/TraceStore.js
@@ -54,8 +54,13 @@ class InMemoryTraceStore {
             const toMs = new Date(options.to).getTime();
             results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
         }
-        // Sort newest first
-        results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        // Sort newest first; tiebreak by correlationId for stable ordering
+        results.sort((a, b) => {
+            const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+            if (dt !== 0)
+                return dt;
+            return a.correlationId.localeCompare(b.correlationId);
+        });
         // Apply pagination
         const offset = options.offset ?? 0;
         const limit = options.limit ?? 100;
@@ -177,7 +182,13 @@ class FileTraceStore {
             const toMs = new Date(options.to).getTime();
             results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
         }
-        results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        // Sort newest first; tiebreak by correlationId for stable ordering
+        results.sort((a, b) => {
+            const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+            if (dt !== 0)
+                return dt;
+            return a.correlationId.localeCompare(b.correlationId);
+        });
         const offset = options.offset ?? 0;
         const limit = options.limit ?? 100;
         return results.slice(offset, offset + limit);

--- a/os-platform/core/trace/TraceStore.ts
+++ b/os-platform/core/trace/TraceStore.ts
@@ -120,8 +120,12 @@ export class InMemoryTraceStore implements TraceStore {
       results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
     }
 
-    // Sort newest first
-    results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    // Sort newest first; tiebreak by correlationId for stable ordering
+    results.sort((a, b) => {
+      const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+      if (dt !== 0) return dt;
+      return a.correlationId.localeCompare(b.correlationId);
+    });
 
     // Apply pagination
     const offset = options.offset ?? 0;
@@ -278,7 +282,12 @@ export class FileTraceStore implements TraceStore {
       results = results.filter(e => new Date(e.timestamp).getTime() <= toMs);
     }
 
-    results.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    // Sort newest first; tiebreak by correlationId for stable ordering
+    results.sort((a, b) => {
+      const dt = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+      if (dt !== 0) return dt;
+      return a.correlationId.localeCompare(b.correlationId);
+    });
 
     const offset = options.offset ?? 0;
     const limit = options.limit ?? 100;


### PR DESCRIPTION
## Lane C-lite: Trace List Hardening

Two cheap hardening items for the `GET /pilot/traces` endpoint shipped in PR #511.

### Changes

| Item | What | Why |
|------|------|-----|
| **Stable sort tiebreak** | Sort by `timestamp DESC, correlationId ASC` | Deterministic pagination when events share a timestamp |
| **Default 30d retention window** | `from=now-30d` when caller specifies neither `from` nor `to` | Prevents unbounded full-table scans |

### Files Changed (6)

- `os-platform/core/trace/TraceStore.ts` — `InMemoryTraceStore.query()` + `FileTraceStore.query()` tiebreaker
- `os-platform/core/trace/TraceService.ts` — `TraceService.query()` tiebreaker
- `os-platform/core/api/PilotController.ts` — `effectiveFrom = from ?? now-30d`
- `os-platform/core/trace/TraceStore.js` + `TraceService.js` — rebuilt via `build:core-js`
- `os-platform/core/tests/trace-list-query.test.mjs` — +1 tiebreak determinism test

### Evidence

| Gate | Result |
|------|--------|
| `pnpm run type-check` | 0 errors |
| Core tests (phase83/85/86 + trace-list) | 78/78 pass |
| New tiebreak test | deterministic across repeated runs |

AI-Collaboration: GitHub Copilot (Lane C-lite)

## Summary by Sourcery

Ensure deterministic ordering and sane defaults for trace list queries to harden the trace listing endpoint.

Enhancements:
- Add correlationId-based tiebreaker to trace query sorting so traces with identical timestamps have stable ordering.
- Apply a default 30-day lookback window for trace queries when no from/to bounds are specified to avoid unbounded scans.

Tests:
- Add a trace store test verifying deterministic ordering when multiple events share the same timestamp.