### PR TITLE
feat(pilot): R1 payload shaping — CostForge + Levy contract alignment

### DIFF
--- a/os-platform/core/pilot/handlers.real.js
+++ b/os-platform/core/pilot/handlers.real.js
@@ -49,10 +49,10 @@ const runValuationModelHandler = async (params, context, _tool) => {
     assertCountyMatch(params.county, context.countyId);
     const { token } = await (0, pilotAuth_js_1.acquirePilotToken)();
     const raw = await (0, backendClient_js_1.backendPost)('/api/costforge/calculate', {
-        parcelId: params.parcelId,
-        taxYear: params.taxYear,
-        modelType: params.modelType ?? 'cost',
-        countyId: context.countyId,
+        parcelNumber: params.parcelId,
+        countyCode: params.county,
+        region: params.county,
+        buildingType: params.modelType ?? 'cost',
     }, { token });
     const data = (0, backendClient_js_1.unwrapBackend)(raw, 'Valuation model failed');
     return {
@@ -60,7 +60,7 @@ const runValuationModelHandler = async (params, context, _tool) => {
         taxYear: params.taxYear,
         modelType: params.modelType ?? 'cost',
         estimatedValue: data.estimatedValue ?? 0,
-        confidence: data.confidence ?? 0,
+        confidence: data.confidence ?? data.confidenceScore ?? 0,
         components: data.components ?? data.costBreakdown ?? {},
     };
 };
@@ -149,24 +149,27 @@ function createSearchTraceHandler(traceService) {
 const summarizeLevyRateRealHandler = async (params, context, _tool) => {
     assertCountyMatch(params.county, context.countyId);
     const { token } = await (0, pilotAuth_js_1.acquirePilotToken)();
-    const raw = await (0, backendClient_js_1.backendPost)('/api/levy-calculation/calculate-rate', {
-        countyId: context.countyId,
-        taxYear: params.taxYear,
-        districtCode: params.districtCode,
-    }, { token });
-    const data = (0, backendClient_js_1.unwrapBackend)(raw, 'Levy rate calculation failed');
-    // Normalize backend response — backend may return different shapes
-    const components = data.components
-        ?? data.districtRates?.map(d => ({ name: d.district, rate: d.rate }))
-        ?? [];
-    const totalRate = data.totalRate
-        ?? data.levyRate
-        ?? components.reduce((sum, c) => sum + c.rate, 0);
+    // Use GET /history which returns persisted levy data — matches "summarize" semantics
+    // (POST /calculate-rate needs budgetAmount+assessedValue which this tool doesn't collect)
+    const qs = new URLSearchParams();
+    qs.set('taxYear', String(params.taxYear));
+    if (params.districtCode)
+        qs.set('districtId', params.districtCode);
+    const raw = await (0, backendClient_js_1.backendGet)(`/api/levy-calculation/history?${qs.toString()}`, { token });
+    const records = (0, backendClient_js_1.unwrapBackend)(raw, 'Levy history lookup failed');
+    // Normalize into the expected component shape
+    const components = (Array.isArray(records) ? records : []).map(r => ({
+        name: r.taxingDistrict || r.purpose || 'unknown',
+        rate: r.taxRate ?? 0,
+    }));
+    const totalRate = components.reduce((sum, c) => sum + c.rate, 0);
     const scopeNote = params.districtCode ? ` District ${params.districtCode} applied.` : '';
     return {
         components: components.sort((a, b) => b.rate - a.rate),
         totalRate: Math.round(totalRate * 100) / 100,
-        explanation: `Levy components for ${params.taxYear} total $${totalRate.toFixed(2)} per $1,000 assessed value.${scopeNote}`,
+        explanation: components.length > 0
+            ? `Levy components for ${params.taxYear} total $${totalRate.toFixed(2)} per $1,000 assessed value.${scopeNote}`
+            : `No levy records found for ${params.taxYear}.${scopeNote} Use calculate-rate to model new scenarios.`,
     };
 };
 exports.summarizeLevyRateRealHandler = summarizeLevyRateRealHandler;

--- a/os-platform/core/pilot/handlers.real.ts
+++ b/os-platform/core/pilot/handlers.real.ts
@@ -146,13 +146,14 @@ export const runValuationModelHandler: ToolHandler<
   const raw = await backendPost<{
     estimatedValue?: number;
     confidence?: number;
+    confidenceScore?: number;
     components?: Record<string, number>;
     costBreakdown?: Record<string, number>;
   }>('/api/costforge/calculate', {
-    parcelId: params.parcelId,
-    taxYear: params.taxYear,
-    modelType: params.modelType ?? 'cost',
-    countyId: context.countyId,
+    parcelNumber: params.parcelId,
+    countyCode: params.county,
+    region: params.county,
+    buildingType: params.modelType ?? 'cost',
   }, { token });
   const data = unwrapBackend(raw, 'Valuation model failed');
 
@@ -161,7 +162,7 @@ export const runValuationModelHandler: ToolHandler<
     taxYear: params.taxYear,
     modelType: params.modelType ?? 'cost',
     estimatedValue: data.estimatedValue ?? 0,
-    confidence: data.confidence ?? 0,
+    confidence: data.confidence ?? data.confidenceScore ?? 0,
     components: data.components ?? data.costBreakdown ?? {},
   };
 };
@@ -278,32 +279,33 @@ export const summarizeLevyRateRealHandler: ToolHandler<
   assertCountyMatch(params.county, context.countyId);
 
   const { token } = await acquirePilotToken();
-  const raw = await backendPost<{
-    components?: Array<{ name: string; rate: number }>;
-    levyRate?: number;
-    totalRate?: number;
-    districtRates?: Array<{ district: string; rate: number }>;
-  }>('/api/levy-calculation/calculate-rate', {
-    countyId: context.countyId,
-    taxYear: params.taxYear,
-    districtCode: params.districtCode,
-  }, { token });
-  const data = unwrapBackend(raw, 'Levy rate calculation failed');
 
-  // Normalize backend response — backend may return different shapes
-  const components = data.components
-    ?? data.districtRates?.map(d => ({ name: d.district, rate: d.rate }))
-    ?? [];
-  const totalRate = data.totalRate
-    ?? data.levyRate
-    ?? components.reduce((sum: number, c: { rate: number }) => sum + c.rate, 0);
+  // Use GET /history which returns persisted levy data — matches "summarize" semantics
+  // (POST /calculate-rate needs budgetAmount+assessedValue which this tool doesn't collect)
+  const qs = new URLSearchParams();
+  qs.set('taxYear', String(params.taxYear));
+  if (params.districtCode) qs.set('districtId', params.districtCode);
+
+  const raw = await backendGet<
+    Array<{ taxingDistrict: string; taxRate: number; levyAmount: number; taxYear: number; purpose: string }>
+  >(`/api/levy-calculation/history?${qs.toString()}`, { token });
+  const records = unwrapBackend(raw, 'Levy history lookup failed');
+
+  // Normalize into the expected component shape
+  const components = (Array.isArray(records) ? records : []).map(r => ({
+    name: r.taxingDistrict || r.purpose || 'unknown',
+    rate: r.taxRate ?? 0,
+  }));
+  const totalRate = components.reduce((sum, c) => sum + c.rate, 0);
 
   const scopeNote = params.districtCode ? ` District ${params.districtCode} applied.` : '';
 
   return {
-    components: components.sort((a: { rate: number }, b: { rate: number }) => b.rate - a.rate),
+    components: components.sort((a, b) => b.rate - a.rate),
     totalRate: Math.round(totalRate * 100) / 100,
-    explanation: `Levy components for ${params.taxYear} total $${totalRate.toFixed(2)} per $1,000 assessed value.${scopeNote}`,
+    explanation: components.length > 0
+      ? `Levy components for ${params.taxYear} total $${totalRate.toFixed(2)} per $1,000 assessed value.${scopeNote}`
+      : `No levy records found for ${params.taxYear}.${scopeNote} Use calculate-rate to model new scenarios.`,
   };
 };
 

--- a/os-platform/core/tests/r1-payload-smoke.test.mjs
+++ b/os-platform/core/tests/r1-payload-smoke.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * TerraFusion OS – R1 Payload Shaping Smoke Test
+ *
+ * Proves that R1 handler payloads now match backend request contracts:
+ *   1. run_valuation_model sends correct PropertyCostCalculationRequest shape
+ *      → expect 200 or 404 (parcel not in DB) — NOT 400 (validation failure)
+ *   2. summarize_levy_rate_components calls GET /history
+ *      → expect 200 with array (possibly empty) — NOT 400/403
+ *   3. Direct HTTP: shaped CostForge payload no longer fails model validation
+ *   4. Direct HTTP: levy history returns 200 with array
+ *
+ * Requires:
+ *   TF_API_PORT=5046 (or backend running on 5046)
+ *
+ * Run:
+ *   TF_API_PORT=5046 node --test os-platform/core/tests/r1-payload-smoke.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+process.env.TF_API_PORT = process.env.TF_API_PORT || '5046';
+
+let ToolRegistry, ToolRunner, registerPhase84Handlers, registerR1Handlers;
+let acquirePilotToken, clearPilotToken, backendPost, backendGet;
+let TraceService, traceService;
+
+before(async () => {
+  const pilotMod = await import('../pilot/index.js');
+  const traceMod = await import('../trace/index.js');
+  const pilot = pilotMod.default || pilotMod;
+  const trace = traceMod.default || traceMod;
+
+  ToolRegistry = pilot.ToolRegistry;
+  ToolRunner = pilot.ToolRunner;
+  registerPhase84Handlers = pilot.registerPhase84Handlers;
+  registerR1Handlers = pilot.registerR1Handlers;
+  acquirePilotToken = pilot.acquirePilotToken;
+  clearPilotToken = pilot.clearPilotToken;
+  backendPost = pilot.backendPost;
+  backendGet = pilot.backendGet;
+  TraceService = trace.TraceService;
+  traceService = trace.traceService;
+});
+
+describe('R1 Payload Shaping (backend on :5046)', () => {
+
+  // ── Direct HTTP: CostForge shaped payload passes validation ───────
+
+  it('shaped CostForge payload passes validation (no 400)', async () => {
+    const { token } = await acquirePilotToken();
+
+    // This is the shaped payload: parcelNumber + countyCode (not parcelId + countyId)
+    const result = await backendPost('/api/costforge/calculate', {
+      parcelNumber: 'R-SMOKE-001',
+      countyCode: 'benton',
+      region: 'benton',
+      buildingType: 'cost',
+    }, { token });
+
+    // Should NOT be 400 (model validation). Expect 200 or 404 (parcel not found).
+    assert.notEqual(result.status, 400, `Shaped payload should not trigger validation 400, got: ${result.raw ?? result.error}`);
+    assert.notEqual(result.status, 401, 'Auth should pass');
+    assert.notEqual(result.status, 403, 'Authz should pass');
+
+    // 404 is the expected response when parcel doesn't exist in DB
+    if (result.status === 404) {
+      console.log('  ✅ CostForge: 404 (parcel not in DB) — validation passed, auth passed');
+    } else if (result.ok) {
+      console.log(`  ✅ CostForge: 200 — full success`);
+    } else {
+      console.log(`  ⚠️  CostForge: ${result.status} — ${result.error}`);
+    }
+  });
+
+  // ── Direct HTTP: Levy history returns 200 ─────────────────────────
+
+  it('levy history endpoint returns 200 with array', async () => {
+    const { token } = await acquirePilotToken();
+
+    const result = await backendGet('/api/levy-calculation/history?taxYear=2025', { token });
+
+    assert.equal(result.ok, true, `Levy history should return 200, got ${result.status}: ${result.error}`);
+    assert.ok(Array.isArray(result.data), 'Levy history should return an array');
+    console.log(`  ✅ Levy history: 200 with ${result.data.length} records`);
+  });
+
+  // ── Handler: run_valuation_model no longer 400 ────────────────────
+
+  it('run_valuation_model handler gets 200 or 404 (not 400)', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+    registerPhase84Handlers(runner);
+    registerR1Handlers(runner, traceService);
+
+    const result = await runner.execute({
+      toolId: 'run_valuation_model',
+      params: {
+        county: 'benton',
+        parcelId: 'R-SMOKE-001',
+        taxYear: 2026,
+      },
+      context: {
+        countyId: 'benton',
+        userId: 'payload-smoke-test',
+        roles: ['appraiser'],
+        mode: 'pilot',
+        confirmation: true,
+        reasonCode: 'annual_certification',
+      },
+    });
+
+    if (result.ok === false) {
+      // Should be a "not found" error, not a validation error
+      assert.ok(
+        !result.error.includes('400') && !result.error.includes('Bad Request'),
+        `Payload shaping should eliminate 400 validation errors: ${result.error}`
+      );
+      // 404 "not found" is the expected correct domain response
+      const is404 = result.error.includes('404') || result.error.toLowerCase().includes('not found');
+      console.log(`  ✅ run_valuation_model: ${is404 ? '404 (parcel not in DB)' : result.error} — validation passed`);
+    } else {
+      console.log(`  ✅ run_valuation_model: 200 — estimatedValue=${result.result.estimatedValue}`);
+    }
+  });
+
+  // ── Handler: summarize_levy_rate_components returns success ────────
+
+  it('summarize_levy_rate_components handler returns 200', async () => {
+    const registry = new ToolRegistry();
+    await registry.initialize();
+    const runner = new ToolRunner({ registry });
+    registerPhase84Handlers(runner);
+    registerR1Handlers(runner, traceService);
+
+    const result = await runner.execute({
+      toolId: 'summarize_levy_rate_components',
+      params: { county: 'benton', taxYear: 2025 },
+      context: {
+        countyId: 'benton',
+        userId: 'payload-smoke-test',
+        roles: ['appraiser'],
+        mode: 'muse',
+      },
+    });
+
+    assert.equal(result.ok, true, `Levy handler should succeed, got error: ${result.error}`);
+    assert.ok(Array.isArray(result.result.components), 'components should be an array');
+    assert.equal(typeof result.result.totalRate, 'number', 'totalRate should be a number');
+    assert.ok(result.result.explanation, 'explanation should be non-empty');
+    console.log(`  ✅ summarize_levy: 200 — ${result.result.components.length} components, totalRate=${result.result.totalRate}`);
+    console.log(`     explanation: "${result.result.explanation}"`);
+  });
+
+  // ── Regression: auth smoke still holds ────────────────────────────
+
+  it('unauthenticated calls still return 401', async () => {
+    const noAuth = await backendPost('/api/costforge/calculate', {
+      parcelNumber: 'R-001',
+      countyCode: 'benton',
+    });
+    assert.equal(noAuth.status, 401, 'Unauthenticated CostForge should be 401');
+
+    const port = process.env.TF_API_PORT || '5046';
+    const levyRes = await fetch(`http://localhost:${port}/api/levy-calculation/history`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    assert.equal(levyRes.status, 401, 'Unauthenticated Levy history should be 401');
+    console.log('  ✅ Unauthenticated calls still blocked (401)');
+  });
+});


### PR DESCRIPTION
## R1 Tool Payload Shaping

Converts 400 validation errors into domain-correct responses (200/404) by aligning handler payloads with backend request contracts.

### Changes

**CostForge handler** (\un_valuation_model\):
- Send \parcelNumber\ (string) instead of \parcelId\ (was rejected as non-Guid)
- Send \countyCode\ + \egion\ instead of \countyId\ (backend expects county code for context matching)
- Result: **400 → 404** (auth + contract pass, parcel lookup correct)

**Levy handler** (\summarize_levy_rate_components\):
- Switch from \POST /calculate-rate\ (requires budgetAmount/assessedValue the tool doesn't collect) to \GET /history\ (matches 'summarize' semantics, needs only taxYear)
- Result: **400 → 200** (full success, returns levy records array)

### Evidence

| Tool | Before | After | Proof |
|------|--------|-------|-------|
| CostForge | 400 (validation) | 404 (parcel not in DB) | Auth + contract pass |
| Levy | 400 (validation) | 200 (empty array) | Full success |
| Unauth calls | 401 | 401 | No regression |

\\\
r1-payload-smoke: 5/5 pass
r1-auth-smoke:    7/7 pass (no regression)
type-check:       clean
phase83-tools:    32/32 pass
\\\

### CostForge 404 explanation

The 404 is correct behavior: the parcel \R-SMOKE-001\ doesn't exist in the dev SQLite DB. The payload now passes model validation and county context matching — the next step is seeding test parcels or using known Benton County parcel numbers.

### Scope

- \os-platform/core/pilot/handlers.real.ts\ — payload field mapping fixes
- \os-platform/core/pilot/handlers.real.js\ — generated CJS output
- \os-platform/core/tests/r1-payload-smoke.test.mjs\ — new 5-test smoke suite

No backend changes. No governance surface changes.