### PR TITLE
fix(proxy): use internal TLS for staging until DNS is restored

### DIFF
--- a/ops/edge-proxy/Caddyfile
+++ b/ops/edge-proxy/Caddyfile
@@ -8,5 +8,11 @@ terrafusionmarket.com {
 }
 
 staging.terrafusionmarket.com {
+	# Use internal CA (self-signed) until staging DNS A record is restored.
+	# ACME HTTP-01 requires DNS to resolve; without it Caddy won't serve HTTPS.
+	# The health check uses curl -k (skip TLS verify) for the --resolve fallback
+	# so self-signed certs work fine for automated verification.
+	# TODO: Remove 'tls internal' once staging.terrafusionmarket.com DNS is live.
+	tls internal
 	reverse_proxy terrafusion-staging-proxy-1:80
 }


### PR DESCRIPTION
## Problem

Staging deploy run 22961093555 failed at health verification. The edge Caddy cannot complete ACME HTTP-01 challenge for `staging.terrafusionmarket.com` because the DNS A record is NXDOMAIN. Without a valid cert, Caddy refuses to serve HTTPS for that domain, and all 18 health check attempts (both public URL and `--resolve` fallback) time out.

## Fix

Add `tls internal` to the staging domain block in the edge Caddyfile. This uses Caddy's built-in CA to generate a self-signed certificate immediately, without ACME. The health check's `curl -k` flag accepts self-signed certs during the `--resolve` fallback path.

## When to revert

Remove `tls internal` once `staging.terrafusionmarket.com` DNS A record is restored at Hostinger → `72.60.126.11`. ACME will then work normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled TLS support for the staging environment using self-signed certificates for secure communication during testing and automated checks. This is a temporary configuration to be updated once DNS is fully live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->