### PR TITLE
feat(pilot): R1 execution spine wiring — real handler override + live backend dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,6 +302,8 @@ secrets/
 
 # Database files
 *.db
+*.db-wal
+*.db-shm
 *.sqlite
 *.sqlite3
 data/postgres*/

--- a/os-platform/core/pilot/dev-pilot-runtime.mjs
+++ b/os-platform/core/pilot/dev-pilot-runtime.mjs
@@ -457,6 +457,10 @@ async function getCompareRunner() {
       // Presence of TF_API_BASE_URL or TF_API_PORT signals a running backend.
       if (process.env.TF_API_BASE_URL || process.env.TF_API_PORT) {
         registerR1Handlers(runner, traceService);
+        const target = process.env.TF_API_BASE_URL || `http://localhost:${process.env.TF_API_PORT}`;
+        console.log(`[pilot] R1 real handlers active → backend ${target}`);
+      } else {
+        console.log("[pilot] R1 real handlers inactive (no TF_API_BASE_URL/TF_API_PORT) → canned stubs");
       }
       return runner;
     })();

--- a/os-platform/core/pilot/dev-pilot-runtime.mjs
+++ b/os-platform/core/pilot/dev-pilot-runtime.mjs
@@ -4,7 +4,8 @@ import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ToolRegistry, ToolRunner, registerPhase84Handlers } from "./index.js";
+import { ToolRegistry, ToolRunner, registerPhase84Handlers, registerR1Handlers } from "./index.js";
+import { traceService } from "../trace/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -452,6 +453,11 @@ async function getCompareRunner() {
       await registry.initialize(path.resolve(REPO_ROOT, "tools/registry/terrapilot.tools.json"));
       const runner = new ToolRunner({ registry });
       registerPhase84Handlers(runner);
+      // Register R1 real handlers when backend is available.
+      // Presence of TF_API_BASE_URL or TF_API_PORT signals a running backend.
+      if (process.env.TF_API_BASE_URL || process.env.TF_API_PORT) {
+        registerR1Handlers(runner, traceService);
+      }
       return runner;
     })();
   }

--- a/os-platform/core/tests/r1-boot-wiring.test.mjs
+++ b/os-platform/core/tests/r1-boot-wiring.test.mjs
@@ -1,0 +1,202 @@
+/**
+ * TerraFusion OS – R1 Boot Wiring Test
+ *
+ * Validates that registerR1Handlers properly overrides canned Phase 8.4 stubs.
+ * Ensures the execution spine is wired: when real handlers are registered,
+ * they replace the canned handlers for the same toolIds.
+ *
+ * This is a critical integration test for AC-1/AC-4 (governed execution path).
+ */
+
+import assert from 'node:assert/strict';
+import { before, afterEach, describe, it } from 'node:test';
+
+let ToolRegistry,
+  ToolRunner,
+  registerPhase84Handlers,
+  registerR1Handlers,
+  TraceService,
+  traceService;
+
+before(async () => {
+  const pilotModule = await import('../pilot/index.js');
+  const traceModule = await import('../trace/index.js');
+
+  const pilot = pilotModule.default || pilotModule;
+  const trace = traceModule.default || traceModule;
+
+  ToolRegistry = pilot.ToolRegistry;
+  ToolRunner = pilot.ToolRunner;
+  registerPhase84Handlers = pilot.registerPhase84Handlers;
+  registerR1Handlers = pilot.registerR1Handlers;
+  TraceService = trace.TraceService;
+  traceService = trace.traceService;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(data, status = 200) {
+  globalThis.fetch = async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    text: async () => JSON.stringify(data),
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const R1_MVP_TOOL_IDS = [
+  'run_valuation_model',
+  'explain_value_change',
+  'route_to_parcel',
+  'search_trace_by_correlation',
+  'summarize_levy_rate_components',
+];
+
+const R1_WEEK3_TOOL_IDS = [
+  'explain_model_inputs',
+  'compare_assessed_value_history',
+  'summarize_parcel_casefile',
+  'add_dossier_note',
+  'query_parcel_layers',
+];
+
+// ══════════════════════════════════════════════════════════════════════
+// Registration Tests
+// ══════════════════════════════════════════════════════════════════════
+
+describe('R1 Boot Wiring', () => {
+  it('registerR1Handlers registers all 10 real handlers', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+
+    // First register canned handlers (baseline)
+    registerPhase84Handlers(runner);
+    const cannedHandlers = runner.getRegisteredHandlers();
+
+    // Now override with R1 real handlers
+    registerR1Handlers(runner, traceService);
+    const realHandlers = runner.getRegisteredHandlers();
+
+    // All 10 R1 tool IDs should be registered
+    for (const toolId of [...R1_MVP_TOOL_IDS, ...R1_WEEK3_TOOL_IDS]) {
+      assert.ok(
+        realHandlers.includes(toolId),
+        `Expected ${toolId} to be registered after registerR1Handlers`
+      );
+    }
+  });
+
+  it('R1 real handlers override canned stubs (run_valuation_model calls backend)', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+
+    registerPhase84Handlers(runner);
+    registerR1Handlers(runner, traceService);
+
+    // Mock backend response for CostForge
+    mockFetch({
+      estimatedValue: 250000,
+      confidence: 0.88,
+      components: { land: 100000, improvements: 150000 },
+    });
+
+    const result = await runner.execute({
+      toolId: 'run_valuation_model',
+      params: {
+        county: 'benton',
+        parcelId: 'R-001',
+        taxYear: 2026,
+      },
+      context: {
+        countyId: 'benton',
+        userId: 'test-user',
+        roles: ['appraiser'],
+        mode: 'pilot',
+        confirmation: true,
+        reasonCode: 'annual_certification',
+      },
+    });
+
+    assert.ok(result.ok, `Expected ok=true, got error: ${result.error}`);
+    assert.equal(result.result.estimatedValue, 250000);
+    assert.equal(result.result.confidence, 0.88);
+  });
+
+  it('search_trace_by_correlation uses real TraceService', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const localTrace = new TraceService();
+    const runner = new ToolRunner({ registry, trace: localTrace });
+
+    registerR1Handlers(runner, localTrace);
+
+    // Emit a test trace event so there's data to find
+    const testCorrelationId = 'test-corr-123';
+    localTrace.emitWithPiiHandling(
+      {
+        type: 'tool_invoked',
+        toolId: 'test_tool',
+        correlationId: testCorrelationId,
+        context: { countyId: 'benton', userId: 'test', roles: ['appraiser'], mode: 'pilot' },
+        summary: 'Test event',
+      },
+      'none'
+    );
+
+    const result = await runner.execute({
+      toolId: 'search_trace_by_correlation',
+      params: { county: 'benton', correlationId: testCorrelationId },
+      context: {
+        countyId: 'benton',
+        userId: 'test-user',
+        roles: ['administrator'],
+        mode: 'pilot',
+      },
+    });
+
+    assert.ok(result.ok, `Expected ok=true, got error: ${result.error}`);
+    assert.ok(result.result.found, 'Expected found=true for matching correlationId');
+    assert.ok(result.result.events.length > 0, 'Expected at least one event');
+  });
+
+  it('summarize_levy_rate_components calls real backend', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+
+    registerR1Handlers(runner, traceService);
+
+    mockFetch({
+      components: [
+        { name: 'State School', rate: 3.12 },
+        { name: 'Local School', rate: 2.45 },
+        { name: 'County General', rate: 1.85 },
+      ],
+      totalRate: 7.42,
+    });
+
+    const result = await runner.execute({
+      toolId: 'summarize_levy_rate_components',
+      params: { county: 'benton', taxYear: 2026 },
+      context: {
+        countyId: 'benton',
+        userId: 'test-user',
+        roles: ['appraiser'],
+        mode: 'muse',
+      },
+    });
+
+    assert.ok(result.ok, `Expected ok=true, got error: ${result.error}`);
+    assert.equal(result.result.totalRate, 7.42);
+    assert.equal(result.result.components.length, 3);
+    assert.ok(result.result.explanation.includes('2026'));
+  });
+});

--- a/os-platform/core/tests/r1-live-smoke.test.mjs
+++ b/os-platform/core/tests/r1-live-smoke.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * TerraFusion OS – R1 Live Smoke Test
+ *
+ * Narrow end-to-end smoke against a running backend (port 5046).
+ * Proves R1 real handlers dispatch to real endpoints — NOT canned stubs.
+ *
+ * Evidence model:
+ *   - run_valuation_model: Handler calls POST /api/costforge/calculate.
+ *     Backend returns 401/403 (auth required). Canned stub would return fake data.
+ *     A backend-sourced error proves real dispatch.
+ *   - search_trace_by_correlation: Uses real TraceService in-process. Full e2e.
+ *   - summarize_levy_rate_components: Handler calls POST /api/levy-calculation/calculate-rate.
+ *     Backend returns 401/403. Canned stub would return hardcoded rates.
+ *     A backend-sourced error proves real dispatch.
+ *
+ * Requires:
+ *   TF_API_PORT=5046 (or backend running on 5046)
+ *   Backend started: dotnet run --project backend/src/TerraFusion.API
+ *
+ * Run:
+ *   TF_API_PORT=5046 node --test os-platform/core/tests/r1-live-smoke.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+// Force backend target — this test MUST hit the real backend.
+process.env.TF_API_PORT = process.env.TF_API_PORT || '5046';
+
+let ToolRegistry, ToolRunner, registerPhase84Handlers, registerR1Handlers;
+let TraceService, traceService;
+
+before(async () => {
+  const pilotMod = await import('../pilot/index.js');
+  const traceMod = await import('../trace/index.js');
+
+  const pilot = pilotMod.default || pilotMod;
+  const trace = traceMod.default || traceMod;
+
+  ToolRegistry = pilot.ToolRegistry;
+  ToolRunner = pilot.ToolRunner;
+  registerPhase84Handlers = pilot.registerPhase84Handlers;
+  registerR1Handlers = pilot.registerR1Handlers;
+  TraceService = trace.TraceService;
+  traceService = trace.traceService;
+});
+
+// ── Preflight: verify backend is reachable ──────────────────────────
+
+describe('R1 Live Smoke (backend on :5046)', () => {
+  it('preflight: backend /health responds', async () => {
+    const port = process.env.TF_API_PORT || '5046';
+    const res = await fetch(`http://localhost:${port}/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    assert.equal(res.status, 200, 'Backend /health must return 200');
+    const body = await res.json();
+    assert.equal(body.status, 'Healthy');
+  });
+
+  // ── Smoke 1: run_valuation_model → real backend dispatch ────────
+
+  it('run_valuation_model dispatches to real backend (not canned)', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+
+    // Register canned first, then R1 real handlers (production order)
+    registerPhase84Handlers(runner);
+    registerR1Handlers(runner, traceService);
+
+    const result = await runner.execute({
+      toolId: 'run_valuation_model',
+      params: {
+        county: 'benton',
+        parcelId: 'R-001',
+        taxYear: 2026,
+      },
+      context: {
+        countyId: 'benton',
+        userId: 'smoke-test',
+        roles: ['appraiser'],
+        mode: 'pilot',
+        confirmation: true,
+        reasonCode: 'annual_certification',
+      },
+    });
+
+    // Real handler hits backend → backend returns 401/403 (no auth token).
+    // Canned handler would return ok=true with fake estimatedValue.
+    // An error containing "Backend" or status code proves real dispatch.
+    assert.equal(result.ok, false, 'Expected error (backend auth required)');
+    assert.ok(
+      result.error && (result.error.includes('Backend') || result.error.includes('401') || result.error.includes('403')),
+      `Error should reference backend HTTP status, got: ${result.error}`
+    );
+    console.log(`  ✅ run_valuation_model dispatched to real backend → ${result.error}`);
+  });
+
+  // ── Smoke 2: search_trace_by_correlation → real TraceService e2e ─
+
+  it('search_trace_by_correlation full e2e via real TraceService', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const localTrace = new TraceService();
+    const runner = new ToolRunner({ registry, trace: localTrace });
+
+    registerR1Handlers(runner, localTrace);
+
+    // Emit a real trace event
+    const corrId = `smoke-${Date.now()}`;
+    localTrace.emitWithPiiHandling(
+      {
+        type: 'tool_invoked',
+        toolId: 'run_valuation_model',
+        correlationId: corrId,
+        context: { countyId: 'benton', userId: 'smoke', roles: ['appraiser'], mode: 'pilot' },
+        summary: 'Smoke test trace event',
+      },
+      'none'
+    );
+
+    const result = await runner.execute({
+      toolId: 'search_trace_by_correlation',
+      params: { county: 'benton', correlationId: corrId },
+      context: {
+        countyId: 'benton',
+        userId: 'smoke-test',
+        roles: ['administrator'],
+        mode: 'pilot',
+      },
+    });
+
+    assert.ok(result.ok, `Expected ok=true, got error: ${result.error}`);
+    assert.ok(result.result.found, 'Expected found=true');
+    assert.ok(result.result.events.length >= 1, 'Expected at least 1 trace event');
+    assert.equal(result.result.events[0].type, 'tool_invoked');
+    assert.equal(result.result.events[0].toolId, 'run_valuation_model');
+    console.log(`  ✅ search_trace_by_correlation returned ${result.result.events.length} event(s) for ${corrId}`);
+  });
+
+  // ── Smoke 3: summarize_levy_rate_components → real backend dispatch
+
+  it('summarize_levy_rate_components dispatches to real backend (not canned)', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+
+    registerPhase84Handlers(runner);
+    registerR1Handlers(runner, traceService);
+
+    const result = await runner.execute({
+      toolId: 'summarize_levy_rate_components',
+      params: { county: 'benton', taxYear: 2026 },
+      context: {
+        countyId: 'benton',
+        userId: 'smoke-test',
+        roles: ['appraiser'],
+        mode: 'muse',
+      },
+    });
+
+    // Real handler hits backend → backend returns 401/403 (no auth token).
+    // Canned handler would return ok=true with hardcoded rates [3.12, 2.45, 1.85].
+    // An error containing "Backend" or status code proves real dispatch.
+    assert.equal(result.ok, false, 'Expected error (backend auth required)');
+    assert.ok(
+      result.error && (result.error.includes('Backend') || result.error.includes('401') || result.error.includes('403')),
+      `Error should reference backend HTTP status, got: ${result.error}`
+    );
+    console.log(`  ✅ summarize_levy_rate_components dispatched to real backend → ${result.error}`);
+  });
+});


### PR DESCRIPTION
## Scope

R1 execution spine wiring only. Wires the 10 real R1 handlers into the pilot runtime boot sequence, replacing canned Phase 8.4 stubs for the same toolIds.

## What changed

| File | Change |
|------|--------|
| `os-platform/core/pilot/dev-pilot-runtime.mjs` | Conditional `registerR1Handlers()` call + startup logging |
| `os-platform/core/tests/r1-boot-wiring.test.mjs` | 4 unit tests (mocked fetch, registration + override proof) |
| `os-platform/core/tests/r1-live-smoke.test.mjs` | 4 live smoke tests (real backend on :5046) |

**Lane-pure:** only `os-platform/core/**` touched. No forbidden paths.

## Proof

### Live smoke evidence (backend on :5046)

| Tool | Result | What it proves |
|------|--------|----------------|
| `/health` | `200 Healthy` | Backend reachable |
| `run_valuation_model` | `Backend 401: Unauthorized` | Real dispatch to `/api/costforge/calculate` (canned stub returns fake data) |
| `search_trace_by_correlation` | 1 real trace event returned | **Fully backend-functional** via real TraceService |
| `summarize_levy_rate_components` | `Backend 401: Unauthorized` | Real dispatch to `/api/levy-calculation/calculate-rate` (canned stub returns hardcoded rates) |

### Gate results

- `pnpm run type-check` — clean
- `phase83-tools` — 32/32 pass
- `r1-boot-wiring` — 4/4 pass
- `r1-live-smoke` — 4/4 pass
- Pre-push quality gate — unit tests 164/164, backend build 0 errors

### Startup logging (Risk 1 mitigation)

```
[pilot] R1 real handlers active → backend http://localhost:5046
[pilot] R1 real handlers inactive (no TF_API_BASE_URL/TF_API_PORT) → canned stubs
```

## Current state

- `run_valuation_model` and `summarize_levy_rate_components` are now **backend-reachable**
- `search_trace_by_correlation` is now **fully backend-functional**
- Remaining work is **auth/role enablement for full successful protected-tool execution**, not spine wiring

## Known limitation

Protected endpoints (CostForge, Levy) currently require valid auth/role context for full 200-path completion. The 401 results prove real dispatch; full auth plumbing is a **next lane**.

## Next lane

Auth/role enablement for the execution spine runtime path:
- Dev-token or pilot-auth plumbing for R1 tool execution
- Permission alignment for CostForge (`calculate:property-cost`) and Levy (`LevyClerk,Assessor,Admin` roles)

---

AI-Collaboration: GitHub Copilot
Government: FISMA compliance