### PR TITLE
Lane F: Trace durability — atomic prune, corruption metric, restart correctness

### DIFF
--- a/os-platform/core/tests/lane-f-trace-durability.test.mjs
+++ b/os-platform/core/tests/lane-f-trace-durability.test.mjs
@@ -1,0 +1,286 @@
+/**
+ * TerraFusion OS – Lane F: Trace Durability + Restart Correctness Tests
+ *
+ * Tests for:
+ *   1. Restart persistence: write N events, new instance reads same N
+ *   2. Deterministic ordering after restart
+ *   3. Corruption handling: malformed lines skipped, count exposed
+ *   4. Atomic prune: temp+rename pattern (no partial writes)
+ *   5. Empty file recovery: new store on empty file works
+ *   6. Partial corruption: valid events survive alongside corrupt lines
+ *
+ * Run: node --test os-platform/core/tests/lane-f-trace-durability.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { before, after, describe, it } from 'node:test';
+
+// ============================================================================
+// Dynamic imports
+// ============================================================================
+
+let FileTraceStore, InMemoryTraceStore, TraceService;
+
+before(async () => {
+  const trace = await import('../trace/index.js');
+  FileTraceStore = trace.FileTraceStore;
+  InMemoryTraceStore = trace.InMemoryTraceStore;
+  TraceService = trace.TraceService;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const TEST_DIR = join(tmpdir(), `lane-f-test-${Date.now()}`);
+
+function tempFile(name) {
+  return join(TEST_DIR, `${name}-${randomUUID().slice(0, 8)}.jsonl`);
+}
+
+function makeEvent(overrides = {}) {
+  return {
+    eventId: overrides.eventId ?? randomUUID(),
+    type: overrides.type ?? 'tool_invoked',
+    toolId: overrides.toolId ?? 'test_tool',
+    correlationId: overrides.correlationId ?? `corr-${randomUUID().slice(0, 8)}`,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    schemaVersion: '1.0.0',
+    summary: overrides.summary ?? 'test event',
+    context: {
+      countyId: overrides.countyId ?? 'benton',
+      userId: overrides.userId ?? 'test-user',
+      sessionId: 'sess-001',
+      mode: 'pilot',
+      parcelId: overrides.parcelId ?? undefined,
+      ...(overrides.context || {}),
+    },
+  };
+}
+
+before(() => {
+  if (!existsSync(TEST_DIR)) mkdirSync(TEST_DIR, { recursive: true });
+});
+
+after(() => {
+  try { rmSync(TEST_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Restart persistence
+// ══════════════════════════════════════════════════════════════════════
+
+describe('FileTraceStore: restart persistence', () => {
+  it('new instance reads events written by previous instance', async () => {
+    const fp = tempFile('restart');
+    const store1 = new FileTraceStore({ filePath: fp });
+
+    const e1 = makeEvent({ toolId: 'tool_a', timestamp: '2025-06-01T00:00:00.000Z' });
+    const e2 = makeEvent({ toolId: 'tool_b', timestamp: '2025-06-02T00:00:00.000Z' });
+    const e3 = makeEvent({ toolId: 'tool_c', timestamp: '2025-06-03T00:00:00.000Z' });
+
+    await store1.append(e1);
+    await store1.append(e2);
+    await store1.append(e3);
+
+    // "Restart" — new instance from same file
+    const store2 = new FileTraceStore({ filePath: fp });
+    const count = await store2.count();
+    assert.equal(count, 3);
+
+    const all = await store2.query({ limit: 10 });
+    assert.equal(all.length, 3);
+  });
+
+  it('events are in deterministic order after restart', async () => {
+    const fp = tempFile('order');
+    const store1 = new FileTraceStore({ filePath: fp });
+
+    const e1 = makeEvent({ toolId: 'first', timestamp: '2025-01-01T00:00:00.000Z', correlationId: 'c1' });
+    const e2 = makeEvent({ toolId: 'second', timestamp: '2025-06-01T00:00:00.000Z', correlationId: 'c2' });
+    const e3 = makeEvent({ toolId: 'third', timestamp: '2025-12-01T00:00:00.000Z', correlationId: 'c3' });
+
+    await store1.append(e1);
+    await store1.append(e2);
+    await store1.append(e3);
+
+    // Restart
+    const store2 = new FileTraceStore({ filePath: fp });
+    const results = await store2.query({ limit: 10 });
+
+    // Newest first
+    assert.equal(results[0].toolId, 'third');
+    assert.equal(results[1].toolId, 'second');
+    assert.equal(results[2].toolId, 'first');
+  });
+
+  it('getById works after restart', async () => {
+    const fp = tempFile('getbyid');
+    const store1 = new FileTraceStore({ filePath: fp });
+    const e = makeEvent({ toolId: 'target' });
+    await store1.append(e);
+
+    const store2 = new FileTraceStore({ filePath: fp });
+    const found = await store2.getById(e.eventId);
+    assert.ok(found);
+    assert.equal(found.toolId, 'target');
+  });
+
+  it('getByCorrelationId works after restart', async () => {
+    const fp = tempFile('corr');
+    const store1 = new FileTraceStore({ filePath: fp });
+    const corrId = `corr-${randomUUID().slice(0, 8)}`;
+    await store1.append(makeEvent({ correlationId: corrId, type: 'tool_invoked' }));
+    await store1.append(makeEvent({ correlationId: corrId, type: 'tool_completed' }));
+    await store1.append(makeEvent({ correlationId: 'other' }));
+
+    const store2 = new FileTraceStore({ filePath: fp });
+    const chain = await store2.getByCorrelationId(corrId);
+    assert.equal(chain.length, 2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Corruption handling
+// ══════════════════════════════════════════════════════════════════════
+
+describe('FileTraceStore: corruption handling', () => {
+  it('skips malformed lines and counts them', async () => {
+    const fp = tempFile('corrupt');
+    const valid = makeEvent({ toolId: 'good' });
+
+    // Write file with mix of valid and corrupt lines
+    const content = [
+      JSON.stringify(valid),
+      'THIS IS NOT JSON',
+      '{"partial": true',
+      JSON.stringify(makeEvent({ toolId: 'also_good' })),
+      '',
+    ].join('\n');
+    writeFileSync(fp, content, 'utf-8');
+
+    const store = new FileTraceStore({ filePath: fp });
+    const count = await store.count();
+    assert.equal(count, 2, 'should load only valid events');
+    assert.equal(store.getCorruptLineCount(), 2, 'should count 2 corrupt lines');
+  });
+
+  it('healthy() returns true even with some corrupt lines', async () => {
+    const fp = tempFile('partial-corrupt');
+    writeFileSync(fp, 'NOT JSON\n' + JSON.stringify(makeEvent()) + '\n', 'utf-8');
+
+    const store = new FileTraceStore({ filePath: fp });
+    assert.equal(await store.healthy(), true);
+    assert.equal(store.getCorruptLineCount(), 1);
+  });
+
+  it('completely corrupt file loads as empty', async () => {
+    const fp = tempFile('all-corrupt');
+    writeFileSync(fp, 'garbage\nmore garbage\n', 'utf-8');
+
+    const store = new FileTraceStore({ filePath: fp });
+    const count = await store.count();
+    assert.equal(count, 0);
+    assert.equal(store.getCorruptLineCount(), 2);
+  });
+
+  it('empty file loads cleanly with zero corruption', async () => {
+    const fp = tempFile('empty');
+    writeFileSync(fp, '', 'utf-8');
+
+    const store = new FileTraceStore({ filePath: fp });
+    const count = await store.count();
+    assert.equal(count, 0);
+    assert.equal(store.getCorruptLineCount(), 0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Atomic prune (temp + rename)
+// ══════════════════════════════════════════════════════════════════════
+
+describe('FileTraceStore: atomic prune', () => {
+  it('prune rewrites file atomically (no .tmp residue)', async () => {
+    const fp = tempFile('atomic');
+    const store = new FileTraceStore({ filePath: fp });
+
+    await store.append(makeEvent({ timestamp: new Date(Date.now() - 60000).toISOString() }));
+    await store.append(makeEvent({ timestamp: new Date().toISOString() }));
+
+    await store.prune(30000);
+
+    // No temp file left behind
+    assert.equal(existsSync(fp + '.tmp'), false, 'temp file should not survive');
+
+    // File has exactly 1 line
+    const raw = readFileSync(fp, 'utf-8').trim();
+    const lines = raw.split('\n').filter(l => l.trim().length > 0);
+    assert.equal(lines.length, 1);
+  });
+
+  it('prune to empty writes empty file', async () => {
+    const fp = tempFile('prune-empty');
+    const store = new FileTraceStore({ filePath: fp });
+    await store.append(makeEvent({ timestamp: new Date(Date.now() - 60000).toISOString() }));
+
+    // Small delay for timestamp precision
+    await new Promise(r => setTimeout(r, 5));
+    await store.prune(0);
+
+    const raw = readFileSync(fp, 'utf-8');
+    assert.equal(raw, '');
+  });
+
+  it('file survives restart after prune', async () => {
+    const fp = tempFile('prune-restart');
+    const store1 = new FileTraceStore({ filePath: fp });
+
+    const old = makeEvent({ toolId: 'old', timestamp: new Date(Date.now() - 120000).toISOString() });
+    const recent = makeEvent({ toolId: 'recent', timestamp: new Date().toISOString() });
+
+    await store1.append(old);
+    await store1.append(recent);
+    await store1.prune(60000);
+
+    // Restart
+    const store2 = new FileTraceStore({ filePath: fp });
+    const count = await store2.count();
+    assert.equal(count, 1);
+
+    const all = await store2.query({ limit: 10 });
+    assert.equal(all[0].toolId, 'recent');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// TraceService + FileTraceStore integration: restart
+// ══════════════════════════════════════════════════════════════════════
+
+describe('TraceService: restart with FileTraceStore', () => {
+  it('events persisted via service are available after restart', async () => {
+    const fp = tempFile('svc-restart');
+    const store1 = new FileTraceStore({ filePath: fp });
+    const svc1 = new TraceService({ store: store1 });
+
+    svc1.emit({
+      type: 'tool_invoked',
+      toolId: 'test_tool',
+      correlationId: 'c1',
+      summary: 'invoked',
+      context: { countyId: 'benton', userId: 'u1', sessionId: 's1' },
+    });
+
+    // Wait for fire-and-forget persistence
+    await new Promise(r => setTimeout(r, 50));
+
+    // Restart with new store and service
+    const store2 = new FileTraceStore({ filePath: fp });
+    const svc2 = new TraceService({ store: store2 });
+
+    const events = await svc2.queryAsync({ limit: 10 });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].toolId, 'test_tool');
+  });
+});

--- a/os-platform/core/trace/TraceStore.js
+++ b/os-platform/core/trace/TraceStore.js
@@ -182,7 +182,13 @@ class FileTraceStore {
     constructor(options) {
         this.events = [];
         this.loaded = false;
+        /** Count of malformed lines skipped during load (corruption metric) */
+        this.corruptLineCount = 0;
         this.filePath = options.filePath;
+    }
+    /** Number of malformed lines skipped during last load */
+    getCorruptLineCount() {
+        return this.corruptLineCount;
     }
     /**
      * Ensure events are loaded from disk. Idempotent.
@@ -208,6 +214,7 @@ class FileTraceStore {
             }
             catch {
                 // Skip malformed lines — append-only means we never fix them
+                this.corruptLineCount++;
             }
         }
     }
@@ -304,9 +311,11 @@ class FileTraceStore {
         this.events = this.events.filter(e => new Date(e.timestamp).getTime() >= cutoff);
         const removed = before - this.events.length;
         if (removed > 0) {
-            // Rewrite file with surviving events
+            // Atomic rewrite: write to temp file, then rename (prevents partial writes on crash)
+            const tmpPath = this.filePath + '.tmp';
             const lines = this.events.map(e => JSON.stringify(e)).join('\n');
-            (0, fs_1.writeFileSync)(this.filePath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+            (0, fs_1.writeFileSync)(tmpPath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+            (0, fs_1.renameSync)(tmpPath, this.filePath);
         }
         return removed;
     }

--- a/os-platform/core/trace/TraceStore.ts
+++ b/os-platform/core/trace/TraceStore.ts
@@ -8,8 +8,8 @@
  *   - PostgresTraceStore: R2 future (Drizzle ORM, see schema.ts)
  */
 
-import { readFileSync, appendFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { dirname } from 'path';
+import { readFileSync, appendFileSync, existsSync, mkdirSync, writeFileSync, renameSync } from 'fs';
+import { dirname, join } from 'path';
 import type { TraceEvent, TraceQueryOptions } from '../types/index.js';
 
 // ============================================================================
@@ -290,9 +290,16 @@ export class FileTraceStore implements TraceStore {
   private events: TraceEvent[] = [];
   private filePath: string;
   private loaded = false;
+  /** Count of malformed lines skipped during load (corruption metric) */
+  private corruptLineCount = 0;
 
   constructor(options: FileTraceStoreOptions) {
     this.filePath = options.filePath;
+  }
+
+  /** Number of malformed lines skipped during last load */
+  getCorruptLineCount(): number {
+    return this.corruptLineCount;
   }
 
   /**
@@ -320,6 +327,7 @@ export class FileTraceStore implements TraceStore {
         this.events.push(event);
       } catch {
         // Skip malformed lines — append-only means we never fix them
+        this.corruptLineCount++;
       }
     }
   }
@@ -436,9 +444,11 @@ export class FileTraceStore implements TraceStore {
     );
     const removed = before - this.events.length;
     if (removed > 0) {
-      // Rewrite file with surviving events
+      // Atomic rewrite: write to temp file, then rename (prevents partial writes on crash)
+      const tmpPath = this.filePath + '.tmp';
       const lines = this.events.map(e => JSON.stringify(e)).join('\n');
-      writeFileSync(this.filePath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+      writeFileSync(tmpPath, lines.length > 0 ? lines + '\n' : '', 'utf-8');
+      renameSync(tmpPath, this.filePath);
     }
     return removed;
   }


### PR DESCRIPTION
## Summary

FileTraceStore hardening for data durability and restart correctness.

### Changes

**Atomic prune** (`TraceStore.ts`):
- `prune()` now writes to temp file (`.tmp`) then `renameSync` — crash mid-write cannot corrupt the data file
- Eliminates the partial-write data loss vector

**Corruption metric** (`TraceStore.ts`):
- `ensureLoaded()` now increments `corruptLineCount` on malformed/unparseable lines
- `getCorruptLineCount()` public accessor exposes the metric
- Previously: corrupt lines silently discarded

### Tests (12 new)

| Category | Tests | What they prove |
|----------|-------|-----------------|
| Restart persistence | 4 | Write N events → new instance → same N events, deterministic order, getById, getByCorrelationId |
| Corruption handling | 4 | Malformed lines skipped + counted, all-corrupt = empty, empty file clean |
| Atomic prune | 3 | No .tmp residue, prune-to-empty, restart after prune |
| Service integration | 1 | emit via TraceService → restart → queryAsync returns events |

### Gates

- **type-check**: 0 errors
- **build:core-js**: clean
- **Tests**: 150/150 pass (12 new + 138 baseline)

### Lane context

Lane F follows Lane E (auth audit trail) and Lane D (retention pruning + parcel index).
