### PR TITLE
fix(ci): remove cat intermediary from SSH docker login to prevent hang

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -198,12 +198,16 @@ jobs:
         run: |
           set -euo pipefail
           # Authenticate deploy user to GHCR (token is short-lived, expires after workflow run)
-          printf '%s' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "cat | docker login ghcr.io -u ${{ github.actor }} --password-stdin >/dev/null 2>&1"
+          # Pipe token directly to docker login (no 'cat' intermediary — it hangs on SSH EOF).
+          # Trailing newline ensures --password-stdin reads the complete token immediately.
+          printf '%s\n' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker login ghcr.io -u ${{ github.actor }} --password-stdin" >/dev/null 2>&1
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" <<'SSH'
           set -euo pipefail
-          docker pull "$BACKEND_IMAGE" >/dev/null
-          docker pull "$FRONTEND_IMAGE" >/dev/null
+          echo "Pulling backend image..."
+          docker pull "$BACKEND_IMAGE"
+          echo "Pulling frontend image..."
+          docker pull "$FRONTEND_IMAGE"
           SSH
 
       - name: Deploy runtime bundle on VPS

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -123,12 +123,15 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          printf '%s' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "cat | docker login ghcr.io -u ${{ github.actor }} --password-stdin >/dev/null 2>&1"
+          # Pipe token directly to docker login (no 'cat' intermediary — it hangs on SSH EOF).
+          printf '%s\n' "$GHCR_TOKEN" | ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker login ghcr.io -u ${{ github.actor }} --password-stdin" >/dev/null 2>&1
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" <<'SSH'
           set -euo pipefail
-          docker pull "$BACKEND_IMAGE" >/dev/null
-          docker pull "$FRONTEND_IMAGE" >/dev/null
+          echo "Pulling backend image..."
+          docker pull "$BACKEND_IMAGE"
+          echo "Pulling frontend image..."
+          docker pull "$FRONTEND_IMAGE"
           SSH
 
       - name: Roll back runtime bundle on VPS


### PR DESCRIPTION
## Problem
E1 attempt 5 (run 22927203259) hung at 'Preflight - GHCR pull on VPS' for 30+ minutes. Investigation showed:
- **No docker process running on VPS** — the hang was in the docker login SSH, not docker pull
- The pattern `printf '%s' TOKEN | ssh ... 'cat | docker login --password-stdin'` has two bugs:
  1. `cat` waits for EOF on SSH stdin, but EOF propagation through SSH is unreliable
  2. `printf '%s'` sends no trailing newline, leaving `--password-stdin` waiting for a complete line

## Fix
- **Remove `cat |` intermediary** — SSH already forwards stdin to the remote command
- **Add trailing newline** (`printf '%s\n'`) so `--password-stdin` reads the complete token immediately
- **Show docker pull progress** — removed `>/dev/null` for pipeline visibility
- **Applied to both** `release-lane.yml` and `rollback-staging.yml`

## Evidence
- Run [22927203259](https://github.com/bsvalues/terrafusion_os_1.0/actions/runs/22927203259) stuck at GHCR pull step
- VPS `ps aux | grep docker` showed no docker pull process
- Stale SSH session (PID 7896 from 20:24) with zero child processes confirmed the login SSH was the hang point

## Summary by Sourcery

Fix CI SSH-based Docker login to GHCR to prevent hangs and improve visibility of image pulls.

Bug Fixes:
- Adjust remote Docker login over SSH to read the full GHCR token without hanging by piping stdin directly to docker and ensuring a trailing newline.

Enhancements:
- Expose Docker image pull progress in release and rollback workflows for better pipeline observability.

CI:
- Update release and rollback GitHub Actions workflows to use a more reliable SSH Docker login pattern and show pull progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD deployment workflows to enhance reliability and clarity of build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->