### PR TITLE
feat(shell): R1 Week 3 frontend (CC-11..CC-14)

### DIFF
--- a/frontend/apps/os-shell/src/components/workbench/ContextRibbon.tsx
+++ b/frontend/apps/os-shell/src/components/workbench/ContextRibbon.tsx
@@ -99,7 +99,7 @@ function riskLevelStyle(risk?: string | null) {
     case 'write_low':
       return { bg: 'hsl(var(--tf-accent) / 0.15)', color: 'hsl(var(--tf-accent))', label: '🟡 write_low' };
     case 'read_only':
-      return { bg: 'hsl(var(--tf-success) / 0.15)', color: 'hsl(var(--tf-success, 160 60% 45%))', label: '🟢 read_only' };
+      return { bg: 'hsl(var(--tf-success) / 0.15)', color: 'hsl(var(--tf-success))', label: '🟢 read_only' };
     default:
       return null;
   }

--- a/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
+++ b/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
@@ -40,11 +40,11 @@ export interface PolicyGuardUIProps {
 // Risk → visual mapping
 // ============================================================================
 
-const RISK_CONFIG: Record<RiskLevel, { emoji: string; label: string; toneClass: string }> = {
-  read_only:    { emoji: '🟢', label: 'Read Only',   toneClass: 'bg-emerald-500/15 text-emerald-700' },
-  write_low:    { emoji: '🟡', label: 'Write (Low)',  toneClass: 'bg-amber-500/15 text-amber-700' },
-  write_high:   { emoji: '🟠', label: 'Write (High)', toneClass: 'bg-orange-500/15 text-orange-700' },
-  irreversible: { emoji: '🔴', label: 'Irreversible', toneClass: 'bg-red-500/15 text-red-700' },
+const RISK_CONFIG: Record<RiskLevel, { emoji: string; label: string; colorVar: string }> = {
+  read_only:    { emoji: '🟢', label: 'Read Only',    colorVar: '--tf-success' },
+  write_low:    { emoji: '🟡', label: 'Write (Low)',   colorVar: '--tf-accent' },
+  write_high:   { emoji: '🟠', label: 'Write (High)',  colorVar: '--tf-warning' },
+  irreversible: { emoji: '🔴', label: 'Irreversible',  colorVar: '--tf-error' },
 };
 
 // ============================================================================
@@ -69,7 +69,12 @@ export const PolicyGuardUI: React.FC<PolicyGuardUIProps> = ({
       {/* Write-lane badge */}
       {lane && (
         <span
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium border border-border bg-muted/60 text-foreground"
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: 'hsl(var(--tf-accent) / 0.1)',
+            color: 'hsl(var(--tf-accent))',
+            border: '1px solid hsl(var(--tf-accent) / 0.2)',
+          }}
           data-testid="lane-badge"
         >
           📝 {lane}
@@ -79,7 +84,11 @@ export const PolicyGuardUI: React.FC<PolicyGuardUIProps> = ({
       {/* Risk level badge */}
       {riskCfg && (
         <span
-          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium ${riskCfg.toneClass}`}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: `hsl(var(${riskCfg.colorVar}) / 0.15)`,
+            color: `hsl(var(${riskCfg.colorVar}))`,
+          }}
           data-testid="risk-badge"
         >
           {riskCfg.emoji} {riskCfg.label}


### PR DESCRIPTION
## PR 2 — CP Frontend: R1 Week 3 UI Components

### What
Frontend components and service hardening for the Workbench policy/trace experience.

### Components (CC-11, CC-12)
- **ContextRibbon** (enhanced): Added `pilotMode`, `userRole`, `activeRisk`, `activeCorrelationId` props + Row 3 pilot status display
- **PolicyGuardUI** (new): Renders lane, risk, mode, role, county-isolation, and confirmation-required badges. All colors use design tokens (`--tf-accent`, `--tf-info`, `--tf-success`, etc.)
- **useParcelTrace** (new): React hook wrapping `usePilotTraceList` with parcel-scoped filtering

### Services (CC-13, CC-14 — stub removal)
- **atlasService**: Removed `DEFAULT_LAYERS`/`DEFAULT_PARCELS` fallback data, all methods now propagate real backend errors
- **dossierService**: Removed `DEFAULT_DOCUMENTS`/`DEFAULT_EVIDENCE`/`DEFAULT_CHAIN` fallback data

### Files (6)
| File | Status |
|------|--------|
| `ContextRibbon.tsx` | Modified (+ props, + Row 3) |
| `PolicyGuardUI.tsx` | New |
| `workbench/index.ts` | Modified (+ export) |
| `useParcelTrace.ts` | New |
| `atlasService.ts` | Modified (stubs removed) |
| `dossierService.ts` | Modified (stubs removed) |

### Gate Evidence
| Gate | Result |
|------|--------|
| `type-check` | Clean (0 errors) |
| UI token ratchet | 195 = baseline (no regression) |

### Scope
`frontend/apps/os-shell/**` — CP absorbing Claude Code scope for R1 (Claude Code benched).

### Backend Dependency
Service methods call endpoints delivered in PR 3 (CX backend). Until those land, services return real HTTP errors.

AI-Collaboration: GitHub Copilot

## Summary by Sourcery

Add new workbench UI elements for displaying pilot policy context while removing frontend fallback data in favor of real backend responses.

New Features:
- Extend the ContextRibbon with pilot mode, user role, risk level, and correlation ID indicators in a new status row.
- Introduce a reusable PolicyGuardUI component to surface lane, risk, mode, role, county isolation, and confirmation-required badges.
- Add a useParcelTrace hook that exposes parcel-scoped pilot trace events for the workbench experience.

Enhancements:
- Export the new PolicyGuardUI types and component from the workbench index for broader shell usage.

Chores:
- Remove atlas and dossier service stub fallback data so that all methods now propagate real backend errors, with 404s mapped to null where expected.