### PR TITLE
feat(trace): Lane E — Authorization Audit Trail + Access-Denied Metrics

### DIFF
--- a/os-platform/core/api/PilotController.ts
+++ b/os-platform/core/api/PilotController.ts
@@ -630,6 +630,23 @@ export function createPilotRouter(runner?: ToolRunner): Router {
       countyId: user.countyId,
     };
 
+    // Audit: emit trace_accessed event for this request
+    // NOTE: parcelId intentionally omitted from context to prevent audit events
+    // from appearing in parcel-scoped queries (avoids audit noise in feed)
+    const accessCorrelationId = `trace-list-${randomUUID().slice(0, 8)}`;
+    traceService.emit({
+      type: 'trace_accessed',
+      toolId: 'pilot:traces:list',
+      correlationId: accessCorrelationId,
+      summary: `Trace list accessed: parcelId=${parcelId}`,
+      context: {
+        countyId: principal.countyId,
+        userId: principal.userId,
+        sessionId: '',
+        mode: 'pilot',
+      },
+    });
+
     // Query trace events (async path for persistent store)
     const events = await traceService.queryAsync({
       parcelId,
@@ -641,13 +658,39 @@ export function createPilotRouter(runner?: ToolRunner): Router {
     });
 
     // Filter by county isolation + access control
+    let filteredCount = 0;
     const visibleEvents = events.filter(e => {
       // Always deny cross-county
-      if (e.context.countyId.toLowerCase() !== principal.countyId.toLowerCase()) return false;
+      if (e.context.countyId.toLowerCase() !== principal.countyId.toLowerCase()) {
+        recordAccessDenied('cross_county');
+        filteredCount++;
+        return false;
+      }
       // Elevated roles see all in-county; others only own
       if (hasElevatedTraceRole(principal)) return true;
-      return e.context.userId === principal.userId;
+      if (e.context.userId !== principal.userId) {
+        recordAccessDenied('user_mismatch');
+        filteredCount++;
+        return false;
+      }
+      return true;
     });
+
+    // Audit: emit permission_denied if events were filtered out
+    if (filteredCount > 0) {
+      traceService.emit({
+        type: 'permission_denied',
+        toolId: 'pilot:traces:list',
+        correlationId: accessCorrelationId,
+        summary: `Trace list: ${filteredCount} event(s) filtered by access control`,
+        context: {
+          countyId: principal.countyId,
+          userId: principal.userId,
+          sessionId: '',
+          mode: 'pilot',
+        },
+      });
+    }
 
     return res.json({
       events: visibleEvents,
@@ -677,11 +720,38 @@ export function createPilotRouter(runner?: ToolRunner): Router {
     };
 
     if (!hasElevatedTraceRole(principal)) {
+      traceService.emit({
+        type: 'permission_denied',
+        toolId: 'pilot:traces:stats',
+        correlationId: `trace-stats-${randomUUID().slice(0, 8)}`,
+        summary: `Trace stats access denied: user=${principal.userId}`,
+        context: {
+          countyId: principal.countyId,
+          userId: principal.userId,
+          sessionId: '',
+          mode: 'pilot',
+        },
+      });
+      recordAccessDenied('user_mismatch');
       return res.status(403).json({
         error: 'ACCESS_DENIED',
         message: 'Trace stats require elevated role',
       });
     }
+
+    // Audit: emit trace_accessed for stats
+    traceService.emit({
+      type: 'trace_accessed',
+      toolId: 'pilot:traces:stats',
+      correlationId: `trace-stats-${randomUUID().slice(0, 8)}`,
+      summary: `Trace stats accessed by ${principal.userId}`,
+      context: {
+        countyId: principal.countyId,
+        userId: principal.userId,
+        sessionId: '',
+        mode: 'pilot',
+      },
+    });
 
     const stats = await traceService.stats();
     return res.json(stats);

--- a/os-platform/core/tests/lane-e-trace-authz.test.mjs
+++ b/os-platform/core/tests/lane-e-trace-authz.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * TerraFusion OS – Lane E: Trace Authorization + Audit Tests
+ *
+ * Tests for:
+ *   1. trace_accessed / permission_denied event types are valid TraceEventTypes
+ *   2. Access control correctly filters cross-county & cross-user events
+ *   3. Audit trail: trace_accessed events are emittable via TraceService
+ *   4. Audit trail: permission_denied events are emittable via TraceService
+ *   5. Access denied metrics increment on cross-county and user-mismatch
+ *   6. ToolId filtering is bounded by parcelId (no cross-parcel inference)
+ *
+ * Run: node --test os-platform/core/tests/lane-e-trace-authz.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { before, beforeEach, describe, it } from 'node:test';
+
+// ============================================================================
+// Dynamic imports
+// ============================================================================
+
+let TraceService, InMemoryTraceStore;
+let evaluateTraceAccess, filterVisibleTraceEvents, hasElevatedTraceRole;
+let recordAccessDenied, getAccessDeniedMetrics, resetAccessDeniedMetrics;
+
+before(async () => {
+  const trace = await import('../trace/index.js');
+  TraceService = trace.TraceService;
+  InMemoryTraceStore = trace.InMemoryTraceStore;
+  evaluateTraceAccess = trace.evaluateTraceAccess;
+  filterVisibleTraceEvents = trace.filterVisibleTraceEvents;
+  hasElevatedTraceRole = trace.hasElevatedTraceRole;
+  recordAccessDenied = trace.recordAccessDenied;
+  getAccessDeniedMetrics = trace.getAccessDeniedMetrics;
+  resetAccessDeniedMetrics = trace.resetAccessDeniedMetrics;
+});
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const USER_ALICE = { userId: 'alice', roles: ['appraiser'], countyId: 'benton' };
+const USER_BOB = { userId: 'bob', roles: ['appraiser'], countyId: 'benton' };
+const ADMIN_BENTON = { userId: 'admin-b', roles: ['admin'], countyId: 'benton' };
+const ADMIN_YAKIMA = { userId: 'admin-y', roles: ['admin'], countyId: 'yakima' };
+const VIEWER = { userId: 'viewer', roles: ['viewer'], countyId: 'benton' };
+
+function makeEvent(overrides = {}) {
+  return {
+    eventId: randomUUID(),
+    type: overrides.type ?? 'tool_invoked',
+    toolId: overrides.toolId ?? 'test_tool',
+    correlationId: overrides.correlationId ?? `corr-${randomUUID().slice(0, 8)}`,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    schemaVersion: '1.0.0',
+    summary: overrides.summary ?? 'test event',
+    context: {
+      countyId: overrides.countyId ?? 'benton',
+      userId: overrides.userId ?? 'alice',
+      sessionId: 'sess-001',
+      mode: 'pilot',
+      parcelId: overrides.parcelId ?? undefined,
+      ...(overrides.context || {}),
+    },
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// New event types: trace_accessed + permission_denied
+// ══════════════════════════════════════════════════════════════════════
+
+describe('Audit event types', () => {
+  it('trace_accessed is emittable via TraceService', () => {
+    const store = new InMemoryTraceStore();
+    const svc = new TraceService({ store });
+
+    svc.emit({
+      type: 'trace_accessed',
+      toolId: 'pilot:traces:list',
+      correlationId: `trace-list-${randomUUID().slice(0, 8)}`,
+      summary: 'Trace list accessed: parcelId=P-100',
+      context: {
+        countyId: 'benton',
+        userId: 'alice',
+        sessionId: '',
+        mode: 'pilot',
+        parcelId: 'P-100',
+      },
+    });
+
+    const events = svc.query({ type: 'trace_accessed' });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].toolId, 'pilot:traces:list');
+  });
+
+  it('permission_denied is emittable via TraceService', () => {
+    const store = new InMemoryTraceStore();
+    const svc = new TraceService({ store });
+
+    svc.emit({
+      type: 'permission_denied',
+      toolId: 'pilot:traces:list',
+      correlationId: `trace-list-${randomUUID().slice(0, 8)}`,
+      summary: 'Trace list: 3 event(s) filtered by access control',
+      context: {
+        countyId: 'benton',
+        userId: 'bob',
+        sessionId: '',
+        mode: 'pilot',
+        parcelId: 'P-100',
+      },
+    });
+
+    const events = svc.query({ type: 'permission_denied' });
+    assert.equal(events.length, 1);
+    assert.ok(events[0].summary.includes('filtered'));
+  });
+
+  it('trace_accessed for stats endpoint', () => {
+    const store = new InMemoryTraceStore();
+    const svc = new TraceService({ store });
+
+    svc.emit({
+      type: 'trace_accessed',
+      toolId: 'pilot:traces:stats',
+      correlationId: `trace-stats-${randomUUID().slice(0, 8)}`,
+      summary: 'Trace stats accessed by admin-b',
+      context: {
+        countyId: 'benton',
+        userId: 'admin-b',
+        sessionId: '',
+        mode: 'pilot',
+      },
+    });
+
+    const events = svc.query({ type: 'trace_accessed' });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].toolId, 'pilot:traces:stats');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Cross-county isolation for trace list
+// ══════════════════════════════════════════════════════════════════════
+
+describe('Cross-county trace list isolation', () => {
+  it('cross-county events are filtered out', () => {
+    const bentonEvent = makeEvent({ countyId: 'benton', userId: 'alice' });
+    const yakimaEvent = makeEvent({ countyId: 'yakima', userId: 'alice' });
+
+    const visible = filterVisibleTraceEvents(USER_ALICE, [bentonEvent, yakimaEvent]);
+    assert.equal(visible.length, 1);
+    assert.equal(visible[0].context.countyId, 'benton');
+  });
+
+  it('admin cannot see cross-county events', () => {
+    const yakimaEvent = makeEvent({ countyId: 'yakima', userId: 'alice' });
+    const decision = evaluateTraceAccess(ADMIN_BENTON, yakimaEvent);
+    assert.equal(decision.allowed, false);
+    assert.ok(decision.reason.includes('Cross-county'));
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Cross-user isolation for trace list
+// ══════════════════════════════════════════════════════════════════════
+
+describe('Cross-user trace list isolation', () => {
+  it('non-elevated user cannot see other users events', () => {
+    const aliceEvent = makeEvent({ countyId: 'benton', userId: 'alice' });
+    const decision = evaluateTraceAccess(USER_BOB, aliceEvent);
+    assert.equal(decision.allowed, false);
+    assert.ok(decision.reason.includes('cannot view traces'));
+  });
+
+  it('elevated admin CAN see other users events in same county', () => {
+    const aliceEvent = makeEvent({ countyId: 'benton', userId: 'alice' });
+    const decision = evaluateTraceAccess(ADMIN_BENTON, aliceEvent);
+    assert.equal(decision.allowed, true);
+    assert.equal(decision.elevatedAccess, true);
+  });
+
+  it('viewer role has no elevated access', () => {
+    assert.equal(hasElevatedTraceRole(VIEWER), false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// ToolId filtering bounded by parcel (no cross-parcel inference)
+// ══════════════════════════════════════════════════════════════════════
+
+describe('ToolId filtering is parcel-bounded', () => {
+  it('querying with toolId + parcelId returns only matching parcel events', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ parcelId: 'P-100', toolId: 'run_valuation_model' }));
+    await store.append(makeEvent({ parcelId: 'P-200', toolId: 'run_valuation_model' }));
+    await store.append(makeEvent({ parcelId: 'P-100', toolId: 'explain_value_change' }));
+
+    // Query scoped to P-100 + run_valuation_model
+    const results = await store.query({ parcelId: 'P-100', toolId: 'run_valuation_model' });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].context.parcelId, 'P-100');
+    assert.equal(results[0].toolId, 'run_valuation_model');
+  });
+
+  it('toolId filter on wrong parcel returns empty (no existence leak)', async () => {
+    const store = new InMemoryTraceStore();
+    await store.append(makeEvent({ parcelId: 'P-200', toolId: 'secret_tool' }));
+
+    // Query scoped to P-100 — should NOT reveal that secret_tool exists on P-200
+    const results = await store.query({ parcelId: 'P-100', toolId: 'secret_tool' });
+    assert.equal(results.length, 0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Access denied metrics
+// ══════════════════════════════════════════════════════════════════════
+
+describe('Access denied metrics', () => {
+  beforeEach(() => {
+    resetAccessDeniedMetrics();
+  });
+
+  it('records cross_county denials', () => {
+    recordAccessDenied('cross_county');
+    recordAccessDenied('cross_county');
+    const m = getAccessDeniedMetrics();
+    assert.equal(m.total, 2);
+    assert.equal(m.crossCounty, 2);
+    assert.equal(m.userMismatch, 0);
+  });
+
+  it('records user_mismatch denials', () => {
+    recordAccessDenied('user_mismatch');
+    const m = getAccessDeniedMetrics();
+    assert.equal(m.total, 1);
+    assert.equal(m.userMismatch, 1);
+  });
+
+  it('tracks mixed denial types', () => {
+    recordAccessDenied('cross_county');
+    recordAccessDenied('user_mismatch');
+    recordAccessDenied('user_mismatch');
+    const m = getAccessDeniedMetrics();
+    assert.equal(m.total, 3);
+    assert.equal(m.crossCounty, 1);
+    assert.equal(m.userMismatch, 2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Stats endpoint: elevated role gate
+// ══════════════════════════════════════════════════════════════════════
+
+describe('Trace stats: elevated role gate', () => {
+  it('admin has elevated access', () => {
+    assert.equal(hasElevatedTraceRole(ADMIN_BENTON), true);
+  });
+
+  it('viewer does NOT have elevated access', () => {
+    assert.equal(hasElevatedTraceRole(VIEWER), false);
+  });
+
+  it('appraiser does NOT have elevated access', () => {
+    assert.equal(hasElevatedTraceRole(USER_ALICE), false);
+  });
+
+  it('compliance_officer has elevated access', () => {
+    const co = { userId: 'co-1', roles: ['compliance_officer'], countyId: 'benton' };
+    assert.equal(hasElevatedTraceRole(co), true);
+  });
+});

--- a/os-platform/core/types/index.d.ts
+++ b/os-platform/core/types/index.d.ts
@@ -85,7 +85,7 @@ export interface ToolExecutionFailure {
     traceEventId?: string;
 }
 export type ToolExecutionResult<TResult = unknown> = ToolExecutionSuccess<TResult> | ToolExecutionFailure;
-export type TraceEventType = 'tool_invoked' | 'tool_completed' | 'tool_failed' | 'value_changed' | 'status_changed' | 'document_generated' | 'approval_requested' | 'approval_granted' | 'approval_denied' | 'redaction_requested' | 'redaction_ticket_created';
+export type TraceEventType = 'tool_invoked' | 'tool_completed' | 'tool_failed' | 'value_changed' | 'status_changed' | 'document_generated' | 'approval_requested' | 'approval_granted' | 'approval_denied' | 'redaction_requested' | 'redaction_ticket_created' | 'trace_accessed' | 'permission_denied';
 export interface TraceEventInput {
     /** Event type */
     type: TraceEventType;

--- a/os-platform/core/types/index.ts
+++ b/os-platform/core/types/index.ts
@@ -130,7 +130,9 @@ export type TraceEventType =
   | 'approval_granted'
   | 'approval_denied'
   | 'redaction_requested'
-  | 'redaction_ticket_created';
+  | 'redaction_ticket_created'
+  | 'trace_accessed'
+  | 'permission_denied';
 
 export interface TraceEventInput {
   /** Event type */


### PR DESCRIPTION
## Lane E: Authorization + Multi-parcel Safety for Traces

### Deliverables

1. **New TraceEventTypes** — \	race_accessed\ and \permission_denied\ added to the canonical union type (both \.ts\ and \.d.ts\).

2. **Audit trail on /pilot/traces** — Every request emits a \	race_accessed\ event with a unique correlationId. When events are filtered out by access control (cross-county or cross-user), a \permission_denied\ event is also emitted with the count of filtered events.

3. **Access-denied metrics on /pilot/traces** — \ecordAccessDenied()\ now called for each filtered event on the list endpoint (previously only on \/trace/:correlationId\).

4. **Audit trail on /pilot/traces/stats** — Denied requests emit \permission_denied\; successful requests emit \	race_accessed\. Both carry correlationId for trace chain lookup.

5. **ToolId filtering proven parcel-bounded** — Tests prove that querying with a toolId scoped to a different parcel returns empty, preventing cross-parcel existence inference.

### Access Control Rules (unchanged from Phase 7.1)
- Default: user sees only own traces (\ctor.userId === me\)
- Elevated roles (admin, compliance_officer, auditor, supervisor): see any trace in same county
- Cross-county: always denied
- 403 returned (never 404) to prevent existence leaking

### Evidence
- Tests: 17/17 new (lane-e-trace-authz.test.mjs) + 145/145 existing (162 total)
- Gates: type-check 0 errors, build:core-js pass

### Files Changed
- \os-platform/core/types/index.ts\ + \index.d.ts\ — \	race_accessed\, \permission_denied\ event types
- \os-platform/core/api/PilotController.ts\ — audit emission on /traces, /traces/stats
- \os-platform/core/tests/lane-e-trace-authz.test.mjs\ — 17 new tests

## Summary by Sourcery

Add authorization audit trail and access-denied tracking for pilot trace listing and stats endpoints, with new trace event types and coverage tests.

New Features:
- Introduce trace_accessed and permission_denied as canonical trace event types for audit logging.
- Emit audit trace_accessed and permission_denied events on /pilot/traces and /pilot/traces/stats requests with correlation IDs.

Enhancements:
- Record access-denied metrics for each filtered trace event, distinguishing cross-county and user-mismatch denials.
- Enforce and verify parcel-bounded toolId filtering to prevent cross-parcel existence inference in trace queries.

Tests:
- Add lane-e-trace-authz test suite covering audit event emission, access control behavior, access-denied metrics, and parcel-bounded toolId filtering.