### PR TITLE
test(core): run D2 retention/redaction tests under vitest

### DIFF
--- a/os-platform/core/tests/d2-evidence-retention-redaction.test.ts
+++ b/os-platform/core/tests/d2-evidence-retention-redaction.test.ts
@@ -1,20 +1,11 @@
 /**
  * TerraFusion OS - D2 Evidence Retention & Redaction Contract
  */
-import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { describe, expect, it } from 'vitest';
+import { exportNDJSON, toAuditRecord } from '../trace/TraceService.js';
 
-let toAuditRecord;
-let exportNDJSON;
-
-before(async () => {
-  const traceModule = await import('../trace/index.js');
-  const trace = traceModule.default || traceModule;
-  toAuditRecord = trace.toAuditRecord;
-  exportNDJSON = trace.exportNDJSON;
-});
-
-function makeEvent(overrides = {}) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeEvent(overrides: Record<string, any> = {}) {
   return {
     id: overrides.id || 'evt-test-001',
     correlationId: overrides.correlationId || 'corr-test-001',
@@ -44,23 +35,23 @@ describe('D2 Retention Window: exportNDJSON filters by ISO 8601 bounds', () => {
   it('no from/to -> all events included', () => {
     const ndjson = exportNDJSON(allEvents, {});
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 3, 'all 3 events present');
+    expect(lines.length).toBe(3);
   });
 
   it('from filter excludes events before the lower bound', () => {
     const ndjson = exportNDJSON(allEvents, { from: '2026-02-01T00:00:00.000Z' });
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 2, 'early event excluded');
+    expect(lines.length).toBe(2);
     const parsed = lines.map(l => JSON.parse(l));
-    assert.ok(parsed.every(e => e.timestamp >= '2026-02-01T00:00:00.000Z'));
+    expect(parsed.every(e => e.timestamp >= '2026-02-01T00:00:00.000Z')).toBe(true);
   });
 
   it('to filter excludes events after the upper bound', () => {
     const ndjson = exportNDJSON(allEvents, { to: '2026-02-28T23:59:59.999Z' });
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 2, 'late event excluded');
+    expect(lines.length).toBe(2);
     const parsed = lines.map(l => JSON.parse(l));
-    assert.ok(parsed.every(e => e.timestamp <= '2026-02-28T23:59:59.999Z'));
+    expect(parsed.every(e => e.timestamp <= '2026-02-28T23:59:59.999Z')).toBe(true);
   });
 
   it('from + to together define a retention window', () => {
@@ -69,9 +60,9 @@ describe('D2 Retention Window: exportNDJSON filters by ISO 8601 bounds', () => {
       to: '2026-02-28T23:59:59.999Z',
     });
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 1, 'only mid event in window');
+    expect(lines.length).toBe(1);
     const parsed = JSON.parse(lines[0]);
-    assert.equal(parsed.timestamp, '2026-02-15T10:00:00.000Z');
+    expect(parsed.timestamp).toBe('2026-02-15T10:00:00.000Z');
   });
 
   it('empty result when window excludes all events', () => {
@@ -79,7 +70,7 @@ describe('D2 Retention Window: exportNDJSON filters by ISO 8601 bounds', () => {
       from: '2027-01-01T00:00:00.000Z',
       to: '2027-12-31T23:59:59.999Z',
     });
-    assert.equal(ndjson, '', 'empty string for no matching events');
+    expect(ndjson).toBe('');
   });
 });
 
@@ -88,22 +79,22 @@ describe('D2 PII Leak Guard: toAuditRecord sanitizes SSN, phone, email from summ
   it('SSN pattern (###-##-####) is replaced with [SSN_REDACTED]', () => {
     const evt = makeEvent({ summary: 'Owner SSN: 123-45-6789 on file' });
     const record = toAuditRecord(evt);
-    assert.ok(!record.summary.includes('123-45-6789'), 'SSN must not appear');
-    assert.ok(record.summary.includes('[SSN_REDACTED]'), 'SSN replaced with token');
+    expect(record.summary).not.toContain('123-45-6789');
+    expect(record.summary).toContain('[SSN_REDACTED]');
   });
 
   it('phone number is replaced with [PHONE_REDACTED]', () => {
     const evt = makeEvent({ summary: 'Contact: 509-555-1234 for owner' });
     const record = toAuditRecord(evt);
-    assert.ok(!record.summary.includes('509-555-1234'), 'phone must not appear');
-    assert.ok(record.summary.includes('[PHONE_REDACTED]'), 'phone replaced with token');
+    expect(record.summary).not.toContain('509-555-1234');
+    expect(record.summary).toContain('[PHONE_REDACTED]');
   });
 
   it('email is replaced with [EMAIL_REDACTED]', () => {
     const evt = makeEvent({ summary: 'Notify owner@county.gov about appeal' });
     const record = toAuditRecord(evt);
-    assert.ok(!record.summary.includes('owner@county.gov'), 'email must not appear');
-    assert.ok(record.summary.includes('[EMAIL_REDACTED]'), 'email replaced with token');
+    expect(record.summary).not.toContain('owner@county.gov');
+    expect(record.summary).toContain('[EMAIL_REDACTED]');
   });
 
   it('multiple PII types in one summary are all sanitized', () => {
@@ -111,15 +102,15 @@ describe('D2 PII Leak Guard: toAuditRecord sanitizes SSN, phone, email from summ
       summary: 'SSN: 111-22-3333, phone: 509-555-0000, email: test@gov.wa.us',
     });
     const record = toAuditRecord(evt);
-    assert.ok(!record.summary.includes('111-22-3333'), 'SSN removed');
-    assert.ok(!record.summary.includes('509-555-0000'), 'phone removed');
-    assert.ok(!record.summary.includes('test@gov.wa.us'), 'email removed');
+    expect(record.summary).not.toContain('111-22-3333');
+    expect(record.summary).not.toContain('509-555-0000');
+    expect(record.summary).not.toContain('test@gov.wa.us');
   });
 
   it('PII-free summary passes through unchanged', () => {
     const evt = makeEvent({ summary: 'Valuation model updated for parcel 12345' });
     const record = toAuditRecord(evt);
-    assert.equal(record.summary, 'Valuation model updated for parcel 12345');
+    expect(record.summary).toBe('Valuation model updated for parcel 12345');
   });
 });
 
@@ -128,13 +119,13 @@ describe('D2 Redaction Classification: redaction events -> decision redaction', 
   it('redaction_requested -> decision: redaction', () => {
     const evt = makeEvent({ type: 'redaction_requested' });
     const record = toAuditRecord(evt);
-    assert.equal(record.decision, 'redaction');
+    expect(record.decision).toBe('redaction');
   });
 
   it('redaction_ticket_created -> decision: redaction', () => {
     const evt = makeEvent({ type: 'redaction_ticket_created' });
     const record = toAuditRecord(evt);
-    assert.equal(record.decision, 'redaction');
+    expect(record.decision).toBe('redaction');
   });
 });
 
@@ -142,22 +133,22 @@ describe('D2 Redaction Classification: redaction events -> decision redaction', 
 describe('D2 Backward Compatibility: existing decision mappings unaffected', () => {
   it('tool_completed -> decision: allowed', () => {
     const evt = makeEvent({ type: 'tool_completed' });
-    assert.equal(toAuditRecord(evt).decision, 'allowed');
+    expect(toAuditRecord(evt).decision).toBe('allowed');
   });
 
   it('tool_invoked -> decision: allowed', () => {
     const evt = makeEvent({ type: 'tool_invoked' });
-    assert.equal(toAuditRecord(evt).decision, 'allowed');
+    expect(toAuditRecord(evt).decision).toBe('allowed');
   });
 
   it('tool_failed + governance errorCode -> decision: blocked', () => {
     const evt = makeEvent({ type: 'tool_failed', errorCode: 'WRITE_LANE_MISMATCH' });
-    assert.equal(toAuditRecord(evt).decision, 'blocked');
+    expect(toAuditRecord(evt).decision).toBe('blocked');
   });
 
   it('tool_failed + non-governance errorCode -> decision: failed', () => {
     const evt = makeEvent({ type: 'tool_failed', errorCode: 'HANDLER_ERROR' });
-    assert.equal(toAuditRecord(evt).decision, 'failed');
+    expect(toAuditRecord(evt).decision).toBe('failed');
   });
 });
 
@@ -170,7 +161,7 @@ describe('D2 Merge-Check: backwards compatibility with no options arg', () => {
     ];
     const ndjson = exportNDJSON(events);
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 2, 'all events returned with no options');
+    expect(lines.length).toBe(2);
   });
 
   it('exportNDJSON(events) with only auditFormat returns all events as audit records', () => {
@@ -179,15 +170,16 @@ describe('D2 Merge-Check: backwards compatibility with no options arg', () => {
     ];
     const ndjson = exportNDJSON(events, { auditFormat: true });
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 1);
+    expect(lines.length).toBe(1);
     const record = JSON.parse(lines[0]);
-    assert.ok('decision' in record, 'audit record has decision field');
-    assert.ok(!('type' in record), 'audit record does not have raw type field');
+    expect('decision' in record).toBe(true);
+    expect('type' in record).toBe(false);
   });
 });
 
 describe('D2 Merge-Check: invalid/missing timestamps are handled safely', () => {
-  function makeRawEvent(overrides = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makeRawEvent(overrides: Record<string, any> = {}) {
     return {
       id: overrides.id || 'evt-raw',
       correlationId: 'corr-raw',
@@ -208,7 +200,7 @@ describe('D2 Merge-Check: invalid/missing timestamps are handled safely', () => 
     ];
     const ndjson = exportNDJSON(events);
     const lines = ndjson.split('\n');
-    assert.equal(lines.length, 2, 'both events included');
+    expect(lines.length).toBe(2);
   });
 
   it('event with undefined timestamp is excluded by from filter (no crash)', () => {
@@ -219,7 +211,7 @@ describe('D2 Merge-Check: invalid/missing timestamps are handled safely', () => 
     const ndjson = exportNDJSON(events, { from: '2026-01-01T00:00:00.000Z' });
     const lines = ndjson.split('\n').filter(l => l.length > 0);
     // undefined >= 'any string' is false, so it should be excluded
-    assert.equal(lines.length, 1, 'undefined timestamp excluded by from');
+    expect(lines.length).toBe(1);
   });
 
   it('event with empty string timestamp is excluded by from filter (no crash)', () => {
@@ -229,7 +221,7 @@ describe('D2 Merge-Check: invalid/missing timestamps are handled safely', () => 
     ];
     const ndjson = exportNDJSON(events, { from: '2026-01-01T00:00:00.000Z' });
     const lines = ndjson.split('\n').filter(l => l.length > 0);
-    assert.equal(lines.length, 1, 'empty timestamp excluded by from');
+    expect(lines.length).toBe(1);
   });
 });
 
@@ -241,10 +233,10 @@ describe('D2 Merge-Check: PII regex performance on long summaries', () => {
     const start = performance.now();
     const record = toAuditRecord(evt);
     const elapsed = performance.now() - start;
-    assert.ok(elapsed < 50, 'PII sanitization completes in < 50ms, got ' + elapsed.toFixed(2) + 'ms');
-    assert.ok(!record.summary.includes('999-88-7777'), 'SSN redacted in long summary');
-    assert.ok(!record.summary.includes('360-555-9999'), 'phone redacted in long summary');
-    assert.ok(!record.summary.includes('long@test.gov'), 'email redacted in long summary');
+    expect(elapsed).toBeLessThan(50);
+    expect(record.summary).not.toContain('999-88-7777');
+    expect(record.summary).not.toContain('360-555-9999');
+    expect(record.summary).not.toContain('long@test.gov');
   });
 
   it('100K character summary does not cause catastrophic backtracking', () => {
@@ -253,9 +245,7 @@ describe('D2 Merge-Check: PII regex performance on long summaries', () => {
     const start = performance.now();
     const record = toAuditRecord(evt);
     const elapsed = performance.now() - start;
-    assert.ok(elapsed < 200, '100K summary processed in < 200ms, got ' + elapsed.toFixed(2) + 'ms');
-    assert.equal(record.summary, hugeSummary, 'no-PII summary passes through unchanged');
+    expect(elapsed).toBeLessThan(200);
+    expect(record.summary).toBe(hugeSummary);
   });
 });
-
-// Suite 5: Merge-Check Hardening (backwards compat, invalid timestamps, long summary)


### PR DESCRIPTION
Renames D2 test to `.test.ts` so it's included in default vitest runs. No logic changes.

## What changed
- `os-platform/core/tests/d2-evidence-retention-redaction.test.mjs` → `.test.ts`
- Replaced `node:test`/`node:assert` imports with vitest `describe`/`it`/`expect`
- Replaced dynamic `before()` import with static `import { exportNDJSON, toAuditRecord }`
- All 23 test cases preserved with identical assertions, just translated to vitest idiom

## Verification
- `npx vitest run os-platform/core/tests/d2-evidence-retention-redaction.test.ts` — **23/23 pass** ✅
- `pnpm run type-check` ✅
- `pnpm run check:generated` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` — 32/32 ✅
- Pre-push gates: 164/164 unit tests, backend build 0 errors ✅

## Not in scope
- Pre-existing vitest failures (`leak-guard-strict-components-coverage.test.ts`, `leak-guard-coverage-mapping.test.ts`) are tracked separately and NOT touched.

## Summary by Sourcery

Migrate the D2 evidence retention and redaction test suite to run under Vitest with TypeScript, keeping all existing test coverage and behavior intact.

Tests:
- Convert the D2 evidence retention/redaction tests from Node’s built-in test/assert APIs to Vitest’s describe/it/expect so they run as part of the standard Vitest suite.
- Rename the D2 test file to `.test.ts` and switch to static imports for trace utilities, preserving all existing test cases and assertions.