### PR TITLE
CX-22: Parcel Dossier v0 — composition endpoint + cross-county tests

### DIFF
--- a/backend/docs/r1-week2-cx9-endpoint-contracts.md
+++ b/backend/docs/r1-week2-cx9-endpoint-contracts.md
@@ -103,6 +103,22 @@ wiring: the frontend execution spine can call these endpoints with confidence.
 > **CX-22 (Parcel Dossier v0)**: The `/summary` endpoint is a read-only composition
 > returning property core fields, CostForge breakdown, county-scoped levy history
 > (last N, default 10), and dossier notes summary. OwnerSSN excluded from response.
+>
+> **Status codes**:
+> - `400` — Invalid `parcelId` format (regex guard).
+> - `403` — Caller has no `countyId` claim (cannot resolve county context).
+> - `404` — Parcel not found **or** parcel exists but belongs to a different county.
+>   Cross-county access returns 404, not 403, to prevent parcel-existence enumeration.
+>
+> **`levyLimit` query parameter**:
+> - Type: `int`, default: `10`.
+> - Clamped server-side: `min 1`, `max 100`. Values outside this range are silently clamped.
+>
+> **`costBreakdown` nullable semantics**:
+> - Field type: `CostBreakdownDto?` (nullable).
+> - Returns `null` (JSON: `"costBreakdown": null`) when CostForge service throws or
+>   is unavailable. The endpoint still returns `200` with property + levy + notes.
+> - Warning logged server-side when fallback is triggered.
 
 ---
 

--- a/backend/docs/r1-week2-cx9-endpoint-contracts.md
+++ b/backend/docs/r1-week2-cx9-endpoint-contracts.md
@@ -98,6 +98,11 @@ wiring: the frontend execution spine can call these endpoints with confidence.
 | GET | `/{parcelId}/notes` | `read:dossier` | — | JSON (notes array) | Full |
 | POST | `/{parcelId}/notes` | `write:dossier` | `CreateNoteRequest` | JSON (Created) | Full |
 | GET | `/parcels/{parcelId}/casefile` | `read:dossier` | `?include=` | JSON (casefile) | Full |
+| GET | `/parcels/{parcelId}/summary` | `read:dossier` | `?levyLimit=10` | `ParcelDossierDto` | Full |
+
+> **CX-22 (Parcel Dossier v0)**: The `/summary` endpoint is a read-only composition
+> returning property core fields, CostForge breakdown, county-scoped levy history
+> (last N, default 10), and dossier notes summary. OwnerSSN excluded from response.
 
 ---
 

--- a/backend/docs/r1-week3-cx22-parcel-dossier-v0-evidence.md
+++ b/backend/docs/r1-week3-cx22-parcel-dossier-v0-evidence.md
@@ -1,5 +1,15 @@
 # CX-22: Parcel Dossier v0 — Evidence Report
 
+## Provenance
+
+| Field | Value |
+|-------|-------|
+| **Branch** | `r1/cx22-parcel-dossier-v0` |
+| **Commit** | `2f824b522` |
+| **PR** | [#556](https://github.com/bsvalues/terrafusion_os_1.0/pull/556) |
+| **Base** | `r1/integration` |
+| **Author** | AI-Collaboration: GitHub Copilot (CX-22 session) |
+
 ## Summary
 Implements `GET /api/dossier/parcels/{parcelId}/summary` — a read-only composition
 endpoint returning property core fields, CostForge breakdown, county-scoped levy
@@ -94,3 +104,35 @@ Regression: CX-19D2 (5 tests ✓), CX-15 (5 tests ✓), AtlasDossier (7 tests �
 - **No new DI registrations required** — `ICostForgeService` was already registered in
   `Program.cs` (CX-8).
 - **Retry-idempotency**: GET endpoint, fully idempotent by nature.
+
+## Reproduction Commands
+
+```bash
+# Build (from backend/)
+dotnet build src/TerraFusion.API/TerraFusion.API.csproj -c Release --no-restore
+
+# Run CX-22 tests only
+dotnet test tests/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj \
+  --filter "FullyQualifiedName~R1Week5Cx22" --verbosity normal
+
+# Run full regression (CX-15 + CX-19 + CX-22 + AtlasDossier)
+dotnet test tests/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj \
+  --filter "FullyQualifiedName~R1Week5|FullyQualifiedName~R1Week4Cx15|FullyQualifiedName~AtlasDossier" \
+  --verbosity normal
+```
+
+## Performance Verification
+
+Query count for `GET /parcels/{parcelId}/summary`:
+
+| Step | Operation | Query Count | Notes |
+|------|-----------|-------------|-------|
+| 1 | `ResolveCountyIdAsync()` | 0–1 | 0 if Guid claim, 1 if name/FIPS lookup |
+| 2 | Property lookup | 1 | `FirstOrDefaultAsync` with `Select` projection, `AsNoTracking` |
+| 3 | CostForge breakdown | 1 (service) | Single `GetCostBreakdownAsync` call; null on failure |
+| 4 | Levy history | 1 | `Where + OrderByDescending + Take(N) + Select`, `AsNoTracking` |
+| 5 | Notes count | 1 | `CountAsync` |
+| 6 | Latest note date | 0–1 | `MaxAsync` only if count > 0 |
+
+**Total: 4–6 DB queries, O(1) per field group**. No N+1. No full-entity materialization.
+All read queries use `AsNoTracking()` and server-side `Select` projection.

--- a/backend/docs/r1-week3-cx22-parcel-dossier-v0-evidence.md
+++ b/backend/docs/r1-week3-cx22-parcel-dossier-v0-evidence.md
@@ -1,0 +1,96 @@
+# CX-22: Parcel Dossier v0 — Evidence Report
+
+## Summary
+Implements `GET /api/dossier/parcels/{parcelId}/summary` — a read-only composition
+endpoint returning property core fields, CostForge breakdown, county-scoped levy
+history, and dossier notes summary. All data is county-isolated.
+
+## Endpoint Contract
+
+| Field | Value |
+|-------|-------|
+| **Route** | `GET /api/dossier/parcels/{parcelId}/summary?levyLimit=10` |
+| **Auth** | `[Authorize]` + `RequiresPermission("read:dossier")` |
+| **County Isolation** | Full (`ResolveCountyIdAsync` → property+levy+notes all county-scoped) |
+| **Response DTO** | `ParcelDossierDto` |
+| **PII** | OwnerSSN excluded from response |
+
+## Response Shape
+
+```json
+{
+  "parcelId": "CX19-BENTON-P1",
+  "countyId": "19190019-...",
+  "property": {
+    "id": "...",
+    "parcelNumber": "CX19-BN-001",
+    "address": "100 Main St, Kennewick, WA",
+    "ownerName": "...",
+    "propertyType": "...",
+    "yearBuilt": 1990,
+    "assessedValue": 250000,
+    "landValue": 100000,
+    "improvementValue": 150000,
+    "marketValue": 260000,
+    "assessmentDate": "2026-...",
+    "taxYear": 2026
+  },
+  "costBreakdown": {
+    "propertyId": "...",
+    "totalValue": 100000,
+    "categories": [...]
+  },
+  "levyHistory": [
+    {
+      "taxLevyId": "...",
+      "taxingDistrict": "BENTON-GEN-001",
+      "taxRate": 0.0123,
+      "levyAmount": 3075,
+      "taxYear": 2026,
+      "purpose": "General Fund",
+      "effectiveDate": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "notes": {
+    "noteCount": 1,
+    "latestNoteAt": "2026-..."
+  },
+  "generatedAtUtc": "2026-..."
+}
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/TerraFusion.API/DTOs/ParcelDossierDto.cs` | NEW — composition DTO |
+| `backend/src/TerraFusion.API/Controllers/DossierController.cs` | Add `ICostForgeService` injection + `/summary` endpoint |
+| `backend/tests/.../R1Week5/R1Week5Cx22ParcelDossierV0Tests.cs` | NEW — 6 integration tests |
+| `backend/tests/.../R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs` | Add `GetCostBreakdownAsync` mock + TaxLevy seed data |
+| `backend/tests/.../R1Week3/AtlasDossierControllerGuardsTests.cs` | Fix constructor for new `ICostForgeService` param |
+| `backend/tests/.../R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs` | Fix constructor for new `ICostForgeService` param |
+| `backend/docs/r1-week2-cx9-endpoint-contracts.md` | CX-22 bump — new `/summary` row + note |
+
+## Test Evidence
+
+| Test | Validates |
+|------|-----------|
+| `ParcelSummary_SameCounty_Returns200WithExpectedShape` | 200 + correct parcelId, countyId, property, notes, levy, costBreakdown |
+| `ParcelSummary_CrossCounty_Returns404` | Benton user → King parcel → 404 (not leaked) |
+| `ParcelSummary_NonExistentParcel_Returns404` | Non-existent parcel → 404 |
+| `ParcelSummary_NoClaim_Returns403` | No countyId claim → 403 |
+| `ParcelSummary_InvalidParcelFormat_Returns400` | SQL-injection-style parcel → 400 |
+| `ParcelSummary_LevyHistory_DoesNotLeakCrossCounty` | Levy array contains zero King records |
+
+Regression: CX-19D2 (5 tests ✓), CX-15 (5 tests ✓), AtlasDossier (7 tests ✓).
+
+## Design Notes
+
+- **CostForge integration**: `ICostForgeService.GetCostBreakdownAsync()` called with graceful
+  try/catch fallback. If CostForge is unavailable, `costBreakdown` returns null — the endpoint
+  still returns property + levy + notes.
+- **Levy history is county-scoped** (not parcel-scoped) because levies apply at the district
+  level, not individual parcel level. The `levyLimit` parameter caps results (default 10, max 100).
+- **No new DI registrations required** — `ICostForgeService` was already registered in
+  `Program.cs` (CX-8).
+- **Retry-idempotency**: GET endpoint, fully idempotent by nature.

--- a/backend/src/TerraFusion.API/Controllers/DossierController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DossierController.cs
@@ -3,13 +3,15 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using System.Text.RegularExpressions;
 using TerraFusion.Core.Entities;
-using TerraFusion.Data;
+using TerraFusion.Core.Services;
+using TerraFusion.API.DTOs;
 using TerraFusion.API.Security;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
 
 namespace TerraFusion.API.Controllers;
 
 /// <summary>
-/// TerraDossier — Notes CRUD for R1.
+/// TerraDossier — Notes CRUD + Parcel Dossier composition for R1.
 /// Write-lane: dossier. County isolation enforced on all queries.
 /// </summary>
 [ApiController]
@@ -17,13 +19,15 @@ namespace TerraFusion.API.Controllers;
 [Authorize]
 public class DossierController : ControllerBase
 {
-    private readonly TerraFusionDbContext _db;
+    private readonly DataDbContext _db;
+    private readonly ICostForgeService _costForge;
     private readonly ILogger<DossierController> _logger;
     private static readonly Regex ParcelIdPattern = new("^[A-Za-z0-9._-]{1,50}$", RegexOptions.Compiled);
 
-    public DossierController(TerraFusionDbContext db, ILogger<DossierController> logger)
+    public DossierController(DataDbContext db, ICostForgeService costForge, ILogger<DossierController> logger)
     {
         _db = db;
+        _costForge = costForge;
         _logger = logger;
     }
 
@@ -272,6 +276,111 @@ public class DossierController : ControllerBase
             {
                 notes = new { count = notes.Count, summary = $"{notes.Count} case note(s)" },
             },
+        });
+    }
+
+    // ── GET /api/dossier/parcels/{parcelId}/summary ──────────────────
+
+    /// <summary>
+    /// Parcel Dossier v0 — composition view aggregating property, cost breakdown,
+    /// levy history, and notes summary. County-isolated. Read-only.
+    /// </summary>
+    [HttpGet("parcels/{parcelId}/summary")]
+    [RequiresPermission("read:dossier")]
+    [ProducesResponseType(typeof(ParcelDossierDto), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(403)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetParcelSummary(string parcelId, [FromQuery] int levyLimit = 10)
+    {
+        parcelId = parcelId.Trim();
+        if (!IsValidParcelId(parcelId))
+            return BadRequest(new { error = "Invalid parcelId format" });
+
+        if (levyLimit < 1) levyLimit = 1;
+        if (levyLimit > 100) levyLimit = 100;
+
+        var countyId = await ResolveCountyIdAsync();
+        if (countyId is null)
+            return Forbid();
+
+        // ── Property (county-isolated) ──────────────────────────────
+        var property = await _db.Properties
+            .AsNoTracking()
+            .Where(p => p.ParcelId == parcelId && p.CountyId == countyId.Value)
+            .Select(p => new ParcelPropertySummary
+            {
+                Id = p.Id,
+                ParcelNumber = p.ParcelNumber,
+                Address = p.Address,
+                OwnerName = p.OwnerName,
+                PropertyType = p.PropertyType,
+                YearBuilt = p.YearBuilt,
+                AssessedValue = p.AssessedValue,
+                LandValue = p.LandValue,
+                ImprovementValue = p.ImprovementValue,
+                MarketValue = p.MarketValue,
+                AssessmentDate = p.AssessmentDate,
+                TaxYear = p.TaxYear,
+            })
+            .FirstOrDefaultAsync();
+
+        if (property is null)
+            return NotFound(new { error = "Parcel not found" });
+
+        // ── CostForge breakdown (graceful fallback) ─────────────────
+        CostBreakdownDto? costBreakdown = null;
+        try
+        {
+            costBreakdown = await _costForge.GetCostBreakdownAsync(property.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "CostForge breakdown unavailable for property {PropertyId}", property.Id);
+        }
+
+        // ── Levy history (county-isolated, last N) ──────────────────
+        var levyHistory = await _db.TaxLevies
+            .AsNoTracking()
+            .Where(t => t.CountyId == countyId.Value && t.IsActive)
+            .OrderByDescending(t => t.EffectiveDate)
+            .Take(levyLimit)
+            .Select(t => new LevyHistorySummary
+            {
+                TaxLevyId = t.Id,
+                TaxingDistrict = t.TaxingDistrict ?? string.Empty,
+                TaxRate = (double)t.TaxRate,
+                LevyAmount = (double)t.LevyAmount,
+                TaxYear = t.TaxYear,
+                Purpose = t.Purpose ?? string.Empty,
+                EffectiveDate = t.EffectiveDate,
+            })
+            .ToListAsync();
+
+        // ── Dossier notes summary ───────────────────────────────────
+        var noteCount = await _db.DossierNotes
+            .Where(n => n.ParcelId == parcelId && n.CountyId == countyId.Value)
+            .CountAsync();
+
+        var latestNoteAt = noteCount > 0
+            ? await _db.DossierNotes
+                .Where(n => n.ParcelId == parcelId && n.CountyId == countyId.Value)
+                .MaxAsync(n => (DateTime?)n.CreatedAt)
+            : null;
+
+        return Ok(new ParcelDossierDto
+        {
+            ParcelId = parcelId,
+            CountyId = countyId.Value,
+            Property = property,
+            CostBreakdown = costBreakdown,
+            LevyHistory = levyHistory,
+            Notes = new DossierNotesSummary
+            {
+                NoteCount = noteCount,
+                LatestNoteAt = latestNoteAt,
+            },
+            GeneratedAtUtc = DateTime.UtcNow,
         });
     }
 }

--- a/backend/src/TerraFusion.API/DTOs/ParcelDossierDto.cs
+++ b/backend/src/TerraFusion.API/DTOs/ParcelDossierDto.cs
@@ -1,0 +1,51 @@
+using TerraFusion.Core.Services;
+
+namespace TerraFusion.API.DTOs;
+
+/// <summary>
+/// Parcel Dossier v0 — composition view aggregating property, cost, levy, and notes.
+/// Read-only. County-isolated. No PII (OwnerSSN excluded).
+/// </summary>
+public sealed record ParcelDossierDto
+{
+    public string ParcelId { get; init; } = string.Empty;
+    public Guid CountyId { get; init; }
+    public ParcelPropertySummary? Property { get; init; }
+    public CostBreakdownDto? CostBreakdown { get; init; }
+    public List<LevyHistorySummary> LevyHistory { get; init; } = new();
+    public DossierNotesSummary Notes { get; init; } = new();
+    public DateTime GeneratedAtUtc { get; init; }
+}
+
+public sealed record ParcelPropertySummary
+{
+    public Guid Id { get; init; }
+    public string ParcelNumber { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public string? OwnerName { get; init; }
+    public string? PropertyType { get; init; }
+    public int? YearBuilt { get; init; }
+    public decimal AssessedValue { get; init; }
+    public decimal LandValue { get; init; }
+    public decimal ImprovementValue { get; init; }
+    public decimal MarketValue { get; init; }
+    public DateTime AssessmentDate { get; init; }
+    public int TaxYear { get; init; }
+}
+
+public sealed record LevyHistorySummary
+{
+    public Guid TaxLevyId { get; init; }
+    public string TaxingDistrict { get; init; } = string.Empty;
+    public double TaxRate { get; init; }
+    public double LevyAmount { get; init; }
+    public int TaxYear { get; init; }
+    public string Purpose { get; init; } = string.Empty;
+    public DateTime EffectiveDate { get; init; }
+}
+
+public sealed record DossierNotesSummary
+{
+    public int NoteCount { get; init; }
+    public DateTime? LatestNoteAt { get; init; }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
@@ -5,19 +5,21 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using TerraFusion.API.Controllers;
 using TerraFusion.Core.Entities;
-using TerraFusion.Data;
+using TerraFusion.Core.Services;
 using Xunit;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
 using Task = System.Threading.Tasks.Task;
 
 namespace TerraFusion.Unit.Tests.R1Week3;
 
 public class AtlasDossierControllerGuardsTests
 {
-    private static TerraFusionDbContext CreateDbContext(string name)
+    private static DataDbContext CreateDbContext(string name)
     {
-        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+        var options = new DbContextOptionsBuilder<DataDbContext>()
             .UseInMemoryDatabase(name)
             .Options;
 
@@ -25,7 +27,7 @@ public class AtlasDossierControllerGuardsTests
             .AddInMemoryCollection(new Dictionary<string, string?>())
             .Build();
 
-        return new TerraFusionDbContext(options, config);
+        return new DataDbContext(options, config);
     }
 
     private static ClaimsPrincipal CreatePrincipal(string countyClaim, string userId = "unit-user", string? countyCodeClaim = null)
@@ -207,7 +209,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.CreateNote(
@@ -244,7 +246,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.GetCasefile("PARCEL-300", include: null);
@@ -276,7 +278,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal("BENTON"));
 
         var result = await controller.CreateNote(

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
@@ -266,7 +266,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         db.Properties.Add(CreateProperty(benton.Id, "CX15-PROP-5", "CX15-PARCEL-5"));
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal("BENTON", "BENTON", "cx15-author"));
 
         var createdResult = await controller.CreateNote(
@@ -306,7 +306,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(benton.Id.ToString(), "BENTON"));
 
         var result = await controller.GetNotes("CX15-PARCEL-6");
@@ -322,7 +322,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
     public async Task Dossier_InvalidParcelId_ReturnsBadRequest()
     {
         await using var db = CreateDbContext(nameof(Dossier_InvalidParcelId_ReturnsBadRequest));
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(Guid.NewGuid().ToString(), "BENTON"));
 
         var result = await controller.GetCasefile("bad parcel id!", include: null);

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19CrossCountyNonLeakTests.cs
@@ -618,6 +618,38 @@ public sealed class Cx19CrossCountyFactory : WebApplicationFactory<ApiProgram>
         await db.SaveChangesAsync();
       }
 
+      // ── Seed TaxLevies (one per county) ──────────────────────
+      if (!await db.TaxLevies.AnyAsync(t => t.CountyId == BentonCountyId))
+      {
+        db.TaxLevies.Add(new TaxLevy
+        {
+          Id = Guid.NewGuid(),
+          CountyId = BentonCountyId,
+          TaxingDistrict = "BENTON-GEN-001",
+          TaxRate = 0.0123m,
+          LevyAmount = 3075m,
+          TaxYear = 2026,
+          Purpose = "General Fund",
+          EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+          IsActive = true,
+        });
+
+        db.TaxLevies.Add(new TaxLevy
+        {
+          Id = Guid.NewGuid(),
+          CountyId = KingCountyId,
+          TaxingDistrict = "KING-GEN-001",
+          TaxRate = 0.0099m,
+          LevyAmount = 7425m,
+          TaxYear = 2026,
+          Purpose = "General Fund — SHOULD NOT LEAK",
+          EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+          IsActive = true,
+        });
+
+        await db.SaveChangesAsync();
+      }
+
       _seeded = true;
     }
     finally
@@ -644,6 +676,19 @@ public sealed class Cx19CrossCountyFactory : WebApplicationFactory<ApiProgram>
           ConfidenceScore = 0.95,
           AnalysisDate = DateTime.UtcNow,
           AnalysisMethod = "cx19-test",
+        });
+
+    costForgeMock
+        .Setup(m => m.GetCostBreakdownAsync(It.IsAny<Guid>()))
+        .ReturnsAsync((Guid propertyId) => new CostBreakdownDto
+        {
+          PropertyId = propertyId,
+          TotalValue = 100000m,
+          Categories = new List<CostCategoryDto>
+          {
+            new() { Name = "Land", Amount = 40000m, Percentage = 40.0 },
+            new() { Name = "Improvement", Amount = 60000m, Percentage = 60.0 },
+          },
         });
 
     services.AddScoped(_ => costForgeMock.Object);

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx22ParcelDossierV0Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx22ParcelDossierV0Tests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ApiProgram = TerraFusion.API.Program;
+
+namespace TerraFusion.Unit.Tests.R1Week5;
+
+/// <summary>
+/// CX-22: Parcel Dossier v0 — cross-county isolation + shape tests.
+/// Uses Cx19CrossCountyFactory (shared Benton/King seed data).
+/// </summary>
+[Trait("Category", "R1Week5")]
+[Trait("Category", "CX22")]
+[Trait("Category", "Integration")]
+public sealed class R1Week5Cx22ParcelDossierV0Tests
+    : IClassFixture<Cx19CrossCountyFactory>, IAsyncLifetime
+{
+    private readonly Cx19CrossCountyFactory _factory;
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public R1Week5Cx22ParcelDossierV0Tests(Cx19CrossCountyFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── Same-county: returns 200 with expected shape ──────────────────
+
+    [Fact]
+    public async Task ParcelSummary_SameCounty_Returns200WithExpectedShape()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync(
+            $"/api/dossier/parcels/{Cx19CrossCountyFactory.BentonParcelId}/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("parcelId").GetString().Should().Be(Cx19CrossCountyFactory.BentonParcelId);
+        root.GetProperty("countyId").GetGuid().Should().Be(Cx19CrossCountyFactory.BentonCountyId);
+
+        // Property section present
+        var property = root.GetProperty("property");
+        property.GetProperty("id").GetGuid().Should().Be(Cx19CrossCountyFactory.BentonPropertyGuid);
+        property.GetProperty("address").GetString().Should().NotBeNullOrEmpty();
+        property.GetProperty("assessedValue").GetDecimal().Should().Be(250000m);
+
+        // Notes summary present
+        var notes = root.GetProperty("notes");
+        notes.GetProperty("noteCount").GetInt32().Should().BeGreaterOrEqualTo(1);
+
+        // Levy history present (county-scoped)
+        var levyHistory = root.GetProperty("levyHistory");
+        levyHistory.GetArrayLength().Should().BeGreaterOrEqualTo(1);
+
+        // CostBreakdown present (from mock)
+        root.TryGetProperty("costBreakdown", out var cb).Should().BeTrue();
+        if (cb.ValueKind != JsonValueKind.Null)
+        {
+            cb.GetProperty("totalValue").GetDecimal().Should().BeGreaterThan(0);
+        }
+
+        // Timestamp
+        root.GetProperty("generatedAtUtc").GetDateTime().Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
+    }
+
+    // ── Cross-county: Benton user cannot see King parcel ──────────────
+
+    [Fact]
+    public async Task ParcelSummary_CrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync(
+            $"/api/dossier/parcels/{Cx19CrossCountyFactory.KingParcelId}/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Non-existent parcel: 404 ──────────────────────────────────────
+
+    [Fact]
+    public async Task ParcelSummary_NonExistentParcel_Returns404()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync("/api/dossier/parcels/DOES-NOT-EXIST/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── No county claim: 403 ──────────────────────────────────────────
+
+    [Fact]
+    public async Task ParcelSummary_NoClaim_Returns403()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx22-no-county");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id", Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+
+        var response = await client.GetAsync(
+            $"/api/dossier/parcels/{Cx19CrossCountyFactory.BentonParcelId}/summary");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Forbidden, HttpStatusCode.Unauthorized);
+    }
+
+    // ── Invalid parcel format: 400 ────────────────────────────────────
+
+    [Fact]
+    public async Task ParcelSummary_InvalidParcelFormat_Returns400()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync("/api/dossier/parcels/INVALID%3B%20DROP%20TABLE/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── Levy history contains ONLY Benton levies (cross-county non-leak) ──
+
+    [Fact]
+    public async Task ParcelSummary_LevyHistory_DoesNotLeakCrossCounty()
+    {
+        using var client = CreateBentonClient();
+        var response = await client.GetAsync(
+            $"/api/dossier/parcels/{Cx19CrossCountyFactory.BentonParcelId}/summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var levyHistory = doc.RootElement.GetProperty("levyHistory");
+
+        foreach (var levy in levyHistory.EnumerateArray())
+        {
+            var district = levy.GetProperty("taxingDistrict").GetString()!;
+            district.Should().NotContain("KING",
+                "Benton user must not see King county levy data");
+
+            var purpose = levy.GetProperty("purpose").GetString()!;
+            purpose.Should().NotContain("SHOULD NOT LEAK",
+                "Benton user must not see King county levy purposes");
+        }
+    }
+
+    // ── Helper: create Benton-county authenticated client ─────────────
+
+    private HttpClient CreateBentonClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx22-benton-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Test-CountyId", Cx19CrossCountyFactory.BentonCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id", Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+}


### PR DESCRIPTION
## CX-22: Parcel Dossier v0

**Highest-leverage composition endpoint**: `GET /api/dossier/parcels/{parcelId}/summary`

Returns a single JSON payload combining:
- **Property core fields** — county-isolated, OwnerSSN excluded
- **CostForge breakdown** — via `ICostForgeService`, graceful fallback to null
- **Levy history** — last N (default 10), county-scoped
- **Dossier notes summary** — count + latest timestamp

### County Isolation
All data paths enforce county isolation via `ResolveCountyIdAsync()`. Cross-county access returns 404 (not 403) to avoid parcel existence leaks.

### Files Changed (8 files, +493/-14)
| File | Change |
|------|--------|
| `DTOs/ParcelDossierDto.cs` | NEW — composition response DTO |
| `Controllers/DossierController.cs` | Add `ICostForgeService` + `/summary` endpoint |
| `R1Week5Cx22ParcelDossierV0Tests.cs` | NEW — 6 integration tests |
| `R1Week5Cx19CrossCountyNonLeakTests.cs` | Add `GetCostBreakdownAsync` mock + TaxLevy seed |
| `AtlasDossierControllerGuardsTests.cs` | Fix constructor (new `ICostForgeService` param) |
| `R1Week4Cx15BackendValidationSuiteTests.cs` | Fix constructor (new `ICostForgeService` param) |
| `r1-week2-cx9-endpoint-contracts.md` | CX-22 bump — new `/summary` row |
| `r1-week3-cx22-parcel-dossier-v0-evidence.md` | NEW — evidence report |

### Test Evidence
| Test | Result |
|------|--------|
| 6 CX-22 tests | ✅ PASS |
| 5 CX-19D2/CX-15 tests | ✅ PASS (no regression) |
| 7 AtlasDossier tests | ✅ PASS (no regression) |

### Delivery Chain
CX-20/#552 → CX-21/#553 → **CX-22** (this PR)