### PR TITLE
fix(config): C1 — pin *.snap to eol=lf preventing cross-platform churn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,9 @@
 # Unix/Linux shells (keep LF)
 *.sh text eol=lf
 
+# --- Test snapshots (vitest/jest — always LF to prevent cross-platform churn) ---
+*.snap text eol=lf
+
 # --- Source code (explicit text classification) ---
 # .NET Backend
 *.cs text


### PR DESCRIPTION
## Lane C1: Snapshot Churn Hygiene

### Problem
On Windows with `core.autocrlf=input`, vitest snapshot rewrites could produce CRLF working copies that git sees as dirty — forcing a manual "restore two .snap files" ritual after every `git checkout -B <branch> origin/r1/integration` + hook cycle.

### Root Cause
`.gitattributes` had no `*.snap` rule. The `* text=auto` fallback left line-ending normalization to git's autodetection, which on Windows can produce CRLF/LF mismatches when vitest rewrites snapshot files.

### Fix
Add `*.snap text eol=lf` to `.gitattributes`, pinning snapshot files to LF regardless of platform.

### Evidence
- **Tests**: 164 passed (8 files, 0 failures)
- **All pre-push gates passed**: unit tests, security scan, performance benchmark, AI swarm monitor, government compliance, backend build
- **Byte verification**: Both snap files byte-identical to committed versions after vitest run
- **Scope**: Config-only change (`.gitattributes`), no code modified

### Files Changed
- `.gitattributes` — Add `*.snap text eol=lf` rule

### Acceptance Criteria
After `git checkout -B <branch> origin/r1/integration` + hooks, `git status --short` stays empty. No more snapshot restoration ritual.

## Summary by Sourcery

Bug Fixes:
- Prevent Vitest snapshot files from appearing modified on Windows due to inconsistent CRLF/LF normalization by Git.