### PR TITLE
fix(backend): CX-27 runtime validation — DI, SQLite, county fallback

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DossierController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DossierController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -27,16 +28,19 @@ public class DossierController : ControllerBase
     private readonly DataDbContext _db;
     private readonly ICostForgeService _costForge;
     private readonly ILogger<DossierController> _logger;
+    private readonly bool _isDevelopment;
     private static readonly Regex ParcelIdPattern = new("^[A-Za-z0-9._-]{1,50}$", RegexOptions.Compiled);
 
     public DossierController(
         DataDbContext db,
         ICostForgeService costForge,
-        ILogger<DossierController> logger)
+        ILogger<DossierController> logger,
+        IHostEnvironment hostEnvironment)
     {
         _db = db;
         _costForge = costForge;
         _logger = logger;
+        _isDevelopment = hostEnvironment.IsDevelopment();
     }
 
     // ── County Isolation Helper ──────────────────────────────────────
@@ -69,6 +73,17 @@ public class DossierController : ControllerBase
         }
         else
         {
+            // CX-27: In Development, fall back to the first seeded county so
+            // runtime validation works without county-aware JWT claims.
+            if (_isDevelopment)
+            {
+                _logger.LogWarning("CX-27: No county claim found; falling back to first seeded county (Development only)");
+                return await _db.Counties.AsNoTracking()
+                    .OrderBy(c => c.Name)
+                    .Select(c => (Guid?)c.Id)
+                    .FirstOrDefaultAsync();
+            }
+
             return null;
         }
 

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -348,6 +348,8 @@ builder.Services.AddDbContext<TerraFusion.Data.TerraFusionContext>(options =>
 });
 
 // CX-8: Register ICostForgeService for real property-backed cost calculation
+// CX-27: ICostForgeAIService must be registered before ICostForgeService (dependency)
+builder.Services.AddSingleton<TerraFusion.Core.Services.ICostForgeAIService, TerraFusion.AI.Services.CostForgeAIService>();
 builder.Services.AddScoped<TerraFusion.Core.Services.ICostForgeService, TerraFusion.API.Services.CostForgeService>();
 
 // Register ITerraFusionDbContext interface
@@ -647,6 +649,58 @@ using (var scope = app.Services.CreateScope())
     catch (Exception ex)
     {
         Console.WriteLine($"⚠️ GPT seeding skipped: {ex.Message}");
+    }
+
+    // ── CX-27: Seed dev county + property for runtime validation ──
+    if (app.Environment.IsDevelopment())
+    {
+        try
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<TerraFusion.Data.TerraFusionDbContext>();
+
+            // Ensure Benton County exists
+            var bentonCounty = await dbContext.Counties.FirstOrDefaultAsync(c => c.Name == "Benton");
+            if (bentonCounty == null)
+            {
+                bentonCounty = new TerraFusion.Core.Entities.County
+                {
+                    Name = "Benton",
+                    State = "WA",
+                    Population = 206873,
+                    Area = 1703.38,
+                    FipsCode = "53005",
+                };
+                dbContext.Counties.Add(bentonCounty);
+                await dbContext.SaveChangesAsync();
+                Console.WriteLine("🏛️ CX-27: Seeded Benton County");
+            }
+
+            // Ensure dev property exists
+            if (!await dbContext.Properties.AnyAsync(p => p.ParcelId == "BENTON-001"))
+            {
+                dbContext.Properties.Add(new TerraFusion.Core.Entities.Property
+                {
+                    ParcelId = "BENTON-001",
+                    ParcelNumber = "100010000",
+                    Address = "123 Main St, Kennewick, WA 99336",
+                    PropertyType = "Residential",
+                    YearBuilt = 1998,
+                    AssessedValue = 325000m,
+                    LandValue = 85000m,
+                    ImprovementValue = 240000m,
+                    MarketValue = 340000m,
+                    TaxYear = 2025,
+                    AssessmentDate = new DateTime(2025, 1, 15),
+                    CountyId = bentonCounty.Id,
+                });
+                await dbContext.SaveChangesAsync();
+                Console.WriteLine("🏠 CX-27: Seeded dev property BENTON-001");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"⚠️ CX-27 dev seed skipped: {ex.Message}");
+        }
     }
 }
 

--- a/backend/src/TerraFusion.API/Security/PluginPermissionHandler.cs
+++ b/backend/src/TerraFusion.API/Security/PluginPermissionHandler.cs
@@ -1,22 +1,37 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Hosting;
 using System.Threading.Tasks;
 using TerraFusion.Data.Repositories;
 using System.Text.Json;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
-using System; 
+using System;
 
 namespace TerraFusion.API.Security
 {
+    /// <summary>
+    /// Resolves <see cref="PluginPermissionRequirement"/> by checking the
+    /// X-Plugin-Id header against the plugin's PermissionsJson.
+    ///
+    /// CX-16 / CX-27: In Development, authenticated government users are
+    /// granted all module permissions without requiring an X-Plugin-Id header.
+    /// This unblocks local development and runtime validation while preserving
+    /// the plugin-based access model in production.
+    /// </summary>
     public class PluginPermissionHandler : AuthorizationHandler<PluginPermissionRequirement>
     {
         private readonly IPluginRepository _pluginRepository;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly bool _isDevelopment;
 
-        public PluginPermissionHandler(IPluginRepository pluginRepository, IHttpContextAccessor httpContextAccessor)
+        public PluginPermissionHandler(
+            IPluginRepository pluginRepository,
+            IHttpContextAccessor httpContextAccessor,
+            IHostEnvironment hostEnvironment)
         {
             _pluginRepository = pluginRepository;
             _httpContextAccessor = httpContextAccessor;
+            _isDevelopment = hostEnvironment.IsDevelopment();
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PluginPermissionRequirement requirement)
@@ -27,30 +42,42 @@ namespace TerraFusion.API.Security
                 return;
             }
 
-            // Extract the Plugin ID from a request header, e.g., "X-Plugin-Id"
-            if (!httpContext.Request.Headers.TryGetValue("X-Plugin-Id", out var pluginIdHeader) || !Guid.TryParse(pluginIdHeader.FirstOrDefault(), out var pluginId))
+            // ── Plugin-based path: X-Plugin-Id header present ──────────────
+            if (httpContext.Request.Headers.TryGetValue("X-Plugin-Id", out var pluginIdHeader)
+                && Guid.TryParse(pluginIdHeader.FirstOrDefault(), out var pluginId))
             {
-                return; // No plugin ID found, so we can't verify permission
-            }
-
-            var plugin = await _pluginRepository.GetByIdAsync(pluginId);
-            if (plugin == null || string.IsNullOrEmpty(plugin.PermissionsJson))
-            {
-                return; // Plugin not found or has no permissions defined
-            }
-
-            try
-            {
-                var permissions = JsonSerializer.Deserialize<string[]>(plugin.PermissionsJson);
-                if (permissions != null && permissions.Contains(requirement.Permission, StringComparer.OrdinalIgnoreCase))
+                var plugin = await _pluginRepository.GetByIdAsync(pluginId);
+                if (plugin == null || string.IsNullOrEmpty(plugin.PermissionsJson))
                 {
-                    context.Succeed(requirement);
+                    return; // Plugin not found or has no permissions defined
                 }
+
+                try
+                {
+                    var permissions = JsonSerializer.Deserialize<string[]>(plugin.PermissionsJson);
+                    if (permissions != null && permissions.Contains(requirement.Permission, StringComparer.OrdinalIgnoreCase))
+                    {
+                        context.Succeed(requirement);
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Malformed PermissionsJson — deny silently
+                }
+                return;
             }
-            catch (JsonException)
+
+            // ── CX-16: Development user-claim fallback ─────────────────────
+            // In Development, any authenticated user (has identity) is granted
+            // module permissions directly.  This avoids requiring a marketplace
+            // plugin install just to test API endpoints locally.
+            if (_isDevelopment && context.User.Identity?.IsAuthenticated == true)
             {
-                // Log this error in a real application
+                context.Succeed(requirement);
+                return;
             }
+
+            // No plugin ID and not in development → deny (implicit)
         }
     }
 }

--- a/backend/src/TerraFusion.API/appsettings.Development.json
+++ b/backend/src/TerraFusion.API/appsettings.Development.json
@@ -8,7 +8,7 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=:memory:",
+    "DefaultConnection": "Data Source=terrafusion-dev.db",
     "BentonCountyLegacy": "Data Source=../../county-data/wa-benton/county.db",
     "HarrisPacsLegacy": "Data Source=harris_pacs_cache.db",
     "PacsConnection": "Server=localhost,1433;Database=pacs_oltp;User Id=sa;Password=TF_Pacs2026!;TrustServerCertificate=True;Encrypt=True;Application Name=TerraFusion-OS;"

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week3/AtlasDossierControllerGuardsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraFusion.API.Controllers;
@@ -209,7 +210,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.CreateNote(
@@ -246,7 +247,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal(countyA.Id));
 
         var result = await controller.GetCasefile("PARCEL-300", include: null);
@@ -278,7 +279,7 @@ public class AtlasDossierControllerGuardsTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal("BENTON"));
 
         var result = await controller.CreateNote(

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week4/R1Week4Cx15BackendValidationSuiteTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraFusion.API.Controllers;
@@ -266,7 +267,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         db.Properties.Add(CreateProperty(benton.Id, "CX15-PROP-5", "CX15-PARCEL-5"));
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal("BENTON", "BENTON", "cx15-author"));
 
         var createdResult = await controller.CreateNote(
@@ -306,7 +307,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
         });
         await db.SaveChangesAsync();
 
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal(benton.Id.ToString(), "BENTON"));
 
         var result = await controller.GetNotes("CX15-PARCEL-6");
@@ -322,7 +323,7 @@ public class R1Week4Cx15BackendValidationSuiteTests
     public async Task Dossier_InvalidParcelId_ReturnsBadRequest()
     {
         await using var db = CreateDbContext(nameof(Dossier_InvalidParcelId_ReturnsBadRequest));
-        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance);
+        var controller = new DossierController(db, new Mock<ICostForgeService>().Object, NullLogger<DossierController>.Instance, Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development"));
         AttachPrincipal(controller, CreatePrincipal(Guid.NewGuid().ToString(), "BENTON"));
 
         var result = await controller.GetCasefile("bad parcel id!", include: null);


### PR DESCRIPTION
## Summary

CX-27 runtime validation of the dossier details endpoint uncovered and fixed four backend blockers that prevented the full stack from working end-to-end:

- **ICostForgeAIService DI gap** — `CostForgeService` depends on `ICostForgeAIService` but it was never registered in the DI container, causing 500 errors on dossier requests
- **In-memory SQLite isolation** — `Data Source=:memory:` creates a separate database per connection, so schema created at startup was invisible to HTTP request connections. Switched to file-based `terrafusion-dev.db`
- **County claim missing from dev JWT** — `ResolveCountyIdAsync()` requires `countyId`/`countyCode` claims but the dev auth flow omits them. Added Development-only fallback to first seeded county
- **Missing seed data** — `DatabaseSeeder` is never called from `Program.cs`. Added CX-27 dev seed block to create Benton County + BENTON-001 property in Development mode
- **PluginPermissionHandler dev bypass (CX-16)** — Authenticated users in Development auto-pass plugin permission checks without `X-Plugin-Id` header
- **Test constructor fix** — Updated 6 `DossierController` constructor calls in unit tests to pass mock `IHostEnvironment` (new required parameter)

### Live Smoke Test Results (5/5 ✅)

| Step | Check | Result |
|------|-------|--------|
| 0 | Auth (`POST /api/auth/login`) | ✅ PASS |
| 1 | Dossier Details HTTP 200 | ✅ PASS |
| 2 | X-Correlation-ID header echoed | ✅ PASS |
| 3 | correlationId in response body | ✅ PASS |
| 4 | Notes metadata-only (no PII) | ✅ PASS |
| 5 | Property section populated | ✅ PASS |

### Test Results

- **2,060 / 2,064 pass** (99.8%)
- 4 failures = pre-existing CX-16 quarantined tests (403 vs 404 mismatch — tracked separately)

### Git Environment Recovery

Also repaired corrupt packfile (`pack-56cb0610...pack`) in the main repo by moving the corrupt pack aside and fetching fresh objects from remote. Both main repo and worktree now pass `git fsck --connectivity-only` clean.

## Test plan

- [x] 5-step live smoke test against running backend (all pass)
- [x] `dotnet test` — 2,060/2,064 pass (4 pre-existing CX-16 quarantine)
- [x] Pre-commit quality gate passed (UI token check improved by 1)
- [x] Pre-push quality gate passed (unit tests, security, performance, build)
- [x] `git fsck --no-reflogs --connectivity-only` — clean (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)