### PR TITLE
fix(proxy): reload Caddy config after edge proxy file update

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -248,7 +248,7 @@ jobs:
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p /opt/terrafusion/edge-proxy"
           scp -P "$DEPLOY_PORT" edge-proxy/* "$DEPLOY_USER@$DEPLOY_HOST:/opt/terrafusion/edge-proxy/"
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "cd /opt/terrafusion/edge-proxy && docker compose up -d"
+            "cd /opt/terrafusion/edge-proxy && docker compose up -d && docker compose exec -T edge caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || true"
 
       - name: Preflight - GHCR pull on VPS
         shell: bash
@@ -316,6 +316,13 @@ jobs:
                 success=1
                 break
               fi
+            fi
+
+            # Show verbose curl output on first failure to help diagnose connectivity issues
+            if [ "$attempt" -eq 1 ]; then
+              echo "--- Diagnostic: verbose resolve curl ---"
+              curl -vk --resolve "${PUBLIC_HOST}:443:${DEPLOY_HOST}" --resolve "${PUBLIC_HOST}:80:${DEPLOY_HOST}" "$URL" 2>&1 | head -40 || true
+              echo "--- End diagnostic ---"
             fi
 
             echo "Waiting for $URL to report X-Release-Sha=$RELEASE_SHA (attempt $attempt/18)"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -164,6 +164,7 @@ jobs:
           docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge
           if [ -f /opt/terrafusion/edge-proxy/docker-compose.yml ]; then
             cd /opt/terrafusion/edge-proxy && docker compose up -d
+            docker compose exec -T edge caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || true
           fi
           SSH
 

--- a/.github/workflows/rollback-staging.yml
+++ b/.github/workflows/rollback-staging.yml
@@ -167,6 +167,7 @@ jobs:
           docker network inspect terrafusion-edge >/dev/null 2>&1 || docker network create terrafusion-edge
           if [ -f /opt/terrafusion/edge-proxy/docker-compose.yml ]; then
             cd /opt/terrafusion/edge-proxy && docker compose up -d
+            docker compose exec -T edge caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || true
           fi
           SSH
 


### PR DESCRIPTION
## Problem
The edge proxy bootstrap step copies the updated Caddyfile via scp but `docker compose up -d` won't recreate the container if it's already running. Since Caddy reads its config at startup, bind-mount file changes are invisible until explicitly reloaded.

This caused the staging deploy (Run 22961093555, Run 22962405099) to fail: the Caddyfile added `tls internal` in PR #686, but the edge proxy container (started during production deploy) never picked it up. Caddy was still trying ACME for `staging.terrafusionmarket.com` which fails because DNS is NXDOMAIN.

## Fix
- Add `caddy reload` after `docker compose up -d` in the bootstrap step (zero-downtime config reload)
- Add diagnostic verbose curl output on first health check failure for future debugging
- Add `caddy reload` to rollback workflows for consistency

## Testing
This is a workflow-only change. The `caddy reload` command:
- Is zero-downtime (no container restart)
- Is idempotent (safe if config hasn't changed)
- Correctly applies bind-mount Caddyfile changes to a running Caddy process
- The `|| true` ensures it doesn't fail if the container was just created (first deploy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflows to ensure configuration changes are properly applied during edge proxy deployments across all environments.
  * Improved diagnostics in health verification phase to provide detailed troubleshooting information on initial connectivity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->