### PR TITLE
feat(pilot): R1 CostForge 200-path — field mapping + real parcel fixture

### DIFF
--- a/os-platform/core/pilot/handlers.real.js
+++ b/os-platform/core/pilot/handlers.real.js
@@ -55,13 +55,23 @@ const runValuationModelHandler = async (params, context, _tool) => {
         buildingType: params.modelType ?? 'cost',
     }, { token });
     const data = (0, backendClient_js_1.unwrapBackend)(raw, 'Valuation model failed');
+    // CostForge returns totalCost (not estimatedValue) and components as array
+    const estimatedValue = data.totalCost ?? data.estimatedValue ?? 0;
+    const confidence = data.confidence ?? data.confidenceScore ?? 0;
+    let components;
+    if (Array.isArray(data.components)) {
+        components = Object.fromEntries(data.components.map((c) => [c.name, c.amount]));
+    }
+    else {
+        components = data.components ?? data.costBreakdown ?? {};
+    }
     return {
         parcelId: params.parcelId,
         taxYear: params.taxYear,
         modelType: params.modelType ?? 'cost',
-        estimatedValue: data.estimatedValue ?? 0,
-        confidence: data.confidence ?? data.confidenceScore ?? 0,
-        components: data.components ?? data.costBreakdown ?? {},
+        estimatedValue,
+        confidence,
+        components,
     };
 };
 exports.runValuationModelHandler = runValuationModelHandler;

--- a/os-platform/core/pilot/handlers.real.ts
+++ b/os-platform/core/pilot/handlers.real.ts
@@ -144,10 +144,11 @@ export const runValuationModelHandler: ToolHandler<
   const { token } = await acquirePilotToken();
 
   const raw = await backendPost<{
+    totalCost?: number;
     estimatedValue?: number;
     confidence?: number;
     confidenceScore?: number;
-    components?: Record<string, number>;
+    components?: Array<{ name: string; amount: number }> | Record<string, number>;
     costBreakdown?: Record<string, number>;
   }>('/api/costforge/calculate', {
     parcelNumber: params.parcelId,
@@ -157,13 +158,25 @@ export const runValuationModelHandler: ToolHandler<
   }, { token });
   const data = unwrapBackend(raw, 'Valuation model failed');
 
+  // CostForge returns totalCost (not estimatedValue) and components as array
+  const estimatedValue = data.totalCost ?? data.estimatedValue ?? 0;
+  const confidence = data.confidence ?? data.confidenceScore ?? 0;
+  let components: Record<string, number>;
+  if (Array.isArray(data.components)) {
+    components = Object.fromEntries(
+      data.components.map((c: { name: string; amount: number }) => [c.name, c.amount]),
+    );
+  } else {
+    components = (data.components as Record<string, number>) ?? data.costBreakdown ?? {};
+  }
+
   return {
     parcelId: params.parcelId,
     taxYear: params.taxYear,
     modelType: params.modelType ?? 'cost',
-    estimatedValue: data.estimatedValue ?? 0,
-    confidence: data.confidence ?? data.confidenceScore ?? 0,
-    components: data.components ?? data.costBreakdown ?? {},
+    estimatedValue,
+    confidence,
+    components,
   };
 };
 

--- a/os-platform/core/tests/r1-payload-smoke.test.mjs
+++ b/os-platform/core/tests/r1-payload-smoke.test.mjs
@@ -1,13 +1,16 @@
 /**
- * TerraFusion OS – R1 Payload Shaping Smoke Test
+ * TerraFusion OS – R1 CostForge 200-Path Smoke Test
  *
- * Proves that R1 handler payloads now match backend request contracts:
+ * Proves that R1 handler payloads produce full 200-path success:
  *   1. run_valuation_model sends correct PropertyCostCalculationRequest shape
- *      → expect 200 or 404 (parcel not in DB) — NOT 400 (validation failure)
+ *      → expect 200 with real cost analysis for known Benton County parcel
  *   2. summarize_levy_rate_components calls GET /history
- *      → expect 200 with array (possibly empty) — NOT 400/403
- *   3. Direct HTTP: shaped CostForge payload no longer fails model validation
+ *      → expect 200 with array (possibly empty)
+ *   3. Direct HTTP: CostForge returns 200 with real parcel
  *   4. Direct HTTP: levy history returns 200 with array
+ *
+ * Dev DB fixture: parcel 1-0531-100-0001-000 (Benton County, Kennewick)
+ *   AssessedValue=285000, LandValue=75000, ImprovementValue=210000
  *
  * Requires:
  *   TF_API_PORT=5046 (or backend running on 5046)
@@ -45,32 +48,23 @@ before(async () => {
 
 describe('R1 Payload Shaping (backend on :5046)', () => {
 
-  // ── Direct HTTP: CostForge shaped payload passes validation ───────
+  // ── Direct HTTP: CostForge returns 200 with real parcel ─────────
 
-  it('shaped CostForge payload passes validation (no 400)', async () => {
+  it('CostForge returns 200 for known Benton County parcel', async () => {
     const { token } = await acquirePilotToken();
 
-    // This is the shaped payload: parcelNumber + countyCode (not parcelId + countyId)
     const result = await backendPost('/api/costforge/calculate', {
-      parcelNumber: 'R-SMOKE-001',
+      parcelNumber: '1-0531-100-0001-000',
       countyCode: 'benton',
       region: 'benton',
       buildingType: 'cost',
     }, { token });
 
-    // Should NOT be 400 (model validation). Expect 200 or 404 (parcel not found).
-    assert.notEqual(result.status, 400, `Shaped payload should not trigger validation 400, got: ${result.raw ?? result.error}`);
-    assert.notEqual(result.status, 401, 'Auth should pass');
-    assert.notEqual(result.status, 403, 'Authz should pass');
-
-    // 404 is the expected response when parcel doesn't exist in DB
-    if (result.status === 404) {
-      console.log('  ✅ CostForge: 404 (parcel not in DB) — validation passed, auth passed');
-    } else if (result.ok) {
-      console.log(`  ✅ CostForge: 200 — full success`);
-    } else {
-      console.log(`  ⚠️  CostForge: ${result.status} — ${result.error}`);
-    }
+    assert.equal(result.ok, true, `CostForge should return 200, got ${result.status}: ${result.error}`);
+    assert.ok(result.data.totalCost > 0, `totalCost should be > 0, got ${result.data.totalCost}`);
+    assert.ok(result.data.confidenceScore > 0, `confidenceScore should be > 0, got ${result.data.confidenceScore}`);
+    assert.ok(Array.isArray(result.data.components), 'components should be an array');
+    console.log(`  ✅ CostForge: 200 — totalCost=$${result.data.totalCost.toFixed(2)}, confidence=${result.data.confidenceScore}`);
   });
 
   // ── Direct HTTP: Levy history returns 200 ─────────────────────────
@@ -87,7 +81,7 @@ describe('R1 Payload Shaping (backend on :5046)', () => {
 
   // ── Handler: run_valuation_model no longer 400 ────────────────────
 
-  it('run_valuation_model handler gets 200 or 404 (not 400)', async () => {
+  it('run_valuation_model handler returns 200 with cost analysis', async () => {
     const registry = new ToolRegistry();
     await registry.initialize();
     const runner = new ToolRunner({ registry });
@@ -98,7 +92,7 @@ describe('R1 Payload Shaping (backend on :5046)', () => {
       toolId: 'run_valuation_model',
       params: {
         county: 'benton',
-        parcelId: 'R-SMOKE-001',
+        parcelId: '1-0531-100-0001-000',
         taxYear: 2026,
       },
       context: {
@@ -111,18 +105,11 @@ describe('R1 Payload Shaping (backend on :5046)', () => {
       },
     });
 
-    if (result.ok === false) {
-      // Should be a "not found" error, not a validation error
-      assert.ok(
-        !result.error.includes('400') && !result.error.includes('Bad Request'),
-        `Payload shaping should eliminate 400 validation errors: ${result.error}`
-      );
-      // 404 "not found" is the expected correct domain response
-      const is404 = result.error.includes('404') || result.error.toLowerCase().includes('not found');
-      console.log(`  ✅ run_valuation_model: ${is404 ? '404 (parcel not in DB)' : result.error} — validation passed`);
-    } else {
-      console.log(`  ✅ run_valuation_model: 200 — estimatedValue=${result.result.estimatedValue}`);
-    }
+    assert.equal(result.ok, true, `Handler should succeed, got error: ${result.error}`);
+    assert.ok(result.result.estimatedValue > 0, `estimatedValue should be > 0, got ${result.result.estimatedValue}`);
+    assert.ok(result.result.confidence > 0, `confidence should be > 0, got ${result.result.confidence}`);
+    assert.equal(typeof result.result.components, 'object', 'components should be an object');
+    console.log(`  ✅ run_valuation_model: 200 — estimatedValue=$${result.result.estimatedValue.toFixed(2)}, confidence=${result.result.confidence}`);
   });
 
   // ── Handler: summarize_levy_rate_components returns success ────────
@@ -157,7 +144,7 @@ describe('R1 Payload Shaping (backend on :5046)', () => {
 
   it('unauthenticated calls still return 401', async () => {
     const noAuth = await backendPost('/api/costforge/calculate', {
-      parcelNumber: 'R-001',
+      parcelNumber: '1-0531-100-0001-000',
       countyCode: 'benton',
     });
     assert.equal(noAuth.status, 401, 'Unauthenticated CostForge should be 401');


### PR DESCRIPTION
## Summary

Closes the CostForge 404→200 gap. The \un_valuation_model\ tool now returns **200** with a valid cost analysis from the backend.

### Changes

**Handler field mapping** (\handlers.real.ts\ + \.js\):
- Map CostForge \	otalCost\ → \stimatedValue\ (CostForge DTO uses \	otalCost\, not \stimatedValue\)
- Map \components\ array of \{name, amount}\ → \Record<string, number>\ (handler contract expects flat object)
- Map \confidenceScore\ → \confidence\ (already handled, now confirmed end-to-end)

**Smoke test** (\1-payload-smoke.test.mjs\):
- Replaced synthetic parcel \R-SMOKE-001\ with real Benton County parcel \1-0531-100-0001-000\
- All assertions now require 200 with \	otalCost > 0\, \confidence > 0\, valid components
- No more 404-tolerance in tests

### Test Evidence

| Test Suite | Pass | Total |
|------------|------|-------|
| r1-payload-smoke | 5 | 5 |
| r1-auth-smoke | 7 | 7 |
| phase83-tools | 32 | 32 |
| type-check | ✅ | — |
| vitest unit | 164 | 164 |

### Key Result

\\\
CostForge: 200 — totalCost=\,972.66, confidence=0.99
run_valuation_model: 200 — estimatedValue=\,972.66, confidence=0.99
\\\

No data seeding needed — existing dev DB parcels have sufficient property values.

### R1 Auth→Payload→200 Lane Summary

| PR | Status | What |
|----|--------|------|
| #579 | ✅ merged | Auth enablement (401/403→400) |
| #581 | ✅ merged | Payload shaping (400→200/404) |
| **this** | 🟢 ready | CostForge 200-path (404→200) |
