### PR TITLE
CX-19D2: enforce CostForge GET county isolation

### DIFF
--- a/backend/docs/r1-week5-cx19d2-costforge-get-county-isolation-report.md
+++ b/backend/docs/r1-week5-cx19d2-costforge-get-county-isolation-report.md
@@ -1,0 +1,53 @@
+# R1Week5 CX-19D2 CostForge GET County Isolation Report
+
+- Lane: `CX-19D2`
+- Branch: `copilot/r1-week5-cx19d2-costforge-get-county-isolation`
+- Baseline commit at execution start: `d229ed35696233150f7c2a8aef4cce702aacd1af`
+
+## Summary
+
+CostForge GET endpoints that dereference property IDs now enforce server-side county context:
+
+- `GET /api/costforge/{propertyId}/breakdown`
+- `GET /api/costforge/compare/{propertyId1}/{propertyId2}`
+- `GET /api/costforge/{propertyId}/forecast`
+
+Cross-county access now returns `404 NotFound` (non-leak) before service calls.
+
+## Implementation
+
+- `CostForgeController` now resolves county context for each affected GET endpoint.
+- Added county-scoped property existence checks via `PropertyExistsInCountyAsync(...)`.
+- Endpoint behavior:
+  - missing/invalid county context => `Forbid()` (existing policy behavior)
+  - property outside caller county => `NotFound()`
+  - same-county property => normal service flow
+
+## Tests
+
+Added:
+
+- `backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19D2CostForgeGetCountyIsolationIntegrationTests.cs`
+
+Updated existing non-leak golden:
+
+- `backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs`
+  - `CostForge_CrossCounty_Breakdown_NoLeak` now asserts deterministic `404`.
+
+## Commands and Results
+
+```bash
+dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~R1Week5Cx19D2" -nologo -v minimal
+```
+
+Result: `Passed: 5, Failed: 0, Skipped: 0, Total: 5`
+
+```bash
+dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~R1Week5" -nologo -v minimal
+```
+
+Result: `Passed: 113, Failed: 0, Skipped: 0, Total: 113`
+
+## Explicit Non-Leak Statement
+
+For CostForge GET endpoints that accept property IDs, cross-county property retrieval is blocked server-side and returns `404 NotFound`.

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -190,6 +190,13 @@ public class CostForgeController : ControllerBase
         return requested == claimCode || requested == countyName || requested == countyFips;
     }
 
+    private async Task<bool> PropertyExistsInCountyAsync(Guid propertyId, Guid countyId)
+    {
+        return await _db.Properties
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == propertyId && p.CountyId == countyId);
+    }
+
     /// <summary>
     /// Enhanced cost calculation for property assessment
     /// Integrates with frontend EnhancedCostCalculator component
@@ -345,6 +352,18 @@ public class CostForgeController : ControllerBase
     {
         try
         {
+            var countyContext = await ResolveCountyContextAsync();
+            if (countyContext is null)
+            {
+                return Forbid();
+            }
+
+            var propertyExistsInCounty = await PropertyExistsInCountyAsync(propertyId, countyContext.CountyId);
+            if (!propertyExistsInCounty)
+            {
+                return NotFound();
+            }
+
             await _auditLogger.LogDataAccessAsync("CostBreakdown", propertyId.ToString(), "READ",
                 User.FindFirst("sub")?.Value);
 
@@ -370,6 +389,24 @@ public class CostForgeController : ControllerBase
     {
         try
         {
+            var countyContext = await ResolveCountyContextAsync();
+            if (countyContext is null)
+            {
+                return Forbid();
+            }
+
+            var property1ExistsInCounty = await PropertyExistsInCountyAsync(propertyId1, countyContext.CountyId);
+            if (!property1ExistsInCounty)
+            {
+                return NotFound();
+            }
+
+            var property2ExistsInCounty = await PropertyExistsInCountyAsync(propertyId2, countyContext.CountyId);
+            if (!property2ExistsInCounty)
+            {
+                return NotFound();
+            }
+
             await _auditLogger.LogDataAccessAsync("CostComparison", $"{propertyId1}:{propertyId2}", "READ",
                 User.FindFirst("sub")?.Value);
 
@@ -399,6 +436,18 @@ public class CostForgeController : ControllerBase
             if (years < 1 || years > 20)
             {
                 return BadRequest("Forecast years must be between 1 and 20");
+            }
+
+            var countyContext = await ResolveCountyContextAsync();
+            if (countyContext is null)
+            {
+                return Forbid();
+            }
+
+            var propertyExistsInCounty = await PropertyExistsInCountyAsync(propertyId, countyContext.CountyId);
+            if (!propertyExistsInCounty)
+            {
+                return NotFound();
             }
 
             await _auditLogger.LogDataAccessAsync("CostForecast", propertyId.ToString(), "READ",

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs
@@ -159,23 +159,12 @@ public sealed class R1Week5Cx19CrossCountyNonLeakTests
   [Fact]
   public async Task CostForge_CrossCounty_Breakdown_NoLeak()
   {
-    // DOCUMENTED FINDING: CostForge breakdown endpoint (GET {propertyId}/breakdown)
-    // does NOT resolve county context. It passes the propertyId directly to
-    // the service layer without verifying the property belongs to the caller's county.
-    // Compare with POST /calculate which DOES validate via CountyCodeMatchesContext().
-    // This is a county-scoping gap to be addressed in a future CX lane.
     using var client = CreateBentonClient();
     var response = await client.GetAsync(
         $"/api/CostForge/{Cx19CrossCountyFactory.KingPropertyGuid}/breakdown");
 
-    // 204 = service returned null (mock has no setup for GetCostBreakdownAsync)
-    // 200 / 403 / 404 are also acceptable — we document actual behavior
-    var status = response.StatusCode;
-    (status == HttpStatusCode.OK ||
-     status == HttpStatusCode.NoContent ||
-     status == HttpStatusCode.Forbidden ||
-     status == HttpStatusCode.NotFound).Should().BeTrue(
-        $"CostForge breakdown returned {status} — documented: no county scoping on GET breakdown");
+    response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+        "Benton caller should receive 404 for King county property breakdown");
   }
 
   // ════════════════════════════════════════════════════════════════════

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19D2CostForgeGetCountyIsolationIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19D2CostForgeGetCountyIsolationIntegrationTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ApiProgram = TerraFusion.API.Program;
+
+namespace TerraFusion.Unit.Tests.R1Week5;
+
+[Trait("Category", "R1Week5")]
+[Trait("Category", "CX19D2")]
+[Trait("Category", "Integration")]
+public sealed class R1Week5Cx19D2CostForgeGetCountyIsolationIntegrationTests
+    : IClassFixture<Cx19CrossCountyFactory>, IAsyncLifetime
+{
+    private readonly Cx19CrossCountyFactory _factory;
+
+    public R1Week5Cx19D2CostForgeGetCountyIsolationIntegrationTests(Cx19CrossCountyFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CostForge_Breakdown_SameCounty_ReturnsNonLeakSuccessStatus()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync($"/api/CostForge/{Cx19CrossCountyFactory.BentonPropertyGuid}/breakdown");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task CostForge_Breakdown_CrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync($"/api/CostForge/{Cx19CrossCountyFactory.KingPropertyGuid}/breakdown");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CostForge_Forecast_CrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync($"/api/CostForge/{Cx19CrossCountyFactory.KingPropertyGuid}/forecast?years=5");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CostForge_Compare_WhenSecondPropertyCrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync(
+            $"/api/CostForge/compare/{Cx19CrossCountyFactory.BentonPropertyGuid}/{Cx19CrossCountyFactory.KingPropertyGuid}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CostForge_Breakdown_AuthenticatedWithoutCountyClaims_Returns403Or401()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx19d2-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id", Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+
+        var response = await client.GetAsync($"/api/CostForge/{Cx19CrossCountyFactory.BentonPropertyGuid}/breakdown");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Forbidden, HttpStatusCode.Unauthorized);
+    }
+
+    private HttpClient CreateBentonClient(string roles = "Assessor")
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx19d2-benton-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Test-CountyId", Cx19CrossCountyFactory.BentonCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", roles);
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id", Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+}


### PR DESCRIPTION
## Summary
- enforce county context checks for CostForge GET endpoints via server-side claims resolution
- add R1Week5 CX-19D2 integration coverage for same-county success and cross-county non-leak behavior
- add lane report for CX-19D2 evidence and commands

## Scope
- backend-only
- no unrelated file changes

## Validation
- dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~R1Week5Cx19D2" -nologo -v minimal
- dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~R1Week5" -nologo -v minimal
