### PR TITLE
feat(forge): Wave 30 — RCW calculators (84.34, 84.26, 84.36.381)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -2615,6 +2615,303 @@ public class CostForgeController : ControllerBase
     ];
   }
 
+  // ═══════════════════════════════════════════════════════════════════
+  // R2 Wave 30 — RCW Calculators (WA State exemption statutes)
+  // ═══════════════════════════════════════════════════════════════════
+
+  /// <summary>RCW 84.34 — Open Space / Current Use valuation.</summary>
+  [HttpPost("analytics/rcw/84-34")]
+  public async Task<IActionResult> CalculateRcw8434([FromBody] Rcw8434Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // Classification rates per acre (simplified WA schedule)
+      var ratePerAcre = (request.Classification?.ToLowerInvariant()) switch
+      {
+          "farm_and_agricultural" => 500m,
+          "timber" => 300m,
+          "open_space" => 200m,
+          _ => 400m,
+      };
+
+      var currentUseValue = ratePerAcre * request.Acreage;
+      var exemption = request.MarketValue - currentUseValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_34",
+          ParcelId = request.ParcelId ?? "",
+          CurrentUseClassification = request.Classification ?? "open_space",
+          MarketValue = request.MarketValue,
+          ReducedValue = currentUseValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Qualifies = request.Acreage >= 5 && request.MarketValue > 0,
+          DisqualificationReason = request.Acreage < 5
+              ? "Minimum 5 acres required for current-use classification"
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              acreage = request.Acreage,
+              ratePerAcre,
+              classification = request.Classification ?? "open_space",
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          classification = entity.CurrentUseClassification,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+      });
+  }
+
+  /// <summary>RCW 84.26 — Historic Property special valuation.</summary>
+  [HttpPost("analytics/rcw/84-26")]
+  public async Task<IActionResult> CalculateRcw8426([FromBody] Rcw8426Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // Historic property: valuation frozen at pre-rehabilitation value
+      // for 10-year special valuation period
+      var qualifies = request.YearDesignated > 0
+                      && request.RehabilitationCost > 0
+                      && request.RehabilitationCost >= request.PreRehabValue * 0.25m; // 25% minimum
+
+      var reducedValue = qualifies ? request.PreRehabValue : request.MarketValue;
+      var exemption = request.MarketValue - reducedValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var yearsRemaining = qualifies
+          ? Math.Max(0, 10 - (request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year) + request.YearDesignated)
+          : 0;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_26",
+          ParcelId = request.ParcelId ?? "",
+          MarketValue = request.MarketValue,
+          ReducedValue = reducedValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Qualifies = qualifies,
+          DisqualificationReason = !qualifies
+              ? "Rehabilitation cost must be >= 25% of pre-rehabilitation value"
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              preRehabValue = request.PreRehabValue,
+              rehabilitationCost = request.RehabilitationCost,
+              yearDesignated = request.YearDesignated,
+              yearsRemaining,
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+          yearsRemaining,
+      });
+  }
+
+  /// <summary>RCW 84.36.381 — Senior/Disabled Persons exemption.</summary>
+  [HttpPost("analytics/rcw/84-36-381")]
+  public async Task<IActionResult> CalculateRcw8436381([FromBody] Rcw8436381Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // 2025-2026 WA income thresholds (simplified)
+      const decimal tier1Limit = 40_000m;   // Full exemption on excess levy
+      const decimal tier2Limit = 50_000m;   // Partial: frozen value
+      const decimal tier3Limit = 65_000m;   // Partial: reduced rate
+
+      var income = request.Income;
+      string tier;
+      decimal reducedValue;
+      bool qualifies = request.Age >= 61 || request.IsDisabled;
+
+      if (!qualifies)
+      {
+          tier = "none";
+          reducedValue = request.MarketValue;
+      }
+      else if (income <= tier1Limit)
+      {
+          tier = "tier_1";
+          // Exempt from all excess levies, value frozen
+          reducedValue = Math.Min(request.MarketValue, 150_000m);
+      }
+      else if (income <= tier2Limit)
+      {
+          tier = "tier_2";
+          reducedValue = Math.Min(request.MarketValue, 200_000m);
+      }
+      else if (income <= tier3Limit)
+      {
+          tier = "tier_3";
+          reducedValue = Math.Min(request.MarketValue, request.MarketValue * 0.90m);
+      }
+      else
+      {
+          tier = "over_income";
+          reducedValue = request.MarketValue;
+          qualifies = false;
+      }
+
+      var exemption = request.MarketValue - reducedValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_36_381",
+          ParcelId = request.ParcelId ?? "",
+          MarketValue = request.MarketValue,
+          ReducedValue = reducedValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Income = income,
+          Qualifies = qualifies,
+          DisqualificationReason = !qualifies
+              ? (request.Age < 61 && !request.IsDisabled
+                  ? "Must be age 61+ or disabled"
+                  : "Income exceeds maximum threshold")
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              age = request.Age,
+              isDisabled = request.IsDisabled,
+              income,
+              tier,
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+          tier,
+      });
+  }
+
+  /// <summary>Retrieve an RCW calculation result by ID.</summary>
+  [HttpGet("analytics/rcw/{id:int}")]
+  public async Task<IActionResult> GetRcwCalculation(int id)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var result = await _db.Set<RcwCalculation>()
+          .FirstOrDefaultAsync(r => r.Id == id && r.CountyId == ctx.CountyId);
+
+      if (result == null)
+          return NotFound(new { error = "RCW calculation not found" });
+
+      return Ok(new
+      {
+          id = result.Id,
+          statute = result.Statute,
+          parcelId = result.ParcelId,
+          classification = result.CurrentUseClassification,
+          marketValue = result.MarketValue,
+          reducedValue = result.ReducedValue,
+          exemptionAmount = result.ExemptionAmount,
+          taxSavings = result.TaxSavings,
+          qualifies = result.Qualifies,
+          disqualificationReason = result.DisqualificationReason,
+          income = result.Income,
+          taxYear = result.TaxYear,
+          details = result.Details,
+          createdBy = result.CreatedBy,
+          createdAt = result.CreatedAt,
+      });
+  }
+
+  /// <summary>Get RCW calculation history for the county.</summary>
+  [HttpGet("analytics/rcw/history")]
+  public async Task<IActionResult> GetRcwHistory(
+      [FromQuery] string? statute = null,
+      [FromQuery] int limit = 20)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var query = _db.Set<RcwCalculation>()
+          .Where(r => r.CountyId == ctx.CountyId);
+
+      if (!string.IsNullOrEmpty(statute))
+          query = query.Where(r => r.Statute == statute);
+
+      var results = await query
+          .OrderByDescending(r => r.CreatedAt)
+          .Take(Math.Clamp(limit, 1, 100))
+          .Select(r => new
+          {
+              id = r.Id,
+              statute = r.Statute,
+              parcelId = r.ParcelId,
+              qualifies = r.Qualifies,
+              exemptionAmount = r.ExemptionAmount,
+              taxSavings = r.TaxSavings,
+              createdAt = r.CreatedAt,
+          })
+          .ToListAsync();
+
+      return Ok(new { count = results.Count, results });
+  }
+
   internal sealed record CostMatrixEntry(string BuildingType, string BuildingTypeLabel, string Region, decimal BaseCostPerSqft);
   internal sealed record DepreciationBracket(int MinAge, int MaxAge, decimal Factor);
 
@@ -2776,4 +3073,38 @@ public class AnalyticsDto
   public double AverageAccuracy { get; set; }
   public Dictionary<string, int> CalculationsByType { get; set; } = new();
   public Dictionary<string, double> PerformanceMetrics { get; set; } = new();
+}
+
+// ═══ R2 Wave 30 — RCW Calculator DTOs ═══
+
+public class Rcw8434Request
+{
+  public string? ParcelId { get; set; }
+  public string? Classification { get; set; }
+  public decimal MarketValue { get; set; }
+  public decimal Acreage { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class Rcw8426Request
+{
+  public string? ParcelId { get; set; }
+  public decimal MarketValue { get; set; }
+  public decimal PreRehabValue { get; set; }
+  public decimal RehabilitationCost { get; set; }
+  public int YearDesignated { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class Rcw8436381Request
+{
+  public string? ParcelId { get; set; }
+  public decimal MarketValue { get; set; }
+  public int Age { get; set; }
+  public bool IsDisabled { get; set; }
+  public decimal Income { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
 }

--- a/backend/src/TerraFusion.Core/Entities/RcwCalculation.cs
+++ b/backend/src/TerraFusion.Core/Entities/RcwCalculation.cs
@@ -1,0 +1,65 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// R2 Wave 30 — RCW calculation result with county isolation.
+/// Stores results from Washington State RCW exemption/special-use calculators.
+/// </summary>
+public class RcwCalculation
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public Guid CountyId { get; set; }
+
+    /// <summary>RCW statute: rcw_84_34 (Open Space), rcw_84_26 (Historic), rcw_84_36_381 (Senior/Disabled)</summary>
+    [Required]
+    [MaxLength(50)]
+    public string Statute { get; set; } = string.Empty;
+
+    [MaxLength(100)]
+    public string ParcelId { get; set; } = string.Empty;
+
+    /// <summary>Current Use classification for RCW 84.34.</summary>
+    [MaxLength(50)]
+    public string CurrentUseClassification { get; set; } = string.Empty;
+
+    /// <summary>Market value (full, unreduced).</summary>
+    public decimal MarketValue { get; set; }
+
+    /// <summary>Assessed / reduced value after exemption.</summary>
+    public decimal ReducedValue { get; set; }
+
+    /// <summary>Exemption amount (MarketValue - ReducedValue).</summary>
+    public decimal ExemptionAmount { get; set; }
+
+    /// <summary>Tax savings at the given levy rate.</summary>
+    public decimal TaxSavings { get; set; }
+
+    /// <summary>Levy rate used (mills / $1000 or percentage).</summary>
+    public double LevyRate { get; set; }
+
+    /// <summary>Tax year the calculation applies to.</summary>
+    public int TaxYear { get; set; }
+
+    /// <summary>Income (for Senior/Disabled means-test).</summary>
+    public decimal Income { get; set; }
+
+    /// <summary>JSON with statute-specific detail (e.g., age, classification, acreage).</summary>
+    public string Details { get; set; } = "{}";
+
+    /// <summary>Whether the applicant qualifies under this statute.</summary>
+    public bool Qualifies { get; set; }
+
+    /// <summary>Reason for disqualification (empty if qualifies).</summary>
+    [MaxLength(500)]
+    public string DisqualificationReason { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -97,6 +97,9 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<CamaCharacteristic> CamaCharacteristics { get; set; }
   public DbSet<CostMatrix> CostMatrices { get; set; }
 
+  // R2 Wave 30 — RCW Calculators
+  public DbSet<RcwCalculation> RcwCalculations { get; set; }
+
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }
   public DbSet<DossierEvidence> DossierEvidenceItems { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave30/R2Wave30RcwCalculatorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave30/R2Wave30RcwCalculatorTests.cs
@@ -1,0 +1,434 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave30;
+
+[Trait("Category", "R2Wave30")]
+[Trait("Category", "RcwCalculators")]
+public sealed class R2Wave30RcwCalculatorTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w30-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  // ════════════════════════════════════════
+  // RCW 84.34 — Open Space / Current Use
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task Rcw8434_FarmAndAgricultural_ReducesValue()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_FarmAndAgricultural_ReducesValue));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      ParcelId = "P-001",
+      Classification = "farm_and_agricultural",
+      MarketValue = 500_000m,
+      Acreage = 20m,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_34");
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    // 20 acres * $500/acre = $10,000 reduced value
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(10_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(490_000m);
+    doc.RootElement.GetProperty("taxSavings").GetDecimal().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task Rcw8434_TooFewAcres_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_TooFewAcres_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 300_000m,
+      Acreage = 3m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("5 acres");
+  }
+
+  [Fact]
+  public async Task Rcw8434_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 400_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+
+    var entities = await db.Set<RcwCalculation>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].Statute.Should().Be("rcw_84_34");
+  }
+
+  // ════════════════════════════════════════
+  // RCW 84.26 — Historic Property
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task Rcw8426_QualifiedRehab_ReducesToPreRehabValue()
+  {
+    using var db = CreateDbContext(nameof(Rcw8426_QualifiedRehab_ReducesToPreRehabValue));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8426(new Rcw8426Request
+    {
+      ParcelId = "H-001",
+      MarketValue = 400_000m,
+      PreRehabValue = 200_000m,
+      RehabilitationCost = 100_000m, // 50% of pre-rehab → qualifies (>=25%)
+      YearDesignated = 2020,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_26");
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(200_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(200_000m);
+    doc.RootElement.GetProperty("yearsRemaining").GetInt32().Should().BeGreaterThanOrEqualTo(0);
+  }
+
+  [Fact]
+  public async Task Rcw8426_InsufficientRehab_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8426_InsufficientRehab_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8426(new Rcw8426Request
+    {
+      MarketValue = 400_000m,
+      PreRehabValue = 200_000m,
+      RehabilitationCost = 10_000m, // 5% — below 25% threshold
+      YearDesignated = 2020,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("25%");
+  }
+
+  // ════════════════════════════════════════
+  // RCW 84.36.381 — Senior/Disabled
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task Rcw8436381_Tier1_FullExemption()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier1_FullExemption));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      ParcelId = "S-001",
+      MarketValue = 300_000m,
+      Age = 65,
+      Income = 30_000m,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_1");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(150_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(150_000m);
+  }
+
+  [Fact]
+  public async Task Rcw8436381_Tier2_PartialExemption()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier2_PartialExemption));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 62,
+      Income = 45_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_2");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(200_000m);
+  }
+
+  [Fact]
+  public async Task Rcw8436381_Tier3_ReducedRate()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier3_ReducedRate));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 70,
+      Income = 60_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_3");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(270_000m); // 90%
+  }
+
+  [Fact]
+  public async Task Rcw8436381_OverIncome_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_OverIncome_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 65,
+      Income = 100_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("over_income");
+  }
+
+  [Fact]
+  public async Task Rcw8436381_TooYoungNotDisabled_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_TooYoungNotDisabled_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 50,
+      IsDisabled = false,
+      Income = 30_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("61");
+  }
+
+  [Fact]
+  public async Task Rcw8436381_DisabledPersonQualifies()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_DisabledPersonQualifies));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 45,
+      IsDisabled = true,
+      Income = 30_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_1");
+  }
+
+  // ════════════════════════════════════════
+  // Retrieval & County Isolation
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task GetRcwCalculation_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetRcwCalculation_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      ParcelId = "P-001", MarketValue = 500_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    var saved = await db.Set<RcwCalculation>().FirstAsync();
+
+    var result = await controller.GetRcwCalculation(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("id").GetInt32().Should().Be(saved.Id);
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_34");
+  }
+
+  [Fact]
+  public async Task GetRcwCalculation_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetRcwCalculation_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 100_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    var saved = await db.Set<RcwCalculation>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetRcwCalculation(saved.Id);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersOnStatute()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersOnStatute));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 400_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m, Age = 65, Income = 30_000m, LevyRate = 10.0,
+    });
+
+    var result = await controller.GetRcwHistory(statute: "rcw_84_34");
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 200_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}


### PR DESCRIPTION
## Wave 30 — RCW Calculators

Washington State Revised Code exemption and special-use valuation calculators for TerraForge.

### Endpoints
| Route | Statute | Purpose |
|-------|---------|---------|
| `POST analytics/rcw/84-34` | RCW 84.34 | Open Space / Current Use (farm, timber, open space) |
| `POST analytics/rcw/84-26` | RCW 84.26 | Historic Property special valuation |
| `POST analytics/rcw/84-36-381` | RCW 84.36.381 | Senior/Disabled Exemption (3-tier) |
| `GET analytics/rcw/{id}` | — | Retrieve calculation by ID (county-isolated) |
| `GET analytics/rcw/history` | — | History with optional statute filter |

### Business Logic
- **RCW 84.34**: Classification rates per acre (farm $500, timber $300, open_space $200); 5-acre minimum
- **RCW 84.26**: 25% minimum rehab cost threshold; 10-year special valuation period
- **RCW 84.36.381**: 3 income tiers (≤$40K tier_1, ≤$50K tier_2, ≤$65K tier_3); age 61+ or disabled

### Evidence
- Tests: **15/15 pass** (Category=R2Wave30)
- Build: 0 errors, 0 warnings
- Pre-push gates: all passed

### Files
- `RcwCalculation.cs` — Entity
- `TerraFusionDbContext.cs` — DbSet registration
- `CostForgeController.cs` — 5 endpoints + 3 DTOs
- `R2Wave30RcwCalculatorTests.cs` — 15 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Washington State RCW-based exemption calculation endpoints supporting three exemption types: open space/current use, historic property rehabilitation, and senior/disabled homeowners
  * Calculate reduced property values, exemption amounts, and estimated tax savings based on eligibility criteria
  * Retrieve individual calculation results and browse calculation history with optional statute filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->