### PR TITLE
CX-17: scope-classifier ENOBUFS regression test

### DIFF
--- a/tools/scope-classifier/docs/cx-17-enobufs-regression.md
+++ b/tools/scope-classifier/docs/cx-17-enobufs-regression.md
@@ -1,0 +1,35 @@
+# CX-17: scope-classifier ENOBUFS Regression Test
+
+## What this protects
+
+PR #542 replaced `execSync` with `spawnSync` + 64 MB `maxBuffer` in
+`gitTouched.ts` to prevent `ENOBUFS` crashes when `git diff --name-only`
+returns large output (common in monorepos with many changed files).
+
+This regression test ensures the fix is never reverted or weakened.
+
+## Test file
+
+`tests/gitTouched-enobufs.test.ts` — 5 cases:
+
+| # | Scenario | Assertion |
+|---|----------|-----------|
+| 1 | Stdout > 1 MB (~20k lines) | Parses without throw; `maxBuffer` = 64 MB |
+| 2 | Non-zero exit + stderr | Throws with stderr message |
+| 3 | Non-zero exit + empty stderr | Throws with fallback `git ... exited N` |
+| 4 | Spawn error (ENOBUFS) | Surfaces the error |
+| 5 | Multi-segment paths | All roots parsed correctly |
+
+## How to run
+
+```bash
+pnpm -C tools/scope-classifier test
+```
+
+## Evidence
+
+```
+ ✓ tests/gitTouched-enobufs.test.ts  (5 tests) 41ms
+ Test Files  11 passed (11)
+      Tests  19 passed (19)
+```

--- a/tools/scope-classifier/tests/gitTouched-enobufs.test.ts
+++ b/tools/scope-classifier/tests/gitTouched-enobufs.test.ts
@@ -1,0 +1,136 @@
+/**
+ * CX-17: ENOBUFS regression test for gitTouched.ts
+ *
+ * Validates that the spawnSync + maxBuffer fix (PR #542) prevents
+ * buffer overflow on large git diff outputs. Tests three failure modes:
+ *   1. Large stdout (>1 MB) → parses successfully, no throw
+ *   2. Non-zero exit status → throws with stderr message
+ *   3. Spawn error (e.g., ENOBUFS) → surfaces the error
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SpawnSyncReturns } from "node:child_process";
+
+// Mock child_process before importing the module under test
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+// Mock fs.statSync so rootFromPath's repoRoot lookup doesn't hit real FS
+vi.mock("node:fs", () => ({
+  default: {
+    statSync: vi.fn(() => {
+      throw new Error("ENOENT");
+    }),
+  },
+}));
+
+import { spawnSync } from "node:child_process";
+import { computeTouched } from "../src/gitTouched";
+
+const mockedSpawnSync = vi.mocked(spawnSync);
+
+function makeSpawnResult(
+  overrides: Partial<SpawnSyncReturns<string>>,
+): SpawnSyncReturns<string> {
+  return {
+    pid: 1234,
+    output: [],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+    error: undefined,
+    ...overrides,
+  };
+}
+
+describe("gitTouched ENOBUFS regression (CX-17)", () => {
+  beforeEach(() => {
+    mockedSpawnSync.mockReset();
+  });
+
+  it("handles large stdout (>1 MB) without throwing", () => {
+    // Generate >1 MB of file paths (~20,000 lines × ~60 chars each ≈ 1.2 MB)
+    const lines: string[] = [];
+    for (let i = 0; i < 20_000; i++) {
+      lines.push(`backend/src/TerraFusion.API/Controllers/Controller${i}.cs`);
+    }
+    const largeOutput = lines.join("\n") + "\n";
+    expect(largeOutput.length).toBeGreaterThan(1_000_000);
+
+    mockedSpawnSync.mockReturnValue(makeSpawnResult({ stdout: largeOutput }));
+
+    const touched = computeTouched("/fake/repo", "abc123");
+
+    // Should parse without throwing and produce correct roots
+    expect(touched["backend"]).toBe(true);
+    expect(touched["."]).toBe(true);
+
+    // Verify spawnSync was called with the 64 MB maxBuffer
+    expect(mockedSpawnSync).toHaveBeenCalledOnce();
+    const callArgs = mockedSpawnSync.mock.calls[0];
+    expect(callArgs[0]).toBe("git");
+    expect(callArgs[2]).toMatchObject({
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  });
+
+  it("throws on non-zero exit with stderr message", () => {
+    mockedSpawnSync.mockReturnValue(
+      makeSpawnResult({
+        status: 128,
+        stderr: "fatal: bad revision 'nonexistent..HEAD'",
+      }),
+    );
+
+    expect(() => computeTouched("/fake/repo", "nonexistent")).toThrow(
+      "fatal: bad revision 'nonexistent..HEAD'",
+    );
+  });
+
+  it("throws on non-zero exit with fallback message when stderr is empty", () => {
+    mockedSpawnSync.mockReturnValue(
+      makeSpawnResult({ status: 1, stderr: "" }),
+    );
+
+    expect(() => computeTouched("/fake/repo", "abc123")).toThrow(
+      /git .+ exited 1/,
+    );
+  });
+
+  it("surfaces spawn error (e.g., ENOBUFS)", () => {
+    const spawnError = new Error("spawnSync git ENOBUFS");
+    (spawnError as NodeJS.ErrnoException).code = "ENOBUFS";
+
+    mockedSpawnSync.mockReturnValue(
+      makeSpawnResult({ error: spawnError }),
+    );
+
+    expect(() => computeTouched("/fake/repo", "abc123")).toThrow("ENOBUFS");
+  });
+
+  it("parses multi-segment paths correctly from large output", () => {
+    const lines = [
+      "os-platform/core/src/index.ts",
+      "tools/registry/manifest.json",
+      "frontend/apps/os-shell/src/main.tsx",
+      "backend/src/TerraFusion.API/Program.cs",
+      "packages/os-core/dist/index.js",
+    ];
+    mockedSpawnSync.mockReturnValue(
+      makeSpawnResult({ stdout: lines.join("\n") + "\n" }),
+    );
+
+    const touched = computeTouched("/fake/repo", "abc123");
+
+    // Two-segment roots fall back to single-segment when fs.statSync
+    // can't verify the directory (mocked environment).  The important
+    // assertion is that ALL lines are parsed and produce roots.
+    expect(touched["os-platform"]).toBe(true);
+    expect(touched["tools"]).toBe(true);
+    expect(touched["frontend"]).toBe(true);
+    expect(touched["backend"]).toBe(true);
+    expect(touched["packages"]).toBe(true);
+    expect(touched["."]).toBe(true);
+  });
+});


### PR DESCRIPTION
## CX-17: scope-classifier ENOBUFS regression test

### What
Adds 5 vitest cases that mock `spawnSync` to verify the 64 MB `maxBuffer` fix (PR #542) is never reverted.

### Test scenarios
| # | Scenario | Assertion |
|---|----------|-----------|
| 1 | Stdout > 1 MB (~20k lines) | Parses without throw; `maxBuffer` = 64 MB |
| 2 | Non-zero exit + stderr | Throws with stderr message |
| 3 | Non-zero exit + empty stderr | Throws with fallback `git ... exited N` |
| 4 | Spawn error (ENOBUFS) | Surfaces the error |
| 5 | Multi-segment paths | All roots parsed correctly |

### Evidence
```
 ✓ tests/gitTouched-enobufs.test.ts  (5 tests) 41ms
 Test Files  11 passed (11)
      Tests  19 passed (19)
```

### Files (2)
- `tools/scope-classifier/tests/gitTouched-enobufs.test.ts` — regression test
- `tools/scope-classifier/docs/cx-17-enobufs-regression.md` — doc

### Scope
Tools only (`tools/scope-classifier/`). No production code modified.

## Summary by Sourcery

Add regression coverage to ensure gitTouched handles large git diff outputs and ENOBUFS-related failures without regressing the 64 MB buffer configuration.

Documentation:
- Document the ENOBUFS regression test intent, scenarios, and how to run the scope-classifier tests.

Tests:
- Add vitest coverage for gitTouched to validate large stdout handling, non-zero exits, spawn errors, and multi-segment path parsing related to ENOBUFS scenarios.