### PR TITLE
fix(backend): restore PropertiesController auth + fix R2Wave25 isolation test

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/AtlasGisController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AtlasGisController.cs
@@ -30,6 +30,7 @@ public class AtlasGisController : ControllerBase
 
     /// <summary>Geocode an address via the Atlas GIS pipeline.</summary>
     /// <param name="address">Street address to geocode.</param>
+    /// <param name="enricher">Injected geospatial enricher service.</param>
     /// <param name="ct">Request cancellation token.</param>
     [HttpGet("geocode")]
     [ProducesResponseType(typeof(GeocodeResponse), StatusCodes.Status200OK)]
@@ -66,6 +67,7 @@ public class AtlasGisController : ControllerBase
     /// <param name="layer">Layer name to query (default "Parcels").</param>
     /// <param name="bbox">Bounding box as "minLng,minLat,maxLng,maxLat".</param>
     /// <param name="filter">Optional attribute filter.</param>
+    /// <param name="connector">Injected GIS connector service.</param>
     /// <param name="limit">Maximum features to return (default 500).</param>
     /// <param name="ct">Request cancellation token.</param>
     [HttpGet("spatial-query")]
@@ -116,6 +118,7 @@ public class AtlasGisController : ControllerBase
     /// <param name="layerName">Layer name (e.g., Parcels, Zoning, FloodZones).</param>
     /// <param name="bbox">Optional bounding box filter.</param>
     /// <param name="filter">Optional attribute filter.</param>
+    /// <param name="connector">Injected GIS connector service.</param>
     /// <param name="ct">Request cancellation token.</param>
     [HttpGet("layers/{layerName}/features")]
     [ProducesResponseType(typeof(FeatureCollection), StatusCodes.Status200OK)]
@@ -173,6 +176,8 @@ public class AtlasGisController : ControllerBase
     /// the local geometry store.
     /// </summary>
     /// <param name="file">Spatial data file.</param>
+    /// <param name="parser">Injected GIS parse service.</param>
+    /// <param name="sync">Injected GIS sync service.</param>
     /// <param name="import">If true, import parsed polygons into the store (default false).</param>
     /// <param name="ct">Request cancellation token.</param>
     [HttpPost("upload-shapefile")]

--- a/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
+++ b/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
@@ -8,7 +8,7 @@ namespace TerraFusion.API.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[AllowAnonymous]
+[Authorize]
 public class PropertiesController : ControllerBase
 {
     private readonly IPropertyService _propertyService;
@@ -44,7 +44,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet("{id}")]
-    [AllowAnonymous]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<PropertyDto>> GetProperty(Guid id)
     {
         try
@@ -66,14 +66,12 @@ public class PropertiesController : ControllerBase
         }
     }
 
-    private static readonly Guid BentonCountyId = new("19190019-1919-1919-1919-191919191919");
-
     private ActionResult? TryResolveCountyId(Guid? requestedCountyId, out Guid countyId)
     {
         countyId = Guid.Empty;
         var claim = User.FindFirst("countyId")?.Value?.Trim();
         if (string.IsNullOrWhiteSpace(claim) || !Guid.TryParse(claim, out countyId))
-            countyId = BentonCountyId; // dev fallback — anonymous requests see Benton County data
+            return Forbid();
 
         if (requestedCountyId.HasValue && requestedCountyId.Value != countyId)
             return Forbid();

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave25/R2Wave25ForgeValuationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave25/R2Wave25ForgeValuationTests.cs
@@ -718,8 +718,8 @@ public sealed class R2Wave25ForgeValuationTests
 
     var otherCountyId = Guid.NewGuid();
     db.ComparableSales.AddRange(
-      new ComparableSale { ParcelId = "ISO-1", SaleDate = DateTime.UtcNow.AddMonths(-1), SalePrice = 200_000, PropertyType = "residential", CountyId = BentonCountyId, IngestedBy = "test" },
-      new ComparableSale { ParcelId = "ISO-2", SaleDate = DateTime.UtcNow.AddMonths(-1), SalePrice = 500_000, PropertyType = "residential", CountyId = otherCountyId, IngestedBy = "test" }
+      new ComparableSale { ParcelId = "ISO-1", SaleDate = DateTime.UtcNow.AddMonths(-1), SalePrice = 200_000, PropertyType = "residential", QualificationRecommendation = "qualified", CountyId = BentonCountyId, IngestedBy = "test" },
+      new ComparableSale { ParcelId = "ISO-2", SaleDate = DateTime.UtcNow.AddMonths(-1), SalePrice = 500_000, PropertyType = "residential", QualificationRecommendation = "qualified", CountyId = otherCountyId, IngestedBy = "test" }
     );
     await db.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary

- **PropertiesController auth restored**: PR #707 (r0 honesty pass) changed `[Authorize]` to `[AllowAnonymous]` on `PropertiesController`, breaking 7 auth/permission integration tests (Cx18, Cx19D1, R14) — all returning 404 instead of 401/403 because auth middleware never fired. Restores `[Authorize]` + `[RequiresPermission("read:properties")]` + `Forbid()` county fallback.
- **R2Wave25 ComparableSales_IsolatedByCounty seed data**: The `fe6294f6c` (3-layer qualification model refactor) added a `"qualified only"` filter but missed updating the `ComparableSales_IsolatedByCounty` test seed rows to include `QualificationRecommendation = "qualified"` — causing count=0 instead of 1.

## Test plan
- [ ] Backend Gate: 8 previously-failing tests now pass (Cx18 × 3, Cx19D1 × 2, R14 × 1, Cx18D × 2)
- [ ] 1949 pre-existing passing tests remain green
- [ ] R2Wave25 `ComparableSales_IsolatedByCounty` passes (count=1, county-isolated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Properties endpoints now require authentication for all access
  * Added permission-based access control for property data retrieval
  * Enhanced county-level validation to prevent unauthorized cross-county data access

* **Documentation**
  * Improved API documentation for spatial and GIS endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->