### PR TITLE
Lane Z: Fix runtime-lock test — RBAC write:os claim alignment

### DIFF
--- a/os-platform/core/pilot/ToolRunner.js
+++ b/os-platform/core/pilot/ToolRunner.js
@@ -140,7 +140,8 @@ function deriveRequiredClaims(tool) {
     if (tool.touches?.includes('dossier'))
         claims.push('read:dossier');
     // Write tools need write claims for their suite
-    if (tool.writeLane) {
+    // OS-lane tools are governed by admin:trace (no write:os claim in vocabulary)
+    if (tool.writeLane && tool.writeLane !== 'os') {
         claims.push(`write:${tool.writeLane}`);
     }
     // Irreversible tools need approval claim

--- a/os-platform/core/pilot/ToolRunner.ts
+++ b/os-platform/core/pilot/ToolRunner.ts
@@ -198,7 +198,8 @@ function deriveRequiredClaims(tool: Tool): string[] {
   if (tool.touches?.includes('dossier')) claims.push('read:dossier');
 
   // Write tools need write claims for their suite
-  if (tool.writeLane) {
+  // OS-lane tools are governed by admin:trace (no write:os claim in vocabulary)
+  if (tool.writeLane && tool.writeLane !== 'os') {
     claims.push(`write:${tool.writeLane}`);
   }
 

--- a/os-platform/core/tests/runtime-lock.test.mjs
+++ b/os-platform/core/tests/runtime-lock.test.mjs
@@ -162,6 +162,7 @@ describe('RuntimeLock: Enforcement cannot be bypassed', () => {
         toolId: 'request_trace_redaction',
         params: { traceEventId: 'evt-123' },
         context: createTestContext({
+          roles: ['administrator'], // needs approve:irreversible + admin:trace + write:os
           confirmation: true,
           reasonCode: 'court_order',
           supervisorApproval: createSupervisorApproval(),
@@ -234,6 +235,7 @@ describe('RuntimeLock: Enforcement cannot be bypassed', () => {
         toolId: 'request_trace_redaction',
         params: {},
         context: createTestContext({
+          roles: ['administrator'], // needs approve:irreversible + admin:trace + write:os
           confirmation: true,
           reasonCode: 'court_order',
           supervisorApproval: createSupervisorApproval(),


### PR DESCRIPTION
## Summary

Fixes the deterministic failure in `runtime-lock.test.mjs` (2 of 11 tests failing).

### Root Cause

`deriveRequiredClaims()` in ToolRunner generated `write:os` for tools with `writeLane: 'os'`, but the ROLE_VOCABULARY contract defines **no** `write:os` claim. OS-lane operations (e.g. `request_trace_redaction`) are governed by `admin:trace` + `approve:irreversible`, not a separate write claim.

Additionally, the failing tests used `roles: ['appraiser']` which lacks the claims needed for irreversible OS tools.

### Changes (3 files, +6/-2 lines)

| File | Change |
|------|--------|
| `ToolRunner.ts` | `deriveRequiredClaims` skips `write:\` when `writeLane === 'os'` (OS tools gated by `admin:trace` instead) |
| `ToolRunner.js` | Regenerated |
| `runtime-lock.test.mjs` | Both 'allow irreversible' and 'validate passes' tests use `roles: ['administrator']` |

### Why both a code fix AND a test fix

- **Code fix** (the real bug): `write:os` was never in the claim vocabulary — no role could ever satisfy it
- **Test fix** (contract alignment): `appraiser` role lacks `approve:irreversible` and `admin:trace` — using it for a test that expects success was incorrect

### Gates

- **runtime-lock.test.mjs**: 11/11 pass (was 9/11)
- **Full suite**: 149/149 pass, 0 failures
- **type-check**: 0 errors
- **ROLE_VOCABULARY.md**: FROZEN, unchanged

## Summary by Sourcery

Align ToolRunner claim requirements and runtime-lock tests with the RBAC vocabulary for OS-lane tools.

Bug Fixes:
- Stop generating a non-existent write:os claim for OS-lane tools in ToolRunner claim derivation.
- Update runtime-lock tests to use a role with the correct claims for irreversible OS-lane operations.