### PR TITLE
chore(gitignore): ignore _archive evidence folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -559,3 +559,4 @@ tools/registry/autonomy-viewer/bin/*.mjs
 
 # Generated pact artifacts
 pact/
+_archive/


### PR DESCRIPTION
This PR adds _archive/ to .gitignore as local evidence-retention hygiene so archived patch/evidence artifacts do not appear as untracked workspace noise; it is explicitly non-product-code and does not change runtime behavior, APIs, tests, or governance logic.

## Summary by Sourcery

Chores:
- Add _archive/ evidence directory to .gitignore for local artifact hygiene.