### PR TITLE
feat(dossier): CX-22 composed parcel dossier v0 with county isolation

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DossierController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DossierController.cs
@@ -2,28 +2,36 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using System.Text.RegularExpressions;
+using TerraFusion.Core.DTOs;
 using TerraFusion.Core.Entities;
-using TerraFusion.Data;
+using TerraFusion.Core.Services;
 using TerraFusion.API.Security;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
 
 namespace TerraFusion.API.Controllers;
 
 /// <summary>
-/// TerraDossier — Notes CRUD for R1.
+/// TerraDossier — Notes CRUD + composed parcel dossier for R1.
 /// Write-lane: dossier. County isolation enforced on all queries.
+/// Cross-county requests return 404 (anti-enumeration).
 /// </summary>
 [ApiController]
 [Route("api/dossier")]
 [Authorize]
 public class DossierController : ControllerBase
 {
-    private readonly TerraFusionDbContext _db;
+    private readonly DataDbContext _db;
+    private readonly ICostForgeService _costForge;
     private readonly ILogger<DossierController> _logger;
     private static readonly Regex ParcelIdPattern = new("^[A-Za-z0-9._-]{1,50}$", RegexOptions.Compiled);
 
-    public DossierController(TerraFusionDbContext db, ILogger<DossierController> logger)
+    public DossierController(
+        DataDbContext db,
+        ICostForgeService costForge,
+        ILogger<DossierController> logger)
     {
         _db = db;
+        _costForge = costForge;
         _logger = logger;
     }
 
@@ -273,5 +281,141 @@ public class DossierController : ControllerBase
                 notes = new { count = notes.Count, summary = $"{notes.Count} case note(s)" },
             },
         });
+    }
+
+    // ── GET /api/dossier/{parcelId} ───────────────────────────────────
+    // CX-22: Composed parcel dossier v0
+    //   Property core + CostForge summary + Levy history + Notes summary
+    //   County-isolated: cross-county → 404 (anti-enumeration)
+
+    /// <summary>
+    /// Composed parcel dossier (county-isolated).
+    /// Returns property core data, CostForge analysis summary,
+    /// county levy history, and case notes for a single parcel.
+    /// Cross-county requests receive 404 to prevent enumeration.
+    /// </summary>
+    [HttpGet("{parcelId}")]
+    [RequiresPermission("read:dossier")]
+    [ProducesResponseType(typeof(ParcelDossierDto), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(403)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult<ParcelDossierDto>> GetParcelDossier(string parcelId)
+    {
+        parcelId = parcelId.Trim();
+        if (!IsValidParcelId(parcelId))
+            return BadRequest(new { error = "Invalid parcelId format" });
+
+        var countyId = await ResolveCountyIdAsync();
+        if (countyId is null)
+            return Forbid();
+
+        // ── Property core (county-isolated) ──────────────────────
+        var property = await _db.Properties
+            .AsNoTracking()
+            .Include(p => p.County)
+            .FirstOrDefaultAsync(p => p.ParcelId == parcelId && p.CountyId == countyId.Value);
+
+        if (property is null)
+            return NotFound(new { error = "Parcel not found" });
+
+        var dossier = new ParcelDossierDto
+        {
+            ParcelId = parcelId,
+            CountyId = countyId.Value,
+            CountyName = property.County?.Name ?? string.Empty,
+            Property = new ParcelDossierPropertyDto
+            {
+                PropertyId = property.Id,
+                ParcelNumber = property.ParcelNumber,
+                Address = property.Address,
+                PropertyType = property.PropertyType,
+                YearBuilt = property.YearBuilt,
+                AssessedValue = property.AssessedValue,
+                LandValue = property.LandValue,
+                ImprovementValue = property.ImprovementValue,
+                MarketValue = property.MarketValue,
+                TaxYear = property.TaxYear,
+                AssessmentDate = property.AssessmentDate,
+            },
+        };
+
+        // ── CostForge summary (best-effort, nullable) ────────────
+        try
+        {
+            var analysis = await _costForge.AnalyzeCostAsync(property.Id);
+            if (analysis is not null)
+            {
+                dossier.CostForge = new ParcelDossierCostForgeSummaryDto
+                {
+                    TotalCost = analysis.TotalCost,
+                    LandValue = analysis.LandValue,
+                    ImprovementValue = analysis.ImprovementValue,
+                    ConfidenceScore = analysis.ConfidenceScore,
+                    AnalysisDate = analysis.AnalysisDate,
+                    AnalysisMethod = analysis.AnalysisMethod,
+                    ComponentCount = analysis.Components?.Count ?? 0,
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "CostForge analysis unavailable for property {PropertyId}", property.Id);
+            // CostForge section stays null — non-fatal
+        }
+
+        // ── Levy history (county-scoped, most recent 10) ─────────
+        var levyQuery = _db.TaxLevies
+            .AsNoTracking()
+            .Where(t => t.CountyId == countyId.Value && t.IsActive);
+
+        var totalLevies = await levyQuery.CountAsync();
+        var recentLevies = await levyQuery
+            .OrderByDescending(t => t.EffectiveDate)
+            .Take(10)
+            .Select(t => new ParcelDossierLevyEntryDto
+            {
+                TaxLevyId = t.Id,
+                TaxingDistrict = t.TaxingDistrict ?? string.Empty,
+                TaxRate = t.TaxRate,
+                LevyAmount = t.LevyAmount,
+                TaxYear = t.TaxYear,
+                Purpose = t.Purpose ?? string.Empty,
+                EffectiveDate = t.EffectiveDate,
+            })
+            .ToListAsync();
+
+        dossier.Levies = new ParcelDossierLevySummaryDto
+        {
+            TotalRecords = totalLevies,
+            Recent = recentLevies,
+        };
+
+        // ── Notes summary (county-isolated, most recent 5) ───────
+        var notesQuery = _db.DossierNotes
+            .AsNoTracking()
+            .Where(n => n.ParcelId == parcelId && n.CountyId == countyId.Value);
+
+        var totalNotes = await notesQuery.CountAsync();
+        var recentNotes = await notesQuery
+            .OrderByDescending(n => n.CreatedAt)
+            .Take(5)
+            .Select(n => new ParcelDossierNoteEntryDto
+            {
+                NoteId = n.Id,
+                NoteType = n.NoteType,
+                Preview = n.Content.Length > 120 ? n.Content.Substring(0, 120) + "..." : n.Content,
+                CreatedBy = n.CreatedBy,
+                CreatedAt = n.CreatedAt,
+            })
+            .ToListAsync();
+
+        dossier.Notes = new ParcelDossierNotesSummaryDto
+        {
+            TotalCount = totalNotes,
+            Recent = recentNotes,
+        };
+
+        return Ok(dossier);
     }
 }

--- a/backend/src/TerraFusion.Core/DTOs/ParcelDossierDto.cs
+++ b/backend/src/TerraFusion.Core/DTOs/ParcelDossierDto.cs
@@ -1,0 +1,84 @@
+namespace TerraFusion.Core.DTOs;
+
+/// <summary>
+/// CX-22: Composed parcel dossier — read-only view combining
+/// property core, CostForge summary, levy history, and notes.
+/// County-isolated: cross-county requests receive 404.
+/// </summary>
+public class ParcelDossierDto
+{
+    public string ParcelId { get; set; } = string.Empty;
+    public Guid CountyId { get; set; }
+    public string CountyName { get; set; } = string.Empty;
+    public DateTime GeneratedAt { get; set; } = DateTime.UtcNow;
+
+    // ── Property Core ────────────────────────────────────────────
+    public ParcelDossierPropertyDto Property { get; set; } = new();
+
+    // ── CostForge Summary (nullable — analysis may not exist) ───
+    public ParcelDossierCostForgeSummaryDto? CostForge { get; set; }
+
+    // ── Levy History Summary ─────────────────────────────────────
+    public ParcelDossierLevySummaryDto Levies { get; set; } = new();
+
+    // ── Notes Summary ────────────────────────────────────────────
+    public ParcelDossierNotesSummaryDto Notes { get; set; } = new();
+}
+
+public class ParcelDossierPropertyDto
+{
+    public Guid PropertyId { get; set; }
+    public string ParcelNumber { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string? PropertyType { get; set; }
+    public int? YearBuilt { get; set; }
+    public decimal AssessedValue { get; set; }
+    public decimal LandValue { get; set; }
+    public decimal ImprovementValue { get; set; }
+    public decimal MarketValue { get; set; }
+    public int TaxYear { get; set; }
+    public DateTime AssessmentDate { get; set; }
+}
+
+public class ParcelDossierCostForgeSummaryDto
+{
+    public decimal TotalCost { get; set; }
+    public decimal LandValue { get; set; }
+    public decimal ImprovementValue { get; set; }
+    public double ConfidenceScore { get; set; }
+    public DateTime AnalysisDate { get; set; }
+    public string AnalysisMethod { get; set; } = string.Empty;
+    public int ComponentCount { get; set; }
+}
+
+public class ParcelDossierLevySummaryDto
+{
+    public int TotalRecords { get; set; }
+    public List<ParcelDossierLevyEntryDto> Recent { get; set; } = new();
+}
+
+public class ParcelDossierLevyEntryDto
+{
+    public Guid TaxLevyId { get; set; }
+    public string TaxingDistrict { get; set; } = string.Empty;
+    public decimal TaxRate { get; set; }
+    public decimal LevyAmount { get; set; }
+    public int TaxYear { get; set; }
+    public string Purpose { get; set; } = string.Empty;
+    public DateTime EffectiveDate { get; set; }
+}
+
+public class ParcelDossierNotesSummaryDto
+{
+    public int TotalCount { get; set; }
+    public List<ParcelDossierNoteEntryDto> Recent { get; set; } = new();
+}
+
+public class ParcelDossierNoteEntryDto
+{
+    public Guid NoteId { get; set; }
+    public string NoteType { get; set; } = string.Empty;
+    public string Preview { get; set; } = string.Empty;
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
@@ -5,11 +5,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using TerraFusion.API.Controllers;
 using TerraFusion.Core.Entities;
-using TerraFusion.Data;
+using TerraFusion.Core.Services;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
+using TerraFusionDbContext = TerraFusion.Data.TerraFusionDbContext;
 
 namespace TerraFusion.Unit.Tests.R1Week3;
 
@@ -207,7 +209,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.CreateNote(
@@ -244,7 +246,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.GetCasefile("PARCEL-300", include: null);
@@ -276,7 +278,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal("BENTON"));
 
         var result = await controller.CreateNote(

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx22ParcelDossierIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx22ParcelDossierIntegrationTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using ApiProgram = TerraFusion.API.Program;
+
+namespace TerraFusion.Unit.Tests.R1Week3;
+
+/// <summary>
+/// CX-22: Parcel Dossier v0 integration tests.
+///
+/// Verifies:
+///   1. Same-county parcel dossier returns composed response (property + CostForge + levies + notes)
+///   2. Cross-county request returns 404 (anti-enumeration)
+///   3. Missing county claims returns 403/401
+///   4. Invalid parcel ID format returns 400
+///   5. Non-existent parcel returns 404
+///   6. Response shape contains all expected sections
+///
+/// Uses Cx19CrossCountyFactory which seeds Benton/King counties,
+/// one property per county, and one DossierNote per county.
+/// </summary>
+[Trait("Category", "R1Week3")]
+[Trait("Category", "CX22")]
+[Trait("Category", "Integration")]
+public sealed class R1Week3Cx22ParcelDossierIntegrationTests
+    : IClassFixture<TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory>, IAsyncLifetime
+{
+    private readonly TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory _factory;
+
+    public R1Week3Cx22ParcelDossierIntegrationTests(
+        TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── Same-county: composed dossier returns 200 ────────────────────
+
+    [Fact]
+    public async Task ParcelDossier_SameCounty_Returns200WithPropertySection()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+
+        // Property section present with expected fields
+        json.TryGetProperty("property", out var property).Should().BeTrue("response should contain property section");
+        property.TryGetProperty("parcelNumber", out _).Should().BeTrue();
+        property.TryGetProperty("address", out _).Should().BeTrue();
+        property.TryGetProperty("assessedValue", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ParcelDossier_SameCounty_ContainsAllSections()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+
+        // All four composition sections should be present
+        json.TryGetProperty("parcelId", out _).Should().BeTrue("should contain parcelId");
+        json.TryGetProperty("countyId", out _).Should().BeTrue("should contain countyId");
+        json.TryGetProperty("countyName", out _).Should().BeTrue("should contain countyName");
+        json.TryGetProperty("property", out _).Should().BeTrue("should contain property section");
+        json.TryGetProperty("levies", out _).Should().BeTrue("should contain levies section");
+        json.TryGetProperty("notes", out _).Should().BeTrue("should contain notes section");
+        // CostForge is nullable (best-effort), verify presence
+        json.TryGetProperty("costForge", out _).Should().BeTrue("should contain costForge key (may be null)");
+    }
+
+    [Fact]
+    public async Task ParcelDossier_SameCounty_NotesIncludeSeededNote()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+        json.TryGetProperty("notes", out var notes).Should().BeTrue();
+        notes.TryGetProperty("totalCount", out var totalCount).Should().BeTrue();
+        totalCount.GetInt32().Should().BeGreaterOrEqualTo(1, "factory seeds at least one note for Benton");
+    }
+
+    // ── Cross-county: 404 (anti-enumeration) ─────────────────────────
+
+    [Fact]
+    public async Task ParcelDossier_CrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+
+        // Benton user requesting King county parcel → 404 (not 403)
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.KingParcelId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "cross-county access should return 404 for anti-enumeration");
+    }
+
+    // ── Missing county claims: 403/401 ───────────────────────────────
+
+    [Fact]
+    public async Task ParcelDossier_NoCountyClaims_Returns403Or401()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(
+                TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx22-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}");
+
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.Forbidden, HttpStatusCode.Unauthorized);
+    }
+
+    // ── Invalid parcel ID format: 400 ────────────────────────────────
+
+    [Fact]
+    public async Task ParcelDossier_InvalidParcelFormat_Returns400()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync("/api/dossier/invalid parcel!@#");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── Non-existent parcel (same county): 404 ───────────────────────
+
+    [Fact]
+    public async Task ParcelDossier_NonExistentParcel_Returns404()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync("/api/dossier/DOES-NOT-EXIST-99");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private HttpClient CreateBentonClient(string roles = "Assessor")
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(
+                TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx22-benton-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Test-CountyId",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", roles);
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content).RootElement;
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
@@ -266,7 +266,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         db.Properties.Add(CreateProperty(benton.Id, "CX15-PROP-5", "CX15-PARCEL-5"));
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal("BENTON", "BENTON", "cx15-author"));
 
         var createdResult = await controller.CreateNote(
@@ -306,7 +306,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(benton.Id.ToString(), "BENTON"));
 
         var result = await controller.GetNotes("CX15-PARCEL-6");
@@ -322,7 +322,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
     public async Task Dossier_InvalidParcelId_ReturnsBadRequest()
     {
         await using var db = CreateDbContext(nameof(Dossier_InvalidParcelId_ReturnsBadRequest));
-        var controller = new DossierController(db, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
         AttachPrincipal(controller, CreatePrincipal(Guid.NewGuid().ToString(), "BENTON"));
 
         var result = await controller.GetCasefile("bad parcel id!", include: null);


### PR DESCRIPTION
## Summary

- **New endpoint**: `GET /api/dossier/{parcelId}` — composes a single county-isolated parcel dossier from four data sources: Property core, CostForge analysis (best-effort/nullable), Levy history (most recent 10), and Dossier notes (most recent 5)
- **Anti-enumeration**: Cross-county requests return 404 (not 403), preventing property existence leakage
- **New DTOs**: `ParcelDossierDto` and supporting types in `TerraFusion.Core.DTOs`
- **7 new integration tests** (CX-22 trait) covering same-county success, cross-county 404, missing claims 403, invalid format 400, non-existent parcel 404
- **Updated 6 existing test call-sites** to accommodate new `ICostForgeService` constructor parameter on `DossierController`

## Test plan

- [x] `dotnet test` — 919/923 pass (4 pre-existing CX-16 auth failures unchanged)
- [x] 7 CX-22 integration tests all green
- [x] Pre-commit quality gate passed (lint-staged + dotnet format)
- [x] Pre-push quality gate passed (unit tests + frontend build)
- [ ] CI pipeline validates on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)