### PR TITLE
fix(ops): tolerate ssh-keyscan KEX warnings in deploy workflows

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -84,7 +84,8 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts
 
       - name: Preflight - public DNS resolution
         shell: bash

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -60,7 +60,8 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts
 
       - name: Preflight - remote host access
         shell: bash


### PR DESCRIPTION
ssh-keyscan returns non-zero on VPS hosts advertising unsupported KEX methods (sntrup761x25519-sha512). The keyscan still captures host keys, but set -euo pipefail kills the step.

Fix: suppress stderr, allow non-zero exit, then verify host keys were actually captured via grep.

Unblocks staging proof sequence (E1-E4).

## Summary by Sourcery

Relax SSH host key scanning in deployment workflows to tolerate non-zero exits while still verifying known_hosts is populated for the deploy host.

Bug Fixes:
- Prevent deployment and rollback workflows from failing when ssh-keyscan returns non-zero due to unsupported key exchange methods.

CI:
- Adjust release and rollback GitHub Actions workflows to ignore ssh-keyscan stderr/exit code while asserting the deploy host key is recorded in known_hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SSH host key management in deployment and rollback workflows by enhancing error handling and adding explicit verification checks. These changes strengthen the reliability of automated deployment processes and ensure consistent SSH configuration validation across deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->