### PR TITLE
fix(docker): use 127.0.0.1 in HEALTHCHECK (Alpine IPv6 issue)

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -53,7 +53,7 @@ jobs:
           # headers, etc.).  Always overlay from main — old release SHAs may have
           # incompatible versions (e.g. wrong service names in Caddyfile).
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
-          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml frontend/Dockerfile; do
+          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml frontend/Dockerfile backend/Dockerfile; do
             dir="$(dirname "$path")"
             mkdir -p "$dir"
             echo "Overlaying $path from origin/main"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -95,7 +95,7 @@ COPY --from=build /app/publish ./
 
 # Expose and healthcheck
 EXPOSE 5000
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:5000/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:5000/health || exit 1
 
 ENTRYPOINT ["dotnet","TerraFusion.API.dll"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -56,7 +56,7 @@ COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Health check — nginx.conf listens on port 80
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:80/ || exit 1
+    CMD wget -qO- http://127.0.0.1:80/ || exit 1
 
 EXPOSE 80
 


### PR DESCRIPTION
Alpine BusyBox wget resolves localhost to [::1] but Kestrel listens on 0.0.0.0 (IPv4). Changes localhost to 127.0.0.1 in both Dockerfiles, increases backend start-period to 30s, and overlays backend/Dockerfile from main for old SHAs.

## Summary by Sourcery

Update container health checks to use IPv4 loopback and ensure backend Dockerfile is overlaid from main in release workflow.

Bug Fixes:
- Fix container health checks failing on Alpine due to localhost resolving to IPv6 by targeting 127.0.0.1 instead.

Enhancements:
- Increase backend container healthcheck start-period to allow more time for the service to start before checks begin.

CI:
- Extend the release workflow overlay step to include backend/Dockerfile from main for older release SHAs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check configurations in container images to improve deployment stability and initialization timing.
  * Enhanced release deployment workflow to process additional container configurations during the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->