### PR TITLE
Lane K4 — trace export UI action (admin-only)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/ui-observability/TraceExportButton.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/TraceExportButton.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * TraceExportButton.test.tsx
+ *
+ * Lane K4: Contract tests for the admin-only "Export evidence pack" button
+ * in ExecutionConsole.
+ *
+ * Coverage:
+ *   1. Non-admin: button not rendered
+ *   2. Admin: button rendered
+ *   3. Click issues correct request URL (parcelId + correlationId when present)
+ *   4. 403/500 handled gracefully (error state visible)
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExecutionConsole } from '../../components/pilot/ExecutionConsole';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockUseTraceByCorrelationId = jest.fn();
+const mockUseTraceStats = jest.fn();
+const mockGetSession = jest.fn();
+const mockExportTraces = jest.fn();
+
+jest.mock('../../ui/materials/LiquidPanel', () => ({
+  LiquidPanel: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+jest.mock('../../ui/materials/TactileButton', () => ({
+  TactileButton: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock('../../hooks/useTraceByCorrelationId', () => ({
+  useTraceByCorrelationId: (...args: unknown[]) => mockUseTraceByCorrelationId(...args),
+}));
+
+jest.mock('../../hooks/useTraceStats', () => ({
+  useTraceStats: (...args: unknown[]) => mockUseTraceStats(...args),
+}));
+
+jest.mock('../../auth/session', () => ({
+  ...jest.requireActual('../../auth/session'),
+  getSession: () => mockGetSession(),
+}));
+
+jest.mock('../../api/pilotApi', () => ({
+  ...jest.requireActual('../../api/pilotApi'),
+  exportTraces: (...args: unknown[]) => mockExportTraces(...args),
+  requestApprovalToken: jest.fn(),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function hooksDefaults() {
+  mockUseTraceByCorrelationId.mockReturnValue({
+    phase: 'ready',
+    events: [],
+    error: null,
+    refresh: jest.fn(),
+  });
+  mockUseTraceStats.mockReturnValue({
+    diagnostics: null,
+    lastFetchedAt: null,
+    fetchFailed: false,
+    refresh: jest.fn(),
+  });
+}
+
+const succeededState = (overrides?: Record<string, unknown>) => ({
+  phase: 'succeeded' as const,
+  toolId: 'explain_value_change',
+  params: { parcelId: 'P-123' },
+  validation: null,
+  confirmation: null,
+  response: {
+    ok: true,
+    correlationId: 'corr-k4-1',
+    result: 'ok',
+  },
+  correlationId: 'corr-k4-1',
+  error: null,
+  errorCode: null,
+  ...overrides,
+});
+
+const noop = jest.fn();
+const invocation = (stateOverrides?: Record<string, unknown>) => ({
+  state: succeededState(stateOverrides),
+  invoke: noop,
+  confirm: noop,
+  cancel: noop,
+  reset: noop,
+});
+
+const tool = {
+  toolId: 'explain_value_change',
+  suite: 'forge' as const,
+  risk: 'read_only' as const,
+  description: 'Explain value delta.',
+};
+
+// suppress URL.createObjectURL / revokeObjectURL in jsdom
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  hooksDefaults();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('Lane K4: Trace export button', () => {
+  it('does NOT render export button for non-admin user', () => {
+    mockGetSession.mockReturnValue({
+      userId: 'u-viewer',
+      countyId: 'benton',
+      role: 'viewer',
+      permissions: [],
+      mode: 'pilot',
+    });
+
+    render(<ExecutionConsole invocation={invocation()} tool={tool} />);
+
+    expect(screen.queryByTestId('trace-export-btn')).not.toBeInTheDocument();
+  });
+
+  it('renders export button for admin user on terminal state with parcelId', () => {
+    mockGetSession.mockReturnValue({
+      userId: 'u-admin',
+      countyId: 'benton',
+      role: 'admin',
+      permissions: [],
+      mode: 'pilot',
+    });
+
+    render(<ExecutionConsole invocation={invocation()} tool={tool} />);
+
+    const btn = screen.getByTestId('trace-export-btn');
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('Export evidence pack (NDJSON)');
+  });
+
+  it('click calls exportTraces with parcelId and correlationId', async () => {
+    const user = userEvent.setup();
+    mockGetSession.mockReturnValue({
+      userId: 'u-admin',
+      countyId: 'benton',
+      role: 'admin',
+      permissions: [],
+      mode: 'pilot',
+    });
+    mockExportTraces.mockResolvedValue(new Blob(['{}'], { type: 'application/x-ndjson' }));
+
+    // Spy on createElement to verify download was triggered
+    const appendSpy = jest.spyOn(document.body, 'appendChild');
+
+    render(<ExecutionConsole invocation={invocation()} tool={tool} />);
+
+    await user.click(screen.getByTestId('trace-export-btn'));
+
+    await waitFor(() => {
+      expect(mockExportTraces).toHaveBeenCalledWith({
+        parcelId: 'P-123',
+        correlationId: 'corr-k4-1',
+      });
+    });
+
+    // Verify a download anchor was appended
+    await waitFor(() => {
+      const anchors = appendSpy.mock.calls
+        .map((c) => c[0])
+        .filter((el): el is HTMLAnchorElement => el instanceof HTMLAnchorElement);
+      expect(anchors.length).toBeGreaterThanOrEqual(1);
+      const a = anchors[anchors.length - 1];
+      expect(a.download).toMatch(/^trace-export_P-123_corr-k4-1_/);
+      expect(a.download).toMatch(/\.ndjson$/);
+    });
+
+    appendSpy.mockRestore();
+  });
+
+  it('shows error banner on 403 response without crashing console', async () => {
+    const user = userEvent.setup();
+    mockGetSession.mockReturnValue({
+      userId: 'u-admin',
+      countyId: 'benton',
+      role: 'admin',
+      permissions: [],
+      mode: 'pilot',
+    });
+    const err = new Error('Forbidden') as Error & { correlationId?: string; status?: number };
+    err.correlationId = 'corr-denied-1';
+    err.status = 403;
+    mockExportTraces.mockRejectedValue(err);
+
+    render(<ExecutionConsole invocation={invocation()} tool={tool} />);
+
+    await user.click(screen.getByTestId('trace-export-btn'));
+
+    await waitFor(() => {
+      const errEl = screen.getByTestId('trace-export-error');
+      expect(errEl).toHaveTextContent('Forbidden');
+      expect(errEl).toHaveTextContent('corr-denied-1');
+    });
+
+    // Console should still be rendered (not crashed)
+    expect(screen.getByTestId('phase-indicator')).toBeInTheDocument();
+  });
+
+  it('shows error banner on 500 response without crashing console', async () => {
+    const user = userEvent.setup();
+    mockGetSession.mockReturnValue({
+      userId: 'u-admin',
+      countyId: 'benton',
+      role: 'admin',
+      permissions: [],
+      mode: 'pilot',
+    });
+    mockExportTraces.mockRejectedValue(new Error('Internal Server Error'));
+
+    render(<ExecutionConsole invocation={invocation()} tool={tool} />);
+
+    await user.click(screen.getByTestId('trace-export-btn'));
+
+    await waitFor(() => {
+      const errEl = screen.getByTestId('trace-export-error');
+      expect(errEl).toHaveTextContent('Internal Server Error');
+    });
+
+    // Console should still be rendered
+    expect(screen.getByTestId('phase-indicator')).toBeInTheDocument();
+  });
+
+  it('does NOT render export button when parcelId is absent from params', () => {
+    mockGetSession.mockReturnValue({
+      userId: 'u-admin',
+      countyId: 'benton',
+      role: 'admin',
+      permissions: [],
+      mode: 'pilot',
+    });
+
+    render(
+      <ExecutionConsole
+        invocation={invocation({ params: {} })}
+        tool={tool}
+      />
+    );
+
+    expect(screen.queryByTestId('trace-export-btn')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/api/pilotApi.ts
+++ b/frontend/apps/os-shell/src/api/pilotApi.ts
@@ -482,6 +482,60 @@ export async function listPilotTraces(params: PilotTraceListParams): Promise<Pil
   return (await response.json()) as PilotTraceListResponse;
 }
 
+/** Parameters for trace export (NDJSON download). */
+export interface TraceExportParams {
+  parcelId: string;
+  correlationId?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+}
+
+/** Error shape returned by the export endpoint on 4xx/5xx. */
+export interface TraceExportError {
+  error: string;
+  correlationId?: string;
+}
+
+/**
+ * Export trace events as an NDJSON blob (admin/elevated only).
+ * Hits GET /pilot/traces/export with query parameters.
+ *
+ * @returns NDJSON Blob on success; throws with correlationId on failure.
+ */
+export async function exportTraces(params: TraceExportParams): Promise<Blob> {
+  const qs = new URLSearchParams();
+  qs.set('parcelId', params.parcelId);
+  qs.set('format', 'ndjson');
+  if (params.correlationId) qs.set('correlationId', params.correlationId);
+  if (params.from) qs.set('from', params.from);
+  if (params.to) qs.set('to', params.to);
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+
+  const url = `${API_BASE_URL}/pilot/traces/export?${qs.toString()}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: buildPilotHeaders(),
+  });
+
+  if (!response.ok) {
+    let errBody: TraceExportError | undefined;
+    try {
+      errBody = (await response.json()) as TraceExportError;
+    } catch {
+      // non-JSON error body
+    }
+    const msg = errBody?.error ?? `Export failed (${response.status})`;
+    const err = new Error(msg) as Error & { correlationId?: string; status?: number };
+    err.correlationId = errBody?.correlationId;
+    err.status = response.status;
+    throw err;
+  }
+
+  return response.blob();
+}
+
 /**
  * Get global trace-store diagnostics.
  * Requires elevated trace role (enforced server-side).

--- a/frontend/apps/os-shell/src/components/pilot/ExecutionConsole.tsx
+++ b/frontend/apps/os-shell/src/components/pilot/ExecutionConsole.tsx
@@ -14,7 +14,7 @@
 
 import React, { useCallback, useState } from 'react';
 import type { ApprovalToken, PilotTool, Risk } from '../../api/pilotApi';
-import { requestApprovalToken } from '../../api/pilotApi';
+import { exportTraces, requestApprovalToken } from '../../api/pilotApi';
 import { getSession } from '../../auth/session';
 import { LiquidPanel } from '../../ui/materials/LiquidPanel';
 import { TactileButton } from '../../ui/materials/TactileButton';
@@ -210,6 +210,40 @@ export const ExecutionConsole: React.FC<ExecutionConsoleProps> = ({
     reset();
   }, [reset]);
 
+  // K4: Trace export — download NDJSON evidence pack (admin/elevated only)
+  const [exportBusy, setExportBusy] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const handleExport = useCallback(async () => {
+    const parcelId = state.params?.parcelId as string | undefined;
+    if (!parcelId) return;
+    setExportBusy(true);
+    setExportError(null);
+    try {
+      const blob = await exportTraces({
+        parcelId,
+        correlationId: correlationId ?? undefined,
+      });
+      const corrPart = correlationId ?? 'all';
+      const ts = new Date().toISOString().replace(/[:.]/g, '').replace('Z', 'Z');
+      const filename = `trace-export_${parcelId}_${corrPart}_${ts}.ndjson`;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      const e = err as Error & { correlationId?: string };
+      const suffix = e.correlationId ? ` [${e.correlationId}]` : '';
+      setExportError(`${e.message}${suffix}`);
+    } finally {
+      setExportBusy(false);
+    }
+  }, [state.params, correlationId]);
+
   // PR-UI2: Evidence Rail — trace polling, only active on terminal states + toggle
   const [showEvidence, setShowEvidence] = useState(false);
   const isTerminal = phase === 'succeeded' || phase === 'failed';
@@ -287,6 +321,26 @@ export const ExecutionConsole: React.FC<ExecutionConsoleProps> = ({
       {/* Error result */}
       {phase === 'failed' && error && (
         <ErrorDisplay error={error} errorCode={errorCode} />
+      )}
+
+      {/* K4: Admin-only trace export button */}
+      {isTerminal && showDiagnostics && state.params?.parcelId && (
+        <div className='space-y-1' data-testid='trace-export-section'>
+          <TactileButton
+            variant='ghost'
+            size='sm'
+            onClick={handleExport}
+            disabled={exportBusy}
+            data-testid='trace-export-btn'
+          >
+            {exportBusy ? 'Exporting…' : 'Export evidence pack (NDJSON)'}
+          </TactileButton>
+          {exportError && (
+            <p className='text-xs text-red-400' data-testid='trace-export-error'>
+              {exportError}
+            </p>
+          )}
+        </div>
       )}
 
       {/* PR-UI2: Evidence Rail toggle + trace timeline */}


### PR DESCRIPTION
## Lane K4 — Trace Export UI Action (admin-only)

**Branch**: copilot/lane-k4-trace-export-ui
**Base**: r1/integration
**Scope**: frontend/apps/os-shell only — no backend changes

### Deliverables

1. **pilotApi.ts** — `exportTraces()` fetches `GET /pilot/traces/export` returning NDJSON Blob. Error path extracts `correlationId` from JSON error body.
2. **ExecutionConsole.tsx** — Admin-gated 'Export evidence pack (NDJSON)' button. Appears on terminal states (succeeded/failed) when user has elevated trace role AND `parcelId` exists in params. Click triggers download with filename: `trace-export_<parcelId>_<correlationId|all>_<timestamp>.ndjson`. Error banner shows inline (no crash).
3. **TraceExportButton.test.tsx** — 6 contract tests:
   - Non-admin: button not rendered
   - Admin: button rendered
   - Click calls exportTraces with correct parcelId + correlationId
   - 403 error shows banner with correlationId (no crash)
   - 500 error shows banner (no crash)
   - No parcelId in params: button not rendered

### Gate evidence

- `type-check`: CLEAN (core + os-shell)
- `core tests`: 485/485 pass
- `frontend tests`: 6/6 new + 8/8 existing GovernanceRailAndConsole pass
- `touch set`: 3 files only

### Risk

- Button hidden behind `canViewGlobalTraceDiagnostics()` gate — no admin-only UI leak
- Error handling catches all rejections — cannot crash ExecutionConsole
- No new dependencies

Government: FISMA compliance
AI-Collaboration: GitHub Copilot (Lane K4)

## Summary by Sourcery

Add an admin-gated trace export capability to the pilot execution console, backed by a new NDJSON export API client and test coverage.

New Features:
- Expose a pilot API helper to export trace data as an NDJSON blob with support for parcel, correlation, and range filters.
- Add an admin-only 'Export evidence pack (NDJSON)' action to the ExecutionConsole for terminal executions with a parcel ID.

Tests:
- Introduce contract tests validating visibility, behavior, and error handling of the admin-only trace export button in the ExecutionConsole.