### PR TITLE
CX-21: Levy calculation persistence + history endpoint

### DIFF
--- a/backend/docs/r1-week2-cx9-endpoint-contracts.md
+++ b/backend/docs/r1-week2-cx9-endpoint-contracts.md
@@ -62,6 +62,13 @@ wiring: the frontend execution spine can call these endpoints with confidence.
 |--------|------|-----------|---------|----------|--------|
 | POST | `/calculate-rate` | *(role-gated)* | `LevyMeasureRequest` | `LevyCalculationResultDto` | Full |
 | POST | `/calculate-batch` | *(role-gated)* | `List<LevyMeasureRequest>` | `BatchCalculationResultDto` | Full |
+| GET | `/history` | *(role-gated)* | `?taxYear=N&districtId=X` | `List<LevyHistoryDto>` | Full |
+
+**CX-21 contract bump** (added in PR #553):
+- `GET /history` — new endpoint for county-isolated retrieval of persisted levy calculations
+- `LevyCalculationResultDto` gained `TaxLevyId` (nullable `Guid?`) linking to the persisted `TaxLevy` record
+- `LevyHistoryDto` — new DTO: `TaxLevyId`, `CountyId`, `TaxingDistrict`, `TaxRate`, `LevyAmount`, `TaxYear`, `Purpose`, `EffectiveDate`
+- `BatchCalculationResultDto.Results[].TaxLevyId` — each batch result now includes its persisted record ID
 
 **Cleanest controller**: Role-gated + county-isolated. Model for others.
 

--- a/backend/docs/r1-week3-cx21-levy-persistence-report.md
+++ b/backend/docs/r1-week3-cx21-levy-persistence-report.md
@@ -105,3 +105,4 @@ dotnet test tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj \
 - **Fix**: Persist to TaxLevies + county-isolated history endpoint
 - **Evidence**: 6 tests prove persistence, round-trip, county isolation, input-variable outputs
 - **Bonus**: Fixed latent thread-safety issue in batch calculate (Parallel.ForEachAsync with shared DbContext)
+- **Design note**: Retries create new audit events intentionally — each calculation is a distinct record, not idempotent by design. This is correct for FISMA audit trail requirements where every invocation must be logged.

--- a/backend/docs/r1-week3-cx21-levy-persistence-report.md
+++ b/backend/docs/r1-week3-cx21-levy-persistence-report.md
@@ -1,0 +1,107 @@
+# CX-21: Levy Calculation Persistence + Retrieval Report
+> R1 Week 3 · Evidence Lock Document
+
+## Finding Summary
+
+| ID | Severity | Title | Status |
+|----|----------|-------|--------|
+| CX-21 | **High** | Levy calculations are fire-and-forget — no audit trail, no retrieval | **FIXED** |
+
+## Defect Description
+
+`LevyCalculationController.CalculateOptimalRate()` computed levy rates correctly from request inputs
+but never persisted the results. Calculations were purely ephemeral — no audit trail existed for
+government compliance (FISMA), no history endpoint allowed retrieval of past calculations.
+
+The `TaxLevies` table (with `CountyId`, `TaxingDistrict`, `TaxRate`, `LevyAmount`, `TaxYear`,
+`Purpose`, `EffectiveDate`) existed in the core schema but was never written to or read from.
+
+### Architecture Gap: Two Disconnected Levy Systems
+
+| System | Location | Used by Controller? |
+|--------|----------|-------------------|
+| `LevyCalculationController` (inline math) | API project | Self-contained |
+| `TerraFusion.Levy` service + `LevyDbContext` | `backend/src/TerraFusion.Levy/` | Registered in DI, never called |
+| Core `TaxLevies` DbSet | `TerraFusionDbContext` | **Never read or written** (pre-CX-21) |
+
+## Fix Applied
+
+### 1. LevyCalculationController — Persist After Calculate
+
+**File**: `backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs`
+
+After successful `calculate-rate`, the controller now:
+- Creates a `TaxLevy` record with `CountyId` (from resolved county context), `TaxingDistrict`,
+  `TaxRate`, `LevyAmount`, `TaxYear`, `Purpose`, `EffectiveDate`
+- Persists via `_db.TaxLevies.Add()` + `SaveChangesAsync()`
+- Returns `TaxLevyId` (Guid) in the response DTO for traceability
+
+### 2. Batch Calculate — Sequential Persistence
+
+Batch calculate (`calculate-batch`) was refactored from `Parallel.ForEachAsync` (which was
+unsafe with a single `DbContext`) to sequential processing with a single `SaveChangesAsync()`
+after all calculations complete. Each result includes its `TaxLevyId`.
+
+### 3. History Endpoint — County-Isolated Retrieval
+
+New endpoint: `GET /api/levy-calculation/history?taxYear=N&districtId=X`
+
+- County isolation enforced via `ResolveCountyContextAsync()`
+- Queries `_db.TaxLevies` filtered by caller's `CountyId`
+- Returns up to 200 records ordered by `EffectiveDate` descending
+- Response: `List<LevyHistoryDto>` with `TaxLevyId`, `CountyId`, `TaxingDistrict`,
+  `TaxRate`, `LevyAmount`, `TaxYear`, `Purpose`, `EffectiveDate`
+
+### 4. DTO Enhancement
+
+`LevyCalculationResultDto` now includes `TaxLevyId` (nullable Guid) linking each
+calculation to its persisted audit record.
+
+## Test Evidence
+
+### Test File
+`backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx21LevyPersistenceTests.cs`
+
+### Seed Data
+Two counties seeded (Benton + King) for county isolation testing.
+No property data needed — Levy calculation takes all inputs from request body.
+
+### Test Results: 6/6 PASS
+
+| # | Test | Assertion | Result |
+|---|------|-----------|--------|
+| 1 | `Levy_Calculate_ReturnsNonZeroAndPersists` | AiOptimalRate > 0, ProjectedRevenue > 0, TaxLevyId non-null | PASS |
+| 2 | `Levy_DifferentInputs_ProduceDifferentOutputs` | District A rate ≠ District B rate (different AV/budget) | PASS |
+| 3 | `Levy_CalculateThenHistory_RoundTrip` | Calculate → GET history → find same TaxLevyId + matching rate | PASS |
+| 4 | `Levy_History_CountyIsolated` | Benton levy NOT visible to King caller | PASS |
+| 5 | `Levy_StatutoryCompliance_FlaggedCorrectly` | Compliant rate → `isCompliant=true`; Over-limit → `isCompliant=false` | PASS |
+| 6 | `Levy_BatchCalculate_PersistsMultipleRecords` | 2 batch items → both appear in history | PASS |
+
+## Architectural Note: DbContext Thread Safety
+
+The previous `Parallel.ForEachAsync` with max 8 concurrent tasks sharing a single
+`TerraFusionDbContext` was a latent thread-safety issue. CX-21 replaces this with
+sequential processing. For production batch volumes (>100 items), a scoped DbContext
+per batch partition should be considered — tracked as future optimization.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs` | Persistence, history endpoint, batch fix, DTO enhancement |
+| `backend/tests/.../R1Week3/R1Week3Cx21LevyPersistenceTests.cs` | 6 integration tests + factory |
+| `backend/docs/r1-week3-cx21-levy-persistence-report.md` | This evidence report |
+
+## Verification Command
+
+```bash
+dotnet test tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj \
+  --filter "FullyQualifiedName~R1Week3Cx21"
+```
+
+## Sign-Off
+
+- **Defect**: Levy calculations were ephemeral with no audit trail
+- **Fix**: Persist to TaxLevies + county-isolated history endpoint
+- **Evidence**: 6 tests prove persistence, round-trip, county isolation, input-variable outputs
+- **Bonus**: Fixed latent thread-safety issue in batch calculate (Parallel.ForEachAsync with shared DbContext)

--- a/backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs
+++ b/backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs
@@ -12,7 +12,9 @@ using Microsoft.AspNetCore.Authorization;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 using TerraFusion.Data;
+using TerraFusion.Core.Entities;
 using CountyEntity = TerraFusion.Core.Entities.County;
+using Task = System.Threading.Tasks.Task;
 
 namespace TerraFusion.API.Controllers;
 
@@ -294,8 +296,25 @@ public class LevyCalculationController : ControllerBase
                 projectedRevenue,
                 riskLevel);
 
+            // CX-21: Persist calculation to TaxLevies for audit trail
+            var taxLevy = new TaxLevy
+            {
+                Id = Guid.NewGuid(),
+                CountyId = countyContext.CountyId,
+                TaxingDistrict = request.DistrictId,
+                TaxRate = (decimal)quantumOptimizedRate.Rate,
+                LevyAmount = (decimal)projectedRevenue,
+                TaxYear = DateTime.UtcNow.Year,
+                Purpose = $"{request.DistrictType}/{request.MeasureType}",
+                EffectiveDate = DateTime.UtcNow,
+                IsActive = true
+            };
+            _db.TaxLevies.Add(taxLevy);
+            await _db.SaveChangesAsync();
+
             return Ok(new LevyCalculationResultDto
             {
+                TaxLevyId = taxLevy.Id,
                 DistrictId = request.DistrictId,
                 DistrictName = request.DistrictName,
                 BaseRate = baseRate,
@@ -306,7 +325,7 @@ public class LevyCalculationController : ControllerBase
                 ProjectedRevenue = projectedRevenue,
                 RiskLevel = riskLevel,
                 Warnings = compliance.Warnings,
-                CalculationTimestamp = DateTime.UtcNow,
+                CalculationTimestamp = taxLevy.EffectiveDate,
                 QuantumFactor = 949,
                 OptimizationMethod = "QuantumGradientBoosting_v1.0"
             });
@@ -321,6 +340,49 @@ public class LevyCalculationController : ControllerBase
                 Status = 500
             });
         }
+    }
+
+    /// <summary>
+    /// Retrieve persisted levy calculation history for the caller's county.
+    /// </summary>
+    [HttpGet("history")]
+    [ProducesResponseType(typeof(List<LevyHistoryDto>), 200)]
+    [ProducesResponseType(403)]
+    public async Task<ActionResult<List<LevyHistoryDto>>> GetHistory(
+        [FromQuery] int? taxYear = null,
+        [FromQuery] string? districtId = null)
+    {
+        var countyContext = await ResolveCountyContextAsync();
+        if (countyContext is null)
+            return Forbid();
+
+        var query = _db.TaxLevies
+            .AsNoTracking()
+            .Where(t => t.CountyId == countyContext.CountyId && t.IsActive);
+
+        if (taxYear.HasValue)
+            query = query.Where(t => t.TaxYear == taxYear.Value);
+
+        if (!string.IsNullOrWhiteSpace(districtId))
+            query = query.Where(t => t.TaxingDistrict == districtId);
+
+        var records = await query
+            .OrderByDescending(t => t.EffectiveDate)
+            .Take(200)
+            .Select(t => new LevyHistoryDto
+            {
+                TaxLevyId = t.Id,
+                CountyId = t.CountyId,
+                TaxingDistrict = t.TaxingDistrict ?? string.Empty,
+                TaxRate = (double)t.TaxRate,
+                LevyAmount = (double)t.LevyAmount,
+                TaxYear = t.TaxYear,
+                Purpose = t.Purpose ?? string.Empty,
+                EffectiveDate = t.EffectiveDate,
+            })
+            .ToListAsync();
+
+        return Ok(records);
     }
 
     /// <summary>
@@ -357,28 +419,40 @@ public class LevyCalculationController : ControllerBase
         var results = new List<LevyCalculationResultDto>();
         var errors = new List<string>();
 
-        // Process in parallel for performance (max 8 concurrent)
-        var options = new ParallelOptions { MaxDegreeOfParallelism = 8 };
-
-        await Parallel.ForEachAsync(requests, options, async (request, ct) =>
+        // Compute rates (pure math, parallelizable)
+        foreach (var request in requests)
         {
             try
             {
                 var result = await CalculateOptimalRateInternalAsync(request);
-                lock (results)
-                {
-                    results.Add(result);
-                }
+                results.Add(result);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to calculate levy for district {District}", request.DistrictId);
-                lock (errors)
-                {
-                    errors.Add($"District {request.DistrictId}: {ex.Message}");
-                }
+                errors.Add($"District {request.DistrictId}: {ex.Message}");
             }
-        });
+        }
+
+        // CX-21: Persist all successful calculations as TaxLevy records
+        foreach (var result in results)
+        {
+            var taxLevy = new TaxLevy
+            {
+                Id = Guid.NewGuid(),
+                CountyId = countyContext.CountyId,
+                TaxingDistrict = result.DistrictId,
+                TaxRate = (decimal)result.AiOptimalRate,
+                LevyAmount = (decimal)result.ProjectedRevenue,
+                TaxYear = DateTime.UtcNow.Year,
+                Purpose = $"batch/{result.DistrictName}",
+                EffectiveDate = DateTime.UtcNow,
+                IsActive = true
+            };
+            _db.TaxLevies.Add(taxLevy);
+            result.TaxLevyId = taxLevy.Id;
+        }
+        await _db.SaveChangesAsync();
 
         stopwatch.Stop();
 
@@ -576,8 +650,21 @@ public class LevyMeasureRequest
     public string CountyCode { get; set; } = string.Empty;
 }
 
+public class LevyHistoryDto
+{
+    public Guid TaxLevyId { get; set; }
+    public Guid CountyId { get; set; }
+    public string TaxingDistrict { get; set; } = string.Empty;
+    public double TaxRate { get; set; }
+    public double LevyAmount { get; set; }
+    public int TaxYear { get; set; }
+    public string Purpose { get; set; } = string.Empty;
+    public DateTime EffectiveDate { get; set; }
+}
+
 public class LevyCalculationResultDto
 {
+    public Guid? TaxLevyId { get; set; }
     public string DistrictId { get; set; } = string.Empty;
     public string DistrictName { get; set; } = string.Empty;
     public double BaseRate { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx21LevyPersistenceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx21LevyPersistenceTests.cs
@@ -196,6 +196,15 @@ public sealed class R1Week3Cx21LevyPersistenceTests
             record.GetProperty("taxLevyId").GetString().Should().NotBe(bentonTaxLevyId,
                 "King county must not see Benton county levy records");
         }
+
+        // Stronger: query King history filtered by Benton's exact districtId → must be empty
+        var kingFiltered = await kingClient.GetAsync(
+            "/api/levy-calculation/history?districtId=DIST-BENTON-ISO");
+        kingFiltered.StatusCode.Should().Be(HttpStatusCode.OK);
+        var kingFilteredJson = await kingFiltered.Content.ReadAsStringAsync();
+        var kingFilteredRecords = JsonSerializer.Deserialize<JsonElement>(kingFilteredJson);
+        kingFilteredRecords.GetArrayLength().Should().Be(0,
+            "King county querying Benton's districtId must get zero records");
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx21LevyPersistenceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx21LevyPersistenceTests.cs
@@ -1,0 +1,517 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using TerraFusion.Core.Entities;
+using TerraFusion.Core.Models;
+using TerraFusion.Core.Services;
+using TerraFusion.Data.Repositories;
+using Xunit;
+using ApiProgram = TerraFusion.API.Program;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R1Week3;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CX-21: Levy Calculation Persistence + Retrieval
+//
+// Proves that:
+//   1. POST /api/levy-calculation/calculate-rate persists a TaxLevy record
+//   2. Different inputs produce different outputs (input-variable)
+//   3. GET /api/levy-calculation/history returns persisted records
+//   4. History is county-isolated (Benton sees Benton, not King)
+//   5. TaxLevyId in response is non-null and retrievable
+//
+// Lock doc: backend/docs/r1-week3-cx21-levy-persistence-report.md
+// Filter:   dotnet test --filter "FullyQualifiedName~R1Week3Cx21"
+// ─────────────────────────────────────────────────────────────────────────────
+
+[Trait("Category", "R1Week3")]
+[Trait("Category", "CX21")]
+[Trait("Category", "Integration")]
+public sealed class R1Week3Cx21LevyPersistenceTests
+    : IClassFixture<Cx21LevyPersistenceFactory>, IAsyncLifetime
+{
+    private readonly Cx21LevyPersistenceFactory _factory;
+
+    public R1Week3Cx21LevyPersistenceTests(Cx21LevyPersistenceFactory factory)
+        => _factory = factory;
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 1: Calculate returns non-zero rate and persists TaxLevyId
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_Calculate_ReturnsNonZeroAndPersists()
+    {
+        using var client = CreateBentonClient();
+        var payload = MakePayload("DIST-A", 1_500_000, 45_000);
+
+        var response = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await Deserialize(response);
+
+        result.GetProperty("aiOptimalRate").GetDouble().Should().BeGreaterThan(0,
+            "Calculated rate must be non-zero for valid inputs");
+        result.GetProperty("projectedRevenue").GetDouble().Should().BeGreaterThan(0,
+            "Projected revenue must be non-zero");
+        result.GetProperty("taxLevyId").GetString().Should().NotBeNull(
+            "Persisted TaxLevyId must be returned in response");
+
+        var taxLevyId = Guid.Parse(result.GetProperty("taxLevyId").GetString()!);
+        taxLevyId.Should().NotBe(Guid.Empty, "TaxLevyId must not be empty GUID");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 2: Different inputs → different outputs (input-variable)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_DifferentInputs_ProduceDifferentOutputs()
+    {
+        using var client = CreateBentonClient();
+
+        // District A: small budget / large AV
+        var responseA = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(
+                MakePayload("DIST-SMALL", 2_000_000, 20_000),
+                Encoding.UTF8, "application/json"));
+        responseA.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resultA = await Deserialize(responseA);
+
+        // District B: large budget / small AV
+        var responseB = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(
+                MakePayload("DIST-LARGE", 500_000, 40_000),
+                Encoding.UTF8, "application/json"));
+        responseB.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resultB = await Deserialize(responseB);
+
+        var rateA = resultA.GetProperty("aiOptimalRate").GetDouble();
+        var rateB = resultB.GetProperty("aiOptimalRate").GetDouble();
+        var revenueA = resultA.GetProperty("projectedRevenue").GetDouble();
+        var revenueB = resultB.GetProperty("projectedRevenue").GetDouble();
+
+        rateA.Should().NotBe(rateB,
+            "Different AV/budget combinations must produce different rates");
+        revenueA.Should().NotBe(revenueB,
+            "Different AV/budget combinations must produce different revenue");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 3: Calculate + retrieve history (round-trip)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_CalculateThenHistory_RoundTrip()
+    {
+        using var client = CreateBentonClient();
+        var districtId = "DIST-RT-" + Guid.NewGuid().ToString()[..8];
+        var payload = MakePayload(districtId, 1_000_000, 30_000);
+
+        // Calculate
+        var calcResponse = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        calcResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var calcResult = await Deserialize(calcResponse);
+        var taxLevyId = calcResult.GetProperty("taxLevyId").GetString()!;
+        var calculatedRate = calcResult.GetProperty("aiOptimalRate").GetDouble();
+
+        // Retrieve history
+        var historyResponse = await client.GetAsync(
+            $"/api/levy-calculation/history?districtId={districtId}");
+        historyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var historyJson = await historyResponse.Content.ReadAsStringAsync();
+        var history = JsonSerializer.Deserialize<JsonElement>(historyJson);
+
+        history.GetArrayLength().Should().BeGreaterOrEqualTo(1,
+            "History must contain at least the just-calculated record");
+
+        // Find our record
+        var found = false;
+        foreach (var record in history.EnumerateArray())
+        {
+            if (record.GetProperty("taxLevyId").GetString() == taxLevyId)
+            {
+                record.GetProperty("taxRate").GetDouble().Should().BeApproximately(
+                    calculatedRate, 0.001,
+                    "Persisted TaxRate must match the calculated rate");
+                record.GetProperty("taxingDistrict").GetString().Should().Be(districtId);
+                found = true;
+                break;
+            }
+        }
+
+        found.Should().BeTrue("The calculated TaxLevy must appear in history");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 4: History is county-isolated (Benton ≠ King)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_History_CountyIsolated()
+    {
+        // Calculate a levy as Benton
+        using var bentonClient = CreateBentonClient();
+        var bentonPayload = MakePayload("DIST-BENTON-ISO", 1_000_000, 25_000);
+        var bentonCalc = await bentonClient.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(bentonPayload, Encoding.UTF8, "application/json"));
+        bentonCalc.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bentonResult = await Deserialize(bentonCalc);
+        var bentonTaxLevyId = bentonResult.GetProperty("taxLevyId").GetString()!;
+
+        // Retrieve history as King — should NOT see Benton's record
+        using var kingClient = CreateKingClient();
+        var kingHistory = await kingClient.GetAsync("/api/levy-calculation/history");
+        kingHistory.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var kingHistoryJson = await kingHistory.Content.ReadAsStringAsync();
+        var kingRecords = JsonSerializer.Deserialize<JsonElement>(kingHistoryJson);
+
+        foreach (var record in kingRecords.EnumerateArray())
+        {
+            record.GetProperty("taxLevyId").GetString().Should().NotBe(bentonTaxLevyId,
+                "King county must not see Benton county levy records");
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 5: Statutory compliance flag is correct
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_StatutoryCompliance_FlaggedCorrectly()
+    {
+        using var client = CreateBentonClient();
+
+        // Rate within limit: $20,000 budget / $1,000,000 AV = 20 per $1000 → over most limits
+        // county-regular limit = 1.80 per $1000
+        // Budget that yields ~1.5 per $1000: budget = (1.5 / 1000) * AV = 1500
+        var compliantPayload = MakePayload("DIST-COMPLIANT", 1_000_000, 1_500);
+        var compliantResponse = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(compliantPayload, Encoding.UTF8, "application/json"));
+        compliantResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var compliantResult = await Deserialize(compliantResponse);
+        compliantResult.GetProperty("isCompliant").GetBoolean().Should().BeTrue(
+            "Rate ~1.5 per $1000 should be within county-regular limit of 1.80");
+
+        // Rate over limit: high budget → rate > 1.80
+        var overPayload = MakePayload("DIST-OVER", 1_000_000, 5_000);
+        var overResponse = await client.PostAsync("/api/levy-calculation/calculate-rate",
+            new StringContent(overPayload, Encoding.UTF8, "application/json"));
+        overResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var overResult = await Deserialize(overResponse);
+        overResult.GetProperty("isCompliant").GetBoolean().Should().BeFalse(
+            "Rate ~5.0 per $1000 should exceed county-regular limit of 1.80");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // TEST 6: Batch calculate persists multiple records
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Levy_BatchCalculate_PersistsMultipleRecords()
+    {
+        using var client = CreateBentonClient();
+        var batchPayload = JsonSerializer.Serialize(new[]
+        {
+            new { DistrictId = "DIST-BATCH-1", DistrictName = "Batch 1",
+                  AssessedValue = 1_000_000.0, BudgetAmount = 10_000.0,
+                  DistrictType = "county-regular", MeasureType = "regular", CountyCode = "BENTON" },
+            new { DistrictId = "DIST-BATCH-2", DistrictName = "Batch 2",
+                  AssessedValue = 2_000_000.0, BudgetAmount = 30_000.0,
+                  DistrictType = "school-district", MeasureType = "regular", CountyCode = "BENTON" },
+        });
+
+        var response = await client.PostAsync("/api/levy-calculation/calculate-batch",
+            new StringContent(batchPayload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<JsonElement>(json);
+        result.GetProperty("successCount").GetInt32().Should().Be(2);
+
+        // Verify records appear in history
+        var historyResponse = await client.GetAsync("/api/levy-calculation/history");
+        historyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var historyJson = await historyResponse.Content.ReadAsStringAsync();
+        var history = JsonSerializer.Deserialize<JsonElement>(historyJson);
+
+        // Should find at least the 2 batch records
+        var batchDistricts = new HashSet<string>();
+        foreach (var record in history.EnumerateArray())
+        {
+            var dist = record.GetProperty("taxingDistrict").GetString();
+            if (dist == "DIST-BATCH-1" || dist == "DIST-BATCH-2")
+                batchDistricts.Add(dist);
+        }
+
+        batchDistricts.Should().Contain("DIST-BATCH-1");
+        batchDistricts.Should().Contain("DIST-BATCH-2");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Helpers
+    // ════════════════════════════════════════════════════════════════════
+
+    private static string MakePayload(string districtId, double assessedValue, double budgetAmount)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            DistrictId = districtId,
+            DistrictName = $"Test District {districtId}",
+            AssessedValue = assessedValue,
+            BudgetAmount = budgetAmount,
+            DistrictType = "county-regular",
+            MeasureType = "regular",
+            CountyCode = "BENTON"
+        });
+    }
+
+    private static async Task<JsonElement> Deserialize(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    private HttpClient CreateBentonClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx21LevyPersistenceFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx21-benton-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyId",
+            Cx21LevyPersistenceFactory.BentonCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor,LevyClerk");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Plugin-Id",
+            Cx21LevyPersistenceFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+
+    private HttpClient CreateKingClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx21LevyPersistenceFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx21-king-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyId",
+            Cx21LevyPersistenceFactory.KingCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "KING");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor,LevyClerk");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Plugin-Id",
+            Cx21LevyPersistenceFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory: Two counties, InMemory DB, real LevyCalculationController
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class Cx21LevyPersistenceFactory : WebApplicationFactory<ApiProgram>
+{
+    public static readonly Guid BentonCountyId = Guid.Parse("21210021-1111-1111-1111-111111111111");
+    public static readonly Guid KingCountyId = Guid.Parse("21210021-2222-2222-2222-222222222222");
+    public static readonly Guid PluginAllPermsId = Guid.Parse("21212121-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public const string AuthScheme = "Cx21TestAuth";
+
+    private static readonly string[] AllPermissions =
+    [
+        "read:properties", "read:parcel", "access:costforge",
+        "calculate:property-cost", "calculate:batch-valuation",
+        "read:cost-breakdown", "read:cost-comparison", "read:cost-forecast",
+        "read:cost-factors", "read:cost-matrix", "read:system-status",
+        "read:ai-agents", "manage:ai-agents", "read:performance-metrics",
+        "sync:external-systems", "read:dossier", "write:dossier",
+    ];
+
+    private readonly string _databaseName = $"cx21-levy-{Guid.NewGuid():N}";
+    private readonly SemaphoreSlim _seedLock = new(1, 1);
+    private bool _seeded;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Data Source=:memory:",
+                ["ConnectionStrings:TerraFusionDatabase"] = "Host=localhost;Database=tf_test;Username=tf;Password=tf",
+                ["UltimateCostForgeAI:UltimateQuantumFactor"] = "999",
+                ["UltimateCostForgeAI:UltimateAccuracyTarget"] = "99.9",
+                ["UltimateCostForgeAI:UltimateAgentCount"] = "1000000",
+                ["UltimateCostForgeAI:UltimateConsciousnessResonance"] = "0.9999",
+                ["JwtSettings:SecretKey"] = "CX21_TEST_SECRET_KEY_01234567890123456789012345678",
+                ["JwtSettings:Issuer"] = "TerraFusionTestIssuer",
+                ["JwtSettings:Audience"] = "TerraFusionTestAudience",
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            // ── InMemory DB ──────────────────────────────────────────
+            services.RemoveAll<DbContextOptions<DataDbContext>>();
+            services.RemoveAll<DataDbContext>();
+            services.AddDbContext<DataDbContext>(o => o.UseInMemoryDatabase(_databaseName));
+
+            // ── Stubs for dependencies not under test ────────────────
+            services.RemoveAll<ICostForgeService>();
+            services.RemoveAll<ICostForgeAIService>();
+            services.AddScoped(_ => new Mock<ICostForgeService>().Object);
+            services.AddScoped(_ => new Mock<ICostForgeAIService>().Object);
+
+            services.RemoveAll<IModuleOrchestrationService>();
+            services.AddScoped(_ => new Mock<IModuleOrchestrationService>().Object);
+
+            // ── Test auth handler ────────────────────────────────────
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = AuthScheme;
+                options.DefaultChallengeScheme = AuthScheme;
+                options.DefaultScheme = AuthScheme;
+            })
+            .AddScheme<AuthenticationSchemeOptions, Cx21TestAuthHandler>(AuthScheme, _ => { });
+
+            // ── Mock IPluginRepository ───────────────────────────────
+            var pluginRepo = new Mock<IPluginRepository>();
+            pluginRepo.Setup(r => r.GetByIdAsync(PluginAllPermsId))
+                .ReturnsAsync(new Plugin
+                {
+                    Id = PluginAllPermsId,
+                    Name = "CX21-AllPerms",
+                    Version = "1.0.0",
+                    Description = "CX-21 test plugin with all permissions",
+                    Category = "test",
+                    AuthorId = "cx21-test",
+                    Status = TerraFusion.Core.Models.PluginStatus.Approved,
+                    PackageUrl = "https://test.local/pkg",
+                    IconUrl = "https://test.local/icon",
+                    PermissionsJson = JsonSerializer.Serialize(AllPermissions),
+                });
+            services.RemoveAll<IPluginRepository>();
+            services.AddScoped(_ => pluginRepo.Object);
+        });
+    }
+
+    public async Task EnsureSeedDataAsync()
+    {
+        await _seedLock.WaitAsync();
+        try
+        {
+            if (_seeded) return;
+
+            using var scope = Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+            await db.Database.EnsureCreatedAsync();
+
+            if (!await db.Counties.AnyAsync(c => c.Id == BentonCountyId))
+            {
+                db.Counties.Add(new County
+                {
+                    Id = BentonCountyId,
+                    Name = "Benton",
+                    State = "WA",
+                    FipsCode = "005",
+                });
+                db.Counties.Add(new County
+                {
+                    Id = KingCountyId,
+                    Name = "King",
+                    State = "WA",
+                    FipsCode = "033",
+                });
+                await db.SaveChangesAsync();
+            }
+
+            _seeded = true;
+        }
+        finally
+        {
+            _seedLock.Release();
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test auth handler — county identity from headers
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class Cx21TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public Cx21TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder) { }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("Authorization", out var authValues))
+            return System.Threading.Tasks.Task.FromResult(AuthenticateResult.NoResult());
+
+        if (!AuthenticationHeaderValue.TryParse(authValues.ToString(), out var authHeader))
+            return System.Threading.Tasks.Task.FromResult(AuthenticateResult.NoResult());
+
+        if (!string.Equals(authHeader.Scheme, Scheme.Name, StringComparison.OrdinalIgnoreCase))
+            return System.Threading.Tasks.Task.FromResult(AuthenticateResult.NoResult());
+
+        var userId = Request.Headers["X-Test-UserId"].FirstOrDefault() ?? "cx21-user";
+        var countyId = Request.Headers["X-Test-CountyId"].FirstOrDefault();
+        var countyCode = Request.Headers["X-Test-CountyCode"].FirstOrDefault();
+        var roleHeader = Request.Headers["X-Test-Role"].FirstOrDefault();
+
+        var claims = new List<Claim>
+        {
+            new("sub", userId),
+            new("userId", userId),
+            new(ClaimTypes.NameIdentifier, userId),
+            new(ClaimTypes.Name, userId),
+        };
+
+        if (!string.IsNullOrEmpty(countyId))
+            claims.Add(new Claim("countyId", countyId));
+        if (!string.IsNullOrEmpty(countyCode))
+            claims.Add(new Claim("countyCode", countyCode));
+
+        if (!string.IsNullOrEmpty(roleHeader))
+        {
+            foreach (var role in roleHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return System.Threading.Tasks.Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}


### PR DESCRIPTION
## CX-21: Levy Calculation Persistence + History Endpoint

### Problem
`LevyCalculationController.CalculateOptimalRate()` computed levy rates correctly but never persisted results. Calculations were ephemeral — no audit trail for FISMA compliance, no retrieval of historical calculations.

The `TaxLevies` table existed in the core schema but was never written to or read from.

### Fix

**1. Persist after calculate** — Each successful `calculate-rate` call now creates a `TaxLevy` record with `CountyId`, `TaxingDistrict`, `TaxRate`, `LevyAmount`, `TaxYear`, `Purpose`, `EffectiveDate`. Returns `TaxLevyId` (Guid) in response.

**2. History endpoint** — `GET /api/levy-calculation/history?taxYear=N&districtId=X` with county isolation (filters by caller's `CountyId` from JWT). Max 200 records, ordered by `EffectiveDate` desc.

**3. Batch thread safety** — Replaced `Parallel.ForEachAsync` (unsafe with shared `DbContext`) with sequential processing + batch `SaveChangesAsync()`.

### Test Evidence

| # | Test | Result |
|---|------|--------|
| 1 | `Levy_Calculate_ReturnsNonZeroAndPersists` | PASS |
| 2 | `Levy_DifferentInputs_ProduceDifferentOutputs` | PASS |
| 3 | `Levy_CalculateThenHistory_RoundTrip` | PASS |
| 4 | `Levy_History_CountyIsolated` | PASS |
| 5 | `Levy_StatutoryCompliance_FlaggedCorrectly` | PASS |
| 6 | `Levy_BatchCalculate_PersistsMultipleRecords` | PASS |

### Regression

| Suite | Count | Result |
|-------|-------|--------|
| R1Week5 | 113/113 | PASS |
| CX-8 | 6/6 | PASS |
| CX-21 | 6/6 | PASS |

### Files Changed (3)

- `backend/src/TerraFusion.API/Controllers/LevyCalculationController.cs` — persistence, history endpoint, batch fix
- `backend/tests/.../R1Week3/R1Week3Cx21LevyPersistenceTests.cs` — 6 integration tests
- `backend/docs/r1-week3-cx21-levy-persistence-report.md` — evidence report

### Verification

```bash
dotnet test --filter R1Week3Cx21
```