### PR TITLE
feat(r1): parallel streams — GIS controller tests, TDC 713 baseline, BentonCountyMap testids

### DIFF
--- a/backend/TerraFusion.API.Tests/BentonCountyGisControllerTests.cs
+++ b/backend/TerraFusion.API.Tests/BentonCountyGisControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -10,6 +9,7 @@ using TerraFusion.API.Controllers;
 using TerraFusion.Core.Entities;
 using TerraFusion.Data;
 using Xunit;
+using SystemTask = System.Threading.Tasks.Task;
 
 namespace TerraFusion.API.Tests;
 
@@ -51,7 +51,7 @@ public class BentonCountyGisControllerTests
     };
 
     [Fact]
-    public async Task GetParcels_Returns200_WithDefaultLimit()
+    public async SystemTask GetParcels_Returns200_WithDefaultLimit()
     {
         var db = BuildInMemoryDb(Enumerable.Range(1, 20).Select(MakeProperty));
         var controller = new BentonCountyGisController(db, NullLogger<BentonCountyGisController>.Instance);
@@ -64,7 +64,7 @@ public class BentonCountyGisControllerTests
     }
 
     [Fact]
-    public async Task GetParcels_LimitCappedAt500()
+    public async SystemTask GetParcels_LimitCappedAt500()
     {
         var db = BuildInMemoryDb(Enumerable.Range(1, 600).Select(MakeProperty));
         var controller = new BentonCountyGisController(db, NullLogger<BentonCountyGisController>.Instance);
@@ -77,7 +77,7 @@ public class BentonCountyGisControllerTests
     }
 
     [Fact]
-    public async Task GetParcels_FiltersTobentonCountyOnly()
+    public async SystemTask GetParcels_FiltersTobentonCountyOnly()
     {
         var bentonParcels = Enumerable.Range(1, 5).Select(MakeProperty).ToList();
         var otherCounty = new Property


### PR DESCRIPTION
## Summary

- **Stream A**: Fix `Task` ambiguity in `BentonCountyGisControllerTests.cs` — `TerraFusion.Core.Entities.Task` conflicts with `System.Threading.Tasks.Task`; added `SystemTask` alias. `BentonCountyGisController` (3 tests: 200+limit, cap-at-500, county-isolation) builds and passes.
- **Stream B**: TDC ratchet holds at 713 violations ≤ baseline 713. No regressions. No new token violations introduced.
- **Stream C**: `BentonCountyMapIntegration.test.tsx` (4/4) and `BentonCountyMap.tsx` `data-testid` attributes already on main from prior R0 honesty pass.

## Gates

- phase83: 56/56 passing
- vitest unit: 164/164 passing
- TDC: 713 ≤ 713 baseline
- dotnet build: succeeded (warnings only)
- TypeScript: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal refactoring of test infrastructure code with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->