### PR TITLE
feat(dossier): Wave 24 — persistent document management + evidence chain + packet generation

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DossierController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DossierController.cs
@@ -1478,6 +1478,752 @@ public class DossierController : ControllerBase
     ];
   }
 
+  // ══════════════════════════════════════════════════════════════
+  // WAVE 24 — Persistent Document Management + Evidence Chain
+  // Replaces synthesized-only document/evidence indexes with real
+  // DB-backed entities while keeping synthesized views for backward compat.
+  // ══════════════════════════════════════════════════════════════
+
+  // ── Document CRUD ────────────────────────────────────────────
+
+  public sealed record RegisterDocumentRequest(
+      string ParcelId,
+      string Name,
+      string DocumentType,
+      string MimeType,
+      long SizeBytes,
+      string ContentHash,
+      string? Description,
+      string? RetentionClass,
+      string? StoragePath);
+
+  /// <summary>
+  /// Register a new document for a parcel. Creates persistent document metadata record.
+  /// </summary>
+  [HttpPost("documents")]
+  [RequiresPermission("write:dossier")]
+  public async Task<IActionResult> RegisterDocument([FromBody] RegisterDocumentRequest? request)
+  {
+    if (request is null)
+      return BadRequest(new { error = "Request body is required" });
+
+    if (string.IsNullOrWhiteSpace(request.ParcelId) || !IsValidParcelId(request.ParcelId.Trim()))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    if (string.IsNullOrWhiteSpace(request.Name))
+      return BadRequest(new { error = "Document name is required" });
+
+    if (request.Name.Length > 200)
+      return BadRequest(new { error = "Document name must be at most 200 characters" });
+
+    if (string.IsNullOrWhiteSpace(request.DocumentType))
+      return BadRequest(new { error = "Document type is required" });
+
+    if (string.IsNullOrWhiteSpace(request.MimeType))
+      return BadRequest(new { error = "Mime type is required" });
+
+    if (request.SizeBytes < 0)
+      return BadRequest(new { error = "SizeBytes must be non-negative" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var parcelId = request.ParcelId.Trim();
+    var property = await _db.Properties
+        .AsNoTracking()
+        .FirstOrDefaultAsync(p => p.ParcelId == parcelId && p.CountyId == countyId.Value);
+    if (property is null)
+      return NotFound(new { error = "Parcel not found" });
+
+    var entersCustody = BentonDocumentData.DocumentTypes
+        .FirstOrDefault(t => t.Type.Equals(request.DocumentType, StringComparison.OrdinalIgnoreCase))
+        ?.EntersCustodyChain ?? false;
+
+    var document = new DossierDocument
+    {
+      ParcelId = parcelId,
+      Name = request.Name.Trim(),
+      DocumentType = request.DocumentType.Trim(),
+      MimeType = request.MimeType.Trim(),
+      SizeBytes = request.SizeBytes,
+      ContentHash = request.ContentHash?.Trim() ?? "",
+      Description = request.Description?.Trim(),
+      RetentionClass = request.RetentionClass?.Trim(),
+      StoragePath = request.StoragePath?.Trim(),
+      EntersCustodyChain = entersCustody,
+      CountyId = countyId.Value,
+      UploadedBy = User.Identity?.Name ?? "system",
+    };
+
+    _db.DossierDocuments.Add(document);
+    await _db.SaveChangesAsync();
+
+    _logger.LogInformation("Document {DocumentId} registered for parcel {ParcelId}", document.Id, parcelId);
+
+    return CreatedAtAction(nameof(GetPersistentDocument), new { id = document.Id }, new
+    {
+      id = document.Id,
+      parcelId = document.ParcelId,
+      name = document.Name,
+      documentType = document.DocumentType,
+      status = document.Status,
+      uploadedBy = document.UploadedBy,
+      uploadedAt = document.UploadedAt,
+      correlationId = GetOrCreateCorrelationId(),
+    });
+  }
+
+  /// <summary>
+  /// Get a persistent document record by ID.
+  /// </summary>
+  [HttpGet("documents/persistent/{id}")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> GetPersistentDocument(string id)
+  {
+    if (!Guid.TryParse(id, out var documentId))
+      return BadRequest(new { error = "Invalid document id" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var document = await _db.DossierDocuments
+        .AsNoTracking()
+        .FirstOrDefaultAsync(d => d.Id == documentId && d.CountyId == countyId.Value);
+    if (document is null)
+      return NotFound(new { error = "Document not found" });
+
+    return Ok(new
+    {
+      id = document.Id,
+      parcelId = document.ParcelId,
+      name = document.Name,
+      documentType = document.DocumentType,
+      status = document.Status,
+      mimeType = document.MimeType,
+      sizeBytes = document.SizeBytes,
+      contentHash = document.ContentHash,
+      storagePath = document.StoragePath,
+      description = document.Description,
+      retentionClass = document.RetentionClass,
+      entersCustodyChain = document.EntersCustodyChain,
+      uploadedBy = document.UploadedBy,
+      uploadedAt = document.UploadedAt,
+      createdAt = document.CreatedAt,
+      updatedAt = document.UpdatedAt,
+    });
+  }
+
+  public sealed record UpdateDocumentStatusRequest(string Status, string? Reason);
+
+  /// <summary>
+  /// Update document status (active → sealed → archived). Append-only status transitions.
+  /// </summary>
+  [HttpPatch("documents/persistent/{id}/status")]
+  [RequiresPermission("write:dossier")]
+  public async Task<IActionResult> UpdateDocumentStatus(string id, [FromBody] UpdateDocumentStatusRequest? request)
+  {
+    if (!Guid.TryParse(id, out var documentId))
+      return BadRequest(new { error = "Invalid document id" });
+
+    if (request is null || string.IsNullOrWhiteSpace(request.Status))
+      return BadRequest(new { error = "Status is required" });
+
+    var newStatus = request.Status.Trim().ToLowerInvariant();
+    if (newStatus is not ("active" or "sealed" or "archived"))
+      return BadRequest(new { error = "Status must be one of: active, sealed, archived" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var document = await _db.DossierDocuments
+        .FirstOrDefaultAsync(d => d.Id == documentId && d.CountyId == countyId.Value);
+    if (document is null)
+      return NotFound(new { error = "Document not found" });
+
+    // Validate transition: active → sealed → archived (no backward transitions)
+    var validTransitions = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+    {
+      ["active"] = new[] { "sealed", "archived" },
+      ["sealed"] = new[] { "archived" },
+      ["archived"] = Array.Empty<string>(),
+    };
+
+    if (!validTransitions.TryGetValue(document.Status, out var allowed) ||
+        !allowed.Contains(newStatus, StringComparer.OrdinalIgnoreCase))
+      return BadRequest(new { error = $"Cannot transition from '{document.Status}' to '{newStatus}'" });
+
+    document.Status = newStatus;
+    document.UpdatedAt = DateTime.UtcNow;
+    await _db.SaveChangesAsync();
+
+    _logger.LogInformation("Document {DocumentId} status updated to {Status}", document.Id, newStatus);
+
+    return Ok(new
+    {
+      id = document.Id,
+      status = document.Status,
+      updatedAt = document.UpdatedAt,
+      correlationId = GetOrCreateCorrelationId(),
+    });
+  }
+
+  /// <summary>
+  /// List persistent documents for a parcel (county-isolated).
+  /// </summary>
+  [HttpGet("parcels/{parcelId}/documents")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> ListParcelDocuments(string parcelId, [FromQuery] int? limit, [FromQuery] int? offset)
+  {
+    parcelId = parcelId.Trim();
+    if (!IsValidParcelId(parcelId))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var effectiveLimit = NormalizeLimit(limit);
+    var effectiveOffset = NormalizeOffset(offset);
+
+    var query = _db.DossierDocuments
+        .AsNoTracking()
+        .Where(d => d.ParcelId == parcelId && d.CountyId == countyId.Value)
+        .OrderByDescending(d => d.UploadedAt);
+
+    var total = await query.CountAsync();
+    var documents = await query
+        .Skip(effectiveOffset)
+        .Take(effectiveLimit)
+        .Select(d => new
+        {
+          id = d.Id,
+          name = d.Name,
+          documentType = d.DocumentType,
+          status = d.Status,
+          mimeType = d.MimeType,
+          sizeBytes = d.SizeBytes,
+          uploadedBy = d.UploadedBy,
+          uploadedAt = d.UploadedAt,
+        })
+        .ToListAsync();
+
+    return Ok(new
+    {
+      results = documents,
+      total,
+      hasMore = effectiveOffset + documents.Count < total,
+    });
+  }
+
+  // ── Evidence CRUD ────────────────────────────────────────────
+
+  public sealed record RegisterEvidenceRequest(
+      string ParcelId,
+      string Title,
+      string EvidenceType,
+      Guid? DocumentId);
+
+  /// <summary>
+  /// Register a new evidence item for a parcel. Creates initial "created" custody event.
+  /// </summary>
+  [HttpPost("evidence")]
+  [RequiresPermission("write:dossier")]
+  public async Task<IActionResult> RegisterEvidence([FromBody] RegisterEvidenceRequest? request)
+  {
+    if (request is null)
+      return BadRequest(new { error = "Request body is required" });
+
+    if (string.IsNullOrWhiteSpace(request.ParcelId) || !IsValidParcelId(request.ParcelId.Trim()))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    if (string.IsNullOrWhiteSpace(request.Title))
+      return BadRequest(new { error = "Evidence title is required" });
+
+    if (request.Title.Length > 200)
+      return BadRequest(new { error = "Title must be at most 200 characters" });
+
+    if (string.IsNullOrWhiteSpace(request.EvidenceType))
+      return BadRequest(new { error = "Evidence type is required" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var parcelId = request.ParcelId.Trim();
+    var property = await _db.Properties
+        .AsNoTracking()
+        .FirstOrDefaultAsync(p => p.ParcelId == parcelId && p.CountyId == countyId.Value);
+    if (property is null)
+      return NotFound(new { error = "Parcel not found" });
+
+    // Validate DocumentId if provided
+    if (request.DocumentId.HasValue)
+    {
+      var doc = await _db.DossierDocuments
+          .AsNoTracking()
+          .FirstOrDefaultAsync(d => d.Id == request.DocumentId.Value && d.CountyId == countyId.Value);
+      if (doc is null)
+        return BadRequest(new { error = "Referenced document not found" });
+    }
+
+    var actor = User.Identity?.Name ?? "system";
+    var evidence = new DossierEvidence
+    {
+      ParcelId = parcelId,
+      Title = request.Title.Trim(),
+      EvidenceType = request.EvidenceType.Trim(),
+      DocumentId = request.DocumentId,
+      CountyId = countyId.Value,
+      CreatedBy = actor,
+    };
+
+    _db.DossierEvidenceItems.Add(evidence);
+
+    // Create initial custody event
+    var custodyEvent = new DossierCustodyEvent
+    {
+      EvidenceId = evidence.Id,
+      Action = "created",
+      Actor = actor,
+      Hash = ComputeSha256($"evidence:{evidence.Id:N}:{evidence.CreatedAt:O}:{parcelId}"),
+      CountyId = countyId.Value,
+    };
+
+    _db.DossierCustodyEvents.Add(custodyEvent);
+    await _db.SaveChangesAsync();
+
+    _logger.LogInformation("Evidence {EvidenceId} registered for parcel {ParcelId}", evidence.Id, parcelId);
+
+    return CreatedAtAction(nameof(GetPersistentEvidence), new { id = evidence.Id }, new
+    {
+      id = evidence.Id,
+      parcelId = evidence.ParcelId,
+      title = evidence.Title,
+      evidenceType = evidence.EvidenceType,
+      integrity = evidence.Integrity,
+      createdBy = evidence.CreatedBy,
+      createdAt = evidence.CreatedAt,
+      correlationId = GetOrCreateCorrelationId(),
+    });
+  }
+
+  /// <summary>
+  /// Get a persistent evidence record by ID.
+  /// </summary>
+  [HttpGet("evidence/persistent/{id}")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> GetPersistentEvidence(string id)
+  {
+    if (!Guid.TryParse(id, out var evidenceId))
+      return BadRequest(new { error = "Invalid evidence id" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var evidence = await _db.DossierEvidenceItems
+        .AsNoTracking()
+        .FirstOrDefaultAsync(e => e.Id == evidenceId && e.CountyId == countyId.Value);
+    if (evidence is null)
+      return NotFound(new { error = "Evidence item not found" });
+
+    var chainLength = await _db.DossierCustodyEvents
+        .AsNoTracking()
+        .CountAsync(c => c.EvidenceId == evidenceId);
+
+    return Ok(new
+    {
+      id = evidence.Id,
+      parcelId = evidence.ParcelId,
+      title = evidence.Title,
+      evidenceType = evidence.EvidenceType,
+      integrity = evidence.Integrity,
+      documentId = evidence.DocumentId,
+      createdBy = evidence.CreatedBy,
+      createdAt = evidence.CreatedAt,
+      chainLength,
+    });
+  }
+
+  /// <summary>
+  /// List persistent evidence items for a parcel (county-isolated).
+  /// </summary>
+  [HttpGet("parcels/{parcelId}/evidence/persistent")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> ListParcelEvidence(string parcelId, [FromQuery] int? limit, [FromQuery] int? offset)
+  {
+    parcelId = parcelId.Trim();
+    if (!IsValidParcelId(parcelId))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var effectiveLimit = NormalizeLimit(limit);
+    var effectiveOffset = NormalizeOffset(offset);
+
+    var query = _db.DossierEvidenceItems
+        .AsNoTracking()
+        .Where(e => e.ParcelId == parcelId && e.CountyId == countyId.Value)
+        .OrderByDescending(e => e.CreatedAt);
+
+    var total = await query.CountAsync();
+    var evidence = await query
+        .Skip(effectiveOffset)
+        .Take(effectiveLimit)
+        .Select(e => new
+        {
+          id = e.Id,
+          title = e.Title,
+          evidenceType = e.EvidenceType,
+          integrity = e.Integrity,
+          documentId = e.DocumentId,
+          createdBy = e.CreatedBy,
+          createdAt = e.CreatedAt,
+        })
+        .ToListAsync();
+
+    return Ok(new
+    {
+      results = evidence,
+      total,
+      hasMore = effectiveOffset + evidence.Count < total,
+    });
+  }
+
+  // ── Custody Chain Operations ─────────────────────────────────
+
+  public sealed record AddCustodyEventRequest(string Action, string? Notes);
+
+  /// <summary>
+  /// Add a custody event to an evidence item (append-only). Updates integrity status.
+  /// </summary>
+  [HttpPost("evidence/persistent/{id}/custody")]
+  [RequiresPermission("write:dossier")]
+  public async Task<IActionResult> AddCustodyEvent(string id, [FromBody] AddCustodyEventRequest? request)
+  {
+    if (!Guid.TryParse(id, out var evidenceId))
+      return BadRequest(new { error = "Invalid evidence id" });
+
+    if (request is null || string.IsNullOrWhiteSpace(request.Action))
+      return BadRequest(new { error = "Action is required" });
+
+    var action = request.Action.Trim().ToLowerInvariant();
+    var validActions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+      "verified", "transferred", "sealed", "disputed", "hash-verified", "reviewed"
+    };
+
+    if (!validActions.Contains(action))
+      return BadRequest(new { error = $"Invalid action. Must be one of: {string.Join(", ", validActions)}" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var evidence = await _db.DossierEvidenceItems
+        .FirstOrDefaultAsync(e => e.Id == evidenceId && e.CountyId == countyId.Value);
+    if (evidence is null)
+      return NotFound(new { error = "Evidence item not found" });
+
+    var actor = User.Identity?.Name ?? "system";
+
+    // Get previous hash for chain integrity
+    var previousEvent = await _db.DossierCustodyEvents
+        .AsNoTracking()
+        .Where(c => c.EvidenceId == evidenceId)
+        .OrderByDescending(c => c.Timestamp)
+        .FirstOrDefaultAsync();
+
+    var newHash = ComputeSha256(
+        $"custody:{evidenceId:N}:{action}:{DateTime.UtcNow:O}:{previousEvent?.Hash ?? "genesis"}");
+
+    var custodyEvent = new DossierCustodyEvent
+    {
+      EvidenceId = evidenceId,
+      Action = action,
+      Actor = actor,
+      Hash = newHash,
+      Notes = request.Notes?.Trim(),
+      CountyId = countyId.Value,
+    };
+
+    _db.DossierCustodyEvents.Add(custodyEvent);
+
+    // Update evidence integrity based on action
+    if (action is "verified" or "hash-verified")
+      evidence.Integrity = "verified";
+    else if (action is "disputed")
+      evidence.Integrity = "disputed";
+
+    await _db.SaveChangesAsync();
+
+    var chainLength = await _db.DossierCustodyEvents
+        .AsNoTracking()
+        .CountAsync(c => c.EvidenceId == evidenceId);
+
+    _logger.LogInformation("Custody event '{Action}' added to evidence {EvidenceId}", action, evidenceId);
+
+    return Ok(new
+    {
+      eventId = custodyEvent.Id,
+      evidenceId,
+      action = custodyEvent.Action,
+      actor = custodyEvent.Actor,
+      hash = custodyEvent.Hash,
+      timestamp = custodyEvent.Timestamp,
+      chainLength,
+      integrity = evidence.Integrity,
+      correlationId = GetOrCreateCorrelationId(),
+    });
+  }
+
+  /// <summary>
+  /// Get full custody chain for a persistent evidence item.
+  /// </summary>
+  [HttpGet("evidence/persistent/{id}/chain")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> GetPersistentCustodyChain(string id)
+  {
+    if (!Guid.TryParse(id, out var evidenceId))
+      return BadRequest(new { error = "Invalid evidence id" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var evidence = await _db.DossierEvidenceItems
+        .AsNoTracking()
+        .FirstOrDefaultAsync(e => e.Id == evidenceId && e.CountyId == countyId.Value);
+    if (evidence is null)
+      return NotFound(new { error = "Evidence item not found" });
+
+    var events = await _db.DossierCustodyEvents
+        .AsNoTracking()
+        .Where(c => c.EvidenceId == evidenceId)
+        .OrderBy(c => c.Timestamp)
+        .Select(c => new
+        {
+          id = c.Id,
+          action = c.Action,
+          actor = c.Actor,
+          hash = c.Hash,
+          notes = c.Notes,
+          timestamp = c.Timestamp,
+        })
+        .ToListAsync();
+
+    return Ok(new
+    {
+      evidenceId,
+      title = evidence.Title,
+      integrity = evidence.Integrity,
+      chainLength = events.Count,
+      events,
+    });
+  }
+
+  // ── Packet Operations ────────────────────────────────────────
+
+  public sealed record CreatePacketRequest(string ParcelId, string PacketType);
+
+  /// <summary>
+  /// Create an assessment packet from a template. Links matching documents and computes completeness.
+  /// </summary>
+  [HttpPost("packets")]
+  [RequiresPermission("write:dossier")]
+  public async Task<IActionResult> CreatePacket([FromBody] CreatePacketRequest? request)
+  {
+    if (request is null)
+      return BadRequest(new { error = "Request body is required" });
+
+    if (string.IsNullOrWhiteSpace(request.ParcelId) || !IsValidParcelId(request.ParcelId.Trim()))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    if (string.IsNullOrWhiteSpace(request.PacketType))
+      return BadRequest(new { error = "Packet type is required" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var parcelId = request.ParcelId.Trim();
+    var packetType = request.PacketType.Trim();
+
+    var template = BentonDocumentData.PacketTemplates
+        .FirstOrDefault(t => t.PacketType.Equals(packetType, StringComparison.OrdinalIgnoreCase));
+    if (template is null)
+      return BadRequest(new { error = $"Unknown packet type: {packetType}" });
+
+    var property = await _db.Properties
+        .AsNoTracking()
+        .FirstOrDefaultAsync(p => p.ParcelId == parcelId && p.CountyId == countyId.Value);
+    if (property is null)
+      return NotFound(new { error = "Parcel not found" });
+
+    // Find matching persistent documents for this parcel
+    var parcelDocuments = await _db.DossierDocuments
+        .AsNoTracking()
+        .Where(d => d.ParcelId == parcelId && d.CountyId == countyId.Value && d.Status != "archived")
+        .ToListAsync();
+
+    var actor = User.Identity?.Name ?? "system";
+    var packet = new DossierPacket
+    {
+      ParcelId = parcelId,
+      PacketType = template.PacketType,
+      Name = $"{template.Name} - {parcelId}",
+      CountyId = countyId.Value,
+      CreatedBy = actor,
+      TotalRequired = template.RequiredDocumentTypes.Length,
+    };
+
+    var satisfiedCount = 0;
+    foreach (var requiredType in template.RequiredDocumentTypes)
+    {
+      var matchingDoc = parcelDocuments
+          .FirstOrDefault(d => d.DocumentType.Equals(requiredType, StringComparison.OrdinalIgnoreCase));
+
+      var satisfied = matchingDoc is not null;
+      if (satisfied) satisfiedCount++;
+
+      var item = new DossierPacketItem
+      {
+        PacketId = packet.Id,
+        DocumentType = requiredType,
+        DocumentId = matchingDoc?.Id,
+        Required = true,
+        Satisfied = satisfied,
+        SatisfiedAt = satisfied ? matchingDoc!.UploadedAt : null,
+      };
+
+      packet.Items.Add(item);
+    }
+
+    packet.SatisfiedCount = satisfiedCount;
+    packet.CompletenessPercent = packet.TotalRequired > 0
+        ? Math.Round((double)satisfiedCount / packet.TotalRequired * 100, 1)
+        : 0;
+
+    if (packet.CompletenessPercent >= 100)
+      packet.Status = "complete";
+
+    _db.DossierPackets.Add(packet);
+    await _db.SaveChangesAsync();
+
+    _logger.LogInformation("Packet {PacketId} created for parcel {ParcelId} ({PacketType})", packet.Id, parcelId, packetType);
+
+    return CreatedAtAction(nameof(GetPacket), new { id = packet.Id }, new
+    {
+      id = packet.Id,
+      parcelId = packet.ParcelId,
+      packetType = packet.PacketType,
+      name = packet.Name,
+      status = packet.Status,
+      completeness = $"{packet.CompletenessPercent}%",
+      satisfied = packet.SatisfiedCount,
+      total = packet.TotalRequired,
+      items = packet.Items.Select(i => new
+      {
+        documentType = i.DocumentType,
+        required = i.Required,
+        satisfied = i.Satisfied,
+        documentId = i.DocumentId,
+        satisfiedAt = i.SatisfiedAt,
+      }),
+      correlationId = GetOrCreateCorrelationId(),
+    });
+  }
+
+  /// <summary>
+  /// Get a persistent packet record with its items.
+  /// </summary>
+  [HttpGet("packets/{id}")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> GetPacket(string id)
+  {
+    if (!Guid.TryParse(id, out var packetId))
+      return BadRequest(new { error = "Invalid packet id" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var packet = await _db.DossierPackets
+        .AsNoTracking()
+        .Include(p => p.Items)
+        .FirstOrDefaultAsync(p => p.Id == packetId && p.CountyId == countyId.Value);
+    if (packet is null)
+      return NotFound(new { error = "Packet not found" });
+
+    return Ok(new
+    {
+      id = packet.Id,
+      parcelId = packet.ParcelId,
+      packetType = packet.PacketType,
+      name = packet.Name,
+      status = packet.Status,
+      completeness = $"{packet.CompletenessPercent}%",
+      satisfied = packet.SatisfiedCount,
+      total = packet.TotalRequired,
+      createdBy = packet.CreatedBy,
+      createdAt = packet.CreatedAt,
+      updatedAt = packet.UpdatedAt,
+      items = packet.Items.Select(i => new
+      {
+        id = i.Id,
+        documentType = i.DocumentType,
+        required = i.Required,
+        satisfied = i.Satisfied,
+        documentId = i.DocumentId,
+        satisfiedAt = i.SatisfiedAt,
+      }),
+    });
+  }
+
+  /// <summary>
+  /// List packets for a parcel (county-isolated).
+  /// </summary>
+  [HttpGet("parcels/{parcelId}/packets")]
+  [RequiresPermission("read:dossier")]
+  public async Task<IActionResult> ListParcelPackets(string parcelId)
+  {
+    parcelId = parcelId.Trim();
+    if (!IsValidParcelId(parcelId))
+      return BadRequest(new { error = "Invalid parcelId format" });
+
+    var countyId = await ResolveCountyIdAsync();
+    if (countyId is null)
+      return Forbid();
+
+    var packets = await _db.DossierPackets
+        .AsNoTracking()
+        .Where(p => p.ParcelId == parcelId && p.CountyId == countyId.Value)
+        .OrderByDescending(p => p.CreatedAt)
+        .Select(p => new
+        {
+          id = p.Id,
+          packetType = p.PacketType,
+          name = p.Name,
+          status = p.Status,
+          completeness = p.CompletenessPercent,
+          satisfied = p.SatisfiedCount,
+          total = p.TotalRequired,
+          createdAt = p.CreatedAt,
+        })
+        .ToListAsync();
+
+    return Ok(new
+    {
+      results = packets,
+      total = packets.Count,
+    });
+  }
+
   // ── Read-only Dossier Registry Helpers ───────────────────────
 
   private sealed record DossierDocumentIndexItem(
@@ -1623,10 +2369,58 @@ public class DossierController : ControllerBase
           Hash: ComputeSha256($"note-document:{note.Id:N}:{note.CreatedAt:O}:{note.Content}")));
     }
 
+    // Include persistent documents (Wave 24)
+    await AppendPersistentDocumentsAsync(countyId, documents);
+
     return documents
         .OrderByDescending(d => d.UploadedAt)
         .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
         .ToList();
+  }
+
+  /// <summary>
+  /// Append persistent DossierDocuments to the unified index alongside synthesized entries.
+  /// </summary>
+  private async System.Threading.Tasks.Task AppendPersistentDocumentsAsync(Guid countyId, List<DossierDocumentIndexItem> documents)
+  {
+    var persistent = await _db.DossierDocuments
+        .AsNoTracking()
+        .Where(d => d.CountyId == countyId)
+        .Select(d => new
+        {
+          d.Id,
+          d.ParcelId,
+          d.Name,
+          d.DocumentType,
+          d.Status,
+          d.MimeType,
+          d.SizeBytes,
+          d.ContentHash,
+          d.UploadedBy,
+          d.UploadedAt,
+          d.EntersCustodyChain,
+        })
+        .ToListAsync();
+
+    foreach (var doc in persistent)
+    {
+      var sizeLabel = doc.SizeBytes >= 1048576
+          ? $"{doc.SizeBytes / 1048576} MB"
+          : $"{Math.Max(1, doc.SizeBytes / 1024)} KB";
+
+      documents.Add(new DossierDocumentIndexItem(
+          Id: $"pdoc-{doc.Id:N}",
+          Name: doc.Name,
+          Type: doc.DocumentType,
+          ParcelId: doc.ParcelId,
+          UploadedBy: string.IsNullOrWhiteSpace(doc.UploadedBy) ? "County Staff" : doc.UploadedBy,
+          UploadedAt: doc.UploadedAt,
+          Size: sizeLabel,
+          Status: doc.Status,
+          CustodyChain: doc.EntersCustodyChain ? 1 : 0,
+          MimeType: doc.MimeType,
+          Hash: doc.ContentHash));
+    }
   }
 
   private async Task<List<DossierEvidenceIndexItem>> BuildEvidenceIndexAsync(Guid countyId)
@@ -1688,6 +2482,38 @@ public class DossierController : ControllerBase
           Integrity: MapIntegrityStatus(note.NoteType, note.CreatedBy, note.Content),
           ChainLength: 2,
           LastAction: note.NoteType.Replace('_', '-').ToLowerInvariant()));
+    }
+
+    // Include persistent evidence items (Wave 24)
+    var persistentEvidence = await _db.DossierEvidenceItems
+        .AsNoTracking()
+        .Where(e => e.CountyId == countyId)
+        .Select(e => new { e.Id, e.ParcelId, e.Title, e.EvidenceType, e.CreatedBy, e.CreatedAt, e.Integrity })
+        .ToListAsync();
+
+    foreach (var pe in persistentEvidence)
+    {
+      var chainLen = await _db.DossierCustodyEvents
+          .AsNoTracking()
+          .CountAsync(c => c.EvidenceId == pe.Id);
+
+      var lastEvt = await _db.DossierCustodyEvents
+          .AsNoTracking()
+          .Where(c => c.EvidenceId == pe.Id)
+          .OrderByDescending(c => c.Timestamp)
+          .Select(c => c.Action)
+          .FirstOrDefaultAsync();
+
+      evidenceItems.Add(new DossierEvidenceIndexItem(
+          Id: $"pevid-{pe.Id:N}",
+          Title: pe.Title,
+          ParcelId: pe.ParcelId,
+          EvidenceType: pe.EvidenceType,
+          CreatedBy: string.IsNullOrWhiteSpace(pe.CreatedBy) ? "County Staff" : pe.CreatedBy,
+          CreatedAt: pe.CreatedAt,
+          Integrity: pe.Integrity,
+          ChainLength: chainLen,
+          LastAction: lastEvt ?? "created"));
     }
 
     return evidenceItems

--- a/backend/src/TerraFusion.Core/Entities/DossierCustodyEvent.cs
+++ b/backend/src/TerraFusion.Core/Entities/DossierCustodyEvent.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Append-only chain-of-custody event for evidence items.
+/// Write-lane owner: Dossier.
+/// Each event records an action taken on evidence with integrity hash.
+/// </summary>
+public class DossierCustodyEvent
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  public Guid EvidenceId { get; set; }
+  public DossierEvidence Evidence { get; set; } = null!;
+
+  /// <summary>created | verified | transferred | sealed | disputed | hash-verified</summary>
+  [Required]
+  [StringLength(50)]
+  public string Action { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(200)]
+  public string Actor { get; set; } = string.Empty;
+
+  /// <summary>SHA-256 integrity hash at this point in chain.</summary>
+  [StringLength(64)]
+  public string? Hash { get; set; }
+
+  [StringLength(500)]
+  public string? Notes { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/DossierDocument.cs
+++ b/backend/src/TerraFusion.Core/Entities/DossierDocument.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Persistent document record for the Dossier document-management system.
+/// Write-lane owner: Dossier.
+/// Tracks metadata for uploaded/registered documents associated with parcels.
+/// </summary>
+public class DossierDocument
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  [Required]
+  [StringLength(50)]
+  public string ParcelId { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(200)]
+  public string Name { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(50)]
+  public string DocumentType { get; set; } = string.Empty;
+
+  /// <summary>active | sealed | archived</summary>
+  [Required]
+  [StringLength(20)]
+  public string Status { get; set; } = "active";
+
+  [Required]
+  [StringLength(100)]
+  public string MimeType { get; set; } = "application/octet-stream";
+
+  public long SizeBytes { get; set; }
+
+  /// <summary>SHA-256 of file content for tamper detection.</summary>
+  [StringLength(64)]
+  public string ContentHash { get; set; } = string.Empty;
+
+  [StringLength(500)]
+  public string? StoragePath { get; set; }
+
+  [StringLength(500)]
+  public string? Description { get; set; }
+
+  /// <summary>Retention class from WA SOS CORE schedule.</summary>
+  [StringLength(50)]
+  public string? RetentionClass { get; set; }
+
+  public bool EntersCustodyChain { get; set; }
+
+  public Guid CountyId { get; set; }
+  public County County { get; set; } = null!;
+
+  [StringLength(200)]
+  public string UploadedBy { get; set; } = string.Empty;
+
+  public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
+
+  // Audit fields (auto-populated for FISMA compliance)
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+  public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/DossierEvidence.cs
+++ b/backend/src/TerraFusion.Core/Entities/DossierEvidence.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Persistent evidence record linking to documents or property data.
+/// Write-lane owner: Dossier.
+/// Tracks evidence items with integrity status for audit compliance.
+/// </summary>
+public class DossierEvidence
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  [Required]
+  [StringLength(50)]
+  public string ParcelId { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(200)]
+  public string Title { get; set; } = string.Empty;
+
+  /// <summary>field-inspection | valuation-record | legal-document | tax-record | correspondence | photo</summary>
+  [Required]
+  [StringLength(50)]
+  public string EvidenceType { get; set; } = string.Empty;
+
+  /// <summary>pending | verified | disputed</summary>
+  [Required]
+  [StringLength(20)]
+  public string Integrity { get; set; } = "pending";
+
+  /// <summary>Optional link to a DossierDocument.</summary>
+  public Guid? DocumentId { get; set; }
+  public DossierDocument? Document { get; set; }
+
+  public Guid CountyId { get; set; }
+  public County County { get; set; } = null!;
+
+  [StringLength(200)]
+  public string CreatedBy { get; set; } = string.Empty;
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/DossierPacket.cs
+++ b/backend/src/TerraFusion.Core/Entities/DossierPacket.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Assessment packet record — a compliance-ready bundle of documents
+/// for a specific purpose (BOE appeal, certification, exemption review, etc.).
+/// Write-lane owner: Dossier.
+/// </summary>
+public class DossierPacket
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  [Required]
+  [StringLength(50)]
+  public string ParcelId { get; set; } = string.Empty;
+
+  /// <summary>boe_appeal | certification | exemption_review | annual_assessment | desk_review</summary>
+  [Required]
+  [StringLength(50)]
+  public string PacketType { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(200)]
+  public string Name { get; set; } = string.Empty;
+
+  /// <summary>draft | complete | sealed</summary>
+  [Required]
+  [StringLength(20)]
+  public string Status { get; set; } = "draft";
+
+  public double CompletenessPercent { get; set; }
+  public int SatisfiedCount { get; set; }
+  public int TotalRequired { get; set; }
+
+  public Guid CountyId { get; set; }
+  public County County { get; set; } = null!;
+
+  [StringLength(200)]
+  public string CreatedBy { get; set; } = string.Empty;
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+  public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+  public ICollection<DossierPacketItem> Items { get; set; } = new List<DossierPacketItem>();
+}

--- a/backend/src/TerraFusion.Core/Entities/DossierPacketItem.cs
+++ b/backend/src/TerraFusion.Core/Entities/DossierPacketItem.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Line item within a DossierPacket — tracks whether each required document type is satisfied.
+/// Write-lane owner: Dossier.
+/// </summary>
+public class DossierPacketItem
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  public Guid PacketId { get; set; }
+  public DossierPacket Packet { get; set; } = null!;
+
+  /// <summary>Required document type from template (e.g., "deed", "appraisal", "appeal").</summary>
+  [Required]
+  [StringLength(50)]
+  public string DocumentType { get; set; } = string.Empty;
+
+  /// <summary>Matched document, if found.</summary>
+  public Guid? DocumentId { get; set; }
+  public DossierDocument? Document { get; set; }
+
+  public bool Required { get; set; } = true;
+  public bool Satisfied { get; set; }
+
+  public DateTime? SatisfiedAt { get; set; }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -11,473 +11,547 @@ namespace TerraFusion.Data;
 
 public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
 {
-    private readonly IConfiguration _configuration;
+  private readonly IConfiguration _configuration;
 
-    public TerraFusionDbContext(DbContextOptions<TerraFusionDbContext> options, IConfiguration configuration)
-        : base(options)
+  public TerraFusionDbContext(DbContextOptions<TerraFusionDbContext> options, IConfiguration configuration)
+      : base(options)
+  {
+    _configuration = configuration;
+  }
+
+  // Core Government Entities
+  public DbSet<Property> Properties { get; set; }
+  public DbSet<County> Counties { get; set; }
+  public DbSet<CountyDeployment> CountyDeployments { get; set; }
+  public DbSet<PropertyAssessment> PropertyAssessments { get; set; }
+  public DbSet<TaxLevy> TaxLevies { get; set; }
+  public DbSet<GovernmentUser> GovernmentUsers { get; set; }
+  public DbSet<AuditLog> AuditLogs { get; set; }
+
+  // AI System Entities
+  public DbSet<AIAgent> AIAgents { get; set; }
+  public DbSet<AIModel> AIModels { get; set; }
+  public DbSet<PerformanceMetric> PerformanceMetrics { get; set; }
+
+  // NOTE: AI GPT & RAG Entities cannot be added here due to circular dependency
+  // TerraFusion.Data → TerraFusion.AI would create circular reference
+  // These entities are managed directly in TerraFusion.AI services via raw DbContext access
+  // public DbSet<GPTConfiguration> GPTConfigurations { get; set; }
+  // public DbSet<GPTConversation> GPTConversations { get; set; }
+  // public DbSet<GPTMessage> GPTMessages { get; set; }
+  // public DbSet<RAGDataset> RAGDatasets { get; set; }
+  // public DbSet<RAGDocument> RAGDocuments { get; set; }
+  // public DbSet<GPTMarketplaceInstall> GPTMarketplaceInstalls { get; set; }
+  // public DbSet<GPTUsageMetric> GPTUsageMetrics { get; set; }
+
+  // Module System Entities
+  public DbSet<Module> Modules { get; set; }
+  public DbSet<Valuation> Valuations { get; set; }
+
+  // Marketplace Entities
+  public DbSet<Plugin> Plugins { get; set; }
+  public DbSet<PluginSubmission> PluginSubmissions { get; set; }
+  public DbSet<PluginInstallation> PluginInstallations { get; set; }
+  public DbSet<PluginRevenue> PluginRevenue { get; set; }
+  public DbSet<PluginAnalytics> PluginAnalytics { get; set; }
+
+  // Security Entities
+  public DbSet<SecurityEvent> SecurityEvents { get; set; }
+  public DbSet<UserSession> UserSessions { get; set; }
+  public DbSet<PasswordHistory> PasswordHistories { get; set; }
+
+  // Collaboration Entities
+  public DbSet<CollaborationUser> CollaborationUsers { get; set; }
+  public DbSet<Team> Teams { get; set; }
+  public DbSet<TeamMember> TeamMembers { get; set; }
+  public DbSet<Project> Projects { get; set; }
+  public DbSet<ProjectParticipant> ProjectParticipants { get; set; }
+  public DbSet<ProjectDocument> ProjectDocuments { get; set; }
+  public DbSet<TerraFusion.Core.Entities.Task> Tasks { get; set; }
+  public DbSet<TaskComment> TaskComments { get; set; }
+  public DbSet<Milestone> Milestones { get; set; }
+  public DbSet<DocumentPermission> DocumentPermissions { get; set; }
+  public DbSet<CollaborationNotification> CollaborationNotifications { get; set; }
+  public DbSet<AuditEvent> AuditEvents { get; set; }
+  public DbSet<Permission> Permissions { get; set; }
+  public DbSet<UserPermission> UserPermissions { get; set; }
+
+  // Codex 3-6-9 Framework Entities
+  public DbSet<CodexMetric> CodexMetrics { get; set; }
+  public DbSet<CodexScore> CodexScores { get; set; }
+  public DbSet<CodexUltimatePower> CodexUltimatePowerRecords { get; set; }
+  public DbSet<CodexAlert> CodexAlerts { get; set; }
+  public DbSet<NotificationPreferences> NotificationPreferences { get; set; }
+
+  // Experiments
+  // Persisted here to keep experiments in the canonical data store. Keep model simple to avoid circular deps.
+  public DbSet<TerraFusion.Data.Entities.Experiment> Experiments { get; set; }
+  public DbSet<TerraFusion.Data.Entities.ExperimentRun> ExperimentRuns { get; set; }
+
+  // Dossier Entities (R1 Week 3 — CX-11)
+  public DbSet<DossierNote> DossierNotes { get; set; }
+
+  // Dossier Document Management (R2 Wave 24)
+  public DbSet<DossierDocument> DossierDocuments { get; set; }
+  public DbSet<DossierEvidence> DossierEvidenceItems { get; set; }
+  public DbSet<DossierCustodyEvent> DossierCustodyEvents { get; set; }
+  public DbSet<DossierPacket> DossierPackets { get; set; }
+  public DbSet<DossierPacketItem> DossierPacketItems { get; set; }
+
+  // TerraFlow Quantum Command Center Entities (Phase 1 Week 3)
+  public DbSet<QuantumNotebook> QuantumNotebooks { get; set; }
+  public DbSet<AnalysisResult> AnalysisResults { get; set; }
+  public DbSet<Workflow> Workflows { get; set; }
+  public DbSet<WorkflowExecution> WorkflowExecutions { get; set; }
+
+  protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+  {
+    if (!optionsBuilder.IsConfigured)
     {
-        _configuration = configuration;
+      var connectionString = _configuration.GetConnectionString("DefaultConnection");
+
+      if (connectionString?.Contains("Host=") == true)
+      {
+        // PostgreSQL for production
+        optionsBuilder.UseNpgsql(connectionString, options =>
+        {
+          options.EnableRetryOnFailure(
+                      maxRetryCount: 3,
+                      maxRetryDelay: TimeSpan.FromSeconds(5),
+                      errorCodesToAdd: null);
+          options.CommandTimeout(30);
+        });
+      }
+      else
+      {
+        // SQLite for development fallback
+        optionsBuilder.UseSqlite(connectionString ?? "Data Source=terrafusion.db");
+      }
+
+      // Enable sensitive data logging only in development
+      if (_configuration.GetValue<bool>("Logging:EnableSensitiveDataLogging", false))
+      {
+        optionsBuilder.EnableSensitiveDataLogging();
+      }
+
+      optionsBuilder.EnableDetailedErrors();
+    }
+  }
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    base.OnModelCreating(modelBuilder);
+
+    // Configure Module entity
+    modelBuilder.Entity<Module>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+      entity.HasIndex(e => e.Name).IsUnique(); // Prevent duplicate module names
+    });
+
+    // Configure Property entity
+    modelBuilder.Entity<Property>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Address).IsRequired().HasMaxLength(500);
+      entity.Property(e => e.AssessedValue).HasPrecision(18, 2);
+      entity.HasIndex(e => e.ParcelId).IsUnique();
+      entity.HasIndex(e => e.CountyId);
+    });
+
+    // Configure County entity
+    modelBuilder.Entity<County>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.State).IsRequired().HasMaxLength(2);
+      entity.Property(e => e.FipsCode).IsRequired().HasMaxLength(5);
+      entity.HasIndex(e => e.FipsCode).IsUnique();
+    });
+
+    // Configure PropertyAssessment entity
+    modelBuilder.Entity<PropertyAssessment>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.AssessedValue).HasPrecision(18, 2);
+      entity.Property(e => e.MarketValue).HasPrecision(18, 2);
+      entity.HasOne<Property>().WithMany().HasForeignKey(e => e.PropertyId);
+      entity.HasIndex(e => new { e.PropertyId, e.AssessmentYear });
+    });
+
+    // Configure TaxLevy entity
+    modelBuilder.Entity<TaxLevy>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.TaxRate).HasPrecision(8, 6);
+      entity.Property(e => e.LevyAmount).HasPrecision(18, 2);
+      entity.HasOne<County>().WithMany().HasForeignKey(e => e.CountyId);
+    });
+
+    // Configure DossierNote entity (R1 Week 3 — CX-11)
+    modelBuilder.Entity<DossierNote>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Content).IsRequired().HasMaxLength(2000);
+      entity.Property(e => e.NoteType).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.CreatedBy).HasMaxLength(200);
+      entity.HasOne(e => e.County).WithMany().HasForeignKey(e => e.CountyId);
+      entity.HasIndex(e => new { e.CountyId, e.ParcelId });
+    });
+
+    // Configure DossierDocument entity (R2 Wave 24)
+    modelBuilder.Entity<DossierDocument>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.DocumentType).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Status).IsRequired().HasMaxLength(20);
+      entity.Property(e => e.MimeType).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.ContentHash).HasMaxLength(64);
+      entity.Property(e => e.StoragePath).HasMaxLength(500);
+      entity.Property(e => e.Description).HasMaxLength(500);
+      entity.Property(e => e.RetentionClass).HasMaxLength(50);
+      entity.Property(e => e.UploadedBy).HasMaxLength(200);
+      entity.HasOne(e => e.County).WithMany().HasForeignKey(e => e.CountyId);
+      entity.HasIndex(e => new { e.CountyId, e.ParcelId });
+      entity.HasIndex(e => new { e.CountyId, e.DocumentType });
+    });
+
+    // Configure DossierEvidence entity (R2 Wave 24)
+    modelBuilder.Entity<DossierEvidence>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.EvidenceType).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Integrity).IsRequired().HasMaxLength(20);
+      entity.Property(e => e.CreatedBy).HasMaxLength(200);
+      entity.HasOne(e => e.County).WithMany().HasForeignKey(e => e.CountyId);
+      entity.HasOne(e => e.Document).WithMany().HasForeignKey(e => e.DocumentId).IsRequired(false);
+      entity.HasIndex(e => new { e.CountyId, e.ParcelId });
+    });
+
+    // Configure DossierCustodyEvent entity (R2 Wave 24)
+    modelBuilder.Entity<DossierCustodyEvent>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Action).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Actor).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.Hash).HasMaxLength(64);
+      entity.Property(e => e.Notes).HasMaxLength(500);
+      entity.HasOne(e => e.Evidence).WithMany().HasForeignKey(e => e.EvidenceId);
+      entity.HasIndex(e => e.EvidenceId);
+    });
+
+    // Configure DossierPacket entity (R2 Wave 24)
+    modelBuilder.Entity<DossierPacket>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.PacketType).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.Status).IsRequired().HasMaxLength(20);
+      entity.Property(e => e.CreatedBy).HasMaxLength(200);
+      entity.HasOne(e => e.County).WithMany().HasForeignKey(e => e.CountyId);
+      entity.HasMany(e => e.Items).WithOne(i => i.Packet).HasForeignKey(i => i.PacketId);
+      entity.HasIndex(e => new { e.CountyId, e.ParcelId });
+    });
+
+    // Configure DossierPacketItem entity (R2 Wave 24)
+    modelBuilder.Entity<DossierPacketItem>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.DocumentType).IsRequired().HasMaxLength(50);
+      entity.HasOne(e => e.Document).WithMany().HasForeignKey(e => e.DocumentId).IsRequired(false);
+    });
+
+    // Configure GovernmentUser entity
+    modelBuilder.Entity<GovernmentUser>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Email).IsRequired().HasMaxLength(255);
+      entity.Property(e => e.FirstName).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.LastName).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.Department).HasMaxLength(100);
+      entity.Property(e => e.Role).IsRequired().HasMaxLength(50);
+      entity.HasIndex(e => e.Email).IsUnique();
+    });
+
+    // Configure AuditLog entity
+    modelBuilder.Entity<AuditLog>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Type).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.Data).HasColumnType("TEXT");
+      entity.Property(e => e.Timestamp).IsRequired();
+      entity.Property(e => e.UserId).HasMaxLength(450);
+      entity.Property(e => e.UserEmail).HasMaxLength(256);
+      entity.Property(e => e.IpAddress).HasMaxLength(45);
+      entity.Property(e => e.UserAgent).HasMaxLength(500);
+      entity.Property(e => e.RequestPath).HasMaxLength(500);
+      entity.Property(e => e.RequestMethod).HasMaxLength(10);
+      entity.Property(e => e.CorrelationId).HasMaxLength(100);
+      entity.Property(e => e.Severity).HasMaxLength(20);
+      entity.Property(e => e.Source).HasMaxLength(100);
+      entity.HasIndex(e => e.Timestamp);
+      entity.HasIndex(e => e.Type);
+      entity.HasIndex(e => e.UserId);
+    });
+
+    // Configure AIAgent entity
+    modelBuilder.Entity<AIAgent>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.Type).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Status).IsRequired().HasMaxLength(20);
+      entity.Property(e => e.Configuration).HasColumnType("jsonb");
+      entity.HasIndex(e => e.Status);
+    });
+
+    // Configure SecurityEvent entity
+    modelBuilder.Entity<SecurityEvent>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.EventType).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.Description).IsRequired().HasMaxLength(1000);
+      entity.Property(e => e.Metadata).HasColumnType("jsonb");
+      entity.HasIndex(e => e.Timestamp);
+      entity.HasIndex(e => e.EventType);
+    });
+
+    // Configure PasswordHistory entity (Phase 4 Sprint 1)
+    modelBuilder.Entity<PasswordHistory>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.UserId).IsRequired();
+      entity.Property(e => e.PasswordHash).IsRequired().HasMaxLength(500);
+      entity.Property(e => e.CreatedAt).IsRequired();
+      entity.HasIndex(e => new { e.UserId, e.CreatedAt })
+              .HasDatabaseName("IX_PasswordHistory_UserId_CreatedAt");
+      entity.HasOne(e => e.User)
+              .WithMany()
+              .HasForeignKey(e => e.UserId)
+              .OnDelete(DeleteBehavior.Cascade);
+    });
+
+    modelBuilder.Entity<Plugin>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.Version).IsRequired().HasMaxLength(20);
+      entity.Property(e => e.Description).IsRequired();
+      entity.Property(e => e.Category).IsRequired().HasMaxLength(50);
+      entity.Property(e => e.AuthorId).IsRequired();
+      entity.Property(e => e.Status).IsRequired();
+      entity.Property(e => e.SubmittedAt).IsRequired();
+
+      entity.HasIndex(e => e.Name);
+      entity.HasIndex(e => e.Category);
+      entity.HasIndex(e => e.Status);
+    });
+
+    // Apply explicit EF Core configurations to resolve navigation ambiguity
+    modelBuilder.ApplyConfiguration(new CollaborationUserConfiguration());
+    modelBuilder.ApplyConfiguration(new TaskConfiguration());
+
+    // Apply Codex 3-6-9 Framework configurations
+    modelBuilder.ApplyConfiguration(new CodexMetricConfiguration());
+    modelBuilder.ApplyConfiguration(new CodexScoreConfiguration());
+    modelBuilder.ApplyConfiguration(new CodexUltimatePowerConfiguration());
+    modelBuilder.ApplyConfiguration(new CodexAlertConfiguration());
+
+    // Apply TerraFlow Quantum Command Center configurations (Phase 1 Week 3)
+    modelBuilder.ApplyConfiguration(new QuantumNotebookConfiguration());
+    modelBuilder.ApplyConfiguration(new AnalysisResultConfiguration());
+    modelBuilder.ApplyConfiguration(new WorkflowConfiguration());
+    modelBuilder.ApplyConfiguration(new WorkflowExecutionConfiguration());
+
+    // NOTE: TerraFusionGPT Suite configurations temporarily disabled due to circular dependency
+    // These configurations are defined in TerraFusion.Data\Configurations\GPTConfiguration.cs.disabled
+    // Solution: Move GPTConfiguration.cs to TerraFusion.AI\Data\Configurations or use fluent API directly
+    // modelBuilder.ApplyConfiguration(new GPTConfigurationConfiguration());
+    // modelBuilder.ApplyConfiguration(new GPTConversationConfiguration());
+    // modelBuilder.ApplyConfiguration(new GPTMessageConfiguration());
+    // modelBuilder.ApplyConfiguration(new RAGDatasetConfiguration());
+    // modelBuilder.ApplyConfiguration(new RAGDocumentConfiguration());
+    // modelBuilder.ApplyConfiguration(new GPTMarketplaceInstallConfiguration());
+    // modelBuilder.ApplyConfiguration(new GPTUsageMetricConfiguration());
+
+    modelBuilder.Entity<CollaborationNotification>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Id).HasMaxLength(450);
+      entity.Property(e => e.RecipientId).IsRequired().HasMaxLength(450);
+      entity.Property(e => e.SenderId).HasMaxLength(450);
+      entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.Message).IsRequired().HasMaxLength(1000);
+
+      entity.HasOne(e => e.Recipient)
+              .WithMany(u => u.ReceivedNotifications)
+              .HasForeignKey(e => e.RecipientId)
+              .OnDelete(DeleteBehavior.Restrict);
+
+      entity.HasOne(e => e.Sender)
+              .WithMany(u => u.SentNotifications)
+              .HasForeignKey(e => e.SenderId)
+              .OnDelete(DeleteBehavior.SetNull);
+    });
+
+    // Configure Experiment entity
+    modelBuilder.Entity<TerraFusion.Data.Entities.Experiment>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+      entity.Property(e => e.DatasetId).HasMaxLength(100);
+      entity.Property(e => e.DatasetVersion).HasMaxLength(50);
+      entity.Property(e => e.ModelId).HasMaxLength(100);
+      entity.Property(e => e.ModelVersion).HasMaxLength(50);
+      entity.Property(e => e.HyperparamsJson).HasColumnType("jsonb");
+      entity.Property(e => e.SwarmConfigJson).HasColumnType("jsonb");
+      entity.Property(e => e.Owner).HasMaxLength(200);
+      entity.Property(e => e.CreatedAt).IsRequired();
+      entity.HasIndex(e => e.CreatedAt);
+    });
+
+    // Configure ExperimentRun entity
+    modelBuilder.Entity<TerraFusion.Data.Entities.ExperimentRun>(entity =>
+    {
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.ExperimentId).IsRequired();
+      entity.Property(e => e.Status).IsRequired().HasMaxLength(100);
+      entity.Property(e => e.ExecutionDetailsJson).HasColumnType("jsonb");
+      entity.Property(e => e.CreatedAt).IsRequired();
+      entity.HasIndex(e => e.CreatedAt);
+      entity.HasIndex(e => e.ExperimentId);
+      entity.HasIndex(e => e.Status);
+      entity.HasOne<TerraFusion.Data.Entities.Experiment>()
+              .WithMany()
+              .HasForeignKey(e => e.ExperimentId)
+              .OnDelete(DeleteBehavior.Cascade);
+    });
+
+    // Apply all configurations from Configurations folder
+    modelBuilder.ApplyConfiguration(new NotificationPreferencesConfiguration());
+
+    // Configure encryption for sensitive fields
+    ConfigureEncryption(modelBuilder);
+  }
+
+  private void ConfigureEncryption(ModelBuilder modelBuilder)
+  {
+    // Configure field-level encryption for sensitive data
+    modelBuilder.Entity<GovernmentUser>()
+        .Property(e => e.SocialSecurityNumber)
+        .HasConversion(
+            v => EncryptSensitiveData(v),
+            v => DecryptSensitiveData(v));
+
+    modelBuilder.Entity<Property>()
+        .Property(e => e.OwnerSSN)
+        .HasConversion(
+            v => EncryptSensitiveData(v),
+            v => DecryptSensitiveData(v));
+  }
+
+  private string EncryptSensitiveData(string? data)
+  {
+    if (string.IsNullOrEmpty(data))
+      return string.Empty;
+
+    // In production, use proper encryption service
+    // This is a simplified example
+    return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(data));
+  }
+
+  private string? DecryptSensitiveData(string? encryptedData)
+  {
+    if (string.IsNullOrEmpty(encryptedData))
+      return null;
+
+    try
+    {
+      return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encryptedData));
+    }
+    catch
+    {
+      return null;
+    }
+  }
+
+  public override async System.Threading.Tasks.Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    // Add audit logging for all changes
+    var auditEntries = CreateAuditEntries();
+
+    var result = await base.SaveChangesAsync(cancellationToken);
+
+    // Save audit logs after successful save
+    await SaveAuditLogs(auditEntries);
+
+    return result;
+  }
+
+  private List<AuditLog> CreateAuditEntries()
+  {
+    var auditEntries = new List<AuditLog>();
+
+    foreach (var entry in ChangeTracker.Entries())
+    {
+      if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged)
+        continue;
+
+      var auditLog = new AuditLog
+      {
+        Id = Guid.NewGuid(),
+        Type = $"{entry.Entity.GetType().Name}_{entry.State}",
+        Data = System.Text.Json.JsonSerializer.Serialize(GetChanges(entry)),
+        Timestamp = DateTime.UtcNow,
+        UserId = GetCurrentUserId(),
+        Source = "EntityFramework"
+      };
+
+      auditEntries.Add(auditLog);
     }
 
-    // Core Government Entities
-    public DbSet<Property> Properties { get; set; }
-    public DbSet<County> Counties { get; set; }
-    public DbSet<CountyDeployment> CountyDeployments { get; set; }
-    public DbSet<PropertyAssessment> PropertyAssessments { get; set; }
-    public DbSet<TaxLevy> TaxLevies { get; set; }
-    public DbSet<GovernmentUser> GovernmentUsers { get; set; }
-    public DbSet<AuditLog> AuditLogs { get; set; }
+    return auditEntries;
+  }
 
-    // AI System Entities
-    public DbSet<AIAgent> AIAgents { get; set; }
-    public DbSet<AIModel> AIModels { get; set; }
-    public DbSet<PerformanceMetric> PerformanceMetrics { get; set; }
-
-    // NOTE: AI GPT & RAG Entities cannot be added here due to circular dependency
-    // TerraFusion.Data → TerraFusion.AI would create circular reference
-    // These entities are managed directly in TerraFusion.AI services via raw DbContext access
-    // public DbSet<GPTConfiguration> GPTConfigurations { get; set; }
-    // public DbSet<GPTConversation> GPTConversations { get; set; }
-    // public DbSet<GPTMessage> GPTMessages { get; set; }
-    // public DbSet<RAGDataset> RAGDatasets { get; set; }
-    // public DbSet<RAGDocument> RAGDocuments { get; set; }
-    // public DbSet<GPTMarketplaceInstall> GPTMarketplaceInstalls { get; set; }
-    // public DbSet<GPTUsageMetric> GPTUsageMetrics { get; set; }
-
-    // Module System Entities
-    public DbSet<Module> Modules { get; set; }
-    public DbSet<Valuation> Valuations { get; set; }
-
-    // Marketplace Entities
-    public DbSet<Plugin> Plugins { get; set; }
-    public DbSet<PluginSubmission> PluginSubmissions { get; set; }
-    public DbSet<PluginInstallation> PluginInstallations { get; set; }
-    public DbSet<PluginRevenue> PluginRevenue { get; set; }
-    public DbSet<PluginAnalytics> PluginAnalytics { get; set; }
-
-    // Security Entities
-    public DbSet<SecurityEvent> SecurityEvents { get; set; }
-    public DbSet<UserSession> UserSessions { get; set; }
-    public DbSet<PasswordHistory> PasswordHistories { get; set; }
-
-    // Collaboration Entities
-    public DbSet<CollaborationUser> CollaborationUsers { get; set; }
-    public DbSet<Team> Teams { get; set; }
-    public DbSet<TeamMember> TeamMembers { get; set; }
-    public DbSet<Project> Projects { get; set; }
-    public DbSet<ProjectParticipant> ProjectParticipants { get; set; }
-    public DbSet<ProjectDocument> ProjectDocuments { get; set; }
-    public DbSet<TerraFusion.Core.Entities.Task> Tasks { get; set; }
-    public DbSet<TaskComment> TaskComments { get; set; }
-    public DbSet<Milestone> Milestones { get; set; }
-    public DbSet<DocumentPermission> DocumentPermissions { get; set; }
-    public DbSet<CollaborationNotification> CollaborationNotifications { get; set; }
-    public DbSet<AuditEvent> AuditEvents { get; set; }
-    public DbSet<Permission> Permissions { get; set; }
-    public DbSet<UserPermission> UserPermissions { get; set; }
-
-    // Codex 3-6-9 Framework Entities
-    public DbSet<CodexMetric> CodexMetrics { get; set; }
-    public DbSet<CodexScore> CodexScores { get; set; }
-    public DbSet<CodexUltimatePower> CodexUltimatePowerRecords { get; set; }
-    public DbSet<CodexAlert> CodexAlerts { get; set; }
-    public DbSet<NotificationPreferences> NotificationPreferences { get; set; }
-
-    // Experiments
-    // Persisted here to keep experiments in the canonical data store. Keep model simple to avoid circular deps.
-    public DbSet<TerraFusion.Data.Entities.Experiment> Experiments { get; set; }
-    public DbSet<TerraFusion.Data.Entities.ExperimentRun> ExperimentRuns { get; set; }
-
-    // Dossier Entities (R1 Week 3 — CX-11)
-    public DbSet<DossierNote> DossierNotes { get; set; }
-
-    // TerraFlow Quantum Command Center Entities (Phase 1 Week 3)
-    public DbSet<QuantumNotebook> QuantumNotebooks { get; set; }
-    public DbSet<AnalysisResult> AnalysisResults { get; set; }
-    public DbSet<Workflow> Workflows { get; set; }
-    public DbSet<WorkflowExecution> WorkflowExecutions { get; set; }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+  private async System.Threading.Tasks.Task SaveAuditLogs(List<AuditLog> auditEntries)
+  {
+    if (auditEntries.Any())
     {
-        if (!optionsBuilder.IsConfigured)
+      AuditLogs.AddRange(auditEntries);
+      await base.SaveChangesAsync();
+    }
+  }
+
+  private string GetCurrentUserId()
+  {
+    // Get current user from HTTP context or authentication context
+    return "System"; // Placeholder
+  }
+
+  private object GetChanges(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+  {
+    var changes = new Dictionary<string, object>();
+
+    foreach (var property in entry.Properties)
+    {
+      if (property.IsModified)
+      {
+        changes[property.Metadata.Name] = new
         {
-            var connectionString = _configuration.GetConnectionString("DefaultConnection");
-
-            if (connectionString?.Contains("Host=") == true)
-            {
-                // PostgreSQL for production
-                optionsBuilder.UseNpgsql(connectionString, options =>
-                {
-                    options.EnableRetryOnFailure(
-                        maxRetryCount: 3,
-                        maxRetryDelay: TimeSpan.FromSeconds(5),
-                        errorCodesToAdd: null);
-                    options.CommandTimeout(30);
-                });
-            }
-            else
-            {
-                // SQLite for development fallback
-                optionsBuilder.UseSqlite(connectionString ?? "Data Source=terrafusion.db");
-            }
-
-            // Enable sensitive data logging only in development
-            if (_configuration.GetValue<bool>("Logging:EnableSensitiveDataLogging", false))
-            {
-                optionsBuilder.EnableSensitiveDataLogging();
-            }
-
-            optionsBuilder.EnableDetailedErrors();
-        }
+          OldValue = property.OriginalValue,
+          NewValue = property.CurrentValue
+        };
+      }
     }
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-
-        // Configure Module entity
-        modelBuilder.Entity<Module>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.HasIndex(e => e.Name).IsUnique(); // Prevent duplicate module names
-        });
-
-        // Configure Property entity
-        modelBuilder.Entity<Property>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.Address).IsRequired().HasMaxLength(500);
-            entity.Property(e => e.AssessedValue).HasPrecision(18, 2);
-            entity.HasIndex(e => e.ParcelId).IsUnique();
-            entity.HasIndex(e => e.CountyId);
-        });
-
-        // Configure County entity
-        modelBuilder.Entity<County>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.State).IsRequired().HasMaxLength(2);
-            entity.Property(e => e.FipsCode).IsRequired().HasMaxLength(5);
-            entity.HasIndex(e => e.FipsCode).IsUnique();
-        });
-
-        // Configure PropertyAssessment entity
-        modelBuilder.Entity<PropertyAssessment>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.AssessedValue).HasPrecision(18, 2);
-            entity.Property(e => e.MarketValue).HasPrecision(18, 2);
-            entity.HasOne<Property>().WithMany().HasForeignKey(e => e.PropertyId);
-            entity.HasIndex(e => new { e.PropertyId, e.AssessmentYear });
-        });
-
-        // Configure TaxLevy entity
-        modelBuilder.Entity<TaxLevy>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.TaxRate).HasPrecision(8, 6);
-            entity.Property(e => e.LevyAmount).HasPrecision(18, 2);
-            entity.HasOne<County>().WithMany().HasForeignKey(e => e.CountyId);
-        });
-
-        // Configure DossierNote entity (R1 Week 3 — CX-11)
-        modelBuilder.Entity<DossierNote>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.ParcelId).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.Content).IsRequired().HasMaxLength(2000);
-            entity.Property(e => e.NoteType).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.CreatedBy).HasMaxLength(200);
-            entity.HasOne(e => e.County).WithMany().HasForeignKey(e => e.CountyId);
-            entity.HasIndex(e => new { e.CountyId, e.ParcelId });
-        });
-
-        // Configure GovernmentUser entity
-        modelBuilder.Entity<GovernmentUser>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Email).IsRequired().HasMaxLength(255);
-            entity.Property(e => e.FirstName).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.LastName).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Department).HasMaxLength(100);
-            entity.Property(e => e.Role).IsRequired().HasMaxLength(50);
-            entity.HasIndex(e => e.Email).IsUnique();
-        });
-
-        // Configure AuditLog entity
-        modelBuilder.Entity<AuditLog>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Type).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Data).HasColumnType("TEXT");
-            entity.Property(e => e.Timestamp).IsRequired();
-            entity.Property(e => e.UserId).HasMaxLength(450);
-            entity.Property(e => e.UserEmail).HasMaxLength(256);
-            entity.Property(e => e.IpAddress).HasMaxLength(45);
-            entity.Property(e => e.UserAgent).HasMaxLength(500);
-            entity.Property(e => e.RequestPath).HasMaxLength(500);
-            entity.Property(e => e.RequestMethod).HasMaxLength(10);
-            entity.Property(e => e.CorrelationId).HasMaxLength(100);
-            entity.Property(e => e.Severity).HasMaxLength(20);
-            entity.Property(e => e.Source).HasMaxLength(100);
-            entity.HasIndex(e => e.Timestamp);
-            entity.HasIndex(e => e.Type);
-            entity.HasIndex(e => e.UserId);
-        });
-
-        // Configure AIAgent entity
-        modelBuilder.Entity<AIAgent>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Type).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.Status).IsRequired().HasMaxLength(20);
-            entity.Property(e => e.Configuration).HasColumnType("jsonb");
-            entity.HasIndex(e => e.Status);
-        });
-
-        // Configure SecurityEvent entity
-        modelBuilder.Entity<SecurityEvent>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.EventType).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.Description).IsRequired().HasMaxLength(1000);
-            entity.Property(e => e.Metadata).HasColumnType("jsonb");
-            entity.HasIndex(e => e.Timestamp);
-            entity.HasIndex(e => e.EventType);
-        });
-
-        // Configure PasswordHistory entity (Phase 4 Sprint 1)
-        modelBuilder.Entity<PasswordHistory>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.UserId).IsRequired();
-            entity.Property(e => e.PasswordHash).IsRequired().HasMaxLength(500);
-            entity.Property(e => e.CreatedAt).IsRequired();
-            entity.HasIndex(e => new { e.UserId, e.CreatedAt })
-                .HasDatabaseName("IX_PasswordHistory_UserId_CreatedAt");
-            entity.HasOne(e => e.User)
-                .WithMany()
-                .HasForeignKey(e => e.UserId)
-                .OnDelete(DeleteBehavior.Cascade);
-        });
-
-        modelBuilder.Entity<Plugin>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Version).IsRequired().HasMaxLength(20);
-            entity.Property(e => e.Description).IsRequired();
-            entity.Property(e => e.Category).IsRequired().HasMaxLength(50);
-            entity.Property(e => e.AuthorId).IsRequired();
-            entity.Property(e => e.Status).IsRequired();
-            entity.Property(e => e.SubmittedAt).IsRequired();
-
-            entity.HasIndex(e => e.Name);
-            entity.HasIndex(e => e.Category);
-            entity.HasIndex(e => e.Status);
-        });
-
-        // Apply explicit EF Core configurations to resolve navigation ambiguity
-        modelBuilder.ApplyConfiguration(new CollaborationUserConfiguration());
-        modelBuilder.ApplyConfiguration(new TaskConfiguration());
-
-        // Apply Codex 3-6-9 Framework configurations
-        modelBuilder.ApplyConfiguration(new CodexMetricConfiguration());
-        modelBuilder.ApplyConfiguration(new CodexScoreConfiguration());
-        modelBuilder.ApplyConfiguration(new CodexUltimatePowerConfiguration());
-        modelBuilder.ApplyConfiguration(new CodexAlertConfiguration());
-
-        // Apply TerraFlow Quantum Command Center configurations (Phase 1 Week 3)
-        modelBuilder.ApplyConfiguration(new QuantumNotebookConfiguration());
-        modelBuilder.ApplyConfiguration(new AnalysisResultConfiguration());
-        modelBuilder.ApplyConfiguration(new WorkflowConfiguration());
-        modelBuilder.ApplyConfiguration(new WorkflowExecutionConfiguration());
-
-        // NOTE: TerraFusionGPT Suite configurations temporarily disabled due to circular dependency
-        // These configurations are defined in TerraFusion.Data\Configurations\GPTConfiguration.cs.disabled
-        // Solution: Move GPTConfiguration.cs to TerraFusion.AI\Data\Configurations or use fluent API directly
-        // modelBuilder.ApplyConfiguration(new GPTConfigurationConfiguration());
-        // modelBuilder.ApplyConfiguration(new GPTConversationConfiguration());
-        // modelBuilder.ApplyConfiguration(new GPTMessageConfiguration());
-        // modelBuilder.ApplyConfiguration(new RAGDatasetConfiguration());
-        // modelBuilder.ApplyConfiguration(new RAGDocumentConfiguration());
-        // modelBuilder.ApplyConfiguration(new GPTMarketplaceInstallConfiguration());
-        // modelBuilder.ApplyConfiguration(new GPTUsageMetricConfiguration());
-
-        modelBuilder.Entity<CollaborationNotification>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Id).HasMaxLength(450);
-            entity.Property(e => e.RecipientId).IsRequired().HasMaxLength(450);
-            entity.Property(e => e.SenderId).HasMaxLength(450);
-            entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
-            entity.Property(e => e.Message).IsRequired().HasMaxLength(1000);
-
-            entity.HasOne(e => e.Recipient)
-                .WithMany(u => u.ReceivedNotifications)
-                .HasForeignKey(e => e.RecipientId)
-                .OnDelete(DeleteBehavior.Restrict);
-
-            entity.HasOne(e => e.Sender)
-                .WithMany(u => u.SentNotifications)
-                .HasForeignKey(e => e.SenderId)
-                .OnDelete(DeleteBehavior.SetNull);
-        });
-
-        // Configure Experiment entity
-        modelBuilder.Entity<TerraFusion.Data.Entities.Experiment>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
-            entity.Property(e => e.DatasetId).HasMaxLength(100);
-            entity.Property(e => e.DatasetVersion).HasMaxLength(50);
-            entity.Property(e => e.ModelId).HasMaxLength(100);
-            entity.Property(e => e.ModelVersion).HasMaxLength(50);
-            entity.Property(e => e.HyperparamsJson).HasColumnType("jsonb");
-            entity.Property(e => e.SwarmConfigJson).HasColumnType("jsonb");
-            entity.Property(e => e.Owner).HasMaxLength(200);
-            entity.Property(e => e.CreatedAt).IsRequired();
-            entity.HasIndex(e => e.CreatedAt);
-        });
-
-        // Configure ExperimentRun entity
-        modelBuilder.Entity<TerraFusion.Data.Entities.ExperimentRun>(entity =>
-        {
-            entity.HasKey(e => e.Id);
-            entity.Property(e => e.ExperimentId).IsRequired();
-            entity.Property(e => e.Status).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.ExecutionDetailsJson).HasColumnType("jsonb");
-            entity.Property(e => e.CreatedAt).IsRequired();
-            entity.HasIndex(e => e.CreatedAt);
-            entity.HasIndex(e => e.ExperimentId);
-            entity.HasIndex(e => e.Status);
-            entity.HasOne<TerraFusion.Data.Entities.Experiment>()
-                .WithMany()
-                .HasForeignKey(e => e.ExperimentId)
-                .OnDelete(DeleteBehavior.Cascade);
-        });
-
-        // Apply all configurations from Configurations folder
-        modelBuilder.ApplyConfiguration(new NotificationPreferencesConfiguration());
-
-        // Configure encryption for sensitive fields
-        ConfigureEncryption(modelBuilder);
-    }
-
-    private void ConfigureEncryption(ModelBuilder modelBuilder)
-    {
-        // Configure field-level encryption for sensitive data
-        modelBuilder.Entity<GovernmentUser>()
-            .Property(e => e.SocialSecurityNumber)
-            .HasConversion(
-                v => EncryptSensitiveData(v),
-                v => DecryptSensitiveData(v));
-
-        modelBuilder.Entity<Property>()
-            .Property(e => e.OwnerSSN)
-            .HasConversion(
-                v => EncryptSensitiveData(v),
-                v => DecryptSensitiveData(v));
-    }
-
-    private string EncryptSensitiveData(string? data)
-    {
-        if (string.IsNullOrEmpty(data))
-            return string.Empty;
-
-        // In production, use proper encryption service
-        // This is a simplified example
-        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(data));
-    }
-
-    private string? DecryptSensitiveData(string? encryptedData)
-    {
-        if (string.IsNullOrEmpty(encryptedData))
-            return null;
-
-        try
-        {
-            return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encryptedData));
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    public override async System.Threading.Tasks.Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-    {
-        // Add audit logging for all changes
-        var auditEntries = CreateAuditEntries();
-
-        var result = await base.SaveChangesAsync(cancellationToken);
-
-        // Save audit logs after successful save
-        await SaveAuditLogs(auditEntries);
-
-        return result;
-    }
-
-    private List<AuditLog> CreateAuditEntries()
-    {
-        var auditEntries = new List<AuditLog>();
-
-        foreach (var entry in ChangeTracker.Entries())
-        {
-            if (entry.Entity is AuditLog || entry.State == EntityState.Unchanged)
-                continue;
-
-            var auditLog = new AuditLog
-            {
-                Id = Guid.NewGuid(),
-                Type = $"{entry.Entity.GetType().Name}_{entry.State}",
-                Data = System.Text.Json.JsonSerializer.Serialize(GetChanges(entry)),
-                Timestamp = DateTime.UtcNow,
-                UserId = GetCurrentUserId(),
-                Source = "EntityFramework"
-            };
-
-            auditEntries.Add(auditLog);
-        }
-
-        return auditEntries;
-    }
-
-    private async System.Threading.Tasks.Task SaveAuditLogs(List<AuditLog> auditEntries)
-    {
-        if (auditEntries.Any())
-        {
-            AuditLogs.AddRange(auditEntries);
-            await base.SaveChangesAsync();
-        }
-    }
-
-    private string GetCurrentUserId()
-    {
-        // Get current user from HTTP context or authentication context
-        return "System"; // Placeholder
-    }
-
-    private object GetChanges(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
-    {
-        var changes = new Dictionary<string, object>();
-
-        foreach (var property in entry.Properties)
-        {
-            if (property.IsModified)
-            {
-                changes[property.Metadata.Name] = new
-                {
-                    OldValue = property.OriginalValue,
-                    NewValue = property.CurrentValue
-                };
-            }
-        }
-
-        return changes;
-    }
+    return changes;
+  }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
@@ -4854,4 +4854,873 @@ public sealed class R1Week5CxR1ClosureTests
     json.Should().Contain("conversionFactors");
     json.Should().Contain("GeometryServer");
   }
+
+  // ══════════════════════════════════════════════════════════════
+  // WAVE 24 — Dossier Document Management + Evidence Chain Tests
+  // ══════════════════════════════════════════════════════════════
+
+  private static DossierController MakeDossierController(DataDbContext db, string env = "Production")
+  {
+    var costForge = new Mock<CostForgeService>(MockBehavior.Strict);
+    var host = new Mock<IHostEnvironment>();
+    host.SetupGet(h => h.EnvironmentName).Returns(env);
+    return new DossierController(db, costForge.Object, NullLogger<DossierController>.Instance, host.Object);
+  }
+
+  private static DossierController MakeAuthedDossierController(DataDbContext db, Guid countyId, string env = "Production")
+  {
+    var ctrl = MakeDossierController(db, env);
+    AttachPrincipal(ctrl, CreatePrincipal(countyId, "BENTON"));
+    return ctrl;
+  }
+
+  private static async Task<Guid> SeedDocMgmtDataAsync(DataDbContext db)
+  {
+    var countyId = Guid.NewGuid();
+    db.Counties.Add(new County { Id = countyId, Name = "Benton", State = "WA", FipsCode = "003" });
+    db.Properties.Add(CreateProperty(countyId, "DOC-PARCEL-1"));
+    db.Properties.Add(CreateProperty(countyId, "DOC-PARCEL-2"));
+    await db.SaveChangesAsync();
+    return countyId;
+  }
+
+  // ── Document Registration ────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterDocument_ValidRequest_Returns201()
+  {
+    using var db = CreateDbContext(nameof(RegisterDocument_ValidRequest_Returns201));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterDocument(new DossierController.RegisterDocumentRequest(
+        ParcelId: "DOC-PARCEL-1",
+        Name: "Warranty Deed 2026",
+        DocumentType: "deed",
+        MimeType: "application/pdf",
+        SizeBytes: 52430,
+        ContentHash: "abc123def456",
+        Description: "Transfer deed for parcel",
+        RetentionClass: "permanent",
+        StoragePath: null));
+
+    var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+    created.StatusCode.Should().Be(201);
+    var json = JsonSerializer.Serialize(created.Value);
+    json.Should().Contain("DOC-PARCEL-1");
+    json.Should().Contain("deed");
+    json.Should().Contain("Warranty Deed 2026");
+
+    db.DossierDocuments.Count().Should().Be(1);
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterDocument_MissingParcelId_Returns400()
+  {
+    using var db = CreateDbContext(nameof(RegisterDocument_MissingParcelId_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterDocument(new DossierController.RegisterDocumentRequest(
+        ParcelId: "",
+        Name: "Test Doc",
+        DocumentType: "deed",
+        MimeType: "application/pdf",
+        SizeBytes: 100,
+        ContentHash: "x",
+        Description: null,
+        RetentionClass: null,
+        StoragePath: null));
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterDocument_NullBody_Returns400()
+  {
+    using var db = CreateDbContext(nameof(RegisterDocument_NullBody_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterDocument(null);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterDocument_ParcelNotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(RegisterDocument_ParcelNotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterDocument(new DossierController.RegisterDocumentRequest(
+        ParcelId: "NONEXISTENT",
+        Name: "Test",
+        DocumentType: "deed",
+        MimeType: "application/pdf",
+        SizeBytes: 100,
+        ContentHash: "x",
+        Description: null,
+        RetentionClass: null,
+        StoragePath: null));
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterDocument_CountyIsolation_Forbids()
+  {
+    using var db = CreateDbContext(nameof(RegisterDocument_CountyIsolation_Forbids));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var otherCounty = Guid.NewGuid();
+    db.Counties.Add(new County { Id = otherCounty, Name = "Yakima", State = "WA", FipsCode = "077" });
+    await db.SaveChangesAsync();
+    var ctrl = MakeAuthedDossierController(db, otherCounty, "Development");
+
+    var result = await ctrl.RegisterDocument(new DossierController.RegisterDocumentRequest(
+        ParcelId: "DOC-PARCEL-1",
+        Name: "Test",
+        DocumentType: "deed",
+        MimeType: "application/pdf",
+        SizeBytes: 100,
+        ContentHash: "x",
+        Description: null,
+        RetentionClass: null,
+        StoragePath: null));
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── Get Persistent Document ──────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentDocument_Found_ReturnsOk()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentDocument_Found_ReturnsOk));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Test Deed",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      SizeBytes = 4096,
+      ContentHash = "aabbcc",
+      CountyId = countyId,
+      UploadedBy = "test-user",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentDocument(doc.Id.ToString());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Test Deed");
+    json.Should().Contain("deed");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentDocument_InvalidId_Returns400()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentDocument_InvalidId_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentDocument("not-a-guid");
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentDocument_NotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentDocument_NotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentDocument(Guid.NewGuid().ToString());
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── Document Status Updates ──────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task UpdateDocumentStatus_ActiveToSealed_ReturnsOk()
+  {
+    using var db = CreateDbContext(nameof(UpdateDocumentStatus_ActiveToSealed_ReturnsOk));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Seal Test",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      Status = "active",
+      CountyId = countyId,
+      UploadedBy = "test",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.UpdateDocumentStatus(doc.Id.ToString(),
+        new DossierController.UpdateDocumentStatusRequest("sealed", "Certified by assessor"));
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("sealed");
+
+    var updated = await db.DossierDocuments.FindAsync(doc.Id);
+    updated!.Status.Should().Be("sealed");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task UpdateDocumentStatus_InvalidTransition_Returns400()
+  {
+    using var db = CreateDbContext(nameof(UpdateDocumentStatus_InvalidTransition_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Archived Doc",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      Status = "archived",
+      CountyId = countyId,
+      UploadedBy = "test",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.UpdateDocumentStatus(doc.Id.ToString(),
+        new DossierController.UpdateDocumentStatusRequest("active", null));
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task UpdateDocumentStatus_InvalidStatus_Returns400()
+  {
+    using var db = CreateDbContext(nameof(UpdateDocumentStatus_InvalidStatus_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Test",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      CountyId = countyId,
+      UploadedBy = "test",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.UpdateDocumentStatus(doc.Id.ToString(),
+        new DossierController.UpdateDocumentStatusRequest("destroyed", null));
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ── List Parcel Documents ────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task ListParcelDocuments_ReturnsDocuments()
+  {
+    using var db = CreateDbContext(nameof(ListParcelDocuments_ReturnsDocuments));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    db.DossierDocuments.AddRange(
+        new DossierDocument { ParcelId = "DOC-PARCEL-1", Name = "Doc A", DocumentType = "deed", MimeType = "application/pdf", CountyId = countyId, UploadedBy = "a" },
+        new DossierDocument { ParcelId = "DOC-PARCEL-1", Name = "Doc B", DocumentType = "photo", MimeType = "image/jpeg", CountyId = countyId, UploadedBy = "b" },
+        new DossierDocument { ParcelId = "DOC-PARCEL-2", Name = "Doc C", DocumentType = "deed", MimeType = "application/pdf", CountyId = countyId, UploadedBy = "c" });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.ListParcelDocuments("DOC-PARCEL-1", null, null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Doc A");
+    json.Should().Contain("Doc B");
+    json.Should().NotContain("Doc C");
+    json.Should().Contain("\"total\":2");
+  }
+
+  // ── Evidence Registration ────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterEvidence_ValidRequest_Returns201()
+  {
+    using var db = CreateDbContext(nameof(RegisterEvidence_ValidRequest_Returns201));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterEvidence(new DossierController.RegisterEvidenceRequest(
+        ParcelId: "DOC-PARCEL-1",
+        Title: "Field inspection photograph",
+        EvidenceType: "field-inspection",
+        DocumentId: null));
+
+    var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+    created.StatusCode.Should().Be(201);
+    var json = JsonSerializer.Serialize(created.Value);
+    json.Should().Contain("Field inspection photograph");
+    json.Should().Contain("pending");
+
+    db.DossierEvidenceItems.Count().Should().Be(1);
+    db.DossierCustodyEvents.Count().Should().Be(1);
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterEvidence_NullBody_Returns400()
+  {
+    using var db = CreateDbContext(nameof(RegisterEvidence_NullBody_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterEvidence(null);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterEvidence_WithDocumentLink_Returns201()
+  {
+    using var db = CreateDbContext(nameof(RegisterEvidence_WithDocumentLink_Returns201));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Deed",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      CountyId = countyId,
+      UploadedBy = "test",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.RegisterEvidence(new DossierController.RegisterEvidenceRequest(
+        ParcelId: "DOC-PARCEL-1",
+        Title: "Deed evidence",
+        EvidenceType: "legal-document",
+        DocumentId: doc.Id));
+
+    result.Should().BeOfType<CreatedAtActionResult>();
+    var evidence = await db.DossierEvidenceItems.FirstAsync();
+    evidence.DocumentId.Should().Be(doc.Id);
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task RegisterEvidence_InvalidDocumentId_Returns400()
+  {
+    using var db = CreateDbContext(nameof(RegisterEvidence_InvalidDocumentId_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    var result = await ctrl.RegisterEvidence(new DossierController.RegisterEvidenceRequest(
+        ParcelId: "DOC-PARCEL-1",
+        Title: "Test",
+        EvidenceType: "field-inspection",
+        DocumentId: Guid.NewGuid()));
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ── Get Persistent Evidence ──────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentEvidence_Found_ReturnsOk()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentEvidence_Found_ReturnsOk));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var evidence = new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Test Evidence",
+      EvidenceType = "field-inspection",
+      CountyId = countyId,
+      CreatedBy = "test",
+    };
+    db.DossierEvidenceItems.Add(evidence);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentEvidence(evidence.Id.ToString());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Test Evidence");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentEvidence_NotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentEvidence_NotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentEvidence(Guid.NewGuid().ToString());
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── List Parcel Evidence ─────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task ListParcelEvidence_ReturnsEvidence()
+  {
+    using var db = CreateDbContext(nameof(ListParcelEvidence_ReturnsEvidence));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    db.DossierEvidenceItems.AddRange(
+        new DossierEvidence { ParcelId = "DOC-PARCEL-1", Title = "Evid A", EvidenceType = "field-inspection", CountyId = countyId, CreatedBy = "a" },
+        new DossierEvidence { ParcelId = "DOC-PARCEL-1", Title = "Evid B", EvidenceType = "legal-document", CountyId = countyId, CreatedBy = "b" });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.ListParcelEvidence("DOC-PARCEL-1", null, null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Evid A");
+    json.Should().Contain("Evid B");
+    json.Should().Contain("\"total\":2");
+  }
+
+  // ── Custody Chain Operations ─────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task AddCustodyEvent_Verified_UpdatesIntegrity()
+  {
+    using var db = CreateDbContext(nameof(AddCustodyEvent_Verified_UpdatesIntegrity));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var evidence = new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Custody Test",
+      EvidenceType = "field-inspection",
+      Integrity = "pending",
+      CountyId = countyId,
+      CreatedBy = "test",
+    };
+    db.DossierEvidenceItems.Add(evidence);
+    db.DossierCustodyEvents.Add(new DossierCustodyEvent
+    {
+      EvidenceId = evidence.Id,
+      Action = "created",
+      Actor = "test",
+      Hash = "genesis",
+      CountyId = countyId,
+    });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.AddCustodyEvent(evidence.Id.ToString(),
+        new DossierController.AddCustodyEventRequest("verified", "Field verification complete"));
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("verified");
+    json.Should().Contain("\"chainLength\":2");
+
+    var updatedEvidence = await db.DossierEvidenceItems.FindAsync(evidence.Id);
+    updatedEvidence!.Integrity.Should().Be("verified");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task AddCustodyEvent_Disputed_UpdatesIntegrity()
+  {
+    using var db = CreateDbContext(nameof(AddCustodyEvent_Disputed_UpdatesIntegrity));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var evidence = new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Dispute Test",
+      EvidenceType = "legal-document",
+      Integrity = "verified",
+      CountyId = countyId,
+      CreatedBy = "test",
+    };
+    db.DossierEvidenceItems.Add(evidence);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.AddCustodyEvent(evidence.Id.ToString(),
+        new DossierController.AddCustodyEventRequest("disputed", "Hash mismatch detected"));
+
+    result.Should().BeOfType<OkObjectResult>();
+    var updatedEvidence = await db.DossierEvidenceItems.FindAsync(evidence.Id);
+    updatedEvidence!.Integrity.Should().Be("disputed");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task AddCustodyEvent_InvalidAction_Returns400()
+  {
+    using var db = CreateDbContext(nameof(AddCustodyEvent_InvalidAction_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var evidence = new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Test",
+      EvidenceType = "field-inspection",
+      CountyId = countyId,
+      CreatedBy = "test",
+    };
+    db.DossierEvidenceItems.Add(evidence);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.AddCustodyEvent(evidence.Id.ToString(),
+        new DossierController.AddCustodyEventRequest("destroyed", null));
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task AddCustodyEvent_NullBody_Returns400()
+  {
+    using var db = CreateDbContext(nameof(AddCustodyEvent_NullBody_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.AddCustodyEvent(Guid.NewGuid().ToString(), null);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ── Get Persistent Custody Chain ─────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentCustodyChain_ReturnsChain()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentCustodyChain_ReturnsChain));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var evidence = new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Chain Test",
+      EvidenceType = "field-inspection",
+      CountyId = countyId,
+      CreatedBy = "test",
+    };
+    db.DossierEvidenceItems.Add(evidence);
+    db.DossierCustodyEvents.AddRange(
+        new DossierCustodyEvent { EvidenceId = evidence.Id, Action = "created", Actor = "test", Hash = "h1", CountyId = countyId, Timestamp = DateTime.UtcNow.AddMinutes(-10) },
+        new DossierCustodyEvent { EvidenceId = evidence.Id, Action = "verified", Actor = "supervisor", Hash = "h2", CountyId = countyId, Timestamp = DateTime.UtcNow });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentCustodyChain(evidence.Id.ToString());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("created");
+    json.Should().Contain("verified");
+    json.Should().Contain("\"chainLength\":2");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPersistentCustodyChain_NotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(GetPersistentCustodyChain_NotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPersistentCustodyChain(Guid.NewGuid().ToString());
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── Packet Operations ────────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task CreatePacket_ValidRequest_Returns201()
+  {
+    using var db = CreateDbContext(nameof(CreatePacket_ValidRequest_Returns201));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    // Add a deed document so at least one item is satisfied
+    db.DossierDocuments.Add(new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Deed",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      CountyId = countyId,
+      UploadedBy = "test",
+    });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.CreatePacket(new DossierController.CreatePacketRequest(
+        ParcelId: "DOC-PARCEL-1",
+        PacketType: "annual-assessment"));
+
+    var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+    var json = JsonSerializer.Serialize(created.Value);
+    json.Should().Contain("annual-assessment");
+    json.Should().Contain("DOC-PARCEL-1");
+
+    db.DossierPackets.Count().Should().Be(1);
+    db.DossierPacketItems.Count().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task CreatePacket_NullBody_Returns400()
+  {
+    using var db = CreateDbContext(nameof(CreatePacket_NullBody_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.CreatePacket(null);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task CreatePacket_UnknownType_Returns400()
+  {
+    using var db = CreateDbContext(nameof(CreatePacket_UnknownType_Returns400));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.CreatePacket(new DossierController.CreatePacketRequest(
+        ParcelId: "DOC-PARCEL-1",
+        PacketType: "nonexistent_type"));
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task CreatePacket_ParcelNotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(CreatePacket_ParcelNotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.CreatePacket(new DossierController.CreatePacketRequest(
+        ParcelId: "NONEXISTENT",
+        PacketType: "annual-assessment"));
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── Get Packet ───────────────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPacket_Found_ReturnsOk()
+  {
+    using var db = CreateDbContext(nameof(GetPacket_Found_ReturnsOk));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var packet = new DossierPacket
+    {
+      ParcelId = "DOC-PARCEL-1",
+      PacketType = "annual-assessment",
+      Name = "Annual Assessment Packet - DOC-PARCEL-1",
+      CountyId = countyId,
+      CreatedBy = "test",
+      TotalRequired = 3,
+      SatisfiedCount = 1,
+      CompletenessPercent = 33.3,
+    };
+    packet.Items.Add(new DossierPacketItem { PacketId = packet.Id, DocumentType = "deed", Required = true, Satisfied = true });
+    packet.Items.Add(new DossierPacketItem { PacketId = packet.Id, DocumentType = "appraisal", Required = true, Satisfied = false });
+    packet.Items.Add(new DossierPacketItem { PacketId = packet.Id, DocumentType = "photo", Required = true, Satisfied = false });
+    db.DossierPackets.Add(packet);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPacket(packet.Id.ToString());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("annual-assessment");
+    json.Should().Contain("appraisal");
+    json.Should().Contain("appraisal");
+  }
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task GetPacket_NotFound_Returns404()
+  {
+    using var db = CreateDbContext(nameof(GetPacket_NotFound_Returns404));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.GetPacket(Guid.NewGuid().ToString());
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ── List Parcel Packets ──────────────────────────────────────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task ListParcelPackets_ReturnsPackets()
+  {
+    using var db = CreateDbContext(nameof(ListParcelPackets_ReturnsPackets));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    db.DossierPackets.AddRange(
+        new DossierPacket { ParcelId = "DOC-PARCEL-1", PacketType = "annual-assessment", Name = "Annual", CountyId = countyId, CreatedBy = "a" },
+        new DossierPacket { ParcelId = "DOC-PARCEL-1", PacketType = "boe-appeal-defense", Name = "Appeal", CountyId = countyId, CreatedBy = "b" });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.ListParcelPackets("DOC-PARCEL-1");
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("annual-assessment");
+    json.Should().Contain("boe-appeal-defense");
+    json.Should().Contain("\"total\":2");
+  }
+
+  // ── Integration: Document Index includes persistent docs ─────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task SearchDocuments_IncludesPersistentDocuments()
+  {
+    using var db = CreateDbContext(nameof(SearchDocuments_IncludesPersistentDocuments));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    db.DossierDocuments.Add(new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Persistent Survey",
+      DocumentType = "survey",
+      MimeType = "application/pdf",
+      SizeBytes = 8192,
+      ContentHash = "persistent-hash",
+      CountyId = countyId,
+      UploadedBy = "surveyor",
+    });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.SearchDocuments(new DossierController.DocumentSearchRequest(
+        Query: "Persistent Survey",
+        Type: null,
+        Status: null,
+        ParcelId: null,
+        Limit: 50,
+        Offset: 0));
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Persistent Survey");
+    json.Should().Contain("pdoc-");
+  }
+
+  // ── Integration: Evidence Index includes persistent evidence ─
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task SearchEvidence_IncludesPersistentEvidence()
+  {
+    using var db = CreateDbContext(nameof(SearchEvidence_IncludesPersistentEvidence));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    db.DossierEvidenceItems.Add(new DossierEvidence
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Title = "Persistent Field Photo",
+      EvidenceType = "field-inspection",
+      Integrity = "verified",
+      CountyId = countyId,
+      CreatedBy = "field-agent",
+    });
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+    var result = await ctrl.SearchEvidence(new DossierController.EvidenceSearchRequest(
+        ParcelId: "DOC-PARCEL-1",
+        EvidenceType: null,
+        Integrity: null,
+        Limit: 50,
+        Offset: 0));
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    json.Should().Contain("Persistent Field Photo");
+    json.Should().Contain("pevid-");
+  }
+
+  // ── Status transition chain: active → sealed → archived ──────
+
+  [Fact]
+  [Trait("Category", "Wave24")]
+  [Trait("Category", "DossierDocMgmt")]
+  public async Task DocumentStatusTransition_FullChain_Succeeds()
+  {
+    using var db = CreateDbContext(nameof(DocumentStatusTransition_FullChain_Succeeds));
+    var countyId = await SeedDocMgmtDataAsync(db);
+    var doc = new DossierDocument
+    {
+      ParcelId = "DOC-PARCEL-1",
+      Name = "Lifecycle Test",
+      DocumentType = "deed",
+      MimeType = "application/pdf",
+      Status = "active",
+      CountyId = countyId,
+      UploadedBy = "test",
+    };
+    db.DossierDocuments.Add(doc);
+    await db.SaveChangesAsync();
+
+    var ctrl = MakeAuthedDossierController(db, countyId);
+
+    // active → sealed
+    var r1 = await ctrl.UpdateDocumentStatus(doc.Id.ToString(),
+        new DossierController.UpdateDocumentStatusRequest("sealed", "Certified"));
+    r1.Should().BeOfType<OkObjectResult>();
+
+    // sealed → archived
+    var r2 = await ctrl.UpdateDocumentStatus(doc.Id.ToString(),
+        new DossierController.UpdateDocumentStatusRequest("archived", "Retention expired"));
+    r2.Should().BeOfType<OkObjectResult>();
+
+    var final = await db.DossierDocuments.FindAsync(doc.Id);
+    final!.Status.Should().Be("archived");
+  }
 }


### PR DESCRIPTION
## Wave 24: Dossier Document Management Backend

### Summary
Implements persistent document management, evidence chain-of-custody, and assessment packet generation for TerraFusion Dossier.

### New Entities (5 files)
- **DossierDocument** — Persistent document metadata (status lifecycle: active → sealed → archived)
- **DossierEvidence** — Evidence records with integrity tracking (pending → verified/disputed)
- **DossierCustodyEvent** — Append-only hash-chained custody events
- **DossierPacket** — Assessment packet records with completeness tracking
- **DossierPacketItem** — Line items linking required document types to matched documents

### New Endpoints (12)
| Method | Route | Description |
|--------|-------|-------------|
| POST | /documents | Register document |
| GET | /documents/persistent/{id} | Get persistent document |
| PATCH | /documents/persistent/{id}/status | Update document status |
| GET | /parcels/{parcelId}/documents | List parcel documents |
| POST | /evidence | Register evidence |
| GET | /evidence/persistent/{id} | Get persistent evidence |
| GET | /parcels/{parcelId}/evidence/persistent | List parcel evidence |
| POST | /evidence/persistent/{id}/custody | Add custody event |
| GET | /evidence/persistent/{id}/chain | Get custody chain |
| POST | /packets | Create packet from template |
| GET | /packets/{id} | Get packet with items |
| GET | /parcels/{parcelId}/packets | List parcel packets |

### Integration
- Synthesized document/evidence indexes now include persistent data
- Backward compatible with existing endpoints

### Evidence
- **Tests**: 1327 passed, 0 failed (35 new Wave 24 tests)
- **Gates**: type-check PASS, phase83-tools 32/32 PASS
- **Build**: 0 errors, 0 warnings

Government: FISMA compliance
AI-Collaboration: GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* **Wave 24: Persistent Document Management** – Register, retrieve, and manage persistent documents for parcels with status tracking and content integrity verification.
* **Evidence Chain Tracking** – Register evidence items, record custody events, and view complete chain-of-custody histories with integrity hashing.
* **Document Packets** – Create assessment packets with document requirements, track completion status, and manage packet items tied to documents.
* **Custody Event Logging** – Append-only audit trail for evidence actions with actor tracking and timestamps.

**Tests**
* Added comprehensive Wave 24 test coverage for document, evidence, and packet workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->