### PR TITLE
fix(ci): fix heredoc-inside-if bug in SSH retry logic

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -142,10 +142,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
           for attempt in 1 2 3; do
             echo "SSH preflight attempt $attempt/3..."
-            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+            set +e
+            ssh -o ConnectTimeout=30 -o ServerAliveInterval=15 \
+                -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+                "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -153,11 +155,13 @@ jobs:
           test -w "$APP_ROOT"
           test -f "$APP_ROOT/app.env"
           SSH
-            then
+            rc=$?
+            set -e
+            if [ $rc -eq 0 ]; then
               echo "SSH preflight succeeded on attempt $attempt"
               exit 0
             fi
-            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            echo "SSH attempt $attempt failed (exit $rc), waiting 15s..."
             sleep 15
           done
           echo "ERROR: SSH preflight failed after 3 attempts"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -87,10 +87,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
           for attempt in 1 2 3; do
             echo "SSH preflight attempt $attempt/3..."
-            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+            set +e
+            ssh -o ConnectTimeout=30 -o ServerAliveInterval=15 \
+                -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+                "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -101,11 +103,13 @@ jobs:
           test -f "$APP_ROOT/current.sha"
           test -f "$APP_ROOT/previous.sha"
           SSH
-            then
+            rc=$?
+            set -e
+            if [ $rc -eq 0 ]; then
               echo "SSH preflight succeeded on attempt $attempt"
               exit 0
             fi
-            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            echo "SSH attempt $attempt failed (exit $rc), waiting 15s..."
             sleep 15
           done
           echo "ERROR: SSH preflight failed after 3 attempts"

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -89,10 +89,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          SSH_OPTS="-o ConnectTimeout=30 -o ServerAliveInterval=15"
           for attempt in 1 2 3; do
             echo "SSH preflight attempt $attempt/3..."
-            if ssh $SSH_OPTS -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+            set +e
+            ssh -o ConnectTimeout=30 -o ServerAliveInterval=15 \
+                -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+                "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
@@ -103,11 +105,13 @@ jobs:
           test -f "$APP_ROOT/current.sha"
           test -f "$APP_ROOT/previous.sha"
           SSH
-            then
+            rc=$?
+            set -e
+            if [ $rc -eq 0 ]; then
               echo "SSH preflight succeeded on attempt $attempt"
               exit 0
             fi
-            echo "SSH attempt $attempt failed (exit $?), waiting 15s..."
+            echo "SSH attempt $attempt failed (exit $rc), waiting 15s..."
             sleep 15
           done
           echo "ERROR: SSH preflight failed after 3 attempts"


### PR DESCRIPTION
## Root Cause
Run 22945632289 showed SSH connecting and returning exit 0, but the \if ssh ... <<'SSH' ... SSH; then\ construct evaluated as false. The heredoc stdin redirect interferes with bash \if\ control flow on GitHub Actions runners.

## Fix
Replace \if ssh ... <<heredoc; then\ with \set +e; ssh ... <<heredoc; rc=\True; set -e; if [ \ -eq 0 ]; then\ — capturing exit code explicitly.

Applied to: release-lane.yml, rollback-production.yml, rollback-staging.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling and diagnostics in deployment automation workflows to improve reliability and visibility of infrastructure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->