### PR TITLE
chore(generated): skip .claude and dist in check:generated

### DIFF
--- a/tools/registry/check-generated-js.mjs
+++ b/tools/registry/check-generated-js.mjs
@@ -13,6 +13,8 @@ const SKIP_DIRS = new Set([
   'node_modules',
   '.git',
   '.venv',
+  '.claude',
+  'dist',
   '_archive',
   '_pre_restore_safety_20260108_144218',
 ]);


### PR DESCRIPTION
## Scope
- `tools/registry/check-generated-js.mjs` only

## Why
Prevent local auxiliary worktrees and dist artifacts from causing false failures in `check:generated`.

## Gate Proof
- `pnpm run check:generated` -> pass
  - Output: `Generated JS headers verified.`