### PR TITLE
fix(ops): ssh-keyscan retry with timeout and accept-new fallback

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -108,8 +108,21 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-          grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts
+
+          # Keyscan with retries — GitHub Actions runners sometimes need
+          # longer to reach Hostinger VPS (NAT, firewalls, transient DNS).
+          for i in 1 2 3; do
+            ssh-keyscan -T 10 -t ed25519,rsa -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null && break
+            echo "ssh-keyscan attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+
+          # Fallback: if keyscan still failed, accept new keys on first connect
+          if ! grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts 2>/dev/null; then
+            echo "WARNING: ssh-keyscan returned no keys; using StrictHostKeyChecking=accept-new"
+            printf 'Host %s\n  StrictHostKeyChecking accept-new\n' "$DEPLOY_HOST" >> ~/.ssh/config
+            chmod 600 ~/.ssh/config
+          fi
 
       - name: Preflight - public DNS resolution
         shell: bash

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -61,8 +61,21 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-          grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts
+
+          # Keyscan with retries — GitHub Actions runners sometimes need
+          # longer to reach Hostinger VPS (NAT, firewalls, transient DNS).
+          for i in 1 2 3; do
+            ssh-keyscan -T 10 -t ed25519,rsa -p "$DEPLOY_PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null && break
+            echo "ssh-keyscan attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+
+          # Fallback: if keyscan still failed, accept new keys on first connect
+          if ! grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts 2>/dev/null; then
+            echo "WARNING: ssh-keyscan returned no keys; using StrictHostKeyChecking=accept-new"
+            printf 'Host %s\n  StrictHostKeyChecking accept-new\n' "$DEPLOY_HOST" >> ~/.ssh/config
+            chmod 600 ~/.ssh/config
+          fi
 
       - name: Preflight - remote host access
         shell: bash


### PR DESCRIPTION
ssh-keyscan intermittently returns no keys from GH Actions to Hostinger VPS. Adds 3x retry with 10s timeout, explicit key types, and StrictHostKeyChecking=accept-new fallback. Both release-lane.yml and rollback-staging.yml.

## Summary by Sourcery

Improve SSH host key handling in deployment and rollback workflows to make connections to the Hostinger VPS more reliable.

Build:
- Add ssh-keyscan retries with timeout and explicit key types in release and rollback workflows before establishing SSH connections.
- Introduce a StrictHostKeyChecking=accept-new fallback when ssh-keyscan fails to populate known_hosts in GitHub Actions runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SSH connection reliability in deployment workflows by implementing retry-enabled logic (up to 3 attempts with timeouts and backoff).
  * Added automatic fallback configuration handling for cases where initial host key discovery fails, enabling more robust deployments with reduced manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->