### PR TITLE
feat(costforge): Wave 15 — Real sales comparison approach from quarantine fixtures

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -793,6 +793,332 @@ public class CostForgeController : ControllerBase
     });
   }
 
+  // ──── Income Approach endpoints (source: bs-income-valuation-production quarantine) ────
+
+  /// <summary>
+  /// Capitalization rate ranges by property type — Benton County FY 2025.
+  /// Source: Benton County Assessor market study + CoStar, IAAO standards.
+  /// </summary>
+  [HttpGet("income-approach/cap-rates")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetIncomeCapRates()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new
+    {
+      capRates = BentonIncomeData.CapRates,
+      marketCapRate = BentonIncomeData.MarketCapRate,
+      effectiveDate = "2025-01-01",
+      source = "Benton County Assessor – Income Approach Market Study FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Benton County / Tri-Cities economic indicators for income approach context.
+  /// Source: Benton County Assessor economic data, US Census ACS, WA ESD.
+  /// </summary>
+  [HttpGet("income-approach/market-data/benton")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetIncomeMarketData()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new
+    {
+      county = "Benton",
+      state = "WA",
+      BentonIncomeData.MarketData.MedianHouseholdIncome,
+      BentonIncomeData.MarketData.UnemploymentRate,
+      BentonIncomeData.MarketData.PopulationGrowthRate,
+      BentonIncomeData.MarketData.MedianHomePrice,
+      BentonIncomeData.MarketData.MedianPricePerSqft,
+      BentonIncomeData.MarketData.MedianDaysOnMarket,
+      BentonIncomeData.MarketData.MonthsOfInventory,
+      employmentSectors = BentonIncomeData.EmploymentSectors,
+      effectiveDate = "2025-01-01",
+      source = "US Census ACS 2024, WA ESD, Benton-Franklin Trends",
+    });
+  }
+
+  /// <summary>
+  /// Standard operating expense ratios by property type — IAAO / Benton County norms.
+  /// </summary>
+  [HttpGet("income-approach/expense-ratios")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetIncomeExpenseRatios()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new
+    {
+      expenseRatios = BentonIncomeData.ExpenseRatios,
+      expenseCategories = BentonIncomeData.ExpenseCategories,
+      effectiveDate = "2025-01-01",
+      source = "Benton County Assessor – IAAO Operating Expense Standards",
+    });
+  }
+
+  /// <summary>
+  /// Tri-Cities location premium multipliers for sub-market adjustment.
+  /// </summary>
+  [HttpGet("income-approach/location-premiums/benton")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetIncomeLocationPremiums()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new
+    {
+      locationPremiums = BentonIncomeData.LocationPremiums,
+      effectiveDate = "2025-01-01",
+      source = "Benton County Assessor – Tri-Cities Sub-Market Analysis FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Calculate Net Operating Income (NOI) from rental income, vacancy, and expenses.
+  /// NOI = (Annual Rental Income × (1 − Vacancy Rate)) + Other Income − Total Expenses
+  /// </summary>
+  [HttpPost("income-approach/calculate-noi")]
+  [RequiresPermission("access:costforge")]
+  public ActionResult CalculateNoi([FromBody] NoiCalculationRequest request)
+  {
+    if (request.AnnualRentalIncome <= 0)
+      return BadRequest(new { error = "AnnualRentalIncome must be positive." });
+    if (request.VacancyRate < 0 || request.VacancyRate > 100)
+      return BadRequest(new { error = "VacancyRate must be between 0 and 100." });
+
+    var effectiveGrossIncome = BankersRound(
+      request.AnnualRentalIncome * (1m - request.VacancyRate / 100m) + request.OtherIncome);
+
+    var totalExpenses = BankersRound(
+      request.PropertyTaxes + request.Insurance + request.Utilities
+      + request.Maintenance + request.ManagementFees
+      + request.ReplacementReserves + request.OtherExpenses);
+
+    var noi = BankersRound(effectiveGrossIncome - totalExpenses);
+
+    var expenseRatio = effectiveGrossIncome > 0
+      ? BankersRound(totalExpenses / effectiveGrossIncome * 100m)
+      : 0m;
+
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new NoiResult
+    {
+      AnnualRentalIncome = request.AnnualRentalIncome,
+      VacancyRate = request.VacancyRate,
+      OtherIncome = request.OtherIncome,
+      EffectiveGrossIncome = effectiveGrossIncome,
+      TotalExpenses = totalExpenses,
+      ExpenseRatio = expenseRatio,
+      NetOperatingIncome = noi,
+      Source = "Benton County Assessor – Income Approach Calculator FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Full income-approach valuation: NOI ÷ cap rate, with location premium and risk classification.
+  /// </summary>
+  [HttpPost("income-approach/calculate-valuation")]
+  [RequiresPermission("access:costforge")]
+  public ActionResult CalculateIncomeValuation([FromBody] IncomeValuationRequest request)
+  {
+    if (request.AnnualRentalIncome <= 0)
+      return BadRequest(new { error = "AnnualRentalIncome must be positive." });
+    if (request.VacancyRate < 0 || request.VacancyRate > 100)
+      return BadRequest(new { error = "VacancyRate must be between 0 and 100." });
+    if (request.CapRate <= 0 || request.CapRate > 25)
+      return BadRequest(new { error = "CapRate must be between 0 and 25." });
+
+    // NOI calculation
+    var effectiveGrossIncome = BankersRound(
+      request.AnnualRentalIncome * (1m - request.VacancyRate / 100m) + request.OtherIncome);
+
+    var totalExpenses = BankersRound(
+      request.PropertyTaxes + request.Insurance + request.Utilities
+      + request.Maintenance + request.ManagementFees
+      + request.ReplacementReserves + request.OtherExpenses);
+
+    var noi = BankersRound(effectiveGrossIncome - totalExpenses);
+
+    // Location premium
+    var locationMultiplier = BentonIncomeData.LocationPremiums
+      .FirstOrDefault(lp => lp.Location.Equals(request.Location ?? "", StringComparison.OrdinalIgnoreCase))
+      ?.Multiplier ?? 1.00m;
+
+    // Income approach valuation = NOI / cap rate
+    var capRateDecimal = request.CapRate / 100m;
+    var rawValuation = noi > 0 ? BankersRound(noi / capRateDecimal) : 0m;
+    var adjustedValuation = BankersRound(rawValuation * locationMultiplier);
+
+    // Gross Income Multiplier
+    var gim = effectiveGrossIncome > 0
+      ? BankersRound(adjustedValuation / effectiveGrossIncome)
+      : 0m;
+
+    // Risk classification (from quarantine: cap>7 && coc>8=low, cap<4||coc<3=high, else medium)
+    var cashOnCashReturn = rawValuation > 0 ? (double)(noi / rawValuation * 100m) : 0.0;
+    var riskLevel = ClassifyRisk((double)request.CapRate, cashOnCashReturn);
+
+    Response.Headers["X-CostForge-Source"] = "benton-real-income-approach-fy2025";
+    return Ok(new IncomeValuationResult
+    {
+      NetOperatingIncome = noi,
+      CapRate = request.CapRate,
+      Location = request.Location ?? "unspecified",
+      LocationMultiplier = locationMultiplier,
+      PropertyType = request.PropertyType ?? "residential",
+      RawValuation = rawValuation,
+      AdjustedValuation = adjustedValuation,
+      GrossIncomeMultiplier = gim,
+      CashOnCashReturn = BankersRound((decimal)cashOnCashReturn),
+      RiskClassification = riskLevel,
+      EffectiveDate = "2025-01-01",
+      Source = "Benton County Assessor – Income Approach Valuation FY 2025",
+    });
+  }
+
+  internal static string ClassifyRisk(double capRate, double cashOnCash)
+  {
+    if (capRate > 7.0 && cashOnCash > 8.0) return "low";
+    if (capRate < 4.0 || cashOnCash < 3.0) return "high";
+    return "medium";
+  }
+
+  // ──── Income Approach data records ────
+
+  public sealed record NoiCalculationRequest
+  {
+    public decimal AnnualRentalIncome { get; init; }
+    public decimal VacancyRate { get; init; } = 5m;
+    public decimal OtherIncome { get; init; }
+    public decimal PropertyTaxes { get; init; }
+    public decimal Insurance { get; init; }
+    public decimal Utilities { get; init; }
+    public decimal Maintenance { get; init; }
+    public decimal ManagementFees { get; init; }
+    public decimal ReplacementReserves { get; init; }
+    public decimal OtherExpenses { get; init; }
+  }
+
+  public sealed record IncomeValuationRequest
+  {
+    public decimal AnnualRentalIncome { get; init; }
+    public decimal VacancyRate { get; init; } = 5m;
+    public decimal OtherIncome { get; init; }
+    public decimal PropertyTaxes { get; init; }
+    public decimal Insurance { get; init; }
+    public decimal Utilities { get; init; }
+    public decimal Maintenance { get; init; }
+    public decimal ManagementFees { get; init; }
+    public decimal ReplacementReserves { get; init; }
+    public decimal OtherExpenses { get; init; }
+    public decimal CapRate { get; init; } = 5.5m;
+    public string? Location { get; init; }
+    public string? PropertyType { get; init; }
+  }
+
+  internal sealed record NoiResult
+  {
+    public decimal AnnualRentalIncome { get; init; }
+    public decimal VacancyRate { get; init; }
+    public decimal OtherIncome { get; init; }
+    public decimal EffectiveGrossIncome { get; init; }
+    public decimal TotalExpenses { get; init; }
+    public decimal ExpenseRatio { get; init; }
+    public decimal NetOperatingIncome { get; init; }
+    public string Source { get; init; } = "";
+  }
+
+  internal sealed record IncomeValuationResult
+  {
+    public decimal NetOperatingIncome { get; init; }
+    public decimal CapRate { get; init; }
+    public string Location { get; init; } = "";
+    public decimal LocationMultiplier { get; init; }
+    public string PropertyType { get; init; } = "";
+    public decimal RawValuation { get; init; }
+    public decimal AdjustedValuation { get; init; }
+    public decimal GrossIncomeMultiplier { get; init; }
+    public decimal CashOnCashReturn { get; init; }
+    public string RiskClassification { get; init; } = "";
+    public string EffectiveDate { get; init; } = "";
+    public string Source { get; init; } = "";
+  }
+
+  // ──── Benton County Income Approach Reference Data (FY 2025) ────
+
+  internal static class BentonIncomeData
+  {
+    // Market-wide cap rate (Benton County Assessor, CoStar, local market study)
+    public const decimal MarketCapRate = 5.5m;
+
+    // Cap rate ranges by property type (source: bs-income-valuation-production + IAAO standards)
+    public static readonly CapRateRange[] CapRates =
+    [
+      new("residential",  "Single Family Residential", 4.0m, 7.0m, 5.5m),
+      new("multi-family", "Multi-Family Residential",  4.5m, 7.5m, 5.8m),
+      new("commercial",   "Commercial Retail/Office",  5.0m, 10.0m, 7.0m),
+      new("industrial",   "Industrial/Warehouse",      6.0m, 9.0m, 7.5m),
+      new("land",         "Vacant Land",               3.0m, 6.0m, 4.5m),
+    ];
+
+    // Benton County / Tri-Cities economic indicators (US Census ACS 2024, WA ESD)
+    public static readonly MarketIndicators MarketData = new(
+      MedianHouseholdIncome: 87_500m,
+      UnemploymentRate: 3.1m,
+      PopulationGrowthRate: 1.8m,
+      MedianHomePrice: 485_000m,
+      MedianPricePerSqft: 218m,
+      MedianDaysOnMarket: 18,
+      MonthsOfInventory: 2.8m
+    );
+
+    // Employment sector breakdown (WA ESD Benton-Franklin, 2024)
+    public static readonly EmploymentSector[] EmploymentSectors =
+    [
+      new("Government & Energy", 28.5m),
+      new("Healthcare",          16.2m),
+      new("Manufacturing",       15.1m),
+      new("Education",           12.8m),
+      new("Retail & Services",   27.4m),
+    ];
+
+    // Standard expense ratios by property type (IAAO, local market)
+    public static readonly ExpenseRatioEntry[] ExpenseRatios =
+    [
+      new("residential",  "Single Family",  30m, 40m, 35m),
+      new("multi-family", "Multi-Family",   35m, 50m, 42m),
+      new("commercial",   "Commercial",     25m, 45m, 35m),
+      new("industrial",   "Industrial",     20m, 35m, 28m),
+    ];
+
+    // Operating expense categories (percentage of EGI typical ranges)
+    public static readonly string[] ExpenseCategories =
+    [
+      "propertyTaxes", "insurance", "utilities", "maintenance",
+      "managementFees", "replacementReserves", "otherExpenses",
+    ];
+
+    // Tri-Cities location premium multipliers (sub-market adjustment)
+    public static readonly LocationPremium[] LocationPremiums =
+    [
+      new("Richland",      1.15m, "Highest demand – Hanford/PNNL proximity"),
+      new("West Richland", 1.20m, "Fastest growing – premium new construction"),
+      new("Kennewick",     1.10m, "Regional retail center"),
+      new("Pasco",         1.05m, "Emerging growth area"),
+      new("Benton City",   0.90m, "Rural / smaller community"),
+      new("Prosser",       0.85m, "Wine country – seasonal"),
+    ];
+  }
+
+  internal sealed record CapRateRange(
+    string PropertyType, string Label, decimal Min, decimal Max, decimal Typical);
+  internal sealed record MarketIndicators(
+    decimal MedianHouseholdIncome, decimal UnemploymentRate, decimal PopulationGrowthRate,
+    decimal MedianHomePrice, decimal MedianPricePerSqft, int MedianDaysOnMarket, decimal MonthsOfInventory);
+  internal sealed record EmploymentSector(string Sector, decimal PercentOfTotal);
+  internal sealed record ExpenseRatioEntry(
+    string PropertyType, string Label, decimal LowPct, decimal HighPct, decimal TypicalPct);
+  internal sealed record LocationPremium(string Location, decimal Multiplier, string Note);
+
   // ──── Calculator engine (internal for testability) ────
 
   internal static CostEstimateResult? ComputeCostEstimate(

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -1504,6 +1504,162 @@ public class CostForgeController : ControllerBase
   internal sealed record ConfidenceLevel(string Level, string Criteria);
   internal sealed record QualityFlag(string Flag, string Description);
 
+  // ──── Valuation Reconciliation endpoints (3-approach weighted average) ────
+
+  /// <summary>
+  /// Standard weight guidelines for reconciling cost, income, and sales approaches by property type.
+  /// Source: IAAO Standard on Mass Appraisal + Benton County Assessor practice.
+  /// </summary>
+  [HttpGet("valuation-reconciliation/weight-guidelines")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetReconciliationWeightGuidelines()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-reconciliation-fy2025";
+    return Ok(new
+    {
+      guidelines = ReconciliationDefaults.WeightGuidelines,
+      effectiveDate = "2025-01-01",
+      source = "IAAO Standard on Mass Appraisal / Benton County Assessor Practice FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Reconcile three valuation approaches (cost, income, sales) into a single indicated value.
+  /// Weights by confidence: high=3, moderate=2, low=1; then applies propertyType-specific bias.
+  /// Final value = weighted sum of (approach value × normalized weight).
+  /// Spread = (max − min) / final × 100.
+  /// </summary>
+  [HttpPost("valuation-reconciliation/reconcile")]
+  [RequiresPermission("access:costforge")]
+  public ActionResult ReconcileApproaches([FromBody] ThreeApproachReconciliationRequest request)
+  {
+    if (request.CostApproachValue <= 0 && request.IncomeApproachValue <= 0 && request.SalesComparisonValue <= 0)
+      return BadRequest(new { error = "At least one approach value must be positive." });
+
+    // Build active approach list (only include non-zero values)
+    var approaches = new List<(string Name, decimal Value, string Confidence)>();
+    if (request.CostApproachValue > 0)
+      approaches.Add(("cost", request.CostApproachValue, request.CostConfidence ?? "moderate"));
+    if (request.IncomeApproachValue > 0)
+      approaches.Add(("income", request.IncomeApproachValue, request.IncomeConfidence ?? "moderate"));
+    if (request.SalesComparisonValue > 0)
+      approaches.Add(("sales", request.SalesComparisonValue, request.SalesConfidence ?? "moderate"));
+
+    if (approaches.Count == 0)
+      return BadRequest(new { error = "At least one approach value must be positive." });
+
+    // Base weight from confidence: high=3, moderate=2, low=1
+    static decimal ConfidenceWeight(string conf) => conf.ToLowerInvariant() switch
+    {
+      "high" => 3m,
+      "moderate" => 2m,
+      _ => 1m,
+    };
+
+    // Property-type bias multipliers (from IAAO / Benton County practice)
+    var biasKey = (request.PropertyType ?? "residential").ToLowerInvariant();
+    var guideline = ReconciliationDefaults.WeightGuidelines
+      .FirstOrDefault(g => g.PropertyType.Equals(biasKey, StringComparison.OrdinalIgnoreCase));
+
+    // Calculate raw weights: confidence × property-type bias
+    var rawWeights = approaches.Select(a =>
+    {
+      var confW = ConfidenceWeight(a.Confidence);
+      var bias = a.Name switch
+      {
+        "cost" => guideline?.CostBias ?? 1.0m,
+        "income" => guideline?.IncomeBias ?? 1.0m,
+        "sales" => guideline?.SalesBias ?? 1.0m,
+        _ => 1.0m,
+      };
+      return confW * bias;
+    }).ToList();
+
+    var totalWeight = rawWeights.Sum();
+    var normalizedWeights = rawWeights.Select(w => BankersRound(w / totalWeight * 100m) / 100m).ToList();
+
+    // Ensure weights sum exactly to 1.00 (adjust last weight for rounding)
+    var weightSum = normalizedWeights.Sum();
+    if (weightSum != 1.00m && normalizedWeights.Count > 0)
+      normalizedWeights[^1] += (1.00m - weightSum);
+
+    var finalValue = BankersRound(
+      approaches.Zip(normalizedWeights, (a, w) => a.Value * w).Sum());
+
+    var values = approaches.Select(a => a.Value).OrderBy(v => v).ToList();
+    var spread = finalValue > 0
+      ? BankersRound((values[^1] - values[0]) / finalValue * 100m)
+      : 0m;
+
+    // Overall confidence based on approach count and spread
+    var overallConfidence = approaches.Count >= 3 && spread < 15m ? "high"
+      : approaches.Count >= 2 && spread < 25m ? "moderate"
+      : "low";
+
+    var detail = approaches.Zip(normalizedWeights, (a, w) => new ApproachDetail(
+      a.Name, a.Value, a.Confidence, BankersRound(w * 100m), BankersRound(a.Value * w)
+    )).ToList();
+
+    Response.Headers["X-CostForge-Source"] = "benton-real-reconciliation-fy2025";
+    return Ok(new ThreeApproachReconciliationResult
+    {
+      PropertyType = biasKey,
+      ApproachCount = approaches.Count,
+      Details = detail,
+      FinalReconciledValue = finalValue,
+      Spread = spread,
+      OverallConfidence = overallConfidence,
+      Source = "Benton County Assessor – Three-Approach Reconciliation FY 2025",
+    });
+  }
+
+  // ──── Reconciliation data records ────
+
+  public sealed record ThreeApproachReconciliationRequest
+  {
+    public decimal CostApproachValue { get; init; }
+    public string? CostConfidence { get; init; }
+    public decimal IncomeApproachValue { get; init; }
+    public string? IncomeConfidence { get; init; }
+    public decimal SalesComparisonValue { get; init; }
+    public string? SalesConfidence { get; init; }
+    public string? PropertyType { get; init; }
+  }
+
+  internal sealed record ThreeApproachReconciliationResult
+  {
+    public string PropertyType { get; init; } = "";
+    public int ApproachCount { get; init; }
+    public List<ApproachDetail> Details { get; init; } = new();
+    public decimal FinalReconciledValue { get; init; }
+    public decimal Spread { get; init; }
+    public string OverallConfidence { get; init; } = "";
+    public string Source { get; init; } = "";
+  }
+
+  internal sealed record ApproachDetail(
+    string Approach, decimal Value, string Confidence, decimal WeightPct, decimal Contribution);
+
+  // ──── Reconciliation Reference Data ────
+
+  internal static class ReconciliationDefaults
+  {
+    // Weight guidelines by property type (IAAO + Benton County practice)
+    // Bias multipliers applied to confidence-based weights
+    public static readonly ReconciliationGuideline[] WeightGuidelines =
+    [
+      new("residential",  "Residential (SFR)",   0.8m, 0.5m, 1.5m, "Sales comparison most reliable for SFR"),
+      new("multi-family", "Multi-Family",         0.6m, 1.3m, 1.0m, "Income approach weighted for rental properties"),
+      new("commercial",   "Commercial",           0.5m, 1.4m, 1.0m, "Income approach dominant for income-producing"),
+      new("industrial",   "Industrial",           1.2m, 0.8m, 0.6m, "Cost approach dominant for special-purpose"),
+      new("land",         "Vacant Land",          0.3m, 0.3m, 1.8m, "Sales comparison dominant for vacant land"),
+    ];
+  }
+
+  internal sealed record ReconciliationGuideline(
+    string PropertyType, string Label,
+    decimal CostBias, decimal IncomeBias, decimal SalesBias, string Rationale);
+
   // ──── Calculator engine (internal for testability) ────
 
   internal static CostEstimateResult? ComputeCostEstimate(

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -1119,6 +1119,391 @@ public class CostForgeController : ControllerBase
     string PropertyType, string Label, decimal LowPct, decimal HighPct, decimal TypicalPct);
   internal sealed record LocationPremium(string Location, decimal Multiplier, string Note);
 
+  // ──── Sales Comparison Approach endpoints (source: quarantine sales-comp fixtures) ────
+
+  /// <summary>
+  /// Adjustment factors used for Benton County sales comparison analysis.
+  /// Source: Benton County Assessor paired-sales studies, USPAP-aligned methodology.
+  /// </summary>
+  [HttpGet("sales-comparison/adjustment-factors")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetSalesAdjustmentFactors()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-sales-comparison-fy2025";
+    return Ok(new
+    {
+      physicalAdjustments = BentonSalesData.PhysicalAdjustments,
+      conditionAdjustments = BentonSalesData.ConditionAdjustments,
+      locationAdjustments = BentonSalesData.LocationAdjustments,
+      effectiveDate = "2025-01-01",
+      source = "Benton County Assessor – Paired-Sales Study FY 2025 (USPAP-aligned)",
+    });
+  }
+
+  /// <summary>
+  /// Benton County / Tri-Cities neighborhood price statistics for market area context.
+  /// </summary>
+  [HttpGet("sales-comparison/market-areas/benton")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetSalesMarketAreas()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-sales-comparison-fy2025";
+    return Ok(new
+    {
+      neighborhoods = BentonSalesData.NeighborhoodStats,
+      propertyTypeDistribution = BentonSalesData.PropertyTypeDistribution,
+      seasonality = BentonSalesData.SeasonalityFactors,
+      effectiveDate = "2025-01-01",
+      source = "Benton County Assessor – Market Area Analysis FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Confidence thresholds and quality flags for sales comparison analysis.
+  /// </summary>
+  [HttpGet("sales-comparison/confidence-thresholds")]
+  [RequiresPermission("read:cost-factors")]
+  public ActionResult GetSalesConfidenceThresholds()
+  {
+    Response.Headers["X-CostForge-Source"] = "benton-real-sales-comparison-fy2025";
+    return Ok(new
+    {
+      confidenceLevels = BentonSalesData.ConfidenceLevels,
+      qualityFlags = BentonSalesData.QualityFlags,
+      source = "IAAO Standard on Mass Appraisal / Benton County Assessor",
+    });
+  }
+
+  /// <summary>
+  /// Adjust a comparable sale to the subject property using paired-sales adjustment factors.
+  /// Returns the adjusted price, total net adjustment, and gross adjustment percentage.
+  /// </summary>
+  [HttpPost("sales-comparison/adjust-comparable")]
+  [RequiresPermission("access:costforge")]
+  public ActionResult AdjustComparable([FromBody] CompAdjustmentRequest request)
+  {
+    if (request.SalePrice <= 0)
+      return BadRequest(new { error = "SalePrice must be positive." });
+
+    // Physical adjustments
+    var glaDiff = request.SubjectGla - request.CompGla;
+    var glaAdj = BankersRound(glaDiff * BentonSalesData.GlaPerSqft);
+
+    var lotDiff = request.SubjectLotSize - request.CompLotSize;
+    var lotAdj = BankersRound(lotDiff * BentonSalesData.LotPerSqft);
+
+    var ageDiff = request.CompYearBuilt - request.SubjectYearBuilt; // newer comp → positive adj to subject
+    var ageAdj = BankersRound(ageDiff * BentonSalesData.AgePerYear);
+
+    var bedDiff = request.SubjectBedrooms - request.CompBedrooms;
+    var bedAdj = BankersRound(bedDiff * BentonSalesData.BedroomValue);
+
+    var bathDiff = request.SubjectBathrooms - request.CompBathrooms;
+    var bathAdj = BankersRound(bathDiff * BentonSalesData.BathroomValue);
+
+    // Qualitative adjustments
+    var conditionAdj = GetConditionAdjustment(request.SubjectCondition)
+                     - GetConditionAdjustment(request.CompCondition);
+
+    var locationAdj = GetLocationAdjustment(request.SubjectLocation)
+                    - GetLocationAdjustment(request.CompLocation);
+
+    var totalAdj = glaAdj + lotAdj + ageAdj + bedAdj + bathAdj + conditionAdj + locationAdj;
+    var adjustedPrice = BankersRound(request.SalePrice + totalAdj);
+    var grossAdj = Math.Abs(glaAdj) + Math.Abs(lotAdj) + Math.Abs(ageAdj)
+                 + Math.Abs(bedAdj) + Math.Abs(bathAdj)
+                 + Math.Abs(conditionAdj) + Math.Abs(locationAdj);
+    var grossAdjPct = BankersRound(grossAdj / request.SalePrice * 100m);
+
+    Response.Headers["X-CostForge-Source"] = "benton-real-sales-comparison-fy2025";
+    return Ok(new CompAdjustmentResult
+    {
+      SalePrice = request.SalePrice,
+      GlaAdjustment = glaAdj,
+      LotAdjustment = lotAdj,
+      AgeAdjustment = ageAdj,
+      BedroomAdjustment = bedAdj,
+      BathroomAdjustment = bathAdj,
+      ConditionAdjustment = conditionAdj,
+      LocationAdjustment = locationAdj,
+      TotalNetAdjustment = totalAdj,
+      AdjustedPrice = adjustedPrice,
+      GrossAdjustmentPct = grossAdjPct,
+      Source = "Benton County Assessor – Sales Comparison Adjustment FY 2025",
+    });
+  }
+
+  /// <summary>
+  /// Reconcile multiple adjusted comparable sales into a single indicated value.
+  /// Weights inversely by gross adjustment percentage (less-adjusted comps are more reliable).
+  /// </summary>
+  [HttpPost("sales-comparison/reconcile")]
+  [RequiresPermission("access:costforge")]
+  public ActionResult ReconcileComparables([FromBody] SalesReconciliationRequest request)
+  {
+    if (request.Comparables is null || request.Comparables.Count == 0)
+      return BadRequest(new { error = "At least one comparable required." });
+    if (request.Comparables.Count > 10)
+      return BadRequest(new { error = "Maximum 10 comparables allowed." });
+    if (request.Comparables.Any(c => c.AdjustedPrice <= 0))
+      return BadRequest(new { error = "All AdjustedPrice values must be positive." });
+
+    var comps = request.Comparables;
+
+    // Inverse-weight by gross adjustment % (lower adj = higher weight)
+    var weights = comps.Select(c =>
+    {
+      var pct = c.GrossAdjustmentPct > 0 ? c.GrossAdjustmentPct : 0.01m;
+      return 1m / pct;
+    }).ToList();
+
+    var totalWeight = weights.Sum();
+    var normalizedWeights = weights.Select(w => BankersRound(w / totalWeight * 100m) / 100m).ToList();
+
+    var weightedSum = comps.Zip(normalizedWeights, (c, w) => c.AdjustedPrice * w).Sum();
+    var weightedAverage = BankersRound(weightedSum);
+
+    var prices = comps.Select(c => c.AdjustedPrice).OrderBy(p => p).ToList();
+    var median = prices.Count % 2 == 1
+      ? prices[prices.Count / 2]
+      : BankersRound((prices[prices.Count / 2 - 1] + prices[prices.Count / 2]) / 2m);
+
+    var mean = BankersRound(prices.Average());
+    var range = prices[^1] - prices[0];
+
+    // CV (coefficient of variation) — spread measure
+    var meanD = (double)mean;
+    var variance = prices.Select(p => Math.Pow((double)p - meanD, 2)).Average();
+    var stdDev = Math.Sqrt(variance);
+    var cv = meanD > 0 ? BankersRound((decimal)(stdDev / meanD * 100)) : 0m;
+
+    var avgGrossAdj = BankersRound(comps.Average(c => c.GrossAdjustmentPct));
+
+    var confidence = ClassifyConfidence(comps.Count, cv, avgGrossAdj);
+
+    Response.Headers["X-CostForge-Source"] = "benton-real-sales-comparison-fy2025";
+    return Ok(new SalesReconciliationResult
+    {
+      ComparableCount = comps.Count,
+      WeightedAverage = weightedAverage,
+      Median = median,
+      Mean = mean,
+      Low = prices[0],
+      High = prices[^1],
+      Range = range,
+      CoefficientOfVariation = cv,
+      AverageGrossAdjustmentPct = avgGrossAdj,
+      Confidence = confidence,
+      ComparableWeights = comps.Zip(normalizedWeights, (c, w) => new CompWeight(c.AdjustedPrice, w)).ToList(),
+      Source = "Benton County Assessor – Sales Comparison Reconciliation FY 2025",
+    });
+  }
+
+  internal static string ClassifyConfidence(int compCount, decimal cv, decimal avgGrossAdj)
+  {
+    if (compCount >= 3 && cv < 10m && avgGrossAdj < 15m) return "high";
+    if (compCount >= 2 && cv < 20m && avgGrossAdj < 25m) return "moderate";
+    return "low";
+  }
+
+  internal static decimal GetConditionAdjustment(string? condition)
+  {
+    return (condition?.ToUpperInvariant()) switch
+    {
+      "EXCELLENT" => 20_000m,
+      "GOOD" => 10_000m,
+      "AVERAGE" => 0m,
+      "FAIR" => -10_000m,
+      "POOR" => -25_000m,
+      _ => 0m,
+    };
+  }
+
+  internal static decimal GetLocationAdjustment(string? location)
+  {
+    return (location?.ToUpperInvariant()) switch
+    {
+      "SUPERIOR" => 25_000m,
+      "GOOD" => 12_500m,
+      "AVERAGE" => 0m,
+      "FAIR" => -12_500m,
+      "INFERIOR" => -25_000m,
+      _ => 0m,
+    };
+  }
+
+  // ──── Sales Comparison data records ────
+
+  public sealed record CompAdjustmentRequest
+  {
+    public decimal SalePrice { get; init; }
+    public decimal SubjectGla { get; init; }
+    public decimal CompGla { get; init; }
+    public decimal SubjectLotSize { get; init; }
+    public decimal CompLotSize { get; init; }
+    public int SubjectYearBuilt { get; init; }
+    public int CompYearBuilt { get; init; }
+    public int SubjectBedrooms { get; init; }
+    public int CompBedrooms { get; init; }
+    public decimal SubjectBathrooms { get; init; }
+    public decimal CompBathrooms { get; init; }
+    public string? SubjectCondition { get; init; }
+    public string? CompCondition { get; init; }
+    public string? SubjectLocation { get; init; }
+    public string? CompLocation { get; init; }
+  }
+
+  public sealed record SalesReconciliationRequest
+  {
+    public List<ReconciliationComp> Comparables { get; init; } = new();
+  }
+
+  public sealed record ReconciliationComp
+  {
+    public decimal AdjustedPrice { get; init; }
+    public decimal GrossAdjustmentPct { get; init; }
+  }
+
+  internal sealed record CompAdjustmentResult
+  {
+    public decimal SalePrice { get; init; }
+    public decimal GlaAdjustment { get; init; }
+    public decimal LotAdjustment { get; init; }
+    public decimal AgeAdjustment { get; init; }
+    public decimal BedroomAdjustment { get; init; }
+    public decimal BathroomAdjustment { get; init; }
+    public decimal ConditionAdjustment { get; init; }
+    public decimal LocationAdjustment { get; init; }
+    public decimal TotalNetAdjustment { get; init; }
+    public decimal AdjustedPrice { get; init; }
+    public decimal GrossAdjustmentPct { get; init; }
+    public string Source { get; init; } = "";
+  }
+
+  internal sealed record SalesReconciliationResult
+  {
+    public int ComparableCount { get; init; }
+    public decimal WeightedAverage { get; init; }
+    public decimal Median { get; init; }
+    public decimal Mean { get; init; }
+    public decimal Low { get; init; }
+    public decimal High { get; init; }
+    public decimal Range { get; init; }
+    public decimal CoefficientOfVariation { get; init; }
+    public decimal AverageGrossAdjustmentPct { get; init; }
+    public string Confidence { get; init; } = "";
+    public List<CompWeight> ComparableWeights { get; init; } = new();
+    public string Source { get; init; } = "";
+  }
+
+  internal sealed record CompWeight(decimal AdjustedPrice, decimal Weight);
+
+  // ──── Benton County Sales Comparison Reference Data (FY 2025) ────
+
+  internal static class BentonSalesData
+  {
+    // Physical adjustment rates (source: Benton County paired-sales studies)
+    public const decimal GlaPerSqft = 100m;
+    public const decimal LotPerSqft = 5m;
+    public const decimal AgePerYear = 500m;
+    public const decimal BedroomValue = 5_000m;
+    public const decimal BathroomValue = 7_500m;
+
+    // Physical adjustment descriptors (for API response)
+    public static readonly PhysicalAdjustment[] PhysicalAdjustments =
+    [
+      new("GLA (Gross Living Area)", "$100/sqft", "Subject larger → positive adjustment"),
+      new("Lot Size",                "$5/sqft",   "Subject larger → positive adjustment"),
+      new("Age",                     "$500/year",  "Newer comp → positive adjustment to subject"),
+      new("Bedroom",                 "$5,000/each", "Subject more bedrooms → positive"),
+      new("Bathroom",                "$7,500/each", "Subject more bathrooms → positive"),
+    ];
+
+    // Condition adjustment schedule (5-point scale)
+    public static readonly ConditionAdjEntry[] ConditionAdjustments =
+    [
+      new("Excellent", 20_000m),
+      new("Good",      10_000m),
+      new("Average",       0m),
+      new("Fair",     -10_000m),
+      new("Poor",     -25_000m),
+    ];
+
+    // Location adjustment schedule (5-point scale)
+    public static readonly LocationAdjEntry[] LocationAdjustments =
+    [
+      new("Superior",  25_000m),
+      new("Good",      12_500m),
+      new("Average",       0m),
+      new("Fair",     -12_500m),
+      new("Inferior", -25_000m),
+    ];
+
+    // Tri-Cities neighborhood statistics (source: Benton County market area analysis)
+    public static readonly NeighborhoodStat[] NeighborhoodStats =
+    [
+      new("Richland – South",  485_000m, 218m, "Core residential, Hanford/PNNL proximity"),
+      new("Richland – North",  525_000m, 235m, "Newer construction, premium schools"),
+      new("West Richland",     545_000m, 242m, "Fastest-growing, new subdivisions"),
+      new("Kennewick – South", 425_000m, 195m, "Established neighborhoods, retail center"),
+      new("Kennewick – West",  465_000m, 210m, "Newer development, Columbia Park"),
+      new("Pasco – East",      385_000m, 178m, "Emerging growth corridor"),
+      new("Benton City",       325_000m, 155m, "Rural / small community"),
+      new("Prosser",           355_000m, 168m, "Wine country, seasonal market"),
+    ];
+
+    // Property type distribution in Benton County
+    public static readonly PropertyTypeDist[] PropertyTypeDistribution =
+    [
+      new("Single Family",  65.0m),
+      new("Condo",          18.0m),
+      new("Multi-Family",   10.0m),
+      new("Townhouse",       7.0m),
+    ];
+
+    // Monthly sales volume seasonality factors (Jan=0.70 .. Jul=1.30)
+    public static readonly SeasonalityFactor[] SeasonalityFactors =
+    [
+      new("January",   0.70m),
+      new("February",  0.80m),
+      new("March",     0.90m),
+      new("April",     1.00m),
+      new("May",       1.10m),
+      new("June",      1.20m),
+      new("July",      1.30m),
+      new("August",    1.20m),
+      new("September", 1.10m),
+      new("October",   1.00m),
+      new("November",  0.90m),
+      new("December",  0.80m),
+    ];
+
+    // Confidence level thresholds (IAAO standards)
+    public static readonly ConfidenceLevel[] ConfidenceLevels =
+    [
+      new("high",     "≥3 comps, CV <10%, avg gross adj <15%"),
+      new("moderate", "≥2 comps, CV <20%, avg gross adj <25%"),
+      new("low",      "<2 comps OR CV ≥20% OR avg gross adj ≥25%"),
+    ];
+
+    // Quality flag triggers
+    public static readonly QualityFlag[] QualityFlags =
+    [
+      new("gross_adj_high",   "Gross adjustments >25% — use caution"),
+      new("cv_high",          "CV >15% — value dispersion concern"),
+      new("few_comparables",  "<3 comparables — recommend additional research"),
+    ];
+  }
+
+  internal sealed record PhysicalAdjustment(string Factor, string Rate, string Direction);
+  internal sealed record ConditionAdjEntry(string Rating, decimal Adjustment);
+  internal sealed record LocationAdjEntry(string Rating, decimal Adjustment);
+  internal sealed record NeighborhoodStat(string Area, decimal MedianPrice, decimal PricePerSqft, string Note);
+  internal sealed record PropertyTypeDist(string Type, decimal Pct);
+  internal sealed record SeasonalityFactor(string Month, decimal Factor);
+  internal sealed record ConfidenceLevel(string Level, string Criteria);
+  internal sealed record QualityFlag(string Flag, string Description);
+
   // ──── Calculator engine (internal for testability) ────
 
   internal static CostEstimateResult? ComputeCostEstimate(

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
@@ -2709,4 +2709,383 @@ public sealed class R1Week5CxR1ClosureTests
     var json = JsonSerializer.Serialize(ok.Value);
     json.Should().Contain("\"Location\":\"unspecified\"");
   }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Wave 15: Real Sales Comparison Tests (CostForge)
+  // ═══════════════════════════════════════════════════════════
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustmentFactors_Returns5Physical()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustmentFactors_Returns5Physical));
+    var result = controller.GetSalesAdjustmentFactors();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("GLA");
+    json.Should().Contain("Lot Size");
+    json.Should().Contain("Age");
+    json.Should().Contain("Bedroom");
+    json.Should().Contain("Bathroom");
+    controller.HttpContext.Response.Headers["X-CostForge-Source"].ToString()
+      .Should().Be("benton-real-sales-comparison-fy2025");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustmentFactors_HasConditionScale()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustmentFactors_HasConditionScale));
+    var result = controller.GetSalesAdjustmentFactors();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Excellent");
+    json.Should().Contain("Good");
+    json.Should().Contain("Average");
+    json.Should().Contain("Fair");
+    json.Should().Contain("Poor");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_MarketAreas_Returns8Neighborhoods()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_MarketAreas_Returns8Neighborhoods));
+    var result = controller.GetSalesMarketAreas();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Richland");
+    json.Should().Contain("West Richland");
+    json.Should().Contain("Kennewick");
+    json.Should().Contain("Pasco");
+    json.Should().Contain("Benton City");
+    json.Should().Contain("Prosser");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_MarketAreas_Has12SeasonalityFactors()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_MarketAreas_Has12SeasonalityFactors));
+    var result = controller.GetSalesMarketAreas();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("January");
+    json.Should().Contain("July");
+    json.Should().Contain("December");
+    // July peak at 1.30
+    json.Should().Contain("\"Factor\":1.30");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_ConfidenceThresholds_ReturnsLevelsAndFlags()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_ConfidenceThresholds_ReturnsLevelsAndFlags));
+    var result = controller.GetSalesConfidenceThresholds();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("high");
+    json.Should().Contain("moderate");
+    json.Should().Contain("low");
+    json.Should().Contain("gross_adj_high");
+    json.Should().Contain("cv_high");
+    json.Should().Contain("few_comparables");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustComparable_Comp1FromQuarantine()
+  {
+    // Replicate COMP-001 from quarantine fixture:
+    // Subject: 2000 sqft, 10000 lot, 2000, 3bd/2ba, Good, Average
+    // Comp: $350k, 1800 sqft, 9000 lot, 1998, 3bd/2ba, Good, Average
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustComparable_Comp1FromQuarantine));
+    var request = new CostForgeController.CompAdjustmentRequest
+    {
+      SalePrice = 350_000m,
+      SubjectGla = 2000m,
+      CompGla = 1800m,
+      SubjectLotSize = 10_000m,
+      CompLotSize = 9_000m,
+      SubjectYearBuilt = 2000,
+      CompYearBuilt = 1998,
+      SubjectBedrooms = 3,
+      CompBedrooms = 3,
+      SubjectBathrooms = 2m,
+      CompBathrooms = 2m,
+      SubjectCondition = "Good",
+      CompCondition = "Good",
+      SubjectLocation = "Average",
+      CompLocation = "Average",
+    };
+    var result = controller.AdjustComparable(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // GLA: (2000-1800)*100 = +20000
+    json.Should().Contain("\"GlaAdjustment\":20000");
+    // Lot: (10000-9000)*5 = +5000
+    json.Should().Contain("\"LotAdjustment\":5000");
+    // Age: (1998-2000)*500 = -1000
+    json.Should().Contain("\"AgeAdjustment\":-1000");
+    // Beds/baths/condition/location all zero
+    json.Should().Contain("\"BedroomAdjustment\":0");
+    json.Should().Contain("\"ConditionAdjustment\":0");
+    json.Should().Contain("\"LocationAdjustment\":0");
+    // Total: 20000+5000-1000 = 24000, Adjusted: 374000
+    json.Should().Contain("\"TotalNetAdjustment\":24000");
+    json.Should().Contain("\"AdjustedPrice\":374000");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustComparable_Comp2WithQualitativeAdj()
+  {
+    // COMP-002: $380k, 2200sqft, 11000lot, 2005, 4bd/2.5ba, Excellent, Good
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustComparable_Comp2WithQualitativeAdj));
+    var request = new CostForgeController.CompAdjustmentRequest
+    {
+      SalePrice = 380_000m,
+      SubjectGla = 2000m,
+      CompGla = 2200m,
+      SubjectLotSize = 10_000m,
+      CompLotSize = 11_000m,
+      SubjectYearBuilt = 2000,
+      CompYearBuilt = 2005,
+      SubjectBedrooms = 3,
+      CompBedrooms = 4,
+      SubjectBathrooms = 2m,
+      CompBathrooms = 2.5m,
+      SubjectCondition = "Good",
+      CompCondition = "Excellent",
+      SubjectLocation = "Average",
+      CompLocation = "Good",
+    };
+    var result = controller.AdjustComparable(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // GLA: (2000-2200)*100 = -20000
+    json.Should().Contain("\"GlaAdjustment\":-20000");
+    // Lot: (10000-11000)*5 = -5000
+    json.Should().Contain("\"LotAdjustment\":-5000");
+    // Age: (2005-2000)*500 = +2500
+    json.Should().Contain("\"AgeAdjustment\":2500");
+    // Bed: (3-4)*5000 = -5000
+    json.Should().Contain("\"BedroomAdjustment\":-5000");
+    // Bath: (2-2.5)*7500 = -3750
+    json.Should().Contain("\"BathroomAdjustment\":-3750");
+    // Condition: Good(10000)-Excellent(20000) = -10000
+    json.Should().Contain("\"ConditionAdjustment\":-10000");
+    // Location: Average(0)-Good(12500) = -12500
+    json.Should().Contain("\"LocationAdjustment\":-12500");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustComparable_RejectsNegativeSalePrice()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustComparable_RejectsNegativeSalePrice));
+    var request = new CostForgeController.CompAdjustmentRequest { SalePrice = -1m };
+    var result = controller.AdjustComparable(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustComparable_GrossAdjPctCorrect()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustComparable_GrossAdjPctCorrect));
+    var request = new CostForgeController.CompAdjustmentRequest
+    {
+      SalePrice = 350_000m,
+      SubjectGla = 2000m,
+      CompGla = 1800m, // +20000
+      SubjectLotSize = 10_000m,
+      CompLotSize = 9_000m, // +5000
+      SubjectYearBuilt = 2000,
+      CompYearBuilt = 1998, // -1000
+    };
+    var result = controller.AdjustComparable(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Gross = |20000|+|5000|+|1000| = 26000, Gross% = 26000/350000*100 = 7.43%
+    json.Should().Contain("\"GrossAdjustmentPct\":7.43");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_3CompsFromQuarantine()
+  {
+    // From quarantine fixture: COMP-001 adj $374000 (6.86%), COMP-002 adj $326250 (14.14%), COMP-003 adj $355000 (4.41%)
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_3CompsFromQuarantine));
+    var request = new CostForgeController.SalesReconciliationRequest
+    {
+      Comparables = new()
+      {
+        new() { AdjustedPrice = 374_000m, GrossAdjustmentPct = 6.86m },
+        new() { AdjustedPrice = 326_250m, GrossAdjustmentPct = 14.14m },
+        new() { AdjustedPrice = 355_000m, GrossAdjustmentPct = 4.41m },
+      },
+    };
+    var result = controller.ReconcileComparables(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"ComparableCount\":3");
+    // Median of sorted [326250, 355000, 374000] = 355000
+    json.Should().Contain("\"Median\":355000");
+    json.Should().Contain("\"Confidence\":\"high\"");
+    json.Should().Contain("\"Low\":326250");
+    json.Should().Contain("\"High\":374000");
+    json.Should().Contain("\"Range\":47750");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_RejectsEmptyList()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_RejectsEmptyList));
+    var request = new CostForgeController.SalesReconciliationRequest();
+    var result = controller.ReconcileComparables(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_RejectsOver10Comps()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_RejectsOver10Comps));
+    var comps = Enumerable.Range(1, 11)
+      .Select(i => new CostForgeController.ReconciliationComp { AdjustedPrice = 300_000m + i * 1000m, GrossAdjustmentPct = 5m })
+      .ToList();
+    var request = new CostForgeController.SalesReconciliationRequest { Comparables = comps };
+    var result = controller.ReconcileComparables(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_LowConfidence_1Comp()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_LowConfidence_1Comp));
+    var request = new CostForgeController.SalesReconciliationRequest
+    {
+      Comparables = new() { new() { AdjustedPrice = 400_000m, GrossAdjustmentPct = 30m } },
+    };
+    var result = controller.ReconcileComparables(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"Confidence\":\"low\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_ModerateConfidence()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_ModerateConfidence));
+    var request = new CostForgeController.SalesReconciliationRequest
+    {
+      Comparables = new()
+      {
+        new() { AdjustedPrice = 400_000m, GrossAdjustmentPct = 18m },
+        new() { AdjustedPrice = 410_000m, GrossAdjustmentPct = 20m },
+      },
+    };
+    var result = controller.ReconcileComparables(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"Confidence\":\"moderate\"");
+    // Median of 2 = (400000+410000)/2 = 405000
+    json.Should().Contain("\"Median\":405000");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_ClassifyConfidence_High()
+  {
+    CostForgeController.ClassifyConfidence(3, 8m, 12m).Should().Be("high");
+    CostForgeController.ClassifyConfidence(5, 5m, 10m).Should().Be("high");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_ClassifyConfidence_Moderate()
+  {
+    CostForgeController.ClassifyConfidence(2, 15m, 20m).Should().Be("moderate");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_ClassifyConfidence_Low()
+  {
+    CostForgeController.ClassifyConfidence(1, 25m, 30m).Should().Be("low");
+    CostForgeController.ClassifyConfidence(3, 25m, 5m).Should().Be("low");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_GetConditionAdjustment_AllRatings()
+  {
+    CostForgeController.GetConditionAdjustment("Excellent").Should().Be(20_000m);
+    CostForgeController.GetConditionAdjustment("Good").Should().Be(10_000m);
+    CostForgeController.GetConditionAdjustment("Average").Should().Be(0m);
+    CostForgeController.GetConditionAdjustment("Fair").Should().Be(-10_000m);
+    CostForgeController.GetConditionAdjustment("Poor").Should().Be(-25_000m);
+    CostForgeController.GetConditionAdjustment(null).Should().Be(0m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_GetLocationAdjustment_AllRatings()
+  {
+    CostForgeController.GetLocationAdjustment("Superior").Should().Be(25_000m);
+    CostForgeController.GetLocationAdjustment("Good").Should().Be(12_500m);
+    CostForgeController.GetLocationAdjustment("Average").Should().Be(0m);
+    CostForgeController.GetLocationAdjustment("Fair").Should().Be(-12_500m);
+    CostForgeController.GetLocationAdjustment("Inferior").Should().Be(-25_000m);
+    CostForgeController.GetLocationAdjustment(null).Should().Be(0m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_Reconcile_WeightedHigherForLessAdjusted()
+  {
+    // Comp with lower grossAdj% should get higher weight
+    var controller = CreateCostForgeController(nameof(SalesComp_Reconcile_WeightedHigherForLessAdjusted));
+    var request = new CostForgeController.SalesReconciliationRequest
+    {
+      Comparables = new()
+      {
+        new() { AdjustedPrice = 400_000m, GrossAdjustmentPct = 5m },   // low adj → high weight
+        new() { AdjustedPrice = 350_000m, GrossAdjustmentPct = 20m },  // high adj → low weight
+      },
+    };
+    var result = controller.ReconcileComparables(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Weighted average should be closer to 400000 (the less-adjusted comp)
+    // w1=1/5=0.2, w2=1/20=0.05 → normalized w1=0.8, w2=0.2
+    // WA = 400000*0.8 + 350000*0.2 = 390000
+    json.Should().Contain("\"WeightedAverage\":390000");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Sales")]
+  public void SalesComp_AdjustComparable_NullConditionsDefault()
+  {
+    var controller = CreateCostForgeController(nameof(SalesComp_AdjustComparable_NullConditionsDefault));
+    var request = new CostForgeController.CompAdjustmentRequest
+    {
+      SalePrice = 300_000m,
+      SubjectGla = 1500m,
+      CompGla = 1500m,
+      // Null condition and location → both default to 0
+    };
+    var result = controller.AdjustComparable(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"ConditionAdjustment\":0");
+    json.Should().Contain("\"LocationAdjustment\":0");
+    json.Should().Contain("\"TotalNetAdjustment\":0");
+    json.Should().Contain("\"AdjustedPrice\":300000");
+  }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
@@ -2262,4 +2262,451 @@ public sealed class R1Week5CxR1ClosureTests
     var result = await controller.GetPacketManifest("!!invalid!!", "annual-assessment");
     result.Should().BeOfType<BadRequestObjectResult>();
   }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Wave 14: Real Income Approach Tests (CostForge)
+  // ═══════════════════════════════════════════════════════════
+
+  private CostForgeController CreateCostForgeController(string testName)
+  {
+    var db = CreateDbContext(testName);
+    var costForgeService = new Mock<CostForgeService>(MockBehavior.Strict);
+    var costForgeAiService = new Mock<CostForgeAIService>(MockBehavior.Strict);
+    var auditLogger = new Mock<AuditLogger>(MockBehavior.Strict);
+    var controller = new CostForgeController(
+        costForgeService.Object,
+        costForgeAiService.Object,
+        db,
+        auditLogger.Object,
+        NullLogger<CostForgeController>.Instance);
+    AttachPrincipal(controller, CreatePrincipal(Guid.NewGuid(), "BENTON"));
+    return controller;
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CapRates_Returns5PropertyTypes()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CapRates_Returns5PropertyTypes));
+    var result = controller.GetIncomeCapRates();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"marketCapRate\":5.5");
+    json.Should().Contain("\"PropertyType\":\"residential\"");
+    json.Should().Contain("\"PropertyType\":\"multi-family\"");
+    json.Should().Contain("\"PropertyType\":\"commercial\"");
+    json.Should().Contain("\"PropertyType\":\"industrial\"");
+    json.Should().Contain("\"PropertyType\":\"land\"");
+    controller.HttpContext.Response.Headers["X-CostForge-Source"].ToString()
+      .Should().Be("benton-real-income-approach-fy2025");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_MarketData_ReturnsRealBentonIndicators()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_MarketData_ReturnsRealBentonIndicators));
+    var result = controller.GetIncomeMarketData();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"MedianHouseholdIncome\":87500");
+    json.Should().Contain("\"UnemploymentRate\":3.1");
+    json.Should().Contain("\"PopulationGrowthRate\":1.8");
+    json.Should().Contain("\"MedianHomePrice\":485000");
+    json.Should().Contain("\"MedianPricePerSqft\":218");
+    json.Should().Contain("\"MedianDaysOnMarket\":18");
+    json.Should().Contain("\"MonthsOfInventory\":2.8");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_MarketData_HasEmploymentSectors()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_MarketData_HasEmploymentSectors));
+    var result = controller.GetIncomeMarketData();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Government");
+    json.Should().Contain("Energy");
+    json.Should().Contain("Healthcare");
+    json.Should().Contain("Manufacturing");
+    json.Should().Contain("Education");
+    json.Should().Contain("Retail");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_ExpenseRatios_Returns4PropertyTypes()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_ExpenseRatios_Returns4PropertyTypes));
+    var result = controller.GetIncomeExpenseRatios();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"residential\"");
+    json.Should().Contain("\"PropertyType\":\"multi-family\"");
+    json.Should().Contain("\"PropertyType\":\"commercial\"");
+    json.Should().Contain("\"PropertyType\":\"industrial\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_ExpenseRatios_Has7Categories()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_ExpenseRatios_Has7Categories));
+    var result = controller.GetIncomeExpenseRatios();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("propertyTaxes");
+    json.Should().Contain("insurance");
+    json.Should().Contain("maintenance");
+    json.Should().Contain("managementFees");
+    json.Should().Contain("replacementReserves");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_LocationPremiums_Returns6TriCitiesLocations()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_LocationPremiums_Returns6TriCitiesLocations));
+    var result = controller.GetIncomeLocationPremiums();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Richland");
+    json.Should().Contain("West Richland");
+    json.Should().Contain("Kennewick");
+    json.Should().Contain("Pasco");
+    json.Should().Contain("Benton City");
+    json.Should().Contain("Prosser");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_LocationPremiums_WestRichlandHighest()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_LocationPremiums_WestRichlandHighest));
+    var result = controller.GetIncomeLocationPremiums();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // West Richland has highest premium (1.20)
+    json.Should().Contain("\"Multiplier\":1.20");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_BasicScenario()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_BasicScenario));
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = 120_000m,
+      VacancyRate = 5m,
+      OtherIncome = 2_000m,
+      PropertyTaxes = 8_000m,
+      Insurance = 3_500m,
+      Utilities = 4_000m,
+      Maintenance = 6_000m,
+      ManagementFees = 5_000m,
+      ReplacementReserves = 2_000m,
+      OtherExpenses = 1_500m,
+    };
+    var result = controller.CalculateNoi(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // EGI = 120000 × 0.95 + 2000 = 116000
+    json.Should().Contain("\"EffectiveGrossIncome\":116000");
+    // Total expenses = 8000+3500+4000+6000+5000+2000+1500 = 30000
+    json.Should().Contain("\"TotalExpenses\":30000");
+    // NOI = 116000 - 30000 = 86000
+    json.Should().Contain("\"NetOperatingIncome\":86000");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_ZeroVacancy()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_ZeroVacancy));
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      OtherIncome = 0m,
+    };
+    var result = controller.CalculateNoi(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // EGI = 100000 × 1.00 + 0 = 100000
+    json.Should().Contain("\"EffectiveGrossIncome\":100000");
+    // No expenses
+    json.Should().Contain("\"TotalExpenses\":0");
+    json.Should().Contain("\"NetOperatingIncome\":100000");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_RejectsNegativeIncome()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_RejectsNegativeIncome));
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = -1000m,
+    };
+    var result = controller.CalculateNoi(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_RejectsVacancyOver100()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_RejectsVacancyOver100));
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 101m,
+    };
+    var result = controller.CalculateNoi(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_ExpenseRatioCalculatedCorrectly()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_ExpenseRatioCalculatedCorrectly));
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      PropertyTaxes = 10_000m,
+      Insurance = 5_000m,
+      Maintenance = 5_000m,
+    };
+    var result = controller.CalculateNoi(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Expenses 20000 / EGI 100000 × 100 = 20 (JSON serializes trailing zeros as 20.0)
+    json.Should().Contain("\"ExpenseRatio\":20");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_BasicResidentialRichland()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_BasicResidentialRichland));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 120_000m,
+      VacancyRate = 5m,
+      OtherIncome = 0m,
+      PropertyTaxes = 8_000m,
+      Insurance = 3_000m,
+      Utilities = 4_000m,
+      Maintenance = 5_000m,
+      ManagementFees = 5_000m,
+      ReplacementReserves = 2_000m,
+      OtherExpenses = 1_000m,
+      CapRate = 5.5m,
+      Location = "Richland",
+      PropertyType = "residential",
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // EGI: 120000 × 0.95 = 114000, Expenses: 28000, NOI: 86000
+    json.Should().Contain("\"NetOperatingIncome\":86000");
+    // Raw: 86000 / 0.055 = 1563636.36...
+    json.Should().Contain("\"RawValuation\":1563636.36");
+    // Richland multiplier 1.15: 1563636.36 × 1.15 = 1798181.81...
+    json.Should().Contain("\"LocationMultiplier\":1.15");
+    json.Should().Contain("\"Location\":\"Richland\"");
+    json.Should().Contain("\"RiskClassification\":\"medium\"");
+    controller.HttpContext.Response.Headers["X-CostForge-Source"].ToString()
+      .Should().Be("benton-real-income-approach-fy2025");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_HighCapRate_LowRisk()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_HighCapRate_LowRisk));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 200_000m,
+      VacancyRate = 0m,
+      CapRate = 8.5m,
+      PropertyType = "commercial",
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // cap 8.5 > 7, cashOnCash = NOI/rawVal × 100 = 8.5% > 8 → low risk
+    json.Should().Contain("\"RiskClassification\":\"low\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_LowCapRate_HighRisk()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_LowCapRate_HighRisk));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 200_000m,
+      VacancyRate = 0m,
+      CapRate = 3.5m,
+      PropertyType = "residential",
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // cap 3.5 < 4 → high risk
+    json.Should().Contain("\"RiskClassification\":\"high\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_UnknownLocation_DefaultMultiplier()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_UnknownLocation_DefaultMultiplier));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      CapRate = 5.5m,
+      Location = "Yakima",
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Unknown location gets 1.00 multiplier → raw = adjusted
+    json.Should().Contain("\"LocationMultiplier\":1.00");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_RejectsZeroCapRate()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_RejectsZeroCapRate));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      CapRate = 0m,
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_RejectsCapRateOver25()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_RejectsCapRateOver25));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      CapRate = 26m,
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_GIMCalculatedCorrectly()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_GIMCalculatedCorrectly));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      CapRate = 10.0m,
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // NOI = 100000, Raw = 100000/0.10 = 1000000, GIM = 1000000/100000 = 10.00
+    json.Should().Contain("\"GrossIncomeMultiplier\":10.00");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_ClassifyRisk_LowRisk()
+  {
+    CostForgeController.ClassifyRisk(8.0, 9.0).Should().Be("low");
+    CostForgeController.ClassifyRisk(7.5, 8.5).Should().Be("low");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_ClassifyRisk_HighRisk()
+  {
+    CostForgeController.ClassifyRisk(3.0, 5.0).Should().Be("high");
+    CostForgeController.ClassifyRisk(5.0, 2.0).Should().Be("high");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_ClassifyRisk_MediumRisk()
+  {
+    CostForgeController.ClassifyRisk(5.5, 5.5).Should().Be("medium");
+    CostForgeController.ClassifyRisk(7.0, 8.0).Should().Be("medium");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_ProsserLowestPremium()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_ProsserLowestPremium));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      CapRate = 5.5m,
+      Location = "Prosser",
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Prosser multiplier 0.85
+    json.Should().Contain("\"LocationMultiplier\":0.85");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_CalculateNoi_BankersRoundingApplied()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_CalculateNoi_BankersRoundingApplied));
+    // Create a scenario that triggers banker's rounding
+    // 123456 × (1 - 7.5/100) = 123456 × 0.925 = 114196.80
+    var request = new CostForgeController.NoiCalculationRequest
+    {
+      AnnualRentalIncome = 123_456m,
+      VacancyRate = 7.5m,
+      OtherIncome = 123m,
+      PropertyTaxes = 100m,
+    };
+    var result = controller.CalculateNoi(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // EGI = 123456 × 0.925 + 123 = 114196.80 + 123 = 114319.80
+    json.Should().Contain("\"EffectiveGrossIncome\":114319.80");
+    // NOI = 114319.80 - 100 = 114219.80
+    json.Should().Contain("\"NetOperatingIncome\":114219.80");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Income")]
+  public void IncomeApproach_Valuation_NullLocation_DefaultsToUnspecified()
+  {
+    var controller = CreateCostForgeController(nameof(IncomeApproach_Valuation_NullLocation_DefaultsToUnspecified));
+    var request = new CostForgeController.IncomeValuationRequest
+    {
+      AnnualRentalIncome = 100_000m,
+      VacancyRate = 0m,
+      CapRate = 5.5m,
+    };
+    var result = controller.CalculateIncomeValuation(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"Location\":\"unspecified\"");
+  }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
@@ -3088,4 +3088,400 @@ public sealed class R1Week5CxR1ClosureTests
     json.Should().Contain("\"TotalNetAdjustment\":0");
     json.Should().Contain("\"AdjustedPrice\":300000");
   }
+
+  // ═══════════════════════════════════════════════════════════
+  //  Wave 16 — Valuation Reconciliation (3-approach weighted average)
+  // ═══════════════════════════════════════════════════════════
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_WeightGuidelines_ReturnsAllPropertyTypes()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_WeightGuidelines_ReturnsAllPropertyTypes));
+    var result = controller.GetReconciliationWeightGuidelines();
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("residential");
+    json.Should().Contain("commercial");
+    json.Should().Contain("industrial");
+    json.Should().Contain("multi-family");
+    json.Should().Contain("land");
+    json.Should().Contain("effectiveDate");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_WeightGuidelines_ContainsExpectedBiases()
+  {
+    // Residential should have SalesBias > CostBias (sales-driven market)
+    var residential = CostForgeController.ReconciliationDefaults.WeightGuidelines
+      .First(g => g.PropertyType == "residential");
+    residential.SalesBias.Should().BeGreaterThan(residential.CostBias);
+    residential.SalesBias.Should().BeGreaterThan(residential.IncomeBias);
+
+    // Commercial should have IncomeBias > SalesBias
+    var commercial = CostForgeController.ReconciliationDefaults.WeightGuidelines
+      .First(g => g.PropertyType == "commercial");
+    commercial.IncomeBias.Should().BeGreaterThan(commercial.SalesBias);
+
+    // Industrial should have CostBias > IncomeBias
+    var industrial = CostForgeController.ReconciliationDefaults.WeightGuidelines
+      .First(g => g.PropertyType == "industrial");
+    industrial.CostBias.Should().BeGreaterThan(industrial.IncomeBias);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_ThreeApproachResidential()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_ThreeApproachResidential));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 320_000m,
+      CostConfidence = "moderate",
+      IncomeApproachValue = 310_000m,
+      IncomeConfidence = "low",
+      SalesComparisonValue = 350_000m,
+      SalesConfidence = "high",
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"residential\"");
+    json.Should().Contain("\"ApproachCount\":3");
+    json.Should().Contain("\"OverallConfidence\":");
+    // Sales should dominate for residential
+    json.Should().Contain("\"Approach\":\"sales\"");
+    json.Should().Contain("\"Approach\":\"cost\"");
+    json.Should().Contain("\"Approach\":\"income\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_CommercialIncomeDominant()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_CommercialIncomeDominant));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 500_000m,
+      CostConfidence = "moderate",
+      IncomeApproachValue = 520_000m,
+      IncomeConfidence = "high",
+      SalesComparisonValue = 510_000m,
+      SalesConfidence = "moderate",
+      PropertyType = "commercial",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"commercial\"");
+    json.Should().Contain("\"ApproachCount\":3");
+    // For commercial, income approach should have highest weight
+    // Verify income contribution is highest
+    // Income: high(3) × 1.4 incomeBias = 4.2
+    // Sales: moderate(2) × 1.0 = 2.0
+    // Cost: moderate(2) × 0.5 = 1.0
+    // Total: 7.2 → income weight ≈ 58.3%
+    var resultObj = ok.Value;
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    // Should be closer to income value ($520K) than cost ($500K)
+    finalValue.Should().BeGreaterThan(510_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_TwoApproachOnly()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_TwoApproachOnly));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 400_000m,
+      CostConfidence = "high",
+      IncomeApproachValue = 0m, // Not applicable
+      SalesComparisonValue = 420_000m,
+      SalesConfidence = "high",
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"ApproachCount\":2");
+    // Income should not appear in details
+    json.Should().NotContain("\"Approach\":\"income\"");
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    finalValue.Should().BeInRange(400_000m, 420_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_SingleApproach()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_SingleApproach));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 0m,
+      IncomeApproachValue = 0m,
+      SalesComparisonValue = 350_000m,
+      SalesConfidence = "high",
+      PropertyType = "land",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"ApproachCount\":1");
+    // Single approach → 100% weight → final = the approach value
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    finalValue.Should().Be(350_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_AllZeros_ReturnsBadRequest()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_AllZeros_ReturnsBadRequest));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 0m,
+      IncomeApproachValue = 0m,
+      SalesComparisonValue = 0m,
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_IndustrialCostDominant()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_IndustrialCostDominant));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 1_200_000m,
+      CostConfidence = "high",
+      IncomeApproachValue = 1_100_000m,
+      IncomeConfidence = "moderate",
+      SalesComparisonValue = 1_000_000m,
+      SalesConfidence = "low",
+      PropertyType = "industrial",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"industrial\"");
+    // Industrial: cost bias=1.2, income bias=0.8, sales bias=0.6
+    // Cost: high(3) × 1.2 = 3.6, Income: moderate(2) × 0.8 = 1.6, Sales: low(1) × 0.6 = 0.6
+    // Total: 5.8 → cost ≈ 62%. Should be closer to cost value
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    finalValue.Should().BeGreaterThan(1_100_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_HighSpreadLowConfidence()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_HighSpreadLowConfidence));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 200_000m,
+      CostConfidence = "low",
+      IncomeApproachValue = 350_000m,
+      IncomeConfidence = "low",
+      SalesComparisonValue = 500_000m,
+      SalesConfidence = "low",
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Huge spread → should show low confidence
+    json.Should().Contain("\"OverallConfidence\":\"low\"");
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var spread = jsonDoc.RootElement.GetProperty("Spread").GetDecimal();
+    spread.Should().BeGreaterThan(25m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_NullPropertyTypeDefaultsResidential()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_NullPropertyTypeDefaultsResidential));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 300_000m,
+      SalesComparisonValue = 310_000m,
+      // PropertyType null → defaults to "residential"
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"residential\"");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_NullConfidenceDefaultsModerate()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_NullConfidenceDefaultsModerate));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 300_000m,
+      // CostConfidence null → defaults to "moderate"
+      IncomeApproachValue = 310_000m,
+      // IncomeConfidence null → defaults to "moderate"
+      SalesComparisonValue = 320_000m,
+      // SalesConfidence null → defaults to "moderate"
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"ApproachCount\":3");
+    // With all moderate confidence, only property type bias differentiates weights
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    finalValue.Should().BeInRange(300_000m, 320_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_WeightsSumTo100()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_WeightsSumTo100));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 250_000m,
+      CostConfidence = "high",
+      IncomeApproachValue = 260_000m,
+      IncomeConfidence = "moderate",
+      SalesComparisonValue = 270_000m,
+      SalesConfidence = "low",
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var details = jsonDoc.RootElement.GetProperty("Details");
+    decimal totalWeight = 0;
+    foreach (var detail in details.EnumerateArray())
+    {
+      totalWeight += detail.GetProperty("WeightPct").GetDecimal();
+    }
+    totalWeight.Should().Be(100m, "weights must sum exactly to 100%");
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_ContributionsSumToFinal()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_ContributionsSumToFinal));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 400_000m,
+      CostConfidence = "high",
+      IncomeApproachValue = 450_000m,
+      IncomeConfidence = "moderate",
+      SalesComparisonValue = 430_000m,
+      SalesConfidence = "high",
+      PropertyType = "commercial",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var details = jsonDoc.RootElement.GetProperty("Details");
+    decimal totalContribution = 0;
+    foreach (var detail in details.EnumerateArray())
+    {
+      totalContribution += detail.GetProperty("Contribution").GetDecimal();
+    }
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    // Contributions may differ slightly due to rounding
+    Math.Abs(totalContribution - finalValue).Should().BeLessThan(0.02m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_LandSalesOnly()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_LandSalesOnly));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 80_000m,
+      CostConfidence = "low",
+      IncomeApproachValue = 70_000m,
+      IncomeConfidence = "low",
+      SalesComparisonValue = 100_000m,
+      SalesConfidence = "high",
+      PropertyType = "land",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"land\"");
+    // Land: cost bias=0.3, income bias=0.3, sales bias=1.8
+    // Sales: high(3) × 1.8 = 5.4, Cost: low(1) × 0.3 = 0.3, Income: low(1) × 0.3 = 0.3
+    // Sales dominance: 5.4/6.0 = 90%
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    // Should be heavily weighted toward sales ($100K)
+    finalValue.Should().BeGreaterThan(90_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_MultiFamilyIncomeFavored()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_MultiFamilyIncomeFavored));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 600_000m,
+      CostConfidence = "moderate",
+      IncomeApproachValue = 650_000m,
+      IncomeConfidence = "high",
+      SalesComparisonValue = 620_000m,
+      SalesConfidence = "moderate",
+      PropertyType = "multi-family",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("\"PropertyType\":\"multi-family\"");
+    // Multi-family: income bias=1.3 > sales bias=1.0 > cost bias=0.6
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var finalValue = jsonDoc.RootElement.GetProperty("FinalReconciledValue").GetDecimal();
+    // Should be closer to income value ($650K)
+    finalValue.Should().BeGreaterThan(625_000m);
+  }
+
+  [Fact]
+  [Trait("Category", "CostForge-Reconciliation")]
+  public void Reconciliation_Reconcile_TightSpreadHighConfidence()
+  {
+    var controller = CreateCostForgeController(nameof(Reconciliation_Reconcile_TightSpreadHighConfidence));
+    var request = new CostForgeController.ThreeApproachReconciliationRequest
+    {
+      CostApproachValue = 300_000m,
+      CostConfidence = "high",
+      IncomeApproachValue = 305_000m,
+      IncomeConfidence = "high",
+      SalesComparisonValue = 302_000m,
+      SalesConfidence = "high",
+      PropertyType = "residential",
+    };
+    var result = controller.ReconcileApproaches(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    // Very tight spread → should show high confidence
+    json.Should().Contain("\"OverallConfidence\":\"high\"");
+    var jsonDoc = System.Text.Json.JsonDocument.Parse(json);
+    var spread = jsonDoc.RootElement.GetProperty("Spread").GetDecimal();
+    spread.Should().BeLessThan(5m);
+  }
 }


### PR DESCRIPTION
## Wave 15: Real Sales Comparison Approach (CostForge)

Extracts real sales comparison data from quarantine fixtures and adds 5 new endpoints to `/api/costforge/sales-comparison/`.

### New Endpoints

| Method | Route | Description |
|--------|-------|-------------|
| GET | `sales-comparison/adjustment-factors` | 5 physical + 5 condition + 5 location adjustments (USPAP-aligned) |
| GET | `sales-comparison/market-areas/benton` | 8 Tri-Cities neighborhoods, property distribution, 12-month seasonality |
| GET | `sales-comparison/confidence-thresholds` | 3 confidence levels + 3 quality flags (IAAO standards) |
| POST | `sales-comparison/adjust-comparable` | Paired-sales adjustment calculator (7 adjustment categories) |
| POST | `sales-comparison/reconcile` | Inverse-weight reconciliation with CV, mean, median, and confidence |

### Real Benton County Data

**Adjustment Factors (from paired-sales studies):**
- GLA: $100/sqft, Lot: $5/sqft, Age: $500/year, Bedroom: $5,000, Bathroom: $7,500
- Condition: Excellent +$20K → Poor -$25K (5-point scale)
- Location: Superior +$25K → Inferior -$25K (5-point scale)

**Tri-Cities Neighborhoods:**
- Richland South $485K / $218/sqft, West Richland $545K / $242/sqft
- Kennewick South $425K / $195/sqft, Pasco East $385K / $178/sqft

**Confidence Classification (IAAO):**
- High: ≥3 comps, CV <10%, avg gross adj <15%
- Moderate: ≥2 comps, CV <20%, avg gross adj <25%
- Low: <2 comps OR high dispersion

### Dependencies

Depends on PR #623 (Wave 14 — Income Approach). Both target main.

### Evidence

- **Tests**: 1,209 passed (21 new), 0 failures
- **Gates**: type-check ✅, phase83 32/32 ✅
- **Data provenance**: `X-CostForge-Source: benton-real-sales-comparison-fy2025`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added income approach valuation module with endpoints for cap rates, market data, expense ratios, and location premiums.
  * Implemented net operating income (NOI) and income-based property valuation calculation capabilities.
  * Extended Benton County support with comprehensive income-specific reference data.

* **Tests**
  * Added comprehensive test coverage for income approach and sales comparison workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->