### PR TITLE
Docs: Trace contract + durability ADR + security invariants

### DIFF
--- a/docs/adr/ADR-0015-trace-retention-durability.md
+++ b/docs/adr/ADR-0015-trace-retention-durability.md
@@ -1,0 +1,51 @@
+# ADR-0015: Trace Retention and Durability Strategy
+
+Status: Accepted for R1 baseline; durability hardening merged in PR #515.  
+Date: 2026-03-03
+
+## Context
+R1 requires persistent, queryable, county-scoped trace evidence with deterministic behavior and low operational friction. The trace system is implemented in `os-platform/core/trace` and surfaced via Pilot trace endpoints.
+
+## Decision
+1. Use `FileTraceStore` (JSONL append-only) for R1 persistence.
+2. Enforce bounded query behavior by defaulting list queries to a 30-day window when no date bounds are provided.
+3. Keep ordering deterministic (`timestamp DESC`, `correlationId ASC`) for stable pagination.
+4. Expose operability stats via `GET /pilot/traces/stats`, access-controlled by elevated trace roles.
+5. Maintain auditable access via explicit `trace_accessed` and `permission_denied` events.
+
+## Durability and Retention Mechanics
+
+### Current merged baseline (#513/#514 and earlier)
+- `append()` uses synchronous line append to JSONL.
+- `prune(retentionMs)` removes old events and rewrites file with survivors.
+- malformed JSON lines are skipped during load.
+
+### Merge-pending hardening in #515
+- Atomic prune file replacement (`.tmp` + rename) to avoid partial-write corruption windows.
+- Corruption metric (`corruptLineCount`) incremented for malformed lines.
+- Restart-correctness tests for persistence + post-prune behavior.
+
+## Alternatives Considered
+
+### In-place truncate/delete during prune
+- Rejected: higher partial-write and interleaving risk, weak crash safety.
+
+### Delete-on-write strategy
+- Rejected: violates append-only evidence posture; weak audit continuity.
+
+### Cursor pagination now
+- Rejected for R1: higher implementation complexity than needed.
+- Decision: return `nextCursor: null` placeholder now; preserve contract for later migration.
+
+## Risks and Mitigations
+- Risk: audit noise / audit-about-audit loops in parcel feed.
+  - Mitigation: list-access audit events omit `parcelId` so they do not appear in parcel-scoped lists.
+- Risk: access pattern leaks (cross-county or cross-user).
+  - Mitigation: county isolation + role-based filtering + denial metrics.
+- Risk: malformed lines in trace file.
+  - Mitigation: skip malformed lines; count and surface corruption metric (post-#515 merge).
+
+## Consequences
+- R1 gets deterministic evidence behavior with minimal ops dependencies.
+- Durability hardening path remains compatible with current API/contract semantics.
+

--- a/docs/codex/trace-system.md
+++ b/docs/codex/trace-system.md
@@ -1,0 +1,84 @@
+# Trace System Contract (R1 Integration)
+
+Last updated: 2026-03-03  
+Source of truth: `os-platform/core/api/PilotController.ts`, `os-platform/core/trace/TraceService.ts`, `os-platform/core/trace/TraceStore.ts`, PRs #511-#515.
+
+## Scope
+- Endpoint contracts for `GET /pilot/traces` and `GET /pilot/traces/stats`
+- Query semantics and access rules
+- Response shape guarantees
+- Security and audit behavior
+
+## Endpoint: `GET /pilot/traces`
+
+### Request
+- Query params:
+  - `parcelId` (required)
+  - `toolId` (optional)
+  - `from` (optional, ISO 8601 inclusive lower bound)
+  - `to` (optional, ISO 8601 inclusive upper bound)
+  - `limit` (optional, default `50`, clamped `1..200`)
+  - `offset` (optional, default `0`, min `0`)
+
+### Validation
+- `parcelId` missing -> `400 INVALID_REQUEST`
+- invalid `from`/`to` -> `400 INVALID_REQUEST`
+- `from > to` -> `400 INVALID_REQUEST`
+
+### Query Semantics
+- Default window: if neither `from` nor `to` is provided, effective `from = now - 30 days`.
+- Ordering: stable sort `timestamp DESC`, tie-break `correlationId ASC`.
+- Pagination: offset/limit over sorted events.
+- `toolId` filter is parcel-bounded in practice: querying `toolId` under a different parcel returns empty (no cross-parcel existence leak).
+
+### Access Control
+- County isolation is always enforced.
+- Elevated roles can see in-county traces across users.
+- Non-elevated users only see their own trace events.
+- Filtered events are removed from results; response remains `200`.
+
+### Auditing Behavior
+- Every call emits `trace_accessed` (`toolId: pilot:traces:list`).
+- If events are filtered by access control, emits `permission_denied` with filtered count.
+- Guard against audit-feed recursion/noise: audit events for list access intentionally omit `parcelId` in event context, so they do not re-enter parcel-scoped list feeds.
+
+### Response
+- JSON:
+  - `events: TraceEvent[]`
+  - `pagination: { offset, limit, returned }`
+  - `nextCursor: null` (reserved for future cursor pagination)
+
+## Endpoint: `GET /pilot/traces/stats`
+
+### Purpose
+- Returns trace store operability stats.
+
+### Access Control
+- Requires elevated trace role (`admin`/`administrator`/`compliance_officer`/`auditor`/`supervisor` per `TraceAccessControl`).
+- Unauthorized calls return `403 ACCESS_DENIED`.
+
+### Auditing Behavior
+- Denied calls emit `permission_denied` (`toolId: pilot:traces:stats`).
+- Allowed calls emit `trace_accessed` (`toolId: pilot:traces:stats`).
+
+### Response
+- JSON:
+  - `totalEvents: number`
+  - `oldestTimestamp: string | null`
+  - `newestTimestamp: string | null`
+
+## Store and Retention Semantics
+- Store type in R1: `FileTraceStore` (JSONL append-only persistence) via `TraceService` store delegation.
+- `TraceService.emit()` is fire-and-forget persistence (ring buffer remains source for immediate in-memory access; store failures do not fail emit).
+- Retention pruning exists at both `TraceService.prune()` and `TraceStore.prune()`.
+
+## Durability (merged in #515)
+- Atomic prune rewrite (`.tmp` + rename) — crash-safe file replacement.
+- Corruption line counter (`getCorruptLineCount()`) — malformed lines counted during load.
+- Restart/durability hardening tests (12 new tests covering persistence, corruption, atomic prune).
+
+## Security Invariants (merged in #516)
+- No `write:os` claim exists in ROLE_VOCABULARY; OS-lane tools are gated by `admin:trace`.
+- Irreversible OS tools (e.g. `request_trace_redaction`) require `administrator` role with `approve:irreversible` + `admin:trace` claims.
+- `runtime-lock.test.mjs` now deterministic (11/11 pass).
+


### PR DESCRIPTION
## Codex Handoff (docs-only, zero code changes)

Anchors the truth record for Lanes D-F and Z to version control.

### Files

| File | Content |
|------|---------|
| `docs/adr/ADR-0015-trace-retention-durability.md` | Trace retention strategy, atomic prune decision, corruption metric, audit-loop mitigation, cursor placeholder rationale |
| `docs/codex/trace-system.md` | Trace endpoint contracts (`/pilot/traces`, `/pilot/traces/stats`), query semantics (30d default, stable sort), access control, audit behavior, store/retention mechanics, durability hardening (#515), security invariants (#516: no `write:os`, `admin:trace` gating) |

### What this documents

- **Trace contracts**: list/stats endpoints, request validation, response shape, pagination semantics
- **Durability ADR**: atomic prune via temp+rename, corruption line counter, restart correctness
- **Security invariants**: no `write:os` claim in vocabulary, irreversible OS tools require `administrator` + `approve:irreversible` + `admin:trace`
- **Audit behavior**: audit events omit `parcelId` to prevent feed recursion/noise

No code changes. 2 files, +135 lines.
