### PR TITLE
fix(ops): project-level dotnet restore

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -48,10 +48,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Deploy infrastructure (Caddyfile, compose template, Dockerfile) lives on
-          # the default branch and must match the pipeline expectations (service names,
-          # health headers, etc.).  Always overlay from main — old release SHAs may
-          # have incompatible versions (e.g. wrong service names in Caddyfile).
+          # Deploy infrastructure (Caddyfile, compose template) lives on the default
+          # branch and must match the pipeline expectations (service names, health
+          # headers, etc.).  Always overlay from main — old release SHAs may have
+          # incompatible versions (e.g. wrong service names in Caddyfile).
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
           for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml; do
             dir="$(dirname "$path")"
@@ -60,22 +60,12 @@ jobs:
             git show "origin/main:$path" > "$path"
           done
 
-          # Ensure test project stubs exist for dotnet restore of the full .sln
-          for proj in TerraFusion.Unit.Tests TerraFusion.Unit.SmokeTests TerraFusion.Integration.Tests TerraFusion.Tests.Unit; do
-            dir="backend/tests/$proj"
-            if [ ! -f "$dir/$proj.csproj" ]; then
-              mkdir -p "$dir"
-              cat > "$dir/$proj.csproj" <<'CSPROJ'
-          <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>
-          </Project>
-          CSPROJ
-            fi
-          done
-
-          # If the Dockerfile does not already copy test projects, patch it
-          if ! grep -q 'tests/TerraFusion' backend/Dockerfile; then
-            sed -i '/COPY src\/TerraFusion\.Levy\/\*\.csproj/a COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/\nCOPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/\nCOPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/\nCOPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/' backend/Dockerfile
+          # Old SHAs restore from TerraFusion.sln which requires test projects
+          # that are excluded by .dockerignore.  Switch to project-level restore
+          # which resolves transitive deps without needing test .csproj files.
+          if grep -q 'dotnet restore TerraFusion.sln' backend/Dockerfile; then
+            echo "Patching Dockerfile: sln restore → project restore"
+            sed -i 's|dotnet restore TerraFusion\.sln|dotnet restore src/TerraFusion.API/TerraFusion.API.csproj|g' backend/Dockerfile
           fi
 
       - name: Validate environment configuration

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,13 +17,10 @@ COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
-COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/
-COPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/
-COPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/
-COPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/
 
-# Restore dependencies
-RUN dotnet restore TerraFusion.sln --verbosity minimal
+# Restore dependencies (project-level restore resolves transitive deps without
+# requiring test projects, which are excluded by .dockerignore)
+RUN dotnet restore src/TerraFusion.API/TerraFusion.API.csproj --verbosity minimal
 
 # Copy source
 COPY src/TerraFusion.Abstractions/ ./src/TerraFusion.Abstractions/
@@ -61,13 +58,9 @@ COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
-COPY tests/TerraFusion.Unit.Tests/*.csproj ./tests/TerraFusion.Unit.Tests/
-COPY tests/TerraFusion.Unit.SmokeTests/*.csproj ./tests/TerraFusion.Unit.SmokeTests/
-COPY tests/TerraFusion.Integration.Tests/*.csproj ./tests/TerraFusion.Integration.Tests/
-COPY tests/TerraFusion.Tests.Unit/*.csproj ./tests/TerraFusion.Tests.Unit/
 
-# Restore
-RUN dotnet restore TerraFusion.sln --verbosity minimal
+# Restore (project-level to avoid test project dependency)
+RUN dotnet restore src/TerraFusion.API/TerraFusion.API.csproj --verbosity minimal
 
 # Copy all source
 COPY . ./


### PR DESCRIPTION
E1 failed: .dockerignore excludes tests dir. Fix: use project-level restore.

## Summary by Sourcery

Switch backend Docker restore to project-level to avoid dependence on excluded test projects in release builds.

Bug Fixes:
- Fix release pipeline failures caused by solution-level dotnet restore requiring test projects that are excluded by .dockerignore.

Enhancements:
- Simplify the release workflow by removing runtime patching of test project stubs and Dockerfile test copy directives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD build workflow and optimized Docker image generation by removing test project artifacts from the build process
  * Updated build restore strategy to focus on core API project rather than entire solution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->