### PR TITLE
ops(infra): fix infra-probe + finalize evidence memo

### DIFF
--- a/.github/workflows/infra-probe.yml
+++ b/.github/workflows/infra-probe.yml
@@ -99,13 +99,17 @@ jobs:
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" bash -s <<'SSH'
           set -euo pipefail
           echo "--- edge proxy container ---"
-          docker inspect terrafusion-edge-proxy-caddy-1 --format '{{.State.Status}} since {{.State.StartedAt}}' 2>/dev/null || echo "EDGE_PROXY_NOT_FOUND"
+          docker inspect edge-proxy-edge-1 --format '{{.State.Status}} since {{.State.StartedAt}}' 2>/dev/null || echo "EDGE_PROXY_NOT_FOUND"
           echo "--- caddy config test ---"
-          docker exec terrafusion-edge-proxy-caddy-1 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || echo "CADDY_VALIDATE_FAILED"
+          docker exec edge-proxy-edge-1 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>/dev/null || echo "CADDY_VALIDATE_FAILED"
+          echo "--- edge network members ---"
+          docker network inspect terrafusion-edge --format '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null || echo "EDGE_NETWORK_INSPECT_FAILED"
+          echo "--- bound ports (host 80/443) ---"
+          ss -tlnp 2>/dev/null | grep -E ':80\b|:443\b' || echo "NO_EDGE_PORTS"
           echo "--- internal health check (production) ---"
-          curl -sSf --max-time 5 http://terrafusion-production-proxy-1:80/health 2>/dev/null && echo "" || echo "PROD_INTERNAL_UNREACHABLE"
+          docker exec edge-proxy-edge-1 wget -qO- --timeout=5 http://terrafusion-production-proxy-1:80/health 2>/dev/null && echo "" || echo "PROD_INTERNAL_UNREACHABLE"
           echo "--- internal health check (staging) ---"
-          curl -sSf --max-time 5 http://terrafusion-staging-proxy-1:80/health 2>/dev/null && echo "" || echo "STAGING_INTERNAL_UNREACHABLE"
+          docker exec edge-proxy-edge-1 wget -qO- --timeout=5 http://terrafusion-staging-proxy-1:80/health 2>/dev/null && echo "" || echo "STAGING_INTERNAL_UNREACHABLE"
           echo "--- external health check (localhost) ---"
           curl -sSfk --max-time 5 https://127.0.0.1/health -H 'Host: terrafusionmarket.com' 2>/dev/null && echo "" || echo "EXTERNAL_HEALTH_FAILED"
           SSH

--- a/os-platform/core/pilot/ops/production-approval-memo.md
+++ b/os-platform/core/pilot/ops/production-approval-memo.md
@@ -48,15 +48,16 @@ All runs on internal GHCR packages (post-cutover reseed):
 
 ## 4. Coexistence Proof
 
-Both environments running simultaneously behind shared edge proxy (2026-03-11T16:59Z):
+Both environments running simultaneously behind shared edge proxy (2026-03-11T18:55Z):
 
 | Environment | Health | SHA | TLS |
 |-------------|--------|-----|-----|
 | Production | HTTP 200 | `864d651a8b49ec1b2dc2cbca137091dbc1c3b29b` | ACME (Let's Encrypt) |
-| Staging | HTTP 200 | `4a639b5399edf14683157dfae8dd6eaeaae1b7ae` | Internal CA (self-signed) |
+| Staging | HTTP 200 | `134c05cce8dc025f9b8a575a6469da385754cd66` | ACME (Let's Encrypt) |
 
 - Edge proxy: Caddy 2.8-alpine at `/opt/terrafusion/edge-proxy/`
 - Network isolation: `terrafusion-edge` Docker network, per-env stacks have no host port bindings
+- Host-state proof: infra-probe run 22969300402 (`docker ps` shows 7 containers; only `edge-proxy-edge-1` owns host 80/443)
 - Architecture PRs: #684 (edge proxy), #685 (graceful transition), #686 (`tls internal`), #687 (caddy reload)
 
 ## 5. Health Monitoring
@@ -118,14 +119,15 @@ Both environments running simultaneously behind shared edge proxy (2026-03-11T16
 | #686 | `tls internal` for staging |
 | #687 | `caddy reload` after file copy |
 | #688 | Coexistence evidence documentation |
+| #691 | Staging DNS restored, `tls internal` removed |
 
 ## 8. Outstanding Items
 
 | Item | Status | Owner |
 |------|--------|-------|
-| Staging DNS A record | Pending | Manual (Hostinger) |
-| K3s cluster presence | Probe workflow ready | Dispatch `infra-probe.yml` |
-| Remove `tls internal` | Blocked on DNS | Automated after DNS restored |
+| ~~Staging DNS A record~~ | DONE (2026-03-11) | Hostinger — resolves to 72.60.126.11 |
+| ~~K3s cluster presence~~ | CLOSED — not installed | infra-probe run 22965879505 |
+| ~~Remove `tls internal`~~ | DONE (PR #691) | Staging now uses ACME (Let's Encrypt) |
 | Prometheus/Grafana on VPS | Future | Pending resource assessment |
 
 ## 9. Proven Claims
@@ -141,6 +143,8 @@ Both environments running simultaneously behind shared edge proxy (2026-03-11T16
 - [x] Staging and production coexist behind shared edge proxy
 - [x] Automated health monitoring runs every 15 minutes
 - [x] Infrastructure probe available for on-demand diagnostics
+- [x] VPS host-state captured: 7 containers, only edge proxy owns host 80/443 (infra-probe run 22969300402)
+- [x] `terrafusion-edge` bridge network confirmed on VPS (`docker network ls`)
 
 ---
 


### PR DESCRIPTION
## What

1. **Fix infra-probe edge proxy health step**
   - Container name: \	errafusion-edge-proxy-caddy-1\ → \dge-proxy-edge-1\ (matches actual compose project/service)
   - Internal health checks: run via \docker exec\ inside edge container (host namespace cannot reach per-env containers on \	errafusion-edge\ network)
   - Added: \docker network inspect terrafusion-edge\ for network membership evidence
   - Added: \ss -tlnp\ filtered to \:80\/\:443\ for bound port evidence

2. **Finalize production-approval-memo**
   - Reference infra-probe run 22969300402 (VPS host-state proof)
   - Update coexistence proof timestamp and staging SHA/TLS
   - Add PR #691 to fix chronicle
   - Add host-state proven claims

## Evidence

| Proof | Run ID | Result |
|-------|--------|--------|
| Production E1 (deploy) | 22952476204 | SUCCESS |
| Production E2 (release) | 22953010096 | SUCCESS |
| Production E3 (rollback) | 22953429826 | SUCCESS |
| Production E4 (redeploy) | 22953654896 | SUCCESS |
| Staging deploy (PR #691) | 22967959445 | SUCCESS |
| Infra-probe (host-state) | 22969300402 | SUCCESS |
| Production live | HTTP 200, TLS=0 | VERIFIED |
| Staging live | HTTP 200, TLS=0 | VERIFIED |

## Files changed

- \.github/workflows/infra-probe.yml\ — probe fix
- \os-platform/core/pilot/ops/production-approval-memo.md\ — evidence update