### PR TITLE
feat(frontend): CX-25 wire PropertyDossier to real backend details endpoint

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/hooks/useDossierDetails.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/hooks/useDossierDetails.test.ts
@@ -1,0 +1,260 @@
+/**
+ * useDossierDetails.test.ts
+ *
+ * CX-25: Unit tests for the dossier details hook.
+ * Verifies: loading, data fetch, error handling, nullable sections,
+ * correlationId exposure, and refetch.
+ *
+ * Uses vitest (vi.fn / vi.mock) — NOT jest.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useDossierDetails } from '../../hooks/useDossierDetails';
+import type { DossierDetailsResponse } from '../../contracts/dossierDetails';
+
+// ============================================================================
+// Mock dossierService.getDetails
+// ============================================================================
+
+const mockGetDetails = vi.fn<
+  [string, any?],
+  Promise<{ data: DossierDetailsResponse; correlationId: string }>
+>();
+
+vi.mock('../../services/dossierService', () => ({
+  dossierService: {
+    getDetails: (...args: any[]) => mockGetDetails(...args),
+  },
+}));
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const FULL_RESPONSE: DossierDetailsResponse = {
+  parcelId: 'P-001',
+  countyId: 'county-abc',
+  generatedAt: '2026-03-04T12:00:00Z',
+  piiRedacted: true,
+  correlationId: 'dossier-server-12345',
+  links: {
+    self: '/api/dossier/parcels/P-001/details',
+    summary: '/api/dossier/parcels/P-001/summary',
+    details: '/api/dossier/parcels/P-001/details',
+    notes: '/api/dossier/parcels/P-001/notes',
+    casefile: '/api/dossier/parcels/P-001/casefile',
+  },
+  property: {
+    propertyId: 'prop-1',
+    parcelNumber: 'P-001',
+    address: '123 Main St',
+    propertyType: 'Residential',
+    yearBuilt: 1998,
+    assessedValue: 250000,
+    landValue: 80000,
+    improvementValue: 170000,
+    marketValue: 275000,
+    taxYear: 2024,
+    assessmentDate: '2024-01-02T00:00:00Z',
+    classCode: null,
+    useCode: null,
+    neighborhood: null,
+  },
+  valuation: {
+    totalValue: 250000,
+    categoryCount: 2,
+    categories: [
+      { name: 'Land', amount: 80000, percentage: 32.0 },
+      { name: 'Improvements', amount: 170000, percentage: 68.0 },
+    ],
+  },
+  levies: {
+    levyCountTotal: 5,
+    levyCountReturned: 2,
+    recent: [
+      {
+        taxLevyId: 'levy-1',
+        taxingDistrict: 'City of Richland',
+        taxRate: 0.0123,
+        levyAmount: 3075.0,
+        taxYear: 2024,
+        purpose: 'General Fund',
+        effectiveDate: '2024-01-01T00:00:00Z',
+      },
+    ],
+  },
+  notes: {
+    noteCountTotal: 3,
+    noteCountReturned: 2,
+    items: [
+      {
+        noteId: 'note-1',
+        noteType: 'inspection',
+        createdAt: '2024-06-15T10:00:00Z',
+        authorKind: 'staff',
+      },
+    ],
+  },
+};
+
+const PARTIAL_RESPONSE: DossierDetailsResponse = {
+  ...FULL_RESPONSE,
+  valuation: null,
+  levies: null,
+  notes: null,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useDossierDetails', () => {
+  beforeEach(() => {
+    mockGetDetails.mockReset();
+  });
+
+  it('stays idle when parcelId is null', () => {
+    const { result } = renderHook(() => useDossierDetails(null));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.correlationId).toBeNull();
+  });
+
+  it('fetches data when parcelId is provided', async () => {
+    mockGetDetails.mockResolvedValueOnce({
+      data: FULL_RESPONSE,
+      correlationId: 'dossier-server-12345',
+    });
+
+    const { result } = renderHook(() => useDossierDetails('P-001'));
+
+    // Initially loading
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(FULL_RESPONSE);
+    expect(result.current.error).toBeNull();
+    expect(result.current.correlationId).toBe('dossier-server-12345');
+    expect(mockGetDetails).toHaveBeenCalledWith('P-001', undefined);
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockGetDetails.mockRejectedValueOnce(new Error('Dossier API error: 500 Internal Server Error'));
+
+    const { result } = renderHook(() => useDossierDetails('P-002'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error!.message).toContain('500');
+    expect(result.current.error!.code).toBe('FETCH_ERROR');
+  });
+
+  it('returns null for filtered sections (selective includes)', async () => {
+    mockGetDetails.mockResolvedValueOnce({
+      data: PARTIAL_RESPONSE,
+      correlationId: 'dossier-partial-99',
+    });
+
+    const { result } = renderHook(() =>
+      useDossierDetails('P-001', { include: 'property' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+
+    expect(result.current.data!.property).not.toBeNull();
+    expect(result.current.data!.valuation).toBeNull();
+    expect(result.current.data!.levies).toBeNull();
+    expect(result.current.data!.notes).toBeNull();
+  });
+
+  it('exposes correlationId from response body', async () => {
+    mockGetDetails.mockResolvedValueOnce({
+      data: FULL_RESPONSE,
+      correlationId: 'tf-header-corr',
+    });
+
+    const { result } = renderHook(() => useDossierDetails('P-001'));
+
+    await waitFor(() => {
+      expect(result.current.correlationId).not.toBeNull();
+    });
+
+    // Prefers body correlationId over header
+    expect(result.current.correlationId).toBe('dossier-server-12345');
+  });
+
+  it('refetch triggers a new request', async () => {
+    mockGetDetails
+      .mockResolvedValueOnce({
+        data: FULL_RESPONSE,
+        correlationId: 'first-call',
+      })
+      .mockResolvedValueOnce({
+        data: { ...FULL_RESPONSE, correlationId: 'dossier-refresh-2' },
+        correlationId: 'second-call',
+      });
+
+    const { result } = renderHook(() => useDossierDetails('P-001'));
+
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+
+    expect(mockGetDetails).toHaveBeenCalledTimes(1);
+
+    // Trigger refetch
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => {
+      expect(mockGetDetails).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('passes options to getDetails', async () => {
+    mockGetDetails.mockResolvedValueOnce({
+      data: FULL_RESPONSE,
+      correlationId: 'options-test',
+    });
+
+    renderHook(() =>
+      useDossierDetails('P-001', { include: 'property,levies', levyLimit: 5, noteLimit: 10 }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetDetails).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockGetDetails).toHaveBeenCalledWith('P-001', {
+      include: 'property,levies',
+      levyLimit: 5,
+      noteLimit: 10,
+    });
+  });
+
+  it('handles 404 with NOT_FOUND error code', async () => {
+    mockGetDetails.mockRejectedValueOnce(new Error('Dossier API error: 404 Not Found'));
+
+    const { result } = renderHook(() => useDossierDetails('NONEXISTENT'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error!.code).toBe('NOT_FOUND');
+  });
+});

--- a/frontend/apps/os-shell/src/contracts/dossierDetails.ts
+++ b/frontend/apps/os-shell/src/contracts/dossierDetails.ts
@@ -1,0 +1,162 @@
+/**
+ * TerraFusion OS — Dossier Details Contract Interfaces
+ * =================================================================
+ *
+ * TypeScript interfaces mirroring the backend ParcelDossierDetailsDto
+ * and nested records from CX-23/CX-24.
+ *
+ * Key contract rules:
+ * - All section fields are nullable (T | null).
+ *   When ?include= is specified, non-requested sections serialize as null.
+ *   Default (no include param) = all sections populated.
+ * - PII-redacted: note headers contain metadata only (no content/preview).
+ * - County-isolated: cross-county requests return 404 (anti-enumeration).
+ *
+ * @see backend/src/TerraFusion.API/DTOs/ParcelDossierDetailsDto.cs
+ */
+
+// ============================================================================
+// Top-Level Response
+// ============================================================================
+
+/**
+ * Mirrors ParcelDossierDetailsDto.
+ * CX-24: All section fields nullable for selective includes.
+ */
+export interface DossierDetailsResponse {
+  parcelId: string;
+  countyId: string;
+  generatedAt: string; // ISO 8601
+  piiRedacted: boolean;
+
+  /** CX-24: Echoes inbound X-Correlation-ID or server-generated "dossier-" prefix. */
+  correlationId?: string;
+
+  /** CX-24: Stable resource links for evidence navigation. */
+  links?: DossierResourceLinks;
+
+  // ---------- Nullable Sections ----------
+  property: DossierPropertyDetails | null;
+  valuation: DossierValuationSignals | null;
+  levies: DossierLevyDetails | null;
+  notes: DossierNoteHeaders | null;
+}
+
+// ============================================================================
+// Section: Property
+// ============================================================================
+
+/** Mirrors PropertyDetails record. CAMA-ready placeholders included. */
+export interface DossierPropertyDetails {
+  propertyId: string;
+  parcelNumber: string;
+  address: string;
+  propertyType: string | null;
+  yearBuilt: number | null;
+  assessedValue: number;
+  landValue: number;
+  improvementValue: number;
+  marketValue: number;
+  taxYear: number;
+  assessmentDate: string; // ISO 8601
+
+  // CAMA-ready placeholders — null until Property entity gains these columns
+  classCode: string | null;
+  useCode: string | null;
+  neighborhood: string | null;
+}
+
+// ============================================================================
+// Section: Valuation
+// ============================================================================
+
+/** Mirrors ValuationSignals record. */
+export interface DossierValuationSignals {
+  totalValue: number;
+  categoryCount: number;
+  categories: DossierValuationCategory[];
+}
+
+/** Mirrors ValuationCategory record. */
+export interface DossierValuationCategory {
+  name: string;
+  amount: number;
+  percentage: number;
+}
+
+// ============================================================================
+// Section: Levies
+// ============================================================================
+
+/** Mirrors LevyDetails record. */
+export interface DossierLevyDetails {
+  levyCountTotal: number;
+  levyCountReturned: number;
+  recent: DossierLevyEntry[];
+}
+
+/** Mirrors LevyEntry record. */
+export interface DossierLevyEntry {
+  taxLevyId: string;
+  taxingDistrict: string;
+  taxRate: number;
+  levyAmount: number;
+  taxYear: number;
+  purpose: string;
+  effectiveDate: string; // ISO 8601
+}
+
+// ============================================================================
+// Section: Notes (headers only — PII-redacted)
+// ============================================================================
+
+/** Mirrors NoteHeaders record. */
+export interface DossierNoteHeaders {
+  noteCountTotal: number;
+  noteCountReturned: number;
+  items: DossierNoteHeaderItem[];
+}
+
+/**
+ * Mirrors NoteHeaderItem record.
+ * PII-redacted: authorKind replaces createdBy; no content/preview fields.
+ */
+export interface DossierNoteHeaderItem {
+  noteId: string;
+  noteType: string;
+  createdAt: string; // ISO 8601
+  authorKind: string; // e.g. "staff", "system", "taxpayer"
+}
+
+// ============================================================================
+// Resource Links
+// ============================================================================
+
+/**
+ * Mirrors DossierResourceLinks record.
+ * All paths are relative API routes — no host/scheme, safe for any deployment.
+ */
+export interface DossierResourceLinks {
+  self: string;
+  summary: string | null;
+  details: string | null;
+  notes: string;
+  casefile: string;
+}
+
+// ============================================================================
+// Request Options
+// ============================================================================
+
+/**
+ * Options for the getDetails() service call.
+ * Maps to query parameters on GET /api/dossier/parcels/{parcelId}/details
+ */
+export interface DossierDetailsOptions {
+  /** Comma-separated section names: property, valuation, levies, notes */
+  include?: string;
+  /** Max levy entries to return (default: server-side default) */
+  levyLimit?: number;
+  /** Max note headers to return (default: server-side default) */
+  noteLimit?: number;
+}

--- a/frontend/apps/os-shell/src/contracts/index.ts
+++ b/frontend/apps/os-shell/src/contracts/index.ts
@@ -38,3 +38,16 @@ export type {
   TraceEventType,
   TraceSuite,
 } from './trace';
+
+export type {
+  DossierDetailsOptions,
+  DossierDetailsResponse,
+  DossierLevyDetails,
+  DossierLevyEntry,
+  DossierNoteHeaderItem,
+  DossierNoteHeaders,
+  DossierPropertyDetails,
+  DossierResourceLinks,
+  DossierValuationCategory,
+  DossierValuationSignals,
+} from './dossierDetails';

--- a/frontend/apps/os-shell/src/hooks/useDossierDetails.ts
+++ b/frontend/apps/os-shell/src/hooks/useDossierDetails.ts
@@ -22,7 +22,6 @@ import { dossierService } from '../services/dossierService';
 export interface DossierDetailsError {
   message: string;
   code?: string;
-  correlationId?: string;
 }
 
 export interface UseDossierDetailsResult {

--- a/frontend/apps/os-shell/src/hooks/useDossierDetails.ts
+++ b/frontend/apps/os-shell/src/hooks/useDossierDetails.ts
@@ -1,0 +1,124 @@
+/**
+ * useDossierDetails.ts
+ *
+ * CX-25: Fetch structured parcel dossier details from the backend.
+ * Follows the useState + useCallback pattern from useCostForgeAPI.
+ *
+ * Features:
+ * - Auto-fetches on parcelId change
+ * - Handles nullable sections (selective ?include= support)
+ * - Exposes correlationId from response for trace linking
+ * - Supports manual refetch
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DossierDetailsOptions, DossierDetailsResponse } from '../contracts/dossierDetails';
+import { dossierService } from '../services/dossierService';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DossierDetailsError {
+  message: string;
+  code?: string;
+  correlationId?: string;
+}
+
+export interface UseDossierDetailsResult {
+  data: DossierDetailsResponse | null;
+  loading: boolean;
+  error: DossierDetailsError | null;
+  /** Server-echoed correlation ID for trace linking. */
+  correlationId: string | null;
+  /** Trigger a fresh fetch. */
+  refetch: () => void;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Fetch structured dossier details for a parcel.
+ *
+ * @param parcelId - The parcel to fetch details for (null = idle, no fetch).
+ * @param options  - Optional: include, levyLimit, noteLimit.
+ */
+export function useDossierDetails(
+  parcelId: string | null,
+  options?: DossierDetailsOptions,
+): UseDossierDetailsResult {
+  const [data, setData] = useState<DossierDetailsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<DossierDetailsError | null>(null);
+  const [correlationId, setCorrelationId] = useState<string | null>(null);
+
+  // Track the active parcelId to prevent stale closures after unmount / parcel change
+  const activeParcelRef = useRef<string | null>(null);
+
+  // Stable serialization of options for dependency tracking
+  const optionsKey = options
+    ? `${options.include || ''}_${options.levyLimit ?? ''}_${options.noteLimit ?? ''}`
+    : '';
+
+  const fetchDetails = useCallback(
+    async (pid: string) => {
+      // Guard: bail if parcelId changed while we were waiting
+      if (activeParcelRef.current !== pid) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const result = await dossierService.getDetails(pid, options);
+
+        // Guard after async
+        if (activeParcelRef.current !== pid) return;
+
+        setData(result.data);
+        setCorrelationId(result.data.correlationId || result.correlationId);
+      } catch (err) {
+        // Guard after async
+        if (activeParcelRef.current !== pid) return;
+
+        const msg = err instanceof Error ? err.message : String(err);
+        setError({
+          message: msg,
+          code: msg.includes('404') ? 'NOT_FOUND' : 'FETCH_ERROR',
+        });
+        setData(null);
+        setCorrelationId(null);
+      } finally {
+        // Guard after async
+        if (activeParcelRef.current !== pid) return;
+        setLoading(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [optionsKey],
+  );
+
+  // Auto-fetch when parcelId or options change
+  useEffect(() => {
+    if (!parcelId) {
+      activeParcelRef.current = null;
+      setData(null);
+      setLoading(false);
+      setError(null);
+      setCorrelationId(null);
+      return;
+    }
+
+    activeParcelRef.current = parcelId;
+    fetchDetails(parcelId);
+  }, [parcelId, fetchDetails]);
+
+  const refetch = useCallback(() => {
+    if (!parcelId) return;
+    activeParcelRef.current = parcelId;
+    fetchDetails(parcelId);
+  }, [parcelId, fetchDetails]);
+
+  return { data, loading, error, correlationId, refetch };
+}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
@@ -83,8 +83,13 @@ interface SummarizeState {
 // ============================================================================
 // Helper: Format currency for display
 // ============================================================================
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
 function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+  return currencyFormatter.format(value);
 }
 
 // ============================================================================
@@ -391,7 +396,7 @@ export const PropertyDossier: React.FC = () => {
                 {dossierDetails.correlationId}
               </code>
               <button
-                onClick={() => navigator.clipboard.writeText(dossierDetails.correlationId || '')}
+                onClick={() => { navigator.clipboard?.writeText(dossierDetails.correlationId || '').catch(() => { /* clipboard unavailable */ }); }}
                 className='px-1.5 py-0.5 text-xs tf-hover-surface rounded'
                 title='Copy correlation ID'
               >
@@ -434,7 +439,7 @@ export const PropertyDossier: React.FC = () => {
           </div>
         )}
 
-        {/* Details sections — 4 collapsible BentoGrid cards */}
+        {/* Details sections — 4 BentoGrid cards */}
         {dossierDetails.data && (
           <BentoGrid columns={2} gap={1.5} padding={0}>
             {/* Property */}
@@ -623,9 +628,9 @@ export const PropertyDossier: React.FC = () => {
                     {summarizeState.correlationId}
                   </code>
                   <button
-                    onClick={() =>
-                      navigator.clipboard.writeText(summarizeState.correlationId || '')
-                    }
+                    onClick={() => {
+                      navigator.clipboard?.writeText(summarizeState.correlationId || '').catch(() => { /* clipboard unavailable */ });
+                    }}
                     className='px-2 py-1 text-xs tf-hover-surface rounded'
                     title='Copy correlation ID'
                   >

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
@@ -1,10 +1,14 @@
 /**
  * PropertyDossier.tsx
  *
- * Phase 5.2: Property Dossier Tab - Document Management MWUX Slice
- * Real MWUX with document listing, selection, and summarize tool invocation.
+ * Phase 5.2 + CX-25: Property Dossier Tab
  *
- * Architecture: UI → list docs → select → summarize_dossier tool → correlationId UX
+ * Two sections:
+ * 1. Parcel Details — real backend data from GET /api/dossier/parcels/{parcelId}/details
+ *    (property, valuation, levies, note headers — all nullable for selective includes)
+ * 2. Document Management — MWUX with mock document listing + summarize tool invocation
+ *
+ * Architecture: UI → useDossierDetails hook → real API → correlationId UX
  */
 
 import React, { useCallback, useState } from 'react';
@@ -22,6 +26,12 @@ import {
 import { useEvidenceSnapshot } from '../../../hooks/useEvidenceSnapshot';
 import { BentoGrid } from '../../../ui/materials/BentoGrid';
 import { BentoCard } from '../../../ui/materials/BentoCard';
+import { useDossierDetails } from '../../../hooks/useDossierDetails';
+import type {
+  DossierLevyEntry,
+  DossierNoteHeaderItem,
+  DossierValuationCategory,
+} from '../../../contracts/dossierDetails';
 
 /** Document categories for organization */
 const DOCUMENT_CATEGORIES = [
@@ -70,8 +80,185 @@ interface SummarizeState {
   error?: ErrorInfo;
 }
 
+// ============================================================================
+// Helper: Format currency for display
+// ============================================================================
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+}
+
+// ============================================================================
+// Parcel Details Sub-Components
+// ============================================================================
+
+/** Renders "Not included" placeholder when a section is null */
+const SectionNotIncluded: React.FC<{ label: string }> = ({ label }) => (
+  <div className='tf-panel p-4 text-center'>
+    <p className='tf-text-dim text-sm italic'>{label} not included in this request</p>
+  </div>
+);
+
+/** Property details section */
+const PropertySection: React.FC<{ data: NonNullable<import('../../../contracts/dossierDetails').DossierDetailsResponse['property']> }> = ({ data }) => (
+  <div className='space-y-3'>
+    <div className='tf-panel p-4 space-y-2'>
+      <div className='flex justify-between'>
+        <span className='tf-text-dim text-sm'>Address</span>
+        <span className='tf-text text-sm font-medium'>{data.address}</span>
+      </div>
+      <div className='flex justify-between'>
+        <span className='tf-text-dim text-sm'>Parcel</span>
+        <span className='tf-text text-sm'>{data.parcelNumber}</span>
+      </div>
+      {data.propertyType && (
+        <div className='flex justify-between'>
+          <span className='tf-text-dim text-sm'>Type</span>
+          <span className='tf-text text-sm'>{data.propertyType}</span>
+        </div>
+      )}
+      {data.yearBuilt && (
+        <div className='flex justify-between'>
+          <span className='tf-text-dim text-sm'>Year Built</span>
+          <span className='tf-text text-sm'>{data.yearBuilt}</span>
+        </div>
+      )}
+      <div className='border-t tf-border pt-2 mt-2'>
+        <div className='flex justify-between'>
+          <span className='tf-text-dim text-sm'>Assessed Value</span>
+          <span className='tf-text text-sm font-semibold'>{formatCurrency(data.assessedValue)}</span>
+        </div>
+        <div className='flex justify-between'>
+          <span className='tf-text-dim text-sm'>Market Value</span>
+          <span className='tf-text text-sm'>{formatCurrency(data.marketValue)}</span>
+        </div>
+        <div className='flex justify-between'>
+          <span className='tf-text-dim text-sm'>Land / Improvement</span>
+          <span className='tf-text text-sm'>{formatCurrency(data.landValue)} / {formatCurrency(data.improvementValue)}</span>
+        </div>
+      </div>
+      <div className='flex justify-between'>
+        <span className='tf-text-dim text-sm'>Tax Year</span>
+        <span className='tf-text text-sm'>{data.taxYear}</span>
+      </div>
+      {/* CAMA placeholders — only render when populated */}
+      {(data.classCode || data.useCode || data.neighborhood) && (
+        <div className='border-t tf-border pt-2 mt-2'>
+          {data.classCode && (
+            <div className='flex justify-between'>
+              <span className='tf-text-dim text-sm'>Class Code</span>
+              <span className='tf-text text-sm'>{data.classCode}</span>
+            </div>
+          )}
+          {data.useCode && (
+            <div className='flex justify-between'>
+              <span className='tf-text-dim text-sm'>Use Code</span>
+              <span className='tf-text text-sm'>{data.useCode}</span>
+            </div>
+          )}
+          {data.neighborhood && (
+            <div className='flex justify-between'>
+              <span className='tf-text-dim text-sm'>Neighborhood</span>
+              <span className='tf-text text-sm'>{data.neighborhood}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+/** Valuation signals section */
+const ValuationSection: React.FC<{ data: NonNullable<import('../../../contracts/dossierDetails').DossierDetailsResponse['valuation']> }> = ({ data }) => (
+  <div className='space-y-3'>
+    <div className='tf-panel p-4'>
+      <div className='flex justify-between mb-3'>
+        <span className='tf-text-dim text-sm'>Total Value</span>
+        <span className='tf-text font-semibold'>{formatCurrency(data.totalValue)}</span>
+      </div>
+      <div className='space-y-2'>
+        {data.categories.map((cat: DossierValuationCategory, idx: number) => (
+          <div key={idx} className='flex items-center justify-between text-sm'>
+            <span className='tf-text-secondary'>{cat.name}</span>
+            <div className='flex items-center gap-3'>
+              <span className='tf-text'>{formatCurrency(cat.amount)}</span>
+              <span className='tf-text-dim text-xs w-12 text-right'>
+                {cat.percentage.toFixed(1)}%
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+/** Levy details section */
+const LevySection: React.FC<{ data: NonNullable<import('../../../contracts/dossierDetails').DossierDetailsResponse['levies']> }> = ({ data }) => (
+  <div className='space-y-3'>
+    <div className='tf-panel p-4'>
+      <div className='flex justify-between mb-3'>
+        <span className='tf-text-dim text-sm'>
+          Showing {data.levyCountReturned} of {data.levyCountTotal} levies
+        </span>
+      </div>
+      <div className='space-y-2'>
+        {data.recent.map((levy: DossierLevyEntry) => (
+          <div key={levy.taxLevyId} className='tf-overlay rounded p-3 text-sm'>
+            <div className='flex justify-between'>
+              <span className='tf-text font-medium'>{levy.taxingDistrict}</span>
+              <span className='tf-text font-semibold'>{formatCurrency(levy.levyAmount)}</span>
+            </div>
+            <div className='flex justify-between mt-1'>
+              <span className='tf-text-dim text-xs'>{levy.purpose}</span>
+              <span className='tf-text-dim text-xs'>
+                Rate: {levy.taxRate.toFixed(4)} | {levy.taxYear}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+/** Note headers section (PII-redacted: metadata only, no content) */
+const NotesSection: React.FC<{ data: NonNullable<import('../../../contracts/dossierDetails').DossierDetailsResponse['notes']> }> = ({ data }) => (
+  <div className='space-y-3'>
+    <div className='tf-panel p-4'>
+      <div className='flex justify-between mb-3'>
+        <span className='tf-text-dim text-sm'>
+          Showing {data.noteCountReturned} of {data.noteCountTotal} notes (headers only)
+        </span>
+      </div>
+      <div className='space-y-2'>
+        {data.items.map((note: DossierNoteHeaderItem) => (
+          <div key={note.noteId} className='flex items-center justify-between tf-overlay rounded px-3 py-2 text-sm'>
+            <div className='flex items-center gap-2'>
+              <span className='tf-text font-medium'>{note.noteType}</span>
+              <span className='tf-text-dim text-xs'>by {note.authorKind}</span>
+            </div>
+            <span className='tf-text-dim text-xs'>
+              {new Date(note.createdAt).toLocaleDateString()}
+            </span>
+          </div>
+        ))}
+        {data.items.length === 0 && (
+          <p className='tf-text-dim text-sm italic text-center'>No notes recorded</p>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
 export const PropertyDossier: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
+
+  // CX-25: Real dossier details from backend
+  const dossierDetails = useDossierDetails(parcelId);
 
   const [selectedDoc, setSelectedDoc] = useState<DossierDocument | null>(null);
   const [summarizeState, setSummarizeState] = useState<SummarizeState>({ status: 'idle' });
@@ -190,6 +377,111 @@ export const PropertyDossier: React.FC = () => {
         parcelId={parcelId}
         subtitle={`Documents for parcel ${parcelId}`}
       />
+
+      {/* ================================================================ */}
+      {/* CX-25: Parcel Details — real backend data                        */}
+      {/* ================================================================ */}
+      <div data-testid='parcel-details-section'>
+        {/* Correlation ID badge + resource links */}
+        {dossierDetails.correlationId && (
+          <div className='flex items-center gap-3 mb-3 flex-wrap'>
+            <div className='flex items-center gap-2'>
+              <span className='tf-text-dim text-xs'>Correlation:</span>
+              <code className='tf-overlay px-2 py-0.5 rounded text-xs tf-text-secondary'>
+                {dossierDetails.correlationId}
+              </code>
+              <button
+                onClick={() => navigator.clipboard.writeText(dossierDetails.correlationId || '')}
+                className='px-1.5 py-0.5 text-xs tf-hover-surface rounded'
+                title='Copy correlation ID'
+              >
+                Copy
+              </button>
+            </div>
+            {dossierDetails.data?.links && (
+              <div className='flex items-center gap-2 text-xs tf-text-dim'>
+                <span>Links:</span>
+                <span className='tf-text-tertiary'>{dossierDetails.data.links.self}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Loading state */}
+        {dossierDetails.loading && (
+          <div className='tf-status-info rounded-xl p-4 mb-4' role='status'>
+            <div className='flex items-center gap-3'>
+              <div className='w-5 h-5 border-2 rounded-full animate-spin' style={{ borderColor: 'hsl(var(--tf-text) / 0.3)', borderTopColor: 'hsl(var(--tf-text))' }} />
+              <span className='tf-text'>Loading parcel details...</span>
+            </div>
+          </div>
+        )}
+
+        {/* Error state */}
+        {dossierDetails.error && (
+          <div className='tf-status-error rounded-xl p-4 mb-4'>
+            <div className='flex items-center justify-between'>
+              <p className='tf-text text-sm'>
+                Failed to load details: {dossierDetails.error.message}
+              </p>
+              <button
+                onClick={dossierDetails.refetch}
+                className='px-3 py-1 text-xs tf-hover-surface rounded'
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Details sections — 4 collapsible BentoGrid cards */}
+        {dossierDetails.data && (
+          <BentoGrid columns={2} gap={1.5} padding={0}>
+            {/* Property */}
+            <BentoCard title="Property" actions={<span>🏠</span>}>
+              {dossierDetails.data.property
+                ? <PropertySection data={dossierDetails.data.property} />
+                : <SectionNotIncluded label="Property details" />
+              }
+            </BentoCard>
+
+            {/* Valuation */}
+            <BentoCard title="Valuation" actions={<span>💰</span>}>
+              {dossierDetails.data.valuation
+                ? <ValuationSection data={dossierDetails.data.valuation} />
+                : <SectionNotIncluded label="Valuation signals" />
+              }
+            </BentoCard>
+
+            {/* Levies */}
+            <BentoCard title="Tax Levies" actions={<span>🏛️</span>}>
+              {dossierDetails.data.levies
+                ? <LevySection data={dossierDetails.data.levies} />
+                : <SectionNotIncluded label="Levy details" />
+              }
+            </BentoCard>
+
+            {/* Notes (headers only) */}
+            <BentoCard title="Notes" actions={<span>📝</span>}>
+              {dossierDetails.data.notes
+                ? <NotesSection data={dossierDetails.data.notes} />
+                : <SectionNotIncluded label="Note headers" />
+              }
+            </BentoCard>
+          </BentoGrid>
+        )}
+
+        {/* PII redaction badge */}
+        {dossierDetails.data?.piiRedacted && (
+          <div className='flex items-center gap-2 mt-2'>
+            <span className='text-xs tf-text-dim'>🔒 PII redacted</span>
+          </div>
+        )}
+      </div>
+
+      {/* ================================================================ */}
+      {/* Document Management (mock data) — existing MWUX slice            */}
+      {/* ================================================================ */}
 
       {/* Document Categories & List */}
       <BentoGrid columns={3} gap={1.5} padding={0}>

--- a/frontend/apps/os-shell/src/services/dossierService.ts
+++ b/frontend/apps/os-shell/src/services/dossierService.ts
@@ -9,6 +9,7 @@
 
 import { getToken } from '@/auth/authStorage';
 import { getViteEnv } from '@/env/getViteEnv';
+import type { DossierDetailsOptions, DossierDetailsResponse } from '@/contracts/dossierDetails';
 
 const API_BASE_URL = getViteEnv().VITE_API_URL || '';
 const DOSSIER_API = `${API_BASE_URL}/api/dossier`;
@@ -211,6 +212,37 @@ async function dossierPost<T>(path: string, body: unknown): Promise<T> {
   return response.json();
 }
 
+/** Generate a correlation ID matching the CostForge pattern. */
+function generateCorrelationId(): string {
+  return `tf-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/**
+ * GET with X-Correlation-ID header injection.
+ * Returns both the parsed body and the correlation ID echoed by the server.
+ */
+async function dossierGetWithCorrelation<T>(
+  path: string,
+  correlationId?: string,
+): Promise<{ data: T; correlationId: string }> {
+  const cid = correlationId || generateCorrelationId();
+  const headers: Record<string, string> = {
+    ...authHeaders(),
+    'X-Correlation-ID': cid,
+  };
+
+  const response = await fetch(`${DOSSIER_API}${path}`, { headers });
+  if (!response.ok) {
+    throw new Error(`Dossier API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data: T = await response.json();
+
+  // Prefer the server-echoed header; fall back to what we sent
+  const echoed = response.headers.get('X-Correlation-ID') || cid;
+  return { data, correlationId: echoed };
+}
+
 // ============================================================================
 // NOTE: DEFAULT fallback data removed in CC-14 (R1 Week 3).
 // All service methods now propagate errors from the real backend.
@@ -259,6 +291,29 @@ export const dossierService = {
    */
   getStats: async (): Promise<DossierStats> => {
     return dossierGet<DossierStats>('/stats');
+  },
+
+  /**
+   * CX-25: Get structured parcel dossier details.
+   * Calls GET /api/dossier/parcels/{parcelId}/details with:
+   *   - X-Correlation-ID header (generated and returned alongside data)
+   *   - ?include=, ?levyLimit=, ?noteLimit= query parameters
+   *
+   * Returns the full DossierDetailsResponse with nullable sections and
+   * the generated correlationId used for the request.
+   */
+  getDetails: async (
+    parcelId: string,
+    options?: DossierDetailsOptions,
+  ): Promise<{ data: DossierDetailsResponse; correlationId: string }> => {
+    const params = new URLSearchParams();
+    if (options?.include) params.set('include', options.include);
+    if (options?.levyLimit != null) params.set('levyLimit', String(options.levyLimit));
+    if (options?.noteLimit != null) params.set('noteLimit', String(options.noteLimit));
+
+    const qs = params.toString();
+    const path = `/parcels/${encodeURIComponent(parcelId)}/details${qs ? `?${qs}` : ''}`;
+    return dossierGetWithCorrelation<DossierDetailsResponse>(path);
   },
 
   /**


### PR DESCRIPTION
## Summary

- **Wire frontend PropertyDossier tab** to consume the real backend `GET /api/dossier/parcels/{parcelId}/details` endpoint (merged in CX-23/CX-24)
- **Add TypeScript contracts** (`contracts/dossierDetails.ts`) mirroring `ParcelDossierDetailsDto` with nullable sections for selective `?include=` support
- **Add `getDetails()` service method** with X-Correlation-ID header propagation and query parameter construction (`?include=`, `?levyLimit=`, `?noteLimit=`)
- **Add `useDossierDetails` hook** with auto-fetch on parcelId change, stale closure guards, and correlationId exposure
- **Integrate real data UI** in PropertyDossier: 4 BentoGrid sections (Property, Valuation, Tax Levies, Notes) with null-section handling, PII redaction badge, and correlation ID display
- **8 vitest unit tests** covering idle state, data fetch, errors, nullable sections, correlationId, refetch, options passing, and 404 handling

## Files Changed

| File | Change |
|------|--------|
| `contracts/dossierDetails.ts` | **NEW** — TypeScript types mirroring backend DTOs |
| `contracts/index.ts` | **MODIFIED** — barrel exports for 10 new types |
| `services/dossierService.ts` | **MODIFIED** — `getDetails()` + `dossierGetWithCorrelation()` |
| `hooks/useDossierDetails.ts` | **NEW** — data-fetching hook with stale closure protection |
| `pages/workbench/tabs/PropertyDossier.tsx` | **MODIFIED** — real data sections above existing document UI |
| `__tests__/hooks/useDossierDetails.test.ts` | **NEW** — 8 vitest unit tests |

## Key Behaviors

- Sends `X-Correlation-ID` header on every details request (pattern: `tf-{timestamp}-{random}`)
- Handles nullable sections gracefully (selective `?include=` support renders "Not included" placeholder)
- PII-redacted note headers — metadata only, no content/preview fields
- Existing mock document management UI preserved (separate concern from structured details)
- Resource links displayed for evidence navigation

## Test Plan

- [x] New hook tests: 8/8 pass (vitest)
- [x] Backend tests: 2,043/2,047 pass (4 quarantined CX-16 auth — pre-existing)
- [x] Pre-push quality gate: unit tests, security, backend build, frontend build all pass
- [x] UI token violations improved by 1 (194 <= baseline 195)
- [ ] Manual: Navigate to parcel dossier tab → see property/valuation/levies/notes from real endpoint
- [ ] Manual: Verify X-Correlation-ID header sent in browser network tab
- [ ] Manual: Verify correlationId badge renders and copies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)