### PR TITLE
fix(ci): SSH ConnectTimeout + retry for Hostinger VPS resilience

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -117,12 +117,20 @@ jobs:
             sleep 5
           done
 
+          # Global SSH options: faster timeout + keepalive for Hostinger VPS
+          cat > ~/.ssh/config <<SSHCFG
+          Host $DEPLOY_HOST
+            ConnectTimeout 30
+            ServerAliveInterval 15
+            ServerAliveCountMax 3
+          SSHCFG
+
           # Fallback: if keyscan still failed, accept new keys on first connect
           if ! grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts 2>/dev/null; then
             echo "WARNING: ssh-keyscan returned no keys; using StrictHostKeyChecking=accept-new"
-            printf 'Host %s\n  StrictHostKeyChecking accept-new\n' "$DEPLOY_HOST" >> ~/.ssh/config
-            chmod 600 ~/.ssh/config
+            printf '  StrictHostKeyChecking accept-new\n' >> ~/.ssh/config
           fi
+          chmod 600 ~/.ssh/config
 
       - name: Preflight - public DNS resolution
         shell: bash
@@ -134,7 +142,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
+          for attempt in 1 2 3; do
+            echo "SSH preflight attempt $attempt/3..."
+            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -142,6 +153,15 @@ jobs:
           test -w "$APP_ROOT"
           test -f "$APP_ROOT/app.env"
           SSH
+            then
+              echo "SSH preflight succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            sleep 15
+          done
+          echo "ERROR: SSH preflight failed after 3 attempts"
+          exit 1
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -68,17 +68,29 @@ jobs:
             sleep 5
           done
 
+          # Global SSH options: faster timeout + keepalive for Hostinger VPS
+          cat > ~/.ssh/config <<SSHCFG
+          Host $DEPLOY_HOST
+            ConnectTimeout 30
+            ServerAliveInterval 15
+            ServerAliveCountMax 3
+          SSHCFG
+
+          # Fallback: if keyscan still failed, accept new keys on first connect
           if ! grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts 2>/dev/null; then
             echo "WARNING: ssh-keyscan returned no keys; using StrictHostKeyChecking=accept-new"
-            printf 'Host %s\n  StrictHostKeyChecking accept-new\n' "$DEPLOY_HOST" >> ~/.ssh/config
-            chmod 600 ~/.ssh/config
+            printf '  StrictHostKeyChecking accept-new\n' >> ~/.ssh/config
           fi
+          chmod 600 ~/.ssh/config
 
       - name: Preflight - remote host access
         shell: bash
         run: |
           set -euo pipefail
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
+          for attempt in 1 2 3; do
+            echo "SSH preflight attempt $attempt/3..."
+            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -89,6 +101,15 @@ jobs:
           test -f "$APP_ROOT/current.sha"
           test -f "$APP_ROOT/previous.sha"
           SSH
+            then
+              echo "SSH preflight succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            sleep 15
+          done
+          echo "ERROR: SSH preflight failed after 3 attempts"
+          exit 1
 
       - name: Read rollback SHAs
         id: shas

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -70,18 +70,29 @@ jobs:
             sleep 5
           done
 
+          # Global SSH options: faster timeout + keepalive for Hostinger VPS
+          cat > ~/.ssh/config <<SSHCFG
+          Host $DEPLOY_HOST
+            ConnectTimeout 30
+            ServerAliveInterval 15
+            ServerAliveCountMax 3
+          SSHCFG
+
           # Fallback: if keyscan still failed, accept new keys on first connect
           if ! grep -q "$DEPLOY_HOST" ~/.ssh/known_hosts 2>/dev/null; then
             echo "WARNING: ssh-keyscan returned no keys; using StrictHostKeyChecking=accept-new"
-            printf 'Host %s\n  StrictHostKeyChecking accept-new\n' "$DEPLOY_HOST" >> ~/.ssh/config
-            chmod 600 ~/.ssh/config
+            printf '  StrictHostKeyChecking accept-new\n' >> ~/.ssh/config
           fi
+          chmod 600 ~/.ssh/config
 
       - name: Preflight - remote host access
         shell: bash
         run: |
           set -euo pipefail
-          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
+          for attempt in 1 2 3; do
+            echo "SSH preflight attempt $attempt/3..."
+            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -92,6 +103,15 @@ jobs:
           test -f "$APP_ROOT/current.sha"
           test -f "$APP_ROOT/previous.sha"
           SSH
+            then
+              echo "SSH preflight succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            sleep 15
+          done
+          echo "ERROR: SSH preflight failed after 3 attempts"
+          exit 1
 
       - name: Read rollback SHAs
         id: shas


### PR DESCRIPTION
## Summary
Adds SSH hardening across all deploy/rollback workflows:
- Global SSH config with ConnectTimeout=30, ServerAliveInterval=15
- 3-attempt retry loop on Preflight - remote host access step  
- Applied to: release-lane.yml, rollback-staging.yml, rollback-production.yml

## Root Cause
After VPS reboot at 03:38 UTC, GH Actions runner IPs are timing out connecting to port 22. VPS OS firewall (ufw) allows port 22 from all IPs. Hostinger infrastructure-level firewall suspected.

## Impact
Defensive improvement - faster failure detection and retry capability for SSH steps.

## Summary by Sourcery

Harden SSH connectivity and add retry logic in deployment workflows to improve resilience when connecting to the Hostinger VPS.

CI:
- Configure a per-host SSH config with shorter timeouts and keepalive settings for deployment-related SSH connections in release and rollback workflows.
- Add a three-attempt retry loop with delays around SSH preflight checks in release and rollback workflows to better tolerate transient SSH failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Enhanced deployment and rollback workflow resilience with improved SSH connection handling, automatic retry mechanisms, and better management of network timeouts across multiple deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->