### PR TITLE
fix(ci): repair startup bundle matcher

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -164,8 +164,8 @@ jobs:
 
           const indexHtml = fs.readFileSync(indexHtmlPath, 'utf8');
           const startupMatches = [
-            ...indexHtml.matchAll(/<script[^>]+src="\\/assets\\/([^"]+\\.js)"/g),
-            ...indexHtml.matchAll(/<link[^>]+rel="modulepreload"[^>]+href="\\/assets\\/([^"]+\\.js)"/g),
+            ...indexHtml.matchAll(/<script[^>]+src="\/assets\/([^"]+\.js)"/g),
+            ...indexHtml.matchAll(/<link[^>]+rel="modulepreload"[^>]+href="\/assets\/([^"]+\.js)"/g),
           ];
 
           const startupFiles = [...new Set(startupMatches.map((match) => match[1]))];


### PR DESCRIPTION
## Summary
- fix the inline Node regexes in `performance-budget.yml` so the startup bundle matcher parses correctly in GitHub Actions
- preserve the startup-only budget logic introduced in the previous lane

## Validation
- local startup bundle metric probe against `native-shell/ui/dist/index.html`
- startup JS: `469KB`
- total emitted JS: `2539KB`
- budget pass: `true`

## Summary by Sourcery

CI:
- Fix the regular expressions used to detect startup JS assets in the performance-budget GitHub Actions workflow.