### PR TITLE
fix(deploy): add --env-file release.env to evidence collection compose commands

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -291,10 +291,10 @@ jobs:
           mkdir -p evidence
           cp curl_headers.txt evidence/curl_headers.txt
 
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml ps" > evidence/compose_ps.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env ps" > evidence/compose_ps.txt
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "uptime" > evidence/uptime.txt
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml logs --no-color --tail=200 backend" > evidence/logs_backend.txt
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml logs --no-color --tail=200 proxy" > evidence/logs_proxy.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env logs --no-color --tail=200 backend" > evidence/logs_backend.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env logs --no-color --tail=200 proxy" > evidence/logs_proxy.txt
 
           cat > evidence/evidence.txt <<EOF
           operation=deploy

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -225,10 +225,10 @@ jobs:
           mkdir -p evidence
           cp curl_headers.txt evidence/curl_headers.txt
 
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml ps" > evidence/compose_ps.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env ps" > evidence/compose_ps.txt
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "uptime" > evidence/uptime.txt
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml logs --no-color --tail=200 backend" > evidence/logs_backend.txt
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml logs --no-color --tail=200 proxy" > evidence/logs_proxy.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env logs --no-color --tail=200 backend" > evidence/logs_backend.txt
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "cd '$APP_ROOT' && docker compose -f runtime-compose.yml --env-file release.env logs --no-color --tail=200 proxy" > evidence/logs_proxy.txt
 
           cat > evidence/evidence.txt <<EOF
           operation=rollback


### PR DESCRIPTION
## Problem
E1 attempt 8 (run 22930659942) failed at 'Collect deploy evidence' — the last substantive step.

The SSH commands for `docker compose ps` and `docker compose logs` in the evidence collection step don't include `--env-file release.env`, so `TF_BACKEND_IMAGE` and `TF_FRONTEND_IMAGE` are unset on the VPS SSH session.

Error:
```
The "TF_BACKEND_IMAGE" variable is not set. Defaulting to a blank string.
The "TF_FRONTEND_IMAGE" variable is not set. Defaulting to a blank string.
service "backend" has neither an image nor a build context specified: invalid compose project
```

## Fix
Add `--env-file release.env` to all `docker compose` commands in the evidence collection step, matching the deploy step which already uses it.

Applied to both `release-lane.yml` and `rollback-staging.yml`.

## Evidence
- E1 attempt 8 all 17 prior steps passed (SSH, build, push, pull, deploy, health check, SHA invariant)
- Only evidence collection failed due to missing env-file

## Summary by Sourcery

Ensure deploy evidence collection uses the same environment configuration as the deploy steps.

Bug Fixes:
- Include the release.env env-file in docker compose ps and logs commands during deploy evidence collection in the release workflow to avoid missing image variables.
- Include the release.env env-file in docker compose ps and logs commands during deploy evidence collection in the rollback-staging workflow to avoid missing image variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment pipeline environment variable management by centralizing configuration across Docker Compose commands in release and rollback workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->