### PR TITLE
docs(ops): record live staging proof and reissue readiness posture

### DIFF
--- a/os-platform/core/pilot/ops/hostinger-control-plane.md
+++ b/os-platform/core/pilot/ops/hostinger-control-plane.md
@@ -42,9 +42,9 @@ This document contains **no secrets**. Store secrets only in:
 - APP_ROOT: /opt/terrafusion/production
 
 ## GHCR Pull Auth (Staging)
-- Configured on VPS (deploy user): pending verification
-- Method: `docker login ghcr.io` with least-privilege token
-- Date/time verified: pending
+- Configured on VPS (deploy user): yes (workflow-injected per-run token)
+- Method: `printf TOKEN | ssh ... docker login ghcr.io --password-stdin` (no persistent credential)
+- Date/time verified: 2026-03-11T00:28Z (E1 run 22931357865 GHCR pull step)
 
 ## GHCR Pull Auth (Production)
 - Configured on VPS (deploy user): yes/no
@@ -75,13 +75,66 @@ Secrets:
 - DEPLOY_SSH_KEY = (stored in GitHub only)
 
 ## Lane Closure Evidence Index
-- Deploy seed 24531f37a... artifact: (link or artifact name)
-- Deploy 864d651a8... artifact: (link or artifact name)
-- Rollback artifact: (link or artifact name)
-- Redeploy 864d651a8... artifact: (link or artifact name)
-- Production deploy 864d651a8... artifact: (link or artifact name)
+
+### Staging (proven 2026-03-11)
+
+| Dispatch | Workflow | SHA | Run ID | Artifact | Result |
+|----------|----------|-----|--------|----------|--------|
+| E1 seed deploy | release-lane | 24531f37a9ea785a99c1b7e4e1dd70c294af1a0c | 22931357865 | evidence-staging-24531f37a9ea785a99c1b7e4e1dd70c294af1a0c | SUCCESS |
+| E2 release deploy | release-lane | 864d651a8b49ec1b2dc2cbca137091dbc1c3b29b | 22931562617 | evidence-staging-864d651a8b49ec1b2dc2cbca137091dbc1c3b29b | SUCCESS |
+| E3 rollback | rollback-staging | (auto: previous.sha → 24531f3) | 22931846631 | (rollback evidence artifact) | SUCCESS |
+| E4 redeploy | release-lane | 864d651a8b49ec1b2dc2cbca137091dbc1c3b29b | 22932003077 | evidence-staging-864d651a8b49ec1b2dc2cbca137091dbc1c3b29b | SUCCESS |
+
+SHA chain verified on VPS after E4:
+- current.sha = 864d651a8b49ec1b2dc2cbca137091dbc1c3b29b
+- requested.sha = 864d651a8b49ec1b2dc2cbca137091dbc1c3b29b
+- previous.sha = 24531f37a9ea785a99c1b7e4e1dd70c294af1a0c
+
+PR #671 (evidence env-file fix) merged at 2026-03-11T00:50:36Z.
+All 4 successful runs occurred after that merge (E1 created at 00:53:49Z).
+Evidence collection succeeded in all runs.
+
+### Production (pending)
+- Production deploy 864d651a8... artifact: (not yet dispatched)
+- Production rollback artifact: (not yet dispatched)
+
+## Staging Readiness Posture (2026-03-11)
+
+TerraFusion on protected `main` is engineering-ready, governance-ready, and now
+staging-proven through live deploy, rollback, and redeploy evidence.
+
+Proven claims:
+- GitHub Actions can reach the staging host over SSH (port 22)
+- GHCR auth and image pull work from the VPS (workflow-injected token)
+- Runtime bundle deployment works (compose up with env-file)
+- Health verification works (GET /health, X-Release-Sha header)
+- SHA finalization and invariant verification work
+- Rollback workflow can restore the prior state
+- Redeploy can re-establish the target release after rollback
+
+Remaining blockers are **production-only**:
+- Production VPS not yet provisioned/verified
+- Production secrets/config not yet wired
+- Production observability not yet validated
+- Production rollback not yet validated
+- Final approval memo not yet reissued from production artifacts
+
+## Infrastructure Fixes (PRs #660–#671)
+
+| PR | Fix | Proven by |
+|----|-----|-----------|
+| #660–#663 | Workflow scaffolding, SSH config | E1 attempts 1–4 |
+| #664 | SSH keyscan retry + accept-new fallback | E1 attempt 5+ |
+| #665 | Backend Dockerfile project-level restore | E1 attempt 5+ |
+| #666 | Frontend Dockerfile COPY packages/ | E1 attempt 5+ |
+| #667 | GHCR packages:read permission | E1 attempt 5+ |
+| #668 | Alpine HEALTHCHECK 127.0.0.1 (not localhost) | E1 attempt 6+ |
+| #669 | SSH docker login: remove cat pipe, add newline | E1 attempt 6+ |
+| #670 | Health check: GET instead of HEAD (ASP.NET 405) | E1 attempt 8+ |
+| #671 | Evidence collection: add --env-file release.env | E1 attempt 9 (first full green) |
 
 ## Notes
 - Hostinger MCP is optional discovery only; config is local-only and not committed.
-- Production is not approved until staging deploy + rollback + observability proofs exist.
+- Production is not approved until the same live proof sequence is completed against the production target.
 - Any credential or secret ever pasted into chat is compromised and must be rotated before use.
+- Provider firewall (Hostinger) allows only ports 22, 80, 443. Port 65002 is blocked at provider level.


### PR DESCRIPTION
## What changed

Updates `hostinger-control-plane.md` to record the live staging proof evidence
from the 4-dispatch governed sequence completed 2026-03-11.

## Evidence

All four dispatches succeeded:

| Dispatch | Run ID | Result |
|----------|--------|--------|
| E1 seed deploy | 22931357865 | SUCCESS |
| E2 release deploy | 22931562617 | SUCCESS |
| E3 rollback | 22931846631 | SUCCESS |
| E4 redeploy | 22932003077 | SUCCESS |

PR #671 merged before E1 started. All successful runs occurred after that merge.
Evidence collection succeeded in all runs.

SHA chain verified on VPS after E4:
- `current.sha` = `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`
- `requested.sha` = `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b`
- `previous.sha` = `24531f37a9ea785a99c1b7e4e1dd70c294af1a0c`

## Posture change

- **Before**: staging deploy/rollback unproven
- **After**: staging release lane proven; rollback proven; redeploy proven
- **Remaining blockers are production-only**

## Scope

Doc-only change to `os-platform/core/pilot/ops/hostinger-control-plane.md`:
- Filled evidence index with run IDs and artifact names
- Recorded GHCR auth verification timestamp
- Added staging readiness posture section
- Added infrastructure fixes table (PRs #660-#671)
- Added provider firewall note (ports 22, 80, 443 only)

## Summary by Sourcery

Update Hostinger control plane ops documentation to record completed staging deployment proofs and clarify current readiness posture.

Documentation:
- Document verified GHCR pull authentication method and timestamp for staging.
- Record detailed staging lane closure evidence, including dispatch runs, artifacts, and SHA chain verification.
- Add a staging readiness posture section outlining proven behaviors and remaining production-only blockers.
- Introduce an infrastructure fixes table linking recent PRs to resolved deployment issues and their validation runs.
- Clarify production approval criteria and note provider firewall port restrictions in the ops docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised control plane authentication to per-run, non-persistent token flow for staging
  * Added an evidence-backed staging section with proven timestamp and deployment event records
  * Marked production as pending with updated readiness criteria and blockers
  * Documented infrastructure fixes mapping and noted provider firewall restriction (port 65002 blocked)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->