### PR TITLE
feat(trace): Lane D — Retention Pruning, Parcel Index, Ops Stats

### DIFF
--- a/os-platform/core/api/PilotController.ts
+++ b/os-platform/core/api/PilotController.ts
@@ -652,7 +652,39 @@ export function createPilotRouter(runner?: ToolRunner): Router {
     return res.json({
       events: visibleEvents,
       pagination: { offset, limit, returned: visibleEvents.length },
+      nextCursor: null, // Reserved for future cursor-based pagination
     });
+  });
+
+  /**
+   * GET /pilot/traces/stats
+   *
+   * Trace store statistics for operability dashboards.
+   * Returns total event count, oldest/newest timestamps.
+   * Requires elevated trace role (admin, compliance_officer).
+   */
+  router.get('/traces/stats', async (req: AuthenticatedRequest, res: Response) => {
+    const user = req.user ?? {
+      userId: 'anonymous',
+      roles: ['viewer'],
+      countyId: 'benton',
+    };
+
+    const principal: TraceAccessPrincipal = {
+      userId: user.userId,
+      roles: user.roles,
+      countyId: user.countyId,
+    };
+
+    if (!hasElevatedTraceRole(principal)) {
+      return res.status(403).json({
+        error: 'ACCESS_DENIED',
+        message: 'Trace stats require elevated role',
+      });
+    }
+
+    const stats = await traceService.stats();
+    return res.json(stats);
   });
 
   /**

--- a/os-platform/core/tests/lane-d-trace-operability.test.mjs
+++ b/os-platform/core/tests/lane-d-trace-operability.test.mjs
@@ -1,0 +1,352 @@
+/**
+ * TerraFusion OS – Lane D: Trace Operability + Retention Enforcement Tests
+ *
+ * Tests for:
+ *   1. Retention pruning (prune removes old events, keeps recent)
+ *   2. Bounded growth (ring buffer + maxEvents cap)
+ *   3. Parcel index correctness (O(1) lookup, rebuild after prune)
+ *   4. Store stats (totalEvents, oldest/newest timestamps)
+ *   5. FileTraceStore prune (rewrites file with survivors)
+ *   6. TraceService prune + stats delegation
+ *
+ * Run: node --test os-platform/core/tests/lane-d-trace-operability.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { before, after, describe, it } from 'node:test';
+
+// ============================================================================
+// Dynamic imports for ESM compatibility
+// ============================================================================
+
+let InMemoryTraceStore, FileTraceStore, TraceService;
+
+before(async () => {
+  const traceModule = await import('../trace/index.js');
+  const trace = traceModule.default || traceModule;
+  InMemoryTraceStore = trace.InMemoryTraceStore;
+  FileTraceStore = trace.FileTraceStore;
+  TraceService = trace.TraceService;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const TEST_DIR = join(tmpdir(), `lane-d-test-${Date.now()}`);
+
+function tempFile(name) {
+  return join(TEST_DIR, `${name}-${randomUUID().slice(0, 8)}.jsonl`);
+}
+
+function makeEvent(overrides = {}) {
+  return {
+    eventId: overrides.eventId ?? randomUUID(),
+    type: overrides.type ?? 'tool_invoked',
+    toolId: overrides.toolId ?? 'test_tool',
+    correlationId: overrides.correlationId ?? `corr-${randomUUID().slice(0, 8)}`,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    schemaVersion: '1.0.0',
+    summary: overrides.summary ?? 'test event',
+    context: {
+      countyId: overrides.countyId ?? 'benton',
+      userId: overrides.userId ?? 'test-user',
+      sessionId: 'sess-001',
+      parcelId: overrides.parcelId ?? undefined,
+      dossierId: overrides.dossierId ?? undefined,
+      ...(overrides.context || {}),
+    },
+  };
+}
+
+/** Create a timestamp N ms ago */
+function ago(ms) {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+before(() => {
+  if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+});
+
+after(() => {
+  try { rmSync(TEST_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// InMemoryTraceStore — prune
+// ══════════════════════════════════════════════════════════════════════
+
+describe('InMemoryTraceStore: prune()', () => {
+  it('removes events older than retention window', async () => {
+    const store = new InMemoryTraceStore();
+    const old = makeEvent({ timestamp: ago(60_000) }); // 60s ago
+    const recent = makeEvent({ timestamp: new Date().toISOString() });
+
+    await store.append(old);
+    await store.append(recent);
+
+    const removed = await store.prune(30_000); // 30s window
+    assert.equal(removed, 1);
+    assert.equal(await store.count(), 1);
+
+    const remaining = await store.query({});
+    assert.equal(remaining[0].eventId, recent.eventId);
+  });
+
+  it('returns 0 when nothing to prune', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ timestamp: new Date().toISOString() }));
+    const removed = await store.prune(60_000);
+    assert.equal(removed, 0);
+  });
+
+  it('prunes all events when retention is 0', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ timestamp: ago(1) }));
+    await store.append(makeEvent({ timestamp: ago(1) }));
+    // Small delay so events are in the past
+    await new Promise(r => setTimeout(r, 5));
+    const removed = await store.prune(0);
+    assert.equal(removed, 2);
+    assert.equal(await store.count(), 0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// InMemoryTraceStore — parcel index
+// ══════════════════════════════════════════════════════════════════════
+
+describe('InMemoryTraceStore: parcel index', () => {
+  it('returns indexed events for parcelId query', async () => {
+    const store = new InMemoryTraceStore();
+    const e1 = makeEvent({ parcelId: 'P-100', toolId: 'tool_a' });
+    const e2 = makeEvent({ parcelId: 'P-200', toolId: 'tool_b' });
+    const e3 = makeEvent({ parcelId: 'P-100', toolId: 'tool_c' });
+
+    await store.append(e1);
+    await store.append(e2);
+    await store.append(e3);
+
+    const results = await store.query({ parcelId: 'P-100' });
+    assert.equal(results.length, 2);
+    const toolIds = results.map(e => e.toolId).sort();
+    assert.deepEqual(toolIds, ['tool_a', 'tool_c']);
+  });
+
+  it('returns empty for nonexistent parcelId', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ parcelId: 'P-100' }));
+    const results = await store.query({ parcelId: 'P-999' });
+    assert.equal(results.length, 0);
+  });
+
+  it('rebuilds index after prune', async () => {
+    const store = new InMemoryTraceStore();
+    const old = makeEvent({ parcelId: 'P-100', timestamp: ago(60_000) });
+    const recent = makeEvent({ parcelId: 'P-100', timestamp: new Date().toISOString() });
+
+    await store.append(old);
+    await store.append(recent);
+
+    await store.prune(30_000);
+    const results = await store.query({ parcelId: 'P-100' });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].eventId, recent.eventId);
+  });
+
+  it('clears parcel index on clear()', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ parcelId: 'P-100' }));
+    store.clear();
+    const results = await store.query({ parcelId: 'P-100' });
+    assert.equal(results.length, 0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// InMemoryTraceStore — bounded growth
+// ══════════════════════════════════════════════════════════════════════
+
+describe('InMemoryTraceStore: bounded growth', () => {
+  it('trims oldest events when maxEvents exceeded', async () => {
+    const store = new InMemoryTraceStore({ maxEvents: 5 });
+    for (let i = 0; i < 8; i++) {
+      await store.append(makeEvent({ toolId: `tool_${i}` }));
+    }
+    assert.equal(await store.count(), 5);
+
+    // Should retain the 5 newest (tool_3 through tool_7)
+    const results = await store.query({ limit: 10 });
+    const toolIds = results.map(e => e.toolId).sort();
+    assert.ok(toolIds.includes('tool_7'));
+    assert.ok(!toolIds.includes('tool_0'));
+  });
+
+  it('parcel index is correct after trim', async () => {
+    const store = new InMemoryTraceStore({ maxEvents: 3 });
+    await store.append(makeEvent({ parcelId: 'P-1', toolId: 'old_a' }));
+    await store.append(makeEvent({ parcelId: 'P-1', toolId: 'old_b' }));
+    await store.append(makeEvent({ parcelId: 'P-2', toolId: 'mid' }));
+    // This triggers trim — old_a gets dropped
+    await store.append(makeEvent({ parcelId: 'P-1', toolId: 'new_a' }));
+
+    const p1 = await store.query({ parcelId: 'P-1' });
+    // old_a trimmed, old_b + new_a remain
+    assert.equal(p1.length, 2);
+    const toolIds = p1.map(e => e.toolId).sort();
+    assert.deepEqual(toolIds, ['new_a', 'old_b']);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// InMemoryTraceStore — stats
+// ══════════════════════════════════════════════════════════════════════
+
+describe('InMemoryTraceStore: stats()', () => {
+  it('returns null timestamps when empty', async () => {
+    const store = new InMemoryTraceStore();
+    const s = await store.stats();
+    assert.equal(s.totalEvents, 0);
+    assert.equal(s.oldestTimestamp, null);
+    assert.equal(s.newestTimestamp, null);
+  });
+
+  it('reports correct oldest/newest', async () => {
+    const store = new InMemoryTraceStore();
+    const t1 = '2025-01-01T00:00:00.000Z';
+    const t2 = '2025-06-15T12:00:00.000Z';
+    const t3 = '2025-12-31T23:59:59.999Z';
+
+    await store.append(makeEvent({ timestamp: t2 }));
+    await store.append(makeEvent({ timestamp: t1 }));
+    await store.append(makeEvent({ timestamp: t3 }));
+
+    const s = await store.stats();
+    assert.equal(s.totalEvents, 3);
+    assert.equal(s.oldestTimestamp, t1);
+    assert.equal(s.newestTimestamp, t3);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// FileTraceStore — prune + stats
+// ══════════════════════════════════════════════════════════════════════
+
+describe('FileTraceStore: prune()', () => {
+  it('removes old events and rewrites file', async () => {
+    const fp = tempFile('prune');
+    const store = new FileTraceStore({ filePath: fp });
+
+    const old = makeEvent({ timestamp: ago(60_000) });
+    const recent = makeEvent({ timestamp: new Date().toISOString() });
+
+    await store.append(old);
+    await store.append(recent);
+
+    const removed = await store.prune(30_000);
+    assert.equal(removed, 1);
+
+    // Verify file was rewritten — only 1 line
+    const raw = readFileSync(fp, 'utf-8').trim();
+    const lines = raw.split('\n').filter(l => l.trim().length > 0);
+    assert.equal(lines.length, 1);
+    const persisted = JSON.parse(lines[0]);
+    assert.equal(persisted.eventId, recent.eventId);
+  });
+});
+
+describe('FileTraceStore: stats()', () => {
+  it('reports correct stats from file', async () => {
+    const fp = tempFile('stats');
+    const store = new FileTraceStore({ filePath: fp });
+
+    const t1 = '2025-03-01T00:00:00.000Z';
+    const t2 = '2025-09-01T00:00:00.000Z';
+
+    await store.append(makeEvent({ timestamp: t1 }));
+    await store.append(makeEvent({ timestamp: t2 }));
+
+    const s = await store.stats();
+    assert.equal(s.totalEvents, 2);
+    assert.equal(s.oldestTimestamp, t1);
+    assert.equal(s.newestTimestamp, t2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// TraceService — prune + stats delegation
+// ══════════════════════════════════════════════════════════════════════
+
+describe('TraceService: prune()', () => {
+  it('prunes ring buffer events older than window', async () => {
+    const store = new InMemoryTraceStore();
+    const svc = new TraceService({ store, retentionMs: 30_000 });
+
+    // Emit two events with different ages
+    svc.emit({
+      type: 'tool_invoked',
+      toolId: 'old_tool',
+      correlationId: 'c1',
+      summary: 'old',
+      context: { countyId: 'benton', userId: 'u1', sessionId: 's1' },
+    });
+    svc.emit({
+      type: 'tool_invoked',
+      toolId: 'new_tool',
+      correlationId: 'c2',
+      summary: 'new',
+      context: { countyId: 'benton', userId: 'u1', sessionId: 's1' },
+    });
+
+    // Backdate the first ring buffer event
+    const events = svc.query({});
+    if (events.length >= 2) {
+      // The ring buffer is internal; we can only test via prune with a future-leaning window
+      // Since both events have "now" timestamps, prune(30_000) should remove nothing
+      const removed = await svc.prune();
+      assert.equal(removed, 0);
+    }
+  });
+
+  it('delegates to store prune', async () => {
+    const store = new InMemoryTraceStore();
+    const old = makeEvent({ timestamp: ago(60_000) });
+    const recent = makeEvent({ timestamp: new Date().toISOString() });
+    await store.append(old);
+    await store.append(recent);
+
+    const svc = new TraceService({ store, retentionMs: 30_000 });
+    const removed = await svc.prune();
+    assert.ok(removed >= 1, 'should prune at least the old event from store');
+  });
+});
+
+describe('TraceService: stats()', () => {
+  it('delegates to store stats', async () => {
+    const store = new InMemoryTraceStore();
+    const t1 = '2025-01-15T00:00:00.000Z';
+    await store.append(makeEvent({ timestamp: t1 }));
+
+    const svc = new TraceService({ store });
+    const s = await svc.stats();
+    assert.equal(s.totalEvents, 1);
+    assert.equal(s.oldestTimestamp, t1);
+  });
+
+  it('returns ring buffer stats when no store', async () => {
+    const svc = new TraceService({});
+    svc.emit({
+      type: 'tool_invoked',
+      toolId: 'test',
+      correlationId: 'c1',
+      summary: 'test',
+      context: { countyId: 'benton', userId: 'u1', sessionId: 's1' },
+    });
+
+    const s = await svc.stats();
+    assert.equal(s.totalEvents, 1);
+    assert.ok(s.oldestTimestamp !== null);
+  });
+});

--- a/os-platform/core/trace/TraceService.js
+++ b/os-platform/core/trace/TraceService.js
@@ -72,6 +72,7 @@ class TraceService {
         this.enablePayloadStore = options.enablePayloadStore ?? true;
         this.payloadStore = new PayloadReferenceStore();
         this.store = options.store;
+        this.retentionMs = options.retentionMs;
     }
     /**
      * Emit a trace event.
@@ -252,6 +253,48 @@ class TraceService {
             summary: `Ticket ${ticketId} created. Awaiting secure deletion of ${targetPayloadRefs.length} payload(s).`,
         });
         return { requestEvent, ticketEvent, ticketId };
+    }
+    /**
+     * Prune events older than the configured retention window (or explicit retentionMs).
+     * Prunes both in-memory ring buffer and persistent store.
+     * Returns total events removed.
+     */
+    async prune(retentionMs) {
+        const window = retentionMs ?? this.retentionMs;
+        if (!window || window <= 0)
+            return 0;
+        const cutoff = Date.now() - window;
+        // Prune ring buffer
+        const before = this.events.length;
+        this.events = this.events.filter(e => new Date(e.timestamp).getTime() >= cutoff);
+        let removed = before - this.events.length;
+        // Prune persistent store
+        if (this.store) {
+            removed += await this.store.prune(window);
+        }
+        return removed;
+    }
+    /**
+     * Get store statistics.
+     * When persistent store is configured, delegates to it.
+     * Otherwise reports ring buffer stats.
+     */
+    async stats() {
+        if (this.store) {
+            return this.store.stats();
+        }
+        if (this.events.length === 0) {
+            return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+        }
+        let oldest = this.events[0].timestamp;
+        let newest = this.events[0].timestamp;
+        for (const e of this.events) {
+            if (e.timestamp < oldest)
+                oldest = e.timestamp;
+            if (e.timestamp > newest)
+                newest = e.timestamp;
+        }
+        return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
     }
     /**
      * Clear all events (for testing only).

--- a/os-platform/core/trace/TraceService.ts
+++ b/os-platform/core/trace/TraceService.ts
@@ -16,6 +16,7 @@ import type {
     TraceQueryOptions,
 } from '../types/index.js';
 import type { TraceStore } from './TraceStore.js';
+import type { TraceStoreStats } from './TraceStore.js';
 
 // ============================================================================
 // Constants
@@ -96,6 +97,8 @@ export interface TraceServiceOptions {
   enablePayloadStore?: boolean;
   /** Optional persistent store. When set, events are persisted via TraceStore. */
   store?: TraceStore;
+  /** Retention window in ms. When set, prune() removes events older than this on demand. */
+  retentionMs?: number;
 }
 
 export class TraceService {
@@ -104,12 +107,14 @@ export class TraceService {
   private payloadStore: PayloadReferenceStore;
   private enablePayloadStore: boolean;
   private store: TraceStore | undefined;
+  private retentionMs: number | undefined;
 
   constructor(options: TraceServiceOptions = {}) {
     this.ringBufferSize = options.ringBufferSize ?? DEFAULT_RING_BUFFER_SIZE;
     this.enablePayloadStore = options.enablePayloadStore ?? true;
     this.payloadStore = new PayloadReferenceStore();
     this.store = options.store;
+    this.retentionMs = options.retentionMs;
   }
 
   /**
@@ -321,6 +326,49 @@ export class TraceService {
     });
 
     return { requestEvent, ticketEvent, ticketId };
+  }
+
+  /**
+   * Prune events older than the configured retention window (or explicit retentionMs).
+   * Prunes both in-memory ring buffer and persistent store.
+   * Returns total events removed.
+   */
+  async prune(retentionMs?: number): Promise<number> {
+    const window = retentionMs ?? this.retentionMs;
+    if (!window || window <= 0) return 0;
+    const cutoff = Date.now() - window;
+    // Prune ring buffer
+    const before = this.events.length;
+    this.events = this.events.filter(
+      e => new Date(e.timestamp).getTime() >= cutoff
+    );
+    let removed = before - this.events.length;
+    // Prune persistent store
+    if (this.store) {
+      removed += await this.store.prune(window);
+    }
+    return removed;
+  }
+
+  /**
+   * Get store statistics.
+   * When persistent store is configured, delegates to it.
+   * Otherwise reports ring buffer stats.
+   */
+  async stats(): Promise<TraceStoreStats> {
+    if (this.store) {
+      return this.store.stats();
+    }
+    if (this.events.length === 0) {
+      return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+    }
+    let oldest = this.events[0].timestamp;
+    let newest = this.events[0].timestamp;
+    for (const e of this.events) {
+      if (e.timestamp < oldest) oldest = e.timestamp;
+      if (e.timestamp > newest) newest = e.timestamp;
+    }
+    return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
   }
 
   /**

--- a/os-platform/core/trace/TraceStore.js
+++ b/os-platform/core/trace/TraceStore.js
@@ -17,20 +17,58 @@ const path_1 = require("path");
 class InMemoryTraceStore {
     constructor(options = {}) {
         this.events = [];
+        /** Parcel index: parcelId → set of array indices for O(1) lookup */
+        this.parcelIndex = new Map();
         this.maxEvents = options.maxEvents ?? 10000;
     }
     async append(event) {
         this.events.push(event);
+        // Update parcel index
+        const pid = event.context.parcelId;
+        if (pid) {
+            if (!this.parcelIndex.has(pid))
+                this.parcelIndex.set(pid, new Set());
+            this.parcelIndex.get(pid).add(this.events.length - 1);
+        }
         // Trim if over capacity
         if (this.events.length > this.maxEvents) {
             const trimCount = this.events.length - this.maxEvents;
+            this.rebuildIndex(trimCount);
             this.events.splice(0, trimCount);
         }
         return event;
     }
+    /** Rebuild parcel index after trimming first N events */
+    rebuildIndex(trimCount) {
+        this.parcelIndex.clear();
+        for (let i = trimCount; i < this.events.length; i++) {
+            const pid = this.events[i].context.parcelId;
+            if (pid) {
+                if (!this.parcelIndex.has(pid))
+                    this.parcelIndex.set(pid, new Set());
+                this.parcelIndex.get(pid).add(i - trimCount);
+            }
+        }
+    }
     async query(options = {}) {
-        let results = [...this.events];
-        // Apply filters
+        // Use parcel index for the hot path when parcelId is specified
+        let results;
+        if (options.parcelId && this.parcelIndex.has(options.parcelId)) {
+            const indices = this.parcelIndex.get(options.parcelId);
+            results = [];
+            for (const idx of indices) {
+                if (idx < this.events.length)
+                    results.push(this.events[idx]);
+            }
+        }
+        else if (options.parcelId) {
+            // parcelId specified but not in index — empty result
+            results = [];
+        }
+        else {
+            results = [...this.events];
+        }
+        // Apply remaining filters
         if (options.toolId) {
             results = results.filter(e => e.toolId === options.toolId);
         }
@@ -40,11 +78,15 @@ class InMemoryTraceStore {
         if (options.type) {
             results = results.filter(e => e.type === options.type);
         }
-        if (options.parcelId) {
-            results = results.filter(e => e.context.parcelId === options.parcelId);
-        }
-        if (options.dossierId) {
+        if (!options.parcelId && options.dossierId) {
+            // parcelId already handled above; dossierId is a separate filter
             results = results.filter(e => e.context.dossierId === options.dossierId);
+        }
+        if (options.parcelId) {
+            // dossierId filter still applies even when parcel-indexed
+            if (options.dossierId) {
+                results = results.filter(e => e.context.dossierId === options.dossierId);
+            }
         }
         if (options.from) {
             const fromMs = new Date(options.from).getTime();
@@ -92,11 +134,35 @@ class InMemoryTraceStore {
     async healthy() {
         return true;
     }
+    async prune(retentionMs) {
+        const cutoff = Date.now() - retentionMs;
+        const before = this.events.length;
+        this.events = this.events.filter(e => new Date(e.timestamp).getTime() >= cutoff);
+        const removed = before - this.events.length;
+        if (removed > 0)
+            this.rebuildIndex(0);
+        return removed;
+    }
+    async stats() {
+        if (this.events.length === 0) {
+            return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+        }
+        let oldest = this.events[0].timestamp;
+        let newest = this.events[0].timestamp;
+        for (const e of this.events) {
+            if (e.timestamp < oldest)
+                oldest = e.timestamp;
+            if (e.timestamp > newest)
+                newest = e.timestamp;
+        }
+        return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
+    }
     /**
      * Clear all events (for testing).
      */
     clear() {
         this.events = [];
+        this.parcelIndex.clear();
     }
 }
 exports.InMemoryTraceStore = InMemoryTraceStore;
@@ -230,6 +296,34 @@ class FileTraceStore {
     }
     async close() {
         // No-op — sync writes mean nothing to flush
+    }
+    async prune(retentionMs) {
+        this.ensureLoaded();
+        const cutoff = Date.now() - retentionMs;
+        const before = this.events.length;
+        this.events = this.events.filter(e => new Date(e.timestamp).getTime() >= cutoff);
+        const removed = before - this.events.length;
+        if (removed > 0) {
+            // Rewrite file with surviving events
+            const lines = this.events.map(e => JSON.stringify(e)).join('\n');
+            (0, fs_1.writeFileSync)(this.filePath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+        }
+        return removed;
+    }
+    async stats() {
+        this.ensureLoaded();
+        if (this.events.length === 0) {
+            return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+        }
+        let oldest = this.events[0].timestamp;
+        let newest = this.events[0].timestamp;
+        for (const e of this.events) {
+            if (e.timestamp < oldest)
+                oldest = e.timestamp;
+            if (e.timestamp > newest)
+                newest = e.timestamp;
+        }
+        return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
     }
     /** Clear events (testing only — rewrites the file) */
     clear() {

--- a/os-platform/core/trace/TraceStore.ts
+++ b/os-platform/core/trace/TraceStore.ts
@@ -61,6 +61,27 @@ export interface TraceStore {
    * Close the store and release resources (optional).
    */
   close?(): Promise<void>;
+
+  /**
+   * Prune events older than retentionMs from now.
+   * Returns the number of events removed.
+   */
+  prune(retentionMs: number): Promise<number>;
+
+  /**
+   * Get store statistics for observability.
+   */
+  stats(): Promise<TraceStoreStats>;
+}
+
+// ============================================================================
+// Store Stats (for ops/health endpoints)
+// ============================================================================
+
+export interface TraceStoreStats {
+  totalEvents: number;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
 }
 
 // ============================================================================
@@ -75,6 +96,8 @@ export interface InMemoryTraceStoreOptions {
 export class InMemoryTraceStore implements TraceStore {
   private events: TraceEvent[] = [];
   private maxEvents: number;
+  /** Parcel index: parcelId → set of array indices for O(1) lookup */
+  private parcelIndex: Map<string, Set<number>> = new Map();
 
   constructor(options: InMemoryTraceStoreOptions = {}) {
     this.maxEvents = options.maxEvents ?? 10000;
@@ -82,20 +105,52 @@ export class InMemoryTraceStore implements TraceStore {
 
   async append(event: TraceEvent): Promise<TraceEvent> {
     this.events.push(event);
+    // Update parcel index
+    const pid = event.context.parcelId;
+    if (pid) {
+      if (!this.parcelIndex.has(pid)) this.parcelIndex.set(pid, new Set());
+      this.parcelIndex.get(pid)!.add(this.events.length - 1);
+    }
 
     // Trim if over capacity
     if (this.events.length > this.maxEvents) {
       const trimCount = this.events.length - this.maxEvents;
+      this.rebuildIndex(trimCount);
       this.events.splice(0, trimCount);
     }
 
     return event;
   }
 
-  async query(options: TraceQueryOptions = {}): Promise<TraceEvent[]> {
-    let results = [...this.events];
+  /** Rebuild parcel index after trimming first N events */
+  private rebuildIndex(trimCount: number): void {
+    this.parcelIndex.clear();
+    for (let i = trimCount; i < this.events.length; i++) {
+      const pid = this.events[i].context.parcelId;
+      if (pid) {
+        if (!this.parcelIndex.has(pid)) this.parcelIndex.set(pid, new Set());
+        this.parcelIndex.get(pid)!.add(i - trimCount);
+      }
+    }
+  }
 
-    // Apply filters
+  async query(options: TraceQueryOptions = {}): Promise<TraceEvent[]> {
+    // Use parcel index for the hot path when parcelId is specified
+    let results: TraceEvent[];
+    if (options.parcelId && this.parcelIndex.has(options.parcelId)) {
+      const indices = this.parcelIndex.get(options.parcelId)!;
+      results = [];
+      for (const idx of indices) {
+        if (idx < this.events.length) results.push(this.events[idx]);
+      }
+    } else if (options.parcelId) {
+      // parcelId specified but not in index — empty result
+      results = [];
+    } else {
+      results = [...this.events];
+    }
+
+    // Apply remaining filters
     if (options.toolId) {
       results = results.filter(e => e.toolId === options.toolId);
     }
@@ -105,11 +160,15 @@ export class InMemoryTraceStore implements TraceStore {
     if (options.type) {
       results = results.filter(e => e.type === options.type);
     }
-    if (options.parcelId) {
-      results = results.filter(e => e.context.parcelId === options.parcelId);
-    }
-    if (options.dossierId) {
+    if (!options.parcelId && options.dossierId) {
+      // parcelId already handled above; dossierId is a separate filter
       results = results.filter(e => e.context.dossierId === options.dossierId);
+    }
+    if (options.parcelId) {
+      // dossierId filter still applies even when parcel-indexed
+      if (options.dossierId) {
+        results = results.filter(e => e.context.dossierId === options.dossierId);
+      }
     }
     if (options.from) {
       const fromMs = new Date(options.from).getTime();
@@ -171,11 +230,36 @@ export class InMemoryTraceStore implements TraceStore {
     return true;
   }
 
+  async prune(retentionMs: number): Promise<number> {
+    const cutoff = Date.now() - retentionMs;
+    const before = this.events.length;
+    this.events = this.events.filter(
+      e => new Date(e.timestamp).getTime() >= cutoff
+    );
+    const removed = before - this.events.length;
+    if (removed > 0) this.rebuildIndex(0);
+    return removed;
+  }
+
+  async stats(): Promise<TraceStoreStats> {
+    if (this.events.length === 0) {
+      return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+    }
+    let oldest = this.events[0].timestamp;
+    let newest = this.events[0].timestamp;
+    for (const e of this.events) {
+      if (e.timestamp < oldest) oldest = e.timestamp;
+      if (e.timestamp > newest) newest = e.timestamp;
+    }
+    return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
+  }
+
   /**
    * Clear all events (for testing).
    */
   clear(): void {
     this.events = [];
+    this.parcelIndex.clear();
   }
 }
 
@@ -341,6 +425,36 @@ export class FileTraceStore implements TraceStore {
 
   async close(): Promise<void> {
     // No-op — sync writes mean nothing to flush
+  }
+
+  async prune(retentionMs: number): Promise<number> {
+    this.ensureLoaded();
+    const cutoff = Date.now() - retentionMs;
+    const before = this.events.length;
+    this.events = this.events.filter(
+      e => new Date(e.timestamp).getTime() >= cutoff
+    );
+    const removed = before - this.events.length;
+    if (removed > 0) {
+      // Rewrite file with surviving events
+      const lines = this.events.map(e => JSON.stringify(e)).join('\n');
+      writeFileSync(this.filePath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+    }
+    return removed;
+  }
+
+  async stats(): Promise<TraceStoreStats> {
+    this.ensureLoaded();
+    if (this.events.length === 0) {
+      return { totalEvents: 0, oldestTimestamp: null, newestTimestamp: null };
+    }
+    let oldest = this.events[0].timestamp;
+    let newest = this.events[0].timestamp;
+    for (const e of this.events) {
+      if (e.timestamp < oldest) oldest = e.timestamp;
+      if (e.timestamp > newest) newest = e.timestamp;
+    }
+    return { totalEvents: this.events.length, oldestTimestamp: oldest, newestTimestamp: newest };
   }
 
   /** Clear events (testing only — rewrites the file) */

--- a/os-platform/core/trace/index.ts
+++ b/os-platform/core/trace/index.ts
@@ -20,6 +20,7 @@ export {
     type InMemoryTraceStoreOptions,
     type TraceStore,
     type TraceStoreConfig,
+    type TraceStoreStats,
     type TraceStoreType
 } from './TraceStore.js';
 


### PR DESCRIPTION
## Lane D: Trace Operability + Retention Enforcement

### Deliverables

1. **Retention enforcement at storage** — prune(retentionMs) on TraceStore interface + both implementations + TraceService. Removes events older than the retention window; FileTraceStore rewrites the file with survivors.

2. **Index/query plan hardening** — parcelIndex: Map<string, Set<number>> on InMemoryTraceStore for O(1) parcel-scoped lookups. Index rebuilt on trim, prune, and clear.

3. **Contract tightening** — 
extCursor: null reserved in /pilot/traces response for future cursor-based pagination. rom > to validation already present from Lane A.

4. **Ops hooks** — GET /pilot/traces/stats (elevated role required) returning { totalEvents, oldestTimestamp, newestTimestamp }. stats() on TraceStore + TraceService.

### Non-goals (deferred)
- Cursor pagination (reserved field only)
- New UI filtering
- Multi-tenant auth changes

### Evidence
- Tests: 17/17 new (lane-d-trace-operability.test.mjs) + 69/69 existing trace + 32/32 phase83
- Gates: type-check 0 errors, build:core-js pass, vitest 164/164

### Files Changed
- \os-platform/core/trace/TraceStore.ts\ — interface + both implementations
- \os-platform/core/trace/TraceService.ts\ — prune + stats delegation
- \os-platform/core/trace/index.ts\ — TraceStoreStats export
- \os-platform/core/api/PilotController.ts\ — nextCursor + /traces/stats endpoint
- \os-platform/core/tests/lane-d-trace-operability.test.mjs\ — 17 new tests
