### PR TITLE
fix(ci): graceful edge proxy transition on first deploy

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -232,6 +232,18 @@ jobs:
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
             "docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge"
 
+          # Stop the current per-env stack gracefully so the edge proxy can
+          # claim host ports 80/443.  On the very first edge-proxy deploy the
+          # old stack still has host port bindings; after that this is a no-op
+          # because per-env stacks no longer bind host ports.
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          set -euo pipefail
+          cd "$APP_ROOT"
+          if [ -f runtime-compose.yml ] && [ -f release.env ]; then
+            docker compose -f runtime-compose.yml --env-file release.env down --timeout 30 || true
+          fi
+          SSH
+
           # Deploy/update edge proxy (owns host 80/443, routes by hostname)
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p /opt/terrafusion/edge-proxy"
           scp -P "$DEPLOY_PORT" edge-proxy/* "$DEPLOY_USER@$DEPLOY_HOST:/opt/terrafusion/edge-proxy/"


### PR DESCRIPTION
## Problem

The first deploy after PR #684 (shared edge proxy) will fail because the existing production stack still binds host ports 80/443. The new edge proxy tries to claim the same ports and gets a bind error.

## Fix

Add a graceful stop of the current per-env stack before bootstrapping the edge proxy. This frees ports 80/443 for the edge Caddy. The deploy step then restarts the per-env stack with the new compose template (no host ports, joined to edge network).

After the first successful deploy, this becomes a no-op — per-env stacks no longer bind host ports, so the edge proxy can restart freely.

## Changes

- `release-lane.yml`: Added `docker compose down` for current env stack before edge proxy `up -d`

## Sequence on first deploy

1. Stop old per-env stack (frees 80/443)
2. Create `terrafusion-edge` network
3. Start edge proxy (claims 80/443)
4. Pull images, deploy new per-env stack (joins edge network, no host ports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to gracefully stop running services before updating edge proxy infrastructure, improving deployment reliability and preventing port conflicts during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->