### PR TITLE
feat(tools): Lane R - verify-trace-export CLI for evidence integrity

### DIFF
--- a/os-platform/core/tests/lane-r-verify-trace-export.test.mjs
+++ b/os-platform/core/tests/lane-r-verify-trace-export.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * Lane R: verify-trace-export contract tests.
+ *
+ * Tests the CLI verification logic without spawning a subprocess —
+ * we import the hash computation approach and validate against known fixtures.
+ */
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { describe, it, before, after } from 'node:test';
+
+const TOOL_PATH = join(import.meta.dirname, '..', '..', '..', 'tools', 'verify-trace-export.mjs');
+
+let tempDir;
+
+before(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'trace-verify-'));
+});
+
+function writeTempFile(name, content) {
+  const p = join(tempDir, name);
+  writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+function runVerifier(filePath) {
+  const args = [TOOL_PATH];
+  if (filePath !== undefined) args.push(filePath);
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      exitCode: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+    };
+  }
+}
+
+function buildNdjson(events, { includeHeader = true, includeFooter = true, overrideHash, overrideCount } = {}) {
+  const lines = [];
+
+  if (includeHeader) {
+    lines.push(JSON.stringify({
+      type: 'trace_export_header',
+      parcelId: 'P-TEST',
+      correlationId: null,
+      from: '2026-02-01T00:00:00.000Z',
+      to: '2026-03-01T00:00:00.000Z',
+      limit: 500,
+      exportedAt: '2026-03-03T12:00:00.000Z',
+      order: 'timestamp_desc,correlationId_asc,eventId_asc',
+    }));
+  }
+
+  const hash = createHash('sha256');
+  for (const event of events) {
+    const line = JSON.stringify(event);
+    hash.update(line + '\n');
+    lines.push(line);
+  }
+
+  if (includeFooter) {
+    lines.push(JSON.stringify({
+      type: 'trace_export_footer',
+      sha256: overrideHash ?? hash.digest('hex'),
+      count: overrideCount ?? events.length,
+    }));
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function makeEvent(id, correlationId = 'corr-1') {
+  return {
+    eventId: `evt-${id}`,
+    type: 'tool_completed',
+    toolId: 'run_valuation_model',
+    correlationId,
+    summary: `test event ${id}`,
+    timestamp: '2026-03-03T10:00:00.000Z',
+    context: {
+      countyId: 'benton',
+      userId: 'user-1',
+      roles: ['appraiser'],
+      mode: 'pilot',
+      parcelId: 'P-TEST',
+    },
+  };
+}
+
+describe('verify-trace-export', () => {
+  it('exits 2 with no arguments', () => {
+    const result = runVerifier(undefined);
+    // No file path → usage error
+    assert.equal(result.exitCode, 2);
+    assert.match(result.stderr, /usage/i);
+  });
+
+  it('passes for a valid integrity-mode export', () => {
+    const events = [makeEvent(1), makeEvent(2), makeEvent(3)];
+    const ndjson = buildNdjson(events);
+    const path = writeTempFile('valid.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}. stderr: ${result.stderr}`);
+    assert.match(result.stdout, /INTEGRITY CHECK PASSED/);
+    assert.match(result.stdout, /Event count verified: 3/);
+    assert.match(result.stdout, /SHA-256 verified/);
+  });
+
+  it('fails when SHA-256 is tampered', () => {
+    const events = [makeEvent(1)];
+    const ndjson = buildNdjson(events, { overrideHash: 'deadbeef'.repeat(8) });
+    const path = writeTempFile('bad-hash.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /SHA-256 mismatch/);
+    assert.match(result.stderr, /INTEGRITY CHECK FAILED/);
+  });
+
+  it('fails when count is wrong', () => {
+    const events = [makeEvent(1), makeEvent(2)];
+    const ndjson = buildNdjson(events, { overrideCount: 5 });
+    const path = writeTempFile('bad-count.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /count mismatch/i);
+  });
+
+  it('fails when header is missing', () => {
+    const events = [makeEvent(1)];
+    const ndjson = buildNdjson(events, { includeHeader: false });
+    const path = writeTempFile('no-header.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /no trace_export_header/i);
+  });
+
+  it('fails when footer is missing', () => {
+    const events = [makeEvent(1)];
+    const ndjson = buildNdjson(events, { includeFooter: false });
+    const path = writeTempFile('no-footer.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /no trace_export_footer/i);
+  });
+
+  it('hash is deterministic: same events produce same digest', () => {
+    const events = [makeEvent(1), makeEvent(2)];
+    const hash1 = createHash('sha256');
+    const hash2 = createHash('sha256');
+
+    for (const event of events) {
+      const line = JSON.stringify(event) + '\n';
+      hash1.update(line);
+      hash2.update(line);
+    }
+
+    assert.equal(hash1.digest('hex'), hash2.digest('hex'));
+  });
+
+  it('verifies a single-event export', () => {
+    const events = [makeEvent(1)];
+    const ndjson = buildNdjson(events);
+    const path = writeTempFile('single.ndjson', ndjson);
+
+    const result = runVerifier(path);
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /Event count verified: 1/);
+  });
+});

--- a/tools/verify-trace-export.mjs
+++ b/tools/verify-trace-export.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * verify-trace-export.mjs — Operator tool for validating trace export integrity.
+ *
+ * Reads an NDJSON file exported with `includeMeta=1` and verifies:
+ *   1. Header line exists with type `trace_export_header`
+ *   2. Footer line exists with type `trace_export_footer`
+ *   3. SHA-256 hash of event-line bytes matches footer.sha256
+ *   4. Event count matches footer.count
+ *
+ * Usage:
+ *   node tools/verify-trace-export.mjs <path-to-ndjson>
+ *
+ * Exit codes:
+ *   0 — valid
+ *   1 — integrity failure (hash mismatch, count mismatch, missing envelope)
+ *   2 — usage error (no file, file not found)
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { resolve } from 'node:path';
+
+const filePath = process.argv[2];
+
+if (!filePath) {
+  process.stderr.write('Usage: node tools/verify-trace-export.mjs <path-to-ndjson>\n');
+  process.exit(2);
+}
+
+const absolutePath = resolve(filePath);
+
+/** @returns {Promise<{ header: object|null, footer: object|null, eventLines: string[], rawEventLines: string[] }>} */
+async function parseExportFile(path) {
+  const rl = createInterface({
+    input: createReadStream(path, { encoding: 'utf-8' }),
+    crlfDelay: Infinity,
+  });
+
+  const lines = [];
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed) lines.push(trimmed);
+  }
+
+  if (lines.length < 3) {
+    return { header: null, footer: null, eventLines: [], rawEventLines: [] };
+  }
+
+  let header = null;
+  let footer = null;
+
+  try {
+    const first = JSON.parse(lines[0]);
+    if (first.type === 'trace_export_header') header = first;
+  } catch { /* not valid JSON header */ }
+
+  try {
+    const last = JSON.parse(lines[lines.length - 1]);
+    if (last.type === 'trace_export_footer') footer = last;
+  } catch { /* not valid JSON footer */ }
+
+  const eventStart = header ? 1 : 0;
+  const eventEnd = footer ? lines.length - 1 : lines.length;
+  const rawEventLines = lines.slice(eventStart, eventEnd);
+
+  return { header, footer, eventLines: rawEventLines, rawEventLines };
+}
+
+function computeHash(eventLines) {
+  const hash = createHash('sha256');
+  for (const line of eventLines) {
+    // Match the exact bytes the exporter writes: JSON.stringify(event) + "\n"
+    // The event lines we have are already the JSON.stringify output (trimmed of trailing \n by readline).
+    hash.update(line + '\n');
+  }
+  return hash.digest('hex');
+}
+
+const { header, footer, eventLines } = await parseExportFile(absolutePath);
+
+let failures = 0;
+
+if (!header) {
+  process.stderr.write('FAIL: No trace_export_header found on first line.\n');
+  process.stderr.write('      File may not have been exported with includeMeta=1.\n');
+  failures++;
+}
+
+if (!footer) {
+  process.stderr.write('FAIL: No trace_export_footer found on last line.\n');
+  failures++;
+}
+
+if (header && footer) {
+  // Check count
+  if (footer.count !== eventLines.length) {
+    process.stderr.write(
+      `FAIL: Footer count mismatch. footer.count=${footer.count}, actual event lines=${eventLines.length}\n`
+    );
+    failures++;
+  } else {
+    process.stdout.write(`OK:   Event count verified: ${footer.count}\n`);
+  }
+
+  // Check hash
+  const computed = computeHash(eventLines);
+  if (computed !== footer.sha256) {
+    process.stderr.write(
+      `FAIL: SHA-256 mismatch.\n  expected: ${footer.sha256}\n  computed: ${computed}\n`
+    );
+    failures++;
+  } else {
+    process.stdout.write(`OK:   SHA-256 verified: ${computed}\n`);
+  }
+
+  // Summary metadata
+  process.stdout.write(`INFO: parcelId=${header.parcelId}, order=${header.order}\n`);
+  process.stdout.write(`INFO: exported at ${header.exportedAt}\n`);
+  if (header.correlationId) {
+    process.stdout.write(`INFO: correlationId=${header.correlationId}\n`);
+  }
+}
+
+if (failures > 0) {
+  process.stderr.write(`\nVERDICT: INTEGRITY CHECK FAILED (${failures} failure${failures > 1 ? 's' : ''})\n`);
+  process.exit(1);
+} else if (header && footer) {
+  process.stdout.write('\nVERDICT: INTEGRITY CHECK PASSED\n');
+  process.exit(0);
+} else {
+  process.stderr.write('\nVERDICT: INCOMPLETE (missing envelope lines)\n');
+  process.exit(1);
+}


### PR DESCRIPTION
Operator tool to validate NDJSON exports with includeMeta=1. Verifies header/footer presence, SHA-256 hash of event-line bytes, and count. Exit 0=valid, 1=integrity failure, 2=usage error. 8 contract tests. Tests: 496/496 (488+8). No runtime changes.

## Summary by Sourcery

Add a CLI tool to verify integrity of trace NDJSON exports and cover it with contract tests.

New Features:
- Introduce a verify-trace-export CLI tool to validate NDJSON trace exports using header/footer metadata, event counts, and SHA-256 hashes.

Tests:
- Add contract tests for the verify-trace-export CLI covering valid exports, integrity failures, and hash determinism.