### PR TITLE
feat(forge): Wave 31 — Levy certification (RCW 84.52/84.55)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -2615,6 +2615,233 @@ public class CostForgeController : ControllerBase
     ];
   }
 
+  // ═══════════════════════════════════════════════════════════════
+  // Wave 31 — Levy Certification (RCW 84.52 / RCW 84.55)
+  // ═══════════════════════════════════════════════════════════════
+
+  /// <summary>Calculate levy rate for a taxing district and check statutory limits.</summary>
+  [HttpPost("analytics/levy/calculate")]
+  public async Task<IActionResult> CalculateLevy([FromBody] LevyCalculateRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    // RCW 84.55 — 1% annual increase limit
+    var onePercentLimit = req.PriorYearLevy * 1.01m;
+    // Add new construction and annexation values at existing rate
+    var priorRate = req.AssessedValue > 0 ? (double)(req.PriorYearLevy / req.AssessedValue * 1000m) : 0;
+    var ncAddition = req.NewConstructionValue * (decimal)priorRate / 1000m;
+    var annexAddition = req.AnnexationValue * (decimal)priorRate / 1000m;
+    var statutoryLimit = onePercentLimit + ncAddition + annexAddition;
+
+    var certifiedLevy = req.RequestedLevy;
+    var wasReduced = false;
+    var reductionAmount = 0m;
+
+    // Check statutory limit
+    if (certifiedLevy > statutoryLimit)
+    {
+      reductionAmount = certifiedLevy - statutoryLimit;
+      certifiedLevy = statutoryLimit;
+      wasReduced = true;
+    }
+
+    // Compute rate per $1,000 AV
+    var levyRate = req.AssessedValue > 0 ? (double)(certifiedLevy / req.AssessedValue * 1000m) : 0;
+
+    // Constitutional limit: $10 per $1,000 AV (1%)
+    var withinConstitutionalLimit = levyRate <= 10.0;
+    // $5.90 aggregate limit (RCW 84.52.043) — applies to regular levies only
+    var withinAggregateLimit = levyRate <= 5.90;
+
+    // Force constitutional compliance
+    if (!withinConstitutionalLimit && req.AssessedValue > 0)
+    {
+      certifiedLevy = req.AssessedValue * 10m / 1000m;
+      reductionAmount = req.RequestedLevy - certifiedLevy;
+      wasReduced = true;
+      levyRate = 10.0;
+      withinConstitutionalLimit = true;
+    }
+
+    var entity = new TerraFusion.Core.Entities.LevyCertification
+    {
+      CountyId = ctx.CountyId,
+      TaxYear = req.TaxYear > 0 ? req.TaxYear : DateTime.UtcNow.Year,
+      DistrictCode = req.DistrictCode ?? "",
+      DistrictName = req.DistrictName ?? "",
+      PriorYearLevy = req.PriorYearLevy,
+      RequestedLevy = req.RequestedLevy,
+      CertifiedLevy = certifiedLevy,
+      AssessedValue = req.AssessedValue,
+      NewConstructionValue = req.NewConstructionValue,
+      AnnexationValue = req.AnnexationValue,
+      LevyRate = levyRate,
+      StatutoryLimit = statutoryLimit,
+      ConstitutionalLimit = 10.0,
+      AggregateLimit = 5.90,
+      WithinConstitutionalLimit = withinConstitutionalLimit,
+      WithinAggregateLimit = withinAggregateLimit,
+      WasReduced = wasReduced,
+      ReductionAmount = reductionAmount,
+      Status = "draft",
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+    };
+    _db.Set<TerraFusion.Core.Entities.LevyCertification>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      countyId = entity.CountyId,
+      taxYear = entity.TaxYear,
+      districtCode = entity.DistrictCode,
+      districtName = entity.DistrictName,
+      priorYearLevy = entity.PriorYearLevy,
+      requestedLevy = entity.RequestedLevy,
+      certifiedLevy = entity.CertifiedLevy,
+      assessedValue = entity.AssessedValue,
+      newConstructionValue = entity.NewConstructionValue,
+      annexationValue = entity.AnnexationValue,
+      levyRate = entity.LevyRate,
+      statutoryLimit = entity.StatutoryLimit,
+      constitutionalLimit = entity.ConstitutionalLimit,
+      aggregateLimit = entity.AggregateLimit,
+      withinConstitutionalLimit = entity.WithinConstitutionalLimit,
+      withinAggregateLimit = entity.WithinAggregateLimit,
+      wasReduced = entity.WasReduced,
+      reductionAmount = entity.ReductionAmount,
+      status = entity.Status,
+    });
+  }
+
+  /// <summary>Run a multi-district levy balance test (prorationing).</summary>
+  [HttpPost("analytics/levy/balance-test")]
+  public async Task<IActionResult> LevyBalanceTest([FromBody] LevyBalanceTestRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (req.Districts is null || req.Districts.Count == 0)
+      return BadRequest(new { error = "At least one district is required" });
+
+    var results = new List<object>();
+    var totalRate = 0.0;
+
+    foreach (var d in req.Districts)
+    {
+      var rate = d.AssessedValue > 0 ? (double)(d.RequestedLevy / d.AssessedValue * 1000m) : 0;
+      totalRate += rate;
+      results.Add(new
+      {
+        districtCode = d.DistrictCode ?? "",
+        districtName = d.DistrictName ?? "",
+        requestedLevy = d.RequestedLevy,
+        assessedValue = d.AssessedValue,
+        rate = Math.Round(rate, 6),
+      });
+    }
+
+    var aggregatePass = totalRate <= 5.90;
+    var constitutionalPass = totalRate <= 10.0;
+
+    return Ok(new
+    {
+      taxYear = req.TaxYear > 0 ? req.TaxYear : DateTime.UtcNow.Year,
+      districtCount = req.Districts.Count,
+      totalRate = Math.Round(totalRate, 6),
+      aggregateLimit = 5.90,
+      constitutionalLimit = 10.0,
+      aggregatePass,
+      constitutionalPass,
+      prorationRequired = !aggregatePass,
+      districts = results,
+    });
+  }
+
+  /// <summary>Certify a previously-calculated levy (status → certified).</summary>
+  [HttpPost("analytics/levy/{id}/certify")]
+  public async Task<IActionResult> CertifyLevy(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+
+    if (entity is null) return NotFound(new { error = "Levy record not found" });
+    if (entity.Status == "certified")
+      return BadRequest(new { error = "Already certified" });
+    if (!entity.WithinConstitutionalLimit)
+      return BadRequest(new { error = "Cannot certify — exceeds constitutional limit" });
+
+    entity.Status = "certified";
+    await _db.SaveChangesAsync();
+
+    return Ok(new { id = entity.Id, status = entity.Status, certifiedLevy = entity.CertifiedLevy });
+  }
+
+  /// <summary>Get a single levy certification by ID.</summary>
+  [HttpGet("analytics/levy/{id}")]
+  public async Task<IActionResult> GetLevyCertification(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+
+    if (entity is null) return NotFound(new { error = "Levy record not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      taxYear = entity.TaxYear,
+      districtCode = entity.DistrictCode,
+      districtName = entity.DistrictName,
+      requestedLevy = entity.RequestedLevy,
+      certifiedLevy = entity.CertifiedLevy,
+      levyRate = entity.LevyRate,
+      withinConstitutionalLimit = entity.WithinConstitutionalLimit,
+      withinAggregateLimit = entity.WithinAggregateLimit,
+      wasReduced = entity.WasReduced,
+      reductionAmount = entity.ReductionAmount,
+      status = entity.Status,
+    });
+  }
+
+  /// <summary>Get levy certification history for the current county.</summary>
+  [HttpGet("analytics/levy/history")]
+  public async Task<IActionResult> GetLevyHistory([FromQuery] int? taxYear, [FromQuery] string? districtCode)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .Where(e => e.CountyId == ctx.CountyId);
+
+    if (taxYear.HasValue) query = query.Where(e => e.TaxYear == taxYear.Value);
+    if (!string.IsNullOrEmpty(districtCode)) query = query.Where(e => e.DistrictCode == districtCode);
+
+    var items = await query.OrderByDescending(e => e.CreatedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        taxYear = e.TaxYear,
+        districtCode = e.DistrictCode,
+        districtName = e.DistrictName,
+        certifiedLevy = e.CertifiedLevy,
+        levyRate = e.LevyRate,
+        status = e.Status,
+        createdAt = e.CreatedAt,
+      }),
+    });
+  }
+
   internal sealed record CostMatrixEntry(string BuildingType, string BuildingTypeLabel, string Region, decimal BaseCostPerSqft);
   internal sealed record DepreciationBracket(int MinAge, int MaxAge, decimal Factor);
 
@@ -2776,4 +3003,34 @@ public class AnalyticsDto
   public double AverageAccuracy { get; set; }
   public Dictionary<string, int> CalculationsByType { get; set; } = new();
   public Dictionary<string, double> PerformanceMetrics { get; set; } = new();
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Wave 31 — Levy DTOs
+// ═══════════════════════════════════════════════════════════════
+
+public class LevyCalculateRequest
+{
+  public string? DistrictCode { get; set; }
+  public string? DistrictName { get; set; }
+  public decimal PriorYearLevy { get; set; }
+  public decimal RequestedLevy { get; set; }
+  public decimal AssessedValue { get; set; }
+  public decimal NewConstructionValue { get; set; }
+  public decimal AnnexationValue { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class LevyBalanceTestRequest
+{
+  public int TaxYear { get; set; }
+  public List<LevyDistrictInput> Districts { get; set; } = new();
+}
+
+public class LevyDistrictInput
+{
+  public string? DistrictCode { get; set; }
+  public string? DistrictName { get; set; }
+  public decimal RequestedLevy { get; set; }
+  public decimal AssessedValue { get; set; }
 }

--- a/backend/src/TerraFusion.Core/Entities/LevyCertification.cs
+++ b/backend/src/TerraFusion.Core/Entities/LevyCertification.cs
@@ -1,0 +1,95 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Levy certification calculation — tracks levy rate computations,
+/// statutory limits (1% constitutional, $5.90 aggregate), and
+/// certification workflow state for a given tax year.
+/// </summary>
+public class LevyCertification
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  /// <summary>County that owns this certification record.</summary>
+  public Guid CountyId { get; set; }
+
+  /// <summary>Tax year this certification applies to.</summary>
+  public int TaxYear { get; set; }
+
+  /// <summary>Taxing district code (e.g., county, city, school, fire).</summary>
+  [MaxLength(100)]
+  public string DistrictCode { get; set; } = "";
+
+  /// <summary>Taxing district display name.</summary>
+  [MaxLength(250)]
+  public string DistrictName { get; set; } = "";
+
+  /// <summary>Prior-year levy amount in dollars.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal PriorYearLevy { get; set; }
+
+  /// <summary>Requested levy amount for the current year.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal RequestedLevy { get; set; }
+
+  /// <summary>Certified (approved) levy amount after limit checks.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal CertifiedLevy { get; set; }
+
+  /// <summary>Total assessed value in the district.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal AssessedValue { get; set; }
+
+  /// <summary>New-construction value added this year.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal NewConstructionValue { get; set; }
+
+  /// <summary>Annexation value (newly-included territory).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal AnnexationValue { get; set; }
+
+  /// <summary>Computed levy rate per $1,000 assessed value.</summary>
+  public double LevyRate { get; set; }
+
+  /// <summary>WA statutory limit: 1% annual increase (RCW 84.55).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal StatutoryLimit { get; set; }
+
+  /// <summary>1% constitutional limit on levy rate per $1,000 AV.</summary>
+  public double ConstitutionalLimit { get; set; } = 10.0;
+
+  /// <summary>$5.90 aggregate limit per $1,000 AV (RCW 84.52.043).</summary>
+  public double AggregateLimit { get; set; } = 5.90;
+
+  /// <summary>Whether the district is within the 1% constitutional limit.</summary>
+  public bool WithinConstitutionalLimit { get; set; }
+
+  /// <summary>Whether the district is within the $5.90 aggregate limit.</summary>
+  public bool WithinAggregateLimit { get; set; }
+
+  /// <summary>Whether levy was reduced to comply with limits.</summary>
+  public bool WasReduced { get; set; }
+
+  /// <summary>Amount the levy was reduced by (if any).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal ReductionAmount { get; set; }
+
+  /// <summary>Certification status: draft, pending_review, certified, rejected.</summary>
+  [MaxLength(50)]
+  public string Status { get; set; } = "draft";
+
+  /// <summary>JSON details blob with breakdown, limit check details, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  /// <summary>Who created/ran this calculation.</summary>
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -96,6 +96,7 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<ComparableSale> ComparableSales { get; set; }
   public DbSet<CamaCharacteristic> CamaCharacteristics { get; set; }
   public DbSet<CostMatrix> CostMatrices { get; set; }
+  public DbSet<LevyCertification> LevyCertifications { get; set; }
 
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave31/R2Wave31LevyCertificationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave31/R2Wave31LevyCertificationTests.cs
@@ -1,0 +1,401 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave31;
+
+[Trait("Category", "R2Wave31")]
+[Trait("Category", "LevyCertification")]
+public sealed class R2Wave31LevyCertificationTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w31-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  // ════════════════════════════════════════
+  // Levy Calculation
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task CalculateLevy_WithinLimits_ReturnsFullAmount()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_WithinLimits_ReturnsFullAmount));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "FD-1",
+      DistrictName = "Fire District 1",
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_005_000m, // 0.5% increase — within 1%
+      AssessedValue = 500_000_000m,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().Be(1_005_000m);
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("withinConstitutionalLimit").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("status").GetString().Should().Be("draft");
+  }
+
+  [Fact]
+  public async Task CalculateLevy_Exceeds1Percent_ReducesToStatutoryLimit()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_Exceeds1Percent_ReducesToStatutoryLimit));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_100_000m, // 10% increase — exceeds 1%
+      AssessedValue = 500_000_000m,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().BeLessThan(1_100_000m);
+    doc.RootElement.GetProperty("reductionAmount").GetDecimal().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task CalculateLevy_NewConstruction_AddsToLimit()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_NewConstruction_AddsToLimit));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_020_000m,
+      AssessedValue = 500_000_000m,
+      NewConstructionValue = 10_000_000m, // Adds NC at existing rate
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    // Statutory limit = 1,010,000 + (10M * 2.0/1000) = 1,010,000 + 20,000 = 1,030,000
+    doc.RootElement.GetProperty("statutoryLimit").GetDecimal().Should().BeGreaterThan(1_010_000m);
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task CalculateLevy_ExceedsConstitutionalLimit_ForcesCompliance()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_ExceedsConstitutionalLimit_ForcesCompliance));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // Tiny AV → rate would be very high
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 100_000m,
+      RequestedLevy = 100_000m,
+      AssessedValue = 5_000_000m, // rate = 20.0 per $1000 — exceeds 10.0
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("levyRate").GetDouble().Should().Be(10.0);
+    doc.RootElement.GetProperty("withinConstitutionalLimit").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().Be(50_000m); // 5M * 10/1000
+  }
+
+  [Fact]
+  public async Task CalculateLevy_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "CTY",
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+
+    var entities = await db.Set<LevyCertification>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].DistrictCode.Should().Be("CTY");
+  }
+
+  // ════════════════════════════════════════
+  // Balance Test (Prorationing)
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task BalanceTest_WithinAggregate_Passes()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_WithinAggregate_Passes));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new()
+      {
+        new() { DistrictCode = "CTY", RequestedLevy = 1_000_000m, AssessedValue = 1_000_000_000m },
+        new() { DistrictCode = "SCH", RequestedLevy = 2_000_000m, AssessedValue = 1_000_000_000m },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("aggregatePass").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("constitutionalPass").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("prorationRequired").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("districtCount").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task BalanceTest_ExceedsAggregate_RequiresProration()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_ExceedsAggregate_RequiresProration));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new()
+      {
+        new() { DistrictCode = "CTY", RequestedLevy = 3_000_000m, AssessedValue = 500_000_000m }, // 6.0
+        new() { DistrictCode = "SCH", RequestedLevy = 1_000_000m, AssessedValue = 500_000_000m }, // 2.0
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("totalRate").GetDouble().Should().BeGreaterThan(5.90);
+    doc.RootElement.GetProperty("aggregatePass").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("prorationRequired").GetBoolean().Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task BalanceTest_EmptyDistricts_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_EmptyDistricts_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new(),
+    });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ════════════════════════════════════════
+  // Certification Workflow
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task CertifyLevy_TransitionsToCertified()
+  {
+    using var db = CreateDbContext(nameof(CertifyLevy_TransitionsToCertified));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var result = await controller.CertifyLevy(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("status").GetString().Should().Be("certified");
+  }
+
+  [Fact]
+  public async Task CertifyLevy_AlreadyCertified_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(CertifyLevy_AlreadyCertified_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    await controller.CertifyLevy(saved.Id);
+    var result = await controller.CertifyLevy(saved.Id);
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ════════════════════════════════════════
+  // Retrieval & County Isolation
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task GetLevyCertification_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetLevyCertification_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "CTY",
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var result = await controller.GetLevyCertification(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("districtCode").GetString().Should().Be("CTY");
+  }
+
+  [Fact]
+  public async Task GetLevyCertification_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetLevyCertification_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetLevyCertification(saved.Id);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersOnTaxYear()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersOnTaxYear));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m, TaxYear = 2025,
+    });
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 600_000m, AssessedValue = 300_000_000m, TaxYear = 2026,
+    });
+
+    var result = await controller.GetLevyHistory(taxYear: 2026, districtCode: null);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m,
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}


### PR DESCRIPTION
## Wave 31 — Levy Certification

Washington State levy rate calculation and certification workflow per RCW 84.52 and RCW 84.55.

### Endpoints
| Route | Purpose |
|-------|---------|
| `POST analytics/levy/calculate` | Calculate levy rate, check 1% statutory limit + constitutional cap |
| `POST analytics/levy/balance-test` | Multi-district aggregate balance test (prorationing) |
| `POST analytics/levy/{id}/certify` | Certified status transition with limit compliance gate |
| `GET analytics/levy/{id}` | Retrieve by ID with county isolation |
| `GET analytics/levy/history` | History with taxYear/districtCode filters |

### Business Logic
- **RCW 84.55**: 1% annual increase limit with new construction + annexation additions
- **Constitutional limit**: $10 per $1,000 AV (1%) — auto-enforced
- **$5.90 aggregate limit**: RCW 84.52.043 checked in balance test
- **Certification workflow**: draft → certified (with limit compliance gate)

### Evidence
- Tests: **14/14 pass** (Category=R2Wave31)
- Build: 0 errors, 0 warnings
- Pre-push gates: all passed

### Files
- `LevyCertification.cs` — Entity
- `TerraFusionDbContext.cs` — DbSet registration
- `CostForgeController.cs` — 5 endpoints + 3 DTOs
- `R2Wave31LevyCertificationTests.cs` — 14 tests