### PR TITLE
feat(forge): Wave 33 — ETL/Sync engine

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -2615,6 +2615,158 @@ public class CostForgeController : ControllerBase
     ];
   }
 
+  // ═══════════════════════════════════════════════════════════════
+  // Wave 33 — ETL/Sync
+  // ═══════════════════════════════════════════════════════════════
+
+  /// <summary>Start a simulated ETL sync job.</summary>
+  [HttpPost("analytics/etl/sync")]
+  public async Task<IActionResult> StartEtlSync([FromBody] EtlSyncRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (req.Records is null || req.Records.Count == 0)
+      return BadRequest(new { error = "At least one record is required" });
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var processed = 0;
+    var failed = 0;
+    var skipped = 0;
+    var errors = new List<string>();
+
+    foreach (var rec in req.Records)
+    {
+      // Validate: must have a key field
+      if (string.IsNullOrWhiteSpace(rec.Key))
+      {
+        failed++;
+        errors.Add($"Record at index {processed + failed + skipped - 1}: missing key");
+        continue;
+      }
+
+      // Duplicate check via key
+      if (req.Records.Count(r => r.Key == rec.Key) > 1 && processed > 0)
+      {
+        // Simple dedup: skip subsequent duplicates
+        var alreadyCounted = req.Records.Take(processed + failed + skipped).Any(r => r.Key == rec.Key);
+        if (alreadyCounted) { skipped++; continue; }
+      }
+
+      // Validate: data must not be empty
+      if (rec.Data is null || rec.Data.Count == 0)
+      {
+        failed++;
+        errors.Add($"Record '{rec.Key}': empty data payload");
+        continue;
+      }
+
+      processed++;
+    }
+
+    sw.Stop();
+    var totalRecords = req.Records.Count;
+    var durationMs = sw.ElapsedMilliseconds > 0 ? sw.ElapsedMilliseconds : 1;
+    var rps = (double)processed / durationMs * 1000;
+
+    var entity = new TerraFusion.Core.Entities.EtlSyncJob
+    {
+      CountyId = ctx.CountyId,
+      SourceSystem = req.SourceSystem ?? "csv_import",
+      EntityType = req.EntityType ?? "parcels",
+      Direction = req.Direction ?? "inbound",
+      Status = failed == totalRecords ? "failed" : "completed",
+      TotalRecords = totalRecords,
+      ProcessedRecords = processed,
+      FailedRecords = failed,
+      SkippedRecords = skipped,
+      DurationMs = durationMs,
+      RecordsPerSecond = Math.Round(rps, 2),
+      Errors = errors.Count > 0 ? System.Text.Json.JsonSerializer.Serialize(errors) : null,
+      Watermark = DateTime.UtcNow,
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+      StartedAt = DateTime.UtcNow.AddMilliseconds(-durationMs),
+      CompletedAt = DateTime.UtcNow,
+    };
+    _db.Set<TerraFusion.Core.Entities.EtlSyncJob>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      sourceSystem = entity.SourceSystem,
+      entityType = entity.EntityType,
+      direction = entity.Direction,
+      status = entity.Status,
+      totalRecords = entity.TotalRecords,
+      processedRecords = entity.ProcessedRecords,
+      failedRecords = entity.FailedRecords,
+      skippedRecords = entity.SkippedRecords,
+      durationMs = entity.DurationMs,
+      recordsPerSecond = entity.RecordsPerSecond,
+      errors,
+    });
+  }
+
+  /// <summary>Get an ETL sync job by ID.</summary>
+  [HttpGet("analytics/etl/{id}")]
+  public async Task<IActionResult> GetEtlSyncJob(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.EtlSyncJob>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+    if (entity is null) return NotFound(new { error = "ETL job not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      sourceSystem = entity.SourceSystem,
+      entityType = entity.EntityType,
+      direction = entity.Direction,
+      status = entity.Status,
+      totalRecords = entity.TotalRecords,
+      processedRecords = entity.ProcessedRecords,
+      failedRecords = entity.FailedRecords,
+      skippedRecords = entity.SkippedRecords,
+      durationMs = entity.DurationMs,
+      recordsPerSecond = entity.RecordsPerSecond,
+      startedAt = entity.StartedAt,
+      completedAt = entity.CompletedAt,
+    });
+  }
+
+  /// <summary>Get ETL sync job history for the current county.</summary>
+  [HttpGet("analytics/etl/history")]
+  public async Task<IActionResult> GetEtlHistory([FromQuery] string? sourceSystem, [FromQuery] string? entityType)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.EtlSyncJob>()
+      .Where(e => e.CountyId == ctx.CountyId);
+    if (!string.IsNullOrEmpty(sourceSystem)) query = query.Where(e => e.SourceSystem == sourceSystem);
+    if (!string.IsNullOrEmpty(entityType)) query = query.Where(e => e.EntityType == entityType);
+
+    var items = await query.OrderByDescending(e => e.StartedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        sourceSystem = e.SourceSystem,
+        entityType = e.EntityType,
+        status = e.Status,
+        processedRecords = e.ProcessedRecords,
+        failedRecords = e.FailedRecords,
+        startedAt = e.StartedAt,
+      }),
+    });
+  }
+
   internal sealed record CostMatrixEntry(string BuildingType, string BuildingTypeLabel, string Region, decimal BaseCostPerSqft);
   internal sealed record DepreciationBracket(int MinAge, int MaxAge, decimal Factor);
 
@@ -2776,4 +2928,22 @@ public class AnalyticsDto
   public double AverageAccuracy { get; set; }
   public Dictionary<string, int> CalculationsByType { get; set; } = new();
   public Dictionary<string, double> PerformanceMetrics { get; set; } = new();
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Wave 33 — ETL/Sync DTOs
+// ═══════════════════════════════════════════════════════════════
+
+public class EtlSyncRequest
+{
+  public string? SourceSystem { get; set; }
+  public string? EntityType { get; set; }
+  public string? Direction { get; set; }
+  public List<EtlSyncRecord>? Records { get; set; }
+}
+
+public class EtlSyncRecord
+{
+  public string? Key { get; set; }
+  public Dictionary<string, string?>? Data { get; set; }
 }

--- a/backend/src/TerraFusion.Core/Entities/EtlSyncJob.cs
+++ b/backend/src/TerraFusion.Core/Entities/EtlSyncJob.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// ETL sync job — tracks data synchronization operations between
+/// TerraFusion and external systems (Harris PACS, Tyler Vision, Aumentum).
+/// </summary>
+public class EtlSyncJob
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  /// <summary>Source system identifier: harris_pacs, tyler_vision, aumentum, csv_import.</summary>
+  [MaxLength(100)]
+  public string SourceSystem { get; set; } = "";
+
+  /// <summary>Entity type being synced: parcels, sales, permits, assessments.</summary>
+  [MaxLength(100)]
+  public string EntityType { get; set; } = "";
+
+  /// <summary>Direction: inbound (external → TF), outbound (TF → external).</summary>
+  [MaxLength(20)]
+  public string Direction { get; set; } = "inbound";
+
+  /// <summary>Status: queued, running, completed, failed, cancelled.</summary>
+  [MaxLength(30)]
+  public string Status { get; set; } = "queued";
+
+  /// <summary>Total records to process.</summary>
+  public int TotalRecords { get; set; }
+
+  /// <summary>Records successfully processed.</summary>
+  public int ProcessedRecords { get; set; }
+
+  /// <summary>Records that failed processing.</summary>
+  public int FailedRecords { get; set; }
+
+  /// <summary>Records skipped (duplicates, unchanged).</summary>
+  public int SkippedRecords { get; set; }
+
+  /// <summary>Duration in milliseconds.</summary>
+  public long DurationMs { get; set; }
+
+  /// <summary>Throughput in records per second.</summary>
+  public double RecordsPerSecond { get; set; }
+
+  /// <summary>JSON array of error messages for failed records.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Errors { get; set; }
+
+  /// <summary>JSON details blob with field mappings, transform stats, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  /// <summary>Watermark for incremental sync (e.g., last modified timestamp).</summary>
+  public DateTime? Watermark { get; set; }
+
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+  public DateTime? CompletedAt { get; set; }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -96,6 +96,7 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<ComparableSale> ComparableSales { get; set; }
   public DbSet<CamaCharacteristic> CamaCharacteristics { get; set; }
   public DbSet<CostMatrix> CostMatrices { get; set; }
+  public DbSet<EtlSyncJob> EtlSyncJobs { get; set; }
 
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave33/R2Wave33EtlSyncTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave33/R2Wave33EtlSyncTests.cs
@@ -1,0 +1,294 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave33;
+
+[Trait("Category", "R2Wave33")]
+[Trait("Category", "EtlSync")]
+public sealed class R2Wave33EtlSyncTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w33-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static EtlSyncRecord MakeRecord(string key, Dictionary<string, string?>? data = null)
+    => new() { Key = key, Data = data ?? new() { ["field1"] = "value1" } };
+
+  // ════════════════════════════════════════
+  // ETL Sync Job Execution
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task Sync_ValidRecords_AllProcessed()
+  {
+    using var db = CreateDbContext(nameof(Sync_ValidRecords_AllProcessed));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      EntityType = "parcels",
+      Records = new()
+      {
+        MakeRecord("P-001"),
+        MakeRecord("P-002"),
+        MakeRecord("P-003"),
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(3);
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(0);
+    doc.RootElement.GetProperty("sourceSystem").GetString().Should().Be("harris_pacs");
+    doc.RootElement.GetProperty("entityType").GetString().Should().Be("parcels");
+  }
+
+  [Fact]
+  public async Task Sync_MissingKey_RecordFails()
+  {
+    using var db = CreateDbContext(nameof(Sync_MissingKey_RecordFails));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new()
+      {
+        MakeRecord("P-001"),
+        new() { Key = null, Data = new() { ["x"] = "y" } }, // missing key
+        new() { Key = "", Data = new() { ["x"] = "y" } },   // empty key
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(1);
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task Sync_EmptyDataPayload_RecordFails()
+  {
+    using var db = CreateDbContext(nameof(Sync_EmptyDataPayload_RecordFails));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new()
+      {
+        new() { Key = "P-001", Data = new() },
+        new() { Key = "P-002", Data = null },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(2);
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(0);
+    doc.RootElement.GetProperty("status").GetString().Should().Be("failed");
+  }
+
+  [Fact]
+  public async Task Sync_EmptyRecords_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(Sync_EmptyRecords_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest { Records = new() });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task Sync_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(Sync_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "tyler_vision",
+      EntityType = "sales",
+      Direction = "inbound",
+      Records = new() { MakeRecord("S-001") },
+    });
+
+    var entities = await db.Set<EtlSyncJob>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].SourceSystem.Should().Be("tyler_vision");
+    entities[0].EntityType.Should().Be("sales");
+  }
+
+  [Fact]
+  public async Task Sync_IncludesThroughputMetrics()
+  {
+    using var db = CreateDbContext(nameof(Sync_IncludesThroughputMetrics));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001"), MakeRecord("P-002") },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("durationMs").GetInt64().Should().BeGreaterThanOrEqualTo(0);
+    doc.RootElement.GetProperty("recordsPerSecond").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+  }
+
+  // ════════════════════════════════════════
+  // Retrieval & County Isolation
+  // ════════════════════════════════════════
+
+  [Fact]
+  public async Task GetEtlJob_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetEtlJob_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      Records = new() { MakeRecord("P-001") },
+    });
+    var saved = await db.Set<EtlSyncJob>().FirstAsync();
+
+    var result = await controller.GetEtlSyncJob(saved.Id);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("sourceSystem").GetString().Should().Be("harris_pacs");
+  }
+
+  [Fact]
+  public async Task GetEtlJob_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetEtlJob_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001") },
+    });
+    var saved = await db.Set<EtlSyncJob>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetEtlSyncJob(saved.Id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersBySourceSystem()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersBySourceSystem));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      Records = new() { MakeRecord("P-001") },
+    });
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "tyler_vision",
+      Records = new() { MakeRecord("S-001") },
+    });
+
+    var result = await controller.GetEtlHistory(sourceSystem: "harris_pacs", entityType: null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001") },
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}


### PR DESCRIPTION
## Wave 33 — ETL/Sync Engine

Simulated ETL synchronization engine for external system data integration (Harris PACS, Tyler Vision, Aumentum, CSV import).

### Endpoints
| Route | Purpose |
|-------|---------|
| `POST analytics/etl/sync` | Execute sync with validation, dedup, throughput tracking |
| `GET analytics/etl/{id}` | Retrieve job by ID (county-isolated) |
| `GET analytics/etl/history` | History with sourceSystem/entityType filters |

### Features
- Record validation (key presence, data payload)
- Duplicate detection and skipping
- Throughput metrics (records/second, duration)
- Status tracking: queued → completed/failed
- Watermark for incremental sync support

### Evidence
- Tests: **10/10 pass** (Category=R2Wave33)
- Build: 0 errors, 0 warnings
- Pre-push gates: all passed

### Files
- `EtlSyncJob.cs` — Entity
- `TerraFusionDbContext.cs` — DbSet registration
- `CostForgeController.cs` — 3 endpoints + 2 DTOs
- `R2Wave33EtlSyncTests.cs` — 10 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ETL synchronization API now available with ability to initiate, track, and retrieve sync job status.
  * Performance metrics included (duration, throughput) for synchronization monitoring.
  * History tracking with filtering by source system and entity type.
  * Built-in county context isolation for secure multi-tenant operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->