### PR TITLE
feat(api): enforce county isolation for costforge and levy

### DIFF
--- a/backend/docs/r1-week4-security-audit.md
+++ b/backend/docs/r1-week4-security-audit.md
@@ -1,0 +1,81 @@
+# R1 Week 4 Security Audit (CX-13)
+
+Date: 2026-03-03 (America/Los_Angeles)  
+Branch: `codex/r1-week4-ship`
+
+## Scope
+
+R1 backend contract endpoints and direct R1-adjacent routes:
+
+- `POST /api/costforge/calculate`
+- `POST /api/levy-calculation/calculate-rate`
+- `POST /api/levy-calculation/calculate-batch`
+- `GET /api/atlas/parcels/{parcelId}`
+- `GET /api/atlas/parcels/{parcelId}/layers`
+- `GET /api/dossier/{parcelId}/notes`
+- `POST /api/dossier/{parcelId}/notes`
+- `GET /api/dossier/parcels/{parcelId}/casefile`
+
+Out-of-scope: non-R1 controller surfaces.
+
+## Audit Method
+
+1. Static scan of controller attributes (`[Authorize]`, `[RequiresPermission]`).
+2. Query-path scan for county claim resolution and county filters in data access.
+3. Rejection-path tests for cross-county and missing county context.
+
+## Endpoint Verdicts
+
+| Endpoint | Auth Gate | County Isolation Method | Verdict |
+|---|---|---|---|
+| `POST /api/costforge/calculate` | Controller `[Authorize]` + `[RequiresPermission("access:costforge")]`, action `[RequiresPermission("calculate:property-cost")]` | `ResolveCountyContextAsync()` from claims + `CountyCodeMatchesContext()` + property lookup constrained to `p.CountyId == countyContext.CountyId` before valuation | PASS |
+| `POST /api/levy-calculation/calculate-rate` | Controller `[Authorize(Roles = "LevyClerk,Assessor,Admin")]` | `ResolveCountyContextAsync()` from claims + required `request.CountyCode` + `CountyCodeMatchesContext()` reject path | PASS |
+| `POST /api/levy-calculation/calculate-batch` | Controller `[Authorize(Roles = "LevyClerk,Assessor,Admin")]` | Same claim context resolution; every batch item must include `CountyCode` and match claim county context | PASS |
+| `GET /api/atlas/parcels/{parcelId}` | Controller `[Authorize]`, action `[RequiresPermission("read:parcel")]` | `ResolveCountyIdAsync()` from claims + `Properties` query constrained to matching `CountyId` | PASS |
+| `GET /api/atlas/parcels/{parcelId}/layers` | Controller `[Authorize]`, action `[RequiresPermission("read:parcel")]` | `ResolveCountyIdAsync()` + existence check constrained by `CountyId` | PASS |
+| `GET /api/dossier/{parcelId}/notes` | Controller `[Authorize]`, action `[RequiresPermission("read:dossier")]` | `ResolveCountyIdAsync()` + notes query constrained by `CountyId` | PASS |
+| `POST /api/dossier/{parcelId}/notes` | Controller `[Authorize]`, action `[RequiresPermission("write:dossier")]` | `ResolveCountyIdAsync()` + parcel existence check constrained by `CountyId`; persisted note carries claim-resolved `CountyId` | PASS |
+| `GET /api/dossier/parcels/{parcelId}/casefile` | Controller `[Authorize]`, action `[RequiresPermission("read:dossier")]` | `ResolveCountyIdAsync()` + parcel and notes queries constrained by `CountyId` | PASS |
+
+## Evidence (Code References)
+
+- CostForge auth and county isolation:
+  - `backend/src/TerraFusion.API/Controllers/CostForgeController.cs` lines 22-23, 48, 198-258
+- Levy auth and county isolation:
+  - `backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs` lines 41, 55-198, 233-247, 344-354
+- Atlas county isolation:
+  - `backend/src/TerraFusion.API/Controllers/AtlasController.cs` lines 17, 31-65, 151-176, 200-217
+- Dossier county isolation:
+  - `backend/src/TerraFusion.API/Controllers/DossierController.cs` lines 17, 32-66, 146-170, 181-204, 241-255
+
+## Evidence (Tests)
+
+- Existing Week 3 guard suite:
+  - `backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs`
+- New Week 4 guard suite:
+  - `backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs`
+  - Covers same-county success and rejection paths:
+    - `CostForge_SameCountyRequest_ReturnsOk`
+    - `CostForge_CrossCountyRequest_ReturnsForbid`
+    - `CostForge_MissingCountyClaims_ReturnsForbid`
+    - `Levy_SameCountyRequest_ReturnsOk`
+    - `Levy_CrossCountyRequest_ReturnsForbid`
+    - `Levy_MissingCountyClaims_ReturnsForbid`
+
+## Gate Output
+
+Command:
+
+```bash
+dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -nologo -v minimal
+```
+
+Result:
+
+- Passed: `772`
+- Failed: `0`
+- Skipped: `0`
+
+## Exceptions
+
+None in audited R1 scope.

--- a/backend/docs/r1-week4-security-audit.md
+++ b/backend/docs/r1-week4-security-audit.md
@@ -28,7 +28,7 @@ Out-of-scope: non-R1 controller surfaces.
 
 | Endpoint | Auth Gate | County Isolation Method | Verdict |
 |---|---|---|---|
-| `POST /api/costforge/calculate` | Controller `[Authorize]` + `[RequiresPermission("access:costforge")]`, action `[RequiresPermission("calculate:property-cost")]` | `ResolveCountyContextAsync()` from claims + `CountyCodeMatchesContext()` + property lookup constrained to `p.CountyId == countyContext.CountyId` before valuation | PASS |
+| `POST /api/costforge/calculate` | Controller `[Authorize]` + `[RequiresPermission("access:costforge")]`, action `[RequiresPermission("calculate:property-cost")]` | `ResolveCountyContextAsync()` from claims + request requires `CountyCode` or `Region` + `CountyCodeMatchesContext()` reject path + property lookup constrained to `p.CountyId == countyContext.CountyId` before valuation | PASS |
 | `POST /api/levy-calculation/calculate-rate` | Controller `[Authorize(Roles = "LevyClerk,Assessor,Admin")]` | `ResolveCountyContextAsync()` from claims + required `request.CountyCode` + `CountyCodeMatchesContext()` reject path | PASS |
 | `POST /api/levy-calculation/calculate-batch` | Controller `[Authorize(Roles = "LevyClerk,Assessor,Admin")]` | Same claim context resolution; every batch item must include `CountyCode` and match claim county context | PASS |
 | `GET /api/atlas/parcels/{parcelId}` | Controller `[Authorize]`, action `[RequiresPermission("read:parcel")]` | `ResolveCountyIdAsync()` from claims + `Properties` query constrained to matching `CountyId` | PASS |
@@ -58,6 +58,7 @@ Out-of-scope: non-R1 controller surfaces.
     - `CostForge_SameCountyRequest_ReturnsOk`
     - `CostForge_CrossCountyRequest_ReturnsForbid`
     - `CostForge_MissingCountyClaims_ReturnsForbid`
+    - `CostForge_MissingCountyCodeAndRegion_ReturnsBadRequest`
     - `Levy_SameCountyRequest_ReturnsOk`
     - `Levy_CrossCountyRequest_ReturnsForbid`
     - `Levy_MissingCountyClaims_ReturnsForbid`
@@ -72,7 +73,7 @@ dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj -
 
 Result:
 
-- Passed: `772`
+- Passed: `773`
 - Failed: `0`
 - Skipped: `0`
 

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -177,11 +177,11 @@ public class CostForgeController : ControllerBase
     private static bool CountyCodeMatchesContext(string requestedCounty, CountyContext context)
     {
         if (string.IsNullOrWhiteSpace(requestedCounty))
-            return true;
+            return false;
 
         var requested = NormalizeCountyToken(requestedCounty);
         if (requested.Length == 0)
-            return true;
+            return false;
 
         var claimCode = NormalizeCountyToken(context.ClaimCountyCode);
         var countyName = NormalizeCountyToken(context.CountyName);
@@ -220,6 +220,11 @@ public class CostForgeController : ControllerBase
             var requestedCounty = !string.IsNullOrWhiteSpace(request.CountyCode)
                 ? request.CountyCode
                 : request.Region;
+            if (string.IsNullOrWhiteSpace(requestedCounty))
+            {
+                return BadRequest("CountyCode or Region is required");
+            }
+
             if (!CountyCodeMatchesContext(requestedCounty, countyContext))
             {
                 return Forbid();

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.Services;
 using TerraFusion.Core.DTOs;
 using TerraFusion.API.Security;
 using TerraFusion.API.Models;
 using TerraFusion.Abstractions.Interfaces;
 using TerraFusion.Abstractions.DTOs.Responses;
+using TerraFusion.Core.Entities;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
 using System.ComponentModel.DataAnnotations;
 
 namespace TerraFusion.API.Controllers;
@@ -22,22 +25,169 @@ public class CostForgeController : ControllerBase
 {
     private readonly ICostForgeService _costForgeService;
     private readonly ICostForgeAIService _costForgeAIService;
-    private readonly IPropertyService _propertyService;
+    private readonly DataDbContext _db;
     private readonly TerraFusion.Abstractions.Interfaces.IAuditLogger _auditLogger;
     private readonly ILogger<CostForgeController> _logger;
 
     public CostForgeController(
         ICostForgeService costForgeService,
         ICostForgeAIService costForgeAIService,
-        IPropertyService propertyService,
+        DataDbContext db,
         TerraFusion.Abstractions.Interfaces.IAuditLogger auditLogger,
         ILogger<CostForgeController> logger)
     {
         _costForgeService = costForgeService;
         _costForgeAIService = costForgeAIService;
-        _propertyService = propertyService;
+        _db = db;
         _auditLogger = auditLogger;
         _logger = logger;
+    }
+
+    private sealed record CountyContext(Guid CountyId, string? CountyName, string? CountyFipsCode, string? ClaimCountyCode);
+
+    private async Task<CountyContext?> ResolveCountyContextAsync()
+    {
+        var countyIdClaim = User.FindFirst("countyId")?.Value?.Trim();
+        var countyCodeClaim = User.FindFirst("countyCode")?.Value?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(countyIdClaim) && Guid.TryParse(countyIdClaim, out var directCountyId))
+        {
+            var county = await _db.Counties
+                .AsNoTracking()
+                .Where(c => c.Id == directCountyId)
+                .Select(c => new { c.Name, c.FipsCode })
+                .FirstOrDefaultAsync();
+
+            return new CountyContext(directCountyId, county?.Name, county?.FipsCode, countyCodeClaim);
+        }
+
+        var nameCandidates = BuildCountyNameCandidates(countyIdClaim, countyCodeClaim);
+        var fipsCandidates = BuildFipsCandidates(countyIdClaim, countyCodeClaim);
+
+        IQueryable<County> countyQuery = _db.Counties.AsNoTracking();
+
+        if (nameCandidates.Length > 0 && fipsCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c =>
+                nameCandidates.Contains(c.Name) ||
+                (c.FipsCode != null && fipsCandidates.Contains(c.FipsCode)));
+        }
+        else if (nameCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c => nameCandidates.Contains(c.Name));
+        }
+        else if (fipsCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c => c.FipsCode != null && fipsCandidates.Contains(c.FipsCode));
+        }
+        else
+        {
+            return null;
+        }
+
+        var match = await countyQuery
+            .Select(c => new { c.Id, c.Name, c.FipsCode })
+            .FirstOrDefaultAsync();
+
+        return match is null
+            ? null
+            : new CountyContext(match.Id, match.Name, match.FipsCode, countyCodeClaim);
+    }
+
+    private static string[] BuildCountyNameCandidates(params string?[] claims)
+    {
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var claim in claims)
+        {
+            if (string.IsNullOrWhiteSpace(claim))
+                continue;
+
+            var trimmed = claim.Trim();
+            AddCandidate(candidates, trimmed);
+
+            var withoutSuffix = StripCountySuffix(trimmed);
+            AddCandidate(candidates, withoutSuffix);
+
+            var titleCase = ToTitleCaseWords(withoutSuffix);
+            AddCandidate(candidates, titleCase);
+            AddCandidate(candidates, $"{titleCase} County");
+        }
+
+        return candidates.ToArray();
+    }
+
+    private static string[] BuildFipsCandidates(params string?[] claims)
+    {
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var claim in claims)
+        {
+            if (string.IsNullOrWhiteSpace(claim))
+                continue;
+
+            var trimmed = claim.Trim();
+            AddCandidate(candidates, trimmed);
+
+            var digitsOnly = new string(trimmed.Where(char.IsDigit).ToArray());
+            AddCandidate(candidates, digitsOnly);
+        }
+
+        return candidates.ToArray();
+    }
+
+    private static string StripCountySuffix(string value)
+    {
+        return value.EndsWith(" County", StringComparison.OrdinalIgnoreCase)
+            ? value[..^7].TrimEnd()
+            : value;
+    }
+
+    private static string ToTitleCaseWords(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var words = value
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => word.Length == 1
+                ? char.ToUpperInvariant(word[0]).ToString()
+                : $"{char.ToUpperInvariant(word[0])}{word[1..].ToLowerInvariant()}");
+
+        return string.Join(' ', words);
+    }
+
+    private static void AddCandidate(HashSet<string> candidates, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            candidates.Add(value.Trim());
+    }
+
+    private static string NormalizeCountyToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        return value.Trim()
+            .ToUpperInvariant()
+            .Replace(" COUNTY", string.Empty)
+            .Replace(" ", string.Empty)
+            .Replace("-", string.Empty)
+            .Replace("_", string.Empty);
+    }
+
+    private static bool CountyCodeMatchesContext(string requestedCounty, CountyContext context)
+    {
+        if (string.IsNullOrWhiteSpace(requestedCounty))
+            return true;
+
+        var requested = NormalizeCountyToken(requestedCounty);
+        if (requested.Length == 0)
+            return true;
+
+        var claimCode = NormalizeCountyToken(context.ClaimCountyCode);
+        var countyName = NormalizeCountyToken(context.CountyName);
+        var countyFips = NormalizeCountyToken(context.CountyFipsCode);
+
+        return requested == claimCode || requested == countyName || requested == countyFips;
     }
 
     /// <summary>
@@ -61,21 +211,47 @@ public class CostForgeController : ControllerBase
                 return BadRequest("Either PropertyId or ParcelNumber must be provided");
             }
 
+            var countyContext = await ResolveCountyContextAsync();
+            if (countyContext is null)
+            {
+                return Forbid();
+            }
+
+            var requestedCounty = !string.IsNullOrWhiteSpace(request.CountyCode)
+                ? request.CountyCode
+                : request.Region;
+            if (!CountyCodeMatchesContext(requestedCounty, countyContext))
+            {
+                return Forbid();
+            }
+
             CostAnalysisDto result;
 
             if (request.PropertyId != Guid.Empty)
             {
+                var propertyExistsInCounty = await _db.Properties
+                    .AsNoTracking()
+                    .AnyAsync(p => p.Id == request.PropertyId && p.CountyId == countyContext.CountyId);
+
+                if (!propertyExistsInCounty)
+                {
+                    return NotFound($"Property not found for id: {request.PropertyId}");
+                }
+
                 result = await _costForgeService.AnalyzeCostAsync(request.PropertyId);
             }
             else
             {
-                // Get property by parcel number first
-                var property = await _propertyService.GetPropertyByParcelAsync(request.ParcelNumber!);
+                var property = await _db.Properties
+                    .AsNoTracking()
+                    .Where(p => p.ParcelNumber == request.ParcelNumber && p.CountyId == countyContext.CountyId)
+                    .Select(p => new { p.Id })
+                    .FirstOrDefaultAsync();
                 if (property == null)
                 {
                     return NotFound($"Property not found for parcel: {request.ParcelNumber}");
                 }
-                result = await _costForgeService.AnalyzeCostAsync(property);
+                result = await _costForgeService.AnalyzeCostAsync(property.Id);
             }
 
             // Calculate performance metrics - target <150ms
@@ -440,6 +616,7 @@ public class PropertyCostCalculationRequest
 {
     public Guid PropertyId { get; set; }
     public string? ParcelNumber { get; set; }
+    public string? CountyCode { get; set; }
     public string Region { get; set; } = string.Empty;
     public string BuildingType { get; set; } = string.Empty;
     public Dictionary<string, object>? AdditionalParameters { get; set; }

--- a/backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs
+++ b/backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs
@@ -10,6 +10,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Data;
+using CountyEntity = TerraFusion.Core.Entities.County;
 
 namespace TerraFusion.API.Controllers;
 
@@ -39,10 +42,156 @@ namespace TerraFusion.API.Controllers;
 public class LevyCalculationController : ControllerBase
 {
     private readonly ILogger<LevyCalculationController> _logger;
+    private readonly TerraFusionDbContext _db;
 
-    public LevyCalculationController(ILogger<LevyCalculationController> logger)
+    public LevyCalculationController(ILogger<LevyCalculationController> logger, TerraFusionDbContext db)
     {
         _logger = logger;
+        _db = db;
+    }
+
+    private sealed record CountyContext(Guid CountyId, string? CountyName, string? CountyFipsCode, string? ClaimCountyCode);
+
+    private async Task<CountyContext?> ResolveCountyContextAsync()
+    {
+        var countyIdClaim = User.FindFirst("countyId")?.Value?.Trim();
+        var countyCodeClaim = User.FindFirst("countyCode")?.Value?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(countyIdClaim) && Guid.TryParse(countyIdClaim, out var directCountyId))
+        {
+            var county = await _db.Counties
+                .AsNoTracking()
+                .Where(c => c.Id == directCountyId)
+                .Select(c => new { c.Name, c.FipsCode })
+                .FirstOrDefaultAsync();
+
+            return new CountyContext(directCountyId, county?.Name, county?.FipsCode, countyCodeClaim);
+        }
+
+        var nameCandidates = BuildCountyNameCandidates(countyIdClaim, countyCodeClaim);
+        var fipsCandidates = BuildFipsCandidates(countyIdClaim, countyCodeClaim);
+
+        IQueryable<CountyEntity> countyQuery = _db.Counties.AsNoTracking();
+
+        if (nameCandidates.Length > 0 && fipsCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c =>
+                nameCandidates.Contains(c.Name) ||
+                (c.FipsCode != null && fipsCandidates.Contains(c.FipsCode)));
+        }
+        else if (nameCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c => nameCandidates.Contains(c.Name));
+        }
+        else if (fipsCandidates.Length > 0)
+        {
+            countyQuery = countyQuery.Where(c => c.FipsCode != null && fipsCandidates.Contains(c.FipsCode));
+        }
+        else
+        {
+            return null;
+        }
+
+        var match = await countyQuery
+            .Select(c => new { c.Id, c.Name, c.FipsCode })
+            .FirstOrDefaultAsync();
+
+        return match is null
+            ? null
+            : new CountyContext(match.Id, match.Name, match.FipsCode, countyCodeClaim);
+    }
+
+    private static string[] BuildCountyNameCandidates(params string?[] claims)
+    {
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var claim in claims)
+        {
+            if (string.IsNullOrWhiteSpace(claim))
+                continue;
+
+            var trimmed = claim.Trim();
+            AddCandidate(candidates, trimmed);
+
+            var withoutSuffix = StripCountySuffix(trimmed);
+            AddCandidate(candidates, withoutSuffix);
+
+            var titleCase = ToTitleCaseWords(withoutSuffix);
+            AddCandidate(candidates, titleCase);
+            AddCandidate(candidates, $"{titleCase} County");
+        }
+
+        return candidates.ToArray();
+    }
+
+    private static string[] BuildFipsCandidates(params string?[] claims)
+    {
+        var candidates = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var claim in claims)
+        {
+            if (string.IsNullOrWhiteSpace(claim))
+                continue;
+
+            var trimmed = claim.Trim();
+            AddCandidate(candidates, trimmed);
+
+            var digitsOnly = new string(trimmed.Where(char.IsDigit).ToArray());
+            AddCandidate(candidates, digitsOnly);
+        }
+
+        return candidates.ToArray();
+    }
+
+    private static string StripCountySuffix(string value)
+    {
+        return value.EndsWith(" County", StringComparison.OrdinalIgnoreCase)
+            ? value[..^7].TrimEnd()
+            : value;
+    }
+
+    private static string ToTitleCaseWords(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var words = value
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => word.Length == 1
+                ? char.ToUpperInvariant(word[0]).ToString()
+                : $"{char.ToUpperInvariant(word[0])}{word[1..].ToLowerInvariant()}");
+
+        return string.Join(' ', words);
+    }
+
+    private static void AddCandidate(HashSet<string> candidates, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            candidates.Add(value.Trim());
+    }
+
+    private static string NormalizeCountyToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        return value.Trim()
+            .ToUpperInvariant()
+            .Replace(" COUNTY", string.Empty)
+            .Replace(" ", string.Empty)
+            .Replace("-", string.Empty)
+            .Replace("_", string.Empty);
+    }
+
+    private static bool CountyCodeMatchesContext(string requestedCounty, CountyContext context)
+    {
+        if (string.IsNullOrWhiteSpace(requestedCounty))
+            return false;
+
+        var requested = NormalizeCountyToken(requestedCounty);
+        var claimCode = NormalizeCountyToken(context.ClaimCountyCode);
+        var countyName = NormalizeCountyToken(context.CountyName);
+        var countyFips = NormalizeCountyToken(context.CountyFipsCode);
+
+        return requested == claimCode || requested == countyName || requested == countyFips;
     }
 
     /// <summary>
@@ -86,6 +235,16 @@ public class LevyCalculationController : ControllerBase
 
             if (request.BudgetAmount <= 0)
                 return BadRequest("Budget amount must be greater than zero");
+
+            if (string.IsNullOrWhiteSpace(request.CountyCode))
+                return BadRequest("CountyCode is required");
+
+            var countyContext = await ResolveCountyContextAsync();
+            if (countyContext is null)
+                return Forbid();
+
+            if (!CountyCodeMatchesContext(request.CountyCode, countyContext))
+                return Forbid();
 
             // Calculate base rate (per $1,000 assessed value)
             var baseRate = (request.BudgetAmount / request.AssessedValue) * 1000.0;
@@ -181,6 +340,18 @@ public class LevyCalculationController : ControllerBase
 
         if (requests.Count > 100)
             return BadRequest("Batch size limited to 100 measures per request");
+
+        var countyContext = await ResolveCountyContextAsync();
+        if (countyContext is null)
+            return Forbid();
+
+        var hasMissingCountyCode = requests.Any(r => string.IsNullOrWhiteSpace(r.CountyCode));
+        if (hasMissingCountyCode)
+            return BadRequest("CountyCode is required for all batch items");
+
+        var hasCrossCountyRequest = requests.Any(r => !CountyCodeMatchesContext(r.CountyCode, countyContext));
+        if (hasCrossCountyRequest)
+            return Forbid();
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var results = new List<LevyCalculationResultDto>();
@@ -401,6 +572,7 @@ public class LevyMeasureRequest
     [Required]
     public string MeasureType { get; set; } = "regular";
 
+    [Required]
     public string CountyCode { get; set; } = string.Empty;
 }
 

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs
@@ -1,0 +1,278 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Services;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CountyEntity = TerraFusion.Core.Entities.County;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using PropertyEntity = TerraFusion.Core.Entities.Property;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R1Week4;
+
+public class SecurityIsolationAuditGuardsTests
+{
+    private static DataDbContext CreateDbContext(string name)
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        return new DataDbContext(options, config);
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(string? countyIdClaim, string? countyCodeClaim, string userId = "unit-user")
+    {
+        var claims = new List<Claim>
+        {
+            new("sub", userId),
+            new("userId", userId),
+        };
+
+        if (!string.IsNullOrWhiteSpace(countyIdClaim))
+        {
+            claims.Add(new Claim("countyId", countyIdClaim));
+        }
+
+        if (!string.IsNullOrWhiteSpace(countyCodeClaim))
+        {
+            claims.Add(new Claim("countyCode", countyCodeClaim));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+
+    private static void AttachPrincipal(ControllerBase controller, ClaimsPrincipal principal)
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = principal }
+        };
+    }
+
+    private static PropertyEntity CreateProperty(Guid countyId, string propertyId, string parcelNumber)
+    {
+        return new PropertyEntity
+        {
+            Id = Guid.NewGuid(),
+            PropertyId = propertyId,
+            ParcelId = parcelNumber,
+            ParcelNumber = parcelNumber,
+            Address = "123 Main St",
+            PropertyType = "SFR",
+            AssessedValue = 100000,
+            LandValue = 50000,
+            ImprovementValue = 50000,
+            MarketValue = 120000,
+            AssessmentDate = DateTime.UtcNow,
+            LastUpdated = DateTime.UtcNow,
+            TaxYear = 2026,
+            CountyId = countyId,
+        };
+    }
+
+    private static Mock<AuditLogger> CreateAuditLoggerMock()
+    {
+        var mock = new Mock<AuditLogger>();
+        mock.Setup(m => m.LogUserActionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(m => m.LogApiCallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(m => m.LogErrorAsync(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(m => m.LogDataAccessAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(Task.CompletedTask);
+        mock.Setup(m => m.LogSystemEventAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        return mock;
+    }
+
+    [Fact]
+    public async Task CostForge_SameCountyRequest_ReturnsOk()
+    {
+        await using var db = CreateDbContext(nameof(CostForge_SameCountyRequest_ReturnsOk));
+        var benton = new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" };
+        var property = CreateProperty(benton.Id, "PROP-1", "PARCEL-100");
+        db.Counties.Add(benton);
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        var costForgeMock = new Mock<ICostForgeService>();
+        costForgeMock
+            .Setup(m => m.AnalyzeCostAsync(property.Id))
+            .ReturnsAsync(new CostAnalysisDto { PropertyId = property.Id, TotalCost = 100000m, AnalysisDate = DateTime.UtcNow });
+
+        var aiMock = new Mock<ICostForgeAIService>();
+        var auditMock = CreateAuditLoggerMock();
+
+        var controller = new CostForgeController(
+            costForgeMock.Object,
+            aiMock.Object,
+            db,
+            auditMock.Object,
+            NullLogger<CostForgeController>.Instance);
+
+        AttachPrincipal(controller, CreatePrincipal("benton", "BENTON"));
+
+        var result = await controller.CalculatePropertyCost(new PropertyCostCalculationRequest
+        {
+            PropertyId = property.Id,
+            CountyCode = "BENTON",
+            Region = "BENTON",
+            BuildingType = "SFR",
+        });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        costForgeMock.Verify(m => m.AnalyzeCostAsync(property.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task CostForge_CrossCountyRequest_ReturnsForbid()
+    {
+        await using var db = CreateDbContext(nameof(CostForge_CrossCountyRequest_ReturnsForbid));
+        var benton = new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" };
+        var yakima = new CountyEntity { Id = Guid.NewGuid(), Name = "Yakima", State = "WA", FipsCode = "077" };
+        var property = CreateProperty(benton.Id, "PROP-2", "PARCEL-200");
+        db.Counties.AddRange(benton, yakima);
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        var costForgeMock = new Mock<ICostForgeService>();
+        var aiMock = new Mock<ICostForgeAIService>();
+        var auditMock = CreateAuditLoggerMock();
+
+        var controller = new CostForgeController(
+            costForgeMock.Object,
+            aiMock.Object,
+            db,
+            auditMock.Object,
+            NullLogger<CostForgeController>.Instance);
+
+        AttachPrincipal(controller, CreatePrincipal("yakima", "YAKIMA"));
+
+        var result = await controller.CalculatePropertyCost(new PropertyCostCalculationRequest
+        {
+            PropertyId = property.Id,
+            CountyCode = "BENTON",
+            Region = "BENTON",
+            BuildingType = "SFR",
+        });
+
+        Assert.IsType<ForbidResult>(result.Result);
+        costForgeMock.Verify(m => m.AnalyzeCostAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CostForge_MissingCountyClaims_ReturnsForbid()
+    {
+        await using var db = CreateDbContext(nameof(CostForge_MissingCountyClaims_ReturnsForbid));
+        var benton = new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" };
+        var property = CreateProperty(benton.Id, "PROP-3", "PARCEL-300");
+        db.Counties.Add(benton);
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        var controller = new CostForgeController(
+            new Mock<ICostForgeService>().Object,
+            new Mock<ICostForgeAIService>().Object,
+            db,
+            CreateAuditLoggerMock().Object,
+            NullLogger<CostForgeController>.Instance);
+
+        AttachPrincipal(controller, CreatePrincipal(null, null));
+
+        var result = await controller.CalculatePropertyCost(new PropertyCostCalculationRequest
+        {
+            PropertyId = property.Id,
+            CountyCode = "BENTON",
+            Region = "BENTON",
+            BuildingType = "SFR",
+        });
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Levy_SameCountyRequest_ReturnsOk()
+    {
+        await using var db = CreateDbContext(nameof(Levy_SameCountyRequest_ReturnsOk));
+        db.Counties.Add(new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" });
+        await db.SaveChangesAsync();
+
+        var controller = new LevyCalculationController(NullLogger<LevyCalculationController>.Instance, db);
+        AttachPrincipal(controller, CreatePrincipal("benton", "BENTON"));
+
+        var result = await controller.CalculateOptimalRate(new LevyMeasureRequest
+        {
+            DistrictId = "D-1",
+            DistrictName = "District One",
+            AssessedValue = 1000000,
+            BudgetAmount = 10000,
+            DistrictType = "county-regular",
+            MeasureType = "regular",
+            CountyCode = "BENTON",
+        });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Levy_CrossCountyRequest_ReturnsForbid()
+    {
+        await using var db = CreateDbContext(nameof(Levy_CrossCountyRequest_ReturnsForbid));
+        db.Counties.AddRange(
+            new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" },
+            new CountyEntity { Id = Guid.NewGuid(), Name = "Yakima", State = "WA", FipsCode = "077" });
+        await db.SaveChangesAsync();
+
+        var controller = new LevyCalculationController(NullLogger<LevyCalculationController>.Instance, db);
+        AttachPrincipal(controller, CreatePrincipal("yakima", "YAKIMA"));
+
+        var result = await controller.CalculateOptimalRate(new LevyMeasureRequest
+        {
+            DistrictId = "D-2",
+            DistrictName = "District Two",
+            AssessedValue = 1000000,
+            BudgetAmount = 10000,
+            DistrictType = "county-regular",
+            MeasureType = "regular",
+            CountyCode = "BENTON",
+        });
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Levy_MissingCountyClaims_ReturnsForbid()
+    {
+        await using var db = CreateDbContext(nameof(Levy_MissingCountyClaims_ReturnsForbid));
+        db.Counties.Add(new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" });
+        await db.SaveChangesAsync();
+
+        var controller = new LevyCalculationController(NullLogger<LevyCalculationController>.Instance, db);
+        AttachPrincipal(controller, CreatePrincipal(null, null));
+
+        var result = await controller.CalculateOptimalRate(new LevyMeasureRequest
+        {
+            DistrictId = "D-3",
+            DistrictName = "District Three",
+            AssessedValue = 1000000,
+            BudgetAmount = 10000,
+            DistrictType = "county-regular",
+            MeasureType = "regular",
+            CountyCode = "BENTON",
+        });
+
+        Assert.IsType<ForbidResult>(result.Result);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs
@@ -203,6 +203,38 @@ public class SecurityIsolationAuditGuardsTests
     }
 
     [Fact]
+    public async Task CostForge_MissingCountyCodeAndRegion_ReturnsBadRequest()
+    {
+        await using var db = CreateDbContext(nameof(CostForge_MissingCountyCodeAndRegion_ReturnsBadRequest));
+        var benton = new CountyEntity { Id = Guid.NewGuid(), Name = "Benton", State = "WA", FipsCode = "003" };
+        var property = CreateProperty(benton.Id, "PROP-4", "PARCEL-400");
+        db.Counties.Add(benton);
+        db.Properties.Add(property);
+        await db.SaveChangesAsync();
+
+        var costForgeMock = new Mock<ICostForgeService>();
+        var controller = new CostForgeController(
+            costForgeMock.Object,
+            new Mock<ICostForgeAIService>().Object,
+            db,
+            CreateAuditLoggerMock().Object,
+            NullLogger<CostForgeController>.Instance);
+
+        AttachPrincipal(controller, CreatePrincipal("benton", "BENTON"));
+
+        var result = await controller.CalculatePropertyCost(new PropertyCostCalculationRequest
+        {
+            PropertyId = property.Id,
+            CountyCode = " ",
+            Region = " ",
+            BuildingType = "SFR",
+        });
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+        costForgeMock.Verify(m => m.AnalyzeCostAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Levy_SameCountyRequest_ReturnsOk()
     {
         await using var db = CreateDbContext(nameof(Levy_SameCountyRequest_ReturnsOk));


### PR DESCRIPTION
## Summary
- enforce claim-derived county isolation in CostForge and Levy controllers
- add Week 4 security isolation guard tests
- add CX-13 security audit report document

## Scope
- backend-only changes
- no .gitignore or repo-global changes

## Files
- backend/src/TerraFusion.API/Controllers/CostForgeController.cs
- backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs
- backend/tests/TerraFusion.Unit.Tests/R1Week4/SecurityIsolationAuditGuardsTests.cs
- backend/docs/r1-week4-security-audit.md

## Gates (local)
- dotnet build backend/TerraFusion.sln -nologo -v minimal
- dotnet test backend/TerraFusion.sln -nologo -v minimal
