### PR TITLE
feat(costforge): R2.2 — Waves 26-35 CostForge Analytics Integration

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -3412,6 +3412,1864 @@ public class CostForgeController : ControllerBase
     for (int j = 0; j < 6; j++) ser += cof[j] / ++y;
     return -tmp + Math.Log(2.5066282746310005 * ser / x);
   }
+
+
+  // r2/wave-28-forge-spatial-autocorrelation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  //  Wave 28 ΓÇö Spatial Autocorrelation (Moran's I, Geary's C, LISA)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Compute Global Moran's I spatial autocorrelation.</summary>
+  [HttpPost("analytics/spatial/moran")]
+  public async Task<IActionResult> RunGlobalMoranI([FromBody] SpatialAutocorrelationRequest request)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    if (request.Observations is null || request.Observations.Count < 3)
+      return BadRequest(new { error = "At least 3 observations required" });
+
+    int n = request.Observations.Count;
+    var values = request.Observations.Select(o => o.Value).ToArray();
+    double mean = values.Average();
+
+    // Build spatial weight matrix based on coordinates
+    var W = BuildWeightMatrix(request.Observations, request.WeightType ?? "distance", request.DistanceThreshold ?? 0);
+
+    // Global Moran's I = (n/S0) * ╬ú_i ╬ú_j w_ij(x_i - x╠ä)(x_j - x╠ä) / ╬ú_i(x_i - x╠ä)┬▓
+    double s0 = 0;
+    double numerator = 0;
+    double denominator = 0;
+
+    for (int i = 0; i < n; i++)
+      denominator += (values[i] - mean) * (values[i] - mean);
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        s0 += W[i, j];
+        numerator += W[i, j] * (values[i] - mean) * (values[j] - mean);
+      }
+
+    double moranI = denominator > 0 && s0 > 0
+      ? (n / s0) * (numerator / denominator)
+      : 0;
+
+    double expectedI = -1.0 / (n - 1);
+    double variance = ComputeMoranVariance(W, values, n, s0);
+    double zScore = variance > 0 ? (moranI - expectedI) / Math.Sqrt(variance) : 0;
+    double pValue = 2 * (1 - NormalCdf(Math.Abs(zScore)));
+
+    // Local Moran's I (LISA)
+    var localI = new double[n];
+    var clusters = new string[n];
+    for (int i = 0; i < n; i++)
+    {
+      double localNumerator = 0;
+      double wRowSum = 0;
+      for (int j = 0; j < n; j++)
+      {
+        localNumerator += W[i, j] * (values[j] - mean);
+        wRowSum += W[i, j];
+      }
+      double zi = values[i] - mean;
+      localI[i] = denominator > 0 ? n * zi * localNumerator / denominator : 0;
+
+      // Classify: HH, HL, LH, LL, NS
+      double lag = wRowSum > 0 ? localNumerator / wRowSum : 0;
+      double localZ = variance > 0 ? localI[i] / Math.Sqrt(variance) : 0;
+      bool significant = Math.Abs(localZ) > 1.96;
+      clusters[i] = !significant ? "NS"
+        : (zi > 0 && lag > 0) ? "HH"
+        : (zi > 0 && lag <= 0) ? "HL"
+        : (zi <= 0 && lag > 0) ? "LH"
+        : "LL";
+    }
+
+    var entity = new SpatialAnalysis
+    {
+      CountyId = county.CountyId,
+      AnalysisType = "global_moran",
+      VariableName = request.VariableName ?? "assessed_value",
+      WeightMatrixType = request.WeightType ?? "distance",
+      StatisticValue = Math.Round(moranI, 6),
+      ExpectedValue = Math.Round(expectedI, 6),
+      Variance = Math.Round(variance, 6),
+      ZScore = Math.Round(zScore, 4),
+      PValue = Math.Round(pValue, 6),
+      SampleSize = n,
+      LocalIndicators = System.Text.Json.JsonSerializer.Serialize(localI.Select(v => Math.Round(v, 6)).ToArray()),
+      ClusterMap = System.Text.Json.JsonSerializer.Serialize(clusters),
+      CreatedBy = User.Identity?.Name ?? "system"
+    };
+
+    _db.SpatialAnalyses.Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      analysisType = "global_moran",
+      moranI = entity.StatisticValue,
+      expectedI = entity.ExpectedValue,
+      variance = entity.Variance,
+      zScore = entity.ZScore,
+      pValue = entity.PValue,
+      sampleSize = n,
+      interpretation = moranI > expectedI ? "positive spatial autocorrelation (clustering)" : "negative spatial autocorrelation (dispersion)",
+      clusterSummary = new
+      {
+        highHigh = clusters.Count(c => c == "HH"),
+        highLow = clusters.Count(c => c == "HL"),
+        lowHigh = clusters.Count(c => c == "LH"),
+        lowLow = clusters.Count(c => c == "LL"),
+        notSignificant = clusters.Count(c => c == "NS")
+      },
+      localIndicators = localI.Select(v => Math.Round(v, 6)).ToArray(),
+      clusters
+    });
+  }
+
+  /// <summary>Compute Geary's C spatial autocorrelation.</summary>
+  [HttpPost("analytics/spatial/geary")]
+  public async Task<IActionResult> RunGearyC([FromBody] SpatialAutocorrelationRequest request)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    if (request.Observations is null || request.Observations.Count < 3)
+      return BadRequest(new { error = "At least 3 observations required" });
+
+    int n = request.Observations.Count;
+    var values = request.Observations.Select(o => o.Value).ToArray();
+    double mean = values.Average();
+
+    var W = BuildWeightMatrix(request.Observations, request.WeightType ?? "distance", request.DistanceThreshold ?? 0);
+
+    double s0 = 0, numerator = 0, denominator = 0;
+    for (int i = 0; i < n; i++)
+      denominator += (values[i] - mean) * (values[i] - mean);
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        s0 += W[i, j];
+        numerator += W[i, j] * (values[i] - values[j]) * (values[i] - values[j]);
+      }
+
+    // Geary's C = ((n-1) / (2*S0)) * (╬ú w_ij(x_i - x_j)┬▓) / (╬ú(x_i - x╠ä)┬▓)
+    double gearyC = (denominator > 0 && s0 > 0)
+      ? ((n - 1.0) / (2.0 * s0)) * (numerator / denominator)
+      : 1.0; // expected value under randomness
+
+    double expectedC = 1.0;
+    double zScore = gearyC < 1 ? -(1 - gearyC) * Math.Sqrt(n) : (gearyC - 1) * Math.Sqrt(n); // simplified
+    double pValue = 2 * (1 - NormalCdf(Math.Abs(zScore)));
+
+    var entity = new SpatialAnalysis
+    {
+      CountyId = county.CountyId,
+      AnalysisType = "geary_c",
+      VariableName = request.VariableName ?? "assessed_value",
+      WeightMatrixType = request.WeightType ?? "distance",
+      StatisticValue = Math.Round(gearyC, 6),
+      ExpectedValue = expectedC,
+      Variance = 0,
+      ZScore = Math.Round(zScore, 4),
+      PValue = Math.Round(pValue, 6),
+      SampleSize = n,
+      CreatedBy = User.Identity?.Name ?? "system"
+    };
+
+    _db.SpatialAnalyses.Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      analysisType = "geary_c",
+      gearyC = entity.StatisticValue,
+      expectedC,
+      zScore = entity.ZScore,
+      pValue = entity.PValue,
+      sampleSize = n,
+      interpretation = gearyC < 1 ? "positive autocorrelation" : gearyC > 1 ? "negative autocorrelation" : "spatial randomness"
+    });
+  }
+
+  /// <summary>Retrieve stored spatial analysis by ID.</summary>
+  [HttpGet("analytics/spatial/{id:guid}")]
+  public async Task<IActionResult> GetSpatialResult(Guid id)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    var result = await _db.SpatialAnalyses
+      .FirstOrDefaultAsync(s => s.Id == id && s.CountyId == county.CountyId);
+
+    if (result is null) return NotFound(new { error = "Spatial analysis not found" });
+
+    return Ok(new
+    {
+      id = result.Id,
+      analysisType = result.AnalysisType,
+      variableName = result.VariableName,
+      statisticValue = result.StatisticValue,
+      expectedValue = result.ExpectedValue,
+      zScore = result.ZScore,
+      pValue = result.PValue,
+      sampleSize = result.SampleSize,
+      localIndicators = System.Text.Json.JsonSerializer.Deserialize<double[]>(result.LocalIndicators),
+      clusterMap = System.Text.Json.JsonSerializer.Deserialize<string[]>(result.ClusterMap),
+      createdAt = result.CreatedAt
+    });
+  }
+
+  /// <summary>List recent spatial analyses for the county.</summary>
+  [HttpGet("analytics/spatial/history")]
+  public async Task<IActionResult> GetSpatialHistory([FromQuery] int limit = 20)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    limit = Math.Clamp(limit, 1, 100);
+    var results = await _db.SpatialAnalyses
+      .Where(s => s.CountyId == county.CountyId)
+      .OrderByDescending(s => s.CreatedAt)
+      .Take(limit)
+      .Select(s => new
+      {
+        id = s.Id,
+        analysisType = s.AnalysisType,
+        variableName = s.VariableName,
+        statisticValue = s.StatisticValue,
+        pValue = s.PValue,
+        sampleSize = s.SampleSize,
+        createdAt = s.CreatedAt
+      })
+      .ToListAsync();
+
+    return Ok(new { count = results.Count, results });
+  }
+
+  // ΓöÇΓöÇ Spatial helpers ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+  private static double[,] BuildWeightMatrix(List<SpatialObservation> obs, string weightType, double threshold)
+  {
+    int n = obs.Count;
+    var W = new double[n, n];
+
+    // Compute pairwise distances
+    var dists = new double[n, n];
+    for (int i = 0; i < n; i++)
+      for (int j = i + 1; j < n; j++)
+      {
+        double dx = obs[i].X - obs[j].X;
+        double dy = obs[i].Y - obs[j].Y;
+        dists[i, j] = dists[j, i] = Math.Sqrt(dx * dx + dy * dy);
+      }
+
+    // Auto-threshold if not provided
+    if (threshold <= 0)
+    {
+      double maxDist = 0;
+      for (int i = 0; i < n; i++)
+        for (int j = i + 1; j < n; j++)
+          if (dists[i, j] > maxDist) maxDist = dists[i, j];
+      threshold = maxDist / 3.0;
+    }
+
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+      {
+        if (i == j) continue;
+        W[i, j] = weightType switch
+        {
+          "knn" => 0, // handled below
+          "inverse_distance" => dists[i, j] > 0 ? 1.0 / dists[i, j] : 0,
+          _ => dists[i, j] <= threshold ? 1.0 : 0 // binary distance
+        };
+      }
+
+    // KNN: k nearest neighbours
+    if (weightType == "knn")
+    {
+      int k = Math.Min(4, n - 1);
+      for (int i = 0; i < n; i++)
+      {
+        var indices = Enumerable.Range(0, n)
+          .Where(j => j != i)
+          .OrderBy(j => dists[i, j])
+          .Take(k);
+        foreach (var j in indices) W[i, j] = 1.0;
+      }
+    }
+
+    // Row-standardize
+    for (int i = 0; i < n; i++)
+    {
+      double rowSum = 0;
+      for (int j = 0; j < n; j++) rowSum += W[i, j];
+      if (rowSum > 0)
+        for (int j = 0; j < n; j++) W[i, j] /= rowSum;
+    }
+
+    return W;
+  }
+
+  private static double ComputeMoranVariance(double[,] W, double[] values, int n, double s0)
+  {
+    // Simplified variance under normality assumption:
+    // Var(I) Γëê [n┬▓S1 - nS2 + 3S0┬▓] / [S0┬▓(n┬▓-1)] - E(I)┬▓
+    double s1 = 0, s2 = 0;
+    for (int i = 0; i < n; i++)
+    {
+      double rowSum = 0, colSum = 0;
+      for (int j = 0; j < n; j++)
+      {
+        s1 += (W[i, j] + W[j, i]) * (W[i, j] + W[j, i]);
+        rowSum += W[i, j];
+        colSum += W[j, i];
+      }
+      s2 += (rowSum + colSum) * (rowSum + colSum);
+    }
+    s1 /= 2.0;
+
+    double expectedI = -1.0 / (n - 1);
+    double denom = s0 * s0 * ((double)n * n - 1);
+    if (denom == 0) return 0;
+    return ((double)n * n * s1 - (double)n * s2 + 3 * s0 * s0) / denom - expectedI * expectedI;
+  }
+
+  private static double NormalCdf(double x)
+  {
+    // Abramowitz and Stegun approximation (7.1.26)
+    const double a1 = 0.254829592, a2 = -0.284496736, a3 = 1.421413741, a4 = -1.453152027, a5 = 1.061405429;
+    const double p = 0.3275911;
+    double sign = x < 0 ? -1 : 1;
+    x = Math.Abs(x) / Math.Sqrt(2);
+    double t = 1.0 / (1.0 + p * x);
+    double y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.Exp(-x * x);
+    return 0.5 * (1.0 + sign * y);
+  }
+
+
+// ΓöÇΓöÇ Wave 28 Request DTOs ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+
+  // r2/wave-29-forge-market-analysis
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // R2 Wave 29 ΓÇö Market Analysis (comparable sales, time-trend, ratio study)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Run a comparable-sales market analysis for a set of parcels.</summary>
+  [HttpPost("analytics/market/comparable-sales")]
+  public async Task<IActionResult> RunComparableSalesAnalysis(
+      [FromBody] MarketAnalysisRequest request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      if (request.Sales == null || request.Sales.Count < 3)
+          return BadRequest(new { error = "At least 3 sales required" });
+
+      // ΓöÇΓöÇ Basic statistics ΓöÇΓöÇ
+      var prices = request.Sales.Select(s => s.SalePrice).OrderBy(p => p).ToList();
+      var n = prices.Count;
+      var median = n % 2 == 1
+          ? prices[n / 2]
+          : (prices[n / 2 - 1] + prices[n / 2]) / 2m;
+      var mean = prices.Average();
+
+      var sqftPrices = request.Sales
+          .Where(s => s.SquareFeet > 0)
+          .Select(s => s.SalePrice / s.SquareFeet)
+          .OrderBy(p => p).ToList();
+      var medianPsf = sqftPrices.Count > 0
+          ? (sqftPrices.Count % 2 == 1
+              ? sqftPrices[sqftPrices.Count / 2]
+              : (sqftPrices[sqftPrices.Count / 2 - 1] + sqftPrices[sqftPrices.Count / 2]) / 2m)
+          : 0m;
+
+      // ΓöÇΓöÇ Ratio study (COD + PRD) ΓöÇΓöÇ
+      var ratios = request.Sales
+          .Where(s => s.SalePrice > 0 && s.AssessedValue > 0)
+          .Select(s => (double)(s.AssessedValue / s.SalePrice))
+          .ToList();
+
+      double medianRatio = 0, cod = 0, prd = 0;
+      if (ratios.Count > 0)
+      {
+          var sortedRatios = ratios.OrderBy(r => r).ToList();
+          var rn = sortedRatios.Count;
+          medianRatio = rn % 2 == 1
+              ? sortedRatios[rn / 2]
+              : (sortedRatios[rn / 2 - 1] + sortedRatios[rn / 2]) / 2.0;
+
+          if (medianRatio > 0)
+              cod = sortedRatios.Average(r => Math.Abs(r - medianRatio)) / medianRatio * 100.0;
+
+          var meanRatio = ratios.Average();
+          var totalAssessed = request.Sales.Where(s => s.SalePrice > 0 && s.AssessedValue > 0)
+              .Sum(s => (double)s.AssessedValue);
+          var totalSale = request.Sales.Where(s => s.SalePrice > 0 && s.AssessedValue > 0)
+              .Sum(s => (double)s.SalePrice);
+          var weightedMeanRatio = totalSale > 0 ? totalAssessed / totalSale : meanRatio;
+          prd = weightedMeanRatio > 0 ? meanRatio / weightedMeanRatio : 1.0;
+      }
+
+      var entity = new TerraFusion.Core.Entities.MarketAnalysis
+      {
+          CountyId = ctx.CountyId,
+          AnalysisType = "comparable_sales",
+          MarketAreaName = request.MarketAreaName ?? "Unnamed",
+          ParcelIds = System.Text.Json.JsonSerializer.Serialize(
+              request.Sales.Select(s => s.ParcelId).ToList()),
+          SampleSize = n,
+          MedianSalePrice = median,
+          MeanSalePrice = Math.Round(mean, 2),
+          MedianPricePerSqft = Math.Round(medianPsf, 2),
+          CoefficientOfDispersion = Math.Round(cod, 4),
+          PriceRelatedDifferential = Math.Round(prd, 4),
+          MedianRatio = Math.Round(medianRatio, 4),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<TerraFusion.Core.Entities.MarketAnalysis>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          analysisType = entity.AnalysisType,
+          marketAreaName = entity.MarketAreaName,
+          sampleSize = entity.SampleSize,
+          medianSalePrice = entity.MedianSalePrice,
+          meanSalePrice = entity.MeanSalePrice,
+          medianPricePerSqft = entity.MedianPricePerSqft,
+          coefficientOfDispersion = entity.CoefficientOfDispersion,
+          priceRelatedDifferential = entity.PriceRelatedDifferential,
+          medianRatio = entity.MedianRatio,
+      });
+  }
+
+  /// <summary>Run a time-trend analysis for a set of sales.</summary>
+  [HttpPost("analytics/market/time-trend")]
+  public async Task<IActionResult> RunTimeTrendAnalysis(
+      [FromBody] TimeTrendRequest request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      if (request.Sales == null || request.Sales.Count < 3)
+          return BadRequest(new { error = "At least 3 sales required" });
+
+      var sorted = request.Sales.OrderBy(s => s.SaleDate).ToList();
+      var baseDate = sorted.First().SaleDate;
+
+      var xs = sorted.Select(s => (s.SaleDate - baseDate).TotalDays / 30.4375).ToArray();
+      var ys = sorted.Select(s => (double)s.SalePrice).ToArray();
+      var n = xs.Length;
+
+      var xMean = xs.Average();
+      var yMean = ys.Average();
+      var ssxy = 0.0;
+      var ssxx = 0.0;
+      for (int i = 0; i < n; i++)
+      {
+          ssxy += (xs[i] - xMean) * (ys[i] - yMean);
+          ssxx += (xs[i] - xMean) * (xs[i] - xMean);
+      }
+
+      var slope = ssxx > 0 ? ssxy / ssxx : 0;
+      var intercept = yMean - slope * xMean;
+
+      var ssTotal = ys.Sum(y => (y - yMean) * (y - yMean));
+      var ssResidual = 0.0;
+      for (int i = 0; i < n; i++)
+      {
+          var predicted = intercept + slope * xs[i];
+          ssResidual += (ys[i] - predicted) * (ys[i] - predicted);
+      }
+      var rSquared = ssTotal > 0 ? 1.0 - ssResidual / ssTotal : 0;
+
+      var monthlyPctChange = intercept > 0 ? slope / intercept * 100.0 : 0;
+
+      var entity = new TerraFusion.Core.Entities.MarketAnalysis
+      {
+          CountyId = ctx.CountyId,
+          AnalysisType = "time_trend",
+          MarketAreaName = request.MarketAreaName ?? "Unnamed",
+          ParcelIds = System.Text.Json.JsonSerializer.Serialize(
+              sorted.Select(s => s.ParcelId).Where(p => p != null).ToList()),
+          SampleSize = n,
+          TimeTrendCoefficient = Math.Round(monthlyPctChange, 4),
+          TimeTrendRSquared = Math.Round(rSquared, 4),
+          PeriodStart = sorted.First().SaleDate,
+          PeriodEnd = sorted.Last().SaleDate,
+          MedianSalePrice = (decimal)yMean,
+          MeanSalePrice = (decimal)Math.Round(yMean, 2),
+          AdditionalMetrics = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              slopePerMonth = Math.Round(slope, 2),
+              interceptValue = Math.Round(intercept, 2),
+              monthsSpanned = Math.Round(xs.Last(), 1),
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<TerraFusion.Core.Entities.MarketAnalysis>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          analysisType = entity.AnalysisType,
+          marketAreaName = entity.MarketAreaName,
+          sampleSize = entity.SampleSize,
+          timeTrendCoefficient = entity.TimeTrendCoefficient,
+          timeTrendRSquared = entity.TimeTrendRSquared,
+          periodStart = entity.PeriodStart,
+          periodEnd = entity.PeriodEnd,
+          additionalMetrics = entity.AdditionalMetrics,
+      });
+  }
+
+  /// <summary>Run a ratio study for a set of sales with assessed values.</summary>
+  [HttpPost("analytics/market/ratio-study")]
+  public async Task<IActionResult> RunRatioStudy(
+      [FromBody] MarketAnalysisRequest request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      if (request.Sales == null || request.Sales.Count < 3)
+          return BadRequest(new { error = "At least 3 sales required" });
+
+      var valid = request.Sales.Where(s => s.SalePrice > 0 && s.AssessedValue > 0).ToList();
+      if (valid.Count < 3)
+          return BadRequest(new { error = "At least 3 sales with assessed values required" });
+
+      var ratios = valid.Select(s => (double)(s.AssessedValue / s.SalePrice)).OrderBy(r => r).ToList();
+      var n = ratios.Count;
+      var medianRatio = n % 2 == 1
+          ? ratios[n / 2]
+          : (ratios[n / 2 - 1] + ratios[n / 2]) / 2.0;
+      var meanRatio = ratios.Average();
+
+      var cod = medianRatio > 0
+          ? ratios.Average(r => Math.Abs(r - medianRatio)) / medianRatio * 100.0
+          : 0;
+
+      var totalAssessed = valid.Sum(s => (double)s.AssessedValue);
+      var totalSale = valid.Sum(s => (double)s.SalePrice);
+      var weightedMean = totalSale > 0 ? totalAssessed / totalSale : meanRatio;
+      var prd = weightedMean > 0 ? meanRatio / weightedMean : 1.0;
+
+      double W29Percentile(List<double> sorted, double p)
+      {
+          var idx = (sorted.Count - 1) * p;
+          var lo = (int)Math.Floor(idx);
+          var hi = (int)Math.Ceiling(idx);
+          if (lo == hi) return sorted[lo];
+          return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+      }
+
+      var p10 = W29Percentile(ratios, 0.10);
+      var p25 = W29Percentile(ratios, 0.25);
+      var p75 = W29Percentile(ratios, 0.75);
+      var p90 = W29Percentile(ratios, 0.90);
+
+      var iaaoCompliant = cod >= 5.0 && cod <= 15.0 && prd >= 0.98 && prd <= 1.03;
+
+      var entity = new TerraFusion.Core.Entities.MarketAnalysis
+      {
+          CountyId = ctx.CountyId,
+          AnalysisType = "ratio_study",
+          MarketAreaName = request.MarketAreaName ?? "Unnamed",
+          ParcelIds = System.Text.Json.JsonSerializer.Serialize(
+              valid.Select(s => s.ParcelId).ToList()),
+          SampleSize = n,
+          MedianRatio = Math.Round(medianRatio, 4),
+          CoefficientOfDispersion = Math.Round(cod, 4),
+          PriceRelatedDifferential = Math.Round(prd, 4),
+          AdditionalMetrics = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              meanRatio = Math.Round(meanRatio, 4),
+              p10 = Math.Round(p10, 4),
+              p25 = Math.Round(p25, 4),
+              p75 = Math.Round(p75, 4),
+              p90 = Math.Round(p90, 4),
+              iaaoCompliant,
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<TerraFusion.Core.Entities.MarketAnalysis>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          analysisType = entity.AnalysisType,
+          marketAreaName = entity.MarketAreaName,
+          sampleSize = entity.SampleSize,
+          medianRatio = entity.MedianRatio,
+          coefficientOfDispersion = entity.CoefficientOfDispersion,
+          priceRelatedDifferential = entity.PriceRelatedDifferential,
+          additionalMetrics = entity.AdditionalMetrics,
+          iaaoCompliant,
+      });
+  }
+
+  /// <summary>Retrieve a market analysis result by ID.</summary>
+  [HttpGet("analytics/market/{id:int}")]
+  public async Task<IActionResult> GetMarketAnalysis(int id)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var result = await _db.Set<TerraFusion.Core.Entities.MarketAnalysis>()
+          .FirstOrDefaultAsync(m => m.Id == id && m.CountyId == ctx.CountyId);
+
+      if (result == null)
+          return NotFound(new { error = "Market analysis not found" });
+
+      return Ok(new
+      {
+          id = result.Id,
+          analysisType = result.AnalysisType,
+          marketAreaName = result.MarketAreaName,
+          sampleSize = result.SampleSize,
+          medianSalePrice = result.MedianSalePrice,
+          meanSalePrice = result.MeanSalePrice,
+          medianPricePerSqft = result.MedianPricePerSqft,
+          coefficientOfDispersion = result.CoefficientOfDispersion,
+          priceRelatedDifferential = result.PriceRelatedDifferential,
+          medianRatio = result.MedianRatio,
+          timeTrendCoefficient = result.TimeTrendCoefficient,
+          timeTrendRSquared = result.TimeTrendRSquared,
+          periodStart = result.PeriodStart,
+          periodEnd = result.PeriodEnd,
+          additionalMetrics = result.AdditionalMetrics,
+          createdBy = result.CreatedBy,
+          createdAt = result.CreatedAt,
+      });
+  }
+
+  /// <summary>Get market analysis history for the county.</summary>
+  [HttpGet("analytics/market/history")]
+  public async Task<IActionResult> GetMarketAnalysisHistory(
+      [FromQuery] string? analysisType = null,
+      [FromQuery] int limit = 20)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var query = _db.Set<TerraFusion.Core.Entities.MarketAnalysis>()
+          .Where(m => m.CountyId == ctx.CountyId);
+
+      if (!string.IsNullOrEmpty(analysisType))
+          query = query.Where(m => m.AnalysisType == analysisType);
+
+      var results = await query
+          .OrderByDescending(m => m.CreatedAt)
+          .Take(Math.Clamp(limit, 1, 100))
+          .Select(m => new
+          {
+              id = m.Id,
+              analysisType = m.AnalysisType,
+              marketAreaName = m.MarketAreaName,
+              sampleSize = m.SampleSize,
+              medianRatio = m.MedianRatio,
+              coefficientOfDispersion = m.CoefficientOfDispersion,
+              createdAt = m.CreatedAt,
+          })
+          .ToListAsync();
+
+      return Ok(new { count = results.Count, results });
+  }
+
+
+// ΓòÉΓòÉΓòÉ R2 Wave 29 ΓÇö Market Analysis DTOs ΓòÉΓòÉΓòÉ
+
+
+  // r2/wave-30-forge-rcw-calculators
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // R2 Wave 30 ΓÇö RCW Calculators (WA State exemption statutes)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>RCW 84.34 ΓÇö Open Space / Current Use valuation.</summary>
+  [HttpPost("analytics/rcw/84-34")]
+  public async Task<IActionResult> CalculateRcw8434([FromBody] Rcw8434Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // Classification rates per acre (simplified WA schedule)
+      var ratePerAcre = (request.Classification?.ToLowerInvariant()) switch
+      {
+          "farm_and_agricultural" => 500m,
+          "timber" => 300m,
+          "open_space" => 200m,
+          _ => 400m,
+      };
+
+      var currentUseValue = ratePerAcre * request.Acreage;
+      var exemption = request.MarketValue - currentUseValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_34",
+          ParcelId = request.ParcelId ?? "",
+          CurrentUseClassification = request.Classification ?? "open_space",
+          MarketValue = request.MarketValue,
+          ReducedValue = currentUseValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Qualifies = request.Acreage >= 5 && request.MarketValue > 0,
+          DisqualificationReason = request.Acreage < 5
+              ? "Minimum 5 acres required for current-use classification"
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              acreage = request.Acreage,
+              ratePerAcre,
+              classification = request.Classification ?? "open_space",
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          classification = entity.CurrentUseClassification,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+      });
+  }
+
+  /// <summary>RCW 84.26 ΓÇö Historic Property special valuation.</summary>
+  [HttpPost("analytics/rcw/84-26")]
+  public async Task<IActionResult> CalculateRcw8426([FromBody] Rcw8426Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // Historic property: valuation frozen at pre-rehabilitation value
+      // for 10-year special valuation period
+      var qualifies = request.YearDesignated > 0
+                      && request.RehabilitationCost > 0
+                      && request.RehabilitationCost >= request.PreRehabValue * 0.25m; // 25% minimum
+
+      var reducedValue = qualifies ? request.PreRehabValue : request.MarketValue;
+      var exemption = request.MarketValue - reducedValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var yearsRemaining = qualifies
+          ? Math.Max(0, 10 - (request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year) + request.YearDesignated)
+          : 0;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_26",
+          ParcelId = request.ParcelId ?? "",
+          MarketValue = request.MarketValue,
+          ReducedValue = reducedValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Qualifies = qualifies,
+          DisqualificationReason = !qualifies
+              ? "Rehabilitation cost must be >= 25% of pre-rehabilitation value"
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              preRehabValue = request.PreRehabValue,
+              rehabilitationCost = request.RehabilitationCost,
+              yearDesignated = request.YearDesignated,
+              yearsRemaining,
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+          yearsRemaining,
+      });
+  }
+
+  /// <summary>RCW 84.36.381 ΓÇö Senior/Disabled Persons exemption.</summary>
+  [HttpPost("analytics/rcw/84-36-381")]
+  public async Task<IActionResult> CalculateRcw8436381([FromBody] Rcw8436381Request request)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      // 2025-2026 WA income thresholds (simplified)
+      const decimal tier1Limit = 40_000m;   // Full exemption on excess levy
+      const decimal tier2Limit = 50_000m;   // Partial: frozen value
+      const decimal tier3Limit = 65_000m;   // Partial: reduced rate
+
+      var income = request.Income;
+      string tier;
+      decimal reducedValue;
+      bool qualifies = request.Age >= 61 || request.IsDisabled;
+
+      if (!qualifies)
+      {
+          tier = "none";
+          reducedValue = request.MarketValue;
+      }
+      else if (income <= tier1Limit)
+      {
+          tier = "tier_1";
+          // Exempt from all excess levies, value frozen
+          reducedValue = Math.Min(request.MarketValue, 150_000m);
+      }
+      else if (income <= tier2Limit)
+      {
+          tier = "tier_2";
+          reducedValue = Math.Min(request.MarketValue, 200_000m);
+      }
+      else if (income <= tier3Limit)
+      {
+          tier = "tier_3";
+          reducedValue = Math.Min(request.MarketValue, request.MarketValue * 0.90m);
+      }
+      else
+      {
+          tier = "over_income";
+          reducedValue = request.MarketValue;
+          qualifies = false;
+      }
+
+      var exemption = request.MarketValue - reducedValue;
+      if (exemption < 0) exemption = 0;
+      var taxSavings = exemption * (decimal)request.LevyRate / 1000m;
+
+      var entity = new RcwCalculation
+      {
+          CountyId = ctx.CountyId,
+          Statute = "rcw_84_36_381",
+          ParcelId = request.ParcelId ?? "",
+          MarketValue = request.MarketValue,
+          ReducedValue = reducedValue,
+          ExemptionAmount = exemption,
+          TaxSavings = Math.Round(taxSavings, 2),
+          LevyRate = request.LevyRate,
+          TaxYear = request.TaxYear > 0 ? request.TaxYear : DateTime.UtcNow.Year,
+          Income = income,
+          Qualifies = qualifies,
+          DisqualificationReason = !qualifies
+              ? (request.Age < 61 && !request.IsDisabled
+                  ? "Must be age 61+ or disabled"
+                  : "Income exceeds maximum threshold")
+              : "",
+          Details = System.Text.Json.JsonSerializer.Serialize(new
+          {
+              age = request.Age,
+              isDisabled = request.IsDisabled,
+              income,
+              tier,
+          }),
+          CreatedBy = User.Identity?.Name ?? "system",
+          CreatedAt = DateTime.UtcNow,
+      };
+
+      _db.Set<RcwCalculation>().Add(entity);
+      await _db.SaveChangesAsync();
+
+      return Ok(new
+      {
+          id = entity.Id,
+          statute = entity.Statute,
+          parcelId = entity.ParcelId,
+          marketValue = entity.MarketValue,
+          reducedValue = entity.ReducedValue,
+          exemptionAmount = entity.ExemptionAmount,
+          taxSavings = entity.TaxSavings,
+          qualifies = entity.Qualifies,
+          disqualificationReason = entity.DisqualificationReason,
+          tier,
+      });
+  }
+
+  /// <summary>Retrieve an RCW calculation result by ID.</summary>
+  [HttpGet("analytics/rcw/{id:int}")]
+  public async Task<IActionResult> GetRcwCalculation(int id)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var result = await _db.Set<RcwCalculation>()
+          .FirstOrDefaultAsync(r => r.Id == id && r.CountyId == ctx.CountyId);
+
+      if (result == null)
+          return NotFound(new { error = "RCW calculation not found" });
+
+      return Ok(new
+      {
+          id = result.Id,
+          statute = result.Statute,
+          parcelId = result.ParcelId,
+          classification = result.CurrentUseClassification,
+          marketValue = result.MarketValue,
+          reducedValue = result.ReducedValue,
+          exemptionAmount = result.ExemptionAmount,
+          taxSavings = result.TaxSavings,
+          qualifies = result.Qualifies,
+          disqualificationReason = result.DisqualificationReason,
+          income = result.Income,
+          taxYear = result.TaxYear,
+          details = result.Details,
+          createdBy = result.CreatedBy,
+          createdAt = result.CreatedAt,
+      });
+  }
+
+  /// <summary>Get RCW calculation history for the county.</summary>
+  [HttpGet("analytics/rcw/history")]
+  public async Task<IActionResult> GetRcwHistory(
+      [FromQuery] string? statute = null,
+      [FromQuery] int limit = 20)
+  {
+      var ctx = await ResolveCountyContextAsync();
+      if (ctx is null) return Unauthorized(new { error = "County context required." });
+
+      var query = _db.Set<RcwCalculation>()
+          .Where(r => r.CountyId == ctx.CountyId);
+
+      if (!string.IsNullOrEmpty(statute))
+          query = query.Where(r => r.Statute == statute);
+
+      var results = await query
+          .OrderByDescending(r => r.CreatedAt)
+          .Take(Math.Clamp(limit, 1, 100))
+          .Select(r => new
+          {
+              id = r.Id,
+              statute = r.Statute,
+              parcelId = r.ParcelId,
+              qualifies = r.Qualifies,
+              exemptionAmount = r.ExemptionAmount,
+              taxSavings = r.TaxSavings,
+              createdAt = r.CreatedAt,
+          })
+          .ToListAsync();
+
+      return Ok(new { count = results.Count, results });
+  }
+
+
+// ΓòÉΓòÉΓòÉ R2 Wave 30 ΓÇö RCW Calculator DTOs ΓòÉΓòÉΓòÉ
+
+
+  // r2/wave-31-forge-levy-certification
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Wave 31 ΓÇö Levy Certification (RCW 84.52 / RCW 84.55)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Calculate levy rate for a taxing district and check statutory limits.</summary>
+  [HttpPost("analytics/levy/calculate")]
+  public async Task<IActionResult> CalculateLevy([FromBody] LevyCalculateRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    // RCW 84.55 ΓÇö 1% annual increase limit
+    var onePercentLimit = req.PriorYearLevy * 1.01m;
+    // Add new construction and annexation values at existing rate
+    var priorRate = req.AssessedValue > 0 ? (double)(req.PriorYearLevy / req.AssessedValue * 1000m) : 0;
+    var ncAddition = req.NewConstructionValue * (decimal)priorRate / 1000m;
+    var annexAddition = req.AnnexationValue * (decimal)priorRate / 1000m;
+    var statutoryLimit = onePercentLimit + ncAddition + annexAddition;
+
+    var certifiedLevy = req.RequestedLevy;
+    var wasReduced = false;
+    var reductionAmount = 0m;
+
+    // Check statutory limit
+    if (certifiedLevy > statutoryLimit)
+    {
+      reductionAmount = certifiedLevy - statutoryLimit;
+      certifiedLevy = statutoryLimit;
+      wasReduced = true;
+    }
+
+    // Compute rate per $1,000 AV
+    var levyRate = req.AssessedValue > 0 ? (double)(certifiedLevy / req.AssessedValue * 1000m) : 0;
+
+    // Constitutional limit: $10 per $1,000 AV (1%)
+    var withinConstitutionalLimit = levyRate <= 10.0;
+    // $5.90 aggregate limit (RCW 84.52.043) ΓÇö applies to regular levies only
+    var withinAggregateLimit = levyRate <= 5.90;
+
+    // Force constitutional compliance
+    if (!withinConstitutionalLimit && req.AssessedValue > 0)
+    {
+      certifiedLevy = req.AssessedValue * 10m / 1000m;
+      reductionAmount = req.RequestedLevy - certifiedLevy;
+      wasReduced = true;
+      levyRate = 10.0;
+      withinConstitutionalLimit = true;
+    }
+
+    var entity = new TerraFusion.Core.Entities.LevyCertification
+    {
+      CountyId = ctx.CountyId,
+      TaxYear = req.TaxYear > 0 ? req.TaxYear : DateTime.UtcNow.Year,
+      DistrictCode = req.DistrictCode ?? "",
+      DistrictName = req.DistrictName ?? "",
+      PriorYearLevy = req.PriorYearLevy,
+      RequestedLevy = req.RequestedLevy,
+      CertifiedLevy = certifiedLevy,
+      AssessedValue = req.AssessedValue,
+      NewConstructionValue = req.NewConstructionValue,
+      AnnexationValue = req.AnnexationValue,
+      LevyRate = levyRate,
+      StatutoryLimit = statutoryLimit,
+      ConstitutionalLimit = 10.0,
+      AggregateLimit = 5.90,
+      WithinConstitutionalLimit = withinConstitutionalLimit,
+      WithinAggregateLimit = withinAggregateLimit,
+      WasReduced = wasReduced,
+      ReductionAmount = reductionAmount,
+      Status = "draft",
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+    };
+    _db.Set<TerraFusion.Core.Entities.LevyCertification>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      countyId = entity.CountyId,
+      taxYear = entity.TaxYear,
+      districtCode = entity.DistrictCode,
+      districtName = entity.DistrictName,
+      priorYearLevy = entity.PriorYearLevy,
+      requestedLevy = entity.RequestedLevy,
+      certifiedLevy = entity.CertifiedLevy,
+      assessedValue = entity.AssessedValue,
+      newConstructionValue = entity.NewConstructionValue,
+      annexationValue = entity.AnnexationValue,
+      levyRate = entity.LevyRate,
+      statutoryLimit = entity.StatutoryLimit,
+      constitutionalLimit = entity.ConstitutionalLimit,
+      aggregateLimit = entity.AggregateLimit,
+      withinConstitutionalLimit = entity.WithinConstitutionalLimit,
+      withinAggregateLimit = entity.WithinAggregateLimit,
+      wasReduced = entity.WasReduced,
+      reductionAmount = entity.ReductionAmount,
+      status = entity.Status,
+    });
+  }
+
+  /// <summary>Run a multi-district levy balance test (prorationing).</summary>
+  [HttpPost("analytics/levy/balance-test")]
+  public async Task<IActionResult> LevyBalanceTest([FromBody] LevyBalanceTestRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (req.Districts is null || req.Districts.Count == 0)
+      return BadRequest(new { error = "At least one district is required" });
+
+    var results = new List<object>();
+    var totalRate = 0.0;
+
+    foreach (var d in req.Districts)
+    {
+      var rate = d.AssessedValue > 0 ? (double)(d.RequestedLevy / d.AssessedValue * 1000m) : 0;
+      totalRate += rate;
+      results.Add(new
+      {
+        districtCode = d.DistrictCode ?? "",
+        districtName = d.DistrictName ?? "",
+        requestedLevy = d.RequestedLevy,
+        assessedValue = d.AssessedValue,
+        rate = Math.Round(rate, 6),
+      });
+    }
+
+    var aggregatePass = totalRate <= 5.90;
+    var constitutionalPass = totalRate <= 10.0;
+
+    return Ok(new
+    {
+      taxYear = req.TaxYear > 0 ? req.TaxYear : DateTime.UtcNow.Year,
+      districtCount = req.Districts.Count,
+      totalRate = Math.Round(totalRate, 6),
+      aggregateLimit = 5.90,
+      constitutionalLimit = 10.0,
+      aggregatePass,
+      constitutionalPass,
+      prorationRequired = !aggregatePass,
+      districts = results,
+    });
+  }
+
+  /// <summary>Certify a previously-calculated levy (status ΓåÆ certified).</summary>
+  [HttpPost("analytics/levy/{id}/certify")]
+  public async Task<IActionResult> CertifyLevy(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+
+    if (entity is null) return NotFound(new { error = "Levy record not found" });
+    if (entity.Status == "certified")
+      return BadRequest(new { error = "Already certified" });
+    if (!entity.WithinConstitutionalLimit)
+      return BadRequest(new { error = "Cannot certify ΓÇö exceeds constitutional limit" });
+
+    entity.Status = "certified";
+    await _db.SaveChangesAsync();
+
+    return Ok(new { id = entity.Id, status = entity.Status, certifiedLevy = entity.CertifiedLevy });
+  }
+
+  /// <summary>Get a single levy certification by ID.</summary>
+  [HttpGet("analytics/levy/{id}")]
+  public async Task<IActionResult> GetLevyCertification(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+
+    if (entity is null) return NotFound(new { error = "Levy record not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      taxYear = entity.TaxYear,
+      districtCode = entity.DistrictCode,
+      districtName = entity.DistrictName,
+      requestedLevy = entity.RequestedLevy,
+      certifiedLevy = entity.CertifiedLevy,
+      levyRate = entity.LevyRate,
+      withinConstitutionalLimit = entity.WithinConstitutionalLimit,
+      withinAggregateLimit = entity.WithinAggregateLimit,
+      wasReduced = entity.WasReduced,
+      reductionAmount = entity.ReductionAmount,
+      status = entity.Status,
+    });
+  }
+
+  /// <summary>Get levy certification history for the current county.</summary>
+  [HttpGet("analytics/levy/history")]
+  public async Task<IActionResult> GetLevyHistory([FromQuery] int? taxYear, [FromQuery] string? districtCode)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.LevyCertification>()
+      .Where(e => e.CountyId == ctx.CountyId);
+
+    if (taxYear.HasValue) query = query.Where(e => e.TaxYear == taxYear.Value);
+    if (!string.IsNullOrEmpty(districtCode)) query = query.Where(e => e.DistrictCode == districtCode);
+
+    var items = await query.OrderByDescending(e => e.CreatedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        taxYear = e.TaxYear,
+        districtCode = e.DistrictCode,
+        districtName = e.DistrictName,
+        certifiedLevy = e.CertifiedLevy,
+        levyRate = e.LevyRate,
+        status = e.Status,
+        createdAt = e.CreatedAt,
+      }),
+    });
+  }
+
+
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+// Wave 31 ΓÇö Levy DTOs
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+
+  // r2/wave-32-forge-data-quality
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Wave 32 ΓÇö Data Quality Assessment
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Run a data quality assessment on county property data.</summary>
+  [HttpPost("analytics/data-quality/assess")]
+  public async Task<IActionResult> AssessDataQuality([FromBody] DataQualityRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var records = req.Records ?? new List<DataQualityRecord>();
+    var total = records.Count;
+    if (total == 0) return BadRequest(new { error = "At least one record is required" });
+
+    var requiredFields = req.RequiredFields ?? new List<string> { "parcelId", "assessedValue", "landArea" };
+    var timelinessWindow = req.TimelinessWindowDays > 0 ? req.TimelinessWindowDays : 365;
+    var cutoff = DateTime.UtcNow.AddDays(-timelinessWindow);
+
+    var completeCount = 0;
+    var consistentCount = 0;
+    var timelyCount = 0;
+    var accurateCount = 0;
+    var issues = new List<string>();
+
+    foreach (var rec in records)
+    {
+      // Completeness: all required fields non-null/non-empty
+      var fields = rec.Fields ?? new Dictionary<string, string?>();
+      var allPresent = requiredFields.All(f => fields.ContainsKey(f) && !string.IsNullOrWhiteSpace(fields[f]));
+      if (allPresent) completeCount++;
+      else issues.Add($"Record '{rec.ParcelId ?? "?"}': missing required fields");
+
+      // Consistency: assessed value should be >= 0, land area should be > 0 if provided
+      var consistent = true;
+      if (fields.TryGetValue("assessedValue", out var av) && decimal.TryParse(av, out var avVal) && avVal < 0)
+      { consistent = false; issues.Add($"Record '{rec.ParcelId ?? "?"}': negative assessed value"); }
+      if (fields.TryGetValue("landArea", out var la) && decimal.TryParse(la, out var laVal) && laVal <= 0)
+      { consistent = false; issues.Add($"Record '{rec.ParcelId ?? "?"}': non-positive land area"); }
+      if (consistent) consistentCount++;
+
+      // Timeliness: last updated within window
+      if (rec.LastUpdated.HasValue && rec.LastUpdated.Value >= cutoff) timelyCount++;
+      else if (!rec.LastUpdated.HasValue) issues.Add($"Record '{rec.ParcelId ?? "?"}': no update timestamp");
+
+      // Accuracy: value within plausible range
+      if (fields.TryGetValue("assessedValue", out var avAcc) && decimal.TryParse(avAcc, out var accVal))
+      {
+        if (accVal >= 0 && accVal <= 100_000_000m) accurateCount++;
+        else issues.Add($"Record '{rec.ParcelId ?? "?"}': assessed value out of plausible range");
+      }
+      else accurateCount++; // no value field ΓåÆ skip accuracy check
+    }
+
+    var completeness = total > 0 ? Math.Round((double)completeCount / total * 100, 2) : 0;
+    var consistency = total > 0 ? Math.Round((double)consistentCount / total * 100, 2) : 0;
+    var timeliness = total > 0 ? Math.Round((double)timelyCount / total * 100, 2) : 0;
+    var accuracy = total > 0 ? Math.Round((double)accurateCount / total * 100, 2) : 0;
+
+    // Weighted overall: 30% completeness, 25% consistency, 20% timeliness, 25% accuracy
+    var overall = Math.Round(completeness * 0.30 + consistency * 0.25 + timeliness * 0.20 + accuracy * 0.25, 2);
+
+    var grade = overall switch
+    {
+      >= 90 => "A",
+      >= 80 => "B",
+      >= 70 => "C",
+      >= 60 => "D",
+      _ => "F",
+    };
+
+    var entity = new TerraFusion.Core.Entities.DataQualityAssessment
+    {
+      CountyId = ctx.CountyId,
+      Scope = req.Scope ?? "county",
+      ParcelId = req.ParcelId,
+      TotalRecords = total,
+      CompleteRecords = completeCount,
+      CompletenessScore = completeness,
+      ConsistentRecords = consistentCount,
+      ConsistencyScore = consistency,
+      TimelyRecords = timelyCount,
+      TimelinessScore = timeliness,
+      AccurateRecords = accurateCount,
+      AccuracyScore = accuracy,
+      OverallScore = overall,
+      Grade = grade,
+      IssueCount = issues.Count,
+      Issues = System.Text.Json.JsonSerializer.Serialize(issues),
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+    };
+    _db.Set<TerraFusion.Core.Entities.DataQualityAssessment>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      scope = entity.Scope,
+      totalRecords = entity.TotalRecords,
+      completenessScore = entity.CompletenessScore,
+      consistencyScore = entity.ConsistencyScore,
+      timelinessScore = entity.TimelinessScore,
+      accuracyScore = entity.AccuracyScore,
+      overallScore = entity.OverallScore,
+      grade = entity.Grade,
+      issueCount = entity.IssueCount,
+      issues,
+    });
+  }
+
+  /// <summary>Get a data quality assessment by ID.</summary>
+  [HttpGet("analytics/data-quality/{id}")]
+  public async Task<IActionResult> GetDataQualityAssessment(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.DataQualityAssessment>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+    if (entity is null) return NotFound(new { error = "Assessment not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      scope = entity.Scope,
+      totalRecords = entity.TotalRecords,
+      completenessScore = entity.CompletenessScore,
+      consistencyScore = entity.ConsistencyScore,
+      timelinessScore = entity.TimelinessScore,
+      accuracyScore = entity.AccuracyScore,
+      overallScore = entity.OverallScore,
+      grade = entity.Grade,
+      issueCount = entity.IssueCount,
+      createdAt = entity.CreatedAt,
+    });
+  }
+
+  /// <summary>Get data quality assessment history for the current county.</summary>
+  [HttpGet("analytics/data-quality/history")]
+  public async Task<IActionResult> GetDataQualityHistory([FromQuery] string? scope)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.DataQualityAssessment>()
+      .Where(e => e.CountyId == ctx.CountyId);
+    if (!string.IsNullOrEmpty(scope)) query = query.Where(e => e.Scope == scope);
+
+    var items = await query.OrderByDescending(e => e.CreatedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        scope = e.Scope,
+        overallScore = e.OverallScore,
+        grade = e.Grade,
+        issueCount = e.IssueCount,
+        createdAt = e.CreatedAt,
+      }),
+    });
+  }
+
+
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+// Wave 32 ΓÇö Data Quality DTOs
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+
+  // r2/wave-33-forge-etl-sync
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Wave 33 ΓÇö ETL/Sync
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Start a simulated ETL sync job.</summary>
+  [HttpPost("analytics/etl/sync")]
+  public async Task<IActionResult> StartEtlSync([FromBody] EtlSyncRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (req.Records is null || req.Records.Count == 0)
+      return BadRequest(new { error = "At least one record is required" });
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var processed = 0;
+    var failed = 0;
+    var skipped = 0;
+    var errors = new List<string>();
+
+    foreach (var rec in req.Records)
+    {
+      // Validate: must have a key field
+      if (string.IsNullOrWhiteSpace(rec.Key))
+      {
+        failed++;
+        errors.Add($"Record at index {processed + failed + skipped - 1}: missing key");
+        continue;
+      }
+
+      // Duplicate check via key
+      if (req.Records.Count(r => r.Key == rec.Key) > 1 && processed > 0)
+      {
+        // Simple dedup: skip subsequent duplicates
+        var alreadyCounted = req.Records.Take(processed + failed + skipped).Any(r => r.Key == rec.Key);
+        if (alreadyCounted) { skipped++; continue; }
+      }
+
+      // Validate: data must not be empty
+      if (rec.Data is null || rec.Data.Count == 0)
+      {
+        failed++;
+        errors.Add($"Record '{rec.Key}': empty data payload");
+        continue;
+      }
+
+      processed++;
+    }
+
+    sw.Stop();
+    var totalRecords = req.Records.Count;
+    var durationMs = sw.ElapsedMilliseconds > 0 ? sw.ElapsedMilliseconds : 1;
+    var rps = (double)processed / durationMs * 1000;
+
+    var entity = new TerraFusion.Core.Entities.EtlSyncJob
+    {
+      CountyId = ctx.CountyId,
+      SourceSystem = req.SourceSystem ?? "csv_import",
+      EntityType = req.EntityType ?? "parcels",
+      Direction = req.Direction ?? "inbound",
+      Status = failed == totalRecords ? "failed" : "completed",
+      TotalRecords = totalRecords,
+      ProcessedRecords = processed,
+      FailedRecords = failed,
+      SkippedRecords = skipped,
+      DurationMs = durationMs,
+      RecordsPerSecond = Math.Round(rps, 2),
+      Errors = errors.Count > 0 ? System.Text.Json.JsonSerializer.Serialize(errors) : null,
+      Watermark = DateTime.UtcNow,
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+      StartedAt = DateTime.UtcNow.AddMilliseconds(-durationMs),
+      CompletedAt = DateTime.UtcNow,
+    };
+    _db.Set<TerraFusion.Core.Entities.EtlSyncJob>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      sourceSystem = entity.SourceSystem,
+      entityType = entity.EntityType,
+      direction = entity.Direction,
+      status = entity.Status,
+      totalRecords = entity.TotalRecords,
+      processedRecords = entity.ProcessedRecords,
+      failedRecords = entity.FailedRecords,
+      skippedRecords = entity.SkippedRecords,
+      durationMs = entity.DurationMs,
+      recordsPerSecond = entity.RecordsPerSecond,
+      errors,
+    });
+  }
+
+  /// <summary>Get an ETL sync job by ID.</summary>
+  [HttpGet("analytics/etl/{id}")]
+  public async Task<IActionResult> GetEtlSyncJob(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.EtlSyncJob>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+    if (entity is null) return NotFound(new { error = "ETL job not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      sourceSystem = entity.SourceSystem,
+      entityType = entity.EntityType,
+      direction = entity.Direction,
+      status = entity.Status,
+      totalRecords = entity.TotalRecords,
+      processedRecords = entity.ProcessedRecords,
+      failedRecords = entity.FailedRecords,
+      skippedRecords = entity.SkippedRecords,
+      durationMs = entity.DurationMs,
+      recordsPerSecond = entity.RecordsPerSecond,
+      startedAt = entity.StartedAt,
+      completedAt = entity.CompletedAt,
+    });
+  }
+
+  /// <summary>Get ETL sync job history for the current county.</summary>
+  [HttpGet("analytics/etl/history")]
+  public async Task<IActionResult> GetEtlHistory([FromQuery] string? sourceSystem, [FromQuery] string? entityType)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.EtlSyncJob>()
+      .Where(e => e.CountyId == ctx.CountyId);
+    if (!string.IsNullOrEmpty(sourceSystem)) query = query.Where(e => e.SourceSystem == sourceSystem);
+    if (!string.IsNullOrEmpty(entityType)) query = query.Where(e => e.EntityType == entityType);
+
+    var items = await query.OrderByDescending(e => e.StartedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        sourceSystem = e.SourceSystem,
+        entityType = e.EntityType,
+        status = e.Status,
+        processedRecords = e.ProcessedRecords,
+        failedRecords = e.FailedRecords,
+        startedAt = e.StartedAt,
+      }),
+    });
+  }
+
+
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+// Wave 33 ΓÇö ETL/Sync DTOs
+// ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+
+  // r2/wave-34-forge-ml-integration
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Wave 34 ΓÇö ML.NET Integration (Simulated)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  /// <summary>Run a simulated ML prediction for property valuation.</summary>
+  [HttpPost("analytics/ml/predict")]
+  public async Task<IActionResult> MlPredict([FromBody] MlPredictRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (req.Features is null || req.Features.Count == 0)
+      return BadRequest(new { error = "At least one feature is required" });
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+
+    // Simulated ML inference: weighted sum of features
+    var featureValues = new List<double>();
+    var importances = new Dictionary<string, double>();
+    var totalWeight = 0.0;
+    var weightedSum = 0.0;
+
+    foreach (var kvp in req.Features)
+    {
+      if (double.TryParse(kvp.Value?.ToString(), out var val))
+      {
+        featureValues.Add(val);
+        // Assign importance inversely proportional to feature index
+        var importance = 1.0 / (featureValues.Count);
+        importances[kvp.Key] = Math.Round(importance, 4);
+        totalWeight += importance;
+        weightedSum += val * importance;
+      }
+    }
+
+    // Normalize to predicted value
+    var predicted = totalWeight > 0 ? (decimal)Math.Round(weightedSum / totalWeight, 2) : 0m;
+
+    // Simulated model metrics
+    var featureCount = featureValues.Count;
+    var trainingSamples = req.TrainingSamples > 0 ? req.TrainingSamples : 1000;
+    var noise = featureCount > 0 ? 1.0 / (featureCount + 1) : 0.5;
+    var confidence = Math.Round(Math.Min(0.99, 0.75 + (featureCount * 0.03)), 4);
+    var r2 = Math.Round(Math.Min(0.99, 0.80 + (featureCount * 0.02)), 4);
+    var mae = Math.Round(Math.Abs((double)predicted) * noise * 0.05, 2);
+    var rmse = Math.Round(mae * 1.25, 2);
+
+    sw.Stop();
+
+    var entity = new TerraFusion.Core.Entities.MlPrediction
+    {
+      CountyId = ctx.CountyId,
+      ModelType = req.ModelType ?? "property_value",
+      ModelVersion = req.ModelVersion ?? "1.0",
+      ParcelId = req.ParcelId,
+      PredictedValue = predicted,
+      Confidence = confidence,
+      ModelAccuracy = r2,
+      MeanAbsoluteError = (decimal)mae,
+      RootMeanSquaredError = (decimal)rmse,
+      FeatureCount = featureCount,
+      TrainingSamples = trainingSamples,
+      InferenceTimeMs = sw.ElapsedMilliseconds,
+      InputFeatures = System.Text.Json.JsonSerializer.Serialize(req.Features),
+      FeatureImportances = System.Text.Json.JsonSerializer.Serialize(importances),
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+    };
+    _db.Set<TerraFusion.Core.Entities.MlPrediction>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      modelType = entity.ModelType,
+      modelVersion = entity.ModelVersion,
+      parcelId = entity.ParcelId,
+      predictedValue = entity.PredictedValue,
+      confidence = entity.Confidence,
+      modelAccuracy = entity.ModelAccuracy,
+      meanAbsoluteError = entity.MeanAbsoluteError,
+      rootMeanSquaredError = entity.RootMeanSquaredError,
+      featureCount = entity.FeatureCount,
+      trainingSamples = entity.TrainingSamples,
+      inferenceTimeMs = entity.InferenceTimeMs,
+      featureImportances = importances,
+    });
+  }
+
+  /// <summary>Get an ML prediction by ID.</summary>
+  [HttpGet("analytics/ml/{id}")]
+  public async Task<IActionResult> GetMlPrediction(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.MlPrediction>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+    if (entity is null) return NotFound(new { error = "Prediction not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      modelType = entity.ModelType,
+      modelVersion = entity.ModelVersion,
+      parcelId = entity.ParcelId,
+      predictedValue = entity.PredictedValue,
+      confidence = entity.Confidence,
+      modelAccuracy = entity.ModelAccuracy,
+      featureCount = entity.FeatureCount,
+      inferenceTimeMs = entity.InferenceTimeMs,
+      createdAt = entity.CreatedAt,
+    });
+  }
+
+  /// <summary>Get ML prediction history for the current county.</summary>
+  [HttpGet("analytics/ml/history")]
+  public async Task<IActionResult> GetMlHistory([FromQuery] string? modelType)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.MlPrediction>()
+      .Where(e => e.CountyId == ctx.CountyId);
+    if (!string.IsNullOrEmpty(modelType)) query = query.Where(e => e.ModelType == modelType);
+
+    var items = await query.OrderByDescending(e => e.CreatedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        modelType = e.ModelType,
+        parcelId = e.ParcelId,
+        predictedValue = e.PredictedValue,
+        confidence = e.Confidence,
+        createdAt = e.CreatedAt,
+      }),
+    });
+  }
+
+
+// ΓöÇΓöÇ Wave 34 DTOs ΓöÇΓöÇ
+
+
+  // r2/wave-35-forge-valuation-pipeline
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Wave 35 ΓÇö Valuation Pipeline
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  private static readonly string[] PipelineStages =
+    ["ingestion", "quality", "cost", "sales", "income", "reconciliation", "review", "certified"];
+
+  /// <summary>Start a valuation pipeline run.</summary>
+  [HttpPost("pipeline/start")]
+  public async Task<IActionResult> StartPipeline([FromBody] PipelineStartRequest req)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    if (string.IsNullOrWhiteSpace(req.PipelineName))
+      return BadRequest(new { error = "Pipeline name is required" });
+    if (req.TotalParcels <= 0)
+      return BadRequest(new { error = "Total parcels must be positive" });
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+
+    // Simulate pipeline stages
+    var stageDetails = new Dictionary<string, object>();
+    var processed = 0;
+    var failed = 0;
+    var rng = new Random(req.TotalParcels + req.TaxYear);
+    var valueChanges = new List<double>();
+
+    foreach (var stage in PipelineStages)
+    {
+      var stageCount = req.TotalParcels - failed;
+      var stageFailed = (int)(stageCount * rng.NextDouble() * 0.02); // up to 2% fail per stage
+      failed += stageFailed;
+      processed = req.TotalParcels - failed;
+
+      // simulate value change for parcels
+      for (int i = 0; i < Math.Min(stageCount, 50); i++)
+        valueChanges.Add((rng.NextDouble() - 0.3) * 20); // -6% to +14%
+
+      stageDetails[stage] = new { parcels = stageCount, failed = stageFailed, durationMs = rng.Next(100, 2000) };
+    }
+
+    sw.Stop();
+
+    var sortedChanges = valueChanges.OrderBy(x => x).ToList();
+    var avg = sortedChanges.Count > 0 ? sortedChanges.Average() : 0;
+    var median = sortedChanges.Count > 0 ? sortedChanges[sortedChanges.Count / 2] : 0;
+
+    // COD: average absolute deviation / median * 100
+    var absDeviation = sortedChanges.Count > 0 && median != 0
+      ? sortedChanges.Average(x => Math.Abs(x - median)) / Math.Abs(median) * 100
+      : 0;
+    // PRD: mean / weighted mean (simulated close to 1.0)
+    var prd = sortedChanges.Count > 0 ? 1.0 + (rng.NextDouble() - 0.5) * 0.06 : 1.0;
+
+    var entity = new TerraFusion.Core.Entities.ValuationPipeline
+    {
+      CountyId = ctx.CountyId,
+      PipelineName = req.PipelineName,
+      TaxYear = req.TaxYear > 0 ? req.TaxYear : DateTime.UtcNow.Year,
+      TotalParcels = req.TotalParcels,
+      CompletedParcels = processed,
+      FailedParcels = failed,
+      InProgressParcels = 0,
+      CurrentStage = "certified",
+      Status = failed > req.TotalParcels / 2 ? "failed" : "completed",
+      DurationMs = sw.ElapsedMilliseconds,
+      AvgValueChangePercent = Math.Round(avg, 2),
+      MedianValueChangePercent = Math.Round(median, 2),
+      CoefficientOfDispersion = Math.Round(absDeviation, 2),
+      PriceRelatedDifferential = Math.Round(prd, 4),
+      StageDetails = System.Text.Json.JsonSerializer.Serialize(stageDetails),
+      CreatedBy = User.FindFirst("sub")?.Value ?? "system",
+    };
+    _db.Set<TerraFusion.Core.Entities.ValuationPipeline>().Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      pipelineName = entity.PipelineName,
+      taxYear = entity.TaxYear,
+      status = entity.Status,
+      totalParcels = entity.TotalParcels,
+      completedParcels = entity.CompletedParcels,
+      failedParcels = entity.FailedParcels,
+      currentStage = entity.CurrentStage,
+      durationMs = entity.DurationMs,
+      avgValueChangePercent = entity.AvgValueChangePercent,
+      medianValueChangePercent = entity.MedianValueChangePercent,
+      coefficientOfDispersion = entity.CoefficientOfDispersion,
+      priceRelatedDifferential = entity.PriceRelatedDifferential,
+    });
+  }
+
+  /// <summary>Get pipeline run by ID.</summary>
+  [HttpGet("pipeline/{id}")]
+  public async Task<IActionResult> GetPipeline(int id)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var entity = await _db.Set<TerraFusion.Core.Entities.ValuationPipeline>()
+      .FirstOrDefaultAsync(e => e.Id == id && e.CountyId == ctx.CountyId);
+    if (entity is null) return NotFound(new { error = "Pipeline not found" });
+
+    return Ok(new
+    {
+      id = entity.Id,
+      pipelineName = entity.PipelineName,
+      taxYear = entity.TaxYear,
+      status = entity.Status,
+      totalParcels = entity.TotalParcels,
+      completedParcels = entity.CompletedParcels,
+      failedParcels = entity.FailedParcels,
+      currentStage = entity.CurrentStage,
+      durationMs = entity.DurationMs,
+      avgValueChangePercent = entity.AvgValueChangePercent,
+      medianValueChangePercent = entity.MedianValueChangePercent,
+      coefficientOfDispersion = entity.CoefficientOfDispersion,
+      priceRelatedDifferential = entity.PriceRelatedDifferential,
+      stageDetails = entity.StageDetails,
+      createdAt = entity.CreatedAt,
+    });
+  }
+
+  /// <summary>Get pipeline history.</summary>
+  [HttpGet("pipeline/history")]
+  public async Task<IActionResult> GetPipelineHistory([FromQuery] int? taxYear)
+  {
+    var ctx = await ResolveCountyContextAsync();
+    if (ctx is null) return Unauthorized(new { error = "County context required" });
+
+    var query = _db.Set<TerraFusion.Core.Entities.ValuationPipeline>()
+      .Where(e => e.CountyId == ctx.CountyId);
+    if (taxYear.HasValue) query = query.Where(e => e.TaxYear == taxYear.Value);
+
+    var items = await query.OrderByDescending(e => e.CreatedAt).Take(100).ToListAsync();
+
+    return Ok(new
+    {
+      count = items.Count,
+      items = items.Select(e => new
+      {
+        id = e.Id,
+        pipelineName = e.PipelineName,
+        taxYear = e.TaxYear,
+        status = e.Status,
+        totalParcels = e.TotalParcels,
+        completedParcels = e.CompletedParcels,
+        createdAt = e.CreatedAt,
+      }),
+    });
+  }
+
+
+// ΓöÇΓöÇ Wave 35 DTOs ΓöÇΓöÇ
+
 }
 
 public class CostEstimateRequest
@@ -3594,4 +5452,145 @@ public class McVariable
   public double Max { get; set; } = 1.0;
   public double? Mode { get; set; }
   public double? Weight { get; set; }
+}
+
+public class SpatialAutocorrelationRequest
+{
+  public List<SpatialObservation> Observations { get; set; } = new();
+  public string? VariableName { get; set; }
+  public string? WeightType { get; set; }
+  public double? DistanceThreshold { get; set; }
+}
+
+public class SpatialObservation
+{
+  public double X { get; set; }
+  public double Y { get; set; }
+  public double Value { get; set; }
+  public string? ParcelId { get; set; }
+}
+
+public class MarketAnalysisRequest
+{
+  public string? MarketAreaName { get; set; }
+  public List<SaleRecord> Sales { get; set; } = new();
+}
+
+public class SaleRecord
+{
+  public string ParcelId { get; set; } = string.Empty;
+  public decimal SalePrice { get; set; }
+  public decimal AssessedValue { get; set; }
+  public decimal SquareFeet { get; set; }
+  public DateTime SaleDate { get; set; }
+}
+
+public class TimeTrendRequest
+{
+  public string? MarketAreaName { get; set; }
+  public List<SaleRecord> Sales { get; set; } = new();
+}
+
+public class Rcw8434Request
+{
+  public string? ParcelId { get; set; }
+  public string? Classification { get; set; }
+  public decimal MarketValue { get; set; }
+  public decimal Acreage { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class Rcw8426Request
+{
+  public string? ParcelId { get; set; }
+  public decimal MarketValue { get; set; }
+  public decimal PreRehabValue { get; set; }
+  public decimal RehabilitationCost { get; set; }
+  public int YearDesignated { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class Rcw8436381Request
+{
+  public string? ParcelId { get; set; }
+  public decimal MarketValue { get; set; }
+  public int Age { get; set; }
+  public bool IsDisabled { get; set; }
+  public decimal Income { get; set; }
+  public double LevyRate { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class LevyCalculateRequest
+{
+  public string? DistrictCode { get; set; }
+  public string? DistrictName { get; set; }
+  public decimal PriorYearLevy { get; set; }
+  public decimal RequestedLevy { get; set; }
+  public decimal AssessedValue { get; set; }
+  public decimal NewConstructionValue { get; set; }
+  public decimal AnnexationValue { get; set; }
+  public int TaxYear { get; set; }
+}
+
+public class LevyBalanceTestRequest
+{
+  public int TaxYear { get; set; }
+  public List<LevyDistrictInput> Districts { get; set; } = new();
+}
+
+public class LevyDistrictInput
+{
+  public string? DistrictCode { get; set; }
+  public string? DistrictName { get; set; }
+  public decimal RequestedLevy { get; set; }
+  public decimal AssessedValue { get; set; }
+}
+
+public class DataQualityRequest
+{
+  public string? Scope { get; set; }
+  public string? ParcelId { get; set; }
+  public List<string>? RequiredFields { get; set; }
+  public int TimelinessWindowDays { get; set; }
+  public List<DataQualityRecord>? Records { get; set; }
+}
+
+public class DataQualityRecord
+{
+  public string? ParcelId { get; set; }
+  public DateTime? LastUpdated { get; set; }
+  public Dictionary<string, string?>? Fields { get; set; }
+}
+
+public class EtlSyncRequest
+{
+  public string? SourceSystem { get; set; }
+  public string? EntityType { get; set; }
+  public string? Direction { get; set; }
+  public List<EtlSyncRecord>? Records { get; set; }
+}
+
+public class EtlSyncRecord
+{
+  public string? Key { get; set; }
+  public Dictionary<string, string?>? Data { get; set; }
+}
+
+public class MlPredictRequest
+{
+  public string? ModelType { get; set; }
+  public string? ModelVersion { get; set; }
+  public string? ParcelId { get; set; }
+  public Dictionary<string, object?> Features { get; set; } = new();
+  public int TrainingSamples { get; set; }
+}
+
+public class PipelineStartRequest
+{
+  public string? PipelineName { get; set; }
+  public int TaxYear { get; set; }
+  public int TotalParcels { get; set; }
 }

--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -2642,6 +2642,366 @@ public class CostForgeController : ControllerBase
     public int MatrixYear { get; init; }
     public string Source { get; init; } = "";
   }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ██  ANALYTICS: OLS Multiple Regression  (R2 Wave 26)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /// <summary>
+  /// Run OLS multiple regression: value ~ sqft + acreage + age.
+  /// Uses Normal Equations: β = (X'X)⁻¹X'y.
+  /// </summary>
+  [HttpPost("analytics/regression")]
+  public async Task<IActionResult> RunOlsRegression([FromBody] OlsRegressionRequest request)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    if (request.Observations == null || request.Observations.Count < 3)
+      return BadRequest(new { error = "At least 3 observations are required for regression" });
+
+    int n = request.Observations.Count;
+    int p = request.FeatureNames?.Length ?? 3; // default: sqft, acreage, age
+
+    var featureNames = request.FeatureNames ?? new[] { "sqft", "acreage", "age" };
+
+    // Build X matrix (n × p+1 with intercept column) and y vector
+    double[,] X = new double[n, p + 1];
+    double[] y = new double[n];
+
+    for (int i = 0; i < n; i++)
+    {
+      var obs = request.Observations[i];
+      X[i, 0] = 1.0; // intercept
+      for (int j = 0; j < p; j++)
+      {
+        X[i, j + 1] = j < obs.Features.Length ? obs.Features[j] : 0.0;
+      }
+      y[i] = obs.Value;
+    }
+
+    // Normal Equations: β = (X'X)⁻¹ X'y
+    double[,] XtX = MatMul(Transpose(X, n, p + 1), X, p + 1, n, p + 1);
+    double[,]? XtXInv = Invert(XtX, p + 1);
+
+    if (XtXInv is null)
+      return BadRequest(new { error = "Matrix is singular — features may be collinear" });
+
+    double[] Xty = MatVecMul(Transpose(X, n, p + 1), y, p + 1, n);
+    double[] beta = MatVecMul(XtXInv, Xty, p + 1, p + 1);
+
+    double intercept = beta[0];
+    double[] coefficients = beta[1..];
+
+    // Predictions and residuals
+    double[] predictions = new double[n];
+    double[] residuals = new double[n];
+    double yMean = y.Average();
+    double ssRes = 0, ssTot = 0;
+
+    for (int i = 0; i < n; i++)
+    {
+      double pred = intercept;
+      for (int j = 0; j < p; j++)
+        pred += coefficients[j] * X[i, j + 1];
+      predictions[i] = pred;
+      residuals[i] = y[i] - pred;
+      ssRes += residuals[i] * residuals[i];
+      ssTot += (y[i] - yMean) * (y[i] - yMean);
+    }
+
+    double rSquared = ssTot > 0 ? 1.0 - (ssRes / ssTot) : 0.0;
+    double adjRSquared = n > p + 1
+      ? 1.0 - ((1.0 - rSquared) * (n - 1) / (n - p - 1))
+      : rSquared;
+
+    // F-statistic: (R²/p) / ((1-R²)/(n-p-1))
+    double fStat = (n > p + 1 && rSquared < 1.0)
+      ? (rSquared / p) / ((1.0 - rSquared) / (n - p - 1))
+      : 0.0;
+
+    // Standard errors from diagonal of (X'X)⁻¹ × σ²
+    double sigma2 = n > p + 1 ? ssRes / (n - p - 1) : ssRes;
+    double[] stdErrors = new double[p];
+    for (int j = 0; j < p; j++)
+      stdErrors[j] = Math.Sqrt(Math.Abs(XtXInv[j + 1, j + 1] * sigma2));
+
+    // Diagnostics
+    double residMean = residuals.Average();
+    double residStd = Math.Sqrt(residuals.Select(r => (r - residMean) * (r - residMean)).Sum() / Math.Max(n - 1, 1));
+    double maxResid = residuals.Max(r => Math.Abs(r));
+
+    var diagnostics = new
+    {
+      heteroskedasticity = maxResid > 3 * residStd,
+      autocorrelation = false, // simplified — would need Durbin-Watson
+      normality = residStd > 0 && Math.Abs(residMean / residStd) < 2.0,
+      residualStd = Math.Round(residStd, 4),
+      maxAbsResidual = Math.Round(maxResid, 4)
+    };
+
+    // Persist
+    var entity = new RegressionAnalysis
+    {
+      CountyId = county.CountyId,
+      DependentVariable = request.DependentVariable ?? "assessed_value",
+      IndependentVariables = System.Text.Json.JsonSerializer.Serialize(featureNames),
+      Coefficients = System.Text.Json.JsonSerializer.Serialize(coefficients.Select(c => Math.Round(c, 6)).ToArray()),
+      Intercept = Math.Round(intercept, 6),
+      RSquared = Math.Round(rSquared, 6),
+      AdjustedRSquared = Math.Round(adjRSquared, 6),
+      FStatistic = Math.Round(fStat, 6),
+      PValue = fStat > 0 ? Math.Round(1.0 - FDistributionCdf(fStat, p, Math.Max(n - p - 1, 1)), 6) : 1.0,
+      StandardErrors = System.Text.Json.JsonSerializer.Serialize(stdErrors.Select(e => Math.Round(e, 6)).ToArray()),
+      ResidualDiagnostics = System.Text.Json.JsonSerializer.Serialize(diagnostics),
+      SampleSize = n,
+      CreatedBy = User.Identity?.Name ?? "system"
+    };
+
+    _db.RegressionAnalyses.Add(entity);
+    await _db.SaveChangesAsync();
+
+    return Ok(new
+    {
+      id = entity.Id,
+      intercept = entity.Intercept,
+      coefficients = coefficients.Select((c, i) => new { feature = featureNames[i], coefficient = Math.Round(c, 6), standardError = Math.Round(stdErrors[i], 6) }).ToArray(),
+      rSquared = entity.RSquared,
+      adjustedRSquared = entity.AdjustedRSquared,
+      fStatistic = entity.FStatistic,
+      pValue = entity.PValue,
+      sampleSize = n,
+      diagnostics,
+      predictions = predictions.Select(p2 => Math.Round(p2, 2)).ToArray()
+    });
+  }
+
+  /// <summary>Retrieve a stored regression result by ID.</summary>
+  [HttpGet("analytics/regression/{id:guid}")]
+  public async Task<IActionResult> GetRegressionResult(Guid id)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    var result = await _db.RegressionAnalyses
+      .FirstOrDefaultAsync(r => r.Id == id && r.CountyId == county.CountyId);
+
+    if (result is null) return NotFound(new { error = "Regression analysis not found" });
+
+    return Ok(new
+    {
+      id = result.Id,
+      dependentVariable = result.DependentVariable,
+      independentVariables = System.Text.Json.JsonSerializer.Deserialize<string[]>(result.IndependentVariables),
+      coefficients = System.Text.Json.JsonSerializer.Deserialize<double[]>(result.Coefficients),
+      intercept = result.Intercept,
+      rSquared = result.RSquared,
+      adjustedRSquared = result.AdjustedRSquared,
+      fStatistic = result.FStatistic,
+      pValue = result.PValue,
+      standardErrors = System.Text.Json.JsonSerializer.Deserialize<double[]>(result.StandardErrors),
+      diagnostics = System.Text.Json.JsonSerializer.Deserialize<object>(result.ResidualDiagnostics),
+      sampleSize = result.SampleSize,
+      createdBy = result.CreatedBy,
+      createdAt = result.CreatedAt
+    });
+  }
+
+  /// <summary>Retrieve regression diagnostics (residual detail) by ID.</summary>
+  [HttpGet("analytics/regression/{id:guid}/diagnostics")]
+  public async Task<IActionResult> GetRegressionDiagnostics(Guid id)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    var result = await _db.RegressionAnalyses
+      .FirstOrDefaultAsync(r => r.Id == id && r.CountyId == county.CountyId);
+
+    if (result is null) return NotFound(new { error = "Regression analysis not found" });
+
+    return Ok(new
+    {
+      id = result.Id,
+      rSquared = result.RSquared,
+      adjustedRSquared = result.AdjustedRSquared,
+      fStatistic = result.FStatistic,
+      pValue = result.PValue,
+      diagnostics = System.Text.Json.JsonSerializer.Deserialize<object>(result.ResidualDiagnostics),
+      standardErrors = System.Text.Json.JsonSerializer.Deserialize<double[]>(result.StandardErrors),
+      sampleSize = result.SampleSize
+    });
+  }
+
+  /// <summary>List recent regression analyses for the county.</summary>
+  [HttpGet("analytics/regression/history")]
+  public async Task<IActionResult> GetRegressionHistory([FromQuery] int limit = 20)
+  {
+    var county = await ResolveCountyContextAsync();
+    if (county is null) return Unauthorized(new { error = "County context required" });
+
+    limit = Math.Clamp(limit, 1, 100);
+
+    var results = await _db.RegressionAnalyses
+      .Where(r => r.CountyId == county.CountyId)
+      .OrderByDescending(r => r.CreatedAt)
+      .Take(limit)
+      .Select(r => new
+      {
+        id = r.Id,
+        dependentVariable = r.DependentVariable,
+        rSquared = r.RSquared,
+        adjustedRSquared = r.AdjustedRSquared,
+        fStatistic = r.FStatistic,
+        sampleSize = r.SampleSize,
+        createdAt = r.CreatedAt,
+        createdBy = r.CreatedBy
+      })
+      .ToListAsync();
+
+    return Ok(new { count = results.Count, results });
+  }
+
+  // ── OLS Math Helpers ──────────────────────────────────────────────────────
+
+  private static double[,] Transpose(double[,] m, int rows, int cols)
+  {
+    var t = new double[cols, rows];
+    for (int i = 0; i < rows; i++)
+      for (int j = 0; j < cols; j++)
+        t[j, i] = m[i, j];
+    return t;
+  }
+
+  private static double[,] MatMul(double[,] a, double[,] b, int aRows, int aCols, int bCols)
+  {
+    var c = new double[aRows, bCols];
+    for (int i = 0; i < aRows; i++)
+      for (int j = 0; j < bCols; j++)
+        for (int k = 0; k < aCols; k++)
+          c[i, j] += a[i, k] * b[k, j];
+    return c;
+  }
+
+  private static double[] MatVecMul(double[,] m, double[] v, int rows, int cols)
+  {
+    var result = new double[rows];
+    for (int i = 0; i < rows; i++)
+      for (int j = 0; j < cols; j++)
+        result[i] += m[i, j] * v[j];
+    return result;
+  }
+
+  /// <summary>Gauss-Jordan matrix inversion. Returns null if singular.</summary>
+  private static double[,]? Invert(double[,] matrix, int n)
+  {
+    var aug = new double[n, 2 * n];
+    for (int i = 0; i < n; i++)
+    {
+      for (int j = 0; j < n; j++)
+        aug[i, j] = matrix[i, j];
+      aug[i, n + i] = 1.0;
+    }
+
+    for (int col = 0; col < n; col++)
+    {
+      // Partial pivoting
+      int maxRow = col;
+      for (int row = col + 1; row < n; row++)
+        if (Math.Abs(aug[row, col]) > Math.Abs(aug[maxRow, col]))
+          maxRow = row;
+
+      if (Math.Abs(aug[maxRow, col]) < 1e-12) return null; // singular
+
+      // Swap rows
+      for (int j = 0; j < 2 * n; j++)
+        (aug[col, j], aug[maxRow, j]) = (aug[maxRow, j], aug[col, j]);
+
+      // Scale pivot row
+      double pivot = aug[col, col];
+      for (int j = 0; j < 2 * n; j++)
+        aug[col, j] /= pivot;
+
+      // Eliminate column
+      for (int row = 0; row < n; row++)
+      {
+        if (row == col) continue;
+        double factor = aug[row, col];
+        for (int j = 0; j < 2 * n; j++)
+          aug[row, j] -= factor * aug[col, j];
+      }
+    }
+
+    var inv = new double[n, n];
+    for (int i = 0; i < n; i++)
+      for (int j = 0; j < n; j++)
+        inv[i, j] = aug[i, n + j];
+
+    return inv;
+  }
+
+  /// <summary>Approximate F-distribution CDF using Abramowitz-Stegun regularized incomplete beta.</summary>
+  private static double FDistributionCdf(double f, int d1, int d2)
+  {
+    if (f <= 0 || d1 <= 0 || d2 <= 0) return 0;
+    double x = (d1 * f) / (d1 * f + d2);
+    return RegularizedIncompleteBeta(x, d1 / 2.0, d2 / 2.0);
+  }
+
+  private static double RegularizedIncompleteBeta(double x, double a, double b)
+  {
+    if (x <= 0) return 0;
+    if (x >= 1) return 1;
+
+    // Continued fraction approximation (Lentz's method)
+    double lnBeta = LogGamma(a) + LogGamma(b) - LogGamma(a + b);
+    double front = Math.Exp(Math.Log(x) * a + Math.Log(1 - x) * b - lnBeta) / a;
+
+    const int maxIter = 200;
+    const double eps = 1e-10;
+
+    double f2 = 1.0, c = 1.0, d = 1.0 - (a + b) * x / (a + 1.0);
+    if (Math.Abs(d) < 1e-30) d = 1e-30;
+    d = 1.0 / d;
+    f2 = d;
+
+    for (int m = 1; m <= maxIter; m++)
+    {
+      // Even step
+      double num = m * (b - m) * x / ((a + 2.0 * m - 1.0) * (a + 2.0 * m));
+      d = 1.0 + num * d;
+      if (Math.Abs(d) < 1e-30) d = 1e-30;
+      c = 1.0 + num / c;
+      if (Math.Abs(c) < 1e-30) c = 1e-30;
+      d = 1.0 / d;
+      f2 *= c * d;
+
+      // Odd step
+      num = -(a + m) * (a + b + m) * x / ((a + 2.0 * m) * (a + 2.0 * m + 1.0));
+      d = 1.0 + num * d;
+      if (Math.Abs(d) < 1e-30) d = 1e-30;
+      c = 1.0 + num / c;
+      if (Math.Abs(c) < 1e-30) c = 1e-30;
+      d = 1.0 / d;
+      double delta = c * d;
+      f2 *= delta;
+
+      if (Math.Abs(delta - 1.0) < eps) break;
+    }
+
+    return front * f2;
+  }
+
+  private static double LogGamma(double x)
+  {
+    // Lanczos approximation
+    double[] cof = { 76.18009172947146, -86.50532032941677, 24.01409824083091,
+                     -1.231739572450155, 0.1208650973866179e-2, -0.5395239384953e-5 };
+    double y = x, tmp = x + 5.5;
+    tmp -= (x + 0.5) * Math.Log(tmp);
+    double ser = 1.000000000190015;
+    for (int j = 0; j < 6; j++) ser += cof[j] / ++y;
+    return -tmp + Math.Log(2.5066282746310005 * ser / x);
+  }
 }
 
 public class CostEstimateRequest
@@ -2776,4 +3136,21 @@ public class AnalyticsDto
   public double AverageAccuracy { get; set; }
   public Dictionary<string, int> CalculationsByType { get; set; } = new();
   public Dictionary<string, double> PerformanceMetrics { get; set; } = new();
+}
+
+// ═══ OLS Regression Request DTOs (R2 Wave 26) ═══
+
+public class OlsRegressionRequest
+{
+  [Required]
+  public List<RegressionObservation> Observations { get; set; } = new();
+  public string[]? FeatureNames { get; set; }
+  public string? DependentVariable { get; set; }
+}
+
+public class RegressionObservation
+{
+  [Required]
+  public double[] Features { get; set; } = Array.Empty<double>();
+  public double Value { get; set; }
 }

--- a/backend/src/TerraFusion.Core/Entities/DataQualityAssessment.cs
+++ b/backend/src/TerraFusion.Core/Entities/DataQualityAssessment.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Data quality assessment result ΓÇö tracks completeness, consistency,
+/// timeliness, and accuracy scores for county parcel data.
+/// </summary>
+public class DataQualityAssessment
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  /// <summary>County that owns this assessment.</summary>
+  public Guid CountyId { get; set; }
+
+  /// <summary>Scope of assessment: parcel, district, county.</summary>
+  [MaxLength(50)]
+  public string Scope { get; set; } = "county";
+
+  /// <summary>Optional parcel ID if scope is parcel-level.</summary>
+  [MaxLength(50)]
+  public string? ParcelId { get; set; }
+
+  /// <summary>Total records evaluated.</summary>
+  public int TotalRecords { get; set; }
+
+  /// <summary>Records with complete required fields.</summary>
+  public int CompleteRecords { get; set; }
+
+  /// <summary>Completeness score (0-100).</summary>
+  public double CompletenessScore { get; set; }
+
+  /// <summary>Records passing cross-field consistency checks.</summary>
+  public int ConsistentRecords { get; set; }
+
+  /// <summary>Consistency score (0-100).</summary>
+  public double ConsistencyScore { get; set; }
+
+  /// <summary>Records updated within the timeliness window.</summary>
+  public int TimelyRecords { get; set; }
+
+  /// <summary>Timeliness score (0-100).</summary>
+  public double TimelinessScore { get; set; }
+
+  /// <summary>Records within plausible value ranges.</summary>
+  public int AccurateRecords { get; set; }
+
+  /// <summary>Accuracy score (0-100).</summary>
+  public double AccuracyScore { get; set; }
+
+  /// <summary>Weighted overall quality score (0-100).</summary>
+  public double OverallScore { get; set; }
+
+  /// <summary>Quality grade: A (ΓëÑ90), B (ΓëÑ80), C (ΓëÑ70), D (ΓëÑ60), F (&lt;60).</summary>
+  [MaxLength(2)]
+  public string Grade { get; set; } = "F";
+
+  /// <summary>Number of distinct issues found.</summary>
+  public int IssueCount { get; set; }
+
+  /// <summary>JSON array of issue descriptions.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Issues { get; set; }
+
+  /// <summary>JSON details with per-field metrics, histograms, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/EtlSyncJob.cs
+++ b/backend/src/TerraFusion.Core/Entities/EtlSyncJob.cs
@@ -1,0 +1,69 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// ETL sync job ΓÇö tracks data synchronization operations between
+/// TerraFusion and external systems (Harris PACS, Tyler Vision, Aumentum).
+/// </summary>
+public class EtlSyncJob
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  /// <summary>Source system identifier: harris_pacs, tyler_vision, aumentum, csv_import.</summary>
+  [MaxLength(100)]
+  public string SourceSystem { get; set; } = "";
+
+  /// <summary>Entity type being synced: parcels, sales, permits, assessments.</summary>
+  [MaxLength(100)]
+  public string EntityType { get; set; } = "";
+
+  /// <summary>Direction: inbound (external ΓåÆ TF), outbound (TF ΓåÆ external).</summary>
+  [MaxLength(20)]
+  public string Direction { get; set; } = "inbound";
+
+  /// <summary>Status: queued, running, completed, failed, cancelled.</summary>
+  [MaxLength(30)]
+  public string Status { get; set; } = "queued";
+
+  /// <summary>Total records to process.</summary>
+  public int TotalRecords { get; set; }
+
+  /// <summary>Records successfully processed.</summary>
+  public int ProcessedRecords { get; set; }
+
+  /// <summary>Records that failed processing.</summary>
+  public int FailedRecords { get; set; }
+
+  /// <summary>Records skipped (duplicates, unchanged).</summary>
+  public int SkippedRecords { get; set; }
+
+  /// <summary>Duration in milliseconds.</summary>
+  public long DurationMs { get; set; }
+
+  /// <summary>Throughput in records per second.</summary>
+  public double RecordsPerSecond { get; set; }
+
+  /// <summary>JSON array of error messages for failed records.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Errors { get; set; }
+
+  /// <summary>JSON details blob with field mappings, transform stats, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  /// <summary>Watermark for incremental sync (e.g., last modified timestamp).</summary>
+  public DateTime? Watermark { get; set; }
+
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+  public DateTime? CompletedAt { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/LevyCertification.cs
+++ b/backend/src/TerraFusion.Core/Entities/LevyCertification.cs
@@ -1,0 +1,95 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Levy certification calculation ΓÇö tracks levy rate computations,
+/// statutory limits (1% constitutional, $5.90 aggregate), and
+/// certification workflow state for a given tax year.
+/// </summary>
+public class LevyCertification
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  /// <summary>County that owns this certification record.</summary>
+  public Guid CountyId { get; set; }
+
+  /// <summary>Tax year this certification applies to.</summary>
+  public int TaxYear { get; set; }
+
+  /// <summary>Taxing district code (e.g., county, city, school, fire).</summary>
+  [MaxLength(100)]
+  public string DistrictCode { get; set; } = "";
+
+  /// <summary>Taxing district display name.</summary>
+  [MaxLength(250)]
+  public string DistrictName { get; set; } = "";
+
+  /// <summary>Prior-year levy amount in dollars.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal PriorYearLevy { get; set; }
+
+  /// <summary>Requested levy amount for the current year.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal RequestedLevy { get; set; }
+
+  /// <summary>Certified (approved) levy amount after limit checks.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal CertifiedLevy { get; set; }
+
+  /// <summary>Total assessed value in the district.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal AssessedValue { get; set; }
+
+  /// <summary>New-construction value added this year.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal NewConstructionValue { get; set; }
+
+  /// <summary>Annexation value (newly-included territory).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal AnnexationValue { get; set; }
+
+  /// <summary>Computed levy rate per $1,000 assessed value.</summary>
+  public double LevyRate { get; set; }
+
+  /// <summary>WA statutory limit: 1% annual increase (RCW 84.55).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal StatutoryLimit { get; set; }
+
+  /// <summary>1% constitutional limit on levy rate per $1,000 AV.</summary>
+  public double ConstitutionalLimit { get; set; } = 10.0;
+
+  /// <summary>$5.90 aggregate limit per $1,000 AV (RCW 84.52.043).</summary>
+  public double AggregateLimit { get; set; } = 5.90;
+
+  /// <summary>Whether the district is within the 1% constitutional limit.</summary>
+  public bool WithinConstitutionalLimit { get; set; }
+
+  /// <summary>Whether the district is within the $5.90 aggregate limit.</summary>
+  public bool WithinAggregateLimit { get; set; }
+
+  /// <summary>Whether levy was reduced to comply with limits.</summary>
+  public bool WasReduced { get; set; }
+
+  /// <summary>Amount the levy was reduced by (if any).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal ReductionAmount { get; set; }
+
+  /// <summary>Certification status: draft, pending_review, certified, rejected.</summary>
+  [MaxLength(50)]
+  public string Status { get; set; } = "draft";
+
+  /// <summary>JSON details blob with breakdown, limit check details, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  /// <summary>Who created/ran this calculation.</summary>
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/MarketAnalysis.cs
+++ b/backend/src/TerraFusion.Core/Entities/MarketAnalysis.cs
@@ -1,0 +1,85 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// R2 Wave 29 ΓÇö Market area analysis result with county isolation.
+/// Stores market area delineation, comparable sales analysis, time-trend adjustments.
+/// </summary>
+public class MarketAnalysis
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>County isolation (sovereign county model).</summary>
+    [Required]
+    public Guid CountyId { get; set; }
+
+    /// <summary>Analysis type: market_area_delineation | comparable_sales | time_trend | ratio_study</summary>
+    [Required]
+    [MaxLength(50)]
+    public string AnalysisType { get; set; } = string.Empty;
+
+    /// <summary>Human-readable market area name (e.g. "Kennewick NW Residential").</summary>
+    [MaxLength(200)]
+    public string MarketAreaName { get; set; } = string.Empty;
+
+    /// <summary>JSON array of parcel IDs included in the analysis.</summary>
+    public string ParcelIds { get; set; } = "[]";
+
+    /// <summary>Number of parcels / observations.</summary>
+    public int SampleSize { get; set; }
+
+    // ΓöÇΓöÇ Comparable Sales Statistics ΓöÇΓöÇ
+
+    /// <summary>Median sale price in the market area.</summary>
+    public decimal MedianSalePrice { get; set; }
+
+    /// <summary>Mean sale price.</summary>
+    public decimal MeanSalePrice { get; set; }
+
+    /// <summary>Price per square-foot (median).</summary>
+    public decimal MedianPricePerSqft { get; set; }
+
+    /// <summary>Coefficient of dispersion (COD) ΓÇö ratio-study quality metric.</summary>
+    public double CoefficientOfDispersion { get; set; }
+
+    /// <summary>Price-related differential (PRD) ΓÇö vertical equity metric.</summary>
+    public double PriceRelatedDifferential { get; set; }
+
+    /// <summary>Median assessment ratio (assessed / sale).</summary>
+    public double MedianRatio { get; set; }
+
+    // ΓöÇΓöÇ Time Trend ΓöÇΓöÇ
+
+    /// <summary>Monthly time-trend coefficient (percent change per month).</summary>
+    public double TimeTrendCoefficient { get; set; }
+
+    /// <summary>R-squared of time-trend regression.</summary>
+    public double TimeTrendRSquared { get; set; }
+
+    /// <summary>Start date of analysis period.</summary>
+    public DateTime PeriodStart { get; set; }
+
+    /// <summary>End date of analysis period.</summary>
+    public DateTime PeriodEnd { get; set; }
+
+    // ΓöÇΓöÇ Market Area Delineation ΓöÇΓöÇ
+
+    /// <summary>JSON object with boundary or clustering info for the market area.</summary>
+    public string MarketAreaBoundary { get; set; } = "{}";
+
+    /// <summary>JSON array of comparable-sale summary records.</summary>
+    public string ComparableSummary { get; set; } = "[]";
+
+    /// <summary>JSON object with additional statistics or breakdowns.</summary>
+    public string AdditionalMetrics { get; set; } = "{}";
+
+    // ΓöÇΓöÇ Audit ΓöÇΓöÇ
+
+    [MaxLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/MlPrediction.cs
+++ b/backend/src/TerraFusion.Core/Entities/MlPrediction.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// ML model prediction result ΓÇö tracks model execution, input features,
+/// predicted values, confidence scores, and model metadata.
+/// </summary>
+public class MlPrediction
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  /// <summary>Model identifier: property_value, land_classification, market_trend, anomaly_detection.</summary>
+  [MaxLength(100)]
+  public string ModelType { get; set; } = "";
+
+  /// <summary>Model version string.</summary>
+  [MaxLength(50)]
+  public string ModelVersion { get; set; } = "1.0";
+
+  /// <summary>Optional parcel ID the prediction is for.</summary>
+  [MaxLength(50)]
+  public string? ParcelId { get; set; }
+
+  /// <summary>The predicted value (e.g., assessed value, classification label).</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal PredictedValue { get; set; }
+
+  /// <summary>Model confidence score (0-1).</summary>
+  public double Confidence { get; set; }
+
+  /// <summary>R-squared or accuracy metric for the model run.</summary>
+  public double ModelAccuracy { get; set; }
+
+  /// <summary>Mean absolute error from training/validation.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal MeanAbsoluteError { get; set; }
+
+  /// <summary>Root mean squared error from training/validation.</summary>
+  [Column(TypeName = "decimal(18,2)")]
+  public decimal RootMeanSquaredError { get; set; }
+
+  /// <summary>Number of features used in prediction.</summary>
+  public int FeatureCount { get; set; }
+
+  /// <summary>Number of training samples used.</summary>
+  public int TrainingSamples { get; set; }
+
+  /// <summary>Inference time in milliseconds.</summary>
+  public long InferenceTimeMs { get; set; }
+
+  /// <summary>JSON blob with input features used for prediction.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? InputFeatures { get; set; }
+
+  /// <summary>JSON blob with feature importances / SHAP values.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? FeatureImportances { get; set; }
+
+  /// <summary>JSON details with full model metrics, hyperparams, etc.</summary>
+  [Column(TypeName = "nvarchar(max)")]
+  public string? Details { get; set; }
+
+  [MaxLength(200)]
+  public string CreatedBy { get; set; } = "";
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/RcwCalculation.cs
+++ b/backend/src/TerraFusion.Core/Entities/RcwCalculation.cs
@@ -1,0 +1,65 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// R2 Wave 30 ΓÇö RCW calculation result with county isolation.
+/// Stores results from Washington State RCW exemption/special-use calculators.
+/// </summary>
+public class RcwCalculation
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public Guid CountyId { get; set; }
+
+    /// <summary>RCW statute: rcw_84_34 (Open Space), rcw_84_26 (Historic), rcw_84_36_381 (Senior/Disabled)</summary>
+    [Required]
+    [MaxLength(50)]
+    public string Statute { get; set; } = string.Empty;
+
+    [MaxLength(100)]
+    public string ParcelId { get; set; } = string.Empty;
+
+    /// <summary>Current Use classification for RCW 84.34.</summary>
+    [MaxLength(50)]
+    public string CurrentUseClassification { get; set; } = string.Empty;
+
+    /// <summary>Market value (full, unreduced).</summary>
+    public decimal MarketValue { get; set; }
+
+    /// <summary>Assessed / reduced value after exemption.</summary>
+    public decimal ReducedValue { get; set; }
+
+    /// <summary>Exemption amount (MarketValue - ReducedValue).</summary>
+    public decimal ExemptionAmount { get; set; }
+
+    /// <summary>Tax savings at the given levy rate.</summary>
+    public decimal TaxSavings { get; set; }
+
+    /// <summary>Levy rate used (mills / $1000 or percentage).</summary>
+    public double LevyRate { get; set; }
+
+    /// <summary>Tax year the calculation applies to.</summary>
+    public int TaxYear { get; set; }
+
+    /// <summary>Income (for Senior/Disabled means-test).</summary>
+    public decimal Income { get; set; }
+
+    /// <summary>JSON with statute-specific detail (e.g., age, classification, acreage).</summary>
+    public string Details { get; set; } = "{}";
+
+    /// <summary>Whether the applicant qualifies under this statute.</summary>
+    public bool Qualifies { get; set; }
+
+    /// <summary>Reason for disqualification (empty if qualifies).</summary>
+    [MaxLength(500)]
+    public string DisqualificationReason { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/RegressionAnalysis.cs
+++ b/backend/src/TerraFusion.Core/Entities/RegressionAnalysis.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Persistent record of an OLS multiple regression analysis on property valuation data.
+/// Stores coefficients, fit metrics, and diagnostic flags.
+/// Write lane: Forge (TerraForge).
+/// </summary>
+public class RegressionAnalysis
+{
+  public Guid Id { get; set; } = Guid.NewGuid();
+
+  [Required]
+  public Guid CountyId { get; set; }
+
+  /// <summary>Comma-separated parcel IDs used in the analysis sample.</summary>
+  [StringLength(8000)]
+  public string ParcelIds { get; set; } = string.Empty;
+
+  [Required]
+  [StringLength(100)]
+  public string DependentVariable { get; set; } = "assessed_value";
+
+  /// <summary>JSON array of independent variable names, e.g. ["sqft","acreage","age"].</summary>
+  [Required]
+  [StringLength(2000)]
+  public string IndependentVariables { get; set; } = "[]";
+
+  /// <summary>JSON array of coefficient values (same order as IndependentVariables).</summary>
+  [Required]
+  [StringLength(2000)]
+  public string Coefficients { get; set; } = "[]";
+
+  public double Intercept { get; set; }
+
+  public double RSquared { get; set; }
+
+  public double AdjustedRSquared { get; set; }
+
+  public double FStatistic { get; set; }
+
+  public double PValue { get; set; }
+
+  /// <summary>JSON array of standard errors for each coefficient.</summary>
+  [StringLength(2000)]
+  public string StandardErrors { get; set; } = "[]";
+
+  /// <summary>JSON object with diagnostic flags: heteroskedasticity, autocorrelation, normality.</summary>
+  [StringLength(4000)]
+  public string ResidualDiagnostics { get; set; } = "{}";
+
+  public int SampleSize { get; set; }
+
+  // ── Ownership ──
+  [StringLength(100)]
+  public string CreatedBy { get; set; } = "system";
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/RegressionAnalysis.cs
+++ b/backend/src/TerraFusion.Core/Entities/RegressionAnalysis.cs
@@ -52,7 +52,7 @@ public class RegressionAnalysis
 
   public int SampleSize { get; set; }
 
-  // ── Ownership ──
+  // ΓöÇΓöÇ Ownership ΓöÇΓöÇ
   [StringLength(100)]
   public string CreatedBy { get; set; } = "system";
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/backend/src/TerraFusion.Core/Entities/SpatialAnalysis.cs
+++ b/backend/src/TerraFusion.Core/Entities/SpatialAnalysis.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>Stores spatial autocorrelation analysis results (Moran's I, Local Moran, etc.).</summary>
+public class SpatialAnalysis
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public Guid Id { get; set; }
+
+  public Guid CountyId { get; set; }
+
+  /// <summary>Type of analysis: global_moran, local_moran, geary_c.</summary>
+  public string AnalysisType { get; set; } = "global_moran";
+
+  /// <summary>Variable analysed (e.g. "assessed_value").</summary>
+  public string VariableName { get; set; } = "assessed_value";
+
+  /// <summary>Weight matrix type: queen, rook, distance, knn.</summary>
+  public string WeightMatrixType { get; set; } = "queen";
+
+  /// <summary>Global statistic value.</summary>
+  public double StatisticValue { get; set; }
+
+  /// <summary>Expected value under null hypothesis of spatial randomness.</summary>
+  public double ExpectedValue { get; set; }
+
+  /// <summary>Variance under null hypothesis.</summary>
+  public double Variance { get; set; }
+
+  /// <summary>Z-score for significance testing.</summary>
+  public double ZScore { get; set; }
+
+  /// <summary>P-value (two-tailed).</summary>
+  public double PValue { get; set; }
+
+  /// <summary>Number of spatial units.</summary>
+  public int SampleSize { get; set; }
+
+  /// <summary>JSON-serialised local indicators (LISA) per observation.</summary>
+  public string LocalIndicators { get; set; } = "[]";
+
+  /// <summary>JSON-serialised cluster classification (HH, HL, LH, LL, NS).</summary>
+  public string ClusterMap { get; set; } = "[]";
+
+  public string CreatedBy { get; set; } = "system";
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/ValuationPipeline.cs
+++ b/backend/src/TerraFusion.Core/Entities/ValuationPipeline.cs
@@ -1,0 +1,78 @@
+// TerraFusion OS ΓÇö Wave 35: Valuation Pipeline
+// Tracks end-to-end valuation pipeline runs with stage-level metrics.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Records a full valuation pipeline execution across multiple stages
+/// (data ingestion, quality check, cost approach, sales comp, income approach,
+///  reconciliation, review, certification).
+/// </summary>
+public class ValuationPipeline
+{
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public int Id { get; set; }
+
+  /// <summary>County tenant key.</summary>
+  public Guid CountyId { get; set; }
+
+  /// <summary>Pipeline run name (e.g. "2026-annual-reval").</summary>
+  [MaxLength(200)]
+  public string PipelineName { get; set; } = string.Empty;
+
+  /// <summary>Tax year this pipeline targets.</summary>
+  public int TaxYear { get; set; }
+
+  /// <summary>Total parcels in scope.</summary>
+  public int TotalParcels { get; set; }
+
+  /// <summary>Parcels that completed all stages.</summary>
+  public int CompletedParcels { get; set; }
+
+  /// <summary>Parcels that failed at any stage.</summary>
+  public int FailedParcels { get; set; }
+
+  /// <summary>Parcels still in progress.</summary>
+  public int InProgressParcels { get; set; }
+
+  /// <summary>Current stage: ingestion|quality|cost|sales|income|reconciliation|review|certified.</summary>
+  [MaxLength(50)]
+  public string CurrentStage { get; set; } = "ingestion";
+
+  /// <summary>Overall status: queued|running|completed|failed|cancelled.</summary>
+  [MaxLength(30)]
+  public string Status { get; set; } = "queued";
+
+  /// <summary>Total duration in milliseconds.</summary>
+  public long DurationMs { get; set; }
+
+  /// <summary>Average value change percentage from prior year.</summary>
+  public double AvgValueChangePercent { get; set; }
+
+  /// <summary>Median value change percentage.</summary>
+  public double MedianValueChangePercent { get; set; }
+
+  /// <summary>Coefficient of dispersion (lower is better).</summary>
+  public double CoefficientOfDispersion { get; set; }
+
+  /// <summary>Price-related differential (ideal: 1.00).</summary>
+  public double PriceRelatedDifferential { get; set; }
+
+  /// <summary>Stage-level timing and counts (JSON).</summary>
+  [Column(TypeName = "text")]
+  public string? StageDetails { get; set; }
+
+  /// <summary>Error details (JSON).</summary>
+  [Column(TypeName = "text")]
+  public string? Errors { get; set; }
+
+  /// <summary>User who initiated the pipeline.</summary>
+  [MaxLength(200)]
+  public string? CreatedBy { get; set; }
+
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -97,6 +97,9 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<CamaCharacteristic> CamaCharacteristics { get; set; }
   public DbSet<CostMatrix> CostMatrices { get; set; }
 
+  // Forge Analytics (R2 Wave 26)
+  public DbSet<RegressionAnalysis> RegressionAnalyses { get; set; }
+
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }
   public DbSet<DossierEvidence> DossierEvidenceItems { get; set; }

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -104,6 +104,16 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<BayesianAnalysis> BayesianAnalyses { get; set; }
   public DbSet<MonteCarloSimulation> MonteCarloSimulations { get; set; }
 
+  // Forge Analytics (R2 Waves 28-35)
+  public DbSet<SpatialAnalysis> SpatialAnalyses { get; set; }
+  public DbSet<MarketAnalysis> MarketAnalyses { get; set; }
+  public DbSet<RcwCalculation> RcwCalculations { get; set; }
+  public DbSet<LevyCertification> LevyCertifications { get; set; }
+  public DbSet<DataQualityAssessment> DataQualityAssessments { get; set; }
+  public DbSet<EtlSyncJob> EtlSyncJobs { get; set; }
+  public DbSet<MlPrediction> MlPredictions { get; set; }
+  public DbSet<ValuationPipeline> ValuationPipelines { get; set; }
+
   // Dossier Document Management (R2 Wave 24)
   public DbSet<DossierDocument> DossierDocuments { get; set; }
   public DbSet<DossierEvidence> DossierEvidenceItems { get; set; }

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave26/R2Wave26OlsRegressionTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave26/R2Wave26OlsRegressionTests.cs
@@ -1,0 +1,610 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave26;
+
+[Trait("Category", "R2Wave26")]
+[Trait("Category", "OlsRegression")]
+public sealed class R2Wave26OlsRegressionTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private const string BentonFips = "003";
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+  {
+    return new ClaimsPrincipal(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w26-test-user"),
+      new Claim("userId", "w26-test-user"),
+    ], "TestAuth"));
+  }
+
+  private static ClaimsPrincipal CreateEmptyPrincipal()
+    => new(new ClaimsIdentity());
+
+  private static void AttachPrincipal(ControllerBase controller, ClaimsPrincipal principal)
+  {
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal },
+    };
+  }
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var costForge = new Mock<CostForgeService>(MockBehavior.Strict);
+    var costForgeAi = new Mock<CostForgeAIService>(MockBehavior.Strict);
+    var auditLogger = new Mock<AuditLogger>(MockBehavior.Strict);
+
+    var controller = new CostForgeController(
+      costForge.Object, costForgeAi.Object, db, auditLogger.Object,
+      NullLogger<CostForgeController>.Instance);
+
+    AttachPrincipal(controller, principal ?? CreatePrincipal(BentonCountyId));
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId)
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County
+      {
+        Id = countyId,
+        Name = "Benton",
+        State = "WA",
+        FipsCode = BentonFips,
+      });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Perfect linear relationship: value = 100 + 2*sqft + 3*acreage - 0.5*age
+  // ═══════════════════════════════════════════════════════════════
+
+  private static OlsRegressionRequest CreatePerfectLinearRequest()
+  {
+    // value = 100 + 2*sqft + 3*acreage - 0.5*age
+    return new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft", "acreage", "age" },
+      DependentVariable = "assessed_value",
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1000.0, 0.5, 10.0 }, Value = 100 + 2 * 1000 + 3 * 0.5 - 0.5 * 10 },   // 2096.5
+        new() { Features = new[] { 1500.0, 1.0, 20.0 }, Value = 100 + 2 * 1500 + 3 * 1.0 - 0.5 * 20 },   // 3093.0
+        new() { Features = new[] { 2000.0, 0.25, 5.0 }, Value = 100 + 2 * 2000 + 3 * 0.25 - 0.5 * 5 },   // 4098.25
+        new() { Features = new[] { 800.0, 2.0, 30.0 }, Value = 100 + 2 * 800 + 3 * 2.0 - 0.5 * 30 },     // 1691.0
+        new() { Features = new[] { 2500.0, 0.75, 15.0 }, Value = 100 + 2 * 2500 + 3 * 0.75 - 0.5 * 15 }, // 5094.75
+      }
+    };
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_ReturnsRSquaredNearOne()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_ReturnsRSquaredNearOne));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("rSquared").GetDouble().Should().BeGreaterThan(0.999);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_RecoversCorrectCoefficients()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_RecoversCorrectCoefficients));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var intercept = doc.RootElement.GetProperty("intercept").GetDouble();
+    intercept.Should().BeApproximately(100.0, 1.0);
+
+    var coeffArray = doc.RootElement.GetProperty("coefficients");
+    var sqftCoeff = coeffArray[0].GetProperty("coefficient").GetDouble();
+    sqftCoeff.Should().BeApproximately(2.0, 0.1);
+
+    var acreageCoeff = coeffArray[1].GetProperty("coefficient").GetDouble();
+    acreageCoeff.Should().BeApproximately(3.0, 0.1);
+
+    var ageCoeff = coeffArray[2].GetProperty("coefficient").GetDouble();
+    ageCoeff.Should().BeApproximately(-0.5, 0.1);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_HasCorrectSampleSize()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_HasCorrectSampleSize));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("sampleSize").GetInt32().Should().Be(5);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_ReturnsPredictions()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_ReturnsPredictions));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var predictions = doc.RootElement.GetProperty("predictions");
+    predictions.GetArrayLength().Should().Be(5);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_FStatNonNegative()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_FStatNonNegative));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    // Perfect fit: R²=1.0, F-stat → ∞ (clamped to 0 to avoid division by zero)
+    doc.RootElement.GetProperty("fStatistic").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_PerfectLinear_PersistsToDatabase()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_PerfectLinear_PersistsToDatabase));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var stored = await db.RegressionAnalyses.FirstOrDefaultAsync();
+    stored.Should().NotBeNull();
+    stored!.CountyId.Should().Be(BentonCountyId);
+    stored.SampleSize.Should().Be(5);
+    stored.RSquared.Should().BeGreaterThan(0.99);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Noisy data — R² should be moderate (not 1.0)
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task RunOlsRegression_NoisyData_RSquaredBelowOne()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_NoisyData_RSquaredBelowOne));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft", "acreage", "age" },
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1200.0, 0.3, 12.0 }, Value = 250000 },
+        new() { Features = new[] { 1800.0, 0.5, 8.0 },  Value = 350000 },
+        new() { Features = new[] { 2200.0, 1.0, 25.0 }, Value = 310000 },
+        new() { Features = new[] { 900.0, 0.2, 40.0 },  Value = 180000 },
+        new() { Features = new[] { 3000.0, 2.0, 5.0 },  Value = 520000 },
+        new() { Features = new[] { 1500.0, 0.4, 18.0 }, Value = 285000 },
+        new() { Features = new[] { 2600.0, 1.5, 3.0 },  Value = 470000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var r2 = doc.RootElement.GetProperty("rSquared").GetDouble();
+    r2.Should().BeGreaterThan(0.5).And.BeLessThan(1.0);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_NoisyData_AdjustedRSquaredLessThanRSquared()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_NoisyData_AdjustedRSquaredLessThanRSquared));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft", "acreage", "age" },
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1200.0, 0.3, 12.0 }, Value = 250000 },
+        new() { Features = new[] { 1800.0, 0.5, 8.0 },  Value = 350000 },
+        new() { Features = new[] { 2200.0, 1.0, 25.0 }, Value = 310000 },
+        new() { Features = new[] { 900.0, 0.2, 40.0 },  Value = 180000 },
+        new() { Features = new[] { 3000.0, 2.0, 5.0 },  Value = 520000 },
+        new() { Features = new[] { 1500.0, 0.4, 18.0 }, Value = 285000 },
+        new() { Features = new[] { 2600.0, 1.5, 3.0 },  Value = 470000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var r2 = doc.RootElement.GetProperty("rSquared").GetDouble();
+    var adjR2 = doc.RootElement.GetProperty("adjustedRSquared").GetDouble();
+    adjR2.Should().BeLessThanOrEqualTo(r2);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Edge cases
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task RunOlsRegression_TooFewObservations_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_TooFewObservations_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1000.0, 0.5, 10.0 }, Value = 250000 },
+        new() { Features = new[] { 2000.0, 1.0, 20.0 }, Value = 350000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_EmptyObservations_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_EmptyObservations_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest { Observations = new() };
+    var result = await controller.RunOlsRegression(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_NoCountyContext_ReturnsUnauthorized()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_NoCountyContext_ReturnsUnauthorized));
+    var controller = CreateController(db, CreateEmptyPrincipal());
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_SingleFeature_Works()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_SingleFeature_Works));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft" },
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1000.0 }, Value = 200000 },
+        new() { Features = new[] { 1500.0 }, Value = 300000 },
+        new() { Features = new[] { 2000.0 }, Value = 400000 },
+        new() { Features = new[] { 2500.0 }, Value = 500000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    // Perfect linear: R² should be ~1.0
+    doc.RootElement.GetProperty("rSquared").GetDouble().Should().BeGreaterThan(0.99);
+    doc.RootElement.GetProperty("coefficients").GetArrayLength().Should().Be(1);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // Retrieval endpoints
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task GetRegressionResult_ExistingId_ReturnsStored()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionResult_ExistingId_ReturnsStored));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // First run a regression
+    var runResult = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    var ok = runResult.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+    var id = doc.RootElement.GetProperty("id").GetGuid();
+
+    // Retrieve it
+    var getResult = await controller.GetRegressionResult(id);
+    var getOk = getResult.Should().BeOfType<OkObjectResult>().Subject;
+    var getJson = System.Text.Json.JsonSerializer.Serialize(getOk.Value);
+    var getDoc = System.Text.Json.JsonDocument.Parse(getJson);
+
+    getDoc.RootElement.GetProperty("rSquared").GetDouble().Should().BeGreaterThan(0.99);
+    getDoc.RootElement.GetProperty("sampleSize").GetInt32().Should().Be(5);
+  }
+
+  [Fact]
+  public async Task GetRegressionResult_NonexistentId_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionResult_NonexistentId_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.GetRegressionResult(Guid.NewGuid());
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetRegressionResult_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionResult_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // Run from Benton
+    var runResult = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    var ok = runResult.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+    var id = doc.RootElement.GetProperty("id").GetGuid();
+
+    // Try from different county
+    var otherCountyId = Guid.NewGuid();
+    await SeedCounty(db, otherCountyId);
+    var otherController = CreateController(db, CreatePrincipal(otherCountyId, "OTHER"));
+
+    var result = await otherController.GetRegressionResult(id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetRegressionDiagnostics_ExistingId_ReturnsDiagnostics()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionDiagnostics_ExistingId_ReturnsDiagnostics));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var runResult = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    var ok = runResult.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+    var id = doc.RootElement.GetProperty("id").GetGuid();
+
+    var diagResult = await controller.GetRegressionDiagnostics(id);
+    var diagOk = diagResult.Should().BeOfType<OkObjectResult>().Subject;
+    var diagJson = System.Text.Json.JsonSerializer.Serialize(diagOk.Value);
+    var diagDoc = System.Text.Json.JsonDocument.Parse(diagJson);
+
+    diagDoc.RootElement.GetProperty("rSquared").GetDouble().Should().BeGreaterThan(0.99);
+    diagDoc.RootElement.GetProperty("sampleSize").GetInt32().Should().Be(5);
+  }
+
+  [Fact]
+  public async Task GetRegressionHistory_EmptyInitially_ReturnsEmptyList()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionHistory_EmptyInitially_ReturnsEmptyList));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.GetRegressionHistory(10);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task GetRegressionHistory_AfterRun_ContainsEntry()
+  {
+    using var db = CreateDbContext(nameof(GetRegressionHistory_AfterRun_ContainsEntry));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunOlsRegression(CreatePerfectLinearRequest());
+
+    var result = await controller.GetRegressionHistory(10);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  // R² bounds and mathematical properties
+  // ═══════════════════════════════════════════════════════════════
+
+  [Fact]
+  public async Task RunOlsRegression_RSquared_BoundedZeroToOne()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_RSquared_BoundedZeroToOne));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft", "acreage" },
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1000.0, 0.5 }, Value = 200000 },
+        new() { Features = new[] { 1500.0, 0.8 }, Value = 340000 },
+        new() { Features = new[] { 1200.0, 1.0 }, Value = 220000 },
+        new() { Features = new[] { 2000.0, 0.3 }, Value = 380000 },
+        new() { Features = new[] { 1800.0, 1.5 }, Value = 410000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var r2 = doc.RootElement.GetProperty("rSquared").GetDouble();
+    r2.Should().BeGreaterThanOrEqualTo(0.0).And.BeLessThanOrEqualTo(1.0);
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_Diagnostics_ContainsExpectedKeys()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_Diagnostics_ContainsExpectedKeys));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var diag = doc.RootElement.GetProperty("diagnostics");
+    diag.TryGetProperty("heteroskedasticity", out _).Should().BeTrue();
+    diag.TryGetProperty("autocorrelation", out _).Should().BeTrue();
+    diag.TryGetProperty("normality", out _).Should().BeTrue();
+    diag.TryGetProperty("residualStd", out _).Should().BeTrue();
+    diag.TryGetProperty("maxAbsResidual", out _).Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_StandardErrors_AllPositive()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_StandardErrors_AllPositive));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "sqft", "acreage", "age" },
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 1200.0, 0.3, 12.0 }, Value = 250000 },
+        new() { Features = new[] { 1800.0, 0.5, 8.0 },  Value = 350000 },
+        new() { Features = new[] { 2200.0, 1.0, 25.0 }, Value = 310000 },
+        new() { Features = new[] { 900.0, 0.2, 40.0 },  Value = 180000 },
+        new() { Features = new[] { 3000.0, 2.0, 5.0 },  Value = 520000 },
+        new() { Features = new[] { 1500.0, 0.4, 18.0 }, Value = 285000 },
+        new() { Features = new[] { 2600.0, 1.5, 3.0 },  Value = 470000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var coeffs = doc.RootElement.GetProperty("coefficients");
+    foreach (var coeff in coeffs.EnumerateArray())
+    {
+      coeff.GetProperty("standardError").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+    }
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_ReturnedId_IsValidGuid()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_ReturnedId_IsValidGuid));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunOlsRegression(CreatePerfectLinearRequest());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var id = doc.RootElement.GetProperty("id").GetGuid();
+    id.Should().NotBeEmpty();
+  }
+
+  [Fact]
+  public async Task RunOlsRegression_CustomFeatureNames_Persisted()
+  {
+    using var db = CreateDbContext(nameof(RunOlsRegression_CustomFeatureNames_Persisted));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var request = new OlsRegressionRequest
+    {
+      FeatureNames = new[] { "bedroom_count", "bathroom_count" },
+      DependentVariable = "sale_price",
+      Observations = new List<RegressionObservation>
+      {
+        new() { Features = new[] { 3.0, 2.0 }, Value = 300000 },
+        new() { Features = new[] { 4.0, 3.0 }, Value = 450000 },
+        new() { Features = new[] { 2.0, 1.0 }, Value = 200000 },
+        new() { Features = new[] { 5.0, 3.0 }, Value = 500000 },
+      }
+    };
+
+    var result = await controller.RunOlsRegression(request);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+    var doc = System.Text.Json.JsonDocument.Parse(json);
+
+    var coeffs = doc.RootElement.GetProperty("coefficients");
+    coeffs[0].GetProperty("feature").GetString().Should().Be("bedroom_count");
+    coeffs[1].GetProperty("feature").GetString().Should().Be("bathroom_count");
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave28/R2Wave28SpatialAutocorrelationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave28/R2Wave28SpatialAutocorrelationTests.cs
@@ -1,0 +1,373 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave28;
+
+[Trait("Category", "R2Wave28")]
+[Trait("Category", "SpatialAutocorrelation")]
+public sealed class R2Wave28SpatialAutocorrelationTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string code = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", code),
+      new Claim("sub", "w28-test"),
+      new Claim("userId", "w28-test"),
+    ], "TestAuth"));
+
+  private static ClaimsPrincipal CreateEmptyPrincipal() => new(new ClaimsIdentity());
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? p = null)
+  {
+    var c = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db, new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+    c.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = p ?? CreatePrincipal(BentonCountyId) }
+    };
+    return c;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid id)
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == id))
+    {
+      db.Counties.Add(new County { Id = id, Name = "Benton", State = "WA", FipsCode = "003" });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static System.Text.Json.JsonDocument Parse(object value)
+    => System.Text.Json.JsonDocument.Parse(System.Text.Json.JsonSerializer.Serialize(value));
+
+  // ΓöÇΓöÇ Clustered data: high values near each other ΓöÇΓöÇ
+
+  private static SpatialAutocorrelationRequest CreateClusteredRequest()
+  {
+    return new SpatialAutocorrelationRequest
+    {
+      VariableName = "assessed_value",
+      WeightType = "distance",
+      Observations = new()
+      {
+        // Cluster of high values (north)
+        new() { X = 0, Y = 10, Value = 500000 },
+        new() { X = 1, Y = 10, Value = 510000 },
+        new() { X = 0, Y = 11, Value = 505000 },
+        new() { X = 1, Y = 11, Value = 520000 },
+        // Cluster of low values (south)
+        new() { X = 0, Y = 0, Value = 150000 },
+        new() { X = 1, Y = 0, Value = 140000 },
+        new() { X = 0, Y = 1, Value = 145000 },
+        new() { X = 1, Y = 1, Value = 135000 },
+      }
+    };
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Global Moran's I
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task MoranI_ClusteredData_PositiveAutocorrelation()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ClusteredData_PositiveAutocorrelation));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var doc = Parse(ok.Value!);
+
+    // Clustered data should have Moran's I > expected value (positive autocorrelation)
+    double moranI = doc.RootElement.GetProperty("moranI").GetDouble();
+    double expectedI = doc.RootElement.GetProperty("expectedI").GetDouble();
+    moranI.Should().BeGreaterThan(expectedI);
+  }
+
+  [Fact]
+  public async Task MoranI_ClusteredData_InterpretationIsClustering()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ClusteredData_InterpretationIsClustering));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("interpretation").GetString()
+      .Should().Contain("clustering");
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsValidZScoreAndPValue()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsValidZScoreAndPValue));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("pValue").GetDouble()
+      .Should().BeGreaterThanOrEqualTo(0).And.BeLessThanOrEqualTo(1);
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsClusterSummary()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsClusterSummary));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    var clusters = doc.RootElement.GetProperty("clusterSummary");
+    clusters.TryGetProperty("highHigh", out _).Should().BeTrue();
+    clusters.TryGetProperty("lowLow", out _).Should().BeTrue();
+    clusters.TryGetProperty("notSignificant", out _).Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task MoranI_ReturnsLocalIndicators()
+  {
+    using var db = CreateDbContext(nameof(MoranI_ReturnsLocalIndicators));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("localIndicators").GetArrayLength().Should().Be(8);
+    doc.RootElement.GetProperty("clusters").GetArrayLength().Should().Be(8);
+  }
+
+  [Fact]
+  public async Task MoranI_PersistsToDatabase()
+  {
+    using var db = CreateDbContext(nameof(MoranI_PersistsToDatabase));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var stored = await db.SpatialAnalyses.FirstOrDefaultAsync();
+    stored.Should().NotBeNull();
+    stored!.AnalysisType.Should().Be("global_moran");
+    stored.SampleSize.Should().Be(8);
+  }
+
+  [Fact]
+  public async Task MoranI_TooFewObs_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(MoranI_TooFewObs_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = new SpatialAutocorrelationRequest
+    {
+      Observations = new()
+      {
+        new() { X = 0, Y = 0, Value = 100000 },
+        new() { X = 1, Y = 1, Value = 200000 },
+      }
+    };
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task MoranI_NoCounty_ReturnsUnauthorized()
+  {
+    using var db = CreateDbContext(nameof(MoranI_NoCounty_ReturnsUnauthorized));
+    var ctrl = CreateController(db, CreateEmptyPrincipal());
+    var result = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Geary's C
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GearyC_ClusteredData_LessThanOne()
+  {
+    using var db = CreateDbContext(nameof(GearyC_ClusteredData_LessThanOne));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGearyC(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    // Clustered data: Geary's C < 1 indicates positive autocorrelation
+    doc.RootElement.GetProperty("gearyC").GetDouble().Should().BeLessThan(1.0);
+  }
+
+  [Fact]
+  public async Task GearyC_InterpretationPositive()
+  {
+    using var db = CreateDbContext(nameof(GearyC_InterpretationPositive));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.RunGearyC(CreateClusteredRequest());
+    var doc = Parse(((OkObjectResult)result).Value!);
+
+    doc.RootElement.GetProperty("interpretation").GetString()
+      .Should().Contain("positive");
+  }
+
+  [Fact]
+  public async Task GearyC_PersistsAsGearyType()
+  {
+    using var db = CreateDbContext(nameof(GearyC_PersistsAsGearyType));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGearyC(CreateClusteredRequest());
+    var stored = await db.SpatialAnalyses.FirstOrDefaultAsync();
+    stored!.AnalysisType.Should().Be("geary_c");
+  }
+
+  [Fact]
+  public async Task GearyC_TooFewObs_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(GearyC_TooFewObs_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = new SpatialAutocorrelationRequest
+    {
+      Observations = new() { new() { X = 0, Y = 0, Value = 100000 } }
+    };
+    var result = await ctrl.RunGearyC(request);
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval endpoints
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetSpatialResult_ExistingId_ReturnsStored()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialResult_ExistingId_ReturnsStored));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var runResult = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var id = Parse(((OkObjectResult)runResult).Value!).RootElement.GetProperty("id").GetGuid();
+
+    var getResult = await ctrl.GetSpatialResult(id);
+    var doc = Parse(((OkObjectResult)getResult).Value!);
+    doc.RootElement.GetProperty("analysisType").GetString().Should().Be("global_moran");
+    doc.RootElement.GetProperty("sampleSize").GetInt32().Should().Be(8);
+  }
+
+  [Fact]
+  public async Task GetSpatialResult_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialResult_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var runResult = await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    var id = Parse(((OkObjectResult)runResult).Value!).RootElement.GetProperty("id").GetGuid();
+
+    var otherCounty = Guid.NewGuid();
+    await SeedCounty(db, otherCounty);
+    var other = CreateController(db, CreatePrincipal(otherCounty, "OTHER"));
+    var result = await other.GetSpatialResult(id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetSpatialHistory_ReturnsEntries()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialHistory_ReturnsEntries));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    await ctrl.RunGlobalMoranI(CreateClusteredRequest());
+    await ctrl.RunGearyC(CreateClusteredRequest());
+
+    var result = await ctrl.GetSpatialHistory(10);
+    var doc = Parse(((OkObjectResult)result).Value!);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task GetSpatialHistory_Empty_ReturnsZeroCount()
+  {
+    using var db = CreateDbContext(nameof(GetSpatialHistory_Empty_ReturnsZeroCount));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var result = await ctrl.GetSpatialHistory(10);
+    var doc = Parse(((OkObjectResult)result).Value!);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Weight types
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task MoranI_KnnWeight_ProducesResult()
+  {
+    using var db = CreateDbContext(nameof(MoranI_KnnWeight_ProducesResult));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = CreateClusteredRequest();
+    request.WeightType = "knn";
+
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<OkObjectResult>();
+  }
+
+  [Fact]
+  public async Task MoranI_InverseDistanceWeight_ProducesResult()
+  {
+    using var db = CreateDbContext(nameof(MoranI_InverseDistanceWeight_ProducesResult));
+    await SeedCounty(db, BentonCountyId);
+    var ctrl = CreateController(db);
+
+    var request = CreateClusteredRequest();
+    request.WeightType = "inverse_distance";
+
+    var result = await ctrl.RunGlobalMoranI(request);
+    result.Should().BeOfType<OkObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave29/R2Wave29MarketAnalysisTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave29/R2Wave29MarketAnalysisTests.cs
@@ -1,0 +1,456 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave29;
+
+[Trait("Category", "R2Wave29")]
+[Trait("Category", "MarketAnalysis")]
+public sealed class R2Wave29MarketAnalysisTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+  private const string BentonFips = "003";
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w29-test-user"),
+      new Claim("userId", "w29-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = BentonFips)
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static List<SaleRecord> MakeSales(int count = 10, decimal basePrice = 250_000m)
+  {
+    var sales = new List<SaleRecord>();
+    for (int i = 0; i < count; i++)
+    {
+      sales.Add(new SaleRecord
+      {
+        ParcelId = $"P-{i:000}",
+        SalePrice = basePrice + i * 10_000m,
+        AssessedValue = (basePrice + i * 10_000m) * 0.95m,
+        SquareFeet = 1500m + i * 100m,
+        SaleDate = new DateTime(2025, 1, 1).AddMonths(i),
+      });
+    }
+    return sales;
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Comparable Sales Analysis
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task ComparableSales_ReturnsMedianAndMean()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_ReturnsMedianAndMean));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { MarketAreaName = "NW Kennewick", Sales = MakeSales(5) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    var root = doc.RootElement;
+
+    root.GetProperty("analysisType").GetString().Should().Be("comparable_sales");
+    root.GetProperty("sampleSize").GetInt32().Should().Be(5);
+    root.GetProperty("medianSalePrice").GetDecimal().Should().BeGreaterThan(0);
+    root.GetProperty("meanSalePrice").GetDecimal().Should().BeGreaterThan(0);
+    root.GetProperty("marketAreaName").GetString().Should().Be("NW Kennewick");
+  }
+
+  [Fact]
+  public async Task ComparableSales_ComputesPricePerSqft()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_ComputesPricePerSqft));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(4) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("medianPricePerSqft").GetDecimal().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task ComparableSales_ComputesCodAndPrd()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_ComputesCodAndPrd));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(10) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("coefficientOfDispersion").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+    doc.RootElement.GetProperty("priceRelatedDifferential").GetDouble().Should().BeGreaterThan(0);
+    doc.RootElement.GetProperty("medianRatio").GetDouble().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task ComparableSales_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+
+    var entities = await db.Set<MarketAnalysis>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].AnalysisType.Should().Be("comparable_sales");
+    entities[0].CountyId.Should().Be(BentonCountyId);
+  }
+
+  [Fact]
+  public async Task ComparableSales_RejectsTooFewSales()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_RejectsTooFewSales));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(2) });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Time Trend Analysis
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task TimeTrend_ComputesPositiveTrendForRisingPrices()
+  {
+    using var db = CreateDbContext(nameof(TimeTrend_ComputesPositiveTrendForRisingPrices));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // Prices rise each month
+    var sales = MakeSales(6);
+
+    var result = await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { MarketAreaName = "Richland", Sales = sales });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("analysisType").GetString().Should().Be("time_trend");
+    doc.RootElement.GetProperty("timeTrendCoefficient").GetDouble().Should().BeGreaterThan(0,
+        "prices are monotonically increasing, so the trend should be positive");
+    doc.RootElement.GetProperty("timeTrendRSquared").GetDouble().Should().BeGreaterThan(0.5);
+  }
+
+  [Fact]
+  public async Task TimeTrend_RecordsPeriodStartAndEnd()
+  {
+    using var db = CreateDbContext(nameof(TimeTrend_RecordsPeriodStartAndEnd));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var sales = MakeSales(4);
+    var result = await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { Sales = sales });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("periodStart").GetDateTime().Should().Be(new DateTime(2025, 1, 1));
+    doc.RootElement.GetProperty("periodEnd").GetDateTime().Should().Be(new DateTime(2025, 4, 1));
+  }
+
+  [Fact]
+  public async Task TimeTrend_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(TimeTrend_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { Sales = MakeSales(5) });
+
+    var entities = await db.Set<MarketAnalysis>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].AnalysisType.Should().Be("time_trend");
+  }
+
+  [Fact]
+  public async Task TimeTrend_RejectsTooFewSales()
+  {
+    using var db = CreateDbContext(nameof(TimeTrend_RejectsTooFewSales));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { Sales = MakeSales(2) });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Ratio Study
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task RatioStudy_ComputesMedianRatioAndCod()
+  {
+    using var db = CreateDbContext(nameof(RatioStudy_ComputesMedianRatioAndCod));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunRatioStudy(
+      new MarketAnalysisRequest { Sales = MakeSales(8) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("analysisType").GetString().Should().Be("ratio_study");
+    // 0.95 ratio since assessed = 0.95 * salePrice
+    doc.RootElement.GetProperty("medianRatio").GetDouble().Should().BeApproximately(0.95, 0.01);
+    doc.RootElement.GetProperty("coefficientOfDispersion").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+    doc.RootElement.GetProperty("priceRelatedDifferential").GetDouble().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task RatioStudy_IncludesIaaoCompliance()
+  {
+    using var db = CreateDbContext(nameof(RatioStudy_IncludesIaaoCompliance));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunRatioStudy(
+      new MarketAnalysisRequest { Sales = MakeSales(8) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.TryGetProperty("iaaoCompliant", out _).Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task RatioStudy_IncludesPercentiles()
+  {
+    using var db = CreateDbContext(nameof(RatioStudy_IncludesPercentiles));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.RunRatioStudy(
+      new MarketAnalysisRequest { Sales = MakeSales(10) });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    var metricsStr = doc.RootElement.GetProperty("additionalMetrics").GetString();
+    metricsStr.Should().NotBeNullOrEmpty();
+    var metrics = JsonDocument.Parse(metricsStr!);
+    metrics.RootElement.TryGetProperty("p10", out _).Should().BeTrue();
+    metrics.RootElement.TryGetProperty("p25", out _).Should().BeTrue();
+    metrics.RootElement.TryGetProperty("p75", out _).Should().BeTrue();
+    metrics.RootElement.TryGetProperty("p90", out _).Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task RatioStudy_RejectsTooFewValidSales()
+  {
+    using var db = CreateDbContext(nameof(RatioStudy_RejectsTooFewValidSales));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // 2 valid sales (below min of 3)
+    var sales = MakeSales(2);
+    var result = await controller.RunRatioStudy(
+      new MarketAnalysisRequest { Sales = sales });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval Endpoints
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetMarketAnalysis_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetMarketAnalysis_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // Create one analysis
+    await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { MarketAreaName = "Test Area", Sales = MakeSales(5) });
+    var saved = await db.Set<MarketAnalysis>().FirstAsync();
+
+    var result = await controller.GetMarketAnalysis(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("id").GetInt32().Should().Be(saved.Id);
+    doc.RootElement.GetProperty("marketAreaName").GetString().Should().Be("Test Area");
+  }
+
+  [Fact]
+  public async Task GetMarketAnalysis_ReturnsNotFoundForWrongCounty()
+  {
+    using var db = CreateDbContext(nameof(GetMarketAnalysis_ReturnsNotFoundForWrongCounty));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    // Create an analysis as Benton
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+    var saved = await db.Set<MarketAnalysis>().FirstAsync();
+
+    // Try to retrieve as Other county
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetMarketAnalysis(saved.Id);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_ReturnsCountyScopedResults()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_ReturnsCountyScopedResults));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+    await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { Sales = MakeSales(4) });
+
+    var result = await controller.GetMarketAnalysisHistory();
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersOnAnalysisType()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersOnAnalysisType));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+    await controller.RunTimeTrendAnalysis(
+      new TimeTrendRequest { Sales = MakeSales(4) });
+
+    var result = await controller.GetMarketAnalysisHistory(analysisType: "time_trend");
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // County Isolation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task ComparableSales_RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(ComparableSales_RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+
+  [Fact]
+  public async Task History_IsolatesCounties()
+  {
+    using var db = CreateDbContext(nameof(History_IsolatesCounties));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.RunComparableSalesAnalysis(
+      new MarketAnalysisRequest { Sales = MakeSales(5) });
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetMarketAnalysisHistory();
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(0);
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave30/R2Wave30RcwCalculatorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave30/R2Wave30RcwCalculatorTests.cs
@@ -1,0 +1,434 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave30;
+
+[Trait("Category", "R2Wave30")]
+[Trait("Category", "RcwCalculators")]
+public sealed class R2Wave30RcwCalculatorTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w30-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // RCW 84.34 ΓÇö Open Space / Current Use
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task Rcw8434_FarmAndAgricultural_ReducesValue()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_FarmAndAgricultural_ReducesValue));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      ParcelId = "P-001",
+      Classification = "farm_and_agricultural",
+      MarketValue = 500_000m,
+      Acreage = 20m,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_34");
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    // 20 acres * $500/acre = $10,000 reduced value
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(10_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(490_000m);
+    doc.RootElement.GetProperty("taxSavings").GetDecimal().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task Rcw8434_TooFewAcres_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_TooFewAcres_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 300_000m,
+      Acreage = 3m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("5 acres");
+  }
+
+  [Fact]
+  public async Task Rcw8434_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(Rcw8434_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 400_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+
+    var entities = await db.Set<RcwCalculation>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].Statute.Should().Be("rcw_84_34");
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // RCW 84.26 ΓÇö Historic Property
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task Rcw8426_QualifiedRehab_ReducesToPreRehabValue()
+  {
+    using var db = CreateDbContext(nameof(Rcw8426_QualifiedRehab_ReducesToPreRehabValue));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8426(new Rcw8426Request
+    {
+      ParcelId = "H-001",
+      MarketValue = 400_000m,
+      PreRehabValue = 200_000m,
+      RehabilitationCost = 100_000m, // 50% of pre-rehab ΓåÆ qualifies (>=25%)
+      YearDesignated = 2020,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_26");
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(200_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(200_000m);
+    doc.RootElement.GetProperty("yearsRemaining").GetInt32().Should().BeGreaterThanOrEqualTo(0);
+  }
+
+  [Fact]
+  public async Task Rcw8426_InsufficientRehab_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8426_InsufficientRehab_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8426(new Rcw8426Request
+    {
+      MarketValue = 400_000m,
+      PreRehabValue = 200_000m,
+      RehabilitationCost = 10_000m, // 5% ΓÇö below 25% threshold
+      YearDesignated = 2020,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("25%");
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // RCW 84.36.381 ΓÇö Senior/Disabled
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task Rcw8436381_Tier1_FullExemption()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier1_FullExemption));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      ParcelId = "S-001",
+      MarketValue = 300_000m,
+      Age = 65,
+      Income = 30_000m,
+      LevyRate = 10.0,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_1");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(150_000m);
+    doc.RootElement.GetProperty("exemptionAmount").GetDecimal().Should().Be(150_000m);
+  }
+
+  [Fact]
+  public async Task Rcw8436381_Tier2_PartialExemption()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier2_PartialExemption));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 62,
+      Income = 45_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_2");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(200_000m);
+  }
+
+  [Fact]
+  public async Task Rcw8436381_Tier3_ReducedRate()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_Tier3_ReducedRate));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 70,
+      Income = 60_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_3");
+    doc.RootElement.GetProperty("reducedValue").GetDecimal().Should().Be(270_000m); // 90%
+  }
+
+  [Fact]
+  public async Task Rcw8436381_OverIncome_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_OverIncome_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 65,
+      Income = 100_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("over_income");
+  }
+
+  [Fact]
+  public async Task Rcw8436381_TooYoungNotDisabled_DoesNotQualify()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_TooYoungNotDisabled_DoesNotQualify));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 50,
+      IsDisabled = false,
+      Income = 30_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("disqualificationReason").GetString().Should().Contain("61");
+  }
+
+  [Fact]
+  public async Task Rcw8436381_DisabledPersonQualifies()
+  {
+    using var db = CreateDbContext(nameof(Rcw8436381_DisabledPersonQualifies));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m,
+      Age = 45,
+      IsDisabled = true,
+      Income = 30_000m,
+      LevyRate = 10.0,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("qualifies").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("tier").GetString().Should().Be("tier_1");
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval & County Isolation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetRcwCalculation_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetRcwCalculation_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      ParcelId = "P-001", MarketValue = 500_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    var saved = await db.Set<RcwCalculation>().FirstAsync();
+
+    var result = await controller.GetRcwCalculation(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("id").GetInt32().Should().Be(saved.Id);
+    doc.RootElement.GetProperty("statute").GetString().Should().Be("rcw_84_34");
+  }
+
+  [Fact]
+  public async Task GetRcwCalculation_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetRcwCalculation_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 100_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    var saved = await db.Set<RcwCalculation>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetRcwCalculation(saved.Id);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersOnStatute()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersOnStatute));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 400_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+    await controller.CalculateRcw8436381(new Rcw8436381Request
+    {
+      MarketValue = 300_000m, Age = 65, Income = 30_000m, LevyRate = 10.0,
+    });
+
+    var result = await controller.GetRcwHistory(statute: "rcw_84_34");
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.CalculateRcw8434(new Rcw8434Request
+    {
+      MarketValue = 200_000m, Acreage = 10m, LevyRate = 10.0,
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave31/R2Wave31LevyCertificationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave31/R2Wave31LevyCertificationTests.cs
@@ -1,0 +1,401 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave31;
+
+[Trait("Category", "R2Wave31")]
+[Trait("Category", "LevyCertification")]
+public sealed class R2Wave31LevyCertificationTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w31-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Levy Calculation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task CalculateLevy_WithinLimits_ReturnsFullAmount()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_WithinLimits_ReturnsFullAmount));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "FD-1",
+      DistrictName = "Fire District 1",
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_005_000m, // 0.5% increase ΓÇö within 1%
+      AssessedValue = 500_000_000m,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().Be(1_005_000m);
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("withinConstitutionalLimit").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("status").GetString().Should().Be("draft");
+  }
+
+  [Fact]
+  public async Task CalculateLevy_Exceeds1Percent_ReducesToStatutoryLimit()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_Exceeds1Percent_ReducesToStatutoryLimit));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_100_000m, // 10% increase ΓÇö exceeds 1%
+      AssessedValue = 500_000_000m,
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().BeLessThan(1_100_000m);
+    doc.RootElement.GetProperty("reductionAmount").GetDecimal().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task CalculateLevy_NewConstruction_AddsToLimit()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_NewConstruction_AddsToLimit));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 1_000_000m,
+      RequestedLevy = 1_020_000m,
+      AssessedValue = 500_000_000m,
+      NewConstructionValue = 10_000_000m, // Adds NC at existing rate
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    // Statutory limit = 1,010,000 + (10M * 2.0/1000) = 1,010,000 + 20,000 = 1,030,000
+    doc.RootElement.GetProperty("statutoryLimit").GetDecimal().Should().BeGreaterThan(1_010_000m);
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task CalculateLevy_ExceedsConstitutionalLimit_ForcesCompliance()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_ExceedsConstitutionalLimit_ForcesCompliance));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // Tiny AV ΓåÆ rate would be very high
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      PriorYearLevy = 100_000m,
+      RequestedLevy = 100_000m,
+      AssessedValue = 5_000_000m, // rate = 20.0 per $1000 ΓÇö exceeds 10.0
+      TaxYear = 2026,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("levyRate").GetDouble().Should().Be(10.0);
+    doc.RootElement.GetProperty("withinConstitutionalLimit").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("wasReduced").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("certifiedLevy").GetDecimal().Should().Be(50_000m); // 5M * 10/1000
+  }
+
+  [Fact]
+  public async Task CalculateLevy_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(CalculateLevy_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "CTY",
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+
+    var entities = await db.Set<LevyCertification>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].DistrictCode.Should().Be("CTY");
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Balance Test (Prorationing)
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task BalanceTest_WithinAggregate_Passes()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_WithinAggregate_Passes));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new()
+      {
+        new() { DistrictCode = "CTY", RequestedLevy = 1_000_000m, AssessedValue = 1_000_000_000m },
+        new() { DistrictCode = "SCH", RequestedLevy = 2_000_000m, AssessedValue = 1_000_000_000m },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("aggregatePass").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("constitutionalPass").GetBoolean().Should().BeTrue();
+    doc.RootElement.GetProperty("prorationRequired").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("districtCount").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task BalanceTest_ExceedsAggregate_RequiresProration()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_ExceedsAggregate_RequiresProration));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new()
+      {
+        new() { DistrictCode = "CTY", RequestedLevy = 3_000_000m, AssessedValue = 500_000_000m }, // 6.0
+        new() { DistrictCode = "SCH", RequestedLevy = 1_000_000m, AssessedValue = 500_000_000m }, // 2.0
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("totalRate").GetDouble().Should().BeGreaterThan(5.90);
+    doc.RootElement.GetProperty("aggregatePass").GetBoolean().Should().BeFalse();
+    doc.RootElement.GetProperty("prorationRequired").GetBoolean().Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task BalanceTest_EmptyDistricts_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(BalanceTest_EmptyDistricts_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.LevyBalanceTest(new LevyBalanceTestRequest
+    {
+      TaxYear = 2026,
+      Districts = new(),
+    });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Certification Workflow
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task CertifyLevy_TransitionsToCertified()
+  {
+    using var db = CreateDbContext(nameof(CertifyLevy_TransitionsToCertified));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var result = await controller.CertifyLevy(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("status").GetString().Should().Be("certified");
+  }
+
+  [Fact]
+  public async Task CertifyLevy_AlreadyCertified_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(CertifyLevy_AlreadyCertified_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    await controller.CertifyLevy(saved.Id);
+    var result = await controller.CertifyLevy(saved.Id);
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval & County Isolation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetLevyCertification_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetLevyCertification_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      DistrictCode = "CTY",
+      RequestedLevy = 500_000m,
+      AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var result = await controller.GetLevyCertification(saved.Id);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("districtCode").GetString().Should().Be("CTY");
+  }
+
+  [Fact]
+  public async Task GetLevyCertification_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetLevyCertification_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m,
+    });
+    var saved = await db.Set<LevyCertification>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetLevyCertification(saved.Id);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersOnTaxYear()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersOnTaxYear));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m, TaxYear = 2025,
+    });
+    await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 600_000m, AssessedValue = 300_000_000m, TaxYear = 2026,
+    });
+
+    var result = await controller.GetLevyHistory(taxYear: 2026, districtCode: null);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.CalculateLevy(new LevyCalculateRequest
+    {
+      RequestedLevy = 500_000m, AssessedValue = 300_000_000m,
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave32/R2Wave32DataQualityTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave32/R2Wave32DataQualityTests.cs
@@ -1,0 +1,359 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave32;
+
+[Trait("Category", "R2Wave32")]
+[Trait("Category", "DataQuality")]
+public sealed class R2Wave32DataQualityTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w32-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static DataQualityRecord MakeRecord(string parcelId, decimal assessedValue, decimal landArea, DateTime? lastUpdated = null)
+    => new()
+    {
+      ParcelId = parcelId,
+      LastUpdated = lastUpdated ?? DateTime.UtcNow,
+      Fields = new Dictionary<string, string?>
+      {
+        ["parcelId"] = parcelId,
+        ["assessedValue"] = assessedValue.ToString(),
+        ["landArea"] = landArea.ToString(),
+      },
+    };
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Quality Assessment
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task Assess_PerfectData_GradeA()
+  {
+    using var db = CreateDbContext(nameof(Assess_PerfectData_GradeA));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new()
+      {
+        MakeRecord("P-001", 250_000m, 5000m),
+        MakeRecord("P-002", 180_000m, 3500m),
+        MakeRecord("P-003", 320_000m, 8000m),
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("overallScore").GetDouble().Should().Be(100);
+    doc.RootElement.GetProperty("grade").GetString().Should().Be("A");
+    doc.RootElement.GetProperty("issueCount").GetInt32().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Assess_MissingFields_LowersCompleteness()
+  {
+    using var db = CreateDbContext(nameof(Assess_MissingFields_LowersCompleteness));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new()
+      {
+        MakeRecord("P-001", 250_000m, 5000m),
+        new() { ParcelId = "P-002", LastUpdated = DateTime.UtcNow, Fields = new() { ["parcelId"] = "P-002" } }, // missing assessedValue & landArea
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("completenessScore").GetDouble().Should().Be(50);
+    doc.RootElement.GetProperty("overallScore").GetDouble().Should().BeLessThan(100);
+  }
+
+  [Fact]
+  public async Task Assess_NegativeAssessedValue_InconsistentRecord()
+  {
+    using var db = CreateDbContext(nameof(Assess_NegativeAssessedValue_InconsistentRecord));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new()
+      {
+        new()
+        {
+          ParcelId = "P-001",
+          LastUpdated = DateTime.UtcNow,
+          Fields = new() { ["parcelId"] = "P-001", ["assessedValue"] = "-50000", ["landArea"] = "5000" },
+        },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("consistencyScore").GetDouble().Should().Be(0);
+    doc.RootElement.GetProperty("issueCount").GetInt32().Should().BeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task Assess_OldRecords_LowTimeliness()
+  {
+    using var db = CreateDbContext(nameof(Assess_OldRecords_LowTimeliness));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var staleDate = DateTime.UtcNow.AddDays(-500);
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      TimelinessWindowDays = 365,
+      Records = new()
+      {
+        MakeRecord("P-001", 250_000m, 5000m, staleDate),
+        MakeRecord("P-002", 180_000m, 3500m, staleDate),
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("timelinessScore").GetDouble().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Assess_OutOfRangeValue_LowAccuracy()
+  {
+    using var db = CreateDbContext(nameof(Assess_OutOfRangeValue_LowAccuracy));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new()
+      {
+        new()
+        {
+          ParcelId = "P-001",
+          LastUpdated = DateTime.UtcNow,
+          Fields = new() { ["parcelId"] = "P-001", ["assessedValue"] = "999999999999", ["landArea"] = "5000" },
+        },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("accuracyScore").GetDouble().Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Assess_EmptyRecords_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(Assess_EmptyRecords_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest { Records = new() });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task Assess_GradeD_ScoreBetween60And70()
+  {
+    using var db = CreateDbContext(nameof(Assess_GradeD_ScoreBetween60And70));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    // 3 good records, 2 bad (missing fields, stale, inconsistent)
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      TimelinessWindowDays = 30,
+      Records = new()
+      {
+        MakeRecord("P-001", 250_000m, 5000m, DateTime.UtcNow),
+        MakeRecord("P-002", 180_000m, 3500m, DateTime.UtcNow),
+        MakeRecord("P-003", 320_000m, 8000m, DateTime.UtcNow),
+        new() { ParcelId = "P-004", LastUpdated = DateTime.UtcNow.AddDays(-60), Fields = new() { ["parcelId"] = "P-004" } },
+        new() { ParcelId = "P-005", Fields = new() { ["parcelId"] = "P-005", ["assessedValue"] = "-1", ["landArea"] = "0" } },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    var score = doc.RootElement.GetProperty("overallScore").GetDouble();
+    score.Should().BeGreaterThanOrEqualTo(40).And.BeLessThan(90);
+  }
+
+  [Fact]
+  public async Task Assess_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(Assess_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Scope = "district",
+      Records = new() { MakeRecord("P-001", 250_000m, 5000m) },
+    });
+
+    var entities = await db.Set<DataQualityAssessment>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].Scope.Should().Be("district");
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval & County Isolation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetAssessment_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetAssessment_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new() { MakeRecord("P-001", 250_000m, 5000m) },
+    });
+    var saved = await db.Set<DataQualityAssessment>().FirstAsync();
+
+    var result = await controller.GetDataQualityAssessment(saved.Id);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("id").GetInt32().Should().Be(saved.Id);
+  }
+
+  [Fact]
+  public async Task GetAssessment_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetAssessment_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new() { MakeRecord("P-001", 250_000m, 5000m) },
+    });
+    var saved = await db.Set<DataQualityAssessment>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetDataQualityAssessment(saved.Id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersByScope()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersByScope));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Scope = "county",
+      Records = new() { MakeRecord("P-001", 250_000m, 5000m) },
+    });
+    await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Scope = "district",
+      Records = new() { MakeRecord("P-002", 180_000m, 3500m) },
+    });
+
+    var result = await controller.GetDataQualityHistory(scope: "district");
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.AssessDataQuality(new DataQualityRequest
+    {
+      Records = new() { MakeRecord("P-001", 250_000m, 5000m) },
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave33/R2Wave33EtlSyncTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave33/R2Wave33EtlSyncTests.cs
@@ -1,0 +1,294 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities;
+using Xunit;
+using AuditLogger = TerraFusion.Abstractions.Interfaces.IAuditLogger;
+using CostForgeAIService = TerraFusion.Core.Services.ICostForgeAIService;
+using CostForgeService = TerraFusion.Core.Services.ICostForgeService;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.R2Wave33;
+
+[Trait("Category", "R2Wave33")]
+[Trait("Category", "EtlSync")]
+public sealed class R2Wave33EtlSyncTests
+{
+  private static readonly Guid BentonCountyId = Guid.NewGuid();
+  private static readonly Guid OtherCountyId = Guid.NewGuid();
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var options = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name)
+      .Options;
+    var config = new ConfigurationBuilder()
+      .AddInMemoryCollection(new Dictionary<string, string?>())
+      .Build();
+    return new DataDbContext(options, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId, string countyCode = "BENTON")
+    => new(new ClaimsIdentity(
+    [
+      new Claim("countyId", countyId.ToString()),
+      new Claim("countyCode", countyCode),
+      new Claim("sub", "w33-test-user"),
+    ], "TestAuth"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal? principal = null)
+  {
+    var controller = new CostForgeController(
+      new Mock<CostForgeService>(MockBehavior.Strict).Object,
+      new Mock<CostForgeAIService>(MockBehavior.Strict).Object,
+      db,
+      new Mock<AuditLogger>(MockBehavior.Strict).Object,
+      NullLogger<CostForgeController>.Instance);
+
+    controller.ControllerContext = new ControllerContext
+    {
+      HttpContext = new DefaultHttpContext { User = principal ?? CreatePrincipal(BentonCountyId) },
+    };
+    return controller;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId, string name = "Benton", string fips = "003")
+  {
+    if (!await db.Counties.AnyAsync(c => c.Id == countyId))
+    {
+      db.Counties.Add(new County { Id = countyId, Name = name, State = "WA", FipsCode = fips });
+      await db.SaveChangesAsync();
+    }
+  }
+
+  private static EtlSyncRecord MakeRecord(string key, Dictionary<string, string?>? data = null)
+    => new() { Key = key, Data = data ?? new() { ["field1"] = "value1" } };
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // ETL Sync Job Execution
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task Sync_ValidRecords_AllProcessed()
+  {
+    using var db = CreateDbContext(nameof(Sync_ValidRecords_AllProcessed));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      EntityType = "parcels",
+      Records = new()
+      {
+        MakeRecord("P-001"),
+        MakeRecord("P-002"),
+        MakeRecord("P-003"),
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(3);
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(0);
+    doc.RootElement.GetProperty("sourceSystem").GetString().Should().Be("harris_pacs");
+    doc.RootElement.GetProperty("entityType").GetString().Should().Be("parcels");
+  }
+
+  [Fact]
+  public async Task Sync_MissingKey_RecordFails()
+  {
+    using var db = CreateDbContext(nameof(Sync_MissingKey_RecordFails));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new()
+      {
+        MakeRecord("P-001"),
+        new() { Key = null, Data = new() { ["x"] = "y" } }, // missing key
+        new() { Key = "", Data = new() { ["x"] = "y" } },   // empty key
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(1);
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(2);
+  }
+
+  [Fact]
+  public async Task Sync_EmptyDataPayload_RecordFails()
+  {
+    using var db = CreateDbContext(nameof(Sync_EmptyDataPayload_RecordFails));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new()
+      {
+        new() { Key = "P-001", Data = new() },
+        new() { Key = "P-002", Data = null },
+      },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("failedRecords").GetInt32().Should().Be(2);
+    doc.RootElement.GetProperty("processedRecords").GetInt32().Should().Be(0);
+    doc.RootElement.GetProperty("status").GetString().Should().Be("failed");
+  }
+
+  [Fact]
+  public async Task Sync_EmptyRecords_ReturnsBadRequest()
+  {
+    using var db = CreateDbContext(nameof(Sync_EmptyRecords_ReturnsBadRequest));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest { Records = new() });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task Sync_PersistsToDb()
+  {
+    using var db = CreateDbContext(nameof(Sync_PersistsToDb));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "tyler_vision",
+      EntityType = "sales",
+      Direction = "inbound",
+      Records = new() { MakeRecord("S-001") },
+    });
+
+    var entities = await db.Set<EtlSyncJob>().ToListAsync();
+    entities.Should().HaveCount(1);
+    entities[0].SourceSystem.Should().Be("tyler_vision");
+    entities[0].EntityType.Should().Be("sales");
+  }
+
+  [Fact]
+  public async Task Sync_IncludesThroughputMetrics()
+  {
+    using var db = CreateDbContext(nameof(Sync_IncludesThroughputMetrics));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001"), MakeRecord("P-002") },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+
+    doc.RootElement.GetProperty("durationMs").GetInt64().Should().BeGreaterThanOrEqualTo(0);
+    doc.RootElement.GetProperty("recordsPerSecond").GetDouble().Should().BeGreaterThanOrEqualTo(0);
+  }
+
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  // Retrieval & County Isolation
+  // ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+  [Fact]
+  public async Task GetEtlJob_RetrievesById()
+  {
+    using var db = CreateDbContext(nameof(GetEtlJob_RetrievesById));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      Records = new() { MakeRecord("P-001") },
+    });
+    var saved = await db.Set<EtlSyncJob>().FirstAsync();
+
+    var result = await controller.GetEtlSyncJob(saved.Id);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("sourceSystem").GetString().Should().Be("harris_pacs");
+  }
+
+  [Fact]
+  public async Task GetEtlJob_WrongCounty_ReturnsNotFound()
+  {
+    using var db = CreateDbContext(nameof(GetEtlJob_WrongCounty_ReturnsNotFound));
+    await SeedCounty(db, BentonCountyId);
+    await SeedCounty(db, OtherCountyId, "Other", "999");
+
+    var bentonController = CreateController(db, CreatePrincipal(BentonCountyId));
+    await bentonController.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001") },
+    });
+    var saved = await db.Set<EtlSyncJob>().FirstAsync();
+
+    var otherController = CreateController(db, CreatePrincipal(OtherCountyId, "OTHER"));
+    var result = await otherController.GetEtlSyncJob(saved.Id);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetHistory_FiltersBySourceSystem()
+  {
+    using var db = CreateDbContext(nameof(GetHistory_FiltersBySourceSystem));
+    await SeedCounty(db, BentonCountyId);
+    var controller = CreateController(db);
+
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "harris_pacs",
+      Records = new() { MakeRecord("P-001") },
+    });
+    await controller.StartEtlSync(new EtlSyncRequest
+    {
+      SourceSystem = "tyler_vision",
+      Records = new() { MakeRecord("S-001") },
+    });
+
+    var result = await controller.GetEtlHistory(sourceSystem: "harris_pacs", entityType: null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    var json = JsonSerializer.Serialize(ok.Value);
+    var doc = JsonDocument.Parse(json);
+    doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+  }
+
+  [Fact]
+  public async Task RequiresCountyContext()
+  {
+    using var db = CreateDbContext(nameof(RequiresCountyContext));
+    var controller = CreateController(db, new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.StartEtlSync(new EtlSyncRequest
+    {
+      Records = new() { MakeRecord("P-001") },
+    });
+
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave34/R2Wave34MlIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave34/R2Wave34MlIntegrationTests.cs
@@ -1,0 +1,330 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Services;
+using Xunit;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+
+namespace TerraFusion.Unit.Tests.R2Wave34;
+
+[Trait("Category", "R2Wave34")]
+public sealed class R2Wave34MlIntegrationTests
+{
+  // ΓöÇΓöÇ helpers ΓöÇΓöÇ
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var opts = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name).Options;
+    var config = new ConfigurationBuilder().Build();
+    return new DataDbContext(opts, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId) =>
+    new(new ClaimsIdentity(new[]
+    {
+      new Claim("countyId", countyId.ToString()),
+      new Claim("sub", "test-user"),
+    }, "test"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal principal)
+  {
+    var ctrl = new CostForgeController(
+      new Mock<ICostForgeService>().Object,
+      new Mock<ICostForgeAIService>().Object,
+      db,
+      new Mock<TerraFusion.Abstractions.Interfaces.IAuditLogger>().Object,
+      NullLogger<CostForgeController>.Instance)
+    {
+      ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = principal } }
+    };
+    return ctrl;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId)
+  {
+    db.Counties.Add(new TerraFusion.Core.Entities.County
+    {
+      Id = countyId,
+      Name = "TestCounty",
+      State = "WA",
+      FipsCode = "00000",
+    });
+    await db.SaveChangesAsync();
+  }
+
+  // ΓöÇΓöÇ predict ΓöÇΓöÇ
+
+  [Fact]
+  public async Task Predict_ValidFeatures_ReturnsOkWithPrediction()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_ValidFeatures_ReturnsOkWithPrediction));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.MlPredict(new MlPredictRequest
+    {
+      ModelType = "property_value",
+      ParcelId = "P001",
+      Features = new() { ["sqft"] = 2000, ["bedrooms"] = 3, ["bathrooms"] = 2 },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((string)val.modelType).Should().Be("property_value");
+    ((string)val.parcelId).Should().Be("P001");
+    ((decimal)val.predictedValue).Should().BeGreaterThan(0);
+    ((double)val.confidence).Should().BeInRange(0.5, 1.0);
+    ((int)val.featureCount).Should().Be(3);
+    ((long)val.inferenceTimeMs).Should().BeGreaterOrEqualTo(0);
+  }
+
+  [Fact]
+  public async Task Predict_EmptyFeatures_ReturnsBadRequest()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_EmptyFeatures_ReturnsBadRequest));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.MlPredict(new MlPredictRequest
+    {
+      ModelType = "property_value",
+      Features = new(),
+    });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task Predict_DefaultsModelTypeAndVersion()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_DefaultsModelTypeAndVersion));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["value"] = 100 },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((string)val.modelType).Should().Be("property_value");
+    ((string)val.modelVersion).Should().Be("1.0");
+  }
+
+  [Fact]
+  public async Task Predict_CustomTrainingSamples_UsesProvided()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_CustomTrainingSamples_UsesProvided));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["sqft"] = 1500 },
+      TrainingSamples = 5000,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.trainingSamples).Should().Be(5000);
+  }
+
+  [Fact]
+  public async Task Predict_ManyFeatures_HigherConfidence()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_ManyFeatures_HigherConfidence));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var fewResult = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["sqft"] = 1000 },
+    });
+    var manyResult = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new()
+      {
+        ["sqft"] = 1000, ["beds"] = 3, ["baths"] = 2,
+        ["lot"] = 5000, ["age"] = 10, ["garage"] = 2,
+      },
+    });
+
+    var fewOk = fewResult.Should().BeOfType<OkObjectResult>().Subject;
+    var manyOk = manyResult.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic fewVal = fewOk.Value!;
+    dynamic manyVal = manyOk.Value!;
+    ((double)manyVal.confidence).Should().BeGreaterThan((double)fewVal.confidence);
+  }
+
+  [Fact]
+  public async Task Predict_AccuracyMetricsAreReasonable()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_AccuracyMetricsAreReasonable));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["sqft"] = 2000, ["beds"] = 4 },
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((double)val.modelAccuracy).Should().BeInRange(0.5, 1.0);
+    ((decimal)val.meanAbsoluteError).Should().BeGreaterOrEqualTo(0);
+    ((decimal)val.rootMeanSquaredError).Should().BeGreaterOrEqualTo((decimal)val.meanAbsoluteError);
+  }
+
+  // ΓöÇΓöÇ persistence & retrieval ΓöÇΓöÇ
+
+  [Fact]
+  public async Task Predict_PersistsToDatabase()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(Predict_PersistsToDatabase));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.MlPredict(new MlPredictRequest
+    {
+      ModelType = "land_classification",
+      ParcelId = "P-PERSIST",
+      Features = new() { ["sqft"] = 2500 },
+    });
+
+    var saved = await db.Set<TerraFusion.Core.Entities.MlPrediction>().FirstOrDefaultAsync();
+    saved.Should().NotBeNull();
+    saved!.ParcelId.Should().Be("P-PERSIST");
+    saved.ModelType.Should().Be("land_classification");
+    saved.CountyId.Should().Be(cid);
+    saved.CreatedBy.Should().Be("test-user");
+  }
+
+  [Fact]
+  public async Task GetMlPrediction_ExistingId_ReturnsOk()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetMlPrediction_ExistingId_ReturnsOk));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var createResult = await ctrl.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["sqft"] = 1000 },
+    });
+    var createOk = (OkObjectResult)createResult;
+    dynamic created = createOk.Value!;
+    int id = (int)created.id;
+
+    var getResult = await ctrl.GetMlPrediction(id);
+    getResult.Should().BeOfType<OkObjectResult>();
+  }
+
+  [Fact]
+  public async Task GetMlPrediction_MissingId_ReturnsNotFound()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetMlPrediction_MissingId_ReturnsNotFound));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.GetMlPrediction(999);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ΓöÇΓöÇ county isolation ΓöÇΓöÇ
+
+  [Fact]
+  public async Task GetMlPrediction_OtherCounty_ReturnsNotFound()
+  {
+    var cidA = Guid.NewGuid();
+    var cidB = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetMlPrediction_OtherCounty_ReturnsNotFound));
+    await SeedCounty(db, cidA);
+    await SeedCounty(db, cidB);
+
+    var ctrlA = CreateController(db, CreatePrincipal(cidA));
+    var createResult = await ctrlA.MlPredict(new MlPredictRequest
+    {
+      Features = new() { ["sqft"] = 1000 },
+    });
+    var createOk = (OkObjectResult)createResult;
+    dynamic created = createOk.Value!;
+    int id = (int)created.id;
+
+    // County B cannot see County A's prediction
+    var ctrlB = CreateController(db, CreatePrincipal(cidB));
+    var getResult = await ctrlB.GetMlPrediction(id);
+    getResult.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ΓöÇΓöÇ history ΓöÇΓöÇ
+
+  [Fact]
+  public async Task GetMlHistory_ReturnsItems()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetMlHistory_ReturnsItems));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.MlPredict(new MlPredictRequest { Features = new() { ["a"] = 1 } });
+    await ctrl.MlPredict(new MlPredictRequest { Features = new() { ["b"] = 2 } });
+
+    var result = await ctrl.GetMlHistory(null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.count).Should().Be(2);
+  }
+
+  [Fact]
+  public async Task GetMlHistory_FiltersByModelType()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetMlHistory_FiltersByModelType));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.MlPredict(new MlPredictRequest { ModelType = "property_value", Features = new() { ["a"] = 1 } });
+    await ctrl.MlPredict(new MlPredictRequest { ModelType = "market_trend", Features = new() { ["b"] = 2 } });
+
+    var result = await ctrl.GetMlHistory("market_trend");
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.count).Should().Be(1);
+  }
+
+  // ΓöÇΓöÇ auth ΓöÇΓöÇ
+
+  [Fact]
+  public async Task Predict_NoAuth_ReturnsUnauthorized()
+  {
+    await using var db = CreateDbContext(nameof(Predict_NoAuth_ReturnsUnauthorized));
+    var ctrl = new CostForgeController(
+      new Mock<ICostForgeService>().Object,
+      new Mock<ICostForgeAIService>().Object,
+      db,
+      new Mock<TerraFusion.Abstractions.Interfaces.IAuditLogger>().Object,
+      NullLogger<CostForgeController>.Instance)
+    {
+      ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+    };
+
+    var result = await ctrl.MlPredict(new MlPredictRequest { Features = new() { ["x"] = 1 } });
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave35/R2Wave35ValuationPipelineTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave35/R2Wave35ValuationPipelineTests.cs
@@ -1,0 +1,332 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Services;
+using Xunit;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+
+namespace TerraFusion.Unit.Tests.R2Wave35;
+
+[Trait("Category", "R2Wave35")]
+public sealed class R2Wave35ValuationPipelineTests
+{
+  // ΓöÇΓöÇ helpers ΓöÇΓöÇ
+
+  private static DataDbContext CreateDbContext(string name)
+  {
+    var opts = new DbContextOptionsBuilder<DataDbContext>()
+      .UseInMemoryDatabase(name).Options;
+    var config = new ConfigurationBuilder().Build();
+    return new DataDbContext(opts, config);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(Guid countyId) =>
+    new(new ClaimsIdentity(new[]
+    {
+      new Claim("countyId", countyId.ToString()),
+      new Claim("sub", "test-user"),
+    }, "test"));
+
+  private static CostForgeController CreateController(DataDbContext db, ClaimsPrincipal principal)
+  {
+    var ctrl = new CostForgeController(
+      new Mock<ICostForgeService>().Object,
+      new Mock<ICostForgeAIService>().Object,
+      db,
+      new Mock<TerraFusion.Abstractions.Interfaces.IAuditLogger>().Object,
+      NullLogger<CostForgeController>.Instance)
+    {
+      ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = principal } }
+    };
+    return ctrl;
+  }
+
+  private static async Task SeedCounty(DataDbContext db, Guid countyId)
+  {
+    db.Counties.Add(new TerraFusion.Core.Entities.County
+    {
+      Id = countyId,
+      Name = "TestCounty",
+      State = "WA",
+      FipsCode = "00000",
+    });
+    await db.SaveChangesAsync();
+  }
+
+  // ΓöÇΓöÇ start pipeline ΓöÇΓöÇ
+
+  [Fact]
+  public async Task StartPipeline_ValidRequest_ReturnsOk()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_ValidRequest_ReturnsOk));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "2026-annual-reval",
+      TaxYear = 2026,
+      TotalParcels = 1000,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((string)val.pipelineName).Should().Be("2026-annual-reval");
+    ((int)val.taxYear).Should().Be(2026);
+    ((int)val.totalParcels).Should().Be(1000);
+    ((string)val.status).Should().BeOneOf("completed", "failed");
+    ((string)val.currentStage).Should().Be("certified");
+    ((int)val.completedParcels).Should().BeLessOrEqualTo(1000);
+    ((int)val.failedParcels).Should().BeGreaterOrEqualTo(0);
+  }
+
+  [Fact]
+  public async Task StartPipeline_MissingName_ReturnsBadRequest()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_MissingName_ReturnsBadRequest));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      TotalParcels = 100,
+    });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task StartPipeline_ZeroParcels_ReturnsBadRequest()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_ZeroParcels_ReturnsBadRequest));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "test",
+      TotalParcels = 0,
+    });
+
+    result.Should().BeOfType<BadRequestObjectResult>();
+  }
+
+  [Fact]
+  public async Task StartPipeline_DefaultsTaxYear()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_DefaultsTaxYear));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "default-year",
+      TotalParcels = 500,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.taxYear).Should().Be(DateTime.UtcNow.Year);
+  }
+
+  [Fact]
+  public async Task StartPipeline_QualityMetricsAreReasonable()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_QualityMetricsAreReasonable));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "quality-test",
+      TaxYear = 2026,
+      TotalParcels = 5000,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((double)val.coefficientOfDispersion).Should().BeGreaterOrEqualTo(0);
+    ((double)val.priceRelatedDifferential).Should().BeInRange(0.9, 1.1);
+  }
+
+  [Fact]
+  public async Task StartPipeline_CompletedPlusFailed_EqualsTotalParcels()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_CompletedPlusFailed_EqualsTotalParcels));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "counts-check",
+      TaxYear = 2026,
+      TotalParcels = 2000,
+    });
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    var completed = (int)val.completedParcels;
+    var failed = (int)val.failedParcels;
+    (completed + failed).Should().Be(2000);
+  }
+
+  // ΓöÇΓöÇ persistence & retrieval ΓöÇΓöÇ
+
+  [Fact]
+  public async Task StartPipeline_PersistsToDatabase()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(StartPipeline_PersistsToDatabase));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "persist-test",
+      TaxYear = 2026,
+      TotalParcels = 100,
+    });
+
+    var saved = await db.Set<TerraFusion.Core.Entities.ValuationPipeline>().FirstOrDefaultAsync();
+    saved.Should().NotBeNull();
+    saved!.PipelineName.Should().Be("persist-test");
+    saved.CountyId.Should().Be(cid);
+    saved.CreatedBy.Should().Be("test-user");
+  }
+
+  [Fact]
+  public async Task GetPipeline_ExistingId_ReturnsOk()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetPipeline_ExistingId_ReturnsOk));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var createResult = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "get-test",
+      TaxYear = 2026,
+      TotalParcels = 100,
+    });
+    var createOk = (OkObjectResult)createResult;
+    dynamic created = createOk.Value!;
+    int id = (int)created.id;
+
+    var getResult = await ctrl.GetPipeline(id);
+    var getOk = getResult.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = getOk.Value!;
+    ((string)val.pipelineName).Should().Be("get-test");
+    ((string)val.stageDetails).Should().NotBeNullOrEmpty();
+  }
+
+  [Fact]
+  public async Task GetPipeline_MissingId_ReturnsNotFound()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetPipeline_MissingId_ReturnsNotFound));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    var result = await ctrl.GetPipeline(999);
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ΓöÇΓöÇ county isolation ΓöÇΓöÇ
+
+  [Fact]
+  public async Task GetPipeline_OtherCounty_ReturnsNotFound()
+  {
+    var cidA = Guid.NewGuid();
+    var cidB = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetPipeline_OtherCounty_ReturnsNotFound));
+    await SeedCounty(db, cidA);
+    await SeedCounty(db, cidB);
+
+    var ctrlA = CreateController(db, CreatePrincipal(cidA));
+    var createResult = await ctrlA.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "isolation-test",
+      TaxYear = 2026,
+      TotalParcels = 100,
+    });
+    var createOk = (OkObjectResult)createResult;
+    dynamic created = createOk.Value!;
+    int id = (int)created.id;
+
+    var ctrlB = CreateController(db, CreatePrincipal(cidB));
+    var getResult = await ctrlB.GetPipeline(id);
+    getResult.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  // ΓöÇΓöÇ history ΓöÇΓöÇ
+
+  [Fact]
+  public async Task GetPipelineHistory_ReturnsItems()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetPipelineHistory_ReturnsItems));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.StartPipeline(new PipelineStartRequest { PipelineName = "a", TotalParcels = 100, TaxYear = 2026 });
+    await ctrl.StartPipeline(new PipelineStartRequest { PipelineName = "b", TotalParcels = 200, TaxYear = 2026 });
+
+    var result = await ctrl.GetPipelineHistory(null);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.count).Should().Be(2);
+  }
+
+  [Fact]
+  public async Task GetPipelineHistory_FiltersByTaxYear()
+  {
+    var cid = Guid.NewGuid();
+    await using var db = CreateDbContext(nameof(GetPipelineHistory_FiltersByTaxYear));
+    await SeedCounty(db, cid);
+    var ctrl = CreateController(db, CreatePrincipal(cid));
+
+    await ctrl.StartPipeline(new PipelineStartRequest { PipelineName = "y25", TotalParcels = 100, TaxYear = 2025 });
+    await ctrl.StartPipeline(new PipelineStartRequest { PipelineName = "y26", TotalParcels = 200, TaxYear = 2026 });
+
+    var result = await ctrl.GetPipelineHistory(2025);
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    dynamic val = ok.Value!;
+    ((int)val.count).Should().Be(1);
+  }
+
+  // ΓöÇΓöÇ auth ΓöÇΓöÇ
+
+  [Fact]
+  public async Task StartPipeline_NoAuth_ReturnsUnauthorized()
+  {
+    await using var db = CreateDbContext(nameof(StartPipeline_NoAuth_ReturnsUnauthorized));
+    var ctrl = new CostForgeController(
+      new Mock<ICostForgeService>().Object,
+      new Mock<ICostForgeAIService>().Object,
+      db,
+      new Mock<TerraFusion.Abstractions.Interfaces.IAuditLogger>().Object,
+      NullLogger<CostForgeController>.Instance)
+    {
+      ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+    };
+
+    var result = await ctrl.StartPipeline(new PipelineStartRequest
+    {
+      PipelineName = "unauth",
+      TotalParcels = 100,
+    });
+    result.Should().BeOfType<UnauthorizedObjectResult>();
+  }
+}


### PR DESCRIPTION
## R2.2 CostForge Analytics Integration

Integrates Waves 26-35 into CostForge controller, adding 33 new analytics endpoints covering the full valuation pipeline.

### Wave Summary

| Wave | Domain | Endpoints |
|------|--------|-----------|
| 26 | OLS Regression | calculate, get-result, history |
| 27 | Bayesian + Monte Carlo | Already merged (PR #636) |
| 28 | Spatial Autocorrelation | Moran's I, Geary's C, get, history |
| 29 | Market Analysis | comparable-sales, time-trend, ratio-study, get, history |
| 30 | RCW Calculators | 84.34, 84.26, 84.36.381, get, history |
| 31 | Levy Certification | calculate, balance-test, certify, get, history |
| 32 | Data Quality | assess, get, history |
| 33 | ETL Sync | sync, get, history |
| 34 | ML Prediction | predict, get, history |
| 35 | Valuation Pipeline | start, get, history |

### Changes
- 8 new entity types in TerraFusion.Core/Entities/
- 8 new DbSets in TerraFusionDbContext
- 33 new endpoints in CostForgeController (3597 → 5596 lines)
- 80+ new tests across R2Wave28-R2Wave35 test directories

### Evidence
- **Build**: 0 errors, 0 warnings
- **Tests**: 1542/1555 passed (13 pre-existing DX01-DX03 failures, 0 new failures)
- **Wave tests**: 181/181 passed

Government: FISMA compliance
AI-Collaboration: GitHub Copilot