### PR TITLE
fix(dossier): CX-27 runtime smoke fixes — perm claim auth + DI wiring

### DIFF
--- a/backend/docs/cx-27-runtime-smoke-evidence.md
+++ b/backend/docs/cx-27-runtime-smoke-evidence.md
@@ -1,0 +1,101 @@
+# CX-27: Runtime Smoke & Operator Validation — Evidence Report
+
+## Ticket
+**CX-27** — Runtime smoke testing + operator validation  
+**Branch**: `r1/cx27-runtime-smoke-fixes`  
+**Base**: `origin/r1/integration` at CX-26 merge (`3f8de6b02`)
+
+## Purpose
+
+Validate that every Dossier endpoint (CX-22 through CX-26) works against
+a real running backend. Discover and fix deployment-grade issues that unit
+tests cannot catch: DI wiring, auth chain, database configuration, error
+response codes.
+
+## Smoke Test Results
+
+### Happy-Path Endpoints
+
+| Endpoint | CX | Method | URL | Status | Result |
+|----------|----|--------|-----|--------|--------|
+| Summary | CX-22 | GET | `/api/dossier/{parcelId}` | **200** | Full `ParcelDossierDto` with countyName, property, correlationId |
+| Notes | CX-22 | GET | `/api/dossier/{parcelId}/notes` | **200** | Empty list (no notes seeded) |
+| Details | CX-23 | GET | `/api/dossier/parcels/{parcelId}/details` | **200** | Composed dossier with property, levies, notes sections |
+| Casefile | CX-24 | GET | `/api/dossier/parcels/{parcelId}/casefile` | **200** | Casefile summary with correlationId |
+| Evidence | CX-26 | GET | `/api/dossier/parcels/{parcelId}/evidence` | **200** | Full `EvidenceSnapshotDto` with SHA-256 hash |
+
+### Error Paths
+
+| Scenario | Status | Correct? |
+|----------|--------|----------|
+| No auth header | **401** | ✅ Unauthorized |
+| Bad parcel format (`DROP TABLE`) | **400** | ✅ Rejected by regex |
+| Nonexistent parcel | **404** | ✅ Not found |
+| Cross-county (Yakima → Benton parcel) | **404** | ✅ Anti-enumeration |
+
+### Evidence Hash Contract
+
+Two requests to the evidence endpoint 2 seconds apart produced:
+- Different `contentHash` (SHA-256 over serialized snapshot)
+- Different `correlationId` (unique `dossier-` prefix)
+- Different `snapshotTimestamp`
+
+This confirms the point-in-time seal works correctly.
+
+## Issues Found & Fixed
+
+### 1. `[RequiresPermission]` ignored JWT `perm` claims (Design Gap)
+
+**File**: `PluginPermissionHandler.cs`  
+**Symptom**: All `[RequiresPermission("read:dossier")]` endpoints returned 403  
+**Root Cause**: `PluginPermissionHandler` only checked `X-Plugin-Id` header +
+plugin DB lookup. It had no fallback for JWT `perm` claims, meaning direct API
+callers (non-plugin) could never pass the check.  
+**Fix**: Added JWT `perm` claim check as primary path before plugin-ID fallback.
+Uses `context.User.Claims` (already validated by JwtBearerHandler).
+
+### 2. `ICostForgeAIService` not registered in DI (Missing Registration)
+
+**File**: `Program.cs`  
+**Symptom**: 500 Internal Server Error on any dossier endpoint  
+**Root Cause**: `CostForgeService` constructor depends on `ICostForgeAIService`
+but it was never registered in the DI container.  
+**Fix**: Added `builder.Services.AddScoped<ICostForgeAIService, CostForgeAIService>()`
+
+### 3. In-memory SQLite broken for web workloads (Deployment Finding)
+
+**Symptom**: 500 with "no such table: Properties"  
+**Root Cause**: `Data Source=:memory:` in `appsettings.Development.json` creates
+a per-connection database. Each DI scope (request) gets a new empty database.
+`EnsureCreatedAsync()` creates schema on one connection, but it's lost on the next.  
+**Fix**: Override via env var with file-based SQLite:
+`ConnectionStrings__DefaultConnection=Data Source=terrafusion-cx27.db`  
+**Note**: This is a deployment configuration issue, not a code bug. The in-memory
+setting may be intentional for isolated test runners but breaks dev-server usage.
+
+### 4. `ASPNETCORE_ENVIRONMENT` defaults to Production (Deployment Finding)
+
+**Symptom**: Wrong JWT signing key, wrong database connection string  
+**Root Cause**: Without explicit `ASPNETCORE_ENVIRONMENT=Development`, the server
+reads base `appsettings.json` (Production values).  
+**Fix**: Set `$env:ASPNETCORE_ENVIRONMENT = "Development"` before startup.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `Security/PluginPermissionHandler.cs` | Added `perm` claim check (lines 24-36) |
+| `Program.cs` | Added `ICostForgeAIService` DI registration (line 351) |
+
+## Test Environment
+
+- .NET 8, `localhost:5000`, Development mode
+- SQLite file-based (`terrafusion-cx27.db`)
+- JWT: HMAC-SHA256, `Terrafusion.API` issuer, claims include `countyId` + `perm`
+- Benton County GUID: `19190019-1919-1919-1919-191919191919`
+
+## Verdict
+
+**All 5 dossier endpoints operational.** 9/9 test scenarios pass (5 happy, 4 error).
+Two code fixes required (PluginPermissionHandler, Program.cs DI). Two deployment
+findings documented for operator runbook.

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -348,6 +348,7 @@ builder.Services.AddDbContext<TerraFusion.Data.TerraFusionContext>(options =>
 });
 
 // CX-8: Register ICostForgeService for real property-backed cost calculation
+builder.Services.AddScoped<TerraFusion.Core.Services.ICostForgeAIService, TerraFusion.AI.Services.CostForgeAIService>();
 builder.Services.AddScoped<TerraFusion.Core.Services.ICostForgeService, TerraFusion.API.Services.CostForgeService>();
 
 // Register ITerraFusionDbContext interface

--- a/backend/src/TerraFusion.API/Security/PluginPermissionHandler.cs
+++ b/backend/src/TerraFusion.API/Security/PluginPermissionHandler.cs
@@ -21,6 +21,20 @@ namespace TerraFusion.API.Security
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PluginPermissionRequirement requirement)
         {
+            // CX-27: Check JWT "perm" claims first (direct API callers, dev tokens).
+            // This mirrors ModuleAccessHandler's claim-based check and ensures
+            // [RequiresPermission] works for both plugin and direct-auth callers.
+            var hasPermClaim = context.User?.Claims?
+                .Where(c => c.Type == "perm")
+                .Select(c => c.Value)
+                .Any(v => string.Equals(v, requirement.Permission, StringComparison.OrdinalIgnoreCase)) == true;
+
+            if (hasPermClaim)
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
             var httpContext = _httpContextAccessor.HttpContext;
             if (httpContext == null)
             {


### PR DESCRIPTION
## CX-27: Runtime Smoke & Operator Validation

### Summary
Two code fixes discovered during runtime smoke testing of all Dossier endpoints (CX-22 through CX-26).

### Changes

1. **PluginPermissionHandler.cs**: Added JWT `perm` claim check as primary auth path. Without this, `[RequiresPermission]` only worked via `X-Plugin-Id` header, blocking all direct API callers (403).

2. **Program.cs**: Registered `ICostForgeAIService` → `CostForgeAIService` in DI container. `CostForgeService` depends on it but it was never registered, causing 500 on any dossier endpoint.

### Smoke Test Results (9/9 pass)

| Endpoint | Status |
|----------|--------|
| Summary (CX-22) | 200 ✅ |
| Notes (CX-22) | 200 ✅ |
| Details (CX-23) | 200 ✅ |
| Casefile (CX-24) | 200 ✅ |
| Evidence (CX-26) | 200 ✅ |
| No auth | 401 ✅ |
| Bad format | 400 ✅ |
| Not found | 404 ✅ |
| Cross-county | 404 ✅ |

### Deployment Findings (documented, not code fixes)
- `ASPNETCORE_ENVIRONMENT` must be set explicitly (defaults to Production)
- `Data Source=:memory:` in appsettings.Development.json is broken for web workloads (per-connection scoping)

### Evidence
- [backend/docs/cx-27-runtime-smoke-evidence.md](backend/docs/cx-27-runtime-smoke-evidence.md)

Government: FISMA compliance
AI-Collaboration: GitHub Copilot (CX-27)