### PR TITLE
feat(forge): Wave 28 — Spatial Autocorrelation (Moran's I, Geary's C, LISA)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -2615,6 +2615,344 @@ public class CostForgeController : ControllerBase
     ];
   }
 
+  // ══════════════════════════════════════════════════════════════════════════
+  //  Wave 28 — Spatial Autocorrelation (Moran's I, Geary's C, LISA)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  /// <summary>Compute Global Moran's I spatial autocorrelation.</summary>
+  [HttpPost("analytics/spatial/moran")]
+  public async Task<IActionResult> RunGlobalMoranI([FromBody] SpatialAutocorrelationRequest request)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    if (request.Observations is null || request.Observations.Count < 3)
+      return BadRequest(new { error = "At least 3 observations required" });
+
+    int n = request.Observations.Count;
+    var values = request.Observations.Select(o => o.Value).ToArray();
+    double mean = values.Average();
+
+    // Build spatial weight matrix based on coordinates
+    var W = BuildWeightMatrix(request.Observations, request.WeightType ?? "distance", request.DistanceThreshold ?? 0);
+
+    // Global Moran's I = (n/S0) * Σ_i Σ_j w_ij(x_i - x̄)(x_j - x̄) / Σ_i(x_i - x̄)²
+    double s0 = 0;
+    double numerator = 0;
+    double denominator = 0;
+
+    for (int i = 0; i < n; i++)
+      denominator += (values[i] - mean) * (values[i] - mean);
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        s0 += W[i, j];
+        numerator += W[i, j] * (values[i] - mean) * (values[j] - mean);
+      }
+
+    double moranI = denominator > 0 && s0 > 0
+      ? (n / s0) * (numerator / denominator)
+      : 0;
+
+    double expectedI = -1.0 / (n - 1);
+    double variance = ComputeMoranVariance(W, values, n, s0);
+    double zScore = variance > 0 ? (moranI - expectedI) / Math.Sqrt(variance) : 0;
+    double pValue = 2 * (1 - NormalCdf(Math.Abs(zScore)));
+
+    // Local Moran's I (LISA)
+    var localI = new double[n];
+    var clusters = new string[n];
+    for (int i = 0; i < n; i++)
+    {
+      double localNumerator = 0;
+      double wRowSum = 0;
+      for (int j = 0; j < n; j++)
+      {
+        localNumerator += W[i, j] * (values[j] - mean);
+        wRowSum += W[i, j];
+      }
+      double zi = values[i] - mean;
+      localI[i] = denominator > 0 ? n * zi * localNumerator / denominator : 0;
+
+      // Classify: HH, HL, LH, LL, NS
+      double lag = wRowSum > 0 ? localNumerator / wRowSum : 0;
+      double localZ = variance > 0 ? localI[i] / Math.Sqrt(variance) : 0;
+      bool significant = Math.Abs(localZ) > 1.96;
+      clusters[i] = !significant ? "NS"
+        : (zi > 0 && lag > 0) ? "HH"
+        : (zi > 0 && lag <= 0) ? "HL"
+        : (zi <= 0 && lag > 0) ? "LH"
+        : "LL";
+    }
+
+    var entity = new SpatialAnalysis
+    {
+      CountyId = county.CountyId,
+      AnalysisType = "global_moran",
+      VariableName = request.VariableName ?? "assessed_value",
+      WeightMatrixType = request.WeightType ?? "distance",
+      StatisticValue = Math.Round(moranI, 6),
+      ExpectedValue = Math.Round(expectedI, 6),
+      Variance = Math.Round(variance, 6),
+      ZScore = Math.Round(zScore, 4),
+      PValue = Math.Round(pValue, 6),
+      SampleSize = n,
+      LocalIndicators = System.Text.Json.JsonSerializer.Serialize(localI.Select(v => Math.Round(v, 6)).ToArray()),
+      ClusterMap = System.Text.Json.JsonSerializer.Serialize(clusters),
+      CreatedBy = User.Identity?.Name ?? "system"
+    };
+
+    _db.SpatialAnalyses.Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      analysisType = "global_moran",
+      moranI = entity.StatisticValue,
+      expectedI = entity.ExpectedValue,
+      variance = entity.Variance,
+      zScore = entity.ZScore,
+      pValue = entity.PValue,
+      sampleSize = n,
+      interpretation = moranI > expectedI ? "positive spatial autocorrelation (clustering)" : "negative spatial autocorrelation (dispersion)",
+      clusterSummary = new
+      {
+        highHigh = clusters.Count(c => c == "HH"),
+        highLow = clusters.Count(c => c == "HL"),
+        lowHigh = clusters.Count(c => c == "LH"),
+        lowLow = clusters.Count(c => c == "LL"),
+        notSignificant = clusters.Count(c => c == "NS")
+      },
+      localIndicators = localI.Select(v => Math.Round(v, 6)).ToArray(),
+      clusters
+    });
+  }
+
+  /// <summary>Compute Geary's C spatial autocorrelation.</summary>
+  [HttpPost("analytics/spatial/geary")]
+  public async Task<IActionResult> RunGearyC([FromBody] SpatialAutocorrelationRequest request)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    if (request.Observations is null || request.Observations.Count < 3)
+      return BadRequest(new { error = "At least 3 observations required" });
+
+    int n = request.Observations.Count;
+    var values = request.Observations.Select(o => o.Value).ToArray();
+    double mean = values.Average();
+
+    var W = BuildWeightMatrix(request.Observations, request.WeightType ?? "distance", request.DistanceThreshold ?? 0);
+
+    double s0 = 0, numerator = 0, denominator = 0;
+    for (int i = 0; i < n; i++)
+      denominator += (values[i] - mean) * (values[i] - mean);
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        s0 += W[i, j];
+        numerator += W[i, j] * (values[i] - values[j]) * (values[i] - values[j]);
+      }
+
+    // Geary's C = ((n-1) / (2*S0)) * (Σ w_ij(x_i - x_j)²) / (Σ(x_i - x̄)²)
+    double gearyC = (denominator > 0 && s0 > 0)
+      ? ((n - 1.0) / (2.0 * s0)) * (numerator / denominator)
+      : 1.0; // expected value under randomness
+
+    double expectedC = 1.0;
+    double zScore = gearyC < 1 ? -(1 - gearyC) * Math.Sqrt(n) : (gearyC - 1) * Math.Sqrt(n); // simplified
+    double pValue = 2 * (1 - NormalCdf(Math.Abs(zScore)));
+
+    var entity = new SpatialAnalysis
+    {
+      CountyId = county.CountyId,
+      AnalysisType = "geary_c",
+      VariableName = request.VariableName ?? "assessed_value",
+      WeightMatrixType = request.WeightType ?? "distance",
+      StatisticValue = Math.Round(gearyC, 6),
+      ExpectedValue = expectedC,
+      Variance = 0,
+      ZScore = Math.Round(zScore, 4),
+      PValue = Math.Round(pValue, 6),
+      SampleSize = n,
+      CreatedBy = User.Identity?.Name ?? "system"
+    };
+
+    _db.SpatialAnalyses.Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      analysisType = "geary_c",
+      gearyC = entity.StatisticValue,
+      expectedC,
+      zScore = entity.ZScore,
+      pValue = entity.PValue,
+      sampleSize = n,
+      interpretation = gearyC < 1 ? "positive autocorrelation" : gearyC > 1 ? "negative autocorrelation" : "spatial randomness"
+    });
+  }
+
+  /// <summary>Retrieve stored spatial analysis by ID.</summary>
+  [HttpGet("analytics/spatial/{id:guid}")]
+  public async Task<IActionResult> GetSpatialResult(Guid id)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    var result = await _db.SpatialAnalyses
+      .FirstOrDefaultAsync(s => s.Id == id && s.CountyId == county.CountyId);
+
+    if (result is null) return NotFound(new { error = "Spatial analysis not found" });
+
+    return Ok(new
+    {
+      id = result.Id,
+      analysisType = result.AnalysisType,
+      variableName = result.VariableName,
+      statisticValue = result.StatisticValue,
+      expectedValue = result.ExpectedValue,
+      zScore = result.ZScore,
+      pValue = result.PValue,
+      sampleSize = result.SampleSize,
+      localIndicators = System.Text.Json.JsonSerializer.Deserialize<double[]>(result.LocalIndicators),
+      clusterMap = System.Text.Json.JsonSerializer.Deserialize<string[]>(result.ClusterMap),
+      createdAt = result.CreatedAt
+    });
+  }
+
+  /// <summary>List recent spatial analyses for the county.</summary>
+  [HttpGet("analytics/spatial/history")]
+  public async Task<IActionResult> GetSpatialHistory([FromQuery] int limit = 20)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    limit = Math.Clamp(limit, 1, 100);
+    var results = await _db.SpatialAnalyses
+      .Where(s => s.CountyId == county.CountyId)
+      .OrderByDescending(s => s.CreatedAt)
+      .Take(limit)
+      .Select(s => new
+      {
+        id = s.Id,
+        analysisType = s.AnalysisType,
+        variableName = s.VariableName,
+        statisticValue = s.StatisticValue,
+        pValue = s.PValue,
+        sampleSize = s.SampleSize,
+        createdAt = s.CreatedAt
+      })
+      .ToListAsync();
+
+    return Ok(new { count = results.Count, results });
+  }
+
+  // ── Spatial helpers ───────────────────────────────────────────────────────
+
+  private static double[,] BuildWeightMatrix(List<SpatialObservation> obs, string weightType, double threshold)
+  {
+    int n = obs.Count;
+    var W = new double[n, n];
+
+    // Compute pairwise distances
+    var dists = new double[n, n];
+    for (int i = 0; i < n; i++)
+      for (int j = i + 1; j < n; j++)
+      {
+        double dx = obs[i].X - obs[j].X;
+        double dy = obs[i].Y - obs[j].Y;
+        dists[i, j] = dists[j, i] = Math.Sqrt(dx * dx + dy * dy);
+      }
+
+    // Auto-threshold if not provided
+    if (threshold <= 0)
+    {
+      double maxDist = 0;
+      for (int i = 0; i < n; i++)
+        for (int j = i + 1; j < n; j++)
+          if (dists[i, j] > maxDist) maxDist = dists[i, j];
+      threshold = maxDist / 3.0;
+    }
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        if (i == j) continue;
+        W[i, j] = weightType switch
+        {
+          "knn" => 0, // handled below
+          "inverse_distance" => dists[i, j] > 0 ? 1.0 / dists[i, j] : 0,
+          _ => dists[i, j] <= threshold ? 1.0 : 0 // binary distance
+        };
+      }
+
+    // KNN: k nearest neighbours
+    if (weightType == "knn")
+    {
+      int k = Math.Min(4, n - 1);
+      for (int i = 0; i < n; i++)
+      {
+        var indices = Enumerable.Range(0, n)
+          .Where(j => j != i)
+          .OrderBy(j => dists[i, j])
+          .Take(k);
+        foreach (var j in indices) W[i, j] = 1.0;
+      }
+    }
+
+    // Row-standardize
+    for (int i = 0; i < n; i++)
+    {
+      double rowSum = 0;
+      for (int j = 0; j < n; j++) rowSum += W[i, j];
+      if (rowSum > 0)
+        for (int j = 0; j < n; j++) W[i, j] /= rowSum;
+    }
+
+    return W;
+  }
+
+  private static double ComputeMoranVariance(double[,] W, double[] values, int n, double s0)
+  {
+    // Simplified variance under normality assumption:
+    // Var(I) ≈ [n²S1 - nS2 + 3S0²] / [S0²(n²-1)] - E(I)²
+    double s1 = 0, s2 = 0;
+    for (int i = 0; i < n; i++)
+    {
+      double rowSum = 0, colSum = 0;
+      for (int j = 0; j < n; j++)
+      {
+        s1 += (W[i, j] + W[j, i]) * (W[i, j] + W[j, i]);
+        rowSum += W[i, j];
+        colSum += W[j, i];
+      }
+      s2 += (rowSum + colSum) * (rowSum + colSum);
+    }
+    s1 /= 2.0;
+
+    double expectedI = -1.0 / (n - 1);
+    double denom = s0 * s0 * ((double)n * n - 1);
+    if (denom == 0) return 0;
+    return ((double)n * n * s1 - (double)n * s2 + 3 * s0 * s0) / denom - expectedI * expectedI;
+  }
+
+  private static double NormalCdf(double x)
+  {
+    // Abramowitz and Stegun approximation (7.1.26)
+    const double a1 = 0.254829592, a2 = -0.284496736, a3 = 1.421413741, a4 = -1.453152027, a5 = 1.061405429;
+    const double p = 0.3275911;
+    double sign = x < 0 ? -1 : 1;
+    x = Math.Abs(x) / Math.Sqrt(2);
+    double t = 1.0 / (1.0 + p * x);
+    double y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.Exp(-x * x);
+    return 0.5 * (1.0 + sign * y);
+  }
+
   internal sealed record CostMatrixEntry(string BuildingType, string BuildingTypeLabel, string Region, decimal BaseCostPerSqft);
   internal sealed record DepreciationBracket(int MinAge, int MaxAge, decimal Factor);
 
@@ -2776,4 +3114,22 @@ public class AnalyticsDto
   public double AverageAccuracy { get; set; }
   public Dictionary<string, int> CalculationsByType { get; set; } = new();
   public Dictionary<string, double> PerformanceMetrics { get; set; } = new();
+}
+
+// ── Wave 28 Request DTOs ────────────────────────────────────────────────────
+
+public class SpatialAutocorrelationRequest
+{
+  public List<SpatialObservation> Observations { get; set; } = new();
+  public string? VariableName { get; set; }
+  public string? WeightType { get; set; }
+  public double? DistanceThreshold { get; set; }
+}
+
+public class SpatialObservation
+{
+  public double X { get; set; }
+  public double Y { get; set; }
+  public double Value { get; set; }
+  public string? ParcelId { get; set; }
 }

--- a/backend/src/TerraFusion.Core/Entities/SpatialAnalysis.cs
+++ b/backend/src/TerraFusion.Core/Entities/SpatialAnalysis.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>Stores spatial autocorrelation analysis results (Moran's I, Local Moran, etc.).</summary>
+public class SpatialAnalysis
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public Guid Id { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  /// <summary>Type of analysis: global_moran, local_moran, geary_c.</summary>
+  public string AnalysisType { get; set; } = "global_moran";
+
+  /// <summary>Variable analysed (e.g. "assessed_value").</summary>
+  public string VariableName { get; set; } = "assessed_value";
+
+  /// <summary>Weight matrix type: queen, rook, distance, knn.</summary>
+  public string WeightMatrixType { get; set; } = "queen";
+
+  /// <summary>Global statistic value.</summary>
+  public double StatisticValue { get; set; }
+
+  /// <summary>Expected value under null hypothesis of spatial randomness.</summary>
+  public double ExpectedValue { get; set; }
+
+  /// <summary>Variance under null hypothesis.</summary>
+  public double Variance { get; set; }
+
+  /// <summary>Z-score for significance testing.</summary>
+  public double ZScore { get; set; }
+
+  /// <summary>P-value (two-tailed).</summary>
+  public double PValue { get; set; }
+
+  /// <summary>Number of spatial units.</summary>
+  public int SampleSize { get; set; }
+
+  /// <summary>JSON-serialised local indicators (LISA) per observation.</summary>
+  public string LocalIndicators { get; set; } = "[]";
+
+  /// <summary>JSON-serialised cluster classification (HH, HL, LH, LL, NS).</summary>
+  public string ClusterMap { get; set; } = "[]";
+
+  public string CreatedBy { get; set; } = "system";
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -97,6 +97,9 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<CamaCharacteristic> CamaCharacteristics { get; set; }
   public DbSet<CostMatrix> CostMatrices { get; set; }
 
+  // Forge Analytics (R2 Wave 28)
+  public DbSet<SpatialAnalysis> SpatialAnalyses { get; set; }
+
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }
   public DbSet<DossierEvidence> DossierEvidenceItems { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave28/R2Wave28SpatialAutocorrelationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave28/R2Wave28SpatialAutocorrelationTests.cs
@@ -1,0 +1,373 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave28;
+
+[Trait("Category", "R2Wave28")]
+[Trait("Category", "SpatialAutocorrelation")]
+public sealed class R2Wave28SpatialAutocorrelationTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string code = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", code),
+      new Claim("sub", "w28-test"),
+      new Claim("userId", "w28-test"),
+    ], "TestAuth"));
+
+  private static ClaimsPrincipal CreateEmptyPrincipal() => new(new ClaimsIdentity());
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? p = null)
+  {
+    var c = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db, new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+    c.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = p ?? CreatePrincipal(BentonCountyId) }
+    };
+    return c;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid id)
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == id))
+    {
+      db.Counties.Add(new County { Id = id, Name = "Benton", State = "WA", FipsCode = "003" });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static System.Text.Json.JsonDocument Parse(object value)
+    => System.Text.Json.JsonDocument.Parse(System.Text.Json.JsonSerializer.Serialize(value));
+
+  // ── Clustered data: high values near each other ──
+
+  private static SpatialAutocorrelationRequest CreateClusteredRequest()
+  {
+    return new SpatialAutocorrelationRequest
+    {
+      VariableName = "assessed_value",
+      WeightType = "distance",
+      Observations = new()
+      {
+        // Cluster of high values (north)
+        new() { X = 0, Y = 10, Value = 500000 },
+        new() { X = 1, Y = 10, Value = 510000 },
+        new() { X = 0, Y = 11, Value = 505000 },
+        new() { X = 1, Y = 11, Value = 520000 },
+        // Cluster of low values (south)
+        new() { X = 0, Y = 0, Value = 150000 },
+        new() { X = 1, Y = 0, Value = 140000 },
+        new() { X = 0, Y = 1, Value = 145000 },
+        new() { X = 1, Y = 1, Value = 135000 },
+      }
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Global Moran's I
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task MoranI_ClusteredData_PositiveAutocorrelation()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ClusteredData_PositiveAutocorrelation));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var doc = Parse(ok.Value!);
+
+    // Clustered data should have Moran's I > expected value (positive autocorrelation)
+    double moranI = doc.RootElement.GetProperty("moranI").GetDouble();
+    double expectedI = doc.RootElement.GetProperty("expectedI").GetDouble();
+    moranI.Should().BeGreaterThan(expectedI);
+  }
+
+  [Fact]
+  public async Task MoranI_ClusteredData_InterpretationIsClustering()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ClusteredData_InterpretationIsClustering));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("interpretation").GetString()
+      .Should().Contain("clustering");
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsValidZScoreAndPValue()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsValidZScoreAndPValue));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("pValue").GetDouble()
+      .Should().BeGreaterThanOrEqualTo(0).And.BeLessThanOrEqualTo(1);
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsClusterSummary()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsClusterSummary));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    var clusters = doc.RootElement.GetProperty("clusterSummary");
+    clusters.TryGetProperty("highHigh", out _).Should().BeTrue();
+    clusters.TryGetProperty("lowLow", out _).Should().BeTrue();
+    clusters.TryGetProperty("notSignificant", out _).Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsLocalIndicators()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsLocalIndicators));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("localIndicators").GetArrayLength().Should().Be(8);
+    doc.RootElement.GetProperty("clusters").GetArrayLength().Should().Be(8);
+  }
+
+  [Fact]
+  public async Task MoranI_PersistsToDatabase()
+  {
+    using var db = CreateDbContext(nameof(MoranI_PersistsToDatabase));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var stored = await db.SpatialAnalyses.FirstOrDefaultAsync();
+    stored.Should().NotBeNull();
+    stored!.AnalysisType.Should().Be("global_moran");
+    stored.SampleSize.Should().Be(8);
+  }
+
+  [Fact]
+  public async Task MoranI_TooFewObs_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(MoranI_TooFewObs_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = new SpatialAutocorrelationRequest
+    {
+      Observations = new()
+      {
+        new() { X = 0, Y = 0, Value = 100000 },
+        new() { X = 1, Y = 1, Value = 200000 },
+      }
+    };
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task MoranI_NoCounty_ReturnsUnauthorized()
+  {
+    using var db = CreateDbContext(nameof(MoranI_NoCounty_ReturnsUnauthorized));
+    var ctrl = CreateController(db, CreateEmptyPrincipal());
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Geary's C
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task GearyC_ClusteredData_LessThanOne()
+  {
+    using var db = CreateDbContext(nameof(GearyC_ClusteredData_LessThanOne));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGearyC(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    // Clustered data: Geary's C < 1 indicates positive autocorrelation
+    doc.RootElement.GetProperty("gearyC").GetDouble().Should().BeLessThan(1.0);
+  }
+
+  [Fact]
+  public async Task GearyC_InterpretationPositive()
+  {
+    using var db = CreateDbContext(nameof(GearyC_InterpretationPositive));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGearyC(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("interpretation").GetString()
+      .Should().Contain("positive");
+  }
+
+  [Fact]
+  public async Task GearyC_PersistsAsGearyType()
+  {
+    using var db = CreateDbContext(nameof(GearyC_PersistsAsGearyType));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGearyC(CreateClusteredRequest());
+    var stored = await db.SpatialAnalyses.FirstOrDefaultAsync();
+    stored!.AnalysisType.Should().Be("geary_c");
+  }
+
+  [Fact]
+  public async Task GearyC_TooFewObs_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(GearyC_TooFewObs_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = new SpatialAutocorrelationRequest
+    {
+      Observations = new() { new() { X = 0, Y = 0, Value = 100000 } }
+    };
+    var result = await ctrl.RunGearyC(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Retrieval endpoints
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task GetSpatialResult_ExistingId_ReturnsStored()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialResult_ExistingId_ReturnsStored));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var runResult = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var id = Parse(((OkObjectResult)runResult).Value!).RootElement.GetProperty("id").GetGuid();
+
+    var getResult = await ctrl.GetSpatialResult(id);
+    var doc = Parse(((OkObjectResult)getResult).Value!);
+    doc.RootElement.GetProperty("analysisType").GetString().Should().Be("global_moran");
+    doc.RootElement.GetProperty("sampleSize").GetInt32().Should().Be(8);
+  }
+
+  [Fact]
+  public async Task GetSpatialResult_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialResult_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var runResult = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var id = Parse(((OkObjectResult)runResult).Value!).RootElement.GetProperty("id").GetGuid();
+
+    var otherCounty = Guid.NewGuid();
+    await SeedCounty(db, otherCounty);
+    var other = CreateController(db, CreatePrincipal(otherCounty, "OTHER"));
+    var result = await other.GetSpatialResult(id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetSpatialHistory_ReturnsEntries()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialHistory_ReturnsEntries));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    await ctrl.RunGearyC(CreateClusteredRequest());
+
+    var result = await ctrl.GetSpatialHistory(10);
+    var doc = Parse(((OkObjectResult)result).Value!);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task GetSpatialHistory_Empty_ReturnsZeroCount()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialHistory_Empty_ReturnsZeroCount));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.GetSpatialHistory(10);
+    var doc = Parse(((OkObjectResult)result).Value!);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Weight types
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task MoranI_KnnWeight_ProducesResult()
+  {
+    using var db = CreateDbContext(nameof(MoranI_KnnWeight_ProducesResult));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = CreateClusteredRequest();
+    request.WeightType = "knn";
+
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<OkObjectResult>();
+  }
+
+  [Fact]
+  public async Task MoranI_InverseDistanceWeight_ProducesResult()
+  {
+    using var db = CreateDbContext(nameof(MoranI_InverseDistanceWeight_ProducesResult));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = CreateClusteredRequest();
+    request.WeightType = "inverse_distance";
+
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<OkObjectResult>();
+  }
+}


### PR DESCRIPTION
## R2 Wave 28 — Spatial Autocorrelation

### New Entity
- `SpatialAnalysis` — stores spatial autocorrelation results with county isolation

### Endpoints (4)
| Method | Route | Purpose |
|--------|-------|---------|
| POST | `/api/costforge/analytics/spatial/moran` | Global Moran's I + LISA local indicators |
| POST | `/api/costforge/analytics/spatial/geary` | Global Geary's C statistic |
| GET | `/api/costforge/analytics/spatial/{id}` | Retrieve analysis result |
| GET | `/api/costforge/analytics/spatial/history` | County-scoped analysis history |

### Implementation Details
- **Weight matrix types**: distance, knn, inverse_distance (all row-standardized)
- **Moran's I**: Global statistic with z-score/p-value + LISA local indicators
- **Geary's C**: Global statistic with z-score/p-value
- **Cluster classification**: HH, HL, LH, LL, NS (based on α=0.05)
- Pure math: no external dependencies

### Tests
- 18 tests in `R2Wave28SpatialAutocorrelationTests.cs` — all passing
- Covers: positive autocorrelation detection, interpretation strings, z-score/p-value, cluster summary, local indicators, persistence, edge cases, weight matrix types, county isolation

### Gates
- ✅ `dotnet build` — 0 errors, 0 warnings
- ✅ `dotnet test --filter "Category=R2Wave28"` — 18/18 passed
- ✅ Pre-commit quality gate passed
- ✅ Pre-push quality gate passed