### PR TITLE
chore(claude): add dev server launch config with correct API path

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,76 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173,
+      "cwd": "frontend"
+    },
+    {
+      "name": "backend-api",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": [
+        "watch",
+        "run",
+        "--project",
+        "backend/src/TerraFusion.API/TerraFusion.API.csproj"
+      ],
+      "port": 5000
+    },
+    {
+      "name": "pilot-runtime",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["os-platform/core/pilot/dev-pilot-runtime.mjs"],
+      "port": 4317
+    },
+    {
+      "name": "consciousness",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": [
+        "run",
+        "--project",
+        "backend/src/TerraFusion.Consciousness/TerraFusion.Consciousness.csproj"
+      ],
+      "port": 3004
+    },
+    {
+      "name": "gateway",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": [
+        "run",
+        "--project",
+        "backend/TerraFusion.Gateway/TerraFusion.Gateway.csproj"
+      ],
+      "port": 3002
+    },
+    {
+      "name": "operations",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": [
+        "run",
+        "--project",
+        "backend/src/TerraFusion.Operations/TerraFusion.Operations.csproj"
+      ],
+      "port": 5002
+    },
+    {
+      "name": "storybook",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "storybook"],
+      "port": 6006,
+      "cwd": "frontend"
+    },
+    {
+      "name": "streaming-analytics",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": [
+        "run",
+        "--project",
+        "backend/TerraFusion.StreamingAnalytics/TerraFusion.StreamingAnalytics.csproj"
+      ],
+      "port": 3006
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json` with 8 dev server configurations for Claude Code's `preview_start` tool
- Points `backend-api` to `backend/src/TerraFusion.API/TerraFusion.API.csproj` (the real API with 10 project dependencies) on port 5000
- Previously targeted `backend/api-unified/` which is a minimal stub with 5 inline routes and zero project references
- Port 5000 matches the Vite proxy default (`TF_API_PORT || 5000` in `frontend/vite.config.ts:9`)

## Verification
All project paths verified to exist on `origin/main` via `git ls-tree` and `ls`:
- `backend/src/TerraFusion.API/TerraFusion.API.csproj`
- `backend/src/TerraFusion.Consciousness/TerraFusion.Consciousness.csproj`
- `backend/src/TerraFusion.Operations/TerraFusion.Operations.csproj`
- `backend/TerraFusion.Gateway/TerraFusion.Gateway.csproj`
- `backend/TerraFusion.StreamingAnalytics/TerraFusion.StreamingAnalytics.csproj`
- `os-platform/core/pilot/dev-pilot-runtime.mjs`
- `frontend/package.json`

Port binding confirmed:
- `appsettings.Development.json` line 2: `"Port": "5000"`
- `Program.cs` lines 89-90: trusts `ASPNETCORE_URLS` from env (no hardcoded override)
- PID verified running from `backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.exe` on port 5000

## Risk
Low. This is a new tooling config file (`.claude/launch.json`) that only affects Claude Code dev workflow. No application code changes.

## Test plan
- [ ] `preview_start` for `backend-api` launches the real API on port 5000
- [ ] `preview_start` for `frontend` serves Vite dev server on port 5173
- [ ] `preview_start` for `pilot-runtime` serves pilot on port 4317
- [ ] Vite proxy `/api/*` routes to port 5000 without ECONNREFUSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Add .claude/launch.json with launch configurations for backend API, frontend, pilot runtime, and related dev services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Added development environment configuration file containing eight launch profiles. Each profile includes custom runtime executables, command-line arguments, and dedicated network ports for coordinated local service execution. Supports frontend development, multiple backend services including pilot runtime, consciousness component, gateway, operations, storybook, and streaming analytics—enabling simplified multi-service local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->