### PR TITLE
fix(docker): include workspace packages in frontend build context

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -53,7 +53,7 @@ jobs:
           # headers, etc.).  Always overlay from main — old release SHAs may have
           # incompatible versions (e.g. wrong service names in Caddyfile).
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
-          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml; do
+          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml frontend/Dockerfile; do
             dir="$(dirname "$path")"
             mkdir -p "$dir"
             echo "Overlaying $path from origin/main"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,10 @@ RUN echo "fetch-timeout=120000" >> .npmrc && echo "fetch-retries=5" >> .npmrc
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --filter ./frontend...
 
-# Copy frontend source only
+# Copy workspace packages (vite.config.ts resolve aliases reference packages/ui/src/)
+COPY packages/ packages/
+
+# Copy frontend source
 COPY frontend/ frontend/
 
 # Build from workspace root


### PR DESCRIPTION
Frontend Docker build fails: ENOENT /app/packages/ui/src/index.ts. Vite resolve alias needs packages/ in Docker context. Adds COPY packages/ packages/ to Dockerfile and frontend/Dockerfile to overlay list.

## Summary by Sourcery

Include workspace packages in the frontend Docker build context and ensure the release workflow overlays the updated Dockerfile from main.

Bug Fixes:
- Fix frontend Docker builds failing due to missing workspace package sources referenced by Vite aliases.

CI:
- Update release workflow overlay list to include the frontend Dockerfile so Docker builds always use the version from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to improve support for workspace-level packages in the frontend build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->