### PR TITLE
fix(ops): remote GHCR auth + always-overlay infra files

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -48,17 +48,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The release SHA contains the application source, but deploy infrastructure
-          # (Caddyfile, compose template, Dockerfile fixes) may only exist on the
-          # default branch. Overlay those files without touching application source.
+          # Deploy infrastructure (Caddyfile, compose template, Dockerfile) lives on
+          # the default branch and must match the pipeline expectations (service names,
+          # health headers, etc.).  Always overlay from main — old release SHAs may
+          # have incompatible versions (e.g. wrong service names in Caddyfile).
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
           for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml; do
-            if [ ! -f "$path" ]; then
-              dir="$(dirname "$path")"
-              mkdir -p "$dir"
-              echo "Restoring $path from origin/main"
-              git show "origin/main:$path" > "$path"
-            fi
+            dir="$(dirname "$path")"
+            mkdir -p "$dir"
+            echo "Overlaying $path from origin/main"
+            git show "origin/main:$path" > "$path"
           done
 
           # Ensure test project stubs exist for dotnet restore of the full .sln
@@ -191,8 +190,13 @@ jobs:
 
       - name: Preflight - GHCR pull on VPS
         shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Authenticate deploy user to GHCR (token is short-lived, expires after workflow run)
+          printf '%s' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cat | docker login ghcr.io -u ${{ github.actor }} --password-stdin >/dev/null 2>&1"
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" <<'SSH'
           set -euo pipefail
           docker pull "$BACKEND_IMAGE" >/dev/null

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: rollback-staging
@@ -105,8 +106,12 @@ jobs:
 
       - name: Prove GHCR pull on VPS
         shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cat | docker login ghcr.io -u ${{ github.actor }} --password-stdin >/dev/null 2>&1"
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" <<'SSH'
           set -euo pipefail
           docker pull "$BACKEND_IMAGE" >/dev/null


### PR DESCRIPTION
## Problem
1. VPS deploy user has no \~/.docker/config.json\ — \docker pull\ from GHCR will fail
2. Old release SHAs have a Caddyfile with wrong service names (\	errafusion-iron\/\	errafusion-soul\ instead of \ackend\/\rontend\)
3. Rollback workflow lacks \packages: read\ permission for GHCR auth

## Fix
- **Remote GHCR login**: Pipe short-lived \GITHUB_TOKEN\ via stdin to VPS before pull (both \elease-lane\ and \ollback-staging\)
- **Always-overlay infra**: Change overlay step to always use main's Caddyfile and compose template, not just when files are missing
- **Rollback permissions**: Add \packages: read\ to rollback workflow

## Evidence
- \ssh deploy@VPS 'cat ~/.docker/config.json'\ → \NO_DOCKER_CONFIG\
- \git show 864d651a8:ops/proxy/Caddyfile\ → uses \	errafusion-iron\/\	errafusion-soul\
- Token is short-lived, piped via stdin (no CLI exposure)

## Summary by Sourcery

Ensure release and rollback workflows always use current infra config and can authenticate to GHCR from the VPS.

Bug Fixes:
- Always overlay Caddyfile and runtime compose template from the main branch during release to avoid mismatches with older release SHAs.
- Authenticate the remote deploy user to GHCR before pulling backend and frontend images in release and rollback workflows by piping a short-lived token over SSH.
- Grant the rollback-staging workflow read permission on GHCR packages so image pulls succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous deployment workflow processes for improved consistency.
  * Enhanced authentication handling in deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->