### PR TITLE
docs(trace): ADR-0015 + runbook + security mapping + release note

### DIFF
--- a/docs/releases/R1_INTEGRATION_TRACE_510_515.md
+++ b/docs/releases/R1_INTEGRATION_TRACE_510_515.md
@@ -1,0 +1,26 @@
+# R1 Integration Trace Lane Notes (#510-#515)
+
+Last updated: 2026-03-03
+
+## #510 — test: stabilize flaky DesktopIntentContract
+This PR stabilized baseline desktop intent tests, removing flake from surface-workbench icon behavior classification. It restored deterministic CI for UI contract tests and prevented false-negative regressions from blocking unrelated trace and governance work.
+
+## #511 — feat(pilot): Lane A — trace list endpoint + parcel-scoped EvidenceRail feed
+This PR introduced `GET /pilot/traces` and switched EvidenceRail to parcel-scoped list queries with date filtering and pagination. It established the operational read path for trace lists and removed reliance on single-correlation polling for the main workbench trace feed.
+
+## #512 — harden(trace): stable sort tiebreak + default 30d retention window
+This PR hardened list-query determinism and bounded default query cost by adding stable sort (`timestamp DESC`, `correlationId ASC`) and an implicit 30-day window when no date bounds are provided. This removed non-deterministic paging behavior for equal timestamps and reduced unbounded scans.
+
+## #513 — feat(trace): Lane D — Retention Pruning, Parcel Index, Ops Stats
+This PR added retention pruning and operability stats (`/pilot/traces/stats`), plus a parcel index optimization in memory store paths. It provided direct operator visibility (`totalEvents`, oldest/newest timestamps) and formalized retention mechanics across in-memory and file store implementations.
+
+## #514 — feat(trace): Lane E — Authorization Audit Trail + Access-Denied Metrics
+This PR introduced `trace_accessed` and `permission_denied` audit event types and wired them into list/stats endpoint behavior. It strengthened access telemetry, denial accounting, and parcel-bounded tool filtering guarantees to prevent cross-parcel inference.
+
+## #515 — Lane F: Trace durability — atomic prune, corruption metric, restart correctness
+This PR delivered durability hardening: atomic prune rewrite (`.tmp` + rename), malformed-line corruption counting, and restart-correctness test coverage. It closes the R1 trace durability gap and aligns operations with ADR-0015 and the trace-store runbook.
+
+## Security Invariant (Across #511-#515)
+- No cross-parcel inference via tool filters in parcel-scoped queries.
+- Access-denied and trace-access actions are auditable.
+- Stats endpoint remains elevated-role gated with explicit `403` denial behavior.

--- a/docs/runbooks/trace-store.md
+++ b/docs/runbooks/trace-store.md
@@ -1,0 +1,64 @@
+# Runbook: Trace Store Operations (R1)
+
+Last updated: 2026-03-03
+
+## Purpose
+Operator playbook for Pilot trace storage health, retention validation, and access-audit monitoring.
+
+## Endpoints
+- `GET /pilot/traces?parcelId=...`
+- `GET /pilot/traces/stats` (elevated roles only)
+
+## Normal Expectations
+- Trace list returns parcel-scoped events with stable order.
+- List responses include:
+  - `pagination.offset`
+  - `pagination.limit`
+  - `pagination.returned`
+  - `nextCursor: null` (reserved)
+- Stats response includes:
+  - `totalEvents`
+  - `oldestTimestamp`
+  - `newestTimestamp`
+
+## Incident: Corruption metric > 0
+
+Note: explicit corruption metric accessor is delivered in merged PR #515.  
+Malformed lines are skipped and counted for operator visibility.
+
+### Steps
+1. Confirm scope
+   - Verify whether data loss is user-visible (missing trace events) or only parser noise.
+2. Capture stats snapshot
+   - Query `GET /pilot/traces/stats` and record `totalEvents`, `oldestTimestamp`, `newestTimestamp`.
+3. Preserve evidence
+   - Copy current trace file before maintenance action.
+4. Run retention prune in maintenance window
+   - Use existing service prune path; verify event count and timestamp bounds post-prune.
+5. Re-check query invariants
+   - Parcel-bounded query with tool filter should not leak cross-parcel existence.
+6. Escalate
+   - If corruption count rises or stats regress unexpectedly, raise incident and hold further feature rollout.
+
+## Validate Retention Is Working
+1. Capture pre-prune stats.
+2. Execute prune for configured retention window.
+3. Capture post-prune stats.
+4. Verify:
+   - `oldestTimestamp` moves forward (or remains null for empty store).
+   - `newestTimestamp` remains recent.
+   - `totalEvents` decreases only by expired records.
+5. Confirm trace list default behavior:
+   - With no `from`/`to`, list uses last 30 days window.
+
+## Access-Audit Checks
+- For every `GET /pilot/traces` call:
+  - expect `trace_accessed` audit event.
+- If events were filtered:
+  - expect `permission_denied` event with filtered-count summary.
+- For unauthorized `GET /pilot/traces/stats`:
+  - expect `403 ACCESS_DENIED` and `permission_denied` audit event.
+
+## Anti-Recursion Guard
+- Access-audit events for trace list intentionally omit `parcelId` in context.
+- This keeps audit records out of parcel-scoped feeds and avoids recursive audit-noise loops.

--- a/docs/security/trace-access-audit.md
+++ b/docs/security/trace-access-audit.md
@@ -1,0 +1,48 @@
+# Trace Access Audit Mapping
+
+Last updated: 2026-03-03  
+Applies to: Pilot trace endpoints and TraceService event taxonomy.
+
+## Event Mapping
+
+### `trace_accessed`
+- Meaning: an authorized or attempted trace data access operation occurred.
+- Emitted by:
+  - `GET /pilot/traces` (list access)
+  - `GET /pilot/traces/stats` (stats access)
+- Canonical tool IDs:
+  - `pilot:traces:list`
+  - `pilot:traces:stats`
+- Audit class: `access_audit`
+- Security value: attribution of who accessed trace data and when.
+
+### `permission_denied`
+- Meaning: access was denied or records were filtered by policy.
+- Emitted by:
+  - `GET /pilot/traces` when events are filtered by county/user access rules
+  - `GET /pilot/traces/stats` when caller lacks elevated trace role (`403`)
+- Audit class: `policy_enforcement`
+- Security value: evidence of active boundary enforcement and attempted violations.
+
+## Ledger / Evidence Taxonomy Mapping
+- `trace_accessed` -> `evidence.access.trace.read`
+- `permission_denied` -> `evidence.security.access.denied`
+
+## Guard Against Audit-of-Audit Loops
+- Current guard: list-access audit events omit `parcelId`.
+- Result: parcel-scoped list feeds do not include their own access-audit records.
+- Operational requirement: preserve this behavior when extending trace queries; do not add parcel context to list-audit events without an alternate recursion control.
+
+## Security Invariants
+1. Cross-county trace visibility is always denied.
+2. Non-elevated users only see own events.
+3. Elevated roles may see in-county events across users.
+4. Tool filter cannot be used to infer event existence on other parcels.
+5. Unauthorized stats access returns `403` and is auditable.
+
+## Verification References
+- Endpoint behavior: `os-platform/core/api/PilotController.ts`
+- Access control logic: `os-platform/core/trace/TraceAccessControl.ts`
+- Event type union: `os-platform/core/types/index.ts`
+- Contract tests: `os-platform/core/tests/lane-e-trace-authz.test.mjs`
+


### PR DESCRIPTION
## Lane D (Docs) — Trace Documentation

Docs-only. No runtime changes.

### Files
- `docs/runbooks/trace-store.md` — operator runbook for trace storage health + retention
- `docs/security/trace-access-audit.md` — security event mapping for trace endpoints
- `docs/releases/R1_INTEGRATION_TRACE_510_515.md` — release note covering Lanes A-F (#510-#515)

### Evidence
- Pre-commit: prettier formatted all 3 files
- No code changes — zero runtime risk

Government: FISMA compliance
AI-Collaboration: GitHub Copilot (Lane D-docs)

## Summary by Sourcery

Add operational, security, and release documentation for the Pilot trace storage and auditing features.

Documentation:
- Add an operator runbook for trace store health, retention validation, and access-audit monitoring.
- Document trace access audit event mappings, security invariants, and verification references for trace endpoints.
- Add release notes summarizing R1 integration trace lanes and related PRs (#510-#515).