### PR TITLE
ops(proxy): shared edge proxy for staging/production coexistence

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -53,7 +53,7 @@ jobs:
           # headers, etc.).  Always overlay from main — old release SHAs may have
           # incompatible versions (e.g. wrong service names in Caddyfile).
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
-          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml frontend/Dockerfile backend/Dockerfile; do
+          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml ops/edge-proxy/Caddyfile ops/edge-proxy/docker-compose.yml frontend/Dockerfile backend/Dockerfile; do
             dir="$(dirname "$path")"
             mkdir -p "$dir"
             echo "Overlaying $path from origin/main"
@@ -196,11 +196,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf runtime evidence curl_headers.txt
+          rm -rf runtime edge-proxy evidence curl_headers.txt
           mkdir -p runtime/docs/spec-lock
           cp ops/proxy/Caddyfile runtime/Caddyfile
           cp ops/prod/runtime-compose.template.yml runtime/runtime-compose.yml
           cp -R docs/spec-lock/. runtime/docs/spec-lock/
+
+          # Edge proxy bundle (shared across environments)
+          mkdir -p edge-proxy
+          cp ops/edge-proxy/Caddyfile edge-proxy/Caddyfile
+          cp ops/edge-proxy/docker-compose.yml edge-proxy/docker-compose.yml
 
           cat > runtime/release.env <<EOF
           COMPOSE_PROJECT_NAME=terrafusion-${TARGET_ENV}
@@ -218,6 +223,20 @@ jobs:
         run: |
           set -euo pipefail
           scp -P "$DEPLOY_PORT" -r runtime/* "$DEPLOY_USER@$DEPLOY_HOST:$APP_ROOT/"
+
+      - name: Bootstrap shared edge proxy
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Ensure shared Docker network exists
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge"
+
+          # Deploy/update edge proxy (owns host 80/443, routes by hostname)
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p /opt/terrafusion/edge-proxy"
+          scp -P "$DEPLOY_PORT" edge-proxy/* "$DEPLOY_USER@$DEPLOY_HOST:/opt/terrafusion/edge-proxy/"
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd /opt/terrafusion/edge-proxy && docker compose up -d"
 
       - name: Preflight - GHCR pull on VPS
         shell: bash

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -155,6 +155,18 @@ jobs:
           docker pull "$FRONTEND_IMAGE"
           SSH
 
+      - name: Ensure edge proxy is running
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" bash -s <<'SSH'
+          set -euo pipefail
+          docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge
+          if [ -f /opt/terrafusion/edge-proxy/docker-compose.yml ]; then
+            cd /opt/terrafusion/edge-proxy && docker compose up -d
+          fi
+          SSH
+
       - name: Roll back runtime bundle on VPS
         shell: bash
         run: |

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -158,6 +158,18 @@ jobs:
           docker pull "$FRONTEND_IMAGE"
           SSH
 
+      - name: Ensure edge proxy is running
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" bash -s <<'SSH'
+          set -euo pipefail
+          docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge
+          if [ -f /opt/terrafusion/edge-proxy/docker-compose.yml ]; then
+            cd /opt/terrafusion/edge-proxy && docker compose up -d
+          fi
+          SSH
+
       - name: Roll back runtime bundle on VPS
         shell: bash
         run: |

--- a/ops/edge-proxy/Caddyfile
+++ b/ops/edge-proxy/Caddyfile
@@ -1,0 +1,12 @@
+# TerraFusion OS — Shared Edge Proxy
+# Handles TLS termination and hostname-based routing.
+# Per-environment stacks join the terrafusion-edge Docker network;
+# this proxy routes to each environment's internal Caddy by container name.
+
+terrafusionmarket.com {
+	reverse_proxy terrafusion-production-proxy-1:80
+}
+
+staging.terrafusionmarket.com {
+	reverse_proxy terrafusion-staging-proxy-1:80
+}

--- a/ops/edge-proxy/docker-compose.yml
+++ b/ops/edge-proxy/docker-compose.yml
@@ -1,0 +1,25 @@
+# TerraFusion OS — Shared Edge Proxy
+# Owns host ports 80/443.  Per-environment stacks expose their Caddy
+# on the terrafusion-edge network (no host port binding).
+
+services:
+  edge:
+    image: caddy:2.8-alpine
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_edge_data:/data
+      - caddy_edge_config:/config
+    networks:
+      - terrafusion-edge
+
+networks:
+  terrafusion-edge:
+    external: true
+
+volumes:
+  caddy_edge_data:
+  caddy_edge_config:

--- a/ops/prod/runtime-compose.template.yml
+++ b/ops/prod/runtime-compose.template.yml
@@ -2,9 +2,8 @@ services:
   proxy:
     image: caddy:2.8-alpine
     restart: unless-stopped
-    ports:
-      - '80:80'
-      - '443:443'
+    # No host port binding — the shared edge proxy owns 80/443 and
+    # routes to this container by name over the terrafusion-edge network.
     env_file:
       - ./release.env
     volumes:
@@ -16,6 +15,9 @@ services:
         condition: service_healthy
       frontend:
         condition: service_healthy
+    networks:
+      - default
+      - terrafusion-edge
 
   backend:
     image: ${TF_BACKEND_IMAGE}
@@ -41,6 +43,10 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+
+networks:
+  terrafusion-edge:
+    external: true
 
 volumes:
   caddy_data:

--- a/ops/proxy/Caddyfile
+++ b/ops/proxy/Caddyfile
@@ -1,4 +1,6 @@
-{$TF_PUBLIC_HOST:localhost} {
+# Per-environment internal proxy — no TLS (edge proxy handles TLS).
+# Listens on :80 inside the Docker network only.
+:80 {
     encode gzip zstd
 
     @health path /health

--- a/os-platform/core/pilot/ops/hostinger-control-plane.md
+++ b/os-platform/core/pilot/ops/hostinger-control-plane.md
@@ -114,7 +114,7 @@ Secrets:
 - ~~Production SSH fails~~ RESOLVED: v4 key generated on VPS, set via pipe
 - ~~GHCR old public package deletion~~ RESOLVED: 4 packages deleted via `gh api -X DELETE` (2026-03-11)
 - K3s-style kubeconfig material was removed from the repo tree, but cluster trust rotation remains an external infra task if `terrafusion-k8s-api` is still live
-- Staging and production cannot run simultaneously on the same VPS (port 80/443 conflict)
+- ~~Staging and production cannot run simultaneously on the same VPS (port 80/443 conflict)~~ RESOLVED: shared edge proxy routes by hostname (PR #684)
 - `staging.terrafusionmarket.com` DNS A record missing (NXDOMAIN); needs restoration at Hostinger
 
 ## Lane Closure Evidence Index
@@ -185,10 +185,39 @@ Proven claims:
 Remaining items:
 - ~~Delete old public GHCR packages~~ DONE (2026-03-11, anonymous pull confirmed denied)
 - Restore `staging.terrafusionmarket.com` DNS A record at Hostinger
-- Implement port differentiation or shared proxy for staging/production coexistence
+- ~~Implement port differentiation or shared proxy for staging/production coexistence~~ DONE (PR #684, shared edge proxy)
 - K3s trust rotation if cluster is live
 - Production observability validation
 - Final approval memo from production artifacts
+
+## Shared Edge Proxy Architecture (PR #684)
+
+Staging and production coexist on the same VPS via a shared Caddy edge proxy
+that owns host ports 80/443 and routes by hostname.
+
+```
+┌─────────────────────────────────────── VPS 72.60.126.11 ──────────────────────────────────┐
+│                                                                                           │
+│   ┌── Edge Proxy (Caddy) ── ports 80/443 ──┐                                             │
+│   │  terrafusionmarket.com        → terrafusion-production-proxy-1:80                     │
+│   │  staging.terrafusionmarket.com → terrafusion-staging-proxy-1:80                       │
+│   └────────────────────────────────────────┘                                              │
+│              │ terrafusion-edge network │                                                  │
+│   ┌─────────┴───────────┐   ┌──────────┴──────────┐                                      │
+│   │ terrafusion-production │  │ terrafusion-staging  │                                     │
+│   │  proxy → backend:5000 │  │  proxy → backend:5000 │                                     │
+│   │         frontend:80   │  │         frontend:80   │                                     │
+│   └───────────────────────┘  └───────────────────────┘                                    │
+│                                                                                           │
+└───────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+- Edge proxy config: `ops/edge-proxy/Caddyfile` + `ops/edge-proxy/docker-compose.yml`
+- Per-env proxy: `ops/proxy/Caddyfile` (listens `:80`, no TLS — edge handles ACME)
+- Runtime compose: `ops/prod/runtime-compose.template.yml` (no host ports, joins `terrafusion-edge` network)
+- Deployed to: `/opt/terrafusion/edge-proxy/` on VPS
+- TLS: Edge Caddy handles ACME for both domains automatically
+- Graceful degradation: If one env is down, its route returns 502; the other keeps serving
 
 ## Infrastructure Fixes (PRs #660–#671)
 


### PR DESCRIPTION
## Summary

Implements a shared Caddy edge proxy so staging and production can run simultaneously on the same VPS (srv1479342 / 72.60.126.11).

### Architecture

- **Edge proxy** (`ops/edge-proxy/`) owns host ports 80/443, handles TLS via ACME, routes by hostname
- **Per-env proxy** (`ops/proxy/Caddyfile`) listens on `:80` internally (no TLS, no host port binding)
- Both environments join the `terrafusion-edge` Docker network
- `terrafusionmarket.com` → production stack
- `staging.terrafusionmarket.com` → staging stack

### Changes

| File | Change |
|------|--------|
| `ops/edge-proxy/Caddyfile` | New: hostname-based routing to per-env containers |
| `ops/edge-proxy/docker-compose.yml` | New: edge proxy compose (Caddy, ports 80/443) |
| `ops/proxy/Caddyfile` | Changed from `{dollar}TF_PUBLIC_HOST` to `:80` (internal) |
| `ops/prod/runtime-compose.template.yml` | Removed host port mapping, added `terrafusion-edge` network |
| `release-lane.yml` | Overlays edge files from main, bootstraps edge proxy on VPS |
| `rollback-staging.yml` | Ensures edge network + proxy running before rollback |
| `rollback-production.yml` | Same edge proxy safety check |
| `hostinger-control-plane.md` | Architecture diagram, updated remaining items |

### Deployment Notes

First deploy after merge will:
1. Create `terrafusion-edge` Docker network on VPS
2. Deploy edge proxy at `/opt/terrafusion/edge-proxy/`
3. Start per-env stack joined to edge network (no host port conflict)

After both environments are deployed, they coexist without stopping each other.

### Evidence

- type-check: clean
- phase83-tools: 32/32 pass
- Pre-commit gates: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared edge proxy with TLS termination and hostname-based routing, enabling simultaneous staging and production deployment on a single infrastructure.

* **Chores**
  * Updated deployment and rollback workflows to provision and manage edge proxy services.
  * Updated architecture documentation to reflect the new edge proxy setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->