### PR TITLE
fix(ci): use GET instead of HEAD for health check (ASP.NET returns 405)

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -236,7 +236,7 @@ jobs:
           success=0
 
           for attempt in $(seq 1 18); do
-            if curl -fsSI "$URL" > curl_headers.txt; then
+            if curl -fsS -o /dev/null -D curl_headers.txt "$URL"; then
               HEADER_SHA="$(awk 'BEGIN{IGNORECASE=1} /^x-release-sha:/ {print $2}' curl_headers.txt | tr -d '\r')"
               if [ "$HEADER_SHA" = "$RELEASE_SHA" ]; then
                 success=1

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -168,7 +168,7 @@ jobs:
           success=0
 
           for attempt in $(seq 1 18); do
-            if curl -fsSI "$URL" > curl_headers.txt; then
+            if curl -fsS -o /dev/null -D curl_headers.txt "$URL"; then
               HEADER_SHA="$(awk 'BEGIN{IGNORECASE=1} /^x-release-sha:/ {print $2}' curl_headers.txt | tr -d '\r')"
               if [ "$HEADER_SHA" = "$ROLLBACK_SHA" ]; then
                 success=1


### PR DESCRIPTION
E1 attempt 6 containers all healthy, headers correct, but health verification timed out. ASP.NET returns 405 for HEAD. Fix: use GET with -D to capture headers.

## Summary by Sourcery

Update CI release and rollback workflows to use a GET-style curl request that discards the body while capturing response headers for health verification.

CI:
- Adjust health check curl invocation in release workflow to use an explicit output discard while recording response headers.
- Adjust health check curl invocation in rollback workflow to use an explicit output discard while recording response headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow health verification process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->