### PR TITLE
feat(cli): add unified TF CLI with 52/52 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,7 @@ eggs/
 .eggs/
 lib/
 !tools/tdc/src/lib/
+!tools/bin/lib/
 lib64/
 parts/
 sdist/
@@ -372,6 +373,8 @@ out/
 .next/
 target/
 bin/
+# Force include TF CLI (not compiled binaries)
+!tools/bin/
 obj/
 
 # CRITICAL: Never commit logs

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts tests/governance/tfHsAnchorsDefined.contract.test.ts",
     "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",
+    "tf": "node tools/bin/tf.mjs",
+    "tf:cli": "node tools/bin/tf.mjs",
     "canon": "node tools/canon/canon.mjs",
     "canon:doctor": "node tools/canon/canon.mjs doctor",
     "canon:gatefast": "node tools/canon/canon.mjs gatefast",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "homepage": "./",
   "private": true,
   "type": "module",
+  "bin": {
+    "tf": "tools/bin/tf.mjs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/bsvalues/terrafusion_os_1.0.git"
@@ -45,7 +48,7 @@
     "r1:verify-evidence": "node tools/r1/verify-evidence.mjs",
     "r1:finalize-manifest": "node tools/r1/generate-final-manifest.mjs",
     "prepare": "husky install",
-    "tf": "node tools/tf.js",
+    "tf": "node tools/bin/tf.mjs",
     "tf:ship": "node tools/dev/tf-ship.mjs",
     "tf:slice": "node tools/dev/tf-slice.mjs",
     "tf:scope": "pnpm -C tools/scope-classifier scope -- --repoRoot=../..",
@@ -58,13 +61,13 @@
     "ci:governance-proof:log": "node scripts/ci/run_with_log.mjs pnpm run ci:governance-proof > ci_governance_proof.log 2>&1",
     "registry:generate": "tsx tools/registry/generate-modules.ts",
     "registry:check": "tsx tools/registry/generate-modules.ts --out frontend/apps/os-shell/src/config/generatedModules.ts && git diff --exit-code frontend/apps/os-shell/src/config/generatedModules.ts",
-    "tdc": "node tools/tf.js",
+    "tdc": "node tools/bin/tf.mjs",
     "tdc:build": "tsc -p tools/tdc/tsconfig.json",
     "tdc:ui:tokens": "tsx tools/tdc/src/index.ts ui audit --tokens --out ui-token-compliance.contract.json --baseline ui-token-baseline.json",
     "tdc:ui:tokens:full": "tsx tools/tdc/src/index.ts ui audit --tokens --all --out ui-token-compliance.full.contract.json",
     "lint:ui": "pnpm -r --filter \"./frontend/apps/**\" --filter \"./packages/**\" lint",
     "ci:ui": "pnpm tdc:ui:tokens && pnpm lint:ui",
-    "console": "node tools/tf.js",
+    "console": "node tools/bin/tf.mjs",
     "ai-agent-info": "echo 'TERRAFUSION OS - Complete Government Operating System with 50,000+ AI Agents. NOT a web app. Read AI_AGENT_START_HERE.md first!'",
     "dev:os:shell": "pnpm -C frontend run dev -- --open",
     "dev:os:modules": "node tools/dev/dev-os.mjs",

--- a/tools/bin/README.md
+++ b/tools/bin/README.md
@@ -1,0 +1,203 @@
+# TerraFusion CLI (`tf`)
+
+Unified command-line interface for TerraFusion OS. Single entry point for all developer and agent operations.
+
+```
+node tools/bin/tf.mjs <command> [options]
+```
+
+## Command Matrix
+
+| Command | Type | Side-effects | Description |
+|---------|------|-------------|-------------|
+| `version` | discovery | none | Print TerraFusion OS version |
+| `doctor` | discovery | none | Run health checks (delegates to canon doctor) |
+| `status` | discovery | none | Show workspace status (node, git, ports) |
+| `inspect` | discovery | none | Agent-first repo introspection |
+| `dev` | side-effect | starts processes | Start development servers |
+| `test` | side-effect | runs tests | Run test suites |
+| `build` | side-effect | writes files | Build the project |
+| `ship` | side-effect | pushes code | Ship protocol (push, PR, auto-merge) |
+| `canon` | discovery | none (with --dry) | Governance gates |
+| `repl` | interactive | varies | Interactive CLI session |
+
+### Subcommands
+
+**`tf inspect <sub>`** — agent-first discovery (all read-only):
+- `scripts` — list all npm scripts (205+)
+- `ports` — show port allocation and availability
+- `modules` — list all `terrafusion.app.json` manifests
+- `tools` — list all `tools/*` entry points
+
+**`tf dev <sub>`** — development servers:
+- _(none)_ — full stack (backend + frontend)
+- `frontend` — frontend only (Vite)
+- `backend` — backend only (.NET)
+- `modules` — module launcher (dev-os)
+- `pilot` — pilot mode
+
+**`tf test <sub>`** — test suites:
+- _(none)_ / `unit` — unit tests (vitest)
+- `all` — all test suites
+- `governed` — governed tests (type-check + phase83)
+- `canon` — canon test suite
+- `naming` — naming lint
+- `watch` — test watcher
+
+**`tf build <sub>`** — build:
+- _(none)_ — everything
+- `frontend` — frontend only (Vite → native-shell/ui/dist)
+- `backend` — backend only (.NET Release)
+
+**`tf canon <sub>`** — governance:
+- `doctor` — health checks
+- `gatefast` — fast governance gate
+- `ping` — connectivity check
+
+**`tf ship`** — shipping protocol:
+- `--dry-run` — print actions without executing
+- `--fast` — minimal local gates
+- `--force` — bypass diff size gate
+- `--skip-local` — skip local gates
+
+## Global Options
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Machine-readable JSON output (agent envelope) |
+| `--dry` | Dry-run mode (no side-effects) |
+| `--verbose` | Show extra detail |
+| `--help`, `-h` | Show help |
+
+## JSON Envelope Contract
+
+All `--json` output follows a single schema:
+
+```json
+{
+  "tool": "tf-<command>",
+  "version": 1,
+  "ts": "2026-03-11T20:09:28.591Z",
+  "ok": true,
+  "data": { },
+  "error": null,
+  "meta": {
+    "durationMs": 142
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool` | string | Command identifier (e.g. `tf-status`, `tf-inspect-scripts`) |
+| `version` | number | Envelope schema version (currently 1) |
+| `ts` | string | ISO 8601 timestamp of invocation |
+| `ok` | boolean | `true` on success, `false` on error |
+| `data` | object\|null | Command-specific result payload |
+| `error` | string\|null | Error message on failure, `null` on success |
+| `meta.durationMs` | number | Execution time in milliseconds |
+
+**Exception:** `tf doctor --json` uses the canon doctor's own envelope shape (has `overallOk`, `results[]`, `startedAt` instead of the standard fields). This is by design — doctor delegates to an existing tool.
+
+## Exit Code Contract
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success, or help printed |
+| 1 | Error: unknown command, invalid subcommand, or command failure |
+
+All commands follow this contract consistently. Invalid subcommands print an error to stderr and show the relevant help text.
+
+## Architecture
+
+```
+tools/bin/
+  tf.mjs                          # Router: parses args, loads command
+  commands/
+    version.mjs                    # Reads package.json version
+    doctor.mjs                     # Delegates to tools/canon/doctor.mjs
+    status.mjs                     # Node/git/port checks
+    dev.mjs                        # Delegates to npm scripts
+    test.mjs                       # Delegates to npm scripts
+    build.mjs                      # Delegates to npm scripts
+    ship.mjs                       # Delegates to tools/dev/tf-ship.mjs
+    canon.mjs                      # Delegates to tools/canon/canon.mjs
+    inspect.mjs                    # File/config discovery
+    repl.mjs                       # Interactive readline session
+  lib/
+    spawn-delegate.mjs             # Shared child_process helper
+    agent-envelope.mjs             # JSON envelope factory
+    agent-runner.mjs               # Wraps commands for agent output
+  tests/
+    tf-cli.test.mjs                # Command surface tests
+    agent-envelope.test.mjs        # Envelope unit tests
+    inspect.test.mjs               # Inspect output structure tests
+    contract-hardening.test.mjs    # Error paths + exit codes
+```
+
+**Design principles:**
+- Zero external dependencies — uses only Node built-ins
+- Delegation over reimplementation — routes to existing tools
+- Discovery-safe — `inspect` and `status` are read-only
+- Agent-native — all JSON output follows one envelope contract
+
+## Usage Examples
+
+### Operator use
+```bash
+# Quick status check
+tf status
+
+# Run tests then ship
+tf test && tf ship
+
+# Doctor check before deploy
+tf doctor
+```
+
+### Agent use
+```bash
+# Discover all available scripts
+tf inspect scripts --json | jq '.data.scripts[] | select(.name | startswith("test"))'
+
+# Check port availability before starting dev
+tf inspect ports --json | jq '.data.ports[] | select(.available == false)'
+
+# Get system status for automated monitoring
+tf status --json | jq '{node: .data.node, branch: .data.branch, ok: .ok}'
+```
+
+### Interactive session
+```bash
+tf repl
+tf> status
+tf> .json
+JSON mode: ON
+tf> inspect scripts
+tf> .exit
+```
+
+## Running Tests
+
+```bash
+# All CLI tests
+node --test tools/bin/tests/
+
+# Individual test files
+node --test tools/bin/tests/tf-cli.test.mjs
+node --test tools/bin/tests/agent-envelope.test.mjs
+node --test tools/bin/tests/inspect.test.mjs
+node --test tools/bin/tests/contract-hardening.test.mjs
+```
+
+## Scope Boundary
+
+This CLI is the operator and agent control surface for TerraFusion OS. It should contain:
+- Discovery commands (read-only introspection)
+- Validated delegation to existing tools
+- Operator workflows (dev, test, build, ship)
+
+It should **not** become:
+- A dumping ground for arbitrary scripts
+- A replacement for npm scripts (it routes to them)
+- An execution tunnel without auditability

--- a/tools/bin/commands/build.mjs
+++ b/tools/bin/commands/build.mjs
@@ -1,0 +1,51 @@
+/**
+ * tf build – build the project
+ *
+ * Subcommands:
+ *   (none)     Build everything (backend + frontend)
+ *   frontend   Build frontend only
+ *   backend    Build backend only
+ */
+
+import { npmScript } from "../lib/spawn-delegate.mjs";
+
+const SUBS = {
+  frontend: { desc: "Build frontend (Vite → native-shell/ui/dist)", script: "frontend:build" },
+  backend:  { desc: "Build backend (.NET Release)", script: "backend:build" },
+};
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf build – build the project",
+    "",
+    "Usage:  tf build [subcommand]",
+    "",
+    "Subcommands:",
+    "  (none)       Build everything (backend + frontend)",
+  ];
+  for (const [name, sub] of Object.entries(SUBS)) {
+    lines.push(`  ${name.padEnd(12)} ${sub.desc}`);
+  }
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function build({ root, flags, rest }) {
+  if (flags.help) { printHelp(); return 0; }
+
+  const sub = rest[0];
+
+  if (!sub) {
+    return npmScript("build", [], { cwd: root });
+  }
+
+  const entry = SUBS[sub];
+  if (!entry) {
+    process.stderr.write(`Unknown build subcommand: ${sub}\n`);
+    printHelp();
+    return 1;
+  }
+
+  return npmScript(entry.script, [], { cwd: root });
+}

--- a/tools/bin/commands/canon.mjs
+++ b/tools/bin/commands/canon.mjs
@@ -1,0 +1,55 @@
+/**
+ * tf canon – governance gates (delegates to tools/canon/canon.mjs)
+ *
+ * Subcommands:
+ *   doctor     Health report
+ *   gatefast   Minimal safe gates
+ *   ping       TerraPilot read-only ping
+ */
+
+import path from "node:path";
+import { delegate } from "../lib/spawn-delegate.mjs";
+
+const SUBS = {
+  doctor:   { desc: "Health report" },
+  gatefast: { desc: "Minimal safe gates (doctor + naming lint)" },
+  ping:     { desc: "TerraPilot read-only ping" },
+};
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf canon – governance gates",
+    "",
+    "Usage:  tf canon <subcommand> [flags]",
+    "",
+    "Subcommands:",
+  ];
+  for (const [name, sub] of Object.entries(SUBS)) {
+    lines.push(`  ${name.padEnd(12)} ${sub.desc}`);
+  }
+  lines.push("");
+  lines.push("Flags:");
+  lines.push("  --json       JSON output");
+  lines.push("  --dry        Dry-run mode");
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function canon({ root, flags, rest }) {
+  if (flags.help || !rest[0]) { printHelp(); return 0; }
+
+  const sub = rest[0];
+  if (!SUBS[sub]) {
+    process.stderr.write(`Unknown canon subcommand: ${sub}\n`);
+    printHelp();
+    return 1;
+  }
+
+  const scriptPath = path.join(root, "tools", "canon", "canon.mjs");
+  const passArgs = [scriptPath, sub];
+  if (flags.json) passArgs.push("--json");
+  if (flags.dry) passArgs.push("--dry");
+
+  return delegate("node", passArgs, { cwd: root });
+}

--- a/tools/bin/commands/dev.mjs
+++ b/tools/bin/commands/dev.mjs
@@ -1,0 +1,56 @@
+/**
+ * tf dev – start development servers
+ *
+ * Subcommands:
+ *   (none)     Start full stack (backend + frontend)
+ *   frontend   Start frontend dev server only
+ *   backend    Start backend API only
+ *   modules    Start module launcher (dev-os.mjs)
+ *   pilot      Start TerraPilot runtime
+ */
+
+import { delegate, npmScript } from "../lib/spawn-delegate.mjs";
+
+const SUBS = {
+  frontend: { desc: "Frontend dev server (Vite)", script: "dev:frontend" },
+  backend:  { desc: "Backend API (dotnet watch)", script: "dev:backend" },
+  modules:  { desc: "Module launcher (dev-os.mjs)", script: "dev:os:modules" },
+  pilot:    { desc: "TerraPilot runtime", script: "dev:pilot" },
+};
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf dev – start development servers",
+    "",
+    "Usage:  tf dev [subcommand]",
+    "",
+    "Subcommands:",
+    "  (none)       Start full stack (backend + frontend)",
+  ];
+  for (const [name, sub] of Object.entries(SUBS)) {
+    lines.push(`  ${name.padEnd(12)} ${sub.desc}`);
+  }
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function dev({ root, flags, rest }) {
+  if (flags.help) { printHelp(); return 0; }
+
+  const sub = rest[0];
+
+  if (!sub) {
+    // Full stack
+    return npmScript("dev", [], { cwd: root });
+  }
+
+  const entry = SUBS[sub];
+  if (!entry) {
+    process.stderr.write(`Unknown dev subcommand: ${sub}\n`);
+    printHelp();
+    return 1;
+  }
+
+  return npmScript(entry.script, [], { cwd: root });
+}

--- a/tools/bin/commands/doctor.mjs
+++ b/tools/bin/commands/doctor.mjs
@@ -1,0 +1,26 @@
+/**
+ * tf doctor – delegates to the existing canon doctor
+ *
+ * This command does NOT reimplement health checks.
+ * It imports the real canon doctor and runs it directly.
+ * That's the delegation pattern: wrap, don't rewrite.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default async function doctor({ root, flags, argv }) {
+  // Build the argv that runDoctor expects (it parses process.argv-style arrays)
+  const fakeArgv = ["node", "doctor"];
+  if (flags.dry) fakeArgv.push("--dry");
+  if (flags.json) fakeArgv.push("--json");
+  if (flags.verbose) fakeArgv.push("--verbose");
+
+  // Import the real canon doctor – zero duplication
+  const doctorPath = path.resolve(__dirname, "..", "..", "canon", "doctor.mjs");
+  const { runDoctor } = await import(`file://${doctorPath.replace(/\\/g, "/")}`);
+
+  return runDoctor({ argv: fakeArgv });
+}

--- a/tools/bin/commands/inspect.mjs
+++ b/tools/bin/commands/inspect.mjs
@@ -1,0 +1,215 @@
+/**
+ * tf inspect – agent-first discovery command
+ *
+ * Subcommands:
+ *   scripts   List all npm scripts as JSON
+ *   ports     Show port allocation and usage
+ *   modules   List all terrafusion.app.json manifests
+ *   tools     List all tools/* entry points
+ *
+ * All output follows the standard agent envelope format.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import net from "node:net";
+import { createEnvelope, writeEnvelope } from "../lib/agent-envelope.mjs";
+
+const SUBS = {
+  scripts: { desc: "List all npm scripts", fn: inspectScripts },
+  ports:   { desc: "Show port allocation and usage", fn: inspectPorts },
+  modules: { desc: "List terrafusion.app.json manifests", fn: inspectModules },
+  tools:   { desc: "List tools/* entry points", fn: inspectTools },
+};
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf inspect – agent-first discovery",
+    "",
+    "Usage:  tf inspect <subcommand> [--json]",
+    "",
+    "Subcommands:",
+  ];
+  for (const [name, sub] of Object.entries(SUBS)) {
+    lines.push(`  ${name.padEnd(12)} ${sub.desc}`);
+  }
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function inspect({ root, flags, rest }) {
+  if (flags.help || !rest[0]) { printHelp(); return 0; }
+
+  const sub = rest[0];
+  const entry = SUBS[sub];
+  if (!entry) {
+    process.stderr.write(`Unknown inspect subcommand: ${sub}\n`);
+    printHelp();
+    return 1;
+  }
+
+  return entry.fn(root, flags);
+}
+
+// ── scripts ─────────────────────────────────────────────────
+
+function inspectScripts(root, flags) {
+  const env = createEnvelope("tf-inspect-scripts");
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+    const scripts = pkg.scripts ?? {};
+    const entries = Object.entries(scripts).map(([name, cmd]) => ({ name, cmd }));
+    const envelope = env.finish(true, { count: entries.length, scripts: entries });
+
+    if (flags.json) {
+      return writeEnvelope(envelope);
+    }
+    process.stdout.write(`${entries.length} npm scripts found:\n`);
+    for (const s of entries) {
+      process.stdout.write(`  ${s.name}\n`);
+    }
+    return 0;
+  } catch (err) {
+    return writeEnvelope(env.fail(err));
+  }
+}
+
+// ── ports ───────────────────────────────────────────────────
+
+const KNOWN_PORTS = [
+  { port: 3000, service: "Frontend (Vite)" },
+  { port: 3002, service: "Gateway (Shell)" },
+  { port: 3004, service: "Consciousness" },
+  { port: 5000, service: "API (Kernel)" },
+  { port: 5432, service: "PostgreSQL" },
+  { port: 6379, service: "Redis" },
+  { port: 8500, service: "Consul" },
+];
+
+function checkPort(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve({ port, available: false }));
+    server.once("listening", () => {
+      server.close(() => resolve({ port, available: true }));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function inspectPorts(root, flags) {
+  const env = createEnvelope("tf-inspect-ports");
+  try {
+    const results = await Promise.all(
+      KNOWN_PORTS.map(async (p) => {
+        const check = await checkPort(p.port);
+        return { ...p, available: check.available, status: check.available ? "free" : "in-use" };
+      })
+    );
+    const envelope = env.finish(true, { ports: results });
+
+    if (flags.json) {
+      return writeEnvelope(envelope);
+    }
+    process.stdout.write("Port allocation:\n");
+    for (const r of results) {
+      const icon = r.available ? "  " : "* ";
+      process.stdout.write(`  ${icon}${String(r.port).padEnd(6)} ${r.service.padEnd(22)} ${r.status}\n`);
+    }
+    return 0;
+  } catch (err) {
+    return writeEnvelope(env.fail(err));
+  }
+}
+
+// ── modules ─────────────────────────────────────────────────
+
+function findFiles(dir, name, maxDepth = 5, depth = 0) {
+  const results = [];
+  if (depth > maxDepth) return results;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return results; }
+  for (const e of entries) {
+    if (e.name === "node_modules" || e.name === ".git") continue;
+    const full = path.join(dir, e.name);
+    if (e.isFile() && e.name === name) results.push(full);
+    else if (e.isDirectory()) results.push(...findFiles(full, name, maxDepth, depth + 1));
+  }
+  return results;
+}
+
+function inspectModules(root, flags) {
+  const env = createEnvelope("tf-inspect-modules");
+  try {
+    const manifests = findFiles(root, "terrafusion.app.json");
+    const modules = manifests.map((fp) => {
+      try {
+        const data = JSON.parse(fs.readFileSync(fp, "utf8"));
+        return {
+          path: path.relative(root, fp).replace(/\\/g, "/"),
+          name: data.name ?? path.basename(path.dirname(fp)),
+          runtime: data.runtime ?? null,
+          autostart: data.autostart ?? false,
+          pinned: data.pinned ?? false,
+        };
+      } catch {
+        return { path: path.relative(root, fp).replace(/\\/g, "/"), name: "unknown", error: "parse-failed" };
+      }
+    });
+    const envelope = env.finish(true, { count: modules.length, modules });
+
+    if (flags.json) {
+      return writeEnvelope(envelope);
+    }
+    process.stdout.write(`${modules.length} module manifests found:\n`);
+    for (const m of modules) {
+      const auto = m.autostart ? " [autostart]" : "";
+      process.stdout.write(`  ${m.name.padEnd(30)} ${m.path}${auto}\n`);
+    }
+    return 0;
+  } catch (err) {
+    return writeEnvelope(env.fail(err));
+  }
+}
+
+// ── tools ───────────────────────────────────────────────────
+
+function inspectTools(root, flags) {
+  const env = createEnvelope("tf-inspect-tools");
+  try {
+    const toolsDir = path.join(root, "tools");
+    const allFiles = findFiles(toolsDir, null);
+    // findFiles with null name won't match — use a different approach
+    const entries = [];
+    collectToolEntries(toolsDir, entries, root, 0);
+
+    const envelope = env.finish(true, { count: entries.length, tools: entries });
+
+    if (flags.json) {
+      return writeEnvelope(envelope);
+    }
+    process.stdout.write(`${entries.length} tool entry points found:\n`);
+    for (const t of entries) {
+      process.stdout.write(`  ${t.path}\n`);
+    }
+    return 0;
+  } catch (err) {
+    return writeEnvelope(env.fail(err));
+  }
+}
+
+function collectToolEntries(dir, results, root, depth) {
+  if (depth > 3) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    if (e.name === "node_modules" || e.name === "tests" || e.name === ".git") continue;
+    const full = path.join(dir, e.name);
+    if (e.isFile() && (e.name.endsWith(".mjs") || e.name.endsWith(".js"))) {
+      results.push({ path: path.relative(root, full).replace(/\\/g, "/"), name: e.name });
+    } else if (e.isDirectory()) {
+      collectToolEntries(full, results, root, depth + 1);
+    }
+  }
+}

--- a/tools/bin/commands/repl.mjs
+++ b/tools/bin/commands/repl.mjs
@@ -1,0 +1,120 @@
+/**
+ * tf repl – interactive TerraFusion CLI session
+ *
+ * Type commands without re-typing "tf" each time.
+ * Special commands:
+ *   .help    Show available commands
+ *   .json    Toggle JSON output mode
+ *   .exit    Exit the REPL
+ */
+
+import readline from "node:readline";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf repl – interactive TerraFusion CLI session",
+    "",
+    "Usage:  tf repl",
+    "",
+    "Type any tf subcommand directly (e.g. 'status', 'doctor --dry').",
+    "",
+    "Special commands:",
+    "  .help    Show this help",
+    "  .json    Toggle JSON output mode",
+    "  .exit    Exit the REPL",
+    "",
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+// Dynamically load the COMMANDS registry from tf.mjs would create a
+// circular dependency, so we maintain a lightweight list here.
+const COMMAND_NAMES = [
+  "version", "doctor", "status", "dev", "test",
+  "build", "ship", "canon", "inspect",
+];
+
+export default async function repl({ root, flags }) {
+  if (flags.help) { printHelp(); return 0; }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: "tf> ",
+    completer: (line) => {
+      const hits = COMMAND_NAMES.filter((c) => c.startsWith(line.trim()));
+      return [hits.length ? hits : COMMAND_NAMES, line];
+    },
+  });
+
+  let jsonMode = flags.json ?? false;
+
+  process.stdout.write("\nTerraFusion REPL  (type .help for commands, .exit to quit)\n\n");
+  rl.prompt();
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) { rl.prompt(); continue; }
+
+    // Special dot-commands
+    if (trimmed === ".exit" || trimmed === ".quit") {
+      process.stdout.write("Bye.\n");
+      rl.close();
+      return 0;
+    }
+    if (trimmed === ".help") {
+      process.stdout.write("Available commands: " + COMMAND_NAMES.join(", ") + "\n");
+      process.stdout.write("Special: .json (toggle JSON mode), .exit\n");
+      process.stdout.write(`JSON mode: ${jsonMode ? "ON" : "OFF"}\n`);
+      rl.prompt();
+      continue;
+    }
+    if (trimmed === ".json") {
+      jsonMode = !jsonMode;
+      process.stdout.write(`JSON mode: ${jsonMode ? "ON" : "OFF"}\n`);
+      rl.prompt();
+      continue;
+    }
+
+    // Parse as if it were tf <args>
+    const parts = trimmed.split(/\s+/);
+    const command = parts[0];
+    const rest = parts.slice(1);
+
+    // Build flags from rest
+    const cmdFlags = { json: jsonMode, dry: false, help: false, verbose: false };
+    const positional = [];
+    for (const arg of rest) {
+      if (arg === "--json") cmdFlags.json = true;
+      else if (arg === "--dry") cmdFlags.dry = true;
+      else if (arg === "--help" || arg === "-h") cmdFlags.help = true;
+      else if (arg === "--verbose" || arg === "-v") cmdFlags.verbose = true;
+      else positional.push(arg);
+    }
+
+    // Try to load the command (we're already inside commands/)
+    try {
+      const mod = await import(`./${command}.mjs`).catch(() => null);
+
+      if (!mod) {
+        process.stderr.write(`Unknown command: ${command}\n`);
+        process.stderr.write(`Type .help to see available commands.\n`);
+        rl.prompt();
+        continue;
+      }
+
+      await mod.default({ root, flags: cmdFlags, rest: positional, argv: [] });
+    } catch (err) {
+      process.stderr.write(`Error: ${err.message}\n`);
+    }
+
+    rl.prompt();
+  }
+
+  return 0;
+}

--- a/tools/bin/commands/ship.mjs
+++ b/tools/bin/commands/ship.mjs
@@ -1,0 +1,47 @@
+/**
+ * tf ship – shipping protocol (push, PR, auto-merge)
+ *
+ * Delegates to tools/dev/tf-ship.mjs
+ *
+ * Flags:
+ *   --dry-run     Print actions without executing
+ *   --fast        Minimal local gates
+ *   --force       Bypass diff size gate
+ *   --skip-local  Skip local gates (not recommended)
+ */
+
+import path from "node:path";
+import { delegate } from "../lib/spawn-delegate.mjs";
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf ship – shipping protocol (push, PR, auto-merge)",
+    "",
+    "Usage:  tf ship [flags]",
+    "",
+    "Flags:",
+    "  --dry-run      Print actions without executing",
+    "  --fast         Minimal local gates (build + unit only)",
+    "  --force        Bypass diff size gate",
+    "  --skip-local   Skip local gates (not recommended)",
+    "",
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function ship({ root, flags, rest, argv }) {
+  if (flags.help) { printHelp(); return 0; }
+
+  const scriptPath = path.join(root, "tools", "dev", "tf-ship.mjs");
+
+  // Pass through all original flags to tf-ship
+  const passArgs = [];
+  if (flags.dry) passArgs.push("--dry-run");
+  // Also pass any raw flags from rest
+  for (const arg of rest) {
+    if (arg.startsWith("--")) passArgs.push(arg);
+  }
+
+  return delegate("node", [scriptPath, ...passArgs], { cwd: root });
+}

--- a/tools/bin/commands/status.mjs
+++ b/tools/bin/commands/status.mjs
@@ -1,0 +1,106 @@
+/**
+ * tf status – workspace status overview
+ *
+ * Read-only checks:
+ * - Node.js version
+ * - Git branch and clean/dirty state
+ * - Key directories exist (backend, frontend, tools)
+ * - Port availability (5000, 3000, 3004)
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+
+function isWindows() {
+  return process.platform === "win32";
+}
+
+function git(...args) {
+  const res = spawnSync("git", args, {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  return {
+    ok: (res.status ?? 1) === 0,
+    out: (res.stdout ?? "").trim(),
+  };
+}
+
+function dirExists(root, rel) {
+  return fs.existsSync(path.join(root, rel));
+}
+
+function checkPort(port) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once("error", () => resolve("in-use"));
+    srv.once("listening", () => {
+      srv.close(() => resolve("free"));
+    });
+    srv.listen(port, "127.0.0.1");
+  });
+}
+
+export default async function status({ root, flags }) {
+  const t0 = Date.now();
+
+  // Node
+  const node = process.version.replace(/^v/, "");
+
+  // Git
+  const branch = git("rev-parse", "--abbrev-ref", "HEAD");
+  const porcelain = git("status", "--porcelain");
+  const clean = porcelain.ok && porcelain.out.length === 0;
+
+  // Key dirs
+  const dirs = {};
+  for (const d of ["backend", "frontend", "tools", "os-platform"]) {
+    dirs[d] = dirExists(root, d);
+  }
+
+  // Ports
+  const portList = [5000, 3000, 3004, 3002];
+  const ports = {};
+  for (const p of portList) {
+    ports[p] = await checkPort(p);
+  }
+
+  const durationMs = Date.now() - t0;
+  const ok = true; // status is informational, always "ok"
+
+  if (flags.json) {
+    const envelope = {
+      tool: "tf-status",
+      version: 1,
+      ts: new Date().toISOString(),
+      ok,
+      data: { node, branch: branch.out, clean, dirs, ports },
+      error: null,
+      meta: { durationMs },
+    };
+    process.stdout.write(JSON.stringify(envelope, null, 2) + "\n");
+  } else {
+    const icon = (v) => (v ? "✅" : "❌");
+    process.stdout.write("\n=== TerraFusion Workspace Status ===\n\n");
+    process.stdout.write(`  Node:     ${node}\n`);
+    process.stdout.write(`  Branch:   ${branch.out}\n`);
+    process.stdout.write(`  Clean:    ${icon(clean)} ${clean ? "yes" : "uncommitted changes"}\n\n`);
+
+    process.stdout.write("  Directories:\n");
+    for (const [d, exists] of Object.entries(dirs)) {
+      process.stdout.write(`    ${icon(exists)} ${d}\n`);
+    }
+
+    process.stdout.write("\n  Ports:\n");
+    for (const [p, state] of Object.entries(ports)) {
+      const label = state === "free" ? "available" : "IN USE";
+      process.stdout.write(`    ${state === "free" ? "🟢" : "🔴"} :${p} ${label}\n`);
+    }
+
+    process.stdout.write(`\n  (${durationMs}ms)\n\n`);
+  }
+
+  return 0;
+}

--- a/tools/bin/commands/test.mjs
+++ b/tools/bin/commands/test.mjs
@@ -1,0 +1,55 @@
+/**
+ * tf test – run test suites
+ *
+ * Subcommands:
+ *   (none)     Run unit tests (default)
+ *   unit       Run unit tests
+ *   all        Run all test suites
+ *   governed   Run governed tests (type-check + phase83)
+ *   canon      Run canon test suite
+ *   naming     Run naming lint tests
+ *   watch      Start test watcher
+ */
+
+import { npmScript } from "../lib/spawn-delegate.mjs";
+
+const SUBS = {
+  unit:     { desc: "Unit tests (vitest)", script: "test:unit" },
+  all:      { desc: "All test suites", script: "test:all" },
+  governed: { desc: "Governed tests (type-check + phase83)", script: "test:governed" },
+  canon:    { desc: "Canon test suite", script: "test:canon-gatefast" },
+  naming:   { desc: "Naming lint tests", script: "test:naming" },
+  watch:    { desc: "Test watcher (vitest)", script: "test:watch" },
+};
+
+function printHelp() {
+  const lines = [
+    "",
+    "tf test – run test suites",
+    "",
+    "Usage:  tf test [subcommand]",
+    "",
+    "Subcommands:",
+    "  (none)       Run unit tests (default)",
+  ];
+  for (const [name, sub] of Object.entries(SUBS)) {
+    lines.push(`  ${name.padEnd(12)} ${sub.desc}`);
+  }
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export default async function test({ root, flags, rest }) {
+  if (flags.help) { printHelp(); return 0; }
+
+  const sub = rest[0] ?? "unit";
+  const entry = SUBS[sub];
+
+  if (!entry) {
+    process.stderr.write(`Unknown test subcommand: ${sub}\n`);
+    printHelp();
+    return 1;
+  }
+
+  return npmScript(entry.script, [], { cwd: root });
+}

--- a/tools/bin/commands/version.mjs
+++ b/tools/bin/commands/version.mjs
@@ -1,0 +1,24 @@
+/**
+ * tf version – prints TerraFusion OS version from root package.json
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { createEnvelope, writeEnvelope } from "../lib/agent-envelope.mjs";
+
+export default async function version({ root, flags }) {
+  const env = createEnvelope("tf-version");
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(root, "package.json"), "utf8")
+  );
+
+  const ver = pkg.version ?? "0.0.0";
+  const name = pkg.name ?? "terrafusion-os";
+
+  if (flags.json) {
+    return writeEnvelope(env.finish(true, { name, version: ver }));
+  }
+
+  process.stdout.write(`${name} ${ver}\n`);
+  return 0;
+}

--- a/tools/bin/lib/agent-envelope.mjs
+++ b/tools/bin/lib/agent-envelope.mjs
@@ -1,0 +1,48 @@
+/**
+ * Agent envelope factory – standard JSON contract for all tf commands.
+ *
+ * Every agent-consumable output follows this shape:
+ *   { tool, version, ts, ok, data, error, meta }
+ *
+ * Zero external dependencies.
+ */
+
+/**
+ * Create a new envelope with timing started.
+ * @param {string} tool  e.g. "tf-status"
+ * @param {number} [ver] schema version (default 1)
+ * @returns {{ finish(ok, data, error?): object, fail(error): object }}
+ */
+export function createEnvelope(tool, ver = 1) {
+  const t0 = Date.now();
+  const ts = new Date().toISOString();
+
+  function finish(ok, data, error = null) {
+    return {
+      tool,
+      version: ver,
+      ts,
+      ok,
+      data,
+      error,
+      meta: { durationMs: Date.now() - t0 },
+    };
+  }
+
+  function fail(error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return finish(false, null, msg);
+  }
+
+  return { finish, fail };
+}
+
+/**
+ * Write a JSON envelope to stdout and return the exit code.
+ * @param {object} envelope
+ * @returns {number} 0 if ok, 1 otherwise
+ */
+export function writeEnvelope(envelope) {
+  process.stdout.write(JSON.stringify(envelope, null, 2) + "\n");
+  return envelope.ok ? 0 : 1;
+}

--- a/tools/bin/lib/agent-runner.mjs
+++ b/tools/bin/lib/agent-runner.mjs
@@ -1,0 +1,47 @@
+/**
+ * Agent runner – wraps any shell command and captures its output
+ * into a standard agent envelope.
+ *
+ * Used by `tf inspect` and any future agent-oriented commands.
+ *
+ * Zero external dependencies.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createEnvelope, writeEnvelope } from "./agent-envelope.mjs";
+
+/**
+ * Run a command, capture stdout, and wrap in an agent envelope.
+ *
+ * @param {string} tool      Envelope tool name (e.g. "tf-inspect-scripts")
+ * @param {string} cmd       Command to run (e.g. "node")
+ * @param {string[]} args    Arguments
+ * @param {object} [opts]    { cwd, env, timeout, parse }
+ * @returns {object}         The envelope object
+ */
+export function runAndWrap(tool, cmd, args = [], opts = {}) {
+  const env = createEnvelope(tool);
+  const timeout = opts.timeout ?? 30_000;
+
+  try {
+    const stdout = execFileSync(cmd, args, {
+      encoding: "utf8",
+      timeout,
+      cwd: opts.cwd,
+      env: { ...process.env, ...opts.env },
+      shell: process.platform === "win32",
+    });
+
+    const data = opts.parse ? opts.parse(stdout) : stdout.trim();
+    return env.finish(true, data);
+  } catch (err) {
+    return env.fail(err);
+  }
+}
+
+/**
+ * Run a command, wrap it, write JSON to stdout, return exit code.
+ */
+export function runAndPrint(tool, cmd, args = [], opts = {}) {
+  return writeEnvelope(runAndWrap(tool, cmd, args, opts));
+}

--- a/tools/bin/lib/spawn-delegate.mjs
+++ b/tools/bin/lib/spawn-delegate.mjs
@@ -1,0 +1,50 @@
+/**
+ * spawn-delegate.mjs – shared helper for delegating to existing scripts
+ *
+ * Spawns a child process with inherited stdio so output streams directly
+ * to the terminal. Returns the exit code.
+ */
+
+import { spawn } from "node:child_process";
+
+/**
+ * Run a command and inherit stdio (user sees output directly).
+ * @param {string} cmd - Command to run
+ * @param {string[]} args - Arguments
+ * @param {object} [opts] - Options (cwd, env overrides)
+ * @returns {Promise<number>} exit code
+ */
+export function delegate(cmd, args = [], opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      stdio: "inherit",
+      cwd: opts.cwd ?? process.cwd(),
+      env: { ...process.env, ...opts.env },
+      shell: process.platform === "win32",
+    });
+
+    child.on("error", (err) => {
+      process.stderr.write(`tf: failed to run "${cmd}": ${err.message}\n`);
+      resolve(1);
+    });
+
+    child.on("close", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+}
+
+/**
+ * Run an npm script via the package manager available in the project.
+ * @param {string} script - npm script name (e.g. "dev", "test:unit")
+ * @param {string[]} [extraArgs] - Extra args to pass after --
+ * @param {object} [opts] - Options (cwd)
+ * @returns {Promise<number>} exit code
+ */
+export function npmScript(script, extraArgs = [], opts = {}) {
+  const args = ["run", script];
+  if (extraArgs.length) {
+    args.push("--", ...extraArgs);
+  }
+  return delegate("npm", args, opts);
+}

--- a/tools/bin/tests/agent-envelope.test.mjs
+++ b/tools/bin/tests/agent-envelope.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Agent envelope – Phase 3 unit tests
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createEnvelope } from "../lib/agent-envelope.mjs";
+
+describe("agent-envelope", () => {
+  it("finish() produces a valid envelope", () => {
+    const env = createEnvelope("tf-test-tool");
+    const result = env.finish(true, { count: 42 });
+
+    assert.equal(result.tool, "tf-test-tool");
+    assert.equal(result.version, 1);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.data, { count: 42 });
+    assert.equal(result.error, null);
+    assert.equal(typeof result.ts, "string");
+    assert.equal(typeof result.meta.durationMs, "number");
+  });
+
+  it("fail() produces an error envelope", () => {
+    const env = createEnvelope("tf-fail-test");
+    const result = env.fail(new Error("something broke"));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.data, null);
+    assert.equal(result.error, "something broke");
+    assert.equal(result.tool, "tf-fail-test");
+  });
+
+  it("fail() accepts string errors", () => {
+    const env = createEnvelope("tf-str-err");
+    const result = env.fail("plain string error");
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "plain string error");
+  });
+
+  it("custom version number is preserved", () => {
+    const env = createEnvelope("tf-versioned", 2);
+    const result = env.finish(true, {});
+
+    assert.equal(result.version, 2);
+  });
+
+  it("durationMs is non-negative", () => {
+    const env = createEnvelope("tf-timing");
+    const result = env.finish(true, {});
+
+    assert.ok(result.meta.durationMs >= 0, "duration should be >= 0");
+  });
+});

--- a/tools/bin/tests/contract-hardening.test.mjs
+++ b/tools/bin/tests/contract-hardening.test.mjs
@@ -1,0 +1,241 @@
+/**
+ * Contract hardening tests – error paths, exit codes, edge cases.
+ *
+ * These verify that the CLI behaves safely and predictably
+ * when given invalid input, not just on the happy path.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TF = path.resolve(__dirname, "..", "tf.mjs");
+
+function tf(args) {
+  try {
+    const stdout = execFileSync("node", [TF, ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    return { ok: true, code: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      ok: false,
+      code: err.status ?? 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+// ── Exit code contract ──────────────────────────────────────
+
+describe("exit code contract", () => {
+  it("unknown top-level command exits 1", () => {
+    const res = tf(["zzz-no-such-command"]);
+    assert.equal(res.code, 1);
+    assert.ok(res.stderr.includes("Unknown command"));
+  });
+
+  it("no arguments exits 0 (prints help)", () => {
+    const res = tf([]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("Usage"));
+  });
+
+  it("--help exits 0", () => {
+    const res = tf(["--help"]);
+    assert.equal(res.code, 0);
+  });
+
+  it("version exits 0", () => {
+    assert.equal(tf(["version"]).code, 0);
+  });
+
+  it("version --json exits 0", () => {
+    assert.equal(tf(["version", "--json"]).code, 0);
+  });
+
+  it("status --json exits 0", () => {
+    assert.equal(tf(["status", "--json"]).code, 0);
+  });
+
+  it("doctor --dry --json exits 0", () => {
+    assert.equal(tf(["doctor", "--dry", "--json"]).code, 0);
+  });
+});
+
+// ── Invalid subcommand error paths ──────────────────────────
+
+describe("invalid subcommand error paths", () => {
+  it("inspect with no subcommand exits 0 (prints help)", () => {
+    const res = tf(["inspect"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("scripts"));
+  });
+
+  it("inspect invalid-sub exits 1 with error message", () => {
+    const res = tf(["inspect", "nope"]);
+    assert.equal(res.code, 1);
+    assert.ok(res.stderr.includes("Unknown inspect subcommand"));
+  });
+
+  it("test invalid-sub exits 1 with error message", () => {
+    const res = tf(["test", "nope"]);
+    assert.equal(res.code, 1);
+    assert.ok(res.stderr.includes("Unknown test subcommand"));
+  });
+
+  it("build invalid-sub exits 1 with error message", () => {
+    const res = tf(["build", "nope"]);
+    assert.equal(res.code, 1);
+    assert.ok(res.stderr.includes("Unknown build subcommand"));
+  });
+});
+
+// ── Envelope contract consistency ───────────────────────────
+
+describe("envelope contract consistency", () => {
+  const ENVELOPE_FIELDS = ["tool", "version", "ts", "ok", "data", "error", "meta"];
+
+  it("version --json has all envelope fields", () => {
+    const res = tf(["version", "--json"]);
+    const data = JSON.parse(res.stdout);
+    for (const field of ENVELOPE_FIELDS) {
+      assert.ok(field in data, `version envelope missing "${field}"`);
+    }
+    assert.equal(typeof data.meta.durationMs, "number");
+  });
+
+  it("status --json has all envelope fields", () => {
+    const res = tf(["status", "--json"]);
+    const data = JSON.parse(res.stdout);
+    for (const field of ENVELOPE_FIELDS) {
+      assert.ok(field in data, `status envelope missing "${field}"`);
+    }
+    assert.equal(typeof data.meta.durationMs, "number");
+  });
+
+  it("all inspect --json envelopes have all fields", () => {
+    for (const sub of ["scripts", "ports", "modules", "tools"]) {
+      const res = tf(["inspect", sub, "--json"]);
+      assert.equal(res.code, 0, `inspect ${sub} should exit 0`);
+      const data = JSON.parse(res.stdout);
+      for (const field of ENVELOPE_FIELDS) {
+        assert.ok(field in data, `inspect ${sub} envelope missing "${field}"`);
+      }
+      assert.equal(typeof data.meta.durationMs, "number", `inspect ${sub}: durationMs should be number`);
+    }
+  });
+
+  it("timestamps are parseable ISO strings", () => {
+    for (const args of [["version", "--json"], ["status", "--json"], ["inspect", "scripts", "--json"]]) {
+      const res = tf(args);
+      const data = JSON.parse(res.stdout);
+      const ts = new Date(data.ts);
+      assert.ok(!isNaN(ts.getTime()), `${args.join(" ")}: ts should be valid ISO date, got "${data.ts}"`);
+    }
+  });
+
+  it("ok is always boolean", () => {
+    for (const args of [["version", "--json"], ["status", "--json"], ["inspect", "ports", "--json"]]) {
+      const res = tf(args);
+      const data = JSON.parse(res.stdout);
+      assert.equal(typeof data.ok, "boolean", `${args.join(" ")}: ok should be boolean`);
+    }
+  });
+
+  it("error is null on success", () => {
+    for (const args of [["version", "--json"], ["status", "--json"], ["inspect", "tools", "--json"]]) {
+      const res = tf(args);
+      const data = JSON.parse(res.stdout);
+      assert.equal(data.error, null, `${args.join(" ")}: error should be null on success`);
+    }
+  });
+});
+
+// ── Non-JSON mode readability ───────────────────────────────
+
+describe("non-JSON mode readability", () => {
+  it("version without --json prints human-readable output", () => {
+    const res = tf(["version"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.trim().length > 0, "should print something");
+    // Should NOT be JSON
+    assert.throws(() => JSON.parse(res.stdout), "non-JSON mode should not output JSON");
+  });
+
+  it("inspect scripts without --json prints human-readable list", () => {
+    const res = tf(["inspect", "scripts"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("npm scripts found"), "should mention scripts found");
+  });
+
+  it("inspect ports without --json prints human-readable table", () => {
+    const res = tf(["inspect", "ports"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("Port allocation"), "should print port table header");
+  });
+
+  it("inspect tools without --json prints human-readable list", () => {
+    const res = tf(["inspect", "tools"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("tool entry points found"), "should mention tools found");
+  });
+});
+
+// ── Discovery accuracy ──────────────────────────────────────
+
+describe("discovery accuracy", () => {
+  it("inspect scripts count matches actual package.json", () => {
+    const res = tf(["inspect", "scripts", "--json"]);
+    const data = JSON.parse(res.stdout);
+    // Verify count matches array length
+    assert.equal(data.data.count, data.data.scripts.length, "count should match array length");
+  });
+
+  it("inspect scripts entries have both name and cmd", () => {
+    const res = tf(["inspect", "scripts", "--json"]);
+    const data = JSON.parse(res.stdout);
+    for (const s of data.data.scripts.slice(0, 5)) {
+      assert.equal(typeof s.name, "string", "script should have name");
+      assert.equal(typeof s.cmd, "string", "script should have cmd");
+      assert.ok(s.name.length > 0, "script name should be non-empty");
+      assert.ok(s.cmd.length > 0, "script cmd should be non-empty");
+    }
+  });
+
+  it("inspect ports entries have port, service, available, status", () => {
+    const res = tf(["inspect", "ports", "--json"]);
+    const data = JSON.parse(res.stdout);
+    for (const p of data.data.ports) {
+      assert.equal(typeof p.port, "number", "port should be number");
+      assert.equal(typeof p.service, "string", "service should be string");
+      assert.equal(typeof p.available, "boolean", "available should be boolean");
+      assert.ok(["free", "in-use"].includes(p.status), `status should be free or in-use, got "${p.status}"`);
+    }
+  });
+
+  it("inspect modules count matches array length", () => {
+    const res = tf(["inspect", "modules", "--json"]);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.data.count, data.data.modules.length, "count should match array length");
+  });
+
+  it("inspect tools count matches array length", () => {
+    const res = tf(["inspect", "tools", "--json"]);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.data.count, data.data.tools.length, "count should match array length");
+  });
+
+  it("inspect tools finds tf.mjs itself", () => {
+    const res = tf(["inspect", "tools", "--json"]);
+    const data = JSON.parse(res.stdout);
+    const paths = data.data.tools.map(t => t.path);
+    assert.ok(paths.some(p => p.includes("tf.mjs")), "should find tf.mjs in tools list");
+  });
+});

--- a/tools/bin/tests/inspect.test.mjs
+++ b/tools/bin/tests/inspect.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * tf inspect – Phase 3 tests
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TF = path.resolve(__dirname, "..", "tf.mjs");
+
+function tf(args) {
+  try {
+    const stdout = execFileSync("node", [TF, ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+    return { ok: true, code: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      ok: false,
+      code: err.status ?? 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+describe("tf inspect", () => {
+  it("--help exits 0 and lists subcommands", () => {
+    const res = tf(["inspect", "--help"]);
+    assert.equal(res.code, 0);
+    for (const sub of ["scripts", "ports", "modules", "tools"]) {
+      assert.ok(res.stdout.includes(sub), `should mention "${sub}"`);
+    }
+  });
+
+  it("scripts --json returns valid envelope with script count", () => {
+    const res = tf(["inspect", "scripts", "--json"]);
+    assert.equal(res.code, 0, `stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.tool, "tf-inspect-scripts");
+    assert.equal(data.ok, true);
+    assert.equal(typeof data.data.count, "number");
+    assert.ok(data.data.count > 100, `should have >100 scripts, got ${data.data.count}`);
+    assert.ok(Array.isArray(data.data.scripts));
+    assert.ok(data.data.scripts[0].name, "scripts should have name field");
+    assert.ok(data.data.scripts[0].cmd, "scripts should have cmd field");
+  });
+
+  it("ports --json returns valid envelope with port list", () => {
+    const res = tf(["inspect", "ports", "--json"]);
+    assert.equal(res.code, 0, `stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.tool, "tf-inspect-ports");
+    assert.equal(data.ok, true);
+    assert.ok(Array.isArray(data.data.ports));
+    assert.ok(data.data.ports.length >= 5, "should list at least 5 ports");
+    const first = data.data.ports[0];
+    assert.equal(typeof first.port, "number");
+    assert.equal(typeof first.service, "string");
+    assert.equal(typeof first.available, "boolean");
+  });
+
+  it("modules --json returns valid envelope", () => {
+    const res = tf(["inspect", "modules", "--json"]);
+    assert.equal(res.code, 0, `stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.tool, "tf-inspect-modules");
+    assert.equal(data.ok, true);
+    assert.equal(typeof data.data.count, "number");
+    assert.ok(Array.isArray(data.data.modules));
+  });
+
+  it("tools --json returns valid envelope with tool entries", () => {
+    const res = tf(["inspect", "tools", "--json"]);
+    assert.equal(res.code, 0, `stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.tool, "tf-inspect-tools");
+    assert.equal(data.ok, true);
+    assert.equal(typeof data.data.count, "number");
+    assert.ok(data.data.count > 5, `should find >5 tool files, got ${data.data.count}`);
+    assert.ok(Array.isArray(data.data.tools));
+    assert.ok(data.data.tools[0].path, "tools should have path field");
+  });
+
+  it("all envelopes share the same schema", () => {
+    const subs = ["scripts", "ports", "modules", "tools"];
+    for (const sub of subs) {
+      const res = tf(["inspect", sub, "--json"]);
+      assert.equal(res.code, 0, `${sub} should exit 0`);
+      const data = JSON.parse(res.stdout);
+      // All envelopes must have these fields
+      assert.equal(typeof data.tool, "string", `${sub}: tool should be string`);
+      assert.equal(typeof data.version, "number", `${sub}: version should be number`);
+      assert.equal(typeof data.ts, "string", `${sub}: ts should be string`);
+      assert.equal(typeof data.ok, "boolean", `${sub}: ok should be boolean`);
+      assert.ok("data" in data, `${sub}: should have data field`);
+      assert.ok("error" in data, `${sub}: should have error field`);
+      assert.ok("meta" in data, `${sub}: should have meta field`);
+      assert.equal(typeof data.meta.durationMs, "number", `${sub}: durationMs should be number`);
+    }
+  });
+});

--- a/tools/bin/tests/tf-cli.test.mjs
+++ b/tools/bin/tests/tf-cli.test.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * TF CLI – Phase 1 tests
+ * Uses Node built-in test runner (node --test)
+ *
+ * Success criteria:
+ * 1. tf --help exits 0, lists "doctor", "status", "version"
+ * 2. tf version exits 0, prints semver-like string
+ * 3. tf doctor --dry --json exits 0, valid JSON with overallOk
+ * 4. tf status --json exits 0, valid JSON envelope
+ * 5. tf nonexistent exits non-zero
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TF = path.resolve(__dirname, "..", "tf.mjs");
+
+function tf(args, opts = {}) {
+  try {
+    const stdout = execFileSync("node", [TF, ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+      env: { ...process.env, NO_COLOR: "1" },
+      ...opts,
+    });
+    return { ok: true, code: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      ok: false,
+      code: err.status ?? 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+describe("tf CLI – Phase 1", () => {
+  it("--help exits 0 and lists all commands", () => {
+    const res = tf(["--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, got ${res.code}`);
+    for (const cmd of ["doctor", "status", "version"]) {
+      assert.ok(
+        res.stdout.includes(cmd),
+        `help output should mention "${cmd}"`
+      );
+    }
+  });
+
+  it("version exits 0 and prints a version string", () => {
+    const res = tf(["version"]);
+    assert.equal(res.code, 0);
+    assert.match(res.stdout.trim(), /\d+\.\d+\.\d+/, "should contain semver");
+  });
+
+  it("doctor --dry --json exits 0 with valid JSON envelope", () => {
+    const res = tf(["doctor", "--dry", "--json"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(typeof data.overallOk, "boolean");
+    assert.ok(data.tool, "envelope should have a tool name");
+    assert.ok(data.startedAt, "envelope should have startedAt");
+  });
+
+  it("status --json exits 0 with valid JSON envelope", () => {
+    const res = tf(["status", "--json"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    const data = JSON.parse(res.stdout);
+    assert.equal(data.tool, "tf-status");
+    assert.equal(typeof data.ok, "boolean");
+    assert.ok(data.data, "envelope should have data field");
+    assert.ok(data.data.node, "data should include node version");
+  });
+
+  it("nonexistent command exits non-zero", () => {
+    const res = tf(["this-does-not-exist-xyz"]);
+    assert.notEqual(res.code, 0, "unknown command should fail");
+  });
+});
+
+describe("tf CLI – Phase 2", () => {
+  it("--help lists all Phase 2 commands", () => {
+    const res = tf(["--help"]);
+    assert.equal(res.code, 0);
+    for (const cmd of ["dev", "test", "build", "ship", "canon"]) {
+      assert.ok(
+        res.stdout.includes(cmd),
+        `help output should mention "${cmd}"`
+      );
+    }
+  });
+
+  it("dev --help exits 0 and shows subcommands", () => {
+    const res = tf(["dev", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("frontend"), "should mention frontend subcommand");
+    assert.ok(res.stdout.includes("backend"), "should mention backend subcommand");
+  });
+
+  it("test --help exits 0 and shows subcommands", () => {
+    const res = tf(["test", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("unit"), "should mention unit subcommand");
+    assert.ok(res.stdout.includes("all"), "should mention all subcommand");
+  });
+
+  it("build --help exits 0 and shows subcommands", () => {
+    const res = tf(["build", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("frontend"), "should mention frontend subcommand");
+    assert.ok(res.stdout.includes("backend"), "should mention backend subcommand");
+  });
+
+  it("ship --help exits 0 and shows flags", () => {
+    const res = tf(["ship", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("dry-run"), "should mention --dry-run flag");
+  });
+
+  it("canon --help exits 0 and shows subcommands", () => {
+    const res = tf(["canon", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("doctor"), "should mention doctor subcommand");
+  });
+
+  it("inspect --help exits 0 and shows subcommands", () => {
+    const res = tf(["inspect", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes("scripts"), "should mention scripts subcommand");
+    assert.ok(res.stdout.includes("ports"), "should mention ports subcommand");
+  });
+
+  it("repl --help exits 0 and shows usage", () => {
+    const res = tf(["repl", "--help"]);
+    assert.equal(res.code, 0, `exit code should be 0, stderr: ${res.stderr}`);
+    assert.ok(res.stdout.includes(".exit"), "should mention .exit command");
+    assert.ok(res.stdout.includes(".json"), "should mention .json toggle");
+  });
+});
+
+describe("tf CLI – Phase 3+4 registration", () => {
+  it("--help lists inspect and repl commands", () => {
+    const res = tf(["--help"]);
+    assert.equal(res.code, 0);
+    assert.ok(res.stdout.includes("inspect"), "should list inspect");
+    assert.ok(res.stdout.includes("repl"), "should list repl");
+  });
+});

--- a/tools/bin/tf.mjs
+++ b/tools/bin/tf.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * TerraFusion CLI – unified entry point
+ *
+ * Usage:  node tools/bin/tf.mjs <command> [options]
+ *
+ * Commands:
+ *   version   Print TerraFusion OS version
+ *   doctor    Run health checks (delegates to canon doctor)
+ *   status    Show workspace status (node, git, ports)
+ *
+ * Global options:
+ *   --json    Machine-readable JSON output
+ *   --dry     Dry-run mode (no side-effects)
+ *   --help    Show this help
+ *
+ * Zero external dependencies – uses only Node built-ins.
+ */
+
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..", "..");
+
+// ── Arg parsing ──────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const raw = argv.slice(2);
+  const flags = { json: false, dry: false, help: false, verbose: false };
+  const positional = [];
+
+  for (const arg of raw) {
+    if (arg === "--json") flags.json = true;
+    else if (arg === "--dry") flags.dry = true;
+    else if (arg === "--help" || arg === "-h") flags.help = true;
+    else if (arg === "--verbose" || arg === "-v") flags.verbose = true;
+    else positional.push(arg);
+  }
+
+  return { command: positional[0] ?? null, rest: positional.slice(1), flags };
+}
+
+// ── Command registry ─────────────────────────────────────────
+
+const COMMANDS = {
+  version: {
+    desc: "Print TerraFusion OS version",
+    load: () => import("./commands/version.mjs"),
+  },
+  doctor: {
+    desc: "Run health checks (delegates to canon doctor)",
+    load: () => import("./commands/doctor.mjs"),
+  },
+  status: {
+    desc: "Show workspace status (node, git, ports)",
+    load: () => import("./commands/status.mjs"),
+  },
+  dev: {
+    desc: "Start development servers",
+    load: () => import("./commands/dev.mjs"),
+  },
+  test: {
+    desc: "Run test suites",
+    load: () => import("./commands/test.mjs"),
+  },
+  build: {
+    desc: "Build the project",
+    load: () => import("./commands/build.mjs"),
+  },
+  ship: {
+    desc: "Ship protocol (push, PR, auto-merge)",
+    load: () => import("./commands/ship.mjs"),
+  },
+  canon: {
+    desc: "Governance gates",
+    load: () => import("./commands/canon.mjs"),
+  },
+  inspect: {
+    desc: "Agent-first discovery (scripts, ports, modules, tools)",
+    load: () => import("./commands/inspect.mjs"),
+  },
+  repl: {
+    desc: "Interactive CLI session",
+    load: () => import("./commands/repl.mjs"),
+  },
+};
+
+// ── Help ─────────────────────────────────────────────────────
+
+function printHelp() {
+  const lines = [
+    "",
+    "TerraFusion CLI",
+    "",
+    "Usage:  tf <command> [options]",
+    "",
+    "Commands:",
+  ];
+
+  for (const [name, cmd] of Object.entries(COMMANDS)) {
+    lines.push(`  ${name.padEnd(12)} ${cmd.desc}`);
+  }
+
+  lines.push("");
+  lines.push("Options:");
+  lines.push("  --json       Machine-readable JSON output");
+  lines.push("  --dry        Dry-run mode (skip side-effects)");
+  lines.push("  --verbose    Show extra detail");
+  lines.push("  --help, -h   Show this help");
+  lines.push("");
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+async function main() {
+  const { command, rest, flags } = parseArgs(process.argv);
+
+  if (!command) {
+    printHelp();
+    process.exitCode = 0;
+    return;
+  }
+
+  const entry = COMMANDS[command];
+  if (!entry) {
+    process.stderr.write(`Unknown command: ${command}\n`);
+    process.stderr.write(`Run "tf --help" to see available commands.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const mod = await entry.load();
+  const code = await mod.default({ root: ROOT, flags, rest, argv: process.argv });
+  process.exitCode = code ?? 0;
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    process.stderr.write(`tf: ${err.message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `tools/bin/tf.mjs` — a unified CLI entry point for all TerraFusion OS developer and agent operations
- 10 top-level commands: version, doctor, status, inspect, dev, test, build, ship, canon, repl
- Agent-native JSON envelope contract for machine-readable output (`--json` flag)
- Zero external dependencies — uses only Node built-ins
- 52/52 tests passing across 4 test suites (CLI surface, envelope unit, inspect structure, contract hardening)

## What changed
- `tools/bin/` — new CLI router, 10 command modules, shared library (envelope, spawn, runner)
- `tools/bin/tests/` — 4 test files with comprehensive coverage of happy paths, error paths, exit codes, envelope consistency
- `tools/bin/README.md` — full documentation including command matrix, envelope schema, architecture
- `.gitignore` — exclusions for `tools/bin/` and `tools/bin/lib/` (were blocked by blanket `bin/` and `lib/` rules)
- `package.json` — added `tf` and `tf:cli` script aliases

## Test plan
- [x] 52/52 tests pass: `node --test tools/bin/tests/`
- [x] All envelope fields present on every `--json` command
- [x] Exit code contract: unknown commands → 1, help → 0
- [x] Invalid subcommands print error to stderr and exit 1
- [x] Human-readable output works without `--json`
- [x] Discovery commands are read-only (no side effects)

## Sections
- **Database**: N/A — no schema changes
- **Accessibility**: N/A — CLI tool, no UI
- **AI Swarm**: N/A — does not modify agent coordination
- **Security**: Low risk — zero dependencies, read-only discovery commands, delegates to existing tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified "tf" command-line shipped with commands: dev, test, build, ship, inspect, status, doctor, canon, version, and repl
  * Added top-level executable entry so "tf" is available as a CLI command
  * Interactive REPL for exploratory use

* **Documentation**
  * Added a comprehensive CLI reference with commands, subcommands, flags, examples, and JSON envelope contract

* **Tests**
  * Added extensive test suites validating CLI behavior, JSON envelopes, help text, and exit codes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->