### PR TITLE
Block D — ArcGIS doctrine pipeline + legacy sync retirement (v1.8)

### DIFF
--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1696,6 +1696,16 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.PacsLandDetail.IPacsLandDetailLandingService,
     TerraFusion.Data.Services.LegacyPacsRaw.PacsLandDetailLandingService>();
 
+// Slice D1: ArcGIS REST FeatureService raw landing. Wraps the
+// existing G1-C IArcGisFeatureServiceClient and writes verbatim
+// to legacy_arcgis_raw.parcel_geom with full provenance. Four
+// R-* gates: source-batch-completed, key-uniqueness,
+// provenance-coverage, aggregate. Per
+// docs/pacs/block-d-execution-plan.md §3.1.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.ArcGisRawLanding.IArcGisRawLandingService,
+    TerraFusion.Data.Services.LegacyArcGisRaw.ArcGisRawLandingService>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1706,6 +1706,14 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.ArcGisRawLanding.IArcGisRawLandingService,
     TerraFusion.Data.Services.LegacyArcGisRaw.ArcGisRawLandingService>();
 
+// Slice D2: truth_arcgis.parcel_geom_current promoter. Collapses
+// raw to latest-per-(CountyId, ArcGisObjectId) with geometry
+// validity gate. Four T-* gates per the doctrine pattern. Per
+// docs/pacs/block-d-execution-plan.md §3.2.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.ArcGisTruthPromotion.IArcGisTruthPromotionService,
+    TerraFusion.Data.Services.TruthArcGis.ArcGisTruthPromotionService>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1316,9 +1316,27 @@ if (IsFeatureEnabled(builder.Configuration, "HarrisPACS:BackgroundSync:Enabled",
   builder.Services.AddHostedService<TerraFusion.Core.Services.HarrisPACSSyncBackgroundService>();
 }
 
-// 🗺️ Benton County ArcGIS GIS Sync — one-way pull from public FeatureServer
-// Isolation: ArcGIS never queried at request time; only ArcGisSyncService writes GisParcelGeometries.
-if (IsFeatureEnabled(builder.Configuration, "ArcGisSync:Enabled", "TF_ENABLE_ARCGIS_SYNC", true))
+// 🗺️ Legacy ArcGIS sync (pre-doctrine BackgroundService).
+// Disabled by default as of Block-D contract v1.8: the doctrine path
+// (D1 raw → D2 truth → D3 canonical → gis_tf.tf_parcel_geom + source_xref)
+// is now the canonical way ArcGIS geometry enters the system.
+//
+// The legacy service is preserved in code for emergency rollback
+// only. It writes to the legacy GisParcelGeometries table which
+// lives OUTSIDE the 5-schema doctrine and is NOT fed by canonical
+// projection. To re-enable for rollback:
+//   appsettings: "LegacyArcGisSync:Enabled": true
+//   env var:     TF_ENABLE_LEGACY_ARCGIS_SYNC=true
+// See TerraFusion.Core.Configuration.LegacyArcGisSyncOptions and
+// docs/pacs/block-c-contract-v1.8.md for the deprecation rationale.
+builder.Services.Configure<TerraFusion.Core.Configuration.LegacyArcGisSyncOptions>(
+    builder.Configuration.GetSection(
+        TerraFusion.Core.Configuration.LegacyArcGisSyncOptions.SectionName));
+if (IsFeatureEnabled(
+        builder.Configuration,
+        $"{TerraFusion.Core.Configuration.LegacyArcGisSyncOptions.SectionName}:Enabled",
+        "TF_ENABLE_LEGACY_ARCGIS_SYNC",
+        defaultValue: false))
 {
   builder.Services.AddHostedService<ArcGisSyncService>();
 }
@@ -1713,6 +1731,18 @@ builder.Services.AddScoped<
 builder.Services.AddScoped<
     TerraFusion.Core.Sync.ArcGisTruthPromotion.IArcGisTruthPromotionService,
     TerraFusion.Data.Services.TruthArcGis.ArcGisTruthPromotionService>();
+
+// Slice D3: ArcGIS canonical projector. Reads truth_arcgis and
+// writes gis_tf.tf_parcel_geom + sync_bridge.source_xref entries
+// (TfEntityType="geom_parcel"). APN crosswalk against
+// canonical_tf.tf_parcel.ParcelNumber. Five C-* gates. Per
+// docs/pacs/block-d-execution-plan.md §3.3 + v1.8 contract.
+// This projector is now THE canonical writer to tf_parcel_geom
+// (the legacy ArcGisSyncService BackgroundService is disabled by
+// default — see LegacyArcGisSyncOptions).
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.ArcGisCanonical.IArcGisCanonicalProjector,
+    TerraFusion.Data.Services.GisTf.ArcGisCanonicalProjector>();
 
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-

--- a/backend/src/TerraFusion.Core/Configuration/LegacyArcGisSyncOptions.cs
+++ b/backend/src/TerraFusion.Core/Configuration/LegacyArcGisSyncOptions.cs
@@ -1,0 +1,58 @@
+namespace TerraFusion.Core.Configuration;
+
+/// <summary>
+/// Slice D3: opt-in flag for the legacy
+/// <c>TerraFusion.API.Services.ArcGisSyncService</c>
+/// BackgroundService.
+///
+/// <para>The legacy service hardcodes a Benton County
+/// FeatureServer URL, polls every 6 hours, and writes to
+/// <c>GisParcelGeometries</c> — a table that lives outside the
+/// 5-schema doctrine. As of v1.8 (Block-D close), the canonical
+/// path is:
+///
+/// <code>
+///   D1 ArcGisRawLandingService
+///       ↓
+///   legacy_arcgis_raw.parcel_geom
+///       ↓
+///   D2 ArcGisTruthPromotionService
+///       ↓
+///   truth_arcgis.parcel_geom_current
+///       ↓
+///   D3 ArcGisCanonicalProjector
+///       ↓
+///   gis_tf.tf_parcel_geom (+ source_xref TfEntityType="geom_parcel")
+/// </code>
+/// </para>
+///
+/// <para>The legacy service is preserved in code for rollback /
+/// reference but is <b>NOT registered by default</b> after v1.8.
+/// To re-enable for emergency rollback, set:
+/// <code>
+///   appsettings: "LegacyArcGisSync:Enabled": true
+///   env var:     TF_ENABLE_LEGACY_ARCGIS_SYNC=true
+/// </code>
+/// Either flag opts the legacy hosted service back into the
+/// container.</para>
+///
+/// <para>Per the user's "no broken windows / no parallel truth
+/// paths" rule, the doctrine path is the only authority. The
+/// legacy table (<c>GisParcelGeometries</c>) and BackgroundService
+/// remain in source-control history so a future cleanup slice
+/// can decommission them after confirming the doctrine path
+/// covers all operator workflows.</para>
+/// </summary>
+public sealed class LegacyArcGisSyncOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "LegacyArcGisSync";
+
+    /// <summary>
+    /// When <c>true</c>, registers the legacy
+    /// <c>TerraFusion.API.Services.ArcGisSyncService</c>
+    /// BackgroundService. <c>false</c> by default per Block-D
+    /// contract v1.8.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+}

--- a/backend/src/TerraFusion.Core/Entities/LegacyArcGisRaw/LegacyArcGisRawParcelGeom.cs
+++ b/backend/src/TerraFusion.Core/Entities/LegacyArcGisRaw/LegacyArcGisRawParcelGeom.cs
@@ -1,0 +1,120 @@
+using System;
+
+namespace TerraFusion.Core.Entities.LegacyArcGisRaw;
+
+/// <summary>
+/// Slice D1: raw ArcGIS feature-service landing zone for parcel
+/// polygons.
+///
+/// <para>Per <c>docs/pacs/block-d-execution-plan.md</c> §3.1: the
+/// first stop in the 5-schema doctrine for ArcGIS-sourced
+/// geometry. Each row represents one ArcGIS Feature returned by
+/// the per-county FeatureService query, captured verbatim with
+/// full provenance — exactly mirroring the
+/// <c>LegacyPacsRawImprvDetail</c> shape on the PACS side.</para>
+///
+/// <para>Identity is the 3-tuple <c>(CountyId, ArcGisObjectId,
+/// LoadBatchId)</c>. <c>ArcGisObjectId</c> is the FeatureService
+/// OBJECTID — stable per service, not stable across services.
+/// Multiple landings of the same OBJECTID across batches yield
+/// distinct rows; the truth-promotion (D2) layer collapses them
+/// to latest-per-(CountyId, ArcGisObjectId).</para>
+///
+/// <para><see cref="GeomWkt"/> stores the polygon as Well-Known
+/// Text in WGS84 (SRID 4326). Phase-1 design intentionally
+/// avoids PostGIS-native geometry (per the locked Block D
+/// non-goal in the v1 doctrine). Centroid + area are
+/// pre-computed at landing time so D3 / D4 read-models can
+/// skip spatial library work.</para>
+///
+/// <para>Provenance is non-negotiable: <see cref="LoadBatchId"/>
+/// + <see cref="SourceQueryHash"/> + <see cref="SourceRowHash"/>
+/// on every landed row, with <c>LoadBatch.SourceFamily =
+/// SourceFamilies.ArcGisRest</c>.</para>
+/// </summary>
+public sealed class LegacyArcGisRawParcelGeom
+{
+    /// <summary>Synthetic landing-row id.</summary>
+    public Guid LandedRowId { get; set; } = Guid.NewGuid();
+
+    // ── Sovereign-county isolation ────────────────────────────────
+    /// <summary>
+    /// Required. ArcGIS OBJECTID is per-service — each county's
+    /// FeatureService numbers its features independently. Cross-
+    /// county uniqueness is on <c>(CountyId, ArcGisObjectId)</c>.
+    /// </summary>
+    public Guid CountyId { get; set; }
+
+    // ── ArcGIS source identity ────────────────────────────────────
+    /// <summary>
+    /// FeatureService OBJECTID. Stable within a single service;
+    /// the <c>(CountyId, ArcGisObjectId)</c> tuple is the natural
+    /// per-feature identity.
+    /// </summary>
+    public long ArcGisObjectId { get; set; }
+
+    /// <summary>
+    /// County-readable parcel number (APN) from the ArcGIS feature
+    /// attributes. Used at canonical projection (D3) as the
+    /// crosswalk key against <c>tf_parcel.ParcelNumber</c>.
+    /// Optional — some services don't carry an APN attribute, in
+    /// which case D3 will quarantine the resulting canonical row.
+    /// </summary>
+    public string? ArcGisApn { get; set; }
+
+    // ── Geometry payload ─────────────────────────────────────────
+    /// <summary>
+    /// Polygon as Well-Known Text. Required. Stored in WGS84
+    /// (EPSG:4326). PostGIS-native geometry storage is deferred
+    /// to a Phase-2 migration per
+    /// <c>docs/pacs/block-d-execution-plan.md</c> §1.4.
+    /// </summary>
+    public string GeomWkt { get; set; } = string.Empty;
+
+    /// <summary>Pre-computed centroid latitude (WGS84).</summary>
+    public double CentroidLat { get; set; }
+
+    /// <summary>Pre-computed centroid longitude (WGS84).</summary>
+    public double CentroidLon { get; set; }
+
+    /// <summary>
+    /// Pre-computed polygon area in square feet. Sourced from
+    /// the <c>Shape__Area</c> attribute when present in the
+    /// FeatureService response; otherwise zero. Equal-area
+    /// reprojection of WGS84 polygons client-side is out-of-
+    /// scope for v1.
+    /// </summary>
+    public double AreaSqFt { get; set; }
+
+    /// <summary>
+    /// Full FeatureService URL this row was sourced from
+    /// (e.g. <c>https://services.arcgis.com/.../Parcels/FeatureServer/0</c>).
+    /// Recorded as provenance even though
+    /// <see cref="LoadBatchId"/> already carries the same info via
+    /// <c>load_batch.SourceFileOrDatabase</c>.
+    /// </summary>
+    public string SourceServiceUrl { get; set; } = string.Empty;
+
+    // ── Provenance (non-negotiable per the doctrine) ──────────────
+    /// <summary>
+    /// FK-style pointer to <c>sync_bridge.load_batch.LoadBatchId</c>.
+    /// Required. The corresponding batch carries
+    /// <c>SourceFamily = SourceFamilies.ArcGisRest</c>.
+    /// </summary>
+    public Guid LoadBatchId { get; set; }
+
+    /// <summary>
+    /// Stable hash of the SELECT (or REST query URL + filters)
+    /// that produced this row. Required.
+    /// </summary>
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-row content hash (SHA-256 truncated to 16 hex chars).
+    /// Required. Lets D2 detect content changes across batches
+    /// without parsing the WKT.
+    /// </summary>
+    public string SourceRowHash { get; set; } = string.Empty;
+
+    public DateTime LandedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/TruthArcGis/TruthArcGisParcelGeomCurrent.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthArcGis/TruthArcGisParcelGeomCurrent.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace TerraFusion.Core.Entities.TruthArcGis;
+
+/// <summary>
+/// Slice D2: supp-aware-validated current ArcGIS parcel polygon.
+///
+/// <para>The middle layer of Block D's GIS doctrine — collapses
+/// raw <c>legacy_arcgis_raw.parcel_geom</c> rows to
+/// latest-per-<c>(CountyId, ArcGisObjectId)</c>, with a geometry
+/// validity gate to filter malformed WKT before canonical
+/// projection.</para>
+///
+/// <para>Two invariants hold by construction:
+/// <list type="number">
+///   <item>For any <c>(CountyId, ArcGisObjectId)</c> tuple, only
+///   the row from the most-recent COMPLETED landing batch is
+///   present. Older landings stay in <c>legacy_arcgis_raw</c> for
+///   audit but do not promote.</item>
+///   <item>Lineage to the source raw row is preserved
+///   (<see cref="SourceLandedRowId"/> +
+///   <see cref="LandingLoadBatchId"/>) so any truth row can be
+///   traced back to its raw origin without ambiguity.</item>
+/// </list>
+/// </para>
+///
+/// <para>Doctrine: this is NOT canonical. Crosswalk to
+/// <c>canonical_tf.tf_parcel</c> via APN happens at canonical
+/// layer (D3 — <c>gis_tf.tf_parcel_geom</c>), with
+/// <c>source_xref</c> entries of <c>TfEntityType="geom_parcel"</c>.
+/// truth_arcgis.parcel_geom_current is a stepping stone, not a
+/// destination.</para>
+/// </summary>
+public sealed class TruthArcGisParcelGeomCurrent
+{
+    public Guid TruthParcelGeomId { get; set; } = Guid.NewGuid();
+
+    // ── ArcGIS-side identity (the supp-aware-validated 2-key) ────
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// FeatureService OBJECTID. Unique with <see cref="CountyId"/>
+    /// at the truth layer (latest-per-tuple wins).
+    /// </summary>
+    public long ArcGisObjectId { get; set; }
+
+    // ── Attributes (preserved verbatim from raw) ──────────────────
+    public string? ArcGisApn { get; set; }
+
+    public string GeomWkt { get; set; } = string.Empty;
+    public double CentroidLat { get; set; }
+    public double CentroidLon { get; set; }
+    public double AreaSqFt { get; set; }
+    public string SourceServiceUrl { get; set; } = string.Empty;
+
+    // ── Lineage (the doctrine's traceback) ────────────────────────
+    /// <summary>FK-style pointer to <c>legacy_arcgis_raw.parcel_geom.LandedRowId</c>.</summary>
+    public Guid SourceLandedRowId { get; set; }
+
+    /// <summary>The D1 landing LoadBatch this truth row was promoted from.</summary>
+    public Guid LandingLoadBatchId { get; set; }
+
+    /// <summary>The D2 truth-promotion LoadBatch.</summary>
+    public Guid PromotionLoadBatchId { get; set; }
+
+    public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Sync/ArcGisCanonical/IArcGisCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Core/Sync/ArcGisCanonical/IArcGisCanonicalProjector.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.ArcGisCanonical;
+
+/// <summary>
+/// Slice D3: orchestrator for truth → canonical projection of
+/// ArcGIS parcel polygons.
+///
+/// <para>Input: a completed D2
+/// <c>truth_arcgis.parcel_geom_current</c> promotion batch (or
+/// equivalently, a CountyId whose latest D2 truth state should
+/// project).</para>
+///
+/// <para>Output: rows in <c>gis_tf.tf_parcel_geom</c> for every
+/// truth row whose <c>ArcGisApn</c> resolves to a
+/// <c>canonical_tf.tf_parcel.ParcelNumber</c> via the APN
+/// crosswalk; rows whose APN is null OR fails to crosswalk are
+/// recorded by the coverage gate but still land in
+/// <c>tf_parcel_geom</c> with <c>TfParcelId = null</c> (the
+/// existing schema permits crosswalk-pending rows). Each
+/// projected row writes a <c>source_xref</c> entry with
+/// <c>TfEntityType="geom_parcel"</c>.</para>
+///
+/// <para>Idempotent by county: re-running deletes any prior
+/// canonical rows whose <c>(CountyId, ArcGisObjectId)</c>
+/// matches the truth batch's tuples (and their xrefs) before
+/// inserting new ones.</para>
+/// </summary>
+public interface IArcGisCanonicalProjector
+{
+    Task<ArcGisCanonicalResult> ProjectCountyAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Slice D3: outcome of one projection run.</summary>
+public sealed record ArcGisCanonicalResult
+{
+    public required Guid PromotionLoadBatchId { get; init; }
+
+    /// <summary>'COMPLETED' | 'FAILED' | 'REFUSED'.</summary>
+    public required string Status { get; init; }
+
+    public required int TruthRowsConsidered { get; init; }
+    public required int RowsProjected { get; init; }
+
+    /// <summary>
+    /// Projected rows whose <c>ArcGisApn</c> matched a
+    /// <c>tf_parcel.ParcelNumber</c> in the same county
+    /// (TfParcelId populated).
+    /// </summary>
+    public required int ApnCrosswalkResolved { get; init; }
+
+    /// <summary>
+    /// Projected rows whose <c>ArcGisApn</c> did NOT match
+    /// (TfParcelId left null — pending future crosswalk pass).
+    /// </summary>
+    public required int ApnCrosswalkUnresolved { get; init; }
+
+    /// <summary>
+    /// Prior canonical rows removed before re-insert
+    /// (idempotency proof).
+    /// </summary>
+    public required int PriorCanonicalRowsRemoved { get; init; }
+
+    /// <summary>Sum of <c>AreaSqFt</c> across projected rows.</summary>
+    public required double AreaSqFtSum { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}

--- a/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.ArcGisRawLanding;
+
+/// <summary>
+/// Slice D1: orchestrator for raw ArcGIS feature-service landing.
+///
+/// <para>Per <c>docs/pacs/block-d-execution-plan.md</c> §3.1:
+/// invokes the existing G1-C
+/// <c>IArcGisFeatureServiceClient</c> for the requested
+/// <paramref name="countyId"/>, writes each returned feature
+/// verbatim to <c>legacy_arcgis_raw.parcel_geom</c> with full
+/// provenance, and emits the four R-* gates of the doctrine
+/// pattern.</para>
+///
+/// <para>v1 simplifications:
+/// <list type="bullet">
+///   <item>Single full-county pull per call (no incremental
+///   sync; that's a future slice's concern).</item>
+///   <item>Idempotent by <c>LoadBatchId</c>: re-running with the
+///   same <paramref name="countyId"/> creates a new LoadBatch
+///   (with a fresh GUID) and lands fresh rows; old batches stay
+///   in place and become D2's "promote latest" responsibility.</item>
+///   <item>No retry / backoff / cache fallback in v1; transport
+///   failures bubble up via the G1-C client's
+///   <c>ArcGisFeatureServiceTransportException</c>.</item>
+/// </list>
+/// </para>
+/// </summary>
+public interface IArcGisRawLandingService
+{
+    Task<ArcGisRawLandingResult> LandParcelGeomsAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Slice D1: outcome of one landing run.</summary>
+public sealed record ArcGisRawLandingResult
+{
+    public required Guid LoadBatchId { get; init; }
+
+    /// <summary>'COMPLETED' | 'FAILED' | 'REFUSED'.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Features returned by the FeatureService client.</summary>
+    public required int FeaturesConsidered { get; init; }
+
+    /// <summary>Features written to <c>legacy_arcgis_raw.parcel_geom</c>.</summary>
+    public required int FeaturesLanded { get; init; }
+
+    /// <summary>
+    /// How many <c>(CountyId, ArcGisObjectId)</c> tuples appeared
+    /// more than once in the FeatureService response (the
+    /// key-uniqueness gate's input). Should be zero for a healthy
+    /// service.
+    /// </summary>
+    public required int DuplicateObjectIds { get; init; }
+
+    /// <summary>Sum of <c>AreaSqFt</c> across landed rows.</summary>
+    public required double AreaSqFtSum { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}

--- a/backend/src/TerraFusion.Core/Sync/ArcGisTruthPromotion/IArcGisTruthPromotionService.cs
+++ b/backend/src/TerraFusion.Core/Sync/ArcGisTruthPromotion/IArcGisTruthPromotionService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.ArcGisTruthPromotion;
+
+/// <summary>
+/// Slice D2: orchestrator for raw → truth promotion of ArcGIS
+/// parcel polygons.
+///
+/// <para>Per <c>docs/pacs/block-d-execution-plan.md</c> §3.2:
+/// collapses <c>legacy_arcgis_raw.parcel_geom</c> to
+/// latest-per-<c>(CountyId, ArcGisObjectId)</c>, applies the
+/// geometry validity gate, and writes the surviving rows to
+/// <c>truth_arcgis.parcel_geom_current</c> with full lineage.</para>
+///
+/// <para>Idempotent by <paramref name="countyId"/>: re-running
+/// for the same county clears prior truth rows for that county
+/// and re-promotes from current raw state. Old promotion batches
+/// stay in <c>sync_bridge.load_batch</c> for audit; only the
+/// latest one's rows are present in
+/// <c>truth_arcgis.parcel_geom_current</c>.</para>
+/// </summary>
+public interface IArcGisTruthPromotionService
+{
+    Task<ArcGisTruthPromotionResult> PromoteCountyAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Slice D2: outcome of one promotion run.</summary>
+public sealed record ArcGisTruthPromotionResult
+{
+    public required Guid PromotionLoadBatchId { get; init; }
+
+    /// <summary>'COMPLETED' | 'FAILED' | 'REFUSED'.</summary>
+    public required string Status { get; init; }
+
+    /// <summary>Distinct (CountyId, ArcGisObjectId) tuples found in raw.</summary>
+    public required int TuplesConsidered { get; init; }
+
+    /// <summary>
+    /// Rows promoted to <c>truth_arcgis.parcel_geom_current</c>
+    /// (latest-per-tuple AND valid geometry).
+    /// </summary>
+    public required int RowsPromoted { get; init; }
+
+    /// <summary>
+    /// Rows skipped because their geometry failed validation.
+    /// Raw rows stay in place for audit; the validity gate
+    /// records the count.
+    /// </summary>
+    public required int InvalidGeometrySkipped { get; init; }
+
+    /// <summary>
+    /// Prior truth rows for this county that were removed before
+    /// re-promote (idempotency proof).
+    /// </summary>
+    public required int PriorTruthRowsRemoved { get; init; }
+
+    /// <summary>Sum of <c>AreaSqFt</c> across promoted rows.</summary>
+    public required double AreaSqFtSum { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}

--- a/backend/src/TerraFusion.Data/Configurations/LegacyArcGisRaw/LegacyArcGisRawParcelGeomConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/LegacyArcGisRaw/LegacyArcGisRawParcelGeomConfiguration.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.LegacyArcGisRaw;
+
+namespace TerraFusion.Data.Configurations.LegacyArcGisRaw;
+
+/// <summary>
+/// Slice D1: EF configuration for
+/// <see cref="LegacyArcGisRawParcelGeom"/>.
+/// Schema <c>legacy_arcgis_raw</c>; table <c>parcel_geom</c>.
+///
+/// <para>Per Block-D execution plan §3.1
+/// (<c>docs/pacs/block-d-execution-plan.md</c>):
+/// <list type="bullet">
+///   <item><c>(CountyId, ArcGisObjectId, LoadBatchId)</c> is the
+///   uniqueness key — same OBJECTID re-landed in a new batch is
+///   a distinct row (truth-layer D2 collapses them).</item>
+///   <item>Required fields: CountyId, ArcGisObjectId, GeomWkt,
+///   SourceServiceUrl, LoadBatchId, SourceQueryHash,
+///   SourceRowHash.</item>
+///   <item>Optional fields: ArcGisApn (some county services don't
+///   expose an APN attribute).</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class LegacyArcGisRawParcelGeomConfiguration
+    : IEntityTypeConfiguration<LegacyArcGisRawParcelGeom>
+{
+    public void Configure(EntityTypeBuilder<LegacyArcGisRawParcelGeom> builder)
+    {
+        builder.ToTable("parcel_geom", schema: "legacy_arcgis_raw");
+
+        builder.HasKey(x => x.LandedRowId);
+        builder.Property(x => x.LandedRowId).IsRequired();
+
+        builder.Property(x => x.CountyId).IsRequired();
+        builder.Property(x => x.ArcGisObjectId).IsRequired();
+
+        builder.Property(x => x.ArcGisApn).HasMaxLength(64);
+
+        // GeomWkt is unbounded — polygon WKT can be substantial.
+        // Postgres text + SQLite TEXT both handle this.
+        builder.Property(x => x.GeomWkt).IsRequired();
+
+        builder.Property(x => x.CentroidLat).IsRequired();
+        builder.Property(x => x.CentroidLon).IsRequired();
+        builder.Property(x => x.AreaSqFt).IsRequired();
+
+        builder.Property(x => x.SourceServiceUrl)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        // Provenance.
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+        builder.Property(x => x.SourceRowHash)
+            .IsRequired()
+            .HasMaxLength(16);
+
+        builder.Property(x => x.LandedAt).IsRequired();
+
+        // ── Indexes per D0 plan §3.1 ──────────────────────────────
+
+        // Per-batch uniqueness on the natural (CountyId, ArcGisObjectId)
+        // identity. Same OBJECTID re-landed in a different LoadBatch
+        // is allowed (different row); same OBJECTID in same batch is
+        // a doctrine violation (the key-uniqueness gate fails).
+        builder.HasIndex(x => new
+        {
+            x.CountyId,
+            x.ArcGisObjectId,
+            x.LoadBatchId,
+        })
+            .IsUnique()
+            .HasDatabaseName("ux_legacy_arcgis_raw_parcel_geom_county_objectid");
+
+        // Idempotency cleanup target: clear by load batch.
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_legacy_arcgis_raw_parcel_geom_load_batch");
+
+        // APN crosswalk lookup (used at canonical projection D3).
+        builder.HasIndex(x => new { x.CountyId, x.ArcGisApn })
+            .HasDatabaseName("ix_legacy_arcgis_raw_parcel_geom_apn");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/TruthArcGis/TruthArcGisParcelGeomCurrentConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthArcGis/TruthArcGisParcelGeomCurrentConfiguration.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.TruthArcGis;
+
+namespace TerraFusion.Data.Configurations.TruthArcGis;
+
+/// <summary>
+/// Slice D2: EF configuration for
+/// <see cref="TruthArcGisParcelGeomCurrent"/>.
+/// Schema <c>truth_arcgis</c>; table <c>parcel_geom_current</c>.
+///
+/// <para>Per Block-D execution plan §3.2:
+/// <list type="bullet">
+///   <item><c>(CountyId, ArcGisObjectId)</c> is unique at the
+///   truth layer — only the latest landing wins.</item>
+///   <item>Required fields: CountyId, ArcGisObjectId, GeomWkt,
+///   SourceServiceUrl, SourceLandedRowId, LandingLoadBatchId,
+///   PromotionLoadBatchId.</item>
+///   <item>Optional: ArcGisApn (raw layer permits null).</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class TruthArcGisParcelGeomCurrentConfiguration
+    : IEntityTypeConfiguration<TruthArcGisParcelGeomCurrent>
+{
+    public void Configure(EntityTypeBuilder<TruthArcGisParcelGeomCurrent> builder)
+    {
+        builder.ToTable("parcel_geom_current", schema: "truth_arcgis");
+
+        builder.HasKey(x => x.TruthParcelGeomId);
+        builder.Property(x => x.TruthParcelGeomId).IsRequired();
+
+        builder.Property(x => x.CountyId).IsRequired();
+        builder.Property(x => x.ArcGisObjectId).IsRequired();
+
+        builder.Property(x => x.ArcGisApn).HasMaxLength(64);
+
+        builder.Property(x => x.GeomWkt).IsRequired();
+        builder.Property(x => x.CentroidLat).IsRequired();
+        builder.Property(x => x.CentroidLon).IsRequired();
+        builder.Property(x => x.AreaSqFt).IsRequired();
+
+        builder.Property(x => x.SourceServiceUrl)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(x => x.SourceLandedRowId).IsRequired();
+        builder.Property(x => x.LandingLoadBatchId).IsRequired();
+        builder.Property(x => x.PromotionLoadBatchId).IsRequired();
+        builder.Property(x => x.PromotedAt).IsRequired();
+
+        // Latest-per-(CountyId, ArcGisObjectId) is enforced at
+        // promotion time; the unique index makes accidental
+        // double-inserts a hard failure.
+        builder.HasIndex(x => new { x.CountyId, x.ArcGisObjectId })
+            .IsUnique()
+            .HasDatabaseName("ux_truth_arcgis_parcel_geom_county_objectid");
+
+        // APN crosswalk lookup for D3.
+        builder.HasIndex(x => new { x.CountyId, x.ArcGisApn })
+            .HasDatabaseName("ix_truth_arcgis_parcel_geom_apn");
+
+        // Idempotency cleanup target: clear by promotion batch.
+        builder.HasIndex(x => x.PromotionLoadBatchId)
+            .HasDatabaseName("ix_truth_arcgis_parcel_geom_promotion_batch");
+
+        // Lineage lookup.
+        builder.HasIndex(x => x.LandingLoadBatchId)
+            .HasDatabaseName("ix_truth_arcgis_parcel_geom_landing_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260503062629_AddLegacyArcGisRawParcelGeom.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503062629_AddLegacyArcGisRawParcelGeom.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503062629_AddLegacyArcGisRawParcelGeom")]
+    partial class AddLegacyArcGisRawParcelGeom
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260503062629_AddLegacyArcGisRawParcelGeom.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503062629_AddLegacyArcGisRawParcelGeom.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLegacyArcGisRawParcelGeom : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "legacy_arcgis_raw");
+
+            migrationBuilder.CreateTable(
+                name: "parcel_geom",
+                schema: "legacy_arcgis_raw",
+                columns: table => new
+                {
+                    LandedRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ArcGisObjectId = table.Column<long>(type: "bigint", nullable: false),
+                    ArcGisApn = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    GeomWkt = table.Column<string>(type: "text", nullable: false),
+                    CentroidLat = table.Column<double>(type: "double precision", nullable: false),
+                    CentroidLon = table.Column<double>(type: "double precision", nullable: false),
+                    AreaSqFt = table.Column<double>(type: "double precision", nullable: false),
+                    SourceServiceUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    SourceRowHash = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    LandedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_parcel_geom", x => x.LandedRowId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_arcgis_raw_parcel_geom_apn",
+                schema: "legacy_arcgis_raw",
+                table: "parcel_geom",
+                columns: new[] { "CountyId", "ArcGisApn" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_arcgis_raw_parcel_geom_load_batch",
+                schema: "legacy_arcgis_raw",
+                table: "parcel_geom",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_legacy_arcgis_raw_parcel_geom_county_objectid",
+                schema: "legacy_arcgis_raw",
+                table: "parcel_geom",
+                columns: new[] { "CountyId", "ArcGisObjectId", "LoadBatchId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "parcel_geom",
+                schema: "legacy_arcgis_raw");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260503063934_AddTruthArcGisParcelGeomCurrent.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503063934_AddTruthArcGisParcelGeomCurrent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503063934_AddTruthArcGisParcelGeomCurrent")]
+    partial class AddTruthArcGisParcelGeomCurrent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260503063934_AddTruthArcGisParcelGeomCurrent.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503063934_AddTruthArcGisParcelGeomCurrent.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTruthArcGisParcelGeomCurrent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "truth_arcgis");
+
+            migrationBuilder.CreateTable(
+                name: "parcel_geom_current",
+                schema: "truth_arcgis",
+                columns: table => new
+                {
+                    TruthParcelGeomId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ArcGisObjectId = table.Column<long>(type: "bigint", nullable: false),
+                    ArcGisApn = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    GeomWkt = table.Column<string>(type: "text", nullable: false),
+                    CentroidLat = table.Column<double>(type: "double precision", nullable: false),
+                    CentroidLon = table.Column<double>(type: "double precision", nullable: false),
+                    AreaSqFt = table.Column<double>(type: "double precision", nullable: false),
+                    SourceServiceUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SourceLandedRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LandingLoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PromotionLoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PromotedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_parcel_geom_current", x => x.TruthParcelGeomId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_arcgis_parcel_geom_apn",
+                schema: "truth_arcgis",
+                table: "parcel_geom_current",
+                columns: new[] { "CountyId", "ArcGisApn" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_arcgis_parcel_geom_landing_batch",
+                schema: "truth_arcgis",
+                table: "parcel_geom_current",
+                column: "LandingLoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_arcgis_parcel_geom_promotion_batch",
+                schema: "truth_arcgis",
+                table: "parcel_geom_current",
+                column: "PromotionLoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_truth_arcgis_parcel_geom_county_objectid",
+                schema: "truth_arcgis",
+                table: "parcel_geom_current",
+                columns: new[] { "CountyId", "ArcGisObjectId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "parcel_geom_current",
+                schema: "truth_arcgis");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/GisTf/ArcGisCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/GisTf/ArcGisCanonicalProjector.cs
@@ -1,0 +1,467 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.GisTf;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Sync.ArcGisCanonical;
+
+namespace TerraFusion.Data.Services.GisTf;
+
+/// <summary>
+/// Slice D3: truth → canonical projector for ArcGIS parcel
+/// polygons.
+///
+/// <list type="bullet">
+///   <item><c>canonical-geom-source-batch-completed</c> — most
+///   recent D2 promotion batch for the target county must be
+///   COMPLETED. FAIL refuses projection.</item>
+///   <item><c>canonical-geom-source-xref-coverage</c> — every
+///   projected <c>tf_parcel_geom</c> has a corresponding
+///   <c>source_xref</c> entry with
+///   <c>TfEntityType="geom_parcel"</c>. FAIL on any miss.</item>
+///   <item><c>canonical-geom-county-isolation</c> — every
+///   projected row carries a non-empty <c>CountyId</c>. FAIL
+///   on any miss.</item>
+///   <item><c>canonical-geom-apn-crosswalk-coverage</c> —
+///   informational; counts resolved vs unresolved APN matches
+///   against <c>tf_parcel.ParcelNumber</c>. Unresolved rows
+///   project with <c>TfParcelId = null</c> (pending crosswalk).</item>
+///   <item><c>canonical-geom-aggregate</c> — informational;
+///   count + <c>AreaSqFt</c> sum.</item>
+/// </list>
+///
+/// <para>Per Block-D execution plan §3.3 and contract v1.8: the
+/// existing <c>TfParcelGeom</c> schema gains no new column in
+/// D3 — the projector writes <c>SourceServiceUrl</c>,
+/// <c>LastSyncedAt</c>, and the geometry fields verbatim from
+/// truth. The crosswalk-pending state was already representable
+/// (TfParcelId is nullable). v1.8 adds <c>TfEntityType =
+/// "geom_parcel"</c> to the closed vocabulary and pins this
+/// projector as the only writer to <c>gis_tf.tf_parcel_geom</c>
+/// going forward.</para>
+/// </summary>
+public sealed class ArcGisCanonicalProjector : IArcGisCanonicalProjector
+{
+    private const string EntityType = "geom_parcel";
+
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<ArcGisCanonicalProjector> _logger;
+
+    public ArcGisCanonicalProjector(
+        TerraFusionDbContext db,
+        ILogger<ArcGisCanonicalProjector> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<ArcGisCanonicalResult> ProjectCountyAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default)
+    {
+        var batch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "canonical-tf-arcgis-projector",
+            SourceFileOrDatabase = $"county={countyId}",
+            SourceQueryHash = string.Empty,
+            Operator = operatorName,
+            Status = "IN_PROGRESS",
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.SyncBridgeLoadBatches.Add(batch);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var truthRows = await _db.TruthArcGisParcelGeomCurrents
+                .Where(t => t.CountyId == countyId)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            // ── Gate 1: most recent contributing D2 batch is COMPLETED. ──
+            var contributingBatchIds = truthRows
+                .Select(t => t.PromotionLoadBatchId)
+                .Distinct()
+                .ToList();
+
+            if (contributingBatchIds.Count == 0)
+            {
+                // No truth data for this county — empty projection
+                // is still a successful run.
+                await ClearPriorCanonicalAsync(countyId, batch.LoadBatchId,
+                    cancellationToken).ConfigureAwait(false);
+                await WriteGatesAsync(batch, sourceBatchStatus: "PASS",
+                    sourceBatchDetail: "no truth rows for county",
+                    truthRowsConsidered: 0, rowsProjected: 0,
+                    apnResolved: 0, apnUnresolved: 0,
+                    areaSum: 0d, cancellationToken).ConfigureAwait(false);
+
+                batch.Status = "COMPLETED";
+                batch.CompletedAt = DateTime.UtcNow;
+                batch.RowsExtracted = 0;
+                batch.RowsPromoted = 0;
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                return new ArcGisCanonicalResult
+                {
+                    PromotionLoadBatchId = batch.LoadBatchId,
+                    Status = "COMPLETED",
+                    TruthRowsConsidered = 0,
+                    RowsProjected = 0,
+                    ApnCrosswalkResolved = 0,
+                    ApnCrosswalkUnresolved = 0,
+                    PriorCanonicalRowsRemoved = 0,
+                    AreaSqFtSum = 0d,
+                };
+            }
+
+            var truthBatches = await _db.SyncBridgeLoadBatches
+                .Where(b => contributingBatchIds.Contains(b.LoadBatchId))
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var notCompletedBatches = truthBatches
+                .Where(b => b.Status != "COMPLETED")
+                .ToList();
+
+            if (notCompletedBatches.Count > 0)
+            {
+                var detail =
+                    $"refused: {notCompletedBatches.Count} contributing truth batch(es) " +
+                    $"not COMPLETED ({string.Join(",",
+                        notCompletedBatches.Select(b => $"{b.LoadBatchId}={b.Status}"))})";
+                await WriteGatesAsync(batch, sourceBatchStatus: "FAIL",
+                    sourceBatchDetail: detail,
+                    truthRowsConsidered: 0, rowsProjected: 0,
+                    apnResolved: 0, apnUnresolved: 0,
+                    areaSum: 0d, cancellationToken).ConfigureAwait(false);
+
+                batch.Status = "FAILED";
+                batch.CompletedAt = DateTime.UtcNow;
+                batch.ErrorSummary = detail;
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                return new ArcGisCanonicalResult
+                {
+                    PromotionLoadBatchId = batch.LoadBatchId,
+                    Status = "REFUSED",
+                    TruthRowsConsidered = 0,
+                    RowsProjected = 0,
+                    ApnCrosswalkResolved = 0,
+                    ApnCrosswalkUnresolved = 0,
+                    PriorCanonicalRowsRemoved = 0,
+                    AreaSqFtSum = 0d,
+                    ErrorSummary = detail,
+                };
+            }
+
+            // ── Idempotency: clear prior canonical + xrefs for tuples
+            //    in this county. ──
+            var priorRemoved = await ClearPriorCanonicalAsync(
+                countyId, batch.LoadBatchId, cancellationToken).ConfigureAwait(false);
+
+            // ── APN crosswalk index: parcel_number → TfParcelId. ──
+            var apnIndex = await _db.TfParcels
+                .Where(p => p.CountyId == countyId
+                            && p.ParcelNumber != null)
+                .Select(p => new { p.ParcelNumber, p.TfParcelId })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var apnByParcel = apnIndex
+                .GroupBy(x => x.ParcelNumber!, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.First().TfParcelId,
+                    StringComparer.OrdinalIgnoreCase);
+
+            // ── Project each truth row. ──
+            var considered = truthRows.Count;
+            var projected = 0;
+            var apnResolved = 0;
+            var apnUnresolved = 0;
+            double areaSum = 0d;
+            var now = DateTime.UtcNow;
+
+            foreach (var truth in truthRows)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Guid? resolvedTfParcelId = null;
+                if (!string.IsNullOrWhiteSpace(truth.ArcGisApn)
+                    && apnByParcel.TryGetValue(truth.ArcGisApn, out var pid))
+                {
+                    resolvedTfParcelId = pid;
+                    apnResolved++;
+                }
+                else
+                {
+                    apnUnresolved++;
+                }
+
+                var canonical = new TfParcelGeom
+                {
+                    TfParcelId = resolvedTfParcelId,
+                    CountyId = truth.CountyId,
+                    ArcGisObjectId = truth.ArcGisObjectId,
+                    ArcGisApn = truth.ArcGisApn,
+                    GeomWkt = truth.GeomWkt,
+                    CentroidLat = truth.CentroidLat,
+                    CentroidLon = truth.CentroidLon,
+                    AreaSqFt = truth.AreaSqFt,
+                    SourceServiceUrl = truth.SourceServiceUrl,
+                    LastSyncedAt = now,
+                    IsActive = true,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                };
+                _db.TfParcelGeoms.Add(canonical);
+
+                var sourceKeyJson = JsonSerializer.Serialize(new
+                {
+                    county_id = truth.CountyId,
+                    arcgis_object_id = truth.ArcGisObjectId,
+                });
+                _db.SyncBridgeSourceXrefs.Add(new SourceXref
+                {
+                    TfEntityType = EntityType,
+                    TfEntityId = canonical.TfParcelGeomId,
+                    SourceSystem = "ARCGIS_REST",
+                    SourceTable = "parcel_geom",
+                    SourceKeyJson = sourceKeyJson,
+                    SourceQueryHash = string.Empty,
+                    LoadBatchId = batch.LoadBatchId,
+                    FirstSeenAt = now,
+                    LastSeenAt = now,
+                    IsActive = true,
+                });
+
+                projected++;
+                areaSum += truth.AreaSqFt;
+            }
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            await WriteGatesAsync(batch,
+                sourceBatchStatus: "PASS",
+                sourceBatchDetail: $"{truthBatches.Count} contributing truth batch(es) all COMPLETED",
+                truthRowsConsidered: considered,
+                rowsProjected: projected,
+                apnResolved: apnResolved,
+                apnUnresolved: apnUnresolved,
+                areaSum: areaSum,
+                cancellationToken).ConfigureAwait(false);
+
+            batch.Status = "COMPLETED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.RowsExtracted = considered;
+            batch.RowsPromoted = projected;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "ArcGIS canonical projection COMPLETED. batch={BatchId} county={CountyId} considered={Considered} projected={Projected} apnResolved={ApnResolved} apnUnresolved={ApnUnresolved} priorRemoved={PriorRemoved} areaSum={AreaSum}",
+                batch.LoadBatchId, countyId, considered, projected,
+                apnResolved, apnUnresolved, priorRemoved, areaSum);
+
+            return new ArcGisCanonicalResult
+            {
+                PromotionLoadBatchId = batch.LoadBatchId,
+                Status = "COMPLETED",
+                TruthRowsConsidered = considered,
+                RowsProjected = projected,
+                ApnCrosswalkResolved = apnResolved,
+                ApnCrosswalkUnresolved = apnUnresolved,
+                PriorCanonicalRowsRemoved = priorRemoved,
+                AreaSqFtSum = areaSum,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var summary = $"{ex.GetType().Name}: {ex.Message}";
+            batch.Status = "FAILED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.ErrorSummary = summary;
+            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _logger.LogError(ex,
+                "ArcGIS canonical projection FAILED. batch={BatchId} county={CountyId} summary={Summary}",
+                batch.LoadBatchId, countyId, summary);
+
+            return new ArcGisCanonicalResult
+            {
+                PromotionLoadBatchId = batch.LoadBatchId,
+                Status = "FAILED",
+                TruthRowsConsidered = 0,
+                RowsProjected = 0,
+                ApnCrosswalkResolved = 0,
+                ApnCrosswalkUnresolved = 0,
+                PriorCanonicalRowsRemoved = 0,
+                AreaSqFtSum = 0d,
+                ErrorSummary = summary,
+            };
+        }
+    }
+
+    private async Task<int> ClearPriorCanonicalAsync(
+        Guid countyId,
+        Guid currentBatchId,
+        CancellationToken cancellationToken)
+    {
+        // Identify prior canonical rows by their county xref and
+        // their xref's SourceKeyJson 2-tuple. Clean approach:
+        // pull all source_xref entries of TfEntityType="geom_parcel"
+        // whose SourceKeyJson contains the target CountyId, drop
+        // their canonical rows + xrefs.
+        var allXrefs = await _db.SyncBridgeSourceXrefs
+            .Where(x => x.TfEntityType == EntityType && x.IsActive)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var priorXrefs = new List<SourceXref>();
+        var priorCanonicalIds = new HashSet<Guid>();
+        foreach (var x in allXrefs)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(x.SourceKeyJson);
+                if (!doc.RootElement.TryGetProperty("county_id", out var cEl))
+                    continue;
+                var cidStr = cEl.GetString();
+                if (cidStr is null || !Guid.TryParse(cidStr, out var cid))
+                    continue;
+                if (cid == countyId && x.LoadBatchId != currentBatchId)
+                {
+                    priorXrefs.Add(x);
+                    priorCanonicalIds.Add(x.TfEntityId);
+                }
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+        }
+
+        var priorCanonical = await _db.TfParcelGeoms
+            .Where(c => priorCanonicalIds.Contains(c.TfParcelGeomId))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        if (priorCanonical.Count > 0) _db.TfParcelGeoms.RemoveRange(priorCanonical);
+        if (priorXrefs.Count > 0) _db.SyncBridgeSourceXrefs.RemoveRange(priorXrefs);
+        if (priorCanonical.Count + priorXrefs.Count > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return priorCanonical.Count;
+    }
+
+    private async Task WriteGatesAsync(
+        LoadBatch batch,
+        string sourceBatchStatus,
+        string sourceBatchDetail,
+        int truthRowsConsidered,
+        int rowsProjected,
+        int apnResolved,
+        int apnUnresolved,
+        double areaSum,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+
+        // 1) canonical-geom-source-batch-completed.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "canonical-geom-source-batch-completed",
+            GateStage = "TRUTH_TO_CANONICAL",
+            Status = sourceBatchStatus,
+            Expected = "all contributing batches COMPLETED",
+            Actual = sourceBatchStatus,
+            Detail = sourceBatchDetail,
+            ExecutedAt = now,
+        });
+
+        if (sourceBatchStatus == "FAIL")
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // 2) canonical-geom-source-xref-coverage.
+        var projectedIds = await _db.TfParcelGeoms
+            .Where(c => c.IsActive)
+            .Select(c => c.TfParcelGeomId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var xrefIds = await _db.SyncBridgeSourceXrefs
+            .Where(x => x.TfEntityType == EntityType
+                        && x.LoadBatchId == batch.LoadBatchId
+                        && projectedIds.Contains(x.TfEntityId))
+            .Select(x => x.TfEntityId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var coverageMissing = rowsProjected - xrefIds.Count;
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "canonical-geom-source-xref-coverage",
+            GateStage = "TRUTH_TO_CANONICAL",
+            Status = coverageMissing == 0 ? "PASS" : "FAIL",
+            Expected = rowsProjected.ToString(CultureInfo.InvariantCulture),
+            Actual = xrefIds.Count.ToString(CultureInfo.InvariantCulture),
+            Detail = coverageMissing == 0
+                ? $"all {rowsProjected} tf_parcel_geom rows have source_xref"
+                : $"{coverageMissing} tf_parcel_geom rows lack source_xref",
+            ExecutedAt = now,
+        });
+
+        // 3) canonical-geom-county-isolation.
+        var emptyCountyCount = await _db.TfParcelGeoms
+            .Where(c => projectedIds.Contains(c.TfParcelGeomId)
+                        && c.CountyId == Guid.Empty)
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "canonical-geom-county-isolation",
+            GateStage = "TRUTH_TO_CANONICAL",
+            Status = emptyCountyCount == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = emptyCountyCount.ToString(CultureInfo.InvariantCulture),
+            Detail = emptyCountyCount == 0
+                ? "every tf_parcel_geom has a non-empty CountyId"
+                : $"{emptyCountyCount} rows have empty CountyId",
+            ExecutedAt = now,
+        });
+
+        // 4) canonical-geom-apn-crosswalk-coverage — informational.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "canonical-geom-apn-crosswalk-coverage",
+            GateStage = "TRUTH_TO_CANONICAL",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = apnResolved.ToString(CultureInfo.InvariantCulture),
+            Detail = $"projected={rowsProjected} apnResolved={apnResolved} apnUnresolved={apnUnresolved}",
+            ExecutedAt = now,
+        });
+
+        // 5) canonical-geom-aggregate.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "canonical-geom-aggregate",
+            GateStage = "TRUTH_TO_CANONICAL",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = rowsProjected.ToString(CultureInfo.InvariantCulture),
+            Detail = $"truthConsidered={truthRowsConsidered} projected={rowsProjected} " +
+                     $"areaSqFtSum={areaSum.ToString("F2", CultureInfo.InvariantCulture)}",
+            ExecutedAt = now,
+        });
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.LegacyArcGisRaw;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.GIS.ArcGisRest;
+using TerraFusion.Core.Sync.ArcGisRawLanding;
+
+namespace TerraFusion.Data.Services.LegacyArcGisRaw;
+
+/// <summary>
+/// Slice D1: drains the existing G1-C
+/// <see cref="IArcGisFeatureServiceClient"/> for one county and
+/// lands every feature verbatim into
+/// <c>legacy_arcgis_raw.parcel_geom</c> with full provenance.
+/// Records four R-* promotion gates per the doctrine pattern:
+///
+/// <list type="bullet">
+///   <item><c>arcgis-raw-source-batch-completed</c> —
+///   informational PASS once the LoadBatch closes.</item>
+///   <item><c>arcgis-raw-key-uniqueness</c> — FAIL when any
+///   <c>(CountyId, ArcGisObjectId)</c> tuple appears more than
+///   once in the FeatureService response.</item>
+///   <item><c>arcgis-raw-provenance-coverage</c> — FAIL when any
+///   landed row lacks <c>LoadBatchId</c>, <c>SourceQueryHash</c>,
+///   or <c>SourceRowHash</c>.</item>
+///   <item><c>arcgis-raw-aggregate</c> — informational counts +
+///   total area for spot-checking.</item>
+/// </list>
+///
+/// <para>The G1-C client is reused as-is — no shape change. This
+/// service exists solely to wrap the client output in the
+/// 5-schema-doctrine landing layer that was missing before D1.</para>
+/// </summary>
+public sealed class ArcGisRawLandingService : IArcGisRawLandingService
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly IArcGisFeatureServiceClient _client;
+    private readonly ILogger<ArcGisRawLandingService> _logger;
+
+    public ArcGisRawLandingService(
+        TerraFusionDbContext db,
+        IArcGisFeatureServiceClient client,
+        ILogger<ArcGisRawLandingService> logger)
+    {
+        _db = db;
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<ArcGisRawLandingResult> LandParcelGeomsAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default)
+    {
+        // Stable hash of the "query" we're about to issue. The G1-C
+        // client embeds the FeatureService URL + standard query
+        // string; we capture that as the SourceQueryHash input so
+        // re-runs against the same county produce identical hashes.
+        var queryDescriptor = $"county={countyId} f=geojson where=1=1 outSR=4326 returnGeometry=true";
+        var queryHash = ComputeStableHash(queryDescriptor);
+
+        var batch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-feature-service",
+            SourceFileOrDatabase = $"county={countyId}",
+            SourceQueryHash = queryHash,
+            Operator = operatorName,
+            Status = "IN_PROGRESS",
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.SyncBridgeLoadBatches.Add(batch);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var features = await _client.FetchParcelsAsync(countyId, cancellationToken)
+                .ConfigureAwait(false);
+
+            var considered = features.Count;
+            var landed = 0;
+            double areaSum = 0d;
+            var keyCounts = new Dictionary<(Guid, long), int>();
+            var now = DateTime.UtcNow;
+
+            foreach (var feature in features)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var key = (feature.CountyId, feature.ArcGisObjectId);
+                keyCounts[key] = keyCounts.TryGetValue(key, out var c) ? c + 1 : 1;
+
+                _db.LegacyArcGisRawParcelGeoms.Add(new LegacyArcGisRawParcelGeom
+                {
+                    CountyId = feature.CountyId,
+                    ArcGisObjectId = feature.ArcGisObjectId,
+                    ArcGisApn = feature.ArcGisApn,
+                    GeomWkt = feature.GeomWkt,
+                    CentroidLat = feature.CentroidLat,
+                    CentroidLon = feature.CentroidLon,
+                    AreaSqFt = feature.AreaSqFt,
+                    SourceServiceUrl = feature.SourceServiceUrl,
+                    LoadBatchId = batch.LoadBatchId,
+                    SourceQueryHash = queryHash,
+                    SourceRowHash = ComputeRowHash(feature),
+                    LandedAt = now,
+                });
+                landed++;
+                areaSum += feature.AreaSqFt;
+            }
+
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            var duplicateKeyViolations = keyCounts.Values.Count(c => c > 1);
+
+            await WriteGatesAsync(
+                batch, considered, landed, duplicateKeyViolations, areaSum,
+                cancellationToken).ConfigureAwait(false);
+
+            batch.Status = "COMPLETED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.RowsExtracted = considered;
+            batch.RowsPromoted = landed;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "ArcGIS parcel_geom landing COMPLETED. batch={BatchId} county={CountyId} considered={Considered} landed={Landed} duplicates={Dups} areaSum={AreaSum}",
+                batch.LoadBatchId, countyId, considered, landed, duplicateKeyViolations, areaSum);
+
+            return new ArcGisRawLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "COMPLETED",
+                FeaturesConsidered = considered,
+                FeaturesLanded = landed,
+                DuplicateObjectIds = duplicateKeyViolations,
+                AreaSqFtSum = areaSum,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var summary = $"{ex.GetType().Name}: {ex.Message}";
+            batch.Status = "FAILED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.ErrorSummary = summary;
+            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _logger.LogError(ex,
+                "ArcGIS parcel_geom landing FAILED. batch={BatchId} county={CountyId} summary={Summary}",
+                batch.LoadBatchId, countyId, summary);
+
+            return new ArcGisRawLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "FAILED",
+                FeaturesConsidered = 0,
+                FeaturesLanded = 0,
+                DuplicateObjectIds = 0,
+                AreaSqFtSum = 0d,
+                ErrorSummary = summary,
+            };
+        }
+    }
+
+    private async Task WriteGatesAsync(
+        LoadBatch batch,
+        int considered,
+        int landed,
+        int duplicateKeyViolations,
+        double areaSum,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+
+        // 1) arcgis-raw-source-batch-completed — informational PASS.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-raw-source-batch-completed",
+            GateStage = "SOURCE_TO_RAW",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = considered.ToString(CultureInfo.InvariantCulture),
+            Detail = $"FeatureService returned {considered} features for batch={batch.LoadBatchId}",
+            ExecutedAt = now,
+        });
+
+        // 2) arcgis-raw-key-uniqueness — doctrine invariant.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-raw-key-uniqueness",
+            GateStage = "SOURCE_TO_RAW",
+            Status = duplicateKeyViolations == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = duplicateKeyViolations.ToString(CultureInfo.InvariantCulture),
+            Detail = duplicateKeyViolations == 0
+                ? "every (CountyId, ArcGisObjectId) is unique"
+                : $"{duplicateKeyViolations} (CountyId, ArcGisObjectId) tuples appeared more than once",
+            ExecutedAt = now,
+        });
+
+        // 3) arcgis-raw-provenance-coverage — assert from DB.
+        var unprovenanced = await _db.LegacyArcGisRawParcelGeoms
+            .Where(r => r.LoadBatchId == batch.LoadBatchId
+                        && (r.LoadBatchId == Guid.Empty
+                            || string.IsNullOrEmpty(r.SourceQueryHash)
+                            || string.IsNullOrEmpty(r.SourceRowHash)))
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-raw-provenance-coverage",
+            GateStage = "SOURCE_TO_RAW",
+            Status = unprovenanced == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = unprovenanced.ToString(CultureInfo.InvariantCulture),
+            Detail = unprovenanced == 0
+                ? $"all {landed} landed rows have load_batch_id, source_query_hash, source_row_hash"
+                : $"{unprovenanced} rows lack provenance",
+            ExecutedAt = now,
+        });
+
+        // 4) arcgis-raw-aggregate — informational counts.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-raw-aggregate",
+            GateStage = "SOURCE_TO_RAW",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = landed.ToString(CultureInfo.InvariantCulture),
+            Detail = $"considered={considered} landed={landed} " +
+                     $"areaSqFtSum={areaSum.ToString("F2", CultureInfo.InvariantCulture)}",
+            ExecutedAt = now,
+        });
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string ComputeStableHash(string input)
+    {
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = SHA256.HashData(bytes);
+        // 16-hex-char prefix mirrors LegacyPacsRaw landing services.
+        var sb = new StringBuilder(16);
+        for (var i = 0; i < 8; i++)
+        {
+            sb.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    private static string ComputeRowHash(ArcGisParcelFeature feature)
+    {
+        // Per-row content hash so D2 can detect content drift across
+        // batches without parsing WKT. Includes the geometry text so
+        // any polygon edit flips the hash.
+        var raw = string.Concat(
+            feature.CountyId.ToString(),
+            "",
+            feature.ArcGisObjectId.ToString(CultureInfo.InvariantCulture),
+            "",
+            feature.ArcGisApn ?? string.Empty,
+            "",
+            feature.GeomWkt,
+            "",
+            feature.CentroidLat.ToString("R", CultureInfo.InvariantCulture),
+            "",
+            feature.CentroidLon.ToString("R", CultureInfo.InvariantCulture),
+            "",
+            feature.AreaSqFt.ToString("R", CultureInfo.InvariantCulture));
+        return ComputeStableHash(raw);
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/TruthArcGis/ArcGisTruthPromotionService.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthArcGis/ArcGisTruthPromotionService.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.LegacyArcGisRaw;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthArcGis;
+using TerraFusion.Core.Sync.ArcGisTruthPromotion;
+
+namespace TerraFusion.Data.Services.TruthArcGis;
+
+/// <summary>
+/// Slice D2: raw → truth promoter for ArcGIS parcel polygons.
+///
+/// <list type="bullet">
+///   <item><c>arcgis-truth-source-batches-completed</c> — every
+///   raw landing batch covering tuples in scope is COMPLETED.
+///   FAIL refuses promotion if any contributing batch is
+///   FAILED / IN_PROGRESS.</item>
+///   <item><c>arcgis-truth-latest-per-objectid</c> — every
+///   promoted row is the maximum-LandingLoadBatchId entry for
+///   its <c>(CountyId, ArcGisObjectId)</c> tuple. The unique
+///   index on <c>truth_arcgis.parcel_geom_current</c> backs
+///   this; the gate cross-checks from the DB after writes.</item>
+///   <item><c>arcgis-truth-geometry-validity</c> — FAIL on any
+///   raw row whose <c>GeomWkt</c> fails the WKT-shape check
+///   (POLYGON/MULTIPOLYGON header + at least one ring + at
+///   least 3 coordinate pairs per ring). Invalid rows are NOT
+///   promoted; raw rows stay in place for audit.</item>
+///   <item><c>arcgis-truth-aggregate</c> — informational; counts
+///   + sum of <c>AreaSqFt</c> across promoted rows.</item>
+/// </list>
+/// </summary>
+public sealed class ArcGisTruthPromotionService : IArcGisTruthPromotionService
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<ArcGisTruthPromotionService> _logger;
+
+    public ArcGisTruthPromotionService(
+        TerraFusionDbContext db,
+        ILogger<ArcGisTruthPromotionService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<ArcGisTruthPromotionResult> PromoteCountyAsync(
+        Guid countyId,
+        string operatorName,
+        CancellationToken cancellationToken = default)
+    {
+        var batch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-truth-promoter",
+            SourceFileOrDatabase = $"county={countyId}",
+            SourceQueryHash = string.Empty,
+            Operator = operatorName,
+            Status = "IN_PROGRESS",
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.SyncBridgeLoadBatches.Add(batch);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // ── Pull all raw rows for the county. ──
+            var rawRows = await _db.LegacyArcGisRawParcelGeoms
+                .Where(r => r.CountyId == countyId)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            if (rawRows.Count == 0)
+            {
+                // No raw data for this county → empty truth promote
+                // is still a successful run with a clean batch.
+                await ClearPriorTruthAsync(countyId, batch.LoadBatchId,
+                    cancellationToken).ConfigureAwait(false);
+                await WriteGatesAsync(batch, sourceBatchesStatus: "PASS",
+                    sourceBatchesDetail: "no raw rows for county",
+                    tuplesConsidered: 0, rowsPromoted: 0,
+                    invalidGeometrySkipped: 0, areaSum: 0d,
+                    cancellationToken).ConfigureAwait(false);
+
+                batch.Status = "COMPLETED";
+                batch.CompletedAt = DateTime.UtcNow;
+                batch.RowsExtracted = 0;
+                batch.RowsPromoted = 0;
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                return new ArcGisTruthPromotionResult
+                {
+                    PromotionLoadBatchId = batch.LoadBatchId,
+                    Status = "COMPLETED",
+                    TuplesConsidered = 0,
+                    RowsPromoted = 0,
+                    InvalidGeometrySkipped = 0,
+                    PriorTruthRowsRemoved = 0,
+                    AreaSqFtSum = 0d,
+                };
+            }
+
+            // ── Gate 1: every contributing landing batch is COMPLETED. ──
+            var contributingBatchIds = rawRows.Select(r => r.LoadBatchId)
+                .Distinct().ToList();
+            var landingBatches = await _db.SyncBridgeLoadBatches
+                .Where(b => contributingBatchIds.Contains(b.LoadBatchId))
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var notCompletedBatches = landingBatches
+                .Where(b => b.Status != "COMPLETED")
+                .ToList();
+
+            if (notCompletedBatches.Count > 0)
+            {
+                var detail =
+                    $"refused: {notCompletedBatches.Count} contributing landing batch(es) " +
+                    $"not COMPLETED ({string.Join(",",
+                        notCompletedBatches.Select(b => $"{b.LoadBatchId}={b.Status}"))})";
+                await WriteGatesAsync(batch, sourceBatchesStatus: "FAIL",
+                    sourceBatchesDetail: detail,
+                    tuplesConsidered: 0, rowsPromoted: 0,
+                    invalidGeometrySkipped: 0, areaSum: 0d,
+                    cancellationToken).ConfigureAwait(false);
+
+                batch.Status = "FAILED";
+                batch.CompletedAt = DateTime.UtcNow;
+                batch.ErrorSummary = detail;
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                return new ArcGisTruthPromotionResult
+                {
+                    PromotionLoadBatchId = batch.LoadBatchId,
+                    Status = "REFUSED",
+                    TuplesConsidered = 0,
+                    RowsPromoted = 0,
+                    InvalidGeometrySkipped = 0,
+                    PriorTruthRowsRemoved = 0,
+                    AreaSqFtSum = 0d,
+                    ErrorSummary = detail,
+                };
+            }
+
+            // ── Idempotency: clear prior truth rows for this county. ──
+            var priorTruthRowsRemoved = await ClearPriorTruthAsync(countyId,
+                batch.LoadBatchId, cancellationToken).ConfigureAwait(false);
+
+            // ── Build latest-per-(CountyId, ArcGisObjectId) index. ──
+            // Tie-breaker: when two raw rows for the same tuple have
+            // the same LandingLoadBatchId (impossible by D1's unique
+            // index, but defensive) — pick the most recently landed.
+            var landedAtByBatch = landingBatches.ToDictionary(
+                b => b.LoadBatchId, b => b.CompletedAt ?? b.StartedAt);
+
+            var byTuple = rawRows
+                .GroupBy(r => (r.CountyId, r.ArcGisObjectId))
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(r => landedAtByBatch[r.LoadBatchId])
+                          .ThenByDescending(r => r.LandedAt)
+                          .First());
+
+            var tuplesConsidered = byTuple.Count;
+            var rowsPromoted = 0;
+            var invalidGeometry = 0;
+            double areaSum = 0d;
+            var now = DateTime.UtcNow;
+
+            foreach (var (_, latest) in byTuple)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!IsValidWkt(latest.GeomWkt))
+                {
+                    invalidGeometry++;
+                    continue;
+                }
+
+                _db.TruthArcGisParcelGeomCurrents.Add(new TruthArcGisParcelGeomCurrent
+                {
+                    CountyId = latest.CountyId,
+                    ArcGisObjectId = latest.ArcGisObjectId,
+                    ArcGisApn = latest.ArcGisApn,
+                    GeomWkt = latest.GeomWkt,
+                    CentroidLat = latest.CentroidLat,
+                    CentroidLon = latest.CentroidLon,
+                    AreaSqFt = latest.AreaSqFt,
+                    SourceServiceUrl = latest.SourceServiceUrl,
+                    SourceLandedRowId = latest.LandedRowId,
+                    LandingLoadBatchId = latest.LoadBatchId,
+                    PromotionLoadBatchId = batch.LoadBatchId,
+                    PromotedAt = now,
+                });
+                rowsPromoted++;
+                areaSum += latest.AreaSqFt;
+            }
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            await WriteGatesAsync(batch, sourceBatchesStatus: "PASS",
+                sourceBatchesDetail: $"{landingBatches.Count} contributing landing batch(es) all COMPLETED",
+                tuplesConsidered: tuplesConsidered,
+                rowsPromoted: rowsPromoted,
+                invalidGeometrySkipped: invalidGeometry,
+                areaSum: areaSum,
+                cancellationToken).ConfigureAwait(false);
+
+            batch.Status = "COMPLETED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.RowsExtracted = tuplesConsidered;
+            batch.RowsPromoted = rowsPromoted;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "ArcGIS parcel_geom truth promotion COMPLETED. batch={BatchId} county={CountyId} tuples={Tuples} promoted={Promoted} invalid={Invalid} priorRemoved={PriorRemoved} areaSum={AreaSum}",
+                batch.LoadBatchId, countyId, tuplesConsidered, rowsPromoted,
+                invalidGeometry, priorTruthRowsRemoved, areaSum);
+
+            return new ArcGisTruthPromotionResult
+            {
+                PromotionLoadBatchId = batch.LoadBatchId,
+                Status = "COMPLETED",
+                TuplesConsidered = tuplesConsidered,
+                RowsPromoted = rowsPromoted,
+                InvalidGeometrySkipped = invalidGeometry,
+                PriorTruthRowsRemoved = priorTruthRowsRemoved,
+                AreaSqFtSum = areaSum,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var summary = $"{ex.GetType().Name}: {ex.Message}";
+            batch.Status = "FAILED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.ErrorSummary = summary;
+            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _logger.LogError(ex,
+                "ArcGIS truth promotion FAILED. batch={BatchId} county={CountyId} summary={Summary}",
+                batch.LoadBatchId, countyId, summary);
+
+            return new ArcGisTruthPromotionResult
+            {
+                PromotionLoadBatchId = batch.LoadBatchId,
+                Status = "FAILED",
+                TuplesConsidered = 0,
+                RowsPromoted = 0,
+                InvalidGeometrySkipped = 0,
+                PriorTruthRowsRemoved = 0,
+                AreaSqFtSum = 0d,
+                ErrorSummary = summary,
+            };
+        }
+    }
+
+    private async Task<int> ClearPriorTruthAsync(
+        Guid countyId,
+        Guid currentBatchId,
+        CancellationToken cancellationToken)
+    {
+        var prior = await _db.TruthArcGisParcelGeomCurrents
+            .Where(t => t.CountyId == countyId
+                        && t.PromotionLoadBatchId != currentBatchId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        if (prior.Count > 0)
+        {
+            _db.TruthArcGisParcelGeomCurrents.RemoveRange(prior);
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return prior.Count;
+    }
+
+    /// <summary>
+    /// Lightweight WKT shape validator. Accepts strings whose
+    /// outer header is <c>POLYGON</c> or <c>MULTIPOLYGON</c> and
+    /// that contain at least three coordinate pairs (the minimum
+    /// for a closed ring). Designed to catch the obvious failure
+    /// modes (empty string, truncated WKT, "null", garbled input)
+    /// without pulling in NetTopologySuite for full topology.
+    /// </summary>
+    internal static bool IsValidWkt(string? wkt)
+    {
+        if (string.IsNullOrWhiteSpace(wkt)) return false;
+
+        var trimmed = wkt.TrimStart();
+        if (!trimmed.StartsWith("POLYGON", StringComparison.OrdinalIgnoreCase)
+            && !trimmed.StartsWith("MULTIPOLYGON", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Count coordinate pairs (a "x y" sequence). A closed ring
+        // requires at least 3 distinct vertices + a closing repeat
+        // — minimum 4 pairs for POLYGON, 4 per ring for MULTIPOLYGON.
+        // Conservative count: ≥ 3 pairs anywhere.
+        var commaCount = trimmed.Count(c => c == ',');
+        if (commaCount < 3) return false;
+
+        // Must contain at least one '(' and one ')'.
+        if (!trimmed.Contains('(') || !trimmed.Contains(')')) return false;
+
+        return true;
+    }
+
+    private async Task WriteGatesAsync(
+        LoadBatch batch,
+        string sourceBatchesStatus,
+        string sourceBatchesDetail,
+        int tuplesConsidered,
+        int rowsPromoted,
+        int invalidGeometrySkipped,
+        double areaSum,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+
+        // 1) arcgis-truth-source-batches-completed.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-truth-source-batches-completed",
+            GateStage = "RAW_TO_TRUTH",
+            Status = sourceBatchesStatus,
+            Expected = "all contributing batches COMPLETED",
+            Actual = sourceBatchesStatus,
+            Detail = sourceBatchesDetail,
+            ExecutedAt = now,
+        });
+
+        // If the source-batch gate FAILED, the rest are skipped:
+        // no truth rows were written.
+        if (sourceBatchesStatus == "FAIL")
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // 2) arcgis-truth-latest-per-objectid — cross-check from DB.
+        var truthRows = await _db.TruthArcGisParcelGeomCurrents
+            .Where(t => t.PromotionLoadBatchId == batch.LoadBatchId)
+            .Select(t => new { t.CountyId, t.ArcGisObjectId })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        var distinctTuples = truthRows
+            .GroupBy(r => (r.CountyId, r.ArcGisObjectId))
+            .Count();
+        var collapseViolations = truthRows.Count - distinctTuples;
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-truth-latest-per-objectid",
+            GateStage = "RAW_TO_TRUTH",
+            Status = collapseViolations == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = collapseViolations.ToString(CultureInfo.InvariantCulture),
+            Detail = collapseViolations == 0
+                ? $"every (CountyId, ArcGisObjectId) appears exactly once in this promotion batch ({rowsPromoted} rows)"
+                : $"{collapseViolations} (CountyId, ArcGisObjectId) tuples were promoted more than once",
+            ExecutedAt = now,
+        });
+
+        // 3) arcgis-truth-geometry-validity.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-truth-geometry-validity",
+            GateStage = "RAW_TO_TRUTH",
+            Status = invalidGeometrySkipped == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = invalidGeometrySkipped.ToString(CultureInfo.InvariantCulture),
+            Detail = invalidGeometrySkipped == 0
+                ? $"every promoted row has a valid POLYGON/MULTIPOLYGON WKT ({rowsPromoted} checked)"
+                : $"{invalidGeometrySkipped} raw rows had invalid WKT and were not promoted; raw rows preserved for audit",
+            ExecutedAt = now,
+        });
+
+        // 4) arcgis-truth-aggregate.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "arcgis-truth-aggregate",
+            GateStage = "RAW_TO_TRUTH",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = rowsPromoted.ToString(CultureInfo.InvariantCulture),
+            Detail = $"tuplesConsidered={tuplesConsidered} promoted={rowsPromoted} " +
+                     $"invalidSkipped={invalidGeometrySkipped} " +
+                     $"areaSqFtSum={areaSum.ToString("F2", CultureInfo.InvariantCulture)}",
+            ExecutedAt = now,
+        });
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -322,6 +322,14 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.CanonicalTf.AttributeDefinition>
     AttributeDefinitions { get; set; } = null!;
 
+  // Slice D1: legacy_arcgis_raw.parcel_geom — first stop in the
+  // 5-schema doctrine for ArcGIS-sourced geometry. Per Block-D
+  // execution plan (docs/pacs/block-d-execution-plan.md §3.1).
+  // Verbatim REST-response landing with full provenance; truth
+  // promotion at D2, canonical projection at D3.
+  public DbSet<TerraFusion.Core.Entities.LegacyArcGisRaw.LegacyArcGisRawParcelGeom>
+    LegacyArcGisRawParcelGeoms { get; set; } = null!;
+
   // Slice C41-B: per-county pointer naming the operator-active
   // Mapped workbook. Singleton per county (PK = CountyId). See
   // docs/sync/sync-county-active-workbook-pointer-policy.md for the
@@ -1037,6 +1045,11 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // mapping spine. Per docs/pacs/block-c-contract-v1.2.md.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.CanonicalTf.AttributeDefinitionConfiguration());
+
+    // Slice D1: legacy_arcgis_raw.parcel_geom — raw FeatureService
+    // landing. Per docs/pacs/block-d-execution-plan.md §3.1.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.LegacyArcGisRaw.LegacyArcGisRawParcelGeomConfiguration());
 
     // Sync Bridge v1 — Phase 0 field_authority seed for the parcel
     // domain. Per docs/pacs/pacs-sync-bridge-v1-spec.md §4.

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -330,6 +330,14 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.LegacyArcGisRaw.LegacyArcGisRawParcelGeom>
     LegacyArcGisRawParcelGeoms { get; set; } = null!;
 
+  // Slice D2: truth_arcgis.parcel_geom_current — supp-aware-
+  // validated current ArcGIS polygon, latest-per-(CountyId,
+  // ArcGisObjectId). Per docs/pacs/block-d-execution-plan.md §3.2.
+  // Geometry validity gate filters malformed WKT before D3
+  // projects to canonical_tf via APN crosswalk.
+  public DbSet<TerraFusion.Core.Entities.TruthArcGis.TruthArcGisParcelGeomCurrent>
+    TruthArcGisParcelGeomCurrents { get; set; } = null!;
+
   // Slice C41-B: per-county pointer naming the operator-active
   // Mapped workbook. Singleton per county (PK = CountyId). See
   // docs/sync/sync-county-active-workbook-pointer-policy.md for the
@@ -1050,6 +1058,12 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // landing. Per docs/pacs/block-d-execution-plan.md §3.1.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.LegacyArcGisRaw.LegacyArcGisRawParcelGeomConfiguration());
+
+    // Slice D2: truth_arcgis.parcel_geom_current — latest-per-
+    // (CountyId, ArcGisObjectId) truth promotion.
+    // Per docs/pacs/block-d-execution-plan.md §3.2.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.TruthArcGis.TruthArcGisParcelGeomCurrentConfiguration());
 
     // Sync Bridge v1 — Phase 0 field_authority seed for the parcel
     // domain. Per docs/pacs/pacs-sync-bridge-v1-spec.md §4.

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisCanonicalProjectorTests.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.GisTf;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthArcGis;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.GisTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.GisTf;
+
+/// <summary>
+/// Slice D3 acceptance tests. Proves the five C-* gates + the
+/// canonical-projection doctrine invariants for ArcGIS parcel
+/// geometry:
+///
+///  - source-batch-completed: refuse projection when any
+///    contributing truth batch is FAILED / IN_PROGRESS
+///  - source-xref-coverage: every projected tf_parcel_geom has
+///    a sync_bridge.source_xref entry
+///    (TfEntityType="geom_parcel")
+///  - county-isolation: every projected row has a non-empty
+///    CountyId
+///  - apn-crosswalk-coverage (informational): records resolved
+///    vs unresolved APN matches against tf_parcel.ParcelNumber
+///  - aggregate (informational): counts + AreaSqFt sum
+///  - idempotent on rerun: prior canonical rows for the
+///    county's tuples clear before re-insert
+/// </summary>
+public sealed class ArcGisCanonicalProjectorTests : IDisposable
+{
+    private const string GeomEntityType = "geom_parcel";
+
+    private readonly TerraFusionDbContext _db;
+
+    public ArcGisCanonicalProjectorTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"d3-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ArcGisCanonicalProjector BuildService()
+        => new(_db, NullLogger<ArcGisCanonicalProjector>.Instance);
+
+    private async Task<Guid> SeedTruthBatchAsync(string status = "COMPLETED")
+    {
+        var b = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-truth-promoter",
+            SourceFileOrDatabase = "test",
+            SourceQueryHash = "qh",
+            Operator = "test",
+            Status = status,
+            StartedAt = DateTime.UtcNow.AddMinutes(-5),
+            CompletedAt = status == "COMPLETED" ? DateTime.UtcNow.AddMinutes(-1) : null,
+        };
+        _db.SyncBridgeLoadBatches.Add(b);
+        await _db.SaveChangesAsync();
+        return b.LoadBatchId;
+    }
+
+    private async Task SeedTruthAsync(
+        Guid countyId,
+        long objectId,
+        Guid promotionBatchId,
+        string? apn = "100-001",
+        double areaSqFt = 1000.0)
+    {
+        _db.TruthArcGisParcelGeomCurrents.Add(new TruthArcGisParcelGeomCurrent
+        {
+            CountyId = countyId,
+            ArcGisObjectId = objectId,
+            ArcGisApn = apn,
+            GeomWkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            CentroidLat = 46.21,
+            CentroidLon = -119.13,
+            AreaSqFt = areaSqFt,
+            SourceServiceUrl = "https://services.arcgis.com/test/Parcels/FeatureServer/0",
+            SourceLandedRowId = Guid.NewGuid(),
+            LandingLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = promotionBatchId,
+            PromotedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task<Guid> SeedTfParcelAsync(Guid countyId, string parcelNumber)
+    {
+        var p = new TfParcel
+        {
+            CountyId = countyId,
+            ParcelNumber = parcelNumber,
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(p);
+        await _db.SaveChangesAsync();
+        return p.TfParcelId;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Acceptance tests
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HappyPath_ProjectsTruthRows_WithSourceXref()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        var parcelId = await SeedTfParcelAsync(countyId, "100-001");
+        await SeedTruthAsync(countyId, 1, truthBatch, apn: "100-001");
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.TruthRowsConsidered.Should().Be(1);
+        result.RowsProjected.Should().Be(1);
+        result.ApnCrosswalkResolved.Should().Be(1);
+        result.ApnCrosswalkUnresolved.Should().Be(0);
+
+        // Canonical row written.
+        var geom = await _db.TfParcelGeoms.SingleAsync();
+        geom.CountyId.Should().Be(countyId);
+        geom.ArcGisObjectId.Should().Be(1);
+        geom.ArcGisApn.Should().Be("100-001");
+        geom.TfParcelId.Should().Be(parcelId,
+            "APN '100-001' resolved against tf_parcel.ParcelNumber");
+
+        // source_xref written with correct TfEntityType + key shape.
+        var xref = await _db.SyncBridgeSourceXrefs
+            .SingleAsync(x => x.TfEntityType == GeomEntityType);
+        xref.TfEntityId.Should().Be(geom.TfParcelGeomId);
+        using var doc = JsonDocument.Parse(xref.SourceKeyJson);
+        doc.RootElement.GetProperty("county_id").GetString().Should().Be(countyId.ToString());
+        doc.RootElement.GetProperty("arcgis_object_id").GetInt64().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UnresolvedApn_ProjectsWithNullTfParcelId()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        // No tf_parcel for "999-XYZ".
+        await SeedTruthAsync(countyId, 1, truthBatch, apn: "999-XYZ");
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.RowsProjected.Should().Be(1);
+        result.ApnCrosswalkResolved.Should().Be(0);
+        result.ApnCrosswalkUnresolved.Should().Be(1);
+
+        var geom = await _db.TfParcelGeoms.SingleAsync();
+        geom.TfParcelId.Should().BeNull(
+            "TfParcelGeom permits crosswalk-pending state per v1.0 entity schema");
+
+        var coverageGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "canonical-geom-apn-crosswalk-coverage");
+        coverageGate.Detail.Should().Contain("apnUnresolved=1");
+    }
+
+    [Fact]
+    public async Task NullApn_ProjectsWithNullTfParcelId()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch, apn: null);
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.RowsProjected.Should().Be(1);
+        result.ApnCrosswalkUnresolved.Should().Be(1);
+
+        var geom = await _db.TfParcelGeoms.SingleAsync();
+        geom.TfParcelId.Should().BeNull();
+        geom.ArcGisApn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FailedTruthBatch_RefusesProjection()
+    {
+        var countyId = Guid.NewGuid();
+        var failedBatch = await SeedTruthBatchAsync("FAILED");
+        await SeedTruthAsync(countyId, 1, failedBatch);
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.Status.Should().Be("REFUSED");
+        result.RowsProjected.Should().Be(0);
+        (await _db.TfParcelGeoms.CountAsync()).Should().Be(0);
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "canonical-geom-source-batch-completed");
+        gate.Status.Should().Be("FAIL");
+    }
+
+    [Fact]
+    public async Task EveryProjectedGeom_HasSourceXref_AndNonEmptyCountyId()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch);
+        await SeedTruthAsync(countyId, 2, truthBatch);
+        await SeedTruthAsync(countyId, 3, truthBatch);
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.RowsProjected.Should().Be(3);
+
+        // All canonical rows have CountyId.
+        var geoms = await _db.TfParcelGeoms.ToListAsync();
+        geoms.Should().AllSatisfy(g => g.CountyId.Should().NotBe(Guid.Empty));
+
+        // All canonical rows have a source_xref.
+        var geomIds = geoms.Select(g => g.TfParcelGeomId).ToList();
+        var xrefIds = await _db.SyncBridgeSourceXrefs
+            .Where(x => x.TfEntityType == GeomEntityType
+                        && geomIds.Contains(x.TfEntityId))
+            .Select(x => x.TfEntityId)
+            .ToListAsync();
+        xrefIds.Should().HaveCount(3);
+        xrefIds.Should().BeEquivalentTo(geomIds);
+
+        // Source-xref-coverage + county-isolation gates PASS.
+        var xrefGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "canonical-geom-source-xref-coverage");
+        xrefGate.Status.Should().Be("PASS");
+        var isolationGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "canonical-geom-county-isolation");
+        isolationGate.Status.Should().Be("PASS");
+    }
+
+    [Fact]
+    public async Task FiveCStarGatesEmitted_OnSuccess()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch);
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(5);
+        gates.Should().AllSatisfy(g => g.GateStage.Should().Be("TRUTH_TO_CANONICAL"));
+        gates.Select(g => g.GateName).Should().BeEquivalentTo(new[]
+        {
+            "canonical-geom-source-batch-completed",
+            "canonical-geom-source-xref-coverage",
+            "canonical-geom-county-isolation",
+            "canonical-geom-apn-crosswalk-coverage",
+            "canonical-geom-aggregate",
+        });
+    }
+
+    [Fact]
+    public async Task RerunSameCounty_ClearsPriorCanonical_AndRePromotes()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch);
+        await SeedTruthAsync(countyId, 2, truthBatch);
+
+        var run1 = await BuildService().ProjectCountyAsync(countyId, "d3-run1");
+        run1.RowsProjected.Should().Be(2);
+        run1.PriorCanonicalRowsRemoved.Should().Be(0);
+
+        var run2 = await BuildService().ProjectCountyAsync(countyId, "d3-run2");
+        run2.RowsProjected.Should().Be(2);
+        run2.PriorCanonicalRowsRemoved.Should().Be(2,
+            "second run cleans up the 2 canonical rows from run 1 before re-inserting");
+
+        // Final state: 2 canonical rows, no duplicates.
+        (await _db.TfParcelGeoms.CountAsync()).Should().Be(2);
+        (await _db.SyncBridgeSourceXrefs
+            .CountAsync(x => x.TfEntityType == GeomEntityType)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CountyIsolation_ProjectingOne_DoesNotTouchOther()
+    {
+        var benton = Guid.NewGuid();
+        var franklin = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(benton, 1, truthBatch, apn: "benton-1");
+        await SeedTruthAsync(benton, 2, truthBatch, apn: "benton-2");
+        await SeedTruthAsync(franklin, 1, truthBatch, apn: "franklin-1");
+
+        var bentonRun = await BuildService().ProjectCountyAsync(benton, "d3-test");
+        bentonRun.RowsProjected.Should().Be(2);
+
+        var franklinRun = await BuildService().ProjectCountyAsync(franklin, "d3-test");
+        franklinRun.RowsProjected.Should().Be(1);
+        franklinRun.PriorCanonicalRowsRemoved.Should().Be(0,
+            "projecting Franklin must NOT clear Benton's canonical rows");
+
+        (await _db.TfParcelGeoms.CountAsync()).Should().Be(3);
+        (await _db.TfParcelGeoms.CountAsync(g => g.CountyId == benton)).Should().Be(2);
+        (await _db.TfParcelGeoms.CountAsync(g => g.CountyId == franklin)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EmptyCounty_ProjectsCleanly_FivePassGates()
+    {
+        var countyId = Guid.NewGuid();
+        // No truth rows for this county.
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.TruthRowsConsidered.Should().Be(0);
+        result.RowsProjected.Should().Be(0);
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(5);
+        gates.Should().OnlyContain(g => g.Status != "FAIL");
+    }
+
+    [Fact]
+    public async Task AggregateGate_RecordsAreaSum()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch, areaSqFt: 1500.5);
+        await SeedTruthAsync(countyId, 2, truthBatch, areaSqFt: 2500.25);
+        await SeedTruthAsync(countyId, 3, truthBatch, areaSqFt: 1000.0);
+
+        var result = await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        result.AreaSqFtSum.Should().BeApproximately(5000.75, 0.01);
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "canonical-geom-aggregate");
+        gate.Detail.Should().Contain("projected=3");
+        gate.Detail.Should().Contain("areaSqFtSum=5000.75");
+    }
+
+    [Fact]
+    public async Task SourceXref_UsesGeomParcelEntityType_Per_v1_8()
+    {
+        var countyId = Guid.NewGuid();
+        var truthBatch = await SeedTruthBatchAsync();
+        await SeedTruthAsync(countyId, 1, truthBatch);
+
+        await BuildService().ProjectCountyAsync(countyId, "d3-test");
+
+        // The v1.8 contract adds "geom_parcel" to the closed
+        // TfEntityType vocabulary. Confirm the projector uses it
+        // (and only it).
+        var xrefs = await _db.SyncBridgeSourceXrefs.ToListAsync();
+        xrefs.Should().NotBeEmpty();
+        xrefs.Should().OnlyContain(x => x.TfEntityType == "geom_parcel");
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/D4ReadModelEndToEndTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/D4ReadModelEndToEndTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthArcGis;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.GisTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.GisTf;
+
+/// <summary>
+/// Slice D4: read-model end-to-end verification.
+///
+/// <para>Per Block-D execution plan §3.4: confirms that a row
+/// projected through the v1.8 doctrine pipeline (D3 canonical
+/// projector) is reachable via the existing
+/// <see cref="ParcelGeometryReader"/> read path. This is the
+/// operational closure of Block D — proves that the doctrine
+/// pipeline produces canonical state that downstream consumers
+/// can actually query.</para>
+///
+/// <para>The existing
+/// <see cref="ParcelGeometryControllerTests"/> covers the
+/// controller's contract (200/400/403/404 plus cross-county
+/// isolation). D4 adds one integration-shaped test that
+/// exercises the full <c>truth_arcgis → D3 → tf_parcel_geom →
+/// ParcelGeometryReader</c> path end-to-end, validating that
+/// the v1.8 retirement of the legacy BackgroundService doesn't
+/// regress the read-model surface.</para>
+/// </summary>
+public sealed class D4ReadModelEndToEndTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public D4ReadModelEndToEndTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"d4-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task D3Projection_FlowsThroughReader_ToReturnGeometry()
+    {
+        // ── Arrange: seed a tf_parcel with an APN. ──
+        var countyId = Guid.NewGuid();
+        var parcel = new TfParcel
+        {
+            CountyId = countyId,
+            ParcelNumber = "100-001",
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(parcel);
+        await _db.SaveChangesAsync();
+
+        // Seed a truth_arcgis row with the matching APN.
+        var truthBatch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-truth-promoter",
+            SourceFileOrDatabase = "test",
+            SourceQueryHash = "qh",
+            Operator = "test",
+            Status = "COMPLETED",
+            StartedAt = DateTime.UtcNow.AddMinutes(-5),
+            CompletedAt = DateTime.UtcNow.AddMinutes(-1),
+        };
+        _db.SyncBridgeLoadBatches.Add(truthBatch);
+        await _db.SaveChangesAsync();
+
+        _db.TruthArcGisParcelGeomCurrents.Add(new TruthArcGisParcelGeomCurrent
+        {
+            CountyId = countyId,
+            ArcGisObjectId = 42,
+            ArcGisApn = "100-001",
+            GeomWkt = "POLYGON((0 0,10 0,10 10,0 10,0 0))",
+            CentroidLat = 46.21,
+            CentroidLon = -119.13,
+            AreaSqFt = 100.0,
+            SourceServiceUrl = "https://services.arcgis.com/test/Parcels/FeatureServer/0",
+            SourceLandedRowId = Guid.NewGuid(),
+            LandingLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = truthBatch.LoadBatchId,
+            PromotedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        // ── Act: D3 canonical projection. ──
+        var projector = new ArcGisCanonicalProjector(
+            _db, NullLogger<ArcGisCanonicalProjector>.Instance);
+        var projectionResult = await projector.ProjectCountyAsync(countyId, "d4-test");
+
+        projectionResult.Status.Should().Be("COMPLETED");
+        projectionResult.RowsProjected.Should().Be(1);
+        projectionResult.ApnCrosswalkResolved.Should().Be(1,
+            "the APN '100-001' must crosswalk to tf_parcel via ParcelNumber");
+
+        // ── Assert: the read-model returns the geometry. ──
+        var reader = new ParcelGeometryReader(_db);
+        var lookup = await reader.GetGeometryAsync(parcel.TfParcelId);
+
+        lookup.Kind.Should().Be(
+            TerraFusion.Core.GIS.ArcGisRest.ParcelGeometryLookupKind.Found,
+            "D3 projection populated TfParcelId; reader must surface the geometry");
+        lookup.CountyId.Should().Be(countyId);
+        lookup.Payload.Should().NotBeNull();
+        lookup.Payload!.TfParcelId.Should().Be(parcel.TfParcelId);
+        lookup.Payload.GeomWkt.Should().Be("POLYGON((0 0,10 0,10 10,0 10,0 0))");
+        lookup.Payload.CentroidLat.Should().Be(46.21);
+        lookup.Payload.CentroidLon.Should().Be(-119.13);
+        lookup.Payload.AreaSqFt.Should().Be(100.0);
+        lookup.Payload.IsActive.Should().BeTrue();
+        lookup.Payload.SourceServiceUrl.Should()
+            .Be("https://services.arcgis.com/test/Parcels/FeatureServer/0");
+    }
+
+    [Fact]
+    public async Task UnresolvedApn_DoesNotSurface_ViaReader()
+    {
+        // When D3 projects with TfParcelId = null (APN crosswalk
+        // failed), the reader's TfParcelId-keyed lookup must NOT
+        // surface those rows. They live in tf_parcel_geom but
+        // can only be reached by direct (CountyId, ArcGisObjectId)
+        // queries (which are not in the read-model surface today).
+        var countyId = Guid.NewGuid();
+
+        // tf_parcel exists for "100-001" but the truth_arcgis row
+        // points at "999-XYZ" — no crosswalk match.
+        var parcel = new TfParcel
+        {
+            CountyId = countyId,
+            ParcelNumber = "100-001",
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(parcel);
+        await _db.SaveChangesAsync();
+
+        var truthBatch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-truth-promoter",
+            SourceFileOrDatabase = "test",
+            SourceQueryHash = "qh",
+            Operator = "test",
+            Status = "COMPLETED",
+            StartedAt = DateTime.UtcNow.AddMinutes(-5),
+            CompletedAt = DateTime.UtcNow.AddMinutes(-1),
+        };
+        _db.SyncBridgeLoadBatches.Add(truthBatch);
+        await _db.SaveChangesAsync();
+
+        _db.TruthArcGisParcelGeomCurrents.Add(new TruthArcGisParcelGeomCurrent
+        {
+            CountyId = countyId,
+            ArcGisObjectId = 42,
+            ArcGisApn = "999-XYZ", // not in tf_parcel
+            GeomWkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            CentroidLat = 46.21,
+            CentroidLon = -119.13,
+            AreaSqFt = 1.0,
+            SourceServiceUrl = "https://services.arcgis.com/test/Parcels/FeatureServer/0",
+            SourceLandedRowId = Guid.NewGuid(),
+            LandingLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = truthBatch.LoadBatchId,
+            PromotedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var projector = new ArcGisCanonicalProjector(
+            _db, NullLogger<ArcGisCanonicalProjector>.Instance);
+        var projectionResult = await projector.ProjectCountyAsync(countyId, "d4-test");
+
+        projectionResult.RowsProjected.Should().Be(1);
+        projectionResult.ApnCrosswalkResolved.Should().Be(0);
+        projectionResult.ApnCrosswalkUnresolved.Should().Be(1);
+
+        // Reader for the existing tf_parcel returns NoGeometry —
+        // the projected geom row has TfParcelId = null and is not
+        // linked to this parcel.
+        var reader = new ParcelGeometryReader(_db);
+        var lookup = await reader.GetGeometryAsync(parcel.TfParcelId);
+
+        lookup.Kind.Should().Be(
+            TerraFusion.Core.GIS.ArcGisRest.ParcelGeometryLookupKind.NoGeometry,
+            "unresolved-crosswalk geom rows are NOT exposed via the parcel-keyed read model; " +
+            "they're operationally visible only as a coverage-gate metric until a future " +
+            "crosswalk-pass slice closes them");
+        lookup.CountyId.Should().Be(countyId);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/LegacyArcGisSyncOptionsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/LegacyArcGisSyncOptionsTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Configuration;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.GisTf;
+
+/// <summary>
+/// Slice D3 acceptance tests for
+/// <see cref="LegacyArcGisSyncOptions"/>.
+///
+/// <para>Per Block-D contract v1.8: the legacy
+/// <c>TerraFusion.API.Services.ArcGisSyncService</c>
+/// BackgroundService must NOT be registered by default. The
+/// canonical path is the
+/// D1→D2→D3 doctrine pipeline. Legacy can be re-enabled for
+/// emergency rollback by explicit operator opt-in via either
+/// the <c>LegacyArcGisSync:Enabled</c> config key or the
+/// <c>TF_ENABLE_LEGACY_ARCGIS_SYNC</c> environment variable.</para>
+///
+/// <para>These tests verify the options-class behavior + the
+/// configuration-binding contract. The actual DI registration
+/// happens in <c>Program.cs</c> (host-level wiring is exercised
+/// at runtime, not in unit tests); the contract here ensures
+/// that whatever Program.cs reads, the default is <c>false</c>.</para>
+/// </summary>
+public sealed class LegacyArcGisSyncOptionsTests
+{
+    [Fact]
+    public void Default_Enabled_IsFalse()
+    {
+        var options = new LegacyArcGisSyncOptions();
+        options.Enabled.Should().BeFalse(
+            "Block-D contract v1.8 disables the legacy path by default");
+    }
+
+    [Fact]
+    public void SectionName_IsLegacyArcGisSync()
+    {
+        // The contract pins the config-section name. Renaming
+        // it requires a v2 contract bump.
+        LegacyArcGisSyncOptions.SectionName.Should().Be("LegacyArcGisSync");
+    }
+
+    [Fact]
+    public void Bind_FromConfiguration_ReadsEnabledTrue()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["LegacyArcGisSync:Enabled"] = "true",
+            })
+            .Build();
+
+        var options = new LegacyArcGisSyncOptions();
+        configuration.GetSection(LegacyArcGisSyncOptions.SectionName).Bind(options);
+
+        options.Enabled.Should().BeTrue(
+            "explicit operator opt-in via config must flip the flag");
+    }
+
+    [Fact]
+    public void Bind_FromConfiguration_DefaultsFalseWhenSectionAbsent()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var options = new LegacyArcGisSyncOptions();
+        configuration.GetSection(LegacyArcGisSyncOptions.SectionName).Bind(options);
+
+        options.Enabled.Should().BeFalse(
+            "absent config section must leave the default-false intact");
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.GIS.ArcGisRest;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.LegacyArcGisRaw;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.LegacyArcGisRaw;
+
+/// <summary>
+/// Slice D1 acceptance tests. Proves the four R-* gates and the
+/// doctrine invariants for raw ArcGIS landing:
+///  - LoadBatch records SourceFamily = ARCGIS_REST
+///  - every landed row carries LoadBatchId + SourceQueryHash + SourceRowHash
+///  - duplicate (CountyId, ArcGisObjectId) tuples surface via the
+///    key-uniqueness gate
+///  - empty FeatureService responses still complete cleanly with
+///    PASS gates
+///  - aggregate gate sums AreaSqFt
+///  - a transport failure from the G1-C client closes the batch as
+///    FAILED with an error summary, no rows landed
+///  - re-running with the same county creates a new LoadBatch
+///    (different GUID); old batches are NOT cleared (truth-promotion
+///    handles latest-wins)
+/// </summary>
+public sealed class ArcGisRawLandingServiceTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public ArcGisRawLandingServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"d1-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ArcGisRawLandingService BuildService(IArcGisFeatureServiceClient client)
+        => new(_db, client, NullLogger<ArcGisRawLandingService>.Instance);
+
+    private static ArcGisParcelFeature Feature(
+        Guid countyId, long objectId,
+        string? apn = "1234-001",
+        string? geomWkt = null,
+        double centroidLat = 46.21,
+        double centroidLon = -119.13,
+        double areaSqFt = 8500.0,
+        string serviceUrl = "https://services.arcgis.com/test/Parcels/FeatureServer/0")
+    {
+        return new ArcGisParcelFeature
+        {
+            CountyId = countyId,
+            ArcGisObjectId = objectId,
+            ArcGisApn = apn,
+            GeomWkt = geomWkt ??
+                "POLYGON((-119.13 46.21,-119.12 46.21,-119.12 46.22,-119.13 46.22,-119.13 46.21))",
+            CentroidLat = centroidLat,
+            CentroidLon = centroidLon,
+            AreaSqFt = areaSqFt,
+            SourceServiceUrl = serviceUrl,
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Acceptance tests
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HappyPath_LandsAllFeatures_WithFullProvenance()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1, apn: "100-001"),
+            Feature(countyId, 2, apn: "100-002"),
+            Feature(countyId, 3, apn: "100-003"));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.FeaturesConsidered.Should().Be(3);
+        result.FeaturesLanded.Should().Be(3);
+        result.DuplicateObjectIds.Should().Be(0);
+
+        var landed = await _db.LegacyArcGisRawParcelGeoms.ToListAsync();
+        landed.Should().HaveCount(3);
+        landed.Should().AllSatisfy(r =>
+        {
+            r.LoadBatchId.Should().NotBe(Guid.Empty);
+            r.SourceQueryHash.Should().NotBeNullOrEmpty();
+            r.SourceRowHash.Should().NotBeNullOrEmpty();
+            r.SourceRowHash.Length.Should().Be(16,
+                "row hash is SHA-256 truncated to 16 hex chars per D0 spec");
+            r.CountyId.Should().Be(countyId);
+        });
+        landed.Select(r => r.ArcGisObjectId).Should().BeEquivalentTo(new long[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task LoadBatch_CarriesArcGisRestSourceFamily()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(Feature(countyId, 1));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        var batch = await _db.SyncBridgeLoadBatches.SingleAsync();
+        batch.LoadBatchId.Should().Be(result.LoadBatchId);
+        batch.SourceFamily.Should().Be(SourceFamilies.ArcGisRest,
+            "D1 LoadBatch must use SourceFamily = ARCGIS_REST per the v1.0 doctrine");
+        batch.Status.Should().Be("COMPLETED");
+        SourceFamilies.IsKnown(batch.SourceFamily).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LandedRows_PreserveAllFeatureFields_Verbatim()
+    {
+        var countyId = Guid.NewGuid();
+        var feature = Feature(
+            countyId,
+            objectId: 42,
+            apn: "ABC-001-002",
+            geomWkt: "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+            centroidLat: 46.5,
+            centroidLon: -119.25,
+            areaSqFt: 12345.67);
+        var client = new FakeClient(feature);
+
+        await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        var landed = await _db.LegacyArcGisRawParcelGeoms.SingleAsync();
+        landed.ArcGisObjectId.Should().Be(42);
+        landed.ArcGisApn.Should().Be("ABC-001-002");
+        landed.GeomWkt.Should().Be("POLYGON((0 0,1 0,1 1,0 1,0 0))");
+        landed.CentroidLat.Should().Be(46.5);
+        landed.CentroidLon.Should().Be(-119.25);
+        landed.AreaSqFt.Should().Be(12345.67);
+        landed.SourceServiceUrl.Should()
+            .Be("https://services.arcgis.com/test/Parcels/FeatureServer/0");
+    }
+
+    [Fact]
+    public async Task NullApn_LandsAsNull_NotEmptyString()
+    {
+        // Some county FeatureServices don't expose an APN attribute.
+        // The landing layer must preserve null verbatim (D3 will
+        // quarantine the resulting canonical row).
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(Feature(countyId, 1, apn: null));
+
+        await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        var landed = await _db.LegacyArcGisRawParcelGeoms.SingleAsync();
+        landed.ArcGisApn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DuplicateObjectIds_FailsKeyUniquenessGate()
+    {
+        // The G1-C client should never emit duplicates within a
+        // single response — but if it does, the gate catches it
+        // before downstream layers compound the error.
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1),
+            Feature(countyId, 1, apn: "duplicate-of-1"),
+            Feature(countyId, 2));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.FeaturesConsidered.Should().Be(3);
+        result.FeaturesLanded.Should().Be(3);
+        result.DuplicateObjectIds.Should().Be(1,
+            "ObjectId=1 appears twice; one duplicate violation");
+
+        var keyGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-raw-key-uniqueness");
+        keyGate.Status.Should().Be("FAIL");
+        keyGate.Actual.Should().Be("1");
+        keyGate.Detail.Should().Contain("appeared more than once");
+    }
+
+    [Fact]
+    public async Task SameObjectId_DifferentCounties_IsAllowed()
+    {
+        // ObjectIDs are per-service. Same number in different
+        // counties is a different physical feature; the gate must
+        // not fire.
+        var benton = Guid.NewGuid();
+        var franklin = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(benton, 1, apn: "benton-1"),
+            Feature(franklin, 1, apn: "franklin-1"));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(benton, "d1-test");
+
+        result.DuplicateObjectIds.Should().Be(0,
+            "(benton,1) and (franklin,1) are distinct natural keys");
+
+        var keyGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-raw-key-uniqueness");
+        keyGate.Status.Should().Be("PASS");
+    }
+
+    [Fact]
+    public async Task EmptyResponse_LandsZeroRows_AllGatesPass()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(/* no features */);
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.FeaturesConsidered.Should().Be(0);
+        result.FeaturesLanded.Should().Be(0);
+
+        (await _db.LegacyArcGisRawParcelGeoms.CountAsync()).Should().Be(0);
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.LoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(4);
+        gates.Should().OnlyContain(g => g.Status != "FAIL");
+        gates.Select(g => g.GateName).Should().BeEquivalentTo(new[]
+        {
+            "arcgis-raw-source-batch-completed",
+            "arcgis-raw-key-uniqueness",
+            "arcgis-raw-provenance-coverage",
+            "arcgis-raw-aggregate",
+        });
+    }
+
+    [Fact]
+    public async Task AllFourRStarGatesEmitted_OnSuccess()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1, areaSqFt: 1000.0),
+            Feature(countyId, 2, areaSqFt: 2000.0));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.LoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(4);
+        gates.Should().AllSatisfy(g =>
+        {
+            g.GateStage.Should().Be("SOURCE_TO_RAW");
+            g.LoadBatchId.Should().Be(result.LoadBatchId);
+        });
+    }
+
+    [Fact]
+    public async Task AggregateGate_RecordsAreaSqFtSum()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1, areaSqFt: 1500.5),
+            Feature(countyId, 2, areaSqFt: 2500.25),
+            Feature(countyId, 3, areaSqFt: 1000.0));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        result.AreaSqFtSum.Should().BeApproximately(5000.75, 0.01);
+
+        var aggregate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-raw-aggregate");
+        aggregate.Status.Should().Be("PASS");
+        aggregate.Detail.Should().Contain("considered=3");
+        aggregate.Detail.Should().Contain("landed=3");
+        aggregate.Detail.Should().Contain("areaSqFtSum=5000.75");
+    }
+
+    [Fact]
+    public async Task ProvenanceCoverageGate_PassesWhenAllRowsHaveAllThreeProvenanceFields()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1),
+            Feature(countyId, 2));
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-raw-provenance-coverage");
+        gate.Status.Should().Be("PASS");
+        gate.Actual.Should().Be("0");
+        gate.Detail.Should().Contain("all 2 landed rows");
+    }
+
+    [Fact]
+    public async Task TransportFailure_ClosesBatchAsFailed_LandsZeroRows()
+    {
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(throwOnFetch: true);
+
+        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test");
+
+        result.Status.Should().Be("FAILED");
+        result.FeaturesConsidered.Should().Be(0);
+        result.FeaturesLanded.Should().Be(0);
+        result.ErrorSummary.Should().Contain("ArcGisFeatureServiceTransportException");
+
+        var batch = await _db.SyncBridgeLoadBatches.SingleAsync();
+        batch.Status.Should().Be("FAILED");
+        batch.ErrorSummary.Should().NotBeNullOrEmpty();
+        (await _db.LegacyArcGisRawParcelGeoms.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RerunSameCounty_CreatesNewBatch_DoesNotClearOldRows()
+    {
+        // D1's idempotency model is "new batch every run, old rows
+        // stay in place; D2 collapses to latest". Verify both batches
+        // produce rows + both batches close cleanly.
+        var countyId = Guid.NewGuid();
+        var client = new FakeClient(
+            Feature(countyId, 1, apn: "100-001"),
+            Feature(countyId, 2, apn: "100-002"));
+
+        var run1 = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-run1");
+        var run2 = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-run2");
+
+        run1.LoadBatchId.Should().NotBe(run2.LoadBatchId,
+            "every run gets a fresh batch id");
+
+        // Both runs landed 2 rows each → 4 total in raw.
+        (await _db.LegacyArcGisRawParcelGeoms.CountAsync()).Should().Be(4);
+
+        // Each (CountyId, ArcGisObjectId, LoadBatchId) is unique
+        // (the natural-key invariant), but (CountyId, ArcGisObjectId)
+        // appears twice — once per batch.
+        var batchCounts = await _db.LegacyArcGisRawParcelGeoms
+            .GroupBy(r => r.LoadBatchId)
+            .Select(g => g.Count())
+            .ToListAsync();
+        batchCounts.Should().BeEquivalentTo(new[] { 2, 2 });
+
+        // Both batches closed COMPLETED.
+        var statuses = await _db.SyncBridgeLoadBatches
+            .Select(b => b.Status)
+            .ToListAsync();
+        statuses.Should().AllBeEquivalentTo("COMPLETED");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Test doubles
+    // ─────────────────────────────────────────────────────────────────
+
+    private sealed class FakeClient : IArcGisFeatureServiceClient
+    {
+        private readonly IReadOnlyList<ArcGisParcelFeature> _features;
+        private readonly bool _throwOnFetch;
+
+        public FakeClient(params ArcGisParcelFeature[] features)
+        {
+            _features = features;
+            _throwOnFetch = false;
+        }
+
+        public FakeClient(bool throwOnFetch)
+        {
+            _features = Array.Empty<ArcGisParcelFeature>();
+            _throwOnFetch = throwOnFetch;
+        }
+
+        public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
+            Guid countyId,
+            CancellationToken cancellationToken = default)
+        {
+            if (_throwOnFetch)
+            {
+                throw new ArcGisFeatureServiceTransportException(
+                    "simulated transport failure for D1 acceptance test");
+            }
+            return Task.FromResult(_features);
+        }
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/TruthArcGis/ArcGisTruthPromotionServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthArcGis/ArcGisTruthPromotionServiceTests.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.LegacyArcGisRaw;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.TruthArcGis;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.TruthArcGis;
+
+/// <summary>
+/// Slice D2 acceptance tests. Proves the four T-* gates and the
+/// truth-promotion doctrine invariants for ArcGIS parcel geometry:
+///  - source-batches-completed: refuse promotion when any
+///    contributing landing batch is FAILED / IN_PROGRESS
+///  - latest-per-(CountyId, ArcGisObjectId) collapse: only the
+///    most-recent landing wins
+///  - geometry-validity: invalid WKT does not promote
+///  - aggregate: counts + AreaSqFt sum match expectation
+///  - idempotent on rerun: prior truth rows for the county clear
+///  - county isolation: promoting one county does not touch the
+///    other's truth rows
+/// </summary>
+public sealed class ArcGisTruthPromotionServiceTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public ArcGisTruthPromotionServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"d2-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ArcGisTruthPromotionService BuildService()
+        => new(_db, NullLogger<ArcGisTruthPromotionService>.Instance);
+
+    private async Task<Guid> SeedLandingBatchAsync(string status = "COMPLETED")
+    {
+        var b = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-feature-service",
+            SourceFileOrDatabase = "test",
+            SourceQueryHash = "qh",
+            Operator = "test",
+            Status = status,
+            StartedAt = DateTime.UtcNow.AddMinutes(-5),
+            CompletedAt = status == "COMPLETED" ? DateTime.UtcNow.AddMinutes(-1) : null,
+        };
+        _db.SyncBridgeLoadBatches.Add(b);
+        await _db.SaveChangesAsync();
+        return b.LoadBatchId;
+    }
+
+    private async Task SeedRawAsync(
+        Guid countyId,
+        long objectId,
+        Guid landingBatchId,
+        string? wkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+        double areaSqFt = 1000.0,
+        string? apn = "100-001")
+    {
+        _db.LegacyArcGisRawParcelGeoms.Add(new LegacyArcGisRawParcelGeom
+        {
+            CountyId = countyId,
+            ArcGisObjectId = objectId,
+            ArcGisApn = apn,
+            GeomWkt = wkt ?? string.Empty,
+            CentroidLat = 46.21,
+            CentroidLon = -119.13,
+            AreaSqFt = areaSqFt,
+            SourceServiceUrl = "https://services.arcgis.com/test/Parcels/FeatureServer/0",
+            LoadBatchId = landingBatchId,
+            SourceQueryHash = "qh",
+            SourceRowHash = "0123456789abcdef",
+            LandedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Acceptance tests
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HappyPath_PromotesAllRawTuples_WithLineage()
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing);
+        await SeedRawAsync(countyId, 2, landing);
+        await SeedRawAsync(countyId, 3, landing);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.TuplesConsidered.Should().Be(3);
+        result.RowsPromoted.Should().Be(3);
+        result.InvalidGeometrySkipped.Should().Be(0);
+        result.PriorTruthRowsRemoved.Should().Be(0);
+
+        var truth = await _db.TruthArcGisParcelGeomCurrents.ToListAsync();
+        truth.Should().HaveCount(3);
+        truth.Should().AllSatisfy(t =>
+        {
+            t.CountyId.Should().Be(countyId);
+            t.LandingLoadBatchId.Should().Be(landing);
+            t.PromotionLoadBatchId.Should().Be(result.PromotionLoadBatchId);
+            t.SourceLandedRowId.Should().NotBe(Guid.Empty);
+        });
+    }
+
+    [Fact]
+    public async Task LatestLandingWins_SameTuple_ReplacesEarlier()
+    {
+        var countyId = Guid.NewGuid();
+        var oldBatch = await SeedLandingBatchAsync();
+        await Task.Delay(10);
+        var newBatch = await SeedLandingBatchAsync();
+
+        // Same OBJECTID landed in both batches — newer should win.
+        await SeedRawAsync(countyId, 1, oldBatch, areaSqFt: 1000.0);
+        await SeedRawAsync(countyId, 1, newBatch, areaSqFt: 5000.0);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.RowsPromoted.Should().Be(1,
+            "latest-per-tuple collapse: only the newer landing wins");
+
+        var truth = await _db.TruthArcGisParcelGeomCurrents.SingleAsync();
+        truth.AreaSqFt.Should().Be(5000.0,
+            "the AreaSqFt from the LATER landing was selected");
+        truth.LandingLoadBatchId.Should().Be(newBatch);
+    }
+
+    [Fact]
+    public async Task FailedLandingBatch_RefusesPromotion()
+    {
+        var countyId = Guid.NewGuid();
+        var failedBatch = await SeedLandingBatchAsync("FAILED");
+        await SeedRawAsync(countyId, 1, failedBatch);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.Status.Should().Be("REFUSED");
+        result.RowsPromoted.Should().Be(0);
+        result.ErrorSummary.Should().Contain("FAILED");
+
+        (await _db.TruthArcGisParcelGeomCurrents.CountAsync()).Should().Be(0);
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-truth-source-batches-completed");
+        gate.Status.Should().Be("FAIL");
+    }
+
+    [Fact]
+    public async Task InvalidGeometry_NotPromoted_RawPreserved()
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing); // valid
+        await SeedRawAsync(countyId, 2, landing, wkt: ""); // empty WKT
+        await SeedRawAsync(countyId, 3, landing,
+            wkt: "GIBBERISH 1 2 3"); // bad shape
+        await SeedRawAsync(countyId, 4, landing); // valid
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.TuplesConsidered.Should().Be(4);
+        result.RowsPromoted.Should().Be(2);
+        result.InvalidGeometrySkipped.Should().Be(2);
+
+        // Raw rows stay in place for audit.
+        (await _db.LegacyArcGisRawParcelGeoms.CountAsync()).Should().Be(4);
+
+        // Truth has only the valid two.
+        (await _db.TruthArcGisParcelGeomCurrents.CountAsync()).Should().Be(2);
+
+        var validityGate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-truth-geometry-validity");
+        validityGate.Status.Should().Be("FAIL");
+        validityGate.Actual.Should().Be("2");
+    }
+
+    [Theory]
+    [InlineData("POLYGON((0 0,1 0,1 1,0 1,0 0))")]
+    [InlineData("polygon((0 0,1 0,1 1,0 1,0 0))")] // case-insensitive
+    [InlineData("MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)))")]
+    public async Task ValidGeometryShapes_AllPromote(string wkt)
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing, wkt: wkt);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.RowsPromoted.Should().Be(1);
+        result.InvalidGeometrySkipped.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("null")]
+    [InlineData("POLYGON")] // header only
+    [InlineData("POLYGON((0 0))")] // not enough vertices
+    [InlineData("POINT(0 0)")] // wrong shape type
+    public async Task InvalidWktForms_DoNotPromote(string wkt)
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing, wkt: wkt);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.RowsPromoted.Should().Be(0);
+        result.InvalidGeometrySkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RerunSameCounty_ClearsPriorTruth_AndRePromotes()
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing);
+        await SeedRawAsync(countyId, 2, landing);
+
+        var run1 = await BuildService().PromoteCountyAsync(countyId, "d2-run1");
+        run1.RowsPromoted.Should().Be(2);
+        run1.PriorTruthRowsRemoved.Should().Be(0);
+
+        var run2 = await BuildService().PromoteCountyAsync(countyId, "d2-run2");
+        run2.RowsPromoted.Should().Be(2);
+        run2.PriorTruthRowsRemoved.Should().Be(2,
+            "second run cleans up the 2 truth rows from run 1 before re-inserting");
+
+        // Final state: 2 truth rows total, all from run2.
+        var truth = await _db.TruthArcGisParcelGeomCurrents.ToListAsync();
+        truth.Should().HaveCount(2);
+        truth.Should().AllSatisfy(t =>
+            t.PromotionLoadBatchId.Should().Be(run2.PromotionLoadBatchId));
+    }
+
+    [Fact]
+    public async Task CountyIsolation_PromotingOne_DoesNotTouchOther()
+    {
+        var benton = Guid.NewGuid();
+        var franklin = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+
+        await SeedRawAsync(benton, 1, landing, apn: "benton-1");
+        await SeedRawAsync(benton, 2, landing, apn: "benton-2");
+        await SeedRawAsync(franklin, 1, landing, apn: "franklin-1");
+
+        // Promote Benton first.
+        var bentonRun = await BuildService().PromoteCountyAsync(benton, "d2-test");
+        bentonRun.RowsPromoted.Should().Be(2);
+
+        // Promote Franklin — Benton's truth must remain untouched.
+        var franklinRun = await BuildService().PromoteCountyAsync(franklin, "d2-test");
+        franklinRun.RowsPromoted.Should().Be(1);
+        franklinRun.PriorTruthRowsRemoved.Should().Be(0,
+            "promoting Franklin should NOT clear Benton's truth rows");
+
+        var allTruth = await _db.TruthArcGisParcelGeomCurrents.ToListAsync();
+        allTruth.Should().HaveCount(3,
+            "two counties should produce 3 total truth rows after both promote");
+        allTruth.Count(t => t.CountyId == benton).Should().Be(2);
+        allTruth.Count(t => t.CountyId == franklin).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EmptyCounty_PromotesCleanly_WithPassGates()
+    {
+        var countyId = Guid.NewGuid();
+        // No raw rows for this county.
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.Status.Should().Be("COMPLETED");
+        result.TuplesConsidered.Should().Be(0);
+        result.RowsPromoted.Should().Be(0);
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(4);
+        gates.Should().OnlyContain(g => g.Status != "FAIL");
+        gates.Select(g => g.GateName).Should().BeEquivalentTo(new[]
+        {
+            "arcgis-truth-source-batches-completed",
+            "arcgis-truth-latest-per-objectid",
+            "arcgis-truth-geometry-validity",
+            "arcgis-truth-aggregate",
+        });
+    }
+
+    [Fact]
+    public async Task AllFourTStarGatesEmitted_OnSuccess()
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        var gates = await _db.SyncBridgePromotionGateResults
+            .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
+            .ToListAsync();
+        gates.Should().HaveCount(4);
+        gates.Should().AllSatisfy(g =>
+        {
+            g.GateStage.Should().Be("RAW_TO_TRUTH");
+        });
+    }
+
+    [Fact]
+    public async Task AggregateGate_RecordsAreaSum()
+    {
+        var countyId = Guid.NewGuid();
+        var landing = await SeedLandingBatchAsync();
+        await SeedRawAsync(countyId, 1, landing, areaSqFt: 1500.5);
+        await SeedRawAsync(countyId, 2, landing, areaSqFt: 2500.25);
+        await SeedRawAsync(countyId, 3, landing, areaSqFt: 1000.0);
+
+        var result = await BuildService().PromoteCountyAsync(countyId, "d2-test");
+
+        result.AreaSqFtSum.Should().BeApproximately(5000.75, 0.01);
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.GateName == "arcgis-truth-aggregate");
+        gate.Detail.Should().Contain("tuplesConsidered=3");
+        gate.Detail.Should().Contain("promoted=3");
+        gate.Detail.Should().Contain("areaSqFtSum=5000.75");
+    }
+}

--- a/docs/pacs/block-c-contract-v1.8.md
+++ b/docs/pacs/block-c-contract-v1.8.md
@@ -1,0 +1,424 @@
+# Block-C Contract — v1.8 (Block-D D1+D2+D3 + Legacy Sync Retirement)
+
+**Status:** binding doctrine. Version `v1.8`. Frozen 2026-05-03.
+**Predecessor:** `docs/pacs/block-c-contract-v1.7.md` (v1.7, 2026-05-03).
+**Layer:** 3.5 of the PACS doctrine stack — same layer as v1.x.
+
+```text
+docs/pacs/block-c-contract-v1.md             (v1   — base freeze)
+docs/pacs/block-c-contract-v1.1.md           (v1.1 — dict_neighborhood)
+docs/pacs/block-c-contract-v1.2.md           (v1.2 — attribute_definition)
+docs/pacs/block-c-contract-v1.3.md           (v1.3 — nullable AttributeId FKs)
+docs/pacs/block-c-contract-v1.4.md           (v1.4 — QuarantineReasons closed vocab)
+docs/pacs/block-c-contract-v1.5.md           (v1.5 — attribute resolution semantics)
+docs/pacs/block-c-contract-v1.6.md           (v1.6 — two-layer quarantine vocabulary)
+docs/pacs/block-c-contract-v1.7.md           (v1.7 — E4c documented deferral; Block E close)
+docs/pacs/block-c-contract-v1.8.md           (v1.8 — Block-D D1+D2+D3 + legacy retirement) ← this doc
+```
+
+## 0. What v1.8 is
+
+A coordinated minor bump that records:
+
+1. **D1** raw landing (`legacy_arcgis_raw.parcel_geom`) +
+   four R-* gates.
+2. **D2** truth promotion (`truth_arcgis.parcel_geom_current`) +
+   four T-* gates including geometry validity.
+3. **D3** canonical projection (`gis_tf.tf_parcel_geom` +
+   `source_xref` with `TfEntityType="geom_parcel"`) +
+   five C-* gates including APN crosswalk coverage.
+4. **TfEntityType vocabulary addition**: `"geom_parcel"`.
+5. **Legacy retirement**: the
+   `TerraFusion.API.Services.ArcGisSyncService` BackgroundService
+   is **disabled by default** as of v1.8. The doctrine path is now
+   the only canonical writer to `gis_tf.tf_parcel_geom`.
+
+No v1.x-frozen shape is modified. `gis_tf.tf_parcel_geom` already
+existed; D3 is the first service that actually writes to it
+through the doctrine pipeline (with provenance + source_xref
+lineage). All v1.0–v1.7 contracts remain in force.
+
+## 0.5 Doctrine integrity disclosure (carry-forward + new finding)
+
+### Carry-forward
+- v1.4 corrected the canonical-layer `QuarantineReason` vocabulary
+  (NO_OWNER_XREF + BOTH_MISSING were undocumented since v1.0).
+- v1.6 corrected the landing-layer vocabulary
+  (UNKNOWN_I_ATTR_VAL_CD was undocumented).
+- v1.7 deferred E4c by declaration; closed Block E.
+
+### New finding (resolved in v1.8)
+
+The D3 pre-implementation audit discovered **two parallel
+"ArcGisSyncService" implementations** in the codebase:
+
+```text
+1. TerraFusion.Core.GIS.ArcGisRest.IArcGisSyncService  (interface)
+   Implementation:  TerraFusion.Data.Services.GisTf.ArcGisSyncService
+                    (G1-D era, scoped service)
+   Writes to:       gis_tf.tf_parcel_geom (the doctrine-canonical entity)
+   Status pre-v1.8: registered but UNUSED in the shipped flow
+
+2. TerraFusion.API.Services.ArcGisSyncService  (BackgroundService)
+   Run mode:        HostedService, polls every 6 hours
+   Hardcoded URL:   services7.arcgis.com/.../Parcels_and_Assess/FeatureServer/0
+   Writes to:       GisParcelGeometries (a SEPARATE legacy table
+                                         OUTSIDE the 5-schema doctrine)
+   Status pre-v1.8: registered by default, served as the ACTUAL data flow
+```
+
+This is the same drift pattern as v1.4 / v1.6: parallel shipping
+realities that the doctrine docs didn't acknowledge. v1.8 closes
+the gap by:
+
+- Building the D3 canonical projector that finally feeds
+  `gis_tf.tf_parcel_geom` through the doctrine pipeline.
+- Disabling the legacy BackgroundService by default (preserved
+  in code for emergency rollback only).
+- Documenting the legacy table (`GisParcelGeometries`) as
+  out-of-scope for the doctrine — to be decommissioned in a
+  separate cleanup slice once D1→D2→D3 is operationally
+  validated.
+
+The "no broken windows / no parallel truth paths" rule is now
+honored.
+
+---
+
+## 1. What changed since v1.7
+
+```text
+ADDED (new entities + tables):
+  + legacy_arcgis_raw.parcel_geom         (D1 — raw FeatureService landing)
+  + truth_arcgis.parcel_geom_current      (D2 — latest-per-tuple truth)
+  + DbSet<LegacyArcGisRawParcelGeom>      (LegacyArcGisRawParcelGeoms)
+  + DbSet<TruthArcGisParcelGeomCurrent>   (TruthArcGisParcelGeomCurrents)
+  + Migrations:
+      AddLegacyArcGisRawParcelGeom
+      AddTruthArcGisParcelGeomCurrent
+
+ADDED (new services + interfaces):
+  + IArcGisRawLandingService                (D1)
+  + ArcGisRawLandingService
+  + IArcGisTruthPromotionService            (D2)
+  + ArcGisTruthPromotionService
+  + IArcGisCanonicalProjector               (D3)
+  + ArcGisCanonicalProjector
+  + LegacyArcGisSyncOptions { Enabled = false }
+                                            (config-driven retirement flag)
+
+ADDED (new gate vocabulary):
+  + arcgis-raw-source-batch-completed       (D1, R-*)
+  + arcgis-raw-key-uniqueness               (D1, R-*)
+  + arcgis-raw-provenance-coverage          (D1, R-*)
+  + arcgis-raw-aggregate                    (D1, R-*)
+  + arcgis-truth-source-batches-completed   (D2, T-*)
+  + arcgis-truth-latest-per-objectid        (D2, T-*)
+  + arcgis-truth-geometry-validity          (D2, T-*)
+  + arcgis-truth-aggregate                  (D2, T-*)
+  + canonical-geom-source-batch-completed   (D3, C-*)
+  + canonical-geom-source-xref-coverage     (D3, C-*)
+  + canonical-geom-county-isolation         (D3, C-*)
+  + canonical-geom-apn-crosswalk-coverage   (D3, C-*)
+  + canonical-geom-aggregate                (D3, C-*)
+
+ADDED (closed-vocabulary value):
+  + TfEntityType = "geom_parcel"
+    (sync_bridge.source_xref entries written by D3)
+    SourceKeyJson shape: { "county_id": <guid>, "arcgis_object_id": <long> }
+
+CHANGED (config — operator-visible):
+  ~ "ArcGisSync:Enabled" config key (and TF_ENABLE_ARCGIS_SYNC env var)
+    RENAMED + default flipped:
+      OLD: ArcGisSync:Enabled                  (default true)
+           TF_ENABLE_ARCGIS_SYNC               (default true)
+      NEW: LegacyArcGisSync:Enabled            (default false)
+           TF_ENABLE_LEGACY_ARCGIS_SYNC        (default false)
+    Operators running under the old default will see the legacy
+    BackgroundService stop registering after v1.8 deploys. The
+    canonical D1→D2→D3 path replaces it functionally, with full
+    provenance + source_xref lineage.
+
+UNCHANGED:
+  · all v1 §§1-6 shapes
+  · all v1.1–v1.7 additive entries
+  · TfParcelGeom entity shape (v1 unchanged; D3 is the first service
+    to write through the doctrine, but adds NO new column)
+  · QuarantineReasons / LandingQuarantineReasons (v1.4 + v1.6)
+  · No new migration on TfParcelGeom; D3 uses existing schema
+```
+
+---
+
+## 2. D1 — `legacy_arcgis_raw.parcel_geom` (new in v1.8)
+
+File: `backend/src/TerraFusion.Core/Entities/LegacyArcGisRaw/LegacyArcGisRawParcelGeom.cs`
+
+```csharp
+public sealed class LegacyArcGisRawParcelGeom
+{
+    public Guid LandedRowId { get; set; }
+    public Guid CountyId { get; set; }
+    public long ArcGisObjectId { get; set; }
+    public string? ArcGisApn { get; set; }
+    public string GeomWkt { get; set; }                 // varchar(unbounded), required
+    public double CentroidLat { get; set; }
+    public double CentroidLon { get; set; }
+    public double AreaSqFt { get; set; }
+    public string SourceServiceUrl { get; set; }        // varchar(500), required
+    public Guid LoadBatchId { get; set; }               // provenance — required
+    public string SourceQueryHash { get; set; }         // varchar(64), required
+    public string SourceRowHash { get; set; }           // varchar(16), required (SHA-256 prefix)
+    public DateTime LandedAt { get; set; }
+}
+```
+
+Frozen invariants:
+- `(CountyId, ArcGisObjectId, LoadBatchId)` UNIQUE — same OBJECTID
+  re-landed in a NEW batch is a distinct row; same OBJECTID in the
+  SAME batch is a doctrine violation (R-key-uniqueness gate fails).
+- WKT-only storage (PostGIS package install deferred to a
+  Phase-2 slice).
+- Service must record `LoadBatch.SourceFamily =
+  SourceFamilies.ArcGisRest`.
+
+R-* gate vocabulary (frozen):
+- `arcgis-raw-source-batch-completed` (informational PASS)
+- `arcgis-raw-key-uniqueness` (FAIL on dup ObjectId-per-batch)
+- `arcgis-raw-provenance-coverage` (FAIL on missing LoadBatchId
+  / SourceQueryHash / SourceRowHash on any landed row)
+- `arcgis-raw-aggregate` (informational; counts + AreaSqFt sum)
+
+---
+
+## 3. D2 — `truth_arcgis.parcel_geom_current` (new in v1.8)
+
+File: `backend/src/TerraFusion.Core/Entities/TruthArcGis/TruthArcGisParcelGeomCurrent.cs`
+
+```csharp
+public sealed class TruthArcGisParcelGeomCurrent
+{
+    public Guid TruthParcelGeomId { get; set; }
+    public Guid CountyId { get; set; }
+    public long ArcGisObjectId { get; set; }
+    public string? ArcGisApn { get; set; }
+    public string GeomWkt { get; set; }
+    public double CentroidLat { get; set; }
+    public double CentroidLon { get; set; }
+    public double AreaSqFt { get; set; }
+    public string SourceServiceUrl { get; set; }
+    public Guid SourceLandedRowId { get; set; }     // FK to D1
+    public Guid LandingLoadBatchId { get; set; }    // D1 batch
+    public Guid PromotionLoadBatchId { get; set; }  // D2 batch
+    public DateTime PromotedAt { get; set; }
+}
+```
+
+Frozen invariants:
+- `(CountyId, ArcGisObjectId)` UNIQUE — only the latest landing
+  wins.
+- Geometry validity gate: WKT starts with `POLYGON` or
+  `MULTIPOLYGON` (case-insensitive), ≥ 3 coordinate pairs, has
+  `(` and `)`. Lightweight check — full topology validation is
+  Phase-2 PostGIS work.
+- Single-batch lineage (no supp_assoc analog needed for ArcGIS).
+
+T-* gate vocabulary (frozen):
+- `arcgis-truth-source-batches-completed` (FAIL on any
+  IN_PROGRESS / FAILED contributing landing batch)
+- `arcgis-truth-latest-per-objectid` (FAIL on collapse violation)
+- `arcgis-truth-geometry-validity` (FAIL on any invalid WKT
+  skipped — raw rows preserved for audit)
+- `arcgis-truth-aggregate` (informational)
+
+---
+
+## 4. D3 — `gis_tf.tf_parcel_geom` canonical projection (refactor in v1.8)
+
+File: `backend/src/TerraFusion.Data/Services/GisTf/ArcGisCanonicalProjector.cs`
+
+The existing `TfParcelGeom` entity shape is unchanged. v1.8 adds
+a NEW projector that finally writes to it through the doctrine
+pipeline:
+
+```text
+truth_arcgis.parcel_geom_current
+    │
+    ▼  ArcGisCanonicalProjector.ProjectCountyAsync(countyId)
+    │     - APN crosswalk against tf_parcel.ParcelNumber (county-isolated)
+    │     - Resolved → TfParcelId populated
+    │     - Unresolved → TfParcelId = null (crosswalk-pending)
+    │     - sync_bridge.source_xref entry written per row
+    ▼
+gis_tf.tf_parcel_geom + sync_bridge.source_xref(TfEntityType="geom_parcel")
+```
+
+Frozen `source_xref` shape for D3:
+
+```json
+{
+  "TfEntityType": "geom_parcel",
+  "SourceKeyJson": {
+    "county_id": "<guid>",
+    "arcgis_object_id": <long>
+  },
+  "SourceSystem": "ARCGIS_REST",
+  "SourceTable":  "parcel_geom"
+}
+```
+
+Frozen idempotency rule:
+- Re-running for the same county clears prior canonical rows
+  (and their `source_xref` entries) whose JSON-decoded
+  `county_id` matches, then re-inserts.
+- Cross-county isolation: projecting one county does NOT touch
+  any other county's canonical rows.
+
+C-* gate vocabulary (frozen):
+- `canonical-geom-source-batch-completed` (FAIL on any
+  IN_PROGRESS / FAILED contributing truth batch)
+- `canonical-geom-source-xref-coverage` (FAIL when any projected
+  row lacks a source_xref entry)
+- `canonical-geom-county-isolation` (FAIL on any empty CountyId)
+- `canonical-geom-apn-crosswalk-coverage` (informational; counts
+  resolved vs unresolved)
+- `canonical-geom-aggregate` (informational; counts + AreaSqFt
+  sum)
+
+---
+
+## 5. TfEntityType vocabulary — v1.8 additive
+
+```text
+v1.0   parcel | sale | improvement | land | owner | assessment_wsdor
+v1.8   + geom_parcel
+```
+
+Adding a new value remains a v1.x bump (additive). The H2
+schema-shape regression test gains a v1.8 assertion that
+`"geom_parcel"` is a recognized TfEntityType in the
+`source_xref` writes.
+
+---
+
+## 6. Legacy `ArcGisSyncService` retirement (the broken window close)
+
+### What was happening before v1.8
+
+```text
+TerraFusion.API.Services.ArcGisSyncService
+  - HostedService
+  - Hardcoded Benton FeatureServer URL
+  - 6-hour poll cycle
+  - Wrote to: GisParcelGeometries (legacy table, NOT in 5-schema doctrine)
+  - Registered by default via "ArcGisSync:Enabled" config (default: true)
+
+TfParcelGeom (the v1.0-doctrine canonical entity)
+  - Defined but UNFED — no service wrote to it through the doctrine
+  - Existed as documentation of intent, not actual operational state
+
+Result: gis data flowed through the legacy path; the doctrine path was
+hollow.
+```
+
+### What v1.8 does
+
+```text
+1. New doctrine path (D1 → D2 → D3) writes tf_parcel_geom +
+   source_xref(TfEntityType="geom_parcel") with full provenance
+   and 13 gates across 3 stages (R/T/C).
+
+2. Legacy ArcGisSyncService BackgroundService is gated behind
+   LegacyArcGisSync:Enabled (default false). Operators get a
+   clean default; rollback is one config-flip away.
+
+3. The 422-LOC BackgroundService code stays in source tree
+   (NOT deleted). The legacy GisParcelGeometries table stays
+   in the schema. Future cleanup slice can decommission both
+   after D1→D2→D3 is operationally validated.
+```
+
+### Operator-visible config rename
+
+```text
+OLD (v1.7 and earlier):
+  appsettings: "ArcGisSync:Enabled": true   (default)
+  env var:     TF_ENABLE_ARCGIS_SYNC=true   (default)
+
+NEW (v1.8):
+  appsettings: "LegacyArcGisSync:Enabled": false   (default)
+  env var:     TF_ENABLE_LEGACY_ARCGIS_SYNC=false  (default)
+```
+
+Operators running under the old default flip from "legacy
+enabled" to "legacy disabled" automatically when v1.8 deploys.
+This is the intended retirement behavior. To preserve legacy
+behavior temporarily during rollback testing:
+
+```yaml
+# appsettings.<Environment>.json
+"LegacyArcGisSync": {
+  "Enabled": true
+}
+```
+
+---
+
+## 7. Test coverage added in v1.8
+
+```text
+ArcGisRawLandingServiceTests             (12 tests, D1)
+ArcGisTruthPromotionServiceTests         (18 tests, D2)
+ArcGisCanonicalProjectorTests            (11 tests, D3)
+LegacyArcGisSyncOptionsTests             (4 tests, retirement config)
+                                         ──────────
+                                          45 new acceptance tests
+
+Doctrine band totals:
+  Pre-v1.8 (after PR #723 + Block-D base):  386 / 386 green
+  After D1:                                  398 / 398 green   (+12)
+  After D2:                                  416 / 416 green   (+18)
+  After D3 + legacy retirement:              508 / 508 green   (+92, includes
+                                                                resolution-test
+                                                                count drift from
+                                                                shared filter)
+```
+
+---
+
+## 8. What v1.8 does NOT do (carry-forward locks)
+
+```text
+- No PostGIS package install
+- No NetTopologySuite
+- No spatial index
+- No NEW column on TfParcelGeom (existing nullable TfParcelId
+  represents crosswalk-pending state)
+- No deletion of legacy ArcGisSyncService source code
+- No deletion of GisParcelGeometries table
+- No UI / dashboard work
+- No multi-county anything (still Benton-only effective scope)
+- No retry / backoff / cache fallback in D1's REST adapter
+- No incremental sync (full pull only)
+- No TfParcelGeom migration (existing schema sufficient)
+```
+
+---
+
+## 9. v1.8 doctrine frog status
+
+> The map goblin lost its fake mailbox. The doctrine path is
+> the only mailbox. The legacy BackgroundService keeps its
+> source-control pension and can be revived for rollback —
+> nothing else.
+>
+> Block D remaining work:
+>   - D4: read-models verification (existing
+>     ParcelGeometryController stays green; verify or extend
+>     for bbox/neighbor queries).
+>   - Future cleanup slice: decommission GisParcelGeometries
+>     + delete legacy ArcGisSyncService once D1→D2→D3 is
+>     operationally validated.
+>
+> After D4, Block D closes and Block F (operator dashboard
+> parity) opens — the first user-facing block.


### PR DESCRIPTION
## Summary

Closes Block D. The ArcGIS REST FeatureService data flow is now governed by the 5-schema doctrine end-to-end: raw landing → truth promotion → canonical projection → existing read endpoint, with full provenance, idempotency, county isolation, and 13 promotion gates across 3 stages.

The legacy `TerraFusion.API.Services.ArcGisSyncService` BackgroundService — which was writing to a separate non-doctrine table — is retired by default. Code preserved for emergency rollback only.

## What changed

```text
NEW DOCTRINE PATH (D1 → D2 → D3):

  ArcGIS REST FeatureService
       ↓
  legacy_arcgis_raw.parcel_geom            (D1 — verbatim landing)
       ↓
  truth_arcgis.parcel_geom_current         (D2 — latest-per-tuple + WKT validity)
       ↓
  gis_tf.tf_parcel_geom + source_xref      (D3 — APN crosswalk + canonical)
       ↓
  ParcelGeometryController                 (D4 — existing reader, now actually fed)

Each stage records its own LoadBatch with SourceFamily = ARCGIS_REST and
emits its own gates (4 R-* + 4 T-* + 5 C-*).
```

## Doctrine pipeline

| Slice | Commit | Entity / Service | Gates |
|---|---|---|---|
| D0 | `6172da4da` (in PR #723's squash, doc-only) | `docs/pacs/block-d-execution-plan.md` | — |
| D1 | `dd6949faf` | `LegacyArcGisRawParcelGeom` + `ArcGisRawLandingService` | 4 R-* |
| D2 | `6172da4da` | `TruthArcGisParcelGeomCurrent` + `ArcGisTruthPromotionService` | 4 T-* |
| D3 | `b45577275` | `ArcGisCanonicalProjector` + `LegacyArcGisSyncOptions` + v1.8 doctrine | 5 C-* |
| D4 | `5f922061a` | `D4ReadModelEndToEndTests` (e2e verification) | — |

Block-C contract bumped to **v1.8** (`docs/pacs/block-c-contract-v1.8.md`):

- Adds `TfEntityType = "geom_parcel"` to closed vocabulary
- Pins `source_xref.SourceKeyJson` shape for D3: `{ county_id, arcgis_object_id }`
- Documents legacy retirement with full operator-visible config rename
- Carries forward the v1.4 / v1.6 doctrine-integrity-disclosure pattern

## Legacy retirement (the broken-window close)

Pre-v1.8 reality: the codebase had **two parallel ArcGIS sync paths** running in parallel — the legacy `BackgroundService` writing to a non-doctrine table (`GisParcelGeometries`), while the canonical entity (`tf_parcel_geom`) sat unfed. v1.8 unifies by:

```text
1. Building the D3 canonical projector that finally feeds tf_parcel_geom
   through the doctrine.

2. Disabling the legacy BackgroundService by default via
   LegacyArcGisSyncOptions { Enabled = false }.

3. Renaming operator-visible config to make the deprecation explicit:
     OLD: "ArcGisSync:Enabled" / TF_ENABLE_ARCGIS_SYNC          (default true)
     NEW: "LegacyArcGisSync:Enabled" / TF_ENABLE_LEGACY_ARCGIS_SYNC (default false)

4. Preserving legacy code + table in source for emergency rollback.
   Future cleanup slice can decommission once operationally validated.
```

Operators on the old default automatically transition from "legacy enabled" to "legacy disabled" when v1.8 deploys. The doctrine path replaces it functionally with full provenance and source_xref lineage.

## Tests / proof gates

```text
Doctrine band:      510 / 510 green   (1.0s)
   Filter: CanonicalTf | TruthPacs | SyncBridge | Doctrine | LegacyPacsRaw |
           LegacyArcGisRaw | TruthArcGis | GisTf

New tests added in this PR (47 total):
   ArcGisRawLandingServiceTests             (12 tests, D1 R-*)
   ArcGisTruthPromotionServiceTests         (18 tests, D2 T-*)
   ArcGisCanonicalProjectorTests            (11 tests, D3 C-*)
   LegacyArcGisSyncOptionsTests             (4 tests, retirement config)
   D4ReadModelEndToEndTests                 (2 tests, doctrine→reader e2e)

Pre-commit gates:        clean on every commit
   UI token contract:    1582 / 1582 baseline (zero growth)
   dotnet format:        auto-applied
   prettier:             auto-applied on .md
```

## What this PR explicitly does NOT do

```text
✗ No PostGIS install (Phase 2 deferred per D0 non-goals)
✗ No NetTopologySuite (still WKT-only)
✗ No spatial index
✗ No deletion of legacy ArcGisSyncService source code
✗ No deletion of GisParcelGeometries table
✗ No new column on TfParcelGeom (existing nullable TfParcelId
  represents crosswalk-pending state)
✗ No incremental sync (full per-county pull only)
✗ No retry/backoff/cache fallback in D1's REST adapter
✗ No UI / dashboard work
✗ No Block F (operator dashboard parity) work
```

## Known deferrals

```text
- Future cleanup slice: decommission GisParcelGeometries table
  + delete legacy ArcGisSyncService source code, once D1→D2→D3
  is operationally validated.

- E3b: v2 BREAKING flip of AttributeId nullable → non-null
  (waits for backfill source — carry-forward from PR #723).

- E4c: tf_land attribute resolution (waits for L1-B + L1-C
  legacy_pacs_raw.land_attr landing — carry-forward from PR #723).
```

## Next block: F (operator dashboard parity)

After this merges, the next block is **F** per `docs/pacs/blocks-d-through-h-design.md` §F. F is the first user-facing block — five sub-slices that turn the operator's morning dashboard SQL queries into endpoints + panels:

```text
F1 — open work / pending appraisal queue
F2 — sales review queue (uses Block-A canonical sales)
F3 — improvement field-check queue (uses Block-C canonical improvements)
F4 — land segment exception list (uses Block-C canonical land)
F5 — neighborhood ratio study skeleton (uses E1 hood_cd dictionary)
```

F opens from a fresh branch off `main` after this PR merges. No Block F work crosses into this PR.

## Doctrine integrity disclosure

Same pattern as PR #723's v1.4 / v1.6 corrections: the codebase had two parallel ArcGIS sync paths shipping alongside each other; the doctrine docs didn't acknowledge it. The D3 pre-implementation audit caught the drift and v1.8 §0.5 + §6 document it openly. The "no broken windows / no parallel truth paths" rule is now honored.

## Test plan

- [ ] CI green (or red-from-inherited-pre-existing-state per PR #723 precedent)
- [ ] Reviewer confirms: 510/510 doctrine band passes locally
- [ ] Reviewer confirms: D3 source_xref shape uses `TfEntityType="geom_parcel"`
- [ ] Reviewer confirms: legacy ArcGisSyncService is NOT registered by default
- [ ] Reviewer confirms: existing ParcelGeometryController stays green
- [ ] Reviewer confirms: no migration on existing TfParcelGeom (D3 uses existing schema)
- [ ] Reviewer confirms: every D-block emitted-string is reachable via a constant or a
      named gate; no hardcoded magic strings in production projector code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented three-stage ArcGIS parcel geometry pipeline: raw data landing, truth promotion, and canonical projection for improved data quality and traceability.

* **Chores**
  * Legacy ArcGIS synchronization is now disabled by default. It can be re-enabled via `LegacyArcGisSync:Enabled` configuration setting if needed for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->