### PR TITLE
fix(dx03): resolve post-merge Guid mapping contract drift in PropertyService

### DIFF
--- a/backend/src/TerraFusion.Core/Services/PropertyService.cs
+++ b/backend/src/TerraFusion.Core/Services/PropertyService.cs
@@ -232,14 +232,14 @@ public class PropertyService : IPropertyService
     {
         return new PropertyDto
         {
-            Id = MapGuidToInt(property.Id),
+            Id = property.Id,
             ParcelNumber = property.ParcelNumber,
             Address = property.Address,
             OwnerName = property.OwnerName,
             AssessedValue = property.AssessedValue,
             LandValue = property.LandValue,
             ImprovementValue = property.ImprovementValue,
-            CountyId = MapGuidToInt(property.CountyId),
+            CountyId = property.CountyId,
             CountyName = property.County?.Name ?? string.Empty,
             CreatedAt = property.CreatedAt,
             UpdatedAt = property.UpdatedAt
@@ -250,9 +250,9 @@ public class PropertyService : IPropertyService
     {
         return new ValuationDto
         {
-            Id = MapGuidToInt(valuation.Id),
-            PropertyId = MapGuidToInt(valuation.PropertyId),
-            AIModelId = MapGuidToInt(valuation.AIModelId),
+            Id = valuation.Id,
+            PropertyId = valuation.PropertyId,
+            AIModelId = valuation.AIModelId,
             AIModelName = valuation.AIModel?.Name ?? string.Empty,
             EstimatedValue = valuation.EstimatedValue,
             Confidence = valuation.Confidence,
@@ -262,10 +262,5 @@ public class PropertyService : IPropertyService
             ReviewedAt = valuation.ReviewedAt,
             ReviewedBy = valuation.ReviewedBy
         };
-    }
-
-    private static int MapGuidToInt(Guid value)
-    {
-        return BitConverter.ToInt32(value.ToByteArray(), 0);
     }
 }


### PR DESCRIPTION
## Summary
Post-merge validation on 1/integration at 004b17af89e981abcf6ea4add9bcf91c4dbf588 found a compile-time contract drift introduced by overlapping DX-03 lineage (#574 + prior #575).

This PR applies a narrow backend-only hotfix:
- aligns PropertyService DTO mapping with current Guid DTO contract
- removes stale MapGuidToInt(Guid) conversions for DTO fields
- removes now-unused helper

## Compile Error Repro (pre-fix)
dotnet build .\\TerraFusion.sln failed with CS0029 in ackend/src/TerraFusion.Core/Services/PropertyService.cs:
- Cannot implicitly convert type 'int' to 'System.Guid' at lines mapping Id, CountyId, PropertyId, AIModelId

## Fix
Updated ackend/src/TerraFusion.Core/Services/PropertyService.cs:
- PropertyDto.Id = property.Id
- PropertyDto.CountyId = property.CountyId
- ValuationDto.Id = valuation.Id
- ValuationDto.PropertyId = valuation.PropertyId
- ValuationDto.AIModelId = valuation.AIModelId
- deleted MapGuidToInt(Guid) helper

## Verification
On branch copilot/dx03-postmerge-guid-contract-hotfix:
- git fsck --no-reflogs --connectivity-only (connectivity clean)
- dotnet build .\\TerraFusion.sln ✅
- dotnet test .\\tests\\TerraFusion.Unit.Tests\\TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~RealLogin_Assessor_GetProperties_Returns200_Not500" --no-build ✅
- dotnet test .\\tests\\TerraFusion.Unit.Tests\\TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~RealLogin_Assessor_GetPropertiesStats_Returns200_Not500" --no-build ✅

## Scope
Backend-only, one-file hotfix for post-merge DX-03 contract drift.

## Summary by Sourcery

Align PropertyService DTO mappings with Guid-based identifier contracts to fix a post-merge compile-time type mismatch.

Bug Fixes:
- Correct PropertyDto and ValuationDto identifier mappings to use Guid fields directly instead of int conversions, resolving compile errors and contract drift.

Enhancements:
- Remove the obsolete Guid-to-int mapping helper now that DTO identifiers use Guid values consistently.