### PR TITLE
docs(trace): Lane L1 docs - export integrity envelope + K4 terminal-phase gate

### DIFF
--- a/docs/codex/trace-system.md
+++ b/docs/codex/trace-system.md
@@ -82,3 +82,76 @@ Source of truth: `os-platform/core/api/PilotController.ts`, `os-platform/core/tr
 - Irreversible OS tools (e.g. `request_trace_redaction`) require `administrator` role with `approve:irreversible` + `admin:trace` claims.
 - `runtime-lock.test.mjs` now deterministic (11/11 pass).
 
+## Endpoint: `GET /pilot/traces/export` (merged in #523, #525)
+
+### Purpose
+- Downloads trace events as NDJSON file for a given parcel.
+- With `includeMeta=1`, wraps events in an integrity envelope (header + SHA-256 footer) suitable for formal evidence packs.
+
+### Request
+- Query params:
+  - `parcelId` (required)
+  - `correlationId` (optional, filters to single correlation chain)
+  - `from` (optional, ISO 8601 — default: `now - 30 days`)
+  - `to` (optional, ISO 8601 — default: `now`)
+  - `limit` (optional, default `500`, clamped `1..2000`)
+  - `format` (optional, must be `ndjson` if present)
+  - `includeMeta` (optional, `1` or `true` — enables integrity envelope)
+
+### Validation
+- `parcelId` missing → `400 INVALID_REQUEST`
+- Invalid `from`/`to` → `400 INVALID_REQUEST`
+- `from > to` → `400 INVALID_REQUEST`
+- Window exceeds 30 days → `400 INVALID_REQUEST`
+
+### Access Control
+- Requires elevated trace role (same set as `/pilot/traces`).
+- Cross-county export denied → `403 ACCESS_DENIED` (events from other counties are rejected, not silently filtered).
+- Denied calls emit `permission_denied` (`toolId: pilot:traces:export`).
+- Allowed calls emit `trace_accessed` (`toolId: pilot:traces:export`).
+
+### Ordering
+- Stable three-key sort: `timestamp DESC`, `correlationId ASC`, `eventId ASC`.
+- Header `order` field: `timestamp_desc,correlationId_asc,eventId_asc`.
+- Implementation: `sortTraceExportEvents()` in `traceExport.ts`.
+
+### Response: Default Mode (`includeMeta` omitted)
+- Content-Type: `application/x-ndjson; charset=utf-8`
+- Body: one JSON line per event, no header, no footer.
+- Backward compatible with Lane K1-K3 consumers.
+
+### Response: Integrity Mode (`includeMeta=1`)
+- Content-Type: `application/x-ndjson; charset=utf-8`
+- Body structure:
+  1. **Header line** — `{"type":"trace_export_header", "parcelId":..., "correlationId":..., "from":..., "to":..., "limit":..., "exportedAt":..., "order":"timestamp_desc,correlationId_asc,eventId_asc"}`
+  2. **Event lines** — one JSON object per line (same as default mode)
+  3. **Footer line** — `{"type":"trace_export_footer", "sha256":"<hex>", "count":<N>}`
+
+### SHA-256 Hash Contract
+- **Input**: exact bytes of each event line (`JSON.stringify(event) + "\n"`).
+- **Excluded**: header line and footer line are NOT fed to the hash.
+- **Determinism**: same events in same order always produce the same hash. `exportedAt` (in header only) cannot affect the digest.
+- **Verification**: a consumer can recompute the hash by streaming event lines through `SHA-256` and comparing against `footer.sha256`.
+- **Count**: `footer.count` equals the number of event lines (must match count of lines between header and footer).
+
+### Design Rationale
+- Header/footer excluded from hash so that `exportedAt` (a wall-clock timestamp) does not break deterministic verification.
+- Default mode emits bare events for backward compatibility and lightweight consumers.
+- Integrity mode is opt-in to avoid breaking existing download flows.
+
+## K4: Export Action UI Behavior (merged in #524)
+
+### Terminal-Phase Gate
+The "Export Trace" button in `ExecutionConsole.tsx` is gated on `isTerminal`:
+```typescript
+const isTerminal = phase === 'succeeded' || phase === 'failed';
+```
+Export is only available when a tool invocation has reached a terminal phase. This is **intentional behavior**:
+- Prevents mid-execution exports that would capture incomplete event chains.
+- Ensures the correlationId chain is complete before evidence capture.
+- Admin diagnostics panel is similarly gated (`isTerminal && showDiagnostics`).
+
+### Admin-Only Visibility
+- Export action and diagnostics panel require `showDiagnostics` prop (admin role gate).
+- Non-admin users never see the export button or diagnostics drawer.
+


### PR DESCRIPTION
Docs-only. Added export endpoint contract and K4 terminal-phase gate to trace-system.md. No code changes. Tests: 488/488 unchanged.

## Summary by Sourcery

Document the trace export endpoint and terminal-phase export behavior in the trace system codex.

Documentation:
- Describe the GET /pilot/traces/export endpoint, including query parameters, validation rules, access control, ordering, and response formats for default and integrity modes.
- Specify the integrity envelope contract for trace exports, including header/footer structure and SHA-256 hashing semantics.
- Clarify K4 UI behavior by documenting that trace export and diagnostics are gated on terminal tool phases and admin-only visibility.