### PR TITLE
feat(dossier): CX-23 enriched parcel dossier details with PII protection

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DossierController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DossierController.cs
@@ -418,4 +418,212 @@ public class DossierController : ControllerBase
 
         return Ok(dossier);
     }
+
+    // ── GET /api/dossier/{parcelId}/details ──────────────────────────
+    // CX-23: Enriched parcel dossier details
+    //   Full CostForge breakdown, configurable limits, PII-safe note headers
+    //   Selective includes via ?include= query parameter
+    //   County-isolated: cross-county → 404 (anti-enumeration)
+
+    /// <summary>
+    /// Enriched parcel dossier details (county-isolated).
+    /// Returns expanded property data, full CostForge cost breakdown,
+    /// configurable levy history, and PII-safe note headers.
+    /// Use ?include= to select specific sections (property,valuation,costBreakdown,levies,notes).
+    /// Use ?levyLimit= and ?noteLimit= to control history depth.
+    /// Cross-county requests receive 404 to prevent enumeration.
+    /// </summary>
+    [HttpGet("{parcelId}/details")]
+    [RequiresPermission("read:dossier")]
+    [ProducesResponseType(typeof(ParcelDossierDetailsDto), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(403)]
+    [ProducesResponseType(404)]
+    public async Task<ActionResult<ParcelDossierDetailsDto>> GetParcelDossierDetails(
+        string parcelId,
+        [FromQuery] string? include = null,
+        [FromQuery] int levyLimit = 10,
+        [FromQuery] int noteLimit = 5)
+    {
+        parcelId = parcelId.Trim();
+        if (!IsValidParcelId(parcelId))
+            return BadRequest(new { error = "Invalid parcelId format" });
+
+        var countyId = await ResolveCountyIdAsync();
+        if (countyId is null)
+            return Forbid();
+
+        // Clamp limits
+        levyLimit = Math.Clamp(levyLimit, 1, 100);
+        noteLimit = Math.Clamp(noteLimit, 1, 20);
+
+        // Parse selective includes (all if omitted)
+        var sections = ParseIncludes(include);
+
+        // ── Property core (county-isolated) ──────────────────────
+        var property = await _db.Properties
+            .AsNoTracking()
+            .Include(p => p.County)
+            .FirstOrDefaultAsync(p => p.ParcelId == parcelId && p.CountyId == countyId.Value);
+
+        if (property is null)
+            return NotFound(new { error = "Parcel not found" });
+
+        var details = new ParcelDossierDetailsDto
+        {
+            ParcelId = parcelId,
+            CountyId = countyId.Value,
+            CountyName = property.County?.Name ?? string.Empty,
+            PiiRedacted = true,
+        };
+
+        // ── Property section (expanded, PII-safe: no SSN) ────────
+        if (sections.Contains("property"))
+        {
+            details.Property = new DossierDetailPropertyDto
+            {
+                PropertyId = property.Id,
+                ParcelNumber = property.ParcelNumber,
+                Address = property.Address,
+                OwnerName = property.OwnerName,
+                PropertyType = property.PropertyType,
+                YearBuilt = property.YearBuilt,
+            };
+        }
+
+        // ── Valuation signals (semantic extraction) ──────────────
+        if (sections.Contains("valuation"))
+        {
+            details.Valuation = new DossierDetailValuationDto
+            {
+                AssessedValue = property.AssessedValue,
+                LandValue = property.LandValue,
+                ImprovementValue = property.ImprovementValue,
+                MarketValue = property.MarketValue,
+                TaxYear = property.TaxYear,
+                AssessmentDate = property.AssessmentDate,
+            };
+        }
+
+        // ── CostForge breakdown (full hierarchy, nullable) ───────
+        if (sections.Contains("costbreakdown"))
+        {
+            try
+            {
+                var breakdown = await _costForge.GetCostBreakdownAsync(property.Id);
+                var analysis = await _costForge.AnalyzeCostAsync(property.Id);
+
+                if (breakdown is not null)
+                {
+                    details.CostBreakdown = new DossierDetailCostBreakdownDto
+                    {
+                        TotalValue = breakdown.TotalValue,
+                        ConfidenceScore = analysis?.ConfidenceScore ?? 0,
+                        AnalysisDate = analysis?.AnalysisDate ?? DateTime.UtcNow,
+                        AnalysisMethod = analysis?.AnalysisMethod ?? string.Empty,
+                        Categories = breakdown.Categories.Select(c => new DossierDetailCostCategoryDto
+                        {
+                            Name = c.Name,
+                            Amount = c.Amount,
+                            Percentage = c.Percentage,
+                            Components = c.Components.Select(comp => new DossierDetailCostComponentDto
+                            {
+                                Name = comp.Name,
+                                Amount = comp.Amount,
+                                Unit = comp.Unit,
+                                Quantity = comp.Quantity,
+                                UnitCost = comp.UnitCost,
+                            }).ToList(),
+                        }).ToList(),
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "CostForge breakdown unavailable for property {PropertyId}", property.Id);
+                // CostBreakdown stays null — non-fatal
+            }
+        }
+
+        // ── Levy details (county-scoped, configurable depth) ─────
+        if (sections.Contains("levies"))
+        {
+            var levyQuery = _db.TaxLevies
+                .AsNoTracking()
+                .Where(t => t.CountyId == countyId.Value && t.IsActive);
+
+            var totalLevies = await levyQuery.CountAsync();
+            var levyHistory = await levyQuery
+                .OrderByDescending(t => t.EffectiveDate)
+                .Take(levyLimit)
+                .Select(t => new ParcelDossierLevyEntryDto
+                {
+                    TaxLevyId = t.Id,
+                    TaxingDistrict = t.TaxingDistrict ?? string.Empty,
+                    TaxRate = t.TaxRate,
+                    LevyAmount = t.LevyAmount,
+                    TaxYear = t.TaxYear,
+                    Purpose = t.Purpose ?? string.Empty,
+                    EffectiveDate = t.EffectiveDate,
+                })
+                .ToListAsync();
+
+            details.Levies = new DossierDetailLevyDto
+            {
+                TotalCountyLevies = totalLevies,
+                History = levyHistory,
+            };
+        }
+
+        // ── Note headers (metadata-only, PII-safe) ──────────────
+        if (sections.Contains("notes"))
+        {
+            var notesQuery = _db.DossierNotes
+                .AsNoTracking()
+                .Where(n => n.ParcelId == parcelId && n.CountyId == countyId.Value);
+
+            var noteCount = await notesQuery.CountAsync();
+            var noteHeaders = await notesQuery
+                .OrderByDescending(n => n.CreatedAt)
+                .Take(noteLimit)
+                .Select(n => new DossierDetailNoteHeaderDto
+                {
+                    NoteId = n.Id,
+                    CreatedAt = n.CreatedAt,
+                    NoteType = n.NoteType,
+                    AuthorKind = n.CreatedBy.StartsWith("system", StringComparison.OrdinalIgnoreCase)
+                        ? "system" : "user",
+                })
+                .ToListAsync();
+
+            details.Notes = new DossierDetailNotesDto
+            {
+                NoteCount = noteCount,
+                Headers = noteHeaders,
+            };
+        }
+
+        return Ok(details);
+    }
+
+    // ── Include parser ────────────────────────────────────────────────
+
+    private static readonly HashSet<string> AllSections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "property", "valuation", "costbreakdown", "levies", "notes"
+    };
+
+    private static HashSet<string> ParseIncludes(string? include)
+    {
+        if (string.IsNullOrWhiteSpace(include))
+            return new HashSet<string>(AllSections, StringComparer.OrdinalIgnoreCase);
+
+        var requested = include
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => s.ToLowerInvariant())
+            .Where(s => AllSections.Contains(s))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return requested.Count > 0 ? requested : new HashSet<string>(AllSections, StringComparer.OrdinalIgnoreCase);
+    }
 }

--- a/backend/src/TerraFusion.Core/DTOs/ParcelDossierDetailsDto.cs
+++ b/backend/src/TerraFusion.Core/DTOs/ParcelDossierDetailsDto.cs
@@ -1,0 +1,108 @@
+namespace TerraFusion.Core.DTOs;
+
+/// <summary>
+/// CX-23: Enriched parcel dossier details — full CostForge breakdown,
+/// configurable limits, PII-safe note headers, and selective includes.
+/// County-isolated: cross-county requests receive 404.
+/// </summary>
+public class ParcelDossierDetailsDto
+{
+    public string ParcelId { get; set; } = string.Empty;
+    public Guid CountyId { get; set; }
+    public string CountyName { get; set; } = string.Empty;
+    public DateTime GeneratedAt { get; set; } = DateTime.UtcNow;
+    public bool PiiRedacted { get; set; } = true;
+
+    // ── Property (expanded, PII-safe) ──────────────────────────────
+    public DossierDetailPropertyDto? Property { get; set; }
+
+    // ── Valuation Signals (extracted for semantic clarity) ──────────
+    public DossierDetailValuationDto? Valuation { get; set; }
+
+    // ── CostForge Breakdown (full hierarchy, nullable) ─────────────
+    public DossierDetailCostBreakdownDto? CostBreakdown { get; set; }
+
+    // ── Levy Details (configurable depth) ──────────────────────────
+    public DossierDetailLevyDto? Levies { get; set; }
+
+    // ── Note Headers (metadata-only, PII-safe) ─────────────────────
+    public DossierDetailNotesDto? Notes { get; set; }
+}
+
+// ── Property Section ───────────────────────────────────────────────
+
+public class DossierDetailPropertyDto
+{
+    public Guid PropertyId { get; set; }
+    public string ParcelNumber { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string? OwnerName { get; set; }
+    public string? PropertyType { get; set; }
+    public int? YearBuilt { get; set; }
+}
+
+// ── Valuation Signals ──────────────────────────────────────────────
+
+public class DossierDetailValuationDto
+{
+    public decimal AssessedValue { get; set; }
+    public decimal LandValue { get; set; }
+    public decimal ImprovementValue { get; set; }
+    public decimal MarketValue { get; set; }
+    public int TaxYear { get; set; }
+    public DateTime AssessmentDate { get; set; }
+}
+
+// ── CostForge Breakdown ────────────────────────────────────────────
+
+public class DossierDetailCostBreakdownDto
+{
+    public decimal TotalValue { get; set; }
+    public double ConfidenceScore { get; set; }
+    public DateTime AnalysisDate { get; set; }
+    public string AnalysisMethod { get; set; } = string.Empty;
+    public List<DossierDetailCostCategoryDto> Categories { get; set; } = new();
+}
+
+public class DossierDetailCostCategoryDto
+{
+    public string Name { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public double Percentage { get; set; }
+    public List<DossierDetailCostComponentDto> Components { get; set; } = new();
+}
+
+public class DossierDetailCostComponentDto
+{
+    public string Name { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Unit { get; set; } = string.Empty;
+    public double Quantity { get; set; }
+    public decimal UnitCost { get; set; }
+}
+
+// ── Levy Details ───────────────────────────────────────────────────
+
+public class DossierDetailLevyDto
+{
+    public int TotalCountyLevies { get; set; }
+    public List<ParcelDossierLevyEntryDto> History { get; set; } = new();
+}
+
+// ── Note Headers (metadata-only) ───────────────────────────────────
+
+public class DossierDetailNotesDto
+{
+    public int NoteCount { get; set; }
+    public List<DossierDetailNoteHeaderDto> Headers { get; set; } = new();
+}
+
+public class DossierDetailNoteHeaderDto
+{
+    public Guid NoteId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string NoteType { get; set; } = string.Empty;
+
+    /// <summary>"system" or "user" — normalized to prevent PII leakage of author names.</summary>
+    public string AuthorKind { get; set; } = "user";
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx23ParcelDossierDetailsIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/R1Week3Cx23ParcelDossierDetailsIntegrationTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.R1Week3;
+
+/// <summary>
+/// CX-23: Parcel Dossier Details integration tests.
+///
+/// Verifies:
+///   1. Same-county details returns 200 with all sections
+///   2. Selective include returns only requested sections
+///   3. Configurable levyLimit / noteLimit are respected
+///   4. PII metadata flag is present and true
+///   5. Note headers are metadata-only (no content/preview)
+///   6. Cross-county request returns 404 (anti-enumeration)
+///   7. Missing county claims returns 403/401
+///   8. Invalid parcel ID format returns 400
+///   9. Non-existent parcel returns 404
+///  10. OwnerName exposed but OwnerSSN redacted
+///
+/// Uses Cx19CrossCountyFactory which seeds Benton/King counties,
+/// one property per county, and DossierNotes per county.
+/// </summary>
+[Trait("Category", "R1Week3")]
+[Trait("Category", "CX23")]
+[Trait("Category", "Integration")]
+public sealed class R1Week3Cx23ParcelDossierDetailsIntegrationTests
+    : IClassFixture<TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory>, IAsyncLifetime
+{
+    private readonly TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory _factory;
+
+    public R1Week3Cx23ParcelDossierDetailsIntegrationTests(
+        TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── Same-county: full details returns 200 with all sections ────
+
+    [Fact]
+    public async Task Details_SameCounty_Returns200WithAllSections()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+
+        json.TryGetProperty("parcelId", out _).Should().BeTrue("should contain parcelId");
+        json.TryGetProperty("countyId", out _).Should().BeTrue("should contain countyId");
+        json.TryGetProperty("countyName", out _).Should().BeTrue("should contain countyName");
+        json.TryGetProperty("generatedAt", out _).Should().BeTrue("should contain generatedAt");
+        json.TryGetProperty("property", out _).Should().BeTrue("should contain property section");
+        json.TryGetProperty("valuation", out _).Should().BeTrue("should contain valuation section");
+        json.TryGetProperty("levies", out _).Should().BeTrue("should contain levies section");
+        json.TryGetProperty("notes", out _).Should().BeTrue("should contain notes section");
+        // CostBreakdown is nullable (best-effort)
+        json.TryGetProperty("costBreakdown", out _).Should().BeTrue("should contain costBreakdown key (may be null)");
+    }
+
+    // ── PII metadata flag ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Details_SameCounty_HasPiiRedactedFlag()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+        json.TryGetProperty("piiRedacted", out var piiRedacted).Should().BeTrue();
+        piiRedacted.GetBoolean().Should().BeTrue("PII redaction flag should be true");
+    }
+
+    // ── Note headers are metadata-only ────────────────────────────
+
+    [Fact]
+    public async Task Details_SameCounty_NoteHeadersAreMetadataOnly()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+        json.TryGetProperty("notes", out var notes).Should().BeTrue();
+        notes.TryGetProperty("noteCount", out var noteCount).Should().BeTrue();
+        noteCount.GetInt32().Should().BeGreaterOrEqualTo(1, "factory seeds at least one note for Benton");
+
+        notes.TryGetProperty("headers", out var headers).Should().BeTrue();
+        headers.GetArrayLength().Should().BeGreaterOrEqualTo(1);
+
+        var firstHeader = headers[0];
+        firstHeader.TryGetProperty("noteId", out _).Should().BeTrue("header should have noteId");
+        firstHeader.TryGetProperty("createdAt", out _).Should().BeTrue("header should have createdAt");
+        firstHeader.TryGetProperty("noteType", out _).Should().BeTrue("header should have noteType");
+        firstHeader.TryGetProperty("authorKind", out _).Should().BeTrue("header should have authorKind");
+
+        // Must NOT contain content or preview — PII-safe
+        firstHeader.TryGetProperty("content", out _).Should().BeFalse("header must not expose note content");
+        firstHeader.TryGetProperty("preview", out _).Should().BeFalse("header must not expose note preview");
+    }
+
+    // ── Selective includes ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Details_SelectiveInclude_ReturnsOnlyRequestedSections()
+    {
+        using var client = CreateBentonClient();
+
+        // Request only property and valuation sections
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details?include=property,valuation");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+
+        // Requested sections should be present (non-null)
+        json.TryGetProperty("property", out var property).Should().BeTrue();
+        property.ValueKind.Should().NotBe(JsonValueKind.Null, "property was requested");
+
+        json.TryGetProperty("valuation", out var valuation).Should().BeTrue();
+        valuation.ValueKind.Should().NotBe(JsonValueKind.Null, "valuation was requested");
+
+        // Non-requested sections should be null
+        json.TryGetProperty("levies", out var levies).Should().BeTrue();
+        levies.ValueKind.Should().Be(JsonValueKind.Null, "levies was not requested");
+
+        json.TryGetProperty("notes", out var notes).Should().BeTrue();
+        notes.ValueKind.Should().Be(JsonValueKind.Null, "notes was not requested");
+    }
+
+    // ── Configurable limits ───────────────────────────────────────
+
+    [Fact]
+    public async Task Details_CustomNoteLimit_RespectsLimit()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details?include=notes&noteLimit=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+        json.TryGetProperty("notes", out var notes).Should().BeTrue();
+        notes.TryGetProperty("headers", out var headers).Should().BeTrue();
+        headers.GetArrayLength().Should().BeLessOrEqualTo(1, "noteLimit=1 should cap at 1 header");
+    }
+
+    // ── Property section exposes OwnerName (PII-safe, no SSN) ─────
+
+    [Fact]
+    public async Task Details_PropertySection_ExposesOwnerNameButNotSSN()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details?include=property");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await ParseJsonAsync(response);
+        json.TryGetProperty("property", out var property).Should().BeTrue();
+
+        // OwnerName is allowed (not SSN-level PII)
+        property.TryGetProperty("ownerName", out _).Should().BeTrue("OwnerName should be present");
+
+        // OwnerSSN must never appear
+        property.TryGetProperty("ownerSSN", out _).Should().BeFalse("OwnerSSN must NEVER be exposed");
+        property.TryGetProperty("ownerSsn", out _).Should().BeFalse("ownerSsn must NEVER be exposed");
+    }
+
+    // ── Cross-county: 404 (anti-enumeration) ──────────────────────
+
+    [Fact]
+    public async Task Details_CrossCounty_Returns404()
+    {
+        using var client = CreateBentonClient();
+
+        // Benton user requesting King county parcel → 404 (not 403)
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.KingParcelId}/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "cross-county access should return 404 for anti-enumeration");
+    }
+
+    // ── Missing county claims: 403/401 ────────────────────────────
+
+    [Fact]
+    public async Task Details_NoCountyClaims_Returns403Or401()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(
+                TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx23-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", "Assessor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+
+        var response = await client.GetAsync(
+            $"/api/dossier/{TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonParcelId}/details");
+
+        response.StatusCode.Should().BeOneOf(
+            HttpStatusCode.Forbidden, HttpStatusCode.Unauthorized);
+    }
+
+    // ── Invalid parcel ID format: 400 ─────────────────────────────
+
+    [Fact]
+    public async Task Details_InvalidParcelFormat_Returns400()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync("/api/dossier/invalid parcel!@#/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── Non-existent parcel: 404 ──────────────────────────────────
+
+    [Fact]
+    public async Task Details_NonExistentParcel_Returns404()
+    {
+        using var client = CreateBentonClient();
+
+        var response = await client.GetAsync("/api/dossier/DOES-NOT-EXIST-99/details");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private HttpClient CreateBentonClient(string roles = "Assessor")
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(
+                TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "cx23-benton-user");
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Test-CountyId",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.BentonCountyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Role", roles);
+        client.DefaultRequestHeaders.TryAddWithoutValidation(
+            "X-Plugin-Id",
+            TerraFusion.Unit.Tests.R1Week5.Cx19CrossCountyFactory.PluginAllPermsId.ToString());
+        return client;
+    }
+
+    private static async Task<JsonElement> ParseJsonAsync(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content).RootElement;
+    }
+}


### PR DESCRIPTION
## Summary

- **New endpoint**: `GET /api/dossier/{parcelId}/details` — enriched parcel dossier extending CX-22's composed summary
- **Full CostForge breakdown**: Category/component hierarchy (not just summary count)
- **Expanded property**: OwnerName included; OwnerSSN **never** exposed
- **Valuation signals**: Semantically separated from property core for clarity
- **PII-safe note headers**: Metadata-only (noteId, createdAt, noteType, authorKind) — no content/preview
- **Configurable limits**: `?levyLimit=N` (1-100, default 10), `?noteLimit=N` (1-20, default 5)
- **Selective includes**: `?include=property,valuation,costBreakdown,levies,notes` — omit sections for lighter payloads
- **`piiRedacted: true`** metadata flag on every response
- **Anti-enumeration**: Cross-county → 404 (same as CX-22)
- **New DTOs**: `ParcelDossierDetailsDto` and 8 supporting types
- **10 new integration tests** (CX-23 trait) covering all sections, selective includes, PII protection, configurable limits, cross-county, missing claims, invalid format, non-existent parcel

## Test plan

- [x] `dotnet test` — 929/933 pass (4 pre-existing CX-16 auth failures unchanged)
- [x] 10 CX-23 integration tests all green
- [x] Pre-commit quality gate passed (lint-staged + dotnet format)
- [x] Pre-push quality gate passed (unit tests + frontend build)
- [ ] CI pipeline validates on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)