### PR TITLE
feat(shell): week3 frontend wire (ContextRibbon, PolicyGuardUI, real services)

### DIFF
--- a/frontend/apps/os-shell/src/components/workbench/ContextRibbon.tsx
+++ b/frontend/apps/os-shell/src/components/workbench/ContextRibbon.tsx
@@ -45,6 +45,14 @@ export interface ContextRibbonProps {
   onQuickAction?: (action: QuickActionDefinition) => void;
   /** Optional "Pop out" callback for window mode */
   onPopOut?: () => void;
+  /** CC-11: Current pilot/muse mode */
+  pilotMode?: 'pilot' | 'muse';
+  /** CC-11: Current user role */
+  userRole?: string;
+  /** CC-11: Active risk level of current invocation */
+  activeRisk?: 'read_only' | 'write_low' | 'write_high' | 'irreversible' | null;
+  /** CC-11: Active correlationId from current/last invocation */
+  activeCorrelationId?: string | null;
 }
 
 // ============================================================================
@@ -78,6 +86,25 @@ function badgeSeverityStyle(severity?: 'info' | 'warn' | 'danger') {
 // Component
 // ============================================================================
 
+// ============================================================================
+// Risk Level → Style Mapping (CC-11)
+// ============================================================================
+
+function riskLevelStyle(risk?: string | null) {
+  switch (risk) {
+    case 'irreversible':
+      return { bg: 'hsl(var(--tf-error) / 0.2)', color: 'hsl(var(--tf-error))', label: '🔴 irreversible' };
+    case 'write_high':
+      return { bg: 'hsl(var(--tf-warning) / 0.2)', color: 'hsl(var(--tf-warning))', label: '🟠 write_high' };
+    case 'write_low':
+      return { bg: 'hsl(var(--tf-accent) / 0.15)', color: 'hsl(var(--tf-accent))', label: '🟡 write_low' };
+    case 'read_only':
+      return { bg: 'hsl(var(--tf-success) / 0.15)', color: 'hsl(var(--tf-success, 160 60% 45%))', label: '🟢 read_only' };
+    default:
+      return null;
+  }
+}
+
 export const ContextRibbon: React.FC<ContextRibbonProps> = ({
   parcelId,
   address,
@@ -89,6 +116,10 @@ export const ContextRibbon: React.FC<ContextRibbonProps> = ({
   onWorkModeChange,
   onQuickAction,
   onPopOut,
+  pilotMode,
+  userRole,
+  activeRisk,
+  activeCorrelationId,
 }) => {
   // Filter out RESTRICTED badges (user would need higher clearance)
   const visibleBadges = useMemo(
@@ -190,6 +221,78 @@ export const ContextRibbon: React.FC<ContextRibbonProps> = ({
               {badge.label}
             </span>
           ))}
+        </div>
+      )}
+
+      {/* Row 3: Pilot status indicators (CC-11) */}
+      {(pilotMode || userRole || activeRisk || activeCorrelationId) && (
+        <div
+          className="flex items-center gap-3 mt-2 flex-wrap text-xs"
+          data-testid="pilot-status-row"
+        >
+          {/* Role badge */}
+          {userRole && (
+            <span
+              className="px-2 py-0.5 rounded font-medium"
+              style={{
+                background: 'hsl(var(--tf-bg-surface) / 0.5)',
+                color: 'hsl(var(--tf-text) / 0.7)',
+                border: '1px solid hsl(var(--tf-text) / 0.1)',
+              }}
+              data-testid="role-badge"
+            >
+              👤 {userRole}
+            </span>
+          )}
+
+          {/* Mode indicator */}
+          {pilotMode && (
+            <span
+              className="px-2 py-0.5 rounded font-medium"
+              style={{
+                background: pilotMode === 'pilot'
+                  ? 'hsl(var(--tf-accent) / 0.15)'
+                  : 'hsl(270 60% 50% / 0.15)',
+                color: pilotMode === 'pilot'
+                  ? 'hsl(var(--tf-accent))'
+                  : 'hsl(270 60% 65%)',
+              }}
+              data-testid="mode-badge"
+            >
+              {pilotMode === 'pilot' ? '🧭 Pilot' : '✨ Muse'}
+            </span>
+          )}
+
+          {/* Risk level */}
+          {activeRisk && (() => {
+            const rs = riskLevelStyle(activeRisk);
+            return rs ? (
+              <span
+                className="px-2 py-0.5 rounded font-medium"
+                style={{ background: rs.bg, color: rs.color }}
+                data-testid="risk-badge"
+              >
+                {rs.label}
+              </span>
+            ) : null;
+          })()}
+
+          {/* Active correlationId */}
+          {activeCorrelationId && (
+            <span
+              className="px-2 py-0.5 rounded font-mono"
+              style={{
+                background: 'hsl(var(--tf-bg-surface) / 0.4)',
+                color: 'hsl(var(--tf-text) / 0.5)',
+              }}
+              data-testid="correlation-badge"
+              title={`Trace: ${activeCorrelationId}`}
+            >
+              🔗 {activeCorrelationId.length > 20
+                ? `${activeCorrelationId.slice(0, 8)}…${activeCorrelationId.slice(-6)}`
+                : activeCorrelationId}
+            </span>
+          )}
         </div>
       )}
     </LiquidPanel>

--- a/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
+++ b/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
@@ -1,0 +1,164 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * TERRAFUSION OS — POLICY GUARD UI (CC-12)
+ * R1 Week 3: Displays lane, risk, mode, county-isolation badge
+ *
+ * Shows the current invocation's policy context so operators
+ * can see at a glance what write-lane is active, what risk level
+ * applies, and that county isolation is enforced.
+ *
+ * @see 04_TERRAPILOT_COPILOT_SPEC_v3.1.md — Permission model
+ * @see R1_DAY0_CONTRACTS.md — Contract 3 (Role Vocabulary)
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import React from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type RiskLevel = 'read_only' | 'write_low' | 'write_high' | 'irreversible';
+export type PilotMode = 'pilot' | 'muse';
+
+export interface PolicyGuardUIProps {
+  /** Write-lane owner (e.g. 'forge', 'atlas', 'dais', 'dossier', 'os') */
+  lane?: string;
+  /** Tool risk classification */
+  risk?: RiskLevel | null;
+  /** Current pilot/muse mode */
+  mode?: PilotMode;
+  /** County name proving isolation is active */
+  countyName?: string;
+  /** Current user role */
+  role?: string;
+  /** Whether a confirmation dialog is required (write_high / irreversible) */
+  confirmationRequired?: boolean;
+}
+
+// ============================================================================
+// Risk → visual mapping
+// ============================================================================
+
+const RISK_CONFIG: Record<RiskLevel, { emoji: string; label: string; colorVar: string }> = {
+  read_only:    { emoji: '🟢', label: 'Read Only',    colorVar: '--tf-success' },
+  write_low:    { emoji: '🟡', label: 'Write (Low)',   colorVar: '--tf-accent' },
+  write_high:   { emoji: '🟠', label: 'Write (High)',  colorVar: '--tf-warning' },
+  irreversible: { emoji: '🔴', label: 'Irreversible',  colorVar: '--tf-error' },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export const PolicyGuardUI: React.FC<PolicyGuardUIProps> = ({
+  lane,
+  risk,
+  mode,
+  countyName,
+  role,
+  confirmationRequired,
+}) => {
+  const riskCfg = risk ? RISK_CONFIG[risk] : null;
+
+  return (
+    <div
+      className="flex items-center gap-2 flex-wrap text-xs"
+      data-testid="policy-guard-ui"
+    >
+      {/* Write-lane badge */}
+      {lane && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: 'hsl(var(--tf-accent) / 0.1)',
+            color: 'hsl(var(--tf-accent))',
+            border: '1px solid hsl(var(--tf-accent) / 0.2)',
+          }}
+          data-testid="lane-badge"
+        >
+          📝 {lane}
+        </span>
+      )}
+
+      {/* Risk level badge */}
+      {riskCfg && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: `hsl(var(${riskCfg.colorVar}) / 0.15)`,
+            color: `hsl(var(${riskCfg.colorVar}))`,
+          }}
+          data-testid="risk-badge"
+        >
+          {riskCfg.emoji} {riskCfg.label}
+        </span>
+      )}
+
+      {/* Mode badge */}
+      {mode && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: mode === 'pilot'
+              ? 'hsl(var(--tf-accent) / 0.15)'
+              : 'hsl(var(--tf-info) / 0.15)',
+            color: mode === 'pilot'
+              ? 'hsl(var(--tf-accent))'
+              : 'hsl(var(--tf-info))',
+          }}
+          data-testid="mode-badge"
+        >
+          {mode === 'pilot' ? '🧭 Pilot' : '✨ Muse'}
+        </span>
+      )}
+
+      {/* Role badge */}
+      {role && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: 'hsl(var(--tf-bg-surface) / 0.5)',
+            color: 'hsl(var(--tf-text) / 0.7)',
+            border: '1px solid hsl(var(--tf-text) / 0.1)',
+          }}
+          data-testid="role-badge"
+        >
+          👤 {role}
+        </span>
+      )}
+
+      {/* County isolation badge */}
+      {countyName && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
+          style={{
+            background: 'hsl(var(--tf-bg-surface) / 0.4)',
+            color: 'hsl(var(--tf-text) / 0.6)',
+            border: '1px solid hsl(var(--tf-text) / 0.08)',
+          }}
+          data-testid="county-badge"
+        >
+          🔒 {countyName}
+        </span>
+      )}
+
+      {/* Confirmation required warning */}
+      {confirmationRequired && (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-semibold"
+          style={{
+            background: 'hsl(var(--tf-warning) / 0.2)',
+            color: 'hsl(var(--tf-warning))',
+            border: '1px solid hsl(var(--tf-warning) / 0.3)',
+          }}
+          data-testid="confirmation-badge"
+        >
+          ⚠ Confirmation Required
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default PolicyGuardUI;

--- a/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
+++ b/frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx
@@ -40,11 +40,11 @@ export interface PolicyGuardUIProps {
 // Risk → visual mapping
 // ============================================================================
 
-const RISK_CONFIG: Record<RiskLevel, { emoji: string; label: string; colorVar: string }> = {
-  read_only:    { emoji: '🟢', label: 'Read Only',    colorVar: '--tf-success' },
-  write_low:    { emoji: '🟡', label: 'Write (Low)',   colorVar: '--tf-accent' },
-  write_high:   { emoji: '🟠', label: 'Write (High)',  colorVar: '--tf-warning' },
-  irreversible: { emoji: '🔴', label: 'Irreversible',  colorVar: '--tf-error' },
+const RISK_CONFIG: Record<RiskLevel, { emoji: string; label: string; toneClass: string }> = {
+  read_only:    { emoji: '🟢', label: 'Read Only',   toneClass: 'bg-emerald-500/15 text-emerald-700' },
+  write_low:    { emoji: '🟡', label: 'Write (Low)',  toneClass: 'bg-amber-500/15 text-amber-700' },
+  write_high:   { emoji: '🟠', label: 'Write (High)', toneClass: 'bg-orange-500/15 text-orange-700' },
+  irreversible: { emoji: '🔴', label: 'Irreversible', toneClass: 'bg-red-500/15 text-red-700' },
 };
 
 // ============================================================================
@@ -69,12 +69,7 @@ export const PolicyGuardUI: React.FC<PolicyGuardUIProps> = ({
       {/* Write-lane badge */}
       {lane && (
         <span
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
-          style={{
-            background: 'hsl(var(--tf-accent) / 0.1)',
-            color: 'hsl(var(--tf-accent))',
-            border: '1px solid hsl(var(--tf-accent) / 0.2)',
-          }}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium border border-border bg-muted/60 text-foreground"
           data-testid="lane-badge"
         >
           📝 {lane}
@@ -84,11 +79,7 @@ export const PolicyGuardUI: React.FC<PolicyGuardUIProps> = ({
       {/* Risk level badge */}
       {riskCfg && (
         <span
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium"
-          style={{
-            background: `hsl(var(${riskCfg.colorVar}) / 0.15)`,
-            color: `hsl(var(${riskCfg.colorVar}))`,
-          }}
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded font-medium ${riskCfg.toneClass}`}
           data-testid="risk-badge"
         >
           {riskCfg.emoji} {riskCfg.label}

--- a/frontend/apps/os-shell/src/components/workbench/index.ts
+++ b/frontend/apps/os-shell/src/components/workbench/index.ts
@@ -19,4 +19,5 @@ export { ContextRibbon, type ContextRibbonProps } from './ContextRibbon';
 export { WorkModeSelector, type WorkModeSelectorProps } from './WorkModeSelector';
 export { ActivityFeed, type ActivityEntry, type ActivityFeedProps, type ActivitySeverity } from './ActivityFeed';
 export { ParcelContextBanner, type ParcelContextBannerProps } from './ParcelContextBanner';
+export { PolicyGuardUI, type PolicyGuardUIProps, type RiskLevel, type PilotMode } from './PolicyGuardUI';
 

--- a/frontend/apps/os-shell/src/hooks/useParcelTrace.ts
+++ b/frontend/apps/os-shell/src/hooks/useParcelTrace.ts
@@ -1,0 +1,32 @@
+/**
+ * useParcelTrace.ts
+ *
+ * CP-10: Thin wrapper over usePilotTraceList that provides the
+ * useParcelTrace(parcelId) contract required by R1 spec.
+ *
+ * Returns TraceEvent[] for the EvidenceRail.
+ * Calls GET /pilot/traces filtered by parcelId (real backend, not mock).
+ */
+
+import type { PilotTraceEvent } from '../api/pilotApi';
+import { usePilotTraceList, type TraceListPhase } from './usePilotTraceList';
+
+export interface UseParcelTraceResult {
+  phase: TraceListPhase;
+  events: PilotTraceEvent[];
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetch real trace events for a parcel (replaces generateMockActivity).
+ *
+ * @param parcelId - Parcel to query trace events for. null = idle.
+ * @param pollMs - Polling interval in ms. Default 5000.
+ */
+export function useParcelTrace(
+  parcelId: string | null | undefined,
+  pollMs = 5000,
+): UseParcelTraceResult {
+  return usePilotTraceList({ parcelId, pollMs });
+}

--- a/frontend/apps/os-shell/src/services/atlasService.ts
+++ b/frontend/apps/os-shell/src/services/atlasService.ts
@@ -116,28 +116,9 @@ async function atlasPost<T>(path: string, body: unknown): Promise<T> {
 }
 
 // ============================================================================
-// DEFAULT DATA (fallback when API is offline)
+// NOTE: DEFAULT fallback data removed in CC-13 (R1 Week 3).
+// All service methods now propagate errors from the real backend.
 // ============================================================================
-
-const DEFAULT_LAYERS: MapLayer[] = [
-  { id: 'parcels', name: 'Parcel Boundaries', category: 'base', enabled: true, opacity: 100, source: 'Benton County GIS', features: 89_247 },
-  { id: 'aerial', name: 'Aerial Imagery (2025)', category: 'base', enabled: true, opacity: 80, source: 'NAIP/County Flight' },
-  { id: 'streets', name: 'Street Centerlines', category: 'base', enabled: true, opacity: 100, source: 'Benton County GIS', features: 12_840 },
-  { id: 'zoning', name: 'Zoning Districts', category: 'overlay', enabled: false, opacity: 60, source: 'City Planning', features: 156 },
-  { id: 'flood', name: 'FEMA Flood Zones', category: 'overlay', enabled: false, opacity: 50, source: 'FEMA NFHL', features: 342 },
-  { id: 'wetlands', name: 'Wetland Boundaries', category: 'overlay', enabled: false, opacity: 50, source: 'NWI/USFWS', features: 89 },
-  { id: 'slope', name: 'Slope Analysis', category: 'analysis', enabled: false, opacity: 40, source: 'DEM Derived' },
-  { id: 'soil', name: 'Soil Classification', category: 'analysis', enabled: false, opacity: 40, source: 'NRCS SSURGO', features: 2_148 },
-  { id: 'fire', name: 'Wildfire Risk Zones', category: 'analysis', enabled: false, opacity: 40, source: 'WA DNR', features: 64 },
-];
-
-const DEFAULT_PARCELS: ParcelResult[] = [
-  { parcelId: '104841000002000', address: '3210 W Clearwater Ave', owner: 'Johnson, Michael R', acreage: 0.195, zoning: 'R-1', landUse: 'SFR', assessedValue: 378_000 },
-  { parcelId: '104841000015200', address: '3405 W 19th Ave', owner: 'Garcia, Maria L', acreage: 0.188, zoning: 'R-1', landUse: 'SFR', assessedValue: 385_000 },
-  { parcelId: '104841000016300', address: '1208 S Union St', owner: 'Williams, David K', acreage: 0.179, zoning: 'R-2', landUse: 'SFR', assessedValue: 362_000 },
-  { parcelId: '104841000017400', address: '5501 W Canal Dr', owner: 'Thompson, Sarah J', acreage: 0.209, zoning: 'R-1', landUse: 'SFR', assessedValue: 405_000 },
-  { parcelId: '104841000018500', address: '810 N Morain St', owner: 'Anderson, Robert P', acreage: 0.165, zoning: 'R-2', landUse: 'SFR', assessedValue: 348_000 },
-];
 
 // ============================================================================
 // ATLAS SERVICE
@@ -148,29 +129,14 @@ export const atlasService = {
    * Get map layers configuration
    */
   getLayers: async (): Promise<MapLayer[]> => {
-    try {
-      return await atlasGet<MapLayer[]>('/layers');
-    } catch {
-      return DEFAULT_LAYERS;
-    }
+    return atlasGet<MapLayer[]>('/layers');
   },
 
   /**
    * Search parcels by address, ID, or owner
    */
   searchParcels: async (request: ParcelSearchRequest): Promise<ParcelSearchResponse> => {
-    try {
-      return await atlasPost<ParcelSearchResponse>('/parcels/search', request);
-    } catch {
-      const query = request.query.toLowerCase();
-      const filtered = DEFAULT_PARCELS.filter(
-        (p) =>
-          p.parcelId.includes(query) ||
-          p.address.toLowerCase().includes(query) ||
-          p.owner.toLowerCase().includes(query)
-      );
-      return { results: filtered, total: filtered.length, hasMore: false };
-    }
+    return atlasPost<ParcelSearchResponse>('/parcels/search', request);
   },
 
   /**
@@ -178,9 +144,10 @@ export const atlasService = {
    */
   getParcel: async (parcelId: string): Promise<ParcelResult | null> => {
     try {
-      return await atlasGet<ParcelResult>(`/parcels/${parcelId}`);
-    } catch {
-      return DEFAULT_PARCELS.find((p) => p.parcelId === parcelId) ?? null;
+      return await atlasGet<ParcelResult>(`/parcels/${encodeURIComponent(parcelId)}`);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) return null;
+      throw err;
     }
   },
 
@@ -188,39 +155,21 @@ export const atlasService = {
    * Get zoning districts
    */
   getZoningDistricts: async (): Promise<ZoningDistrict[]> => {
-    try {
-      return await atlasGet<ZoningDistrict[]>('/zoning');
-    } catch {
-      return [];
-    }
+    return atlasGet<ZoningDistrict[]>('/zoning');
   },
 
   /**
    * Get flood zones
    */
   getFloodZones: async (): Promise<FloodZone[]> => {
-    try {
-      return await atlasGet<FloodZone[]>('/flood-zones');
-    } catch {
-      return [];
-    }
+    return atlasGet<FloodZone[]>('/flood-zones');
   },
 
   /**
    * Get spatial statistics for the county
    */
   getStats: async (): Promise<SpatialStats> => {
-    try {
-      return await atlasGet<SpatialStats>('/stats');
-    } catch {
-      return {
-        totalParcels: 89_247,
-        totalAcreage: 1_703,
-        zoningDistrictCount: 156,
-        floodZoneCount: 342,
-        lastDataUpdate: '2026-02-15',
-      };
-    }
+    return atlasGet<SpatialStats>('/stats');
   },
 };
 

--- a/frontend/apps/os-shell/src/services/dossierService.ts
+++ b/frontend/apps/os-shell/src/services/dossierService.ts
@@ -140,36 +140,9 @@ async function dossierPost<T>(path: string, body: unknown): Promise<T> {
 }
 
 // ============================================================================
-// DEFAULT DATA (fallback when API is offline)
+// NOTE: DEFAULT fallback data removed in CC-14 (R1 Week 3).
+// All service methods now propagate errors from the real backend.
 // ============================================================================
-
-const DEFAULT_DOCUMENTS: DossierDocument[] = [
-  { id: '1', name: 'Warranty Deed - 3210 W Clearwater Ave.pdf', type: 'deed', parcelId: '104841000002000', uploadedBy: 'County Recorder', uploadedAt: '2026-01-15 09:22', size: '245 KB', status: 'active', custodyChain: 3 },
-  { id: '2', name: 'Exterior Photo Set - Front/Side/Rear.jpg', type: 'photo', parcelId: '104841000002000', uploadedBy: 'Field Appraiser B. Smith', uploadedAt: '2026-02-10 14:35', size: '8.2 MB', status: 'active', custodyChain: 2 },
-  { id: '3', name: 'Cost Approach Worksheet - 2026 Reval.xlsx', type: 'appraisal', parcelId: '104841000002000', uploadedBy: 'Appraiser D. Wilson', uploadedAt: '2026-02-18 11:14', size: '156 KB', status: 'active', custodyChain: 1 },
-  { id: '4', name: 'BOE Appeal Petition #2026-042.pdf', type: 'appeal', parcelId: '104841000015200', uploadedBy: 'Property Owner', uploadedAt: '2026-03-01 16:45', size: '342 KB', status: 'active', custodyChain: 4 },
-  { id: '5', name: 'Sales Verification Letter.pdf', type: 'correspondence', parcelId: '104841000016300', uploadedBy: 'Appraiser M. Lee', uploadedAt: '2026-01-28 10:30', size: '89 KB', status: 'active', custodyChain: 2 },
-  { id: '6', name: 'Floor Plan Sketch - Main Level.svg', type: 'sketch', parcelId: '104841000002000', uploadedBy: 'Field Appraiser B. Smith', uploadedAt: '2026-02-10 15:12', size: '45 KB', status: 'active', custodyChain: 1 },
-  { id: '7', name: 'Annual Assessment Report - District 12.pdf', type: 'report', parcelId: '-', uploadedBy: 'Chief Appraiser', uploadedAt: '2025-12-15 17:00', size: '1.8 MB', status: 'sealed', custodyChain: 5 },
-  { id: '8', name: 'Previous Owner Deed - Transfer 2019.pdf', type: 'deed', parcelId: '104841000002000', uploadedBy: 'County Recorder', uploadedAt: '2019-06-22 09:10', size: '198 KB', status: 'archived', custodyChain: 6 },
-];
-
-const DEFAULT_EVIDENCE: EvidenceItem[] = [
-  { id: 'E-2026-001', title: 'Comparable Sales Grid \u2014 3210 W Clearwater', parcelId: '104841000002000', evidenceType: 'market-data', createdBy: 'Appraiser D. Wilson', createdAt: '2026-02-15', integrity: 'verified', chainLength: 4, lastAction: 'Supervisor review complete' },
-  { id: 'E-2026-002', title: 'Field Inspection Report \u2014 3210 W Clearwater', parcelId: '104841000002000', evidenceType: 'field-inspection', createdBy: 'Field Appraiser B. Smith', createdAt: '2026-02-10', integrity: 'verified', chainLength: 3, lastAction: 'Photos attached & geotagged' },
-  { id: 'E-2026-003', title: 'RCNLD Worksheet \u2014 3210 W Clearwater', parcelId: '104841000002000', evidenceType: 'cost-analysis', createdBy: 'CostForge AI', createdAt: '2026-02-18', integrity: 'verified', chainLength: 2, lastAction: 'AI model output verified by appraiser' },
-  { id: 'E-2026-004', title: 'BOE Appeal Defense Packet \u2014 #2026-042', parcelId: '104841000015200', evidenceType: 'appeal-evidence', createdBy: 'Appraiser M. Lee', createdAt: '2026-03-01', integrity: 'pending', chainLength: 6, lastAction: 'Defense packet assembled, pending review' },
-  { id: 'E-2026-005', title: 'Income Approach \u2014 810 N Morain (Commercial)', parcelId: '104841000018500', evidenceType: 'income-analysis', createdBy: 'Appraiser K. Patel', createdAt: '2026-01-28', integrity: 'verified', chainLength: 3, lastAction: 'Cap rate verified against market' },
-  { id: 'E-2026-006', title: 'DOR Ratio Study Compliance \u2014 District 12', parcelId: '-', evidenceType: 'regulatory', createdBy: 'Chief Appraiser', createdAt: '2026-02-20', integrity: 'verified', chainLength: 5, lastAction: 'Filed with WA DOR' },
-  { id: 'E-2026-007', title: 'Sales Verification \u2014 5501 W Canal Dr', parcelId: '104841000017400', evidenceType: 'market-data', createdBy: 'Appraiser D. Wilson', createdAt: '2026-01-22', integrity: 'disputed', chainLength: 7, lastAction: 'Owner disputes sale conditions' },
-];
-
-const DEFAULT_CHAIN: ChainEvent[] = [
-  { timestamp: '2026-02-15 09:14:22', actor: 'CostForge AI', action: 'Evidence created \u2014 AI-generated comparable grid', hash: 'a3f2...c891' },
-  { timestamp: '2026-02-15 14:30:05', actor: 'Appraiser D. Wilson', action: 'Human review \u2014 adjustments verified', hash: 'b7e1...d432' },
-  { timestamp: '2026-02-16 10:22:18', actor: 'Supervisor R. Chen', action: 'Supervisory review \u2014 approved', hash: 'c5a8...e765' },
-  { timestamp: '2026-02-18 08:00:00', actor: 'TerraTrace', action: 'Evidence sealed \u2014 immutable audit record', hash: 'd912...f098' },
-];
 
 // ============================================================================
 // DOSSIER SERVICE
@@ -180,27 +153,7 @@ export const dossierService = {
    * Search documents
    */
   searchDocuments: async (request: DocumentSearchRequest): Promise<DocumentSearchResponse> => {
-    try {
-      return await dossierPost<DocumentSearchResponse>('/documents/search', request);
-    } catch {
-      let results = DEFAULT_DOCUMENTS;
-      if (request.query) {
-        const q = request.query.toLowerCase();
-        results = results.filter(
-          (d) =>
-            d.name.toLowerCase().includes(q) ||
-            d.parcelId.includes(q) ||
-            d.uploadedBy.toLowerCase().includes(q)
-        );
-      }
-      if (request.type && request.type !== 'all') {
-        results = results.filter((d) => d.type === request.type);
-      }
-      if (request.status && request.status !== 'all') {
-        results = results.filter((d) => d.status === request.status);
-      }
-      return { results, total: results.length, hasMore: false };
-    }
+    return dossierPost<DocumentSearchResponse>('/documents/search', request);
   },
 
   /**
@@ -208,9 +161,10 @@ export const dossierService = {
    */
   getDocument: async (id: string): Promise<DossierDocument | null> => {
     try {
-      return await dossierGet<DossierDocument>(`/documents/${id}`);
-    } catch {
-      return DEFAULT_DOCUMENTS.find((d) => d.id === id) ?? null;
+      return await dossierGet<DossierDocument>(`/documents/${encodeURIComponent(id)}`);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) return null;
+      throw err;
     }
   },
 
@@ -218,55 +172,21 @@ export const dossierService = {
    * Search evidence items
    */
   searchEvidence: async (request: EvidenceSearchRequest): Promise<EvidenceSearchResponse> => {
-    try {
-      return await dossierPost<EvidenceSearchResponse>('/evidence/search', request);
-    } catch {
-      let results = DEFAULT_EVIDENCE;
-      if (request.parcelId) {
-        results = results.filter((e) => e.parcelId === request.parcelId);
-      }
-      if (request.evidenceType && request.evidenceType !== 'all') {
-        results = results.filter((e) => e.evidenceType === request.evidenceType);
-      }
-      if (request.integrity && request.integrity !== 'all') {
-        results = results.filter((e) => e.integrity === request.integrity);
-      }
-      return { results, total: results.length, hasMore: false };
-    }
+    return dossierPost<EvidenceSearchResponse>('/evidence/search', request);
   },
 
   /**
    * Get evidence chain-of-custody events
    */
   getChainOfCustody: async (evidenceId: string): Promise<ChainEvent[]> => {
-    try {
-      return await dossierGet<ChainEvent[]>(`/evidence/${evidenceId}/chain`);
-    } catch {
-      return DEFAULT_CHAIN;
-    }
+    return dossierGet<ChainEvent[]>(`/evidence/${encodeURIComponent(evidenceId)}/chain`);
   },
 
   /**
    * Get dossier statistics
    */
   getStats: async (): Promise<DossierStats> => {
-    try {
-      return await dossierGet<DossierStats>('/stats');
-    } catch {
-      const docs = DEFAULT_DOCUMENTS;
-      const evid = DEFAULT_EVIDENCE;
-      return {
-        totalDocuments: docs.length,
-        activeDocuments: docs.filter((d) => d.status === 'active').length,
-        sealedRecords: docs.filter((d) => d.status === 'sealed').length,
-        archivedDocuments: docs.filter((d) => d.status === 'archived').length,
-        documentTypes: new Set(docs.map((d) => d.type)).size,
-        totalEvidence: evid.length,
-        verifiedEvidence: evid.filter((e) => e.integrity === 'verified').length,
-        pendingEvidence: evid.filter((e) => e.integrity === 'pending').length,
-        disputedEvidence: evid.filter((e) => e.integrity === 'disputed').length,
-      };
-    }
+    return dossierGet<DossierStats>('/stats');
   },
 };
 


### PR DESCRIPTION
## Scope
- `frontend/apps/os-shell/src/components/workbench/ContextRibbon.tsx`
- `frontend/apps/os-shell/src/components/workbench/PolicyGuardUI.tsx`
- `frontend/apps/os-shell/src/components/workbench/index.ts`
- `frontend/apps/os-shell/src/services/atlasService.ts`
- `frontend/apps/os-shell/src/services/dossierService.ts`
- `frontend/apps/os-shell/src/hooks/useParcelTrace.ts`

## Gates
- `pnpm run type-check` -> pass
- `pnpm test -- --runInBand apps/os-shell/src/__tests__/workbench/workbench.contractGates.test.ts apps/os-shell/src/shell/command-palette/__tests__/useParcelSearch.test.ts apps/os-shell/src/pages/workbench/__tests__/WorkbenchTabBar.test.tsx` -> pass (3 suites / 54 tests)

## Summary by Sourcery

Expose new policy and trace UI for the workbench and switch atlas/dossier services to rely on real backend responses instead of local fallbacks.

New Features:
- Add PolicyGuardUI component to display current lane, risk level, pilot mode, user role, county isolation, and confirmation requirements in the workbench.
- Introduce useParcelTrace hook to fetch real pilot trace events for a parcel from the backend API.
- Extend ContextRibbon to surface pilot mode, user role, risk level, and correlation ID badges in the workbench header.

Enhancements:
- Update atlas and dossier service methods to URL-encode identifiers, propagate backend errors, and treat 404s as null for entity lookups.
- Re-export PolicyGuardUI and its related types from the workbench components index for broader use across the shell.