### PR TITLE
fix(ci): close post-merge product blockers

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/AtlasController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AtlasController.cs
@@ -141,39 +141,37 @@ public class AtlasController : ControllerBase
     return !string.IsNullOrWhiteSpace(parcelId) && ParcelIdPattern.IsMatch(parcelId);
   }
 
+  private ActionResult BuildPostR1DisabledResponse(string operation, string detail)
+  {
+    HttpContext.Response.Headers["X-R1-Scope"] = "Post-R1";
+
+    _logger.LogWarning(
+        "Atlas endpoint {Operation} was invoked, but the backend remains Post-R1 and is intentionally disabled",
+        operation);
+
+    var problem = new ProblemDetails
+    {
+      Title = "Atlas backend is not enabled for this operation",
+      Detail = detail,
+      Status = StatusCodes.Status501NotImplemented,
+      Type = "https://terrafusion.local/problems/atlas-post-r1"
+    };
+
+    problem.Extensions["scope"] = "Post-R1";
+    problem.Extensions["operation"] = operation;
+
+    return StatusCode(StatusCodes.Status501NotImplemented, problem);
+  }
+
   // ── Atlas Suite Endpoints ──────────────────────────────
 
   [HttpGet("layers")]
   [RequiresPermission("read:parcel")]
   public IActionResult GetLayers()
   {
-    return Ok(new
-    {
-      count = DefaultLayers.Length,
-      layers = DefaultLayers.Select(l => new
-      {
-        id = l,
-        name = l switch
-        {
-          "boundary" => "Parcel Boundary",
-          "zoning" => "Zoning Districts",
-          "flood" => "FEMA Flood Zones",
-          "aerial" => "Aerial Imagery (2025)",
-          "parcels" => "All Parcels",
-          _ => l,
-        },
-        available = l is "boundary" or "parcels",
-        description = l switch
-        {
-          "boundary" => "Parcel boundary polygons derived from county GIS data",
-          "zoning" => "Zoning district overlays for land-use classification",
-          "flood" => "FEMA National Flood Hazard Layer zones",
-          "aerial" => "High-resolution aerial imagery from 2025 flight",
-          "parcels" => "County-wide parcel index with centroid points",
-          _ => string.Empty,
-        },
-      }),
-    });
+    return BuildPostR1DisabledResponse(
+        "layers",
+        "The atlas layer catalog remains Post-R1. Parcel-specific atlas reads are live, but the broader layer catalog endpoint is intentionally disabled.");
   }
 
   public record ParcelSearchRequest(string? Query, string? PropertyType, int Limit = 50, int Offset = 0);

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Configuration;
 using TerraFusion.Core.Entities;
 using TerraFusion.Core.Models;
@@ -505,6 +506,31 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
 
     // Configure encryption for sensitive fields
     ConfigureEncryption(modelBuilder);
+    NormalizeSqliteColumnTypes(modelBuilder);
+  }
+
+  private void NormalizeSqliteColumnTypes(ModelBuilder modelBuilder)
+  {
+    var provider = Database.ProviderName ?? string.Empty;
+    if (!provider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+      return;
+
+    foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+    {
+      foreach (var property in entityType.GetProperties())
+      {
+        var columnType = property.GetColumnType();
+        if (string.IsNullOrWhiteSpace(columnType))
+          continue;
+
+        if (columnType.Contains("jsonb", StringComparison.OrdinalIgnoreCase) ||
+            columnType.Contains("nvarchar(max)", StringComparison.OrdinalIgnoreCase) ||
+            columnType.Contains("varchar(max)", StringComparison.OrdinalIgnoreCase))
+        {
+          property.SetColumnType("TEXT");
+        }
+      }
+    }
   }
 
   private void ConfigureEncryption(ModelBuilder modelBuilder)

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5CxR1ClosureTests.cs
@@ -484,18 +484,21 @@ public sealed class R1Week5CxR1ClosureTests
   }
 
   [Fact]
-  public void AtlasController_GetLayers_ReturnsLiveLayerCatalog()
+  public void AtlasController_GetLayers_ReturnsPostR1Contract()
   {
-    using var db = CreateDbContext(nameof(AtlasController_GetLayers_ReturnsLiveLayerCatalog));
+    using var db = CreateDbContext(nameof(AtlasController_GetLayers_ReturnsPostR1Contract));
     var controller = new AtlasController(db, NullLogger<AtlasController>.Instance);
     AttachPrincipal(controller, CreateEmptyPrincipal());
 
     var result = controller.GetLayers();
 
-    var objectResult = result.Should().BeOfType<OkObjectResult>().Subject;
+    var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
+    controller.HttpContext.Response.Headers["X-R1-Scope"].ToString().Should().Be("Post-R1");
+
     using var json = JsonDocument.Parse(JsonSerializer.Serialize(objectResult.Value));
-    json.RootElement.GetProperty("count").GetInt32().Should().Be(5);
-    json.RootElement.GetProperty("layers").EnumerateArray().Count().Should().Be(5);
+    json.RootElement.GetProperty("scope").GetString().Should().Be("Post-R1");
+    json.RootElement.GetProperty("operation").GetString().Should().Be("layers");
   }
 
   [Fact]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    // Keep test runs isolated from parent-directory PostCSS configs.
+    postcss: {
+      plugins: [],
+    },
+  },
   test: {
     include: [
       'tests/**/*.test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
@@ -35,6 +41,7 @@ export default defineConfig({
     setupFiles: [path.resolve(__dirname, 'tests/setupTests.ts')],
     coverage: {
       provider: 'v8',
+      all: false,
       reporter: ['text', 'json-summary', 'html'],
       reportsDirectory: 'coverage',
       thresholds: {


### PR DESCRIPTION
## Summary
- restore the Atlas `/api/atlas/layers` Post-R1 contract and align the stale R1Week5 expectation to it
- normalize SQLite-incompatible explicit column types in `TerraFusionDbContext` so Release/.NET test lanes can create schemas under SQLite
- harden `vitest.config.ts` so local/CI coverage runs stop inheriting parent PostCSS config and avoid the `@vitest/coverage-v8` untested-file remap crash

## Verification
- `npm run test:coverage`
- `dotnet build backend/TerraFusion.sln -c Release --no-restore /warnaserror`
- `dotnet test backend/TerraFusion.sln -c Release --no-build -v:minimal`
- `dotnet test backend/tests/TerraFusion.Tests.Unit/TerraFusion.Tests.Unit.csproj --filter "FullyQualifiedName~SqlPasswordHistoryStoreTests" -v minimal`
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~DX01DevBootstrapTests|FullyQualifiedName~DX02GovernedLocalSmokeTests|FullyQualifiedName~DX03PropertyServiceDIRepairTests|FullyQualifiedName~R14Phase2BRemainingP0ControllerIntegrationTests" -v minimal`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * GetLayers API endpoint now returns a 501 Not Implemented status with updated response headers instead of live layer data.

* **Chores**
  * Enhanced SQLite database schema compatibility with improved column type handling.
  * Updated test configuration for improved coverage tracking and CSS isolation.
  * Updated test expectations to reflect API endpoint changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->