### PR TITLE
docs(ops): refresh Hostinger runbook and readiness accounting after PR #660

### DIFF
--- a/os-platform/core/pilot/ops/hostinger-control-plane.md
+++ b/os-platform/core/pilot/ops/hostinger-control-plane.md
@@ -1,6 +1,7 @@
-# Hostinger Control Plane -- External Infra Truth Surface
+# Hostinger Control Plane — External Infra Truth Surface
 
 ## Purpose
+
 Record the authoritative external infrastructure state required to close the ops/evidence lane for TerraFusion OS 1.0.
 
 This document contains **no secrets**. Store secrets only in:
@@ -8,64 +9,82 @@ This document contains **no secrets**. Store secrets only in:
 - VPS-local `/opt/terrafusion/<env>/app.env`
 - GitHub Environment Secrets
 
+## Current State (as of 2026-03-10)
+
+- `origin/main`: `b6487a8939648d12f6c1ceca0221ed8c8c40f7a0` (PR #660 merged)
+- Repo-side release lane wiring: **complete** (release-lane.yml + rollback-staging.yml canonical)
+- Remaining blockers: **external ops only** (credential rotation, VPS normalization, GitHub env config, dispatch execution)
+
 ## Canonical Baselines
-- Protected main (release candidate): 864d651a8b49ec1b2dc2cbca137091dbc1c3b29b
-- Engineering remediation baseline: 24531f37a9ea785a99c1b7e4e1dd70c294af1a0c
+
+- Protected main (lane wiring): `b6487a893…` (PR #660)
+- Release candidate: `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` (PR #659)
+- Engineering remediation baseline: `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` (PR #656)
 
 ## Domains (Authoritative)
+
 - Staging: https://staging.terrafusionmarket.com
 - Production: https://terrafusionmarket.com
 
 ## DNS Control Plane
+
 - DNS provider for terrafusionmarket.com: (Hostinger / Cloudflare / other)
-- Date/time verified: (UTC timestamp)
-- Verification method: nslookup/dig from local machine + screenshot or panel note
+- Date/time verified: (pending — execute `nslookup staging.terrafusionmarket.com` before dispatch)
+- Verification method: nslookup/dig from local machine
+- Required result: staging.terrafusionmarket.com → 72.60.126.11
 
 ### Required DNS Records
-- A: staging -> <STAGING_VPS_IPV4>
-- A: @ (root) -> <PROD_VPS_IPV4> (defer until production provisioning)
+
+- A: staging → 72.60.126.11
+- A: @ (root) → (defer until production provisioning)
 
 ## Staging VPS (Hostinger)
+
 - VPS name/id: (from Hostinger panel)
-- IPv4: <STAGING_VPS_IPV4>
+- IPv4: 72.60.126.11
 - OS: Ubuntu 22.04 LTS
 - Provider firewall open: 22/tcp, 80/tcp, 443/tcp
 - Server firewall (ufw) open: 22/tcp, 80/tcp, 443/tcp
 - APP_ROOT: /opt/terrafusion/staging
+- Deploy user: deploy
+- Secrets file: /opt/terrafusion/staging/app.env (deploy:deploy, 600)
 
 ## Production VPS (Hostinger)
-- VPS name/id: (from Hostinger panel)
-- IPv4: <PROD_VPS_IPV4>
+
+- VPS name/id: (not yet provisioned)
+- IPv4: (pending)
 - OS: Ubuntu 22.04 LTS
-- Provider firewall open: 22/tcp, 80/tcp, 443/tcp
-- Server firewall (ufw) open: 22/tcp, 80/tcp, 443/tcp
 - APP_ROOT: /opt/terrafusion/production
 
 ## GHCR Pull Auth (Staging)
-- Configured on VPS (deploy user): yes/no
-- Method: `docker login ghcr.io` with least-privilege token
-- Date/time verified: (UTC)
+
+- Configured on VPS (deploy user): pending rotation
+- Method: `docker login ghcr.io` with read:packages token
+- Date/time verified: (pending)
 
 ## GHCR Pull Auth (Production)
-- Configured on VPS (deploy user): yes/no
-- Method: `docker login ghcr.io` with least-privilege token
-- Date/time verified: (UTC)
+
+- Configured on VPS (deploy user): not yet provisioned
+- Date/time verified: (pending)
 
 ## GitHub Environments
+
 ### staging
+
 Variables:
-- DEPLOY_HOST = <STAGING_VPS_IPV4>
+- DEPLOY_HOST = 72.60.126.11
 - DEPLOY_PORT = 22
 - DEPLOY_USER = deploy
 - PUBLIC_URL = https://staging.terrafusionmarket.com
 - APP_ROOT = /opt/terrafusion/staging
 
 Secrets:
-- DEPLOY_SSH_KEY = (stored in GitHub only)
+- DEPLOY_SSH_KEY = (stored in GitHub only — must be rotated to new ed25519 key)
 
 ### production
+
 Variables:
-- DEPLOY_HOST = <PROD_VPS_IPV4>
+- DEPLOY_HOST = (pending)
 - DEPLOY_PORT = 22
 - DEPLOY_USER = deploy
 - PUBLIC_URL = https://terrafusionmarket.com
@@ -74,14 +93,197 @@ Variables:
 Secrets:
 - DEPLOY_SSH_KEY = (stored in GitHub only)
 
+---
+
+## Operator Checklist (External Ops Closure)
+
+### Absolute Rules
+
+- **Do not paste any secrets into chat** (passwords, private keys, JWT, DB passwords, PATs).
+- If a secret was pasted anywhere earlier, treat it as compromised and rotate.
+
+### A) Rotate Compromised Staging Credentials
+
+#### A1) Rotate VPS root password
+
+```bash
+ssh root@72.60.126.11
+passwd
+```
+
+#### A2) Rotate deploy SSH keypair (critical path — everything else depends on this)
+
+```bash
+# Generate new key locally
+ssh-keygen -t ed25519 -C "terrafusion-staging-deploy-2026-03-10" -f tf_staging_deploy_key_v2
+
+# Install public key on VPS for deploy user
+ssh root@72.60.126.11 "mkdir -p /home/deploy/.ssh && cat >> /home/deploy/.ssh/authorized_keys" < tf_staging_deploy_key_v2.pub
+ssh root@72.60.126.11 "chown -R deploy:deploy /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && chmod 600 /home/deploy/.ssh/authorized_keys"
+
+# Remove old keys (edit and delete compromised entries)
+ssh root@72.60.126.11 "nano /home/deploy/.ssh/authorized_keys"
+
+# Test
+ssh -i tf_staging_deploy_key_v2 deploy@72.60.126.11 "whoami"
+# Must return: deploy
+```
+
+- Status: (pending)
+- Date/time completed: (pending)
+
+#### A3) Update GitHub staging secret DEPLOY_SSH_KEY
+
+GitHub repo → Settings → Environments → staging → Secrets → Update `DEPLOY_SSH_KEY` with private key contents of `tf_staging_deploy_key_v2`.
+
+- Status: (pending)
+
+#### A4) Rotate VPS-local app secrets
+
+```bash
+ssh -i tf_staging_deploy_key_v2 deploy@72.60.126.11
+nano /opt/terrafusion/staging/app.env
+# Replace: JWT_SECRET, DB_PASSWORD, any other compromised secrets
+chmod 600 /opt/terrafusion/staging/app.env
+```
+
+- Status: (pending)
+
+#### A5) Re-authenticate GHCR on VPS
+
+```bash
+docker logout ghcr.io || true
+docker login ghcr.io -u <GITHUB_USERNAME>
+# Use token with read:packages scope
+```
+
+- Status: (pending)
+
+### B) Normalize VPS to Canonical Lane Layout
+
+Target state: `APP_ROOT=/opt/terrafusion/staging`, secrets at `app.env`, owned by `deploy:deploy`, perms `600`.
+
+```bash
+ssh root@72.60.126.11
+mkdir -p /opt/terrafusion/staging
+chown -R deploy:deploy /opt/terrafusion
+
+# Move secrets if Copilot created them elsewhere
+mv /opt/terrafusion/.env /opt/terrafusion/staging/app.env 2>/dev/null || true
+chown deploy:deploy /opt/terrafusion/staging/app.env 2>/dev/null || true
+chmod 600 /opt/terrafusion/staging/app.env 2>/dev/null || true
+```
+
+Verify:
+
+```bash
+ssh -i tf_staging_deploy_key_v2 deploy@72.60.126.11 "ls -la /opt/terrafusion/staging && stat -c '%U %G %a %n' /opt/terrafusion/staging/app.env"
+# Expected: deploy deploy 600 /opt/terrafusion/staging/app.env
+```
+
+- Status: (pending)
+
+### C) Set GitHub Staging Environment Variables/Secrets
+
+GitHub repo → Settings → Environments → staging:
+
+| Type | Name | Value |
+|------|------|-------|
+| Variable | DEPLOY_HOST | 72.60.126.11 |
+| Variable | DEPLOY_PORT | 22 |
+| Variable | DEPLOY_USER | deploy |
+| Variable | PUBLIC_URL | https://staging.terrafusionmarket.com |
+| Variable | APP_ROOT | /opt/terrafusion/staging |
+| Secret | DEPLOY_SSH_KEY | (private key of tf_staging_deploy_key_v2) |
+
+Ignore any `STAGING_*` values; they are non-authoritative.
+
+- Status: (pending)
+
+### D) DNS Sanity Check (must pass before dispatch)
+
+```bash
+nslookup staging.terrafusionmarket.com
+# Must resolve to 72.60.126.11
+```
+
+- Status: (pending)
+- Resolved to: (pending)
+
+### E) Staging Proof Sequence (4 Dispatches)
+
+#### E1) Seed staging baseline (remediation SHA)
+
+- Workflow: `release-lane`
+- Inputs: `target_env=staging`, `release_sha=24531f37a9ea785a99c1b7e4e1dd70c294af1a0c`
+- Status: (pending)
+- Artifact: (pending)
+- Health: (pending)
+- X-Release-Sha: (pending)
+
+#### E2) Deploy proof SHA (release candidate)
+
+- Workflow: `release-lane`
+- Inputs: `target_env=staging`, `release_sha=864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`
+- Status: (pending)
+- Artifact: (pending)
+- Health: (pending)
+- X-Release-Sha: (pending)
+
+#### E3) Rollback drill
+
+- Workflow: `rollback-staging` (no inputs)
+- Status: (pending)
+- Artifact: (pending)
+- Health: (pending)
+- X-Release-Sha after rollback: (pending — must show 24531f37a…)
+
+#### E4) Redeploy proof SHA
+
+- Workflow: `release-lane`
+- Inputs: `target_env=staging`, `release_sha=864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`
+- Status: (pending)
+- Artifact: (pending)
+- Health: (pending)
+- X-Release-Sha: (pending)
+
+#### Pass Criteria
+
+- `/health` returns HTTP 200
+- `X-Release-Sha` header matches requested SHA
+- Evidence pack contains required schema files and logs
+
+### F) Evidence Refresh (only after artifacts exist)
+
+After all 4 staging artifacts exist, update from receipts only (not from memory):
+
+- [ ] This document (IP, DNS timestamp, artifact names/links)
+- [ ] `production-readiness-accounting.md` (staging deploy/rollback/observability → pass)
+- [ ] Create `ops-evidence-lane-report.md` if needed
+
+### G) Production (deferred — do not start until staging passes)
+
+After staging proof sequence passes:
+1. Provision production VPS
+2. Set GitHub `production` environment with same variable names
+3. Run `release-lane` once for `864d651a8…`
+4. Verify health + X-Release-Sha
+5. Update this document and production-readiness-accounting.md
+
+---
+
 ## Lane Closure Evidence Index
-- Deploy seed 24531f37a... artifact: (link or artifact name)
-- Deploy 864d651a8... artifact: (link or artifact name)
-- Rollback artifact: (link or artifact name)
-- Redeploy 864d651a8... artifact: (link or artifact name)
-- Production deploy 864d651a8... artifact: (link or artifact name)
+
+- Deploy seed 24531f37a… artifact: (pending E1)
+- Deploy 864d651a8… artifact: (pending E2)
+- Rollback artifact: (pending E3)
+- Redeploy 864d651a8… artifact: (pending E4)
+- Production deploy 864d651a8… artifact: (deferred to G)
 
 ## Notes
+
 - Hostinger MCP is optional discovery only; config is local-only and not committed.
 - Production is not approved until staging deploy + rollback + observability proofs exist.
 - Any credential or secret ever pasted into chat is compromised and must be rotated before use.
+- `origin/main` advanced to `b6487a893…` via PR #660 (lane wiring). Release proofs still target `24531f37a…` then `864d651a8…` via `release_sha` input.
+- Fastest next step: **A2 (rotate deploy SSH key)** — everything else depends on a clean, working deploy key.

--- a/os-platform/core/pilot/production-readiness-accounting.md
+++ b/os-platform/core/pilot/production-readiness-accounting.md
@@ -1,310 +1,140 @@
 # Production Readiness Accounting
 
-Date: 2026-03-10 (final pass — PR #656 merged, post-merge governance proof complete)
+Date: 2026-03-10 (post-PR #660 — release lane wiring complete)
 
-This document is a synchronized production-readiness accounting for the CP, CX, and CC lanes based on repository state, local gate runs, and protected-branch governance state. It separates four states that were previously drifting together:
+This is the canonical in-scope production-readiness accounting for the current protected `main` lineage. It supersedes the earlier `24531f37a`-only framing.
 
-- implemented
-- tested locally
-- promoted or merged
-- production-ready
+It distinguishes:
 
-This is the release-decision truth pass, not a claim that all lanes are independently production-ready.
+- `engineering-remediation-baseline`
+- `protected-main`
+- `bookkeeping-only deployment records`
+- `decision-grade operational proof`
 
-## Current Baseline SHA
+This is a release-decision truth pass, not a blanket claim of production approval.
 
-- Protected baseline on `origin/main`: `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` (PR #656 merge commit)
-- Pre-merge protected main: `bdd5036c568bead812a9c77f5032b11a7c74ee19`
-- PR #656 branch head (pre-merge): `e2c02d5ff` (CC+CP remediation on top of `f1196a82e`)
-- PR #656: **MERGED** (2026-03-10T13:55:35Z)
-- CI Seal Gate: **GREEN** (run `22905637108`, all 6 required checks passed)
+## Current Protected Main Lineage
 
-## Merged/Promoted Commit Map
+- Active protected `origin/main`: `b6487a8939648d12f6c1ceca0221ed8c8c40f7a0`
+- PR `#660` merged at: 2026-03-10 (ops: canonical release lane wiring)
+- PR `#660` merge commit: `b6487a8939648d12f6c1ceca0221ed8c8c40f7a0`
+- PR `#660` scope: release-lane.yml, rollback-staging.yml, runtime bundle, Hostinger truth surface
+- Protected release candidate: `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` (PR #659)
+- Engineering remediation baseline from PR `#656`: `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c`
+- PR `#656` merged at: `2026-03-10T13:55:35Z`
+- PR `#659` merged at: `2026-03-10T14:18:33Z`
+- PR `#659` head commit: `a042ce6506f03732493d7b18f3e7d2f0034a5e28`
+- PR `#659` merge commit: `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`
+- PR `#659` touched only `os-platform/core/pilot/production-readiness-accounting.md`
 
-| Lane | Commit | State | Evidence-backed claim |
-| --- | --- | --- | --- |
-| CP | `a581ae2d0` | tagged `r3.0.0`, in history | 53 governed tools, 9 workbench tabs |
-| CP | `00eed894b` | tagged `r3.1.0`, in history | office registry, RBAC vocabulary, officeScope, 18 ACs |
-| CP | `b86382db5` | tagged `r3.2.0`, in history | cross-office trace verification, evidence packet, 30/30 ACs |
-| CX | `ca6ab11a4` | rebased, on PR `#656` branch (`origin/r3/cx-backend-controllers`), not yet merged | Clerk, Treasury, Audit controllers and entities (rebased from `012f7fe3a`) |
-| CX | `f1196a82e` | **MERGED** to protected main via `24531f37a` (PR #656) | CX acceptance tests + security hardening |
-| CC+CP remediation | `e2c02d5ff` | **MERGED** to protected main via `24531f37a` (PR #656) | 9-tab test fix, evidence truth, check:generated fix |
-| CC truth correction | `ff964512a` | historical claim | stated `R16 complete` |
-| CC truth correction | `825366be3` | historical correction | corrected progress ledger overstatement |
-| Protected main | `24531f37a` | current deployable protected baseline (PR #656 merge commit) | Includes all CX + CC + CP remediation work |
+`864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` remains the authoritative release baseline (PR #660 adds deployment tooling, not product code).
 
-## Commands Executed For This Accounting
+## Lineage Truth Map
+
+| Commit | State | Evidence-backed claim |
+| --- | --- | --- |
+| `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` | prior protected main, PR `#656` merge baseline | governed engineering remediation baseline |
+| `a042ce6506f03732493d7b18f3e7d2f0034a5e28` | PR `#659` head | documentation-only accounting publication |
+| `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` | PR `#659` merge | authoritative release baseline |
+| `b6487a8939648d12f6c1ceca0221ed8c8c40f7a0` | current protected main, PR `#660` merge | release lane wiring (ops-only, no product code) |
+
+## Commands Executed For This Refresh
+
+Protected-main proof was refreshed from a clean detached worktree pinned to `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` at `C:\Users\bsval\terrafusion_os_1.0__ops_864`.
 
 | Command | Result |
 | --- | --- |
+| `git ls-remote origin refs/heads/main` | PASS, resolved `origin/main` to `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` |
+| `gh pr view 659 --json number,title,mergedAt,mergeCommit,headRefOid,files` | PASS, PR `#659` merged at `2026-03-10T14:18:33Z`; single-file docs-only change |
+| `gh api repos/bsvalues/terrafusion_os_1.0/branches/main/protection` | PASS, verified required branch-protection checks, strict mode, and admin enforcement |
+| `gh api repos/bsvalues/terrafusion_os_1.0/commits/864d651a8b49ec1b2dc2cbca137091dbc1c3b29b/check-runs` | PASS, verified required checks green on protected SHA |
+| `pnpm install --frozen-lockfile` | PASS |
 | `pnpm run type-check` | PASS |
 | `node --test os-platform/core/tests/phase83-tools.test.mjs` | PASS `32/32` |
 | `node --test os-platform/core/tests/phase85-tools.test.mjs` | PASS `20/20` |
 | `node --test os-platform/core/tests/phase86-toolrunner.test.mjs` | PASS `7/7` |
-| `node --test os-platform/core/tests/r3-acceptance-criteria.test.mjs` | PASS `30/30` |
-| `node --test os-platform/core/tests/r3-cx-acceptance-criteria.test.mjs` | PASS `34/34` |
-| `dotnet build backend/TerraFusion.sln -c Release -v:minimal /nologo` | PASS, `0` warnings, `0` errors |
-| `pnpm run check:generated` | PASS — `.codex_split` added to SKIP_DIRS (blocker #5 resolved) |
-| `pnpm -C frontend run test:tier0 -- apps/os-shell/src/pages/workbench/__tests__/WorkbenchTabBar.test.tsx` | PASS, `19` passed (blocker #3 resolved — 9-tab constitutional test) |
-| `gh api repos/bsvalues/terrafusion_os_1.0/branches/main/protection` | verified required checks and admin enforcement |
-| `gh pr checks 656 --required` | ALL 6 required checks GREEN |
-| `gh pr merge 656 --merge` | MERGED as `24531f37a` (2026-03-10T13:55:35Z) |
-| Post-merge: `pnpm run type-check` | PASS |
-| Post-merge: `phase83-tools.test.mjs` | PASS `32/32` |
-| Post-merge: `phase85-tools.test.mjs` | PASS `20/20` |
-| Post-merge: `phase86-toolrunner.test.mjs` | PASS `7/7` |
-| Post-merge: `r3-acceptance-criteria.test.mjs` | PASS `30/30` |
-| Post-merge: `r3-cx-acceptance-criteria.test.mjs` | PASS `34/34` |
-| Post-merge: `check:generated` | PASS |
-| Post-merge: `WorkbenchTabBar.test.tsx` | PASS `19/19` |
+| `pnpm run check:generated` | PASS |
+| `gh api repos/bsvalues/terrafusion_os_1.0/deployments?sha=864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` | PASS, found GitHub deployment records for `dev`, `staging`, and `production` |
+| `Invoke-WebRequest https://terrafusion-backend-staging.azurecontainerapps.io/health` | FAIL, DNS resolution failed (`No such host is known`) |
+| `Invoke-WebRequest https://terrafusion-frontend-staging.azurecontainerapps.io/health` | FAIL, DNS resolution failed (`No such host is known`) |
+| Heroku MCP `list_apps --all` | BLOCKED, `HEROKU_API_KEY` invalid |
+| Grafana MCP `list_datasources`, `search_dashboards`, `list_alert_rules` | BLOCKED, configured host invalid (`http: no Host in request URL`) |
 
-## Key File Evidence
+## Required Checks On The Protected SHA
 
-- `frontend/apps/os-shell/src/pages/workbench/__tests__/WorkbenchTabBar.test.tsx:28-38` now locks a 9-tab constitutional order (clerk, treasury, audit added — blocker #3 resolved).
-- `frontend/apps/os-shell/src/pages/workbench/__tests__/WorkbenchTabBar.test.tsx:172-177` strips the full 9-icon set via alternation regex.
-- `frontend/apps/os-shell/src/pages/workbench/PropertyWorkbench.tsx:98-106` defines the actual 9-tab governed surface: Summary, Forge, Atlas, Dais, Clerk, Treasury, Audit, Dossier, Pilot.
-- `docs/planning/R3_EVIDENCE_PACKET.md` now qualifies CX claims as branch-only (PR #656) and splits ACs into 30 promoted + 34 branch-only (blocker #4 resolved).
-- `tools/registry/check-generated-js.mjs:12-20` now includes `.codex_split` in SKIP_DIRS (blocker #5 resolved).
+The protected `main` branch requires:
 
-## Definition Of Production
+- `governed-spine`
+- `phase85-tools`
+- `phase86-toolrunner`
+- `🔒 TerraFusion Seal Gate`
+- `🧪 Tier-1 UI Harness Validation`
 
-Production for TerraFusion, for purposes of this accounting, means:
+Those required checks are green on protected SHA `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`.
 
-`Production = a governed, evidence-backed release state in which the protected baseline SHA can be deployed from a clean checkout with required checks green, evidence aligned to that exact SHA, critical operator paths proven end-to-end, unsupported paths failing intentionally, observability and rollback posture available, and no known unresolved blocker on critical operator flows.`
+## Evidence Freshness Conclusion
 
-By that definition, branch-local success is not sufficient. A lane must reconcile local proof, protected-branch truth, and release evidence.
+- The engineering readiness proven at `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` carries forward to `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` because PR `#659` is documentation-only and no product code changed between those SHAs.
+- The current protected baseline has been revalidated in a clean worktree with `type-check`, `phase83`, `phase85`, `phase86`, and `check:generated`.
+- This document is the canonical in-scope SHA refresh for the governed surface.
+- Out-of-scope evidence artifacts outside the core governance surface were not edited in this pass.
 
-## Lane-By-Lane Truth Summary
+## Operational Execution Status
 
-| Lane | Implemented | Local proof | Promoted | Production recommendation |
-| --- | --- | --- | --- | --- |
-| CP | Yes | Strong | Yes, via `r3.0.0`–`r3.2.0` lineage + merge `24531f37a` | `release-ready` |
-| CX | Yes | Strong | Yes, merged via PR #656 (`24531f37a`) | `release-ready` |
-| CC | Yes — truth aligned | Strong (19/19 tests, evidence packet qualified) | Yes, merged via PR #656 (`24531f37a`) | `release-ready` |
+### 0. Release Lane Wiring (NEW — PR #660)
 
-## CP Accounting
+- PR #660 merged to main at `b6487a893…`
+- `release-lane.yml`: canonical workflow_dispatch with `target_env` + `release_sha` inputs
+- `rollback-staging.yml`: canonical workflow_dispatch, reads `current.sha`/`previous.sha` from VPS
+- Workflows consume GitHub environment variables: `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `PUBLIC_URL`, `APP_ROOT` + secret `DEPLOY_SSH_KEY`
+- Runtime bundle, SSH preflight, DNS check, health probe, evidence artifact upload — all wired
+- Status: **pass** (repo-side complete)
 
-### 1. Where we are
+### 1. Staging Deploy
 
-- Assigned lane: governed tool surface, manifest and version truth, acceptance criteria posture, governed execution contracts.
-- Commits in evidence: `a581ae2d0`, `00eed894b`, `b86382db5`.
-- Actually promoted or merged:
-- `r3.0.0`, `r3.1.0`, and `r3.2.0` are present in history.
-- Not currently equivalent to protected baseline:
-- current protected `origin/main` is `bdd5036c5`, not `b86382db5` and not `a15da8fdb`.
-- Tests and gates run:
-- `pnpm run type-check`
-- `phase83-tools.test.mjs` `32/32`
-- `phase85-tools.test.mjs` `20/20`
-- `phase86-toolrunner.test.mjs` `7/7`
-- `r3-acceptance-criteria.test.mjs` `30/30`
-- What passed:
-- core governance tests passed locally
-- governed R3 acceptance passed locally
-- What remains unproven:
-- clean-checkout local reproducibility of `check:generated` in this worktree
-- protected-branch proof on the current `origin/main` baseline after rebasing candidate work
+- GitHub recorded staging deployment `4029987833` from `2026-03-10T14:19:35Z` to `2026-03-10T14:19:44Z`.
+- That record is not decision-grade staging proof. The earlier release-lane.yml only echoed the SHA.
+- PR #660 replaced that with a real VPS deployment workflow, but it has not yet been dispatched.
+- **Remaining external blockers** (see `hostinger-control-plane.md` for full operator checklist):
+  1. Rotate compromised credentials (VPS root pw, deploy SSH keypair, GitHub DEPLOY_SSH_KEY, VPS app.env secrets, GHCR login)
+  2. Normalize VPS layout to `/opt/terrafusion/staging/app.env` with `deploy:deploy` and `600`
+  3. Set GitHub `staging` environment vars/secrets to canonical names
+  4. Execute DNS sanity check (staging.terrafusionmarket.com → 72.60.126.11)
+  5. Run 4-dispatch proof sequence: seed (24531f37a…), deploy (864d651a8…), rollback, redeploy
+- Result: `blocked-on-external-ops`
 
-### 2. Where we want to be
+### 2. Rollback Drill
 
-- CP production means the governed surface is stable on the protected baseline, manifests are truthful, generated JS mirrors are reproducible from source, and the required core-governance checks are green on the release SHA.
-- Before go-live for CP:
-- governed-spine, `phase85-tools`, `phase86-toolrunner`, and Seal Gate must all be green on the exact release SHA
-- tool manifest and generated artifacts must be reproducible from a clean checkout
-- acceptance evidence must name the exact promoted SHA
+- No real staging deployment target was available to roll back.
+- `rollback-staging.yml` is now wired and ready but requires a prior successful deploy to create `current.sha`/`previous.sha`.
+- Result: `blocked-on-staging-deploy`
 
-### 3. What is still needed
+### 3. Observability Verification
 
-- Blockers:
-- shared Seal Gate failure blocks release
-- candidate SHA is not on protected main
-- Bounded follow-up work:
-- rebase candidate onto current `origin/main`
-- rerun required governance checks on the rebased head
-- ~~Bounded follow-up work (RESOLVED):~~
-  - ~~rerun `check:generated` from a clean workspace or harden the scanner~~ → `.codex_split` added to SKIP_DIRS, `check:generated` now passes
-- Governance uncertainties:
-  - ~~current local `check:generated` failure~~ → resolved
-- Local-only proof needing CI confirmation:
-  - all local gates pass; CI confirmation pending rebase and PR update
-- Operational gaps not covered by current tests:
-- this accounting did not perform a deployment or rollback drill
+- Health endpoints for the guessed staging hosts were not reachable (Azure DNS failed).
+- PR #660 targets Hostinger VPS at 72.60.126.11, not Azure Container Apps.
+- Heroku control-plane access is blocked by an invalid token.
+- Grafana control-plane access is blocked by an invalid host configuration.
+- Logs, metrics, alerts, dashboards, and deployed-version visibility were not proven for a live `864d651a8` environment.
+- Result: `blocked-on-staging-deploy`
 
-### 4. Risks if we go live now
+## Final Release Memo
 
-- release evidence could point at a non-protected SHA (candidate `f1196a82e` is not yet merged)
-- ~~a clean operator could fail `check:generated` if workspace policy is not made explicit~~ → mitigated (`.codex_split` in SKIP_DIRS)
-- governance claims are locally reproducible; CI confirmation on rebased PR is the remaining gap
+- Protected main: `b6487a8939648d12f6c1ceca0221ed8c8c40f7a0` (PR #660, lane wiring)
+- Release candidate: `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` (PR #659)
+- Engineering remediation baseline: `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` (PR #656)
+- Accounting published: `yes`, via PR #659, updated post-PR #660
+- Release lane wiring: `pass` (repo-side complete, PR #660)
+- Staging deploy: `blocked-on-external-ops`
+- Rollback verification: `blocked-on-staging-deploy`
+- Observability verification: `blocked-on-staging-deploy`
+- Decision: `not approved`
+- Reason: release lane tooling is complete; external ops (credential rotation, VPS normalization, GitHub env config, 4-dispatch proof sequence) must be executed before decision-grade staging proof exists
 
-### 5. Production recommendation
+## Release Recommendation
 
-- `release-ready`
-
-Reason: CP lane is governance-green on merged protected main (`24531f37a`). All gates pass post-merge.
-
-## CX Accounting
-
-### 1. Where we are
-
-- Assigned lane: controller integration coverage, R14 Phase 2a and 2b continuation for backend posture, P0 backend confidence, release posture for Clerk, Treasury, and Audit controllers.
-- Commits in evidence: `ca6ab11a4` (rebased controllers), `f1196a82e` (rebased CX tests + security).
-- Pre-rebase SHAs (historical): `012f7fe3a`, `a15da8fdb`.
-- Actually promoted or merged:
-- CX branch is rebased onto current protected `origin/main` (`bdd5036c5`)
-- PR `#656` is no longer behind — merge-base matches protected main
-- not yet merged to protected main
-- Tests and gates run:
-- `node --test os-platform/core/tests/r3-cx-acceptance-criteria.test.mjs`
-- `dotnet build backend/TerraFusion.sln -c Release -v:minimal /nologo`
-- PR status checks reviewed; backend/governance checks green on rebased branch
-- What passed:
-- CX acceptance criteria passed locally `34/34`
-- backend solution built cleanly with `0` warnings and `0` errors
-- PR-level `governed-spine`, `phase85-tools`, `phase86-toolrunner`, and Tier-1 UI Harness were green
-- What remains unproven:
-- shared frontend / Seal Gate outcome on the rebased PR
-- merged end-to-end proof on the actual release SHA
-
-### 2. Where we want to be
-
-- CX production means the backend controllers, routes, handler mappings, and security posture are merged to protected main and all required checks are green on the exact release SHA.
-- Before go-live for CX:
-- PR `#656` or equivalent successor must be rebased and merged
-- backend fast gate and Seal Gate must pass on the protected release SHA
-- route contracts used by governed handlers must match what is actually deployed
-
-### 3. What is still needed
-
-- Blockers:
-  - PR `#656` is still open (not yet merged)
-  - ~~PR `#656` is behind base~~ → **RESOLVED** (rebased onto `bdd5036c5`, merge-base matches protected main)
-  - shared frontend / Seal Gate still pending on the rebased PR
-- Bounded follow-up work:
-  - ~~rebase onto current `origin/main`~~ → DONE (`f1196a82e` rebased onto `bdd5036c5`)
-  - resolve the shared frontend gate failure on the rebased PR
-  - merge PR `#656` after Seal Gate goes green
-- Governance uncertainties:
-  - ~~PR base SHA recorded by GitHub is stale~~ → resolved (merge-base = `bdd5036c5`)
-- Local-only proof needing CI confirmation:
-  - `34/34` CX acceptance is local; CI confirmation pending Seal Gate green on rebased `f1196a82e`
-- Operational gaps not covered by current tests:
-- this pass did not execute a full live API smoke against a deployed environment
-
-### 4. Risks if we go live now
-
-- controller code is locally proven and rebased but still unmerged to protected main
-- ~~backend claims could drift from the actual protected deployable SHA~~ → mitigated (rebased, merge-base = `bdd5036c5`)
-- operator-facing tabs may invoke backend capabilities that are locally proven but not yet promotion-proven
-
-### 5. Production recommendation
-
-- `release-ready`
-
-Reason: CX lane merged to protected main via PR #656 (`24531f37a`). Seal Gate green. All governance gates pass post-merge.
-
-## CC Accounting
-
-### 1. Where we are
-
-- Assigned lane: ledger truth, R16 cleanup claims versus actual semantic confidence, release posture narrative, user-facing production honesty.
-- Commits and evidence in scope:
-- `a581ae2d0` introduced the 9-tab workbench surface in tagged history
-- `ff964512a` claimed `R16 complete`
-- `825366be3` later corrected progress-ledger overstatement
-- `docs/planning/R3_EVIDENCE_PACKET.md` currently claims `r3.3.0` and `64 acceptance criteria` as if fully settled release truth
-- Actually promoted or merged:
-- 9-tab workbench implementation exists in history
-- current release narrative is not aligned with protected release truth
-- Tests and gates run:
-- reproduced local failure in `frontend/apps/os-shell/src/pages/workbench/__tests__/WorkbenchTabBar.test.tsx`
-- reviewed current workbench tab definition in `frontend/apps/os-shell/src/pages/workbench/PropertyWorkbench.tsx`
-- What passed:
-- actual workbench implementation clearly contains 9 tabs
-- What remains unproven:
-- current frontend constitutional tests are not aligned with current surface
-- current release evidence packet is not aligned with actual tag truth
-
-### 2. Where we want to be
-
-- CC production means the UI contract tests, release narrative, evidence packet, and operator-facing truth all describe the same protected SHA without overstatement.
-- Before go-live for CC:
-- UI tests must describe the actual 9-tab surface
-- evidence packet must point to real tags and promoted SHAs
-- release wording must survive a truth audit without "branch-only presented as shipped"
-
-### 3. What is still needed
-
-- ~~Blockers (RESOLVED):~~
-  - ~~`WorkbenchTabBar.test.tsx` still hard-codes a 6-tab constitutional order~~ → updated to 9-tab, 19/19 pass
-  - ~~`docs/planning/R3_EVIDENCE_PACKET.md` claims a local `r3.3.0` tag that does not exist in this repo state~~ → CX claims qualified as branch-only
-- Bounded follow-up work:
-  - ~~update frontend constitutional tests to the current governed tab surface~~ → DONE
-  - ~~reconcile release evidence packet to actual tags, SHAs, and promoted state~~ → DONE
-  - ~~remove or qualify any branch-only claim presented as shipped truth~~ → DONE
-- Governance uncertainties:
-- historical R16 narrative already required one correction pass, so release wording should be treated as a governance-sensitive area
-- Local-only proof needing CI confirmation:
-- frontend fix must pass Seal Gate on the rebased candidate
-- Operational gaps not covered by current tests:
-- this pass did not run a fresh end-to-end operator workflow across all 9 tabs in a deployed environment
-
-### 4. Risks if we go live now
-
-- ~~operators would see a surface whose constitutional test contract is stale~~ → resolved (9-tab test, 19/19 pass)
-- ~~release packet would overstate promotion state by naming a tag not present locally~~ → resolved (CX qualified as branch-only)
-- ~~residual risk: frontend constitutional test changes are local; must land on rebased PR for Seal Gate to see them~~ → resolved (merged via PR #656, Seal Gate green)
-
-### 5. Production recommendation
-
-- `release-ready`
-
-Reason: CC lane truth alignment is complete. Constitutional test locks 9-tab surface (19/19 pass), evidence packet is honest, and all changes are merged to protected main with Seal Gate green.
-
-## Go-Live Prerequisites
-
-- ~~Rebase the candidate work onto current protected `origin/main`~~ → DONE (CX rebased to `f1196a82e`, merge-base = `bdd5036c5`)
-- ~~Resolve the failing frontend constitutional tab-order test and make Seal Gate green~~ → DONE (19/19 pass locally)
-- ~~Reconcile `docs/planning/R3_EVIDENCE_PACKET.md` to actual tags, SHAs, and promotion state~~ → DONE (CX qualified as branch-only)
-- ~~Produce clean-checkout proof for `check:generated`~~ → DONE (`.codex_split` added to SKIP_DIRS)
-- ~~Shared frontend / Seal Gate must go green on rebased PR `#656`~~ → DONE (run `22905637108`, all 6 required checks green)
-- ~~Merge PR `#656` to protected main after Seal Gate clears~~ → DONE (merged as `24531f37a`, 2026-03-10T13:55:35Z)
-- ~~Re-run required governance checks on the exact release SHA (post-merge)~~ → DONE (all gates green on merged main)
-- ~~Confirm evidence artifacts, correlation IDs, and release wording all reference the exact promoted SHA~~ → DONE (this document)
-- Perform at least one controlled release-path verification that includes observability and rollback notes for the chosen release SHA
-
-## Blockers
-
-All five tracked blockers are resolved.
-
-1. ~~Shared frontend / Seal Gate not yet green~~ → **RESOLVED** (2026-03-10, Seal Gate green, run `22905637108`)
-2. ~~CX candidate work unmerged~~ → **RESOLVED** (2026-03-10, merged as `24531f37a`)
-3. ~~Frontend constitutional test contract stale~~ → **RESOLVED** (CC lane, 9-tab test 19/19)
-4. ~~Release evidence packet overclaims~~ → **RESOLVED** (CC lane, CX qualified as branch-only → now merged)
-5. ~~`check:generated` scanning `.codex_split`~~ → **RESOLVED** (CP lane, `.codex_split` in SKIP_DIRS)
-
-## Non-Blocking Debt
-
-- No fresh full deployed-environment smoke was run for all 9 workbench tabs in this accounting pass.
-- Unsupported and post-R1 paths were not exhaustively negative-tested in this pass.
-- This pass did not rerun a dedicated secrets scan, deployment rollback drill, or production observability drill.
-
-## Release Decision
-
-**Release decision: approved.**
-
-Merged baseline `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c` is governance-green and passes post-merge proof (`type-check`, `phase83`, `phase85`, `phase86`, `r3`, `r3-cx`, `check:generated`, and 9-tab Workbench constitutional test). All five tracked blockers are resolved. Production deployment proceeds only under the established environment, secrets/config, observability, and rollback controls.
-
-### Release vs. Deployment Status
-
-| Dimension | Status | Evidence |
-| --- | --- | --- |
-| **Release status** | `release-ready` | All governance gates green on merged SHA; all 5 blockers resolved; CI Seal Gate green (run `22905637108`); post-merge local proof green |
-| **Deployment status** | `deploy pending ops confirmation` | Code and governance are release-ready; production deployment requires final confirmation of environment config, secrets, observability, and rollback posture on the merged SHA |
-
-### Evidence Trail
-
-- Merged SHA: `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c`
-- PR: `#656` (`r3/cx-backend-controllers`)
-- Seal Gate run: `22905637108` (all 6 required checks green)
-- Merge timestamp: 2026-03-10T13:55:35Z
-- Post-merge governance proof: all green (type-check, phase83 32/32, phase85 20/20, phase86 7/7, R3 30/30, R3-CX 34/34, check:generated, WorkbenchTabBar 19/19)
+- Release-decision ready: `no`
+- Deploy-to-production ready: `no`
+- Repo-side release lane: `ready` (PR #660)
+- Critical path: rotate deploy SSH key (A2) → normalize VPS (B) → set GitHub env (C) → DNS check (D) → execute 4 dispatches (E)
+- Final recommendation: `do not promote beyond protected main until external ops closure completes and 4-dispatch proof sequence passes`


### PR DESCRIPTION
## Doc-Only Truth Surface Refresh After PR #660

This PR updates the governed ops truth surfaces to match the current canonical state after PR `#660`.

### What changed
- updates `os-platform/core/pilot/ops/hostinger-control-plane.md`
  - records `origin/main` as `b6487a893...`
  - adds the operator checklist for external ops closure
  - records the canonical staging VPS contract and GitHub environment names
- updates `os-platform/core/pilot/production-readiness-accounting.md`
  - records repo-side release lane wiring as complete
  - changes staging deploy / rollback / observability from old failure framing to `blocked-on-external-ops`
  - keeps production decision at `not approved`

### What did not change
- no workflow logic
- no product code
- no secrets
- no claim that staging proof already exists

### Verification
- `node --test os-platform/core/pilot/ops/tests/no-secrets-committed.test.mjs`
- `pnpm exec prettier --check os-platform/core/pilot/ops/hostinger-control-plane.md os-platform/core/pilot/production-readiness-accounting.md`

### Current truth
Repo-side lane wiring is merged on protected `main`, but live closure still depends on:
1. deploy SSH key rotation
2. staging VPS normalization
3. GitHub `staging` environment configuration
4. seed -> deploy -> rollback -> redeploy artifact sequence