### PR TITLE
fix(auth): DX-04 add access:costforge gate to CountyAuditor role

### DIFF
--- a/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
+++ b/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
@@ -148,9 +148,14 @@ namespace TerraFusion.Core.Services
             break;
 
           case "CountyAuditor":
+            // DX-04: Add access:costforge gate so CountyAuditors can reach
+            // read-only CostForge endpoints they already have granular perms for.
+            // Without this, the controller-level [RequiresPermission("access:costforge")]
+            // blocks all requests before endpoint-specific checks run.  Issue #571.
             perms.UnionWith(new[]
             {
                             "read:dossier", "read:properties", "read:parcel",
+                            "access:costforge",
                             "read:cost-breakdown", "read:cost-comparison",
                             "read:cost-factors", "read:cost-matrix",
                             "read:system-status", "read:performance-metrics",

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX04CostForgeGateIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX04CostForgeGateIntegrationTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.R1Week5;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DX-04: CostForge gate integration tests
+//
+// Uses the CX-27 test infrastructure (Cx27PermClaimFactory) to exercise
+// CostForge endpoints through the REAL authorization pipeline with
+// CountyAuditor-equivalent permission sets.
+//
+// This verifies that the access:costforge gate + read perms reach the
+// endpoint, while read perms alone are blocked at the controller level.
+//
+// Filter: dotnet test --filter "FullyQualifiedName~DX04CostForgeGate"
+// ─────────────────────────────────────────────────────────────────────────────
+
+[Trait("Category", "R1Week5")]
+[Trait("Category", "DX04")]
+[Trait("Category", "Integration")]
+public sealed class DX04CostForgeGateIntegrationTests
+    : IClassFixture<Cx27PermClaimFactory>, IAsyncLifetime
+{
+    private readonly Cx27PermClaimFactory _factory;
+
+    public DX04CostForgeGateIntegrationTests(Cx27PermClaimFactory factory) => _factory = factory;
+
+    public Task InitializeAsync() => _factory.EnsureSeedDataAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // ── CountyAuditor perms (gate + read) → 200 on read endpoints ─────
+
+    [Fact]
+    public async Task CostForgeStatus_WithGateAndReadPerm_ReturnsSuccess()
+    {
+        using var client = CreateClient(
+            countyId: Cx27PermClaimFactory.BentonCountyId,
+            permClaims: ["access:costforge", "read:system-status"]);
+
+        var response = await client.GetAsync("/api/costforge/status");
+
+        // Endpoint may return 200 (with data) or 204 (empty) — both prove auth passed.
+        // The critical assertion: NOT 403 (gate blocked) and NOT 401 (unauthenticated).
+        response.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.OK, HttpStatusCode.NoContent },
+            "CountyAuditor with access:costforge + read:system-status should pass the controller gate");
+    }
+
+    [Fact]
+    public async Task CostForgeMetrics_WithGateAndReadPerm_ReturnsSuccess()
+    {
+        using var client = CreateClient(
+            countyId: Cx27PermClaimFactory.BentonCountyId,
+            permClaims: ["access:costforge", "read:performance-metrics"]);
+
+        var response = await client.GetAsync("/api/costforge/metrics");
+
+        response.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.OK, HttpStatusCode.NoContent },
+            "CountyAuditor with access:costforge + read:performance-metrics should pass the controller gate");
+    }
+
+    // ── Read perms WITHOUT gate → 403 (the DX-04 finding) ────────────
+
+    [Fact]
+    public async Task CostForgeStatus_WithReadPermOnly_Returns403()
+    {
+        using var client = CreateClient(
+            countyId: Cx27PermClaimFactory.BentonCountyId,
+            permClaims: ["read:system-status"]); // gate perm missing!
+
+        var response = await client.GetAsync("/api/costforge/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "Without access:costforge gate, controller-level check should block even with endpoint perms");
+    }
+
+    // ── Gate perm WITHOUT endpoint perm → 403 ────────────────────────
+
+    [Fact]
+    public async Task CostForgeCalculate_WithGateButNoWritePerm_Returns403()
+    {
+        using var client = CreateClient(
+            countyId: Cx27PermClaimFactory.BentonCountyId,
+            permClaims: ["access:costforge", "read:system-status"]); // no calculate:property-cost
+
+        var response = await client.PostAsync("/api/costforge/calculate",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "CountyAuditor should not be able to trigger cost calculations — lacks calculate:property-cost");
+    }
+
+    // ── No perms at all → 403 ─────────────────────────────────────────
+
+    [Fact]
+    public async Task CostForgeStatus_NoPerm_Returns403()
+    {
+        using var client = CreateClient(
+            countyId: Cx27PermClaimFactory.BentonCountyId,
+            permClaims: []);
+
+        var response = await client.GetAsync("/api/costforge/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private HttpClient CreateClient(Guid countyId, string[] permClaims)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(Cx27PermClaimFactory.AuthScheme, "token");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-UserId", "dx04-auditor");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyId", countyId.ToString());
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-CountyCode", "BENTON");
+
+        if (permClaims.Length > 0)
+            client.DefaultRequestHeaders.TryAddWithoutValidation("X-Test-Perms", string.Join(",", permClaims));
+
+        return client;
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX04CostForgePermissionNormalizationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/DX04CostForgePermissionNormalizationTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Reflection;
+using FluentAssertions;
+using TerraFusion.Core.Services;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.R1Week5;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DX-04: CostForge permission normalization tests
+//
+// Validates that the CountyAuditor role includes the access:costforge gate
+// permission so that read-only CostForge endpoints are reachable.
+//
+// Issue #571: CountyAuditor had granular read perms (read:cost-breakdown, etc.)
+// but lacked the controller-level access:costforge gate, causing 403 on ALL
+// CostForge routes before endpoint-level checks could run.
+//
+// These tests exercise:
+//   - The permission resolution matrix (unit: ResolvePermissionsForRoles)
+//   - Live CostForge endpoint access with CountyAuditor perms (integration via CX-27 infra)
+//   - Gate enforcement: read-only perms cannot access write endpoints
+//
+// Filter: dotnet test --filter "FullyQualifiedName~DX04"
+// ─────────────────────────────────────────────────────────────────────────────
+
+[Trait("Category", "R1Week5")]
+[Trait("Category", "DX04")]
+public sealed class DX04CostForgePermissionNormalizationTests
+{
+    // ── AC-1: CountyAuditor includes access:costforge gate ─────────────
+
+    [Fact]
+    public void CountyAuditor_Permissions_Include_AccessCostforge()
+    {
+        // Arrange: reflect into the private static method
+        var perms = ResolvePermissions("CountyAuditor");
+
+        // Assert
+        perms.Should().Contain("access:costforge",
+            "CountyAuditor needs the controller-level gate to reach read-only CostForge endpoints");
+    }
+
+    [Fact]
+    public void CountyAuditor_Permissions_Include_ReadOnly_CostForge_Endpoints()
+    {
+        var perms = ResolvePermissions("CountyAuditor");
+
+        perms.Should().Contain("read:cost-breakdown");
+        perms.Should().Contain("read:cost-comparison");
+        perms.Should().Contain("read:cost-factors");
+        perms.Should().Contain("read:cost-matrix");
+        perms.Should().Contain("read:system-status");
+        perms.Should().Contain("read:performance-metrics");
+    }
+
+    [Fact]
+    public void CountyAuditor_Permissions_Exclude_Write_CostForge_Endpoints()
+    {
+        var perms = ResolvePermissions("CountyAuditor");
+
+        perms.Should().NotContain("calculate:property-cost",
+            "CountyAuditor should not be able to trigger cost calculations");
+        perms.Should().NotContain("calculate:batch-valuation",
+            "CountyAuditor should not be able to trigger batch valuations");
+        perms.Should().NotContain("read:cost-forecast",
+            "Forecast is a PropertyAssessor+ permission");
+        perms.Should().NotContain("manage:ai-agents",
+            "Agent management is Administrator-only");
+        perms.Should().NotContain("sync:external-systems",
+            "External sync is Administrator-only");
+    }
+
+    // ── AC-2: GovernmentUser baseline does NOT include access:costforge ──
+
+    [Fact]
+    public void GovernmentUser_Permissions_Exclude_AccessCostforge()
+    {
+        var perms = ResolvePermissions("GovernmentUser");
+
+        perms.Should().NotContain("access:costforge",
+            "GovernmentUser is the base role — CostForge access requires at least CountyAuditor");
+    }
+
+    // ── AC-3: PropertyAssessor and Administrator include gate (regression) ──
+
+    [Theory]
+    [InlineData("PropertyAssessor")]
+    [InlineData("Administrator")]
+    public void PrivilegedRoles_Include_AccessCostforge(string role)
+    {
+        var perms = ResolvePermissions(role);
+
+        perms.Should().Contain("access:costforge",
+            $"{role} must retain the CostForge controller-level gate");
+    }
+
+    // ── AC-4: All four roles resolve without exception ──────────────────
+
+    [Theory]
+    [InlineData("GovernmentUser")]
+    [InlineData("CountyAuditor")]
+    [InlineData("PropertyAssessor")]
+    [InlineData("Administrator")]
+    public void AllRoles_Resolve_Successfully(string role)
+    {
+        var act = () => ResolvePermissions(role);
+
+        act.Should().NotThrow("permission resolution must not fail for known roles");
+    }
+
+    // ── AC-5: Unknown role produces empty permission set ────────────────
+
+    [Fact]
+    public void UnknownRole_Returns_Empty_Permissions()
+    {
+        var perms = ResolvePermissions("NonExistentRole");
+
+        perms.Should().BeEmpty("unknown roles should not receive any permissions");
+    }
+
+    // ── AC-6: CountyAuditor + GovernmentUser union is correct ───────────
+    // (a user with both roles should get CountyAuditor superset)
+
+    [Fact]
+    public void CountyAuditor_Is_Superset_Of_GovernmentUser()
+    {
+        var govPerms = ResolvePermissions("GovernmentUser");
+        var auditorPerms = ResolvePermissions("CountyAuditor");
+
+        // CountyAuditor should include every GovernmentUser permission plus more
+        foreach (var perm in govPerms)
+        {
+            auditorPerms.Should().Contain(perm,
+                $"CountyAuditor should inherit GovernmentUser permission '{perm}'");
+        }
+
+        // And it should have at least one extra
+        auditorPerms.Should().HaveCountGreaterThan(govPerms.Length,
+            "CountyAuditor should have more permissions than GovernmentUser");
+    }
+
+    // ── Reflection helper ──────────────────────────────────────────────
+
+    private static string[] ResolvePermissions(params string[] roles)
+    {
+        var method = typeof(AuthenticationService)
+            .GetMethod("ResolvePermissionsForRoles",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull("ResolvePermissionsForRoles must exist on AuthenticationService");
+
+        var result = method!.Invoke(null, new object[] { roles });
+        return result as string[] ?? Array.Empty<string>();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `access:costforge` to the `CountyAuditor` role in `AuthenticationService.ResolvePermissionsForRoles()`
- CountyAuditors already had granular read permissions (`read:cost-breakdown`, `read:cost-comparison`, etc.) but lacked the controller-level gate, causing **403 on ALL CostForge routes** before endpoint-specific checks could run
- Write operations (`calculate:property-cost`, `manage:ai-agents`, etc.) remain restricted to PropertyAssessor/Administrator roles

Fixes #571

## Files Changed
| File | Change |
|------|--------|
| `AuthenticationService.cs` | Add `access:costforge` to CountyAuditor role |
| `DX04CostForgePermissionNormalizationTests.cs` | **NEW** — 12 unit tests (permission matrix validation) |
| `DX04CostForgeGateIntegrationTests.cs` | **NEW** — 5 integration tests (live endpoint access via CX-27 infra) |

## Test Plan
- [x] 17 DX-04 tests pass (12 unit + 5 integration)
- [x] Full lane gate: 2,110 passed / 0 failed
- [x] Pre-commit + pre-push quality gates pass
- [x] Regression: PropertyAssessor and Administrator retain `access:costforge`
- [x] Regression: GovernmentUser (base role) does NOT get `access:costforge`
- [x] CountyAuditor write denial: `calculate:property-cost` still returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Grant CountyAuditor role access to CostForge while preserving existing permission boundaries and add regression coverage for the authorization behavior.

Bug Fixes:
- Allow CountyAuditor users to pass the CostForge controller gate by including the access:costforge permission in their resolved role permissions.

Tests:
- Add unit tests validating CostForge-related permissions for GovernmentUser, CountyAuditor, PropertyAssessor, and Administrator roles, including role unions and unknown-role behavior.
- Add integration tests exercising CostForge endpoints through the full authorization pipeline to verify correct behavior for various permission combinations.