### PR TITLE
fix(di): DX-03 register IPropertyService and fix DTO type mismatches

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
+++ b/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
@@ -102,7 +102,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpPost("{id}/valuations")]
-    public async Task<ActionResult<ValuationDto>> CreateValuation(int id, CreateValuationDto createDto)
+    public async Task<ActionResult<ValuationDto>> CreateValuation(Guid id, CreateValuationDto createDto)
     {
         try
         {

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -229,6 +229,8 @@ builder.Services.AddScoped<TerraFusion.Core.Services.LegacyDatabaseService>();
 builder.Services.AddScoped<TerraFusion.Core.Services.HarrisPacsLegacyService>();
 // Register Dynamic Property Service (REQUIRED by HarrisPacsLegacyService)
 builder.Services.AddScoped<TerraFusion.Core.Services.IDynamicPropertyService, TerraFusion.Core.Services.DynamicPropertyService>();
+// Register Property Service (REQUIRED by PropertiesController, SystemHub, QuantumMetricsHub)
+builder.Services.AddScoped<TerraFusion.Core.Services.IPropertyService, TerraFusion.Core.Services.PropertyService>();
 
 
 // 🏛️ PACS Adapter - pacscontract.v1 compliant read-only boundary

--- a/backend/src/TerraFusion.Core/DTOs/PropertyDto.cs
+++ b/backend/src/TerraFusion.Core/DTOs/PropertyDto.cs
@@ -4,48 +4,48 @@ namespace TerraFusion.Core.DTOs;
 
 public class PropertyDto
 {
-    public int Id { get; set; }
-    
+    public Guid Id { get; set; }
+
     [Required]
     [StringLength(50)]
     public string ParcelNumber { get; set; } = string.Empty;
-    
+
     [Required]
     [StringLength(500)]
     public string Address { get; set; } = string.Empty;
-    
+
     [StringLength(200)]
     public string? OwnerName { get; set; }
-    
+
     [Range(0, double.MaxValue)]
     public decimal AssessedValue { get; set; }
-    
+
     [Range(0, double.MaxValue)]
     public decimal LandValue { get; set; }
-    
+
     [Range(0, double.MaxValue)]
     public decimal ImprovementValue { get; set; }
-    
+
     [Required]
-    public int CountyId { get; set; }
-    
+    public Guid CountyId { get; set; }
+
     [Required]
     [StringLength(100)]
     public string CountyName { get; set; } = string.Empty;
-    
+
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 }
 
 public class ValuationDto
 {
-    public int Id { get; set; }
-    
+    public Guid Id { get; set; }
+
     [Required]
-    public int PropertyId { get; set; }
-    
+    public Guid PropertyId { get; set; }
+
     [Required]
-    public int AIModelId { get; set; }
+    public Guid AIModelId { get; set; }
     
     [Required]
     [StringLength(100)]
@@ -73,10 +73,10 @@ public class ValuationDto
 public class CreateValuationDto
 {
     [Required]
-    public int PropertyId { get; set; }
-    
+    public Guid PropertyId { get; set; }
+
     [Required]
-    public int AIModelId { get; set; }
+    public Guid AIModelId { get; set; }
     
     [Required]
     [Range(0, double.MaxValue)]
@@ -98,26 +98,26 @@ public class ImportPropertyDto
     [Required]
     [StringLength(50)]
     public string ParcelNumber { get; set; } = string.Empty;
-    
+
     [Required]
     [StringLength(500)]
     public string Address { get; set; } = string.Empty;
-    
+
     [StringLength(200)]
     public string? OwnerName { get; set; }
-    
+
     [Required]
     [Range(0, double.MaxValue)]
     public decimal AssessedValue { get; set; }
-    
+
     [Range(0, double.MaxValue)]
     public decimal LandValue { get; set; }
-    
+
     [Range(0, double.MaxValue)]
     public decimal ImprovementValue { get; set; }
-    
+
     [Required]
-    public int CountyId { get; set; }
+    public Guid CountyId { get; set; }
 }
 
 public class PropertyStatsDto

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX03PropertyServiceDIRepairTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX03PropertyServiceDIRepairTests.cs
@@ -1,0 +1,210 @@
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Security.Claims;
+using TerraFusion.API.Controllers;
+using TerraFusion.API.Seeds;
+using TerraFusion.Core.Mapping;
+using TerraFusion.Core.Services;
+using TerraFusionDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.R1Week5;
+
+/// <summary>
+/// DX-03: Property Service DI Repair — validates that IPropertyService
+/// is registered and PropertiesController no longer returns 500 from DI failure.
+///
+/// Found during DX-02 runtime smoke (PR #569, Issue #570).
+///
+/// Acceptance criteria:
+///   AC-1: PropertyService resolves with real dependencies (DbContext, AutoMapper)
+///   AC-2: GetPropertyByParcel returns data for seeded Benton parcel
+///   AC-3: PropertiesController can be constructed with real PropertyService
+///   AC-4: Controller GetPropertyByParcel returns 200 (not 500) for seeded parcel
+///   AC-5: Controller GetProperties returns paginated results
+/// </summary>
+public class DX03PropertyServiceDIRepairTests
+{
+    // ── AC-1: PropertyService resolves with real dependencies ──────────
+
+    [Fact]
+    public void AC1_PropertyService_CanBeConstructed_WithRealDependencies()
+    {
+        // Arrange
+        using var db = CreateTestDbContext();
+        var mapper = CreateMapper();
+        var logger = Mock.Of<ILogger<PropertyService>>();
+
+        // Act
+        var service = new PropertyService(db, mapper, logger);
+
+        // Assert
+        service.Should().NotBeNull("PropertyService should construct with real dependencies");
+    }
+
+    // ── AC-2: GetPropertyByParcel returns data for seeded parcel ──────
+
+    [Fact]
+    public async Task AC2_GetPropertyByParcel_ReturnsData_ForSeededBentonParcel()
+    {
+        // Arrange
+        await using var db = CreateTestDbContext();
+        await db.Database.EnsureCreatedAsync();
+        await DatabaseSeeder.SeedDossierRuntimeDataAsync(db);
+
+        var mapper = CreateMapper();
+        var logger = Mock.Of<ILogger<PropertyService>>();
+        var service = new PropertyService(db, mapper, logger);
+
+        // Act: query by parcel number (the format used by PropertyService)
+        var result = await service.GetPropertyByParcelAsync("1-0531-100-0001-000");
+
+        // Assert
+        result.Should().NotBeNull("seeded Benton parcel should be retrievable by parcel number");
+        result!.ParcelNumber.Should().Be("1-0531-100-0001-000");
+        result.Address.Should().Contain("Kennewick", "address should contain city");
+    }
+
+    // ── AC-3: PropertiesController can be constructed ─────────────────
+
+    [Fact]
+    public void AC3_PropertiesController_CanBeConstructed_WithPropertyService()
+    {
+        // Arrange
+        using var db = CreateTestDbContext();
+        var mapper = CreateMapper();
+        var serviceLogger = Mock.Of<ILogger<PropertyService>>();
+        var service = new PropertyService(db, mapper, serviceLogger);
+        var controllerLogger = Mock.Of<ILogger<PropertiesController>>();
+
+        // Act
+        var controller = new PropertiesController(service, controllerLogger);
+
+        // Assert
+        controller.Should().NotBeNull("PropertiesController should accept IPropertyService");
+    }
+
+    // ── AC-4: Controller returns 200 for seeded parcel ───────────────
+
+    [Fact]
+    public async Task AC4_GetPropertyByParcel_Returns200_ForSeededParcel()
+    {
+        // Arrange
+        await using var db = CreateTestDbContext();
+        await db.Database.EnsureCreatedAsync();
+        await DatabaseSeeder.SeedDossierRuntimeDataAsync(db);
+
+        var controller = CreatePropertiesController(db);
+
+        // Act
+        var actionResult = await controller.GetPropertyByParcel("1-0531-100-0001-000");
+
+        // Assert: should be 200 OK (not 500 from DI failure)
+        var result = actionResult.Result;
+        result.Should().BeOfType<OkObjectResult>(
+            "seeded Benton parcel should return 200 OK, not 500 from DI failure");
+    }
+
+    [Fact]
+    public async Task AC4_GetPropertyByParcel_Returns404_ForNonExistentParcel()
+    {
+        // Arrange
+        await using var db = CreateTestDbContext();
+        await db.Database.EnsureCreatedAsync();
+        await DatabaseSeeder.SeedDossierRuntimeDataAsync(db);
+
+        var controller = CreatePropertiesController(db);
+
+        // Act
+        var actionResult = await controller.GetPropertyByParcel("NONEXISTENT-999");
+
+        // Assert: should be 404 Not Found (not 500)
+        var result = actionResult.Result;
+        result.Should().BeOfType<NotFoundResult>(
+            "non-existent parcel should return 404, not 500");
+    }
+
+    // ── AC-5: Controller returns paginated results ───────────────────
+
+    [Fact]
+    public async Task AC5_GetProperties_ReturnsPaginatedResults_ForSeededData()
+    {
+        // Arrange
+        await using var db = CreateTestDbContext();
+        await db.Database.EnsureCreatedAsync();
+        await DatabaseSeeder.SeedDossierRuntimeDataAsync(db);
+
+        var controller = CreatePropertiesController(db);
+
+        // Act
+        var actionResult = await controller.GetProperties(page: 1, pageSize: 10);
+
+        // Assert: should return paginated results with seeded properties
+        var result = actionResult.Result;
+        result.Should().BeOfType<OkObjectResult>("paginated query should return 200 OK");
+
+        var okResult = (OkObjectResult)result!;
+        okResult.Value.Should().NotBeNull("response should contain paginated data");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static TerraFusionDbContext CreateTestDbContext()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var db = new TerraFusionDbContext(options, config);
+        db.Database.OpenConnection();
+        return db;
+    }
+
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<TerraFusionMappingProfile>();
+        });
+        return config.CreateMapper();
+    }
+
+    private static PropertiesController CreatePropertiesController(TerraFusionDbContext db)
+    {
+        var mapper = CreateMapper();
+        var serviceLogger = Mock.Of<ILogger<PropertyService>>();
+        var service = new PropertyService(db, mapper, serviceLogger);
+        var controllerLogger = Mock.Of<ILogger<PropertiesController>>();
+
+        var controller = new PropertiesController(service, controllerLogger);
+
+        // Set up HttpContext with Benton county claims
+        var claims = new List<Claim>
+        {
+            new("countyId", DatabaseSeeder.BentonCountyId.ToString()),
+            new("countyCode", "benton"),
+            new("perm", "read:properties")
+        };
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return controller;
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19D1PropertiesCountyIsolationIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx19D1PropertiesCountyIsolationIntegrationTests.cs
@@ -107,6 +107,7 @@ public sealed class R1Week5Cx19D1PropertiesCountyIsolationIntegrationTests
 public sealed class Cx19D1PropertiesIsolationFactory : WebApplicationFactory<ApiProgram>
 {
     private static readonly Guid BentonCountyId = Guid.Parse("d1a10000-0000-0000-0000-000000000001");
+    private static readonly Guid YakimaCountyId = Guid.Parse("d1a10000-0000-0000-0000-000000000002");
     private static readonly Guid BentonPropertyId = Guid.Parse("d1a10000-0000-0000-0000-0000000000a1");
     private static readonly Guid YakimaPropertyId = Guid.Parse("d1a10000-0000-0000-0000-0000000000b1");
     public static readonly Guid PluginAllPermsId = Guid.Parse("d1a10000-0000-0000-0000-0000000000f1");
@@ -145,10 +146,10 @@ public sealed class Cx19D1PropertiesIsolationFactory : WebApplicationFactory<Api
                 mock.Setup(m => m.GetPropertyByIdAsync(BentonPropertyId))
                     .ReturnsAsync(new PropertyDto
                     {
-                        Id = 1,
+                        Id = BentonPropertyId,
                         ParcelNumber = "CX19D1-BENTON-P1",
                         Address = "100 Benton Ave",
-                        CountyId = 1,
+                        CountyId = BentonCountyId,
                         CountyName = "Benton",
                         AssessedValue = 250000,
                         LandValue = 100000,
@@ -158,10 +159,10 @@ public sealed class Cx19D1PropertiesIsolationFactory : WebApplicationFactory<Api
                 mock.Setup(m => m.GetPropertyByIdAsync(YakimaPropertyId))
                     .ReturnsAsync(new PropertyDto
                     {
-                        Id = 2,
+                        Id = YakimaPropertyId,
                         ParcelNumber = "CX19D1-YAKIMA-P1",
                         Address = "200 Yakima Ave",
-                        CountyId = 2,
+                        CountyId = YakimaCountyId,
                         CountyName = "Yakima",
                         AssessedValue = 300000,
                         LandValue = 120000,
@@ -171,10 +172,10 @@ public sealed class Cx19D1PropertiesIsolationFactory : WebApplicationFactory<Api
                 mock.Setup(m => m.GetPropertyByIdAsync(BentonPropertyId, BentonCountyId))
                     .ReturnsAsync(new PropertyDto
                     {
-                        Id = 1,
+                        Id = BentonPropertyId,
                         ParcelNumber = "CX19D1-BENTON-P1",
                         Address = "100 Benton Ave",
-                        CountyId = 1,
+                        CountyId = BentonCountyId,
                         CountyName = "Benton",
                         AssessedValue = 250000,
                         LandValue = 100000,


### PR DESCRIPTION
## Summary

- Register `IPropertyService → PropertyService` in DI container — PropertiesController, SystemHub, and QuantumMetricsHub no longer throw HTTP 500 on service resolution
- Fix `int → Guid` type mismatches in `PropertyDto`, `ValuationDto`, `CreateValuationDto`, `ImportPropertyDto` to match entity types (`Property.Id`, `Valuation.Id`, etc. are all `Guid`)
- Fix `PropertiesController.CreateValuation` route parameter (`int id` → `Guid id`)
- Update CX19D1 county isolation tests for Guid DTO fields

## Root cause

`IPropertyService` was implemented and consumed by 3 classes, but never registered in the DI container (`Program.cs`). Additionally, all DTO types used `int` for ID fields while the EF entities use `Guid`, causing AutoMapper to throw `AutoMapperMappingException: Guid → Int32` at runtime.

## Evidence

Found during DX-02 runtime smoke (PR #569, Finding #1).

## Test plan

- [x] 6 DX-03 acceptance tests pass (AC-1 through AC-5)
- [x] Full lane gate: **2,100 passed, 0 failed, 0 skipped**
- [x] Pre-commit quality gate passed (UI token ratchet, lint-staged, dotnet format)
- [x] Pre-push quality gate passed (164 frontend tests, backend Release build, security, compliance)

Resolves #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Register the property service in the API DI container and align property/valuation DTOs and related endpoints/tests with Guid-based identifiers to resolve runtime failures.

Bug Fixes:
- Register IPropertyService with PropertyService implementation in the API DI container so property consumers no longer fail with 500 on service resolution.
- Correct Property and Valuation DTO ID fields and PropertiesController.CreateValuation route parameter from int to Guid to match entity types and prevent AutoMapper mapping errors.
- Update county isolation integration tests to use Guid IDs in PropertyDto test data consistent with the production model.

Tests:
- Add DX-03 PropertyService DI repair tests to verify service construction, seeded data access, controller wiring, and paginated property retrieval.