### PR TITLE
Lane S — Sidecar HTTP headers for trace export

### DIFF
--- a/os-platform/core/pilot/traceExport.js
+++ b/os-platform/core/pilot/traceExport.js
@@ -58,6 +58,8 @@ function parseTraceExportQuery(query, nowMs = Date.now()) {
     const correlationId = queryString(query, 'correlationId')?.trim() || undefined;
     const rawIncludeMeta = queryString(query, 'includeMeta');
     const includeMeta = rawIncludeMeta === '1' || rawIncludeMeta === 'true';
+    const rawSidecar = queryString(query, 'sidecar');
+    const sidecar = rawSidecar === '1' || rawSidecar === 'true';
     return {
         ok: true,
         value: {
@@ -67,6 +69,7 @@ function parseTraceExportQuery(query, nowMs = Date.now()) {
             to: new Date(effectiveToMs).toISOString(),
             limit,
             includeMeta,
+            sidecar,
         },
     };
 }
@@ -176,6 +179,22 @@ async function handleTraceExport(req, res, traceService) {
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Content-Disposition', `attachment; filename="trace-export-${safeParcelId}${fileSuffix}.ndjson"`);
+    // Compute integrity hash when sidecar headers or inline meta requested
+    const needsHash = params.includeMeta || params.sidecar;
+    let computedHash;
+    if (needsHash) {
+        const hash = (0, crypto_1.createHash)('sha256');
+        for (const event of exportedEvents) {
+            hash.update(`${JSON.stringify(event)}\n`);
+        }
+        computedHash = hash.digest('hex');
+    }
+    // Set sidecar HTTP headers before body writes
+    if (params.sidecar && computedHash !== undefined) {
+        res.setHeader('X-Trace-Export-SHA256', computedHash);
+        res.setHeader('X-Trace-Export-Count', String(exportedEvents.length));
+    }
+    // Write body
     if (params.includeMeta) {
         const header = {
             type: 'trace_export_header',
@@ -188,18 +207,13 @@ async function handleTraceExport(req, res, traceService) {
             order: 'timestamp_desc,correlationId_asc,eventId_asc',
         };
         res.write(`${JSON.stringify(header)}\n`);
-        const hash = (0, crypto_1.createHash)('sha256');
-        let count = 0;
         for (const event of exportedEvents) {
-            const line = `${JSON.stringify(event)}\n`;
-            hash.update(line);
-            res.write(line);
-            count++;
+            res.write(`${JSON.stringify(event)}\n`);
         }
         const footer = {
             type: 'trace_export_footer',
-            sha256: hash.digest('hex'),
-            count,
+            sha256: computedHash,
+            count: exportedEvents.length,
         };
         res.write(`${JSON.stringify(footer)}\n`);
     }

--- a/os-platform/core/pilot/traceExport.ts
+++ b/os-platform/core/pilot/traceExport.ts
@@ -37,6 +37,7 @@ export interface TraceExportParams {
   to: string;
   limit: number;
   includeMeta: boolean;
+  sidecar: boolean;
 }
 
 export type TraceExportParseResult =
@@ -105,6 +106,9 @@ export function parseTraceExportQuery(
   const rawIncludeMeta = queryString(query, 'includeMeta');
   const includeMeta = rawIncludeMeta === '1' || rawIncludeMeta === 'true';
 
+  const rawSidecar = queryString(query, 'sidecar');
+  const sidecar = rawSidecar === '1' || rawSidecar === 'true';
+
   return {
     ok: true,
     value: {
@@ -114,6 +118,7 @@ export function parseTraceExportQuery(
       to: new Date(effectiveToMs).toISOString(),
       limit,
       includeMeta,
+      sidecar,
     },
   };
 }
@@ -242,6 +247,24 @@ export async function handleTraceExport(
     `attachment; filename="trace-export-${safeParcelId}${fileSuffix}.ndjson"`
   );
 
+  // Compute integrity hash when sidecar headers or inline meta requested
+  const needsHash = params.includeMeta || params.sidecar;
+  let computedHash: string | undefined;
+  if (needsHash) {
+    const hash = createHash('sha256');
+    for (const event of exportedEvents) {
+      hash.update(`${JSON.stringify(event)}\n`);
+    }
+    computedHash = hash.digest('hex');
+  }
+
+  // Set sidecar HTTP headers before body writes
+  if (params.sidecar && computedHash !== undefined) {
+    res.setHeader('X-Trace-Export-SHA256', computedHash);
+    res.setHeader('X-Trace-Export-Count', String(exportedEvents.length));
+  }
+
+  // Write body
   if (params.includeMeta) {
     const header = {
       type: 'trace_export_header',
@@ -255,19 +278,14 @@ export async function handleTraceExport(
     };
     res.write(`${JSON.stringify(header)}\n`);
 
-    const hash = createHash('sha256');
-    let count = 0;
     for (const event of exportedEvents) {
-      const line = `${JSON.stringify(event)}\n`;
-      hash.update(line);
-      res.write(line);
-      count++;
+      res.write(`${JSON.stringify(event)}\n`);
     }
 
     const footer = {
       type: 'trace_export_footer',
-      sha256: hash.digest('hex'),
-      count,
+      sha256: computedHash!,
+      count: exportedEvents.length,
     };
     res.write(`${JSON.stringify(footer)}\n`);
   } else {

--- a/os-platform/core/tests/lane-k-trace-export-endpoint.test.mjs
+++ b/os-platform/core/tests/lane-k-trace-export-endpoint.test.mjs
@@ -414,3 +414,121 @@ describe('handleTraceExport', () => {
     assert.equal(hash1.length, 64);
   });
 });
+
+// ── Lane S: sidecar header tests ──
+
+describe('handleTraceExport sidecar headers', () => {
+  it('sidecar=1 emits X-Trace-Export-SHA256 and X-Trace-Export-Count headers', async () => {
+    for (let i = 0; i < 3; i++) {
+      emitTraceEvent({
+        correlationId: `corr-sc-${i}`,
+        context: {
+          countyId: 'benton',
+          userId: `user-sc-${i}`,
+          roles: ['appraiser'],
+          mode: 'pilot',
+          parcelId: 'P-SC',
+        },
+      });
+    }
+
+    const req = {
+      query: { parcelId: 'P-SC', sidecar: '1' },
+      user: { userId: 'admin-1', roles: ['administrator'], countyId: 'benton' },
+    };
+    const res = createMockResponse();
+    await handleTraceExport(req, res, traceService);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers.get('x-trace-export-count'), '3');
+    const sha = res.headers.get('x-trace-export-sha256');
+    assert.equal(typeof sha, 'string');
+    assert.equal(sha.length, 64);
+
+    // Body should be bare events (no header/footer) since includeMeta omitted
+    const lines = parseNdjsonBody(res.bodyText);
+    assert.equal(lines.length, 3);
+    assert.ok(lines.every((l) => l.type === 'tool_completed'));
+  });
+
+  it('sidecar=1 + includeMeta=1 headers match inline footer values', async () => {
+    for (let i = 0; i < 2; i++) {
+      emitTraceEvent({
+        correlationId: `corr-both-${i}`,
+        context: {
+          countyId: 'benton',
+          userId: `user-both-${i}`,
+          roles: ['appraiser'],
+          mode: 'pilot',
+          parcelId: 'P-BOTH',
+        },
+      });
+    }
+
+    const req = {
+      query: { parcelId: 'P-BOTH', sidecar: '1', includeMeta: '1' },
+      user: { userId: 'admin-1', roles: ['administrator'], countyId: 'benton' },
+    };
+    const res = createMockResponse();
+    await handleTraceExport(req, res, traceService);
+
+    const lines = parseNdjsonBody(res.bodyText);
+    const footer = lines[lines.length - 1];
+    assert.equal(footer.type, 'trace_export_footer');
+
+    // HTTP headers must match inline footer
+    assert.equal(res.headers.get('x-trace-export-sha256'), footer.sha256);
+    assert.equal(res.headers.get('x-trace-export-count'), String(footer.count));
+  });
+
+  it('default mode (no sidecar) does not emit sidecar headers', async () => {
+    emitTraceEvent({
+      correlationId: 'corr-no-sc',
+      context: {
+        countyId: 'benton',
+        userId: 'owner-no-sc',
+        roles: ['appraiser'],
+        mode: 'pilot',
+        parcelId: 'P-NOSC',
+      },
+    });
+
+    const req = {
+      query: { parcelId: 'P-NOSC' },
+      user: { userId: 'admin-1', roles: ['administrator'], countyId: 'benton' },
+    };
+    const res = createMockResponse();
+    await handleTraceExport(req, res, traceService);
+
+    assert.equal(res.headers.has('x-trace-export-sha256'), false);
+    assert.equal(res.headers.has('x-trace-export-count'), false);
+  });
+
+  it('sidecar=1 SHA-256 is deterministic across calls', async () => {
+    emitTraceEvent({
+      correlationId: 'corr-det',
+      context: {
+        countyId: 'benton',
+        userId: 'owner-det',
+        roles: ['appraiser'],
+        mode: 'pilot',
+        parcelId: 'P-DET',
+      },
+    });
+
+    const run = async () => {
+      const req = {
+        query: { parcelId: 'P-DET', sidecar: '1' },
+        user: { userId: 'admin-1', roles: ['administrator'], countyId: 'benton' },
+      };
+      const res = createMockResponse();
+      await handleTraceExport(req, res, traceService);
+      return res.headers.get('x-trace-export-sha256');
+    };
+
+    const h1 = await run();
+    const h2 = await run();
+    assert.equal(h1, h2, 'Sidecar SHA-256 must be deterministic');
+    assert.equal(h1.length, 64);
+  });
+});


### PR DESCRIPTION
## Lane S — Sidecar HTTP headers for trace export

**Branch**: copilot/lane-s-sidecar-headers | **Base**: r1/integration | **Scope**: os-platform/core only

### Deliverables

- sidecar=1 query param on GET /pilot/traces/export
- X-Trace-Export-SHA256 header (SHA-256 hex of event-line bytes)
- X-Trace-Export-Count header (event count)
- Combined with includeMeta=1: HTTP headers match inline footer
- Default behavior unchanged

### Tests (4 new, 500 total)

- sidecar=1 emits headers
- sidecar + includeMeta headers match footer
- default mode: no sidecar headers
- sidecar SHA-256 determinism

### Gates

- type-check: 0 errors
- build:core-js: clean
- core tests: 500/500

Government: FISMA compliance
AI-Collaboration: GitHub Copilot (Lane S)

## Summary by Sourcery

Add optional sidecar support to the trace export endpoint, exposing export metadata via HTTP headers while preserving existing default behavior.

New Features:
- Support a sidecar=1 query parameter on GET /pilot/traces/export to enable metadata sidecar mode.
- Emit X-Trace-Export-SHA256 and X-Trace-Export-Count HTTP headers when sidecar mode is enabled, aligned with inline footer metadata when includeMeta=1 is used.

Enhancements:
- Refactor trace export hashing to compute a single deterministic SHA-256 over exported events for reuse by both inline metadata and sidecar headers.

Tests:
- Add tests covering sidecar header emission, consistency with inline footer metadata, absence of headers in default mode, and determinism of the SHA-256 hash.