### PR TITLE
fix(ops): overlay deploy infrastructure for old release SHAs

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -44,6 +44,41 @@ jobs:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 0
 
+      - name: Overlay deploy infrastructure from default branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The release SHA contains the application source, but deploy infrastructure
+          # (Caddyfile, compose template, Dockerfile fixes) may only exist on the
+          # default branch. Overlay those files without touching application source.
+          git fetch origin main --no-tags --depth=1 2>/dev/null || true
+          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml; do
+            if [ ! -f "$path" ]; then
+              dir="$(dirname "$path")"
+              mkdir -p "$dir"
+              echo "Restoring $path from origin/main"
+              git show "origin/main:$path" > "$path"
+            fi
+          done
+
+          # Ensure test project stubs exist for dotnet restore of the full .sln
+          for proj in TerraFusion.Unit.Tests TerraFusion.Unit.SmokeTests TerraFusion.Integration.Tests TerraFusion.Tests.Unit; do
+            dir="backend/tests/$proj"
+            if [ ! -f "$dir/$proj.csproj" ]; then
+              mkdir -p "$dir"
+              cat > "$dir/$proj.csproj" <<'CSPROJ'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+          </Project>
+          CSPROJ
+            fi
+          done
+
+          # If the Dockerfile does not already copy test projects, patch it
+          if ! grep -q 'tests/TerraFusion' backend/Dockerfile; then
+            sed -i '/COPY src\/TerraFusion\.Levy\/\*\.csproj/a COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/\nCOPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/\nCOPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/\nCOPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/' backend/Dockerfile
+          fi
+
       - name: Validate environment configuration
         shell: bash
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,10 @@ COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
+COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/
+COPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/
+COPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/
+COPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/
 
 # Restore dependencies
 RUN dotnet restore TerraFusion.sln --verbosity minimal
@@ -57,6 +61,10 @@ COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
+COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/
+COPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/
+COPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/
+COPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/
 
 # Restore
 RUN dotnet restore TerraFusion.sln --verbosity minimal

--- a/os-platform/core/pilot/ops/hostinger-control-plane.md
+++ b/os-platform/core/pilot/ops/hostinger-control-plane.md
@@ -17,17 +17,17 @@ This document contains **no secrets**. Store secrets only in:
 - Production: https://terrafusionmarket.com
 
 ## DNS Control Plane
-- DNS provider for terrafusionmarket.com: (Hostinger / Cloudflare / other)
-- Date/time verified: (UTC timestamp)
-- Verification method: nslookup/dig from local machine + screenshot or panel note
+- DNS provider for terrafusionmarket.com: Hostinger
+- Date/time verified: 2026-03-10T19:00Z (nslookup from local machine)
+- Verification method: `nslookup staging.terrafusionmarket.com` → 72.60.126.11
 
 ### Required DNS Records
-- A: staging -> <STAGING_VPS_IPV4>
+- A: staging -> 72.60.126.11 ✅ verified
 - A: @ (root) -> <PROD_VPS_IPV4> (defer until production provisioning)
 
 ## Staging VPS (Hostinger)
-- VPS name/id: (from Hostinger panel)
-- IPv4: <STAGING_VPS_IPV4>
+- VPS name/id: srv1479342
+- IPv4: 72.60.126.11
 - OS: Ubuntu 22.04 LTS
 - Provider firewall open: 22/tcp, 80/tcp, 443/tcp
 - Server firewall (ufw) open: 22/tcp, 80/tcp, 443/tcp
@@ -42,9 +42,9 @@ This document contains **no secrets**. Store secrets only in:
 - APP_ROOT: /opt/terrafusion/production
 
 ## GHCR Pull Auth (Staging)
-- Configured on VPS (deploy user): yes/no
+- Configured on VPS (deploy user): pending verification
 - Method: `docker login ghcr.io` with least-privilege token
-- Date/time verified: (UTC)
+- Date/time verified: pending
 
 ## GHCR Pull Auth (Production)
 - Configured on VPS (deploy user): yes/no
@@ -54,7 +54,7 @@ This document contains **no secrets**. Store secrets only in:
 ## GitHub Environments
 ### staging
 Variables:
-- DEPLOY_HOST = <STAGING_VPS_IPV4>
+- DEPLOY_HOST = 72.60.126.11
 - DEPLOY_PORT = 22
 - DEPLOY_USER = deploy
 - PUBLIC_URL = https://staging.terrafusionmarket.com


### PR DESCRIPTION
Fixes Docker build failure in release-lane dispatch for older release SHAs.

**Problem**: The release-lane workflow checks out the target release SHA, but older SHAs (24531f37a..., 864d651a8...) lack:
1. **Test project .csproj copies in Dockerfile** - .sln references 4 test projects not copied
2. **runtime-compose.template.yml** - Added after those SHAs were tagged

**Fix** (3 files):
- **backend/Dockerfile**: Add COPY lines for test project .csproj files (future SHAs)
- **release-lane.yml**: Add 'Overlay deploy infrastructure' step that creates stub test .csproj files, patches old Dockerfiles, and restores missing ops files from origin/main (backward compat for old SHAs)
- **hostinger-control-plane.md**: Record verified staging infra facts

**Evidence**: E1 dispatch run 22920589206 failed at Docker build step. This fix addresses the root cause.

## Summary by Sourcery

Ensure release-lane deployments remain compatible with older release SHAs by overlaying missing deploy infrastructure and test project metadata.

Bug Fixes:
- Prevent Docker build failures in the release-lane workflow when building older release SHAs that lack required test project files and ops assets.

Enhancements:
- Overlay deployment-related files from the default branch during release-lane runs so older release SHAs can be built and deployed without modifying their application source.
- Extend the backend Dockerfile to include test project .csproj files in the build context for consistent solution restores.

CI:
- Update the release-lane GitHub Actions workflow to restore missing ops files, generate stub test projects, and patch legacy Dockerfiles when needed.

Documentation:
- Refresh Hostinger control plane operations documentation with the current staging DNS, VPS, and environment configuration details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to overlay deployment infrastructure from default branch and validate test project availability.
  * Updated Dockerfile to include test projects in build context for both build and development stages.

* **Documentation**
  * Updated control plane documentation with verified Hostinger configuration details, including DNS records, VPS identifiers, and deployment host information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->