### PR TITLE
test(r1): align mock shapes with post-PR#581 handler contracts

### DIFF
--- a/os-platform/core/tests/r1-boot-wiring.test.mjs
+++ b/os-platform/core/tests/r1-boot-wiring.test.mjs
@@ -101,11 +101,15 @@ describe('R1 Boot Wiring', () => {
     registerPhase84Handlers(runner);
     registerR1Handlers(runner, traceService);
 
-    // Mock backend response for CostForge
+    // Mock backend response for CostForge — canonical shape from
+    // POST /api/costforge/calculate (totalCost, confidenceScore, array components)
     mockFetch({
-      estimatedValue: 250000,
-      confidence: 0.88,
-      components: { land: 100000, improvements: 150000 },
+      totalCost: 250000,
+      confidenceScore: 0.88,
+      components: [
+        { name: 'land', amount: 100000 },
+        { name: 'improvements', amount: 150000 },
+      ],
     });
 
     const result = await runner.execute({
@@ -174,13 +178,14 @@ describe('R1 Boot Wiring', () => {
 
     registerR1Handlers(runner, traceService);
 
+    // Mock backend response for POST /api/levy-calculation/calculate-rate
+    // Canonical shape: { aiOptimalRate, baseRate, statutoryLimit, projectedRevenue }
+    // Handler builds 3 components and sets totalRate = Math.round(aiOptimalRate * 100) / 100
     mockFetch({
-      components: [
-        { name: 'State School', rate: 3.12 },
-        { name: 'Local School', rate: 2.45 },
-        { name: 'County General', rate: 1.85 },
-      ],
-      totalRate: 7.42,
+      aiOptimalRate: 7.42,
+      baseRate: 2.5,
+      statutoryLimit: 10.0,
+      projectedRevenue: 500000,
     });
 
     const result = await runner.execute({

--- a/os-platform/core/tests/r1-payload-smoke.test.mjs
+++ b/os-platform/core/tests/r1-payload-smoke.test.mjs
@@ -9,7 +9,7 @@
  *   3. Direct HTTP: CostForge returns 200 with real parcel
  *   4. Direct HTTP: shaped levy calculate-rate payload returns 200
  *
- * Parcel discovery: queries GET /api/properties?pageSize=1 for a real parcel.
+ * Parcel discovery: queries GET /api/properties?pageSize=10 for a real parcel.
  * Falls back to 1-0531-100-0001-000 (Benton County seed parcel) if the
  * endpoint is unavailable. If the fallback parcel is also missing, the test
  * fails with instructions to reseed the dev DB.
@@ -40,30 +40,32 @@ const FALLBACK_PARCEL = BENTON_FIXTURE_PARCEL;
  * Discover a valuation-ready parcel from the backend.
  * Queries GET /api/properties?pageSize=10 and picks the first parcel with
  * improvementValue > 0 (required for CostForge cost calculation).
- * Falls back to FALLBACK_PARCEL if discovery fails.
+ *
+ * Returns the discovered parcel number, or undefined if discovery fails.
+ * Callers should fall back to FALLBACK_PARCEL when undefined is returned.
  */
 async function discoverTestParcel(token) {
   try {
     const result = await backendGet('/api/properties?pageSize=10', { token });
     if (!result.ok) {
-      console.log(`  ⚠️  Parcel discovery failed: ${result.status} ${result.error ?? ''} — using fallback: ${FALLBACK_PARCEL}`);
-      return;
+      console.log(`  ⚠️  Parcel discovery failed: ${result.status} ${result.error ?? ''}`);
+      return undefined;
     }
     const items = result.data?.items ?? [];
     const viable = items.find(p => p.parcelNumber && p.improvementValue > 0);
     if (viable) {
-      TEST_PARCEL = viable.parcelNumber;
-      console.log(`  🔍 Discovered test parcel: ${TEST_PARCEL} (improvementValue=${viable.improvementValue})`);
-      return;
+      console.log(`  🔍 Discovered test parcel: ${viable.parcelNumber} (improvementValue=${viable.improvementValue})`);
+      return viable.parcelNumber;
     }
     if (items.length > 0 && items[0].parcelNumber) {
-      TEST_PARCEL = items[0].parcelNumber;
-      console.log(`  ⚠️  No parcel with improvementValue > 0 found; using first available: ${TEST_PARCEL}`);
-      return;
+      console.log(`  ⚠️  No parcel with improvementValue > 0 found; using first available: ${items[0].parcelNumber}`);
+      return items[0].parcelNumber;
     }
-    console.log(`  ⚠️  /api/properties returned 0 items — using fallback: ${FALLBACK_PARCEL}`);
+    console.log(`  ⚠️  /api/properties returned 0 items`);
+    return undefined;
   } catch (err) {
-    console.log(`  ⚠️  Parcel discovery error: ${err.message} — using fallback: ${FALLBACK_PARCEL}`);
+    console.log(`  ⚠️  Parcel discovery error: ${err.message}`);
+    return undefined;
   }
 }
 
@@ -84,9 +86,16 @@ before(async () => {
   TraceService = trace.TraceService;
   traceService = trace.traceService;
 
-  // Discover a real parcel before any CostForge tests run
+  // Discover a real parcel before any CostForge tests run.
+  // Token is scoped to discovery only — clear after use so each test
+  // manages its own token lifecycle (aligned with test-scoped pattern).
   const { token } = await acquirePilotToken();
-  await discoverTestParcel(token);
+  const discovered = await discoverTestParcel(token);
+  TEST_PARCEL = discovered ?? FALLBACK_PARCEL;
+  if (!discovered) {
+    console.log(`  → Using fallback parcel: ${FALLBACK_PARCEL}`);
+  }
+  clearPilotToken();
 });
 
 describe('R1 Payload Shaping (backend on :5046)', () => {

--- a/os-platform/core/tests/r1-week3.test.mjs
+++ b/os-platform/core/tests/r1-week3.test.mjs
@@ -59,6 +59,35 @@ function mockFetch(data, status = 200) {
   });
 }
 
+/**
+ * URL-aware mock: returns valid auth for /api/auth/login, error for other paths.
+ * Needed for error-propagation tests where the handler calls acquirePilotToken()
+ * (via fetch) before making its real backend call.
+ */
+function mockFetchWithAuth(data, status = 200) {
+  globalThis.fetch = async (url) => {
+    if (typeof url === 'string' && url.includes('/api/auth/login')) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({
+          token: 'mock-token',
+          email: 'admin@gov.',
+          roles: ['appraiser'],
+          expiresAt: new Date(Date.now() + 3600000).toISOString(),
+        }),
+      };
+    }
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      text: async () => JSON.stringify(data),
+    };
+  };
+}
+
 function mockFetchError(message = 'ECONNREFUSED') {
   globalThis.fetch = async () => {
     throw new Error(message);
@@ -140,7 +169,7 @@ describe('Handler: explain_model_inputs (real)', () => {
   });
 
   it('propagates backend errors', async () => {
-    mockFetch({ error: 'Not found' }, 404);
+    mockFetchWithAuth({ error: 'Not found' }, 404);
 
     await assert.rejects(
       () => explainModelInputsRealHandler(
@@ -246,7 +275,7 @@ describe('Handler: compare_assessed_value_history (real)', () => {
   });
 
   it('propagates backend errors', async () => {
-    mockFetch({ error: 'Server error' }, 500);
+    mockFetchWithAuth({ error: 'Server error' }, 500);
 
     await assert.rejects(
       () => compareAssessedValueHistoryRealHandler(
@@ -344,7 +373,7 @@ describe('Handler: summarize_parcel_casefile (real)', () => {
   });
 
   it('propagates backend errors (404 = endpoint not ready)', async () => {
-    mockFetch({ error: 'Not found' }, 404);
+    mockFetchWithAuth({ error: 'Not found' }, 404);
 
     await assert.rejects(
       () => summarizeParcelCasefileRealHandler(
@@ -578,7 +607,7 @@ describe('Handler: add_dossier_note (real)', () => {
   });
 
   it('propagates backend errors', async () => {
-    mockFetch({ error: 'Internal error' }, 500);
+    mockFetchWithAuth({ error: 'Internal error' }, 500);
 
     await assert.rejects(
       () => addDossierNoteRealHandler(
@@ -651,7 +680,7 @@ describe('Handler: query_parcel_layers (real)', () => {
   });
 
   it('propagates backend 404 for unknown parcel', async () => {
-    mockFetch({ error: 'Parcel not found' }, 404);
+    mockFetchWithAuth({ error: 'Parcel not found' }, 404);
 
     await assert.rejects(
       () => queryParcelLayersRealHandler(


### PR DESCRIPTION
## Summary
- **r1-boot-wiring.test.mjs**: CostForge mock now uses canonical `{ totalCost, confidenceScore, components: [{name, amount}] }` shape; Levy mock uses `{ aiOptimalRate, baseRate, statutoryLimit, projectedRevenue }` — both matching the actual POST endpoint response shapes after PR #581 merged
- **r1-payload-smoke.test.mjs**: Fixes Sourcery review feedback from PR #585 — adopts return-value pattern for `discoverTestParcel()` (no module-scoped mutation), fixes comment accuracy (`pageSize=10`), clears pilot token after discovery phase
- **r1-week3.test.mjs**: Adds `mockFetchWithAuth` URL-aware helper that returns valid auth for `/api/auth/login` and error for other paths — fixes 5 error-propagation tests that previously failed because `mockFetch` intercepted `acquirePilotToken()` before the handler's actual backend call

## Test plan
- [x] `node --test tests/r1-boot-wiring.test.mjs` — 4/4 pass ✅
- [x] `node --test tests/r1-week3.test.mjs` — 33/33 pass ✅ (was 29/33 before fix)
- [x] All 6 R1 test files combined — 76/76 pass ✅
- [x] Vitest unit suite — 164/164 pass ✅
- [x] Backend build — 0 warnings, 0 errors ✅
- [x] Pre-push quality gate — all passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)