### PR TITLE
fix(ci): make DNS preflight non-fatal warning in release-lane

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -136,7 +136,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          nslookup "$PUBLIC_HOST"
+          if nslookup "$PUBLIC_HOST"; then
+            echo "DNS resolved OK"
+          else
+            echo "::warning::DNS lookup for $PUBLIC_HOST failed (may be propagating). Deploy continues using IP."
+          fi
 
       - name: Preflight - remote host access
         shell: bash


### PR DESCRIPTION
DNS lookup failure was blocking deploys even though deployment uses DEPLOY_HOST (IP address), not hostname. Run 22947646646 failed because staging.terrafusionmarket.com returned NXDOMAIN.

Converts nslookup to a non-fatal warning so deploys can proceed during DNS propagation delays or when a subdomain record is temporarily absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced DNS resolution handling in the deployment pipeline. Preflight checks now provide clearer diagnostics and warning messages when DNS resolution encounters issues, while still allowing deployments to proceed using IP addresses as fallback. These improvements increase system reliability and operational visibility during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->