### PR TITLE
feat(block-g/G1): ConversionEra provenance across truth_pacs lanes

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/ConversionEras.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/ConversionEras.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.Entities.TruthPacs;
+
+/// <summary>
+/// Slice G1 (v1.10): closed vocabulary for the
+/// <c>ConversionEra</c> column on <c>truth_pacs.*</c> and (later)
+/// <c>canonical_tf.*</c> rows.
+///
+/// <para>Per the v1.0 PACS conversion caveat (acknowledged in
+/// <c>docs/pacs/block-c-contract-v1.md</c> §1, the
+/// sales-ratio-queries.md amendment, and
+/// <c>blocks-d-through-h-design.md</c> §G): Benton County's PACS
+/// instance had a data conversion event before 2017. Sales codes,
+/// improvement attributes, and assessment vocabulary captured on
+/// pre-conversion rows have semantics that may differ from
+/// post-conversion records.</para>
+///
+/// <para><b>Three frozen values:</b>
+/// <list type="bullet">
+///   <item><see cref="PreConversion2017"/> — row was captured
+///   under the pre-2017 vocabulary. Semantically distinct from
+///   post-conversion data; ratio studies and qualification
+///   transforms should treat with care.</item>
+///   <item><see cref="PostConversion"/> — row was captured under
+///   the current vocabulary. Default era for all read endpoints
+///   per v1.10 §3.</item>
+///   <item><see cref="Unknown"/> — era could not be determined
+///   from the underlying data. Reserved for canonical-layer
+///   rows whose contributing truth rows disagree. Truth-layer
+///   rows do NOT use this value because every truth row has a
+///   year column that disambiguates.</item>
+/// </list>
+/// </para>
+///
+/// <para>Adding a new era is intentionally a code change.
+/// There is no runtime extensibility hook — the vocabulary is
+/// closed by design.</para>
+/// </summary>
+public static class ConversionEras
+{
+    /// <summary>
+    /// Captured under the pre-2017 PACS vocabulary. Semantic
+    /// drift from current vocabulary; downstream consumers
+    /// should not treat the row's coded fields as if they had
+    /// post-conversion meaning.
+    /// </summary>
+    public const string PreConversion2017 = "PRE_CONVERSION_2017";
+
+    /// <summary>
+    /// Captured under the current (post-2017) vocabulary. Default
+    /// era for read endpoints per v1.10 §3.
+    /// </summary>
+    public const string PostConversion = "POST_CONVERSION";
+
+    /// <summary>
+    /// Era could not be determined. Reserved for canonical-layer
+    /// rows whose contributing truth rows disagree on era.
+    /// Truth-layer rows do not emit this value.
+    /// </summary>
+    public const string Unknown = "UNKNOWN";
+
+    /// <summary>
+    /// The conversion-cutoff year. Rows with a tax / valuation
+    /// year strictly less than this are
+    /// <see cref="PreConversion2017"/>; rows with year greater
+    /// than or equal are <see cref="PostConversion"/>.
+    /// </summary>
+    public const short CutoverYear = 2018;
+
+    /// <summary>
+    /// Computes the truth-layer era for a row based on its
+    /// year column (<c>PropValYr</c> for sales / improvements
+    /// / land / WSDOR, <c>OwnerTaxYr</c> for owners). Truth
+    /// rows always resolve to either
+    /// <see cref="PreConversion2017"/> or
+    /// <see cref="PostConversion"/>; <see cref="Unknown"/> is
+    /// reserved for canonical layer.
+    /// </summary>
+    /// <param name="year">PACS year column value (1900..2100 expected).</param>
+    public static string FromYear(short year) =>
+        year < CutoverYear ? PreConversion2017 : PostConversion;
+
+    /// <summary>
+    /// All currently-recognized era values. Any value outside
+    /// this set is a doctrine violation when written to a
+    /// <c>ConversionEra</c> column.
+    /// </summary>
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>
+    {
+        PreConversion2017,
+        PostConversion,
+        Unknown,
+    };
+
+    /// <summary>
+    /// True iff <paramref name="value"/> is a recognized era.
+    /// Use at the boundary of any code that writes to
+    /// <c>ConversionEra</c>.
+    /// </summary>
+    public static bool IsKnown(string value) =>
+        !string.IsNullOrEmpty(value) && All.Contains(value);
+}

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsImprvCurrent.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsImprvCurrent.cs
@@ -58,5 +58,14 @@ public sealed class TruthPacsImprvCurrent
     /// <summary>Truth-promotion LoadBatch (the C2 batch).</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G1 (v1.10): conversion-era marker derived from
+    /// <see cref="PropValYr"/> at promotion time. See
+    /// <see cref="ConversionEras"/>. Nullable for back-compat
+    /// with rows promoted before G1; new promotions always set
+    /// it.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsLandCurrent.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsLandCurrent.cs
@@ -61,5 +61,13 @@ public sealed class TruthPacsLandCurrent
     /// <summary>Truth-promotion LoadBatch (the L2 batch).</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G1 (v1.10): conversion-era marker derived from
+    /// <see cref="PropValYr"/> at promotion time. See
+    /// <see cref="ConversionEras"/>. Nullable for back-compat
+    /// with rows promoted before G1.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsOwnerCurrent.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsOwnerCurrent.cs
@@ -71,5 +71,12 @@ public sealed class TruthPacsOwnerCurrent
     /// <summary>Truth-promotion LoadBatch (the B2-A batch).</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G1 (v1.10): conversion-era marker derived from
+    /// <see cref="OwnerTaxYr"/> at promotion time. See
+    /// <see cref="ConversionEras"/>. Nullable for back-compat.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsSale.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsSale.cs
@@ -63,5 +63,12 @@ public sealed class TruthPacsSale
     /// <summary>Truth-promotion LoadBatch.</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G1 (v1.10): conversion-era marker derived from
+    /// <see cref="PropValYr"/> at promotion time. See
+    /// <see cref="ConversionEras"/>. Nullable for back-compat.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsWashPropOwnerVal.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsWashPropOwnerVal.cs
@@ -62,5 +62,12 @@ public sealed class TruthPacsWashPropOwnerVal
     /// <summary>Truth-promotion LoadBatch (the B2-B batch).</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G1 (v1.10): conversion-era marker derived from
+    /// <see cref="PropValYr"/> at promotion time. See
+    /// <see cref="ConversionEras"/>. Nullable for back-compat.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsImprvCurrentConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsImprvCurrentConfiguration.cs
@@ -53,5 +53,10 @@ public sealed class TruthPacsImprvCurrentConfiguration
         // Type-cd scans.
         builder.HasIndex(x => x.ImprvTypeCd)
             .HasDatabaseName("ix_truth_pacs_imprv_type");
+
+        // G1 (v1.10): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_truth_pacs_imprv_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsLandCurrentConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsLandCurrentConfiguration.cs
@@ -61,5 +61,10 @@ public sealed class TruthPacsLandCurrentConfiguration
             .HasDatabaseName("ix_truth_pacs_land_type");
         builder.HasIndex(x => x.LandSegUseCd)
             .HasDatabaseName("ix_truth_pacs_land_use");
+
+        // G1 (v1.10): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_truth_pacs_land_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsOwnerCurrentConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsOwnerCurrentConfiguration.cs
@@ -57,5 +57,10 @@ public sealed class TruthPacsOwnerCurrentConfiguration
         // Lineage lookup.
         builder.HasIndex(x => x.PromotionLoadBatchId)
             .HasDatabaseName("ix_truth_pacs_owner_current_promotion_batch");
+
+        // G1 (v1.10): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_truth_pacs_owner_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsSaleConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsSaleConfiguration.cs
@@ -53,5 +53,10 @@ public sealed class TruthPacsSaleConfiguration : IEntityTypeConfiguration<TruthP
         // Date-range scans.
         builder.HasIndex(x => x.SlDt)
             .HasDatabaseName("ix_truth_pacs_sale_sl_dt");
+
+        // G1 (v1.10): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_truth_pacs_sale_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsWashPropOwnerValConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsWashPropOwnerValConfiguration.cs
@@ -63,5 +63,10 @@ public sealed class TruthPacsWashPropOwnerValConfiguration
         // BOE status scans.
         builder.HasIndex(x => x.BoeStatus)
             .HasDatabaseName("ix_truth_pacs_wpov_boe_status");
+
+        // G1 (v1.10): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_truth_pacs_wpov_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260503075310_AddConversionEraToTruthPacs.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503075310_AddConversionEraToTruthPacs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503075310_AddConversionEraToTruthPacs")]
+    partial class AddConversionEraToTruthPacs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260503075310_AddConversionEraToTruthPacs.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503075310_AddConversionEraToTruthPacs.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConversionEraToTruthPacs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "wash_prop_owner_val",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "owner_current",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "land_current",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_wpov_conversion_era",
+                schema: "truth_pacs",
+                table: "wash_prop_owner_val",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_sale_conversion_era",
+                schema: "truth_pacs",
+                table: "sale",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_owner_conversion_era",
+                schema: "truth_pacs",
+                table: "owner_current",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_land_conversion_era",
+                schema: "truth_pacs",
+                table: "land_current",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_imprv_conversion_era",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                column: "ConversionEra");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_wpov_conversion_era",
+                schema: "truth_pacs",
+                table: "wash_prop_owner_val");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_sale_conversion_era",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_owner_conversion_era",
+                schema: "truth_pacs",
+                table: "owner_current");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_land_conversion_era",
+                schema: "truth_pacs",
+                table: "land_current");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_imprv_conversion_era",
+                schema: "truth_pacs",
+                table: "imprv_current");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "wash_prop_owner_val");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "owner_current");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "land_current");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "truth_pacs",
+                table: "imprv_current");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
@@ -156,6 +156,8 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                     ImprvLoadBatchId = imprvLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G1 (v1.10): conversion-era marker derived from PropValYr.
+                    ConversionEra = ConversionEras.FromYear(imprv.PropValYr),
                     PromotedAt = now,
                 });
                 promoted++;

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsLandCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsLandCurrentTruthPromoter.cs
@@ -160,6 +160,8 @@ public sealed class PacsLandCurrentTruthPromoter : IPacsLandCurrentTruthPromoter
                     LandLoadBatchId = landLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G1 (v1.10): conversion-era marker derived from PropValYr.
+                    ConversionEra = ConversionEras.FromYear(land.PropValYr),
                     PromotedAt = now,
                 });
                 promoted++;

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsOwnerCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsOwnerCurrentTruthPromoter.cs
@@ -193,6 +193,8 @@ public sealed class PacsOwnerCurrentTruthPromoter : IPacsOwnerCurrentTruthPromot
                     AccountLoadBatchId = accountLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G1 (v1.10): conversion-era marker derived from OwnerTaxYr.
+                    ConversionEra = ConversionEras.FromYear(owner.OwnerTaxYr),
                     PromotedAt = now,
                 });
                 promoted++;

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
@@ -196,6 +196,8 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     SaleLoadBatchId = saleLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G1 (v1.10): conversion-era marker derived from PropValYr.
+                    ConversionEra = ConversionEras.FromYear(sale.PropValYr),
                     PromotedAt = now,
                 });
                 promoted++;

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsWashPropOwnerValTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsWashPropOwnerValTruthPromoter.cs
@@ -163,6 +163,8 @@ public sealed class PacsWashPropOwnerValTruthPromoter : IPacsWashPropOwnerValTru
                     WpovLoadBatchId = wpovLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G1 (v1.10): conversion-era marker derived from PropValYr.
+                    ConversionEra = ConversionEras.FromYear(wpov.PropValYr),
                     PromotedAt = now,
                 });
                 promoted++;

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
@@ -905,6 +905,109 @@ public sealed class BlockCContractV1Tests : IDisposable
     }
 
     // ───────────────────────────────────────────────────────────────
+    // v1.10 addendum — ConversionEras closed vocabulary (G1)
+    // ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Contract_v1_10_ConversionEras_AllContainsFrozenSet()
+    {
+        // v1.10 §2: closed vocabulary for the ConversionEra column on
+        // truth_pacs.* (and later canonical_tf.*). Adding a new era is
+        // a v1.x bump — there is no runtime extensibility hook.
+        ConversionEras.All.Should().BeEquivalentTo(new[]
+        {
+            "PRE_CONVERSION_2017",
+            "POST_CONVERSION",
+            "UNKNOWN",
+        }, "Block-C contract v1.10 §2 freezes the ConversionEras vocabulary");
+    }
+
+    [Fact]
+    public void Contract_v1_10_ConversionEras_IsKnown_RejectsUnknown()
+    {
+        ConversionEras.IsKnown(ConversionEras.PreConversion2017).Should().BeTrue();
+        ConversionEras.IsKnown(ConversionEras.PostConversion).Should().BeTrue();
+        ConversionEras.IsKnown(ConversionEras.Unknown).Should().BeTrue();
+        ConversionEras.IsKnown("PRE_2018").Should().BeFalse();
+        ConversionEras.IsKnown("not-an-era").Should().BeFalse();
+        ConversionEras.IsKnown(string.Empty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contract_v1_10_ConversionEras_CutoverYearIs2018()
+    {
+        // v1.10 §2: the cutover boundary is the 2018 valuation/tax
+        // year. Years strictly less than 2018 are pre-conversion;
+        // years >= 2018 are post-conversion.
+        ConversionEras.CutoverYear.Should().Be((short)2018,
+            "Block-C contract v1.10 §2 freezes the conversion cutover year");
+    }
+
+    [Theory]
+    [InlineData((short)2010, "PRE_CONVERSION_2017")]
+    [InlineData((short)2016, "PRE_CONVERSION_2017")]
+    [InlineData((short)2017, "PRE_CONVERSION_2017")]
+    [InlineData((short)2018, "POST_CONVERSION")]
+    [InlineData((short)2019, "POST_CONVERSION")]
+    [InlineData((short)2026, "POST_CONVERSION")]
+    public void Contract_v1_10_ConversionEras_FromYear_RespectsCutover(
+        short year, string expected)
+    {
+        ConversionEras.FromYear(year).Should().Be(expected,
+            "Block-C contract v1.10 §2: FromYear({0}) MUST resolve to {1}",
+            year, expected);
+    }
+
+    [Fact]
+    public void Contract_v1_10_ConversionEras_TruthLayer_NeverEmitsUnknown()
+    {
+        // v1.10 §2: truth-layer rows always have a year column that
+        // disambiguates. Only canonical-layer rows (whose contributing
+        // truth rows can disagree on era) are allowed to carry
+        // UNKNOWN. The FromYear helper is the truth-layer entry point
+        // and must NEVER return UNKNOWN.
+        for (short year = 1900; year <= 2100; year++)
+        {
+            ConversionEras.FromYear(year).Should().NotBe(
+                ConversionEras.Unknown,
+                "Block-C contract v1.10 §2: truth-layer FromYear({0}) " +
+                "MUST resolve to a definite era", year);
+        }
+    }
+
+    [Fact]
+    public void Contract_v1_10_TruthPacs_AllFiveEntities_HaveConversionEraColumn()
+    {
+        // v1.10 §3: all five truth_pacs lanes carry a nullable
+        // ConversionEra column (back-compat with rows promoted before
+        // G1; new promotions always set it).
+        var entityTypes = new[]
+        {
+            typeof(TruthPacsSale),
+            typeof(TruthPacsOwnerCurrent),
+            typeof(TruthPacsWashPropOwnerVal),
+            typeof(TruthPacsImprvCurrent),
+            typeof(TruthPacsLandCurrent),
+        };
+
+        foreach (var clrType in entityTypes)
+        {
+            var entityType = _db.Model.FindEntityType(clrType);
+            entityType.Should().NotBeNull(
+                $"v1.10 §3: {clrType.Name} must be mapped");
+            var conversionEra = entityType!.FindProperty("ConversionEra");
+            conversionEra.Should().NotBeNull(
+                $"v1.10 §3: {clrType.Name}.ConversionEra must exist");
+            conversionEra!.IsNullable.Should().BeTrue(
+                $"v1.10 §3: {clrType.Name}.ConversionEra must be " +
+                "nullable for back-compat with pre-G1 rows");
+            conversionEra.GetMaxLength().Should().Be(20,
+                $"v1.10 §3: {clrType.Name}.ConversionEra max length " +
+                "is 20 (longest vocabulary token + headroom)");
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────
     // §6 — migration list (Block A / B / C scaffolding)
     // ───────────────────────────────────────────────────────────────
 
@@ -949,6 +1052,9 @@ public sealed class BlockCContractV1Tests : IDisposable
             // Block-C contract v1.3 — nullable AttributeId FK on
             // tf_improvement_feature + tf_land (E3a).
             "AddAttributeIdNullableFkToFeatureAndLand",
+            // Block-C contract v1.10 — ConversionEra column + index
+            // on all five truth_pacs lanes (G1).
+            "AddConversionEraToTruthPacs",
         };
 
         foreach (var fragment in requiredFragments)

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsImprvTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
@@ -121,6 +122,8 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
         truth.Should().OnlyContain(t => t.SuppAssocLoadBatchId == suppBatch);
         truth.Should().OnlyContain(t => t.SourceImprvLandedRowId != Guid.Empty);
         truth.Should().OnlyContain(t => t.SourceSuppAssocLandedRowId != Guid.Empty);
+        // G1 (v1.10): conversion-era marker is stamped at promotion (year=2026 ⇒ post-conversion).
+        truth.Should().OnlyContain(t => t.ConversionEra == ConversionEras.PostConversion);
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsLandTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
@@ -125,6 +126,8 @@ public sealed class PacsLandCurrentTruthPromoterTests : IDisposable
         truth.Should().OnlyContain(t => t.SuppAssocLoadBatchId == suppBatch);
         truth.Should().OnlyContain(t => t.SourceLandLandedRowId != Guid.Empty);
         truth.Should().OnlyContain(t => t.SourceSuppAssocLandedRowId != Guid.Empty);
+        // G1 (v1.10): conversion-era marker is stamped at promotion (year=2026 ⇒ post-conversion).
+        truth.Should().OnlyContain(t => t.ConversionEra == ConversionEras.PostConversion);
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsOwnerTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
@@ -144,6 +145,8 @@ public sealed class PacsOwnerCurrentTruthPromoterTests : IDisposable
         truth.SourceOwnerLandedRowId.Should().NotBe(Guid.Empty);
         truth.SourceAccountLandedRowId.Should().NotBe(Guid.Empty);
         truth.SourceSuppAssocLandedRowId.Should().NotBe(Guid.Empty);
+        // G1 (v1.10): conversion-era marker is stamped at promotion (year=2026 ⇒ post-conversion).
+        truth.ConversionEra.Should().Be(ConversionEras.PostConversion);
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsSaleTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
@@ -160,6 +161,8 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
         truth.Should().OnlyContain(t => t.SourceSaleLandedRowId != Guid.Empty);
         truth.Should().OnlyContain(t => t.SourceSuppAssocLandedRowId != Guid.Empty);
         truth.Should().OnlyContain(t => t.PromotionLoadBatchId == result.PromotionLoadBatchId);
+        // G1 (v1.10): conversion-era marker is stamped at promotion (year=2026 ⇒ post-conversion).
+        truth.Should().OnlyContain(t => t.ConversionEra == ConversionEras.PostConversion);
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsWashPropOwnerValTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
@@ -121,6 +122,8 @@ public sealed class PacsWashPropOwnerValTruthPromoterTests : IDisposable
         truth.Should().OnlyContain(t => t.SuppAssocLoadBatchId == suppBatch);
         truth.Should().OnlyContain(t => t.SourceWpovLandedRowId != Guid.Empty);
         truth.Should().OnlyContain(t => t.SourceSuppAssocLandedRowId != Guid.Empty);
+        // G1 (v1.10): conversion-era marker is stamped at promotion (year=2026 ⇒ post-conversion).
+        truth.Should().OnlyContain(t => t.ConversionEra == ConversionEras.PostConversion);
     }
 
     [Fact]

--- a/docs/pacs/block-c-contract-v1.10.md
+++ b/docs/pacs/block-c-contract-v1.10.md
@@ -1,0 +1,209 @@
+# Block-C Contract — v1.10 (G1 ConversionEra Provenance)
+
+**Status:** binding doctrine. Version `v1.10`. Frozen 2026-05-03.
+**Predecessor:** `docs/pacs/block-c-contract-v1.9.md` (v1.9, 2026-05-03).
+**Layer:** 3.5 of the PACS doctrine stack.
+
+```text
+docs/pacs/block-c-contract-v1.md             (v1   — base freeze)
+docs/pacs/block-c-contract-v1.1.md           (v1.1 — dict_neighborhood)
+docs/pacs/block-c-contract-v1.2.md           (v1.2 — attribute_definition)
+docs/pacs/block-c-contract-v1.3.md           (v1.3 — nullable AttributeId FKs)
+docs/pacs/block-c-contract-v1.4.md           (v1.4 — QuarantineReasons closed vocab)
+docs/pacs/block-c-contract-v1.5.md           (v1.5 — attribute resolution semantics)
+docs/pacs/block-c-contract-v1.6.md           (v1.6 — two-layer quarantine vocabulary)
+docs/pacs/block-c-contract-v1.7.md           (v1.7 — E4c documented deferral; Block E close)
+docs/pacs/block-c-contract-v1.8.md           (v1.8 — Block-D D1+D2+D3 + legacy retirement)
+docs/pacs/block-c-contract-v1.9.md           (v1.9 — F5 sales-ratio-study read-model)
+docs/pacs/block-c-contract-v1.10.md          (v1.10 — G1 ConversionEra provenance) ← this doc
+```
+
+## 0. What v1.10 is
+
+A coordinated minor bump that records:
+
+1. **G1** introduces a closed-vocabulary `ConversionEra` column on
+   every `truth_pacs.*` lane. The column stamps each promoted row
+   with the PACS data-conversion era it was captured under, so
+   downstream consumers (canonical projections, ratio studies,
+   read endpoints) can disambiguate pre-2017-conversion semantics
+   from post-conversion semantics without re-deriving them at
+   read time.
+2. The `ConversionEras` static class is the single source of
+   truth for the vocabulary, the cutover year, and the
+   year → era resolution function.
+3. Subsequent slices (G2 era propagation to `canonical_tf.*`, G3
+   `eraFilter` query parameter on read endpoints, G4 promotion
+   gate for pre-conversion-row share) build on this column. They
+   are not in scope for v1.10.
+
+No v1.x-frozen shape is altered destructively. The migration is
+purely additive (5 nullable column adds + 5 indexes).
+
+## 0.5 Doctrine integrity disclosure (carry-forward)
+
+The PACS conversion caveat has been documented across multiple
+predecessor specs (`docs/pacs/block-c-contract-v1.md` §1, the
+`sales-ratio-queries.md` amendment, and
+`blocks-d-through-h-design.md` §G) as a known-but-deferred
+concern. Pre-G1 truth rows do not record which era they came
+from — readers had to infer it from the `PropValYr` / `OwnerTaxYr`
+column at query time. v1.10 closes that gap for all rows promoted
+after the migration; existing rows remain `NULL` until a re-promote
+backfills them.
+
+This is not a v2 break: the column is nullable by design, and
+read endpoints treat `NULL` as "era unknown — fall back to the
+year column". G2 will propagate the column forward; G4 will
+introduce a promotion gate that warns when pre-conversion share
+exceeds an operator-set threshold.
+
+## 1. The vocabulary
+
+`backend/src/TerraFusion.Core/Entities/TruthPacs/ConversionEras.cs`
+
+```csharp
+public const string PreConversion2017 = "PRE_CONVERSION_2017";
+public const string PostConversion    = "POST_CONVERSION";
+public const string Unknown           = "UNKNOWN";
+
+public const short  CutoverYear = 2018;
+```
+
+| Era | Meaning | Where it appears |
+|---|---|---|
+| `PRE_CONVERSION_2017` | Row captured under the pre-2017 PACS vocabulary. Coded fields (sales codes, improvement attributes, assessment vocabulary) may not have post-conversion semantics. | Truth + canonical |
+| `POST_CONVERSION` | Row captured under the current vocabulary. Default era for read endpoints (G3). | Truth + canonical |
+| `UNKNOWN` | Era could not be determined. Reserved for canonical-layer rows whose contributing truth rows disagree on era. | Canonical only |
+
+`ConversionEras.All` is a frozen `IReadOnlySet<string>` over those
+three values. `ConversionEras.IsKnown(value)` is the boundary
+guard for any code that writes to a `ConversionEra` column.
+Adding a new era is intentionally a code change — there is no
+runtime extensibility hook.
+
+## 2. The truth-layer resolution rule
+
+```csharp
+public static string FromYear(short year) =>
+    year < CutoverYear ? PreConversion2017 : PostConversion;
+```
+
+Rules:
+
+- Truth rows always have a year column (`PropValYr` for sales /
+  improvements / land / WSDOR; `OwnerTaxYr` for owners). That
+  column is the input.
+- `FromYear` MUST never return `UNKNOWN`. Truth rows always
+  resolve to a definite era. The doctrine test
+  `Contract_v1_10_ConversionEras_TruthLayer_NeverEmitsUnknown`
+  enforces this across years 1900..2100.
+- The cutover boundary is **strict**: year `< 2018` is pre, year
+  `>= 2018` is post. The exact 2018 boundary is operationally
+  arbitrary but matches Benton's documented data-conversion
+  cutover and is now frozen.
+
+## 3. The schema shape
+
+All five truth_pacs lanes carry a single nullable column with a
+single-column index on the era token. The shape is identical
+across lanes; only the index name varies.
+
+| Entity | Migration column | Index |
+|---|---|---|
+| `TruthPacsSale` | `truth_pacs.sale.ConversionEra` | `ix_truth_pacs_sale_conversion_era` |
+| `TruthPacsOwnerCurrent` | `truth_pacs.owner_current.ConversionEra` | `ix_truth_pacs_owner_conversion_era` |
+| `TruthPacsWashPropOwnerVal` | `truth_pacs.wash_prop_owner_val.ConversionEra` | `ix_truth_pacs_wpov_conversion_era` |
+| `TruthPacsImprvCurrent` | `truth_pacs.imprv_current.ConversionEra` | `ix_truth_pacs_imprv_conversion_era` |
+| `TruthPacsLandCurrent` | `truth_pacs.land_current.ConversionEra` | `ix_truth_pacs_land_conversion_era` |
+
+Column type: `character varying(20)` (longest vocabulary token
+is 19 chars; +1 char of headroom). Nullable for back-compat with
+rows promoted before G1; new promotions always set it.
+
+The indexes exist so G3's `eraFilter` query parameter (default
+`POST_CONVERSION`) can resolve via index seek rather than scan.
+
+Migration: `AddConversionEraToTruthPacs` (Block-C migration list
+addendum). Purely additive: 5 `AddColumn` + 5 `CreateIndex` on
+`Up`; exact reverse on `Down`.
+
+## 4. The promoter wiring
+
+All five truth promoters now stamp the era at row-construction
+time, immediately before `PromotedAt = now`:
+
+```csharp
+// inside each promoter, per row
+ConversionEra = ConversionEras.FromYear(row.PropValYr),  // or .OwnerTaxYr
+PromotedAt    = now,
+```
+
+Touched files:
+
+```text
+backend/src/TerraFusion.Data/Services/TruthPacs/
+  PacsSaleTruthPromoter.cs                (sale.PropValYr)
+  PacsOwnerCurrentTruthPromoter.cs        (owner.OwnerTaxYr)
+  PacsWashPropOwnerValTruthPromoter.cs    (wpov.PropValYr)
+  PacsImprvCurrentTruthPromoter.cs        (imprv.PropValYr)
+  PacsLandCurrentTruthPromoter.cs         (land.PropValYr)
+```
+
+Each promoter's happy-path test now asserts the era is set on
+every promoted row. The seeded year in every happy-path test
+is 2026, so the assertion is
+`t.ConversionEra == ConversionEras.PostConversion`.
+
+## 5. Doctrine integrity tests
+
+New tests in `backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs`:
+
+- `Contract_v1_10_ConversionEras_AllContainsFrozenSet` — the
+  three-value set is frozen.
+- `Contract_v1_10_ConversionEras_IsKnown_RejectsUnknown` —
+  guard rejects out-of-vocabulary tokens including the empty
+  string.
+- `Contract_v1_10_ConversionEras_CutoverYearIs2018` — the
+  numeric boundary is frozen.
+- `Contract_v1_10_ConversionEras_FromYear_RespectsCutover`
+  (theory, 6 cases) — boundary cases at 2017 / 2018 plus
+  representative pre/post years resolve correctly.
+- `Contract_v1_10_ConversionEras_TruthLayer_NeverEmitsUnknown` —
+  truth-layer entry point never returns `UNKNOWN` across
+  1900..2100.
+- `Contract_v1_10_TruthPacs_AllFiveEntities_HaveConversionEraColumn` —
+  reflective check via `_db.Model.FindEntityType(...)` that all
+  five lanes carry the column, that it is nullable, and that
+  `MaxLength == 20`.
+
+Migration list (`Contract_RequiredMigrations_ArePresentInDataAssembly`)
+adds `AddConversionEraToTruthPacs` to the required-fragments
+set.
+
+## 6. What v1.10 does NOT change
+
+- Canonical layer (`canonical_tf.*`) is untouched. G2 will
+  propagate the era forward, including the
+  majority-of-underlying-truth resolution rule that needs
+  `UNKNOWN` for ties.
+- Read endpoints (sales-ratio-study, dashboards) are untouched.
+  G3 will add the `eraFilter` query parameter (default
+  `POST_CONVERSION`) once G2 has populated the canonical column.
+- No promotion gate is added in G1. G4 will introduce a
+  pre-conversion-row-share gate that warns when an inbound batch
+  exceeds a configurable threshold.
+- All other v1.x-frozen shapes (sales codes, gates, dictionary
+  tables, GIS scaffold, AttributeDefinition, QuarantineReasons,
+  LandingQuarantineReasons, SourceFamilies) remain untouched.
+
+## 7. Linked GitHub issues
+
+- **G1** — closed by this slice (this doc).
+- **G2 / G3 / G4** — pending follow-up slices. Tracked under
+  the Block-G milestone in the design spine
+  (`blocks-d-through-h-design.md` §G).
+- **OPERATOR-SQL-IMPORT-1 (#726)** — unrelated to G1 but still
+  blocking F1/F3/F4 per v1.9.
+- **CI-HYGIENE-1 (#724)** — chronic main-state continues to
+  require admin-merge through documented exception.


### PR DESCRIPTION
## Summary
- Stamp every `truth_pacs.*` row with a closed-vocab `ConversionEra` at promotion time, derived from the row's year column. Closes the long-deferred PACS pre-2017 / post-conversion provenance gap so canonical projections, ratio studies, and read endpoints no longer have to re-derive era at query time.
- Doctrine bumped to **v1.10** (`docs/pacs/block-c-contract-v1.10.md`). New regression band in `BlockCContractV1Tests` covers vocabulary freeze, cutover-year freeze, truth-layer never-UNKNOWN invariant, and a reflective check that all 5 truth lanes carry the column with `MaxLength=20`.
- Migration is **purely additive**: 5 `AddColumn` + 5 `CreateIndex` on Up; exact reverse on Down. No destructive drift on unrelated tables — startup-project guard worked.

## What changed
- **New:** `TerraFusion.Core.Entities.TruthPacs.ConversionEras` — closed vocab `{ PRE_CONVERSION_2017, POST_CONVERSION, UNKNOWN }` + `FromYear(short)` + `IsKnown` + frozen `CutoverYear = 2018`.
- **Schema:** Nullable `ConversionEra` (`varchar(20)`) on `TruthPacsSale`, `TruthPacsOwnerCurrent`, `TruthPacsWashPropOwnerVal`, `TruthPacsImprvCurrent`, `TruthPacsLandCurrent`. EF configs add per-table indexes (`ix_truth_pacs_<lane>_conversion_era`).
- **Migration:** `20260503075310_AddConversionEraToTruthPacs` (5 columns + 5 indexes, additive only).
- **Promoters:** All 5 truth promoters now stamp `ConversionEras.FromYear(row.PropValYr)` (or `.OwnerTaxYr` for owners) immediately before `PromotedAt = now`.
- **Tests:** 5 promoter happy-paths assert `ConversionEra == PostConversion` (year=2026 in all happy paths). 6 new doctrine tests + theory in `BlockCContractV1Tests`. Migration list addendum requires `AddConversionEraToTruthPacs`.
- **Doctrine:** `docs/pacs/block-c-contract-v1.10.md` frozen 2026-05-03.

## Out of scope (subsequent G slices)
- **G2** — propagate era to `canonical_tf.*` with majority-of-underlying-truth resolution rule (`UNKNOWN` reserved for ties).
- **G3** — `eraFilter` query param on read endpoints (default `POST_CONVERSION`) once G2 has populated the canonical column.
- **G4** — pre-conversion-row-share promotion gate.

## Test plan
- [x] `dotnet build TerraFusion.sln` — 0 errors, 17 pre-existing warnings.
- [x] `dotnet test --filter "Contract_v1_10"` — 11/11 v1.10 doctrine tests green (vocab freeze, IsKnown guard, 6-case cutover theory, never-UNKNOWN across 1900..2100, reflective shape check on all 5 entities).
- [x] `dotnet test --filter "Pacs*TruthPromoterTests"` — 77/77 promoter tests green across all 5 lanes.
- [x] `Contract_RequiredMigrations_ArePresentInDataAssembly` — green; migration list addendum picked up.
- [x] Pre-commit + pre-push quality gates green.
- [ ] CI runs on the chronic-red main — admin-merge-through pattern (CI-HYGIENE-1 #724) applies if non-G1 jobs flap.

## Doctrine integrity disclosure
Pre-G1 truth rows do not record their era; they remain `NULL` until a re-promote backfills. This is **not** a v2 break — the column is nullable by design and read endpoints will treat `NULL` as "fall back to year column" until G3 lands. Forward-only, no quiet drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ConversionEra classification to property records, automatically categorizing data based on pre-2018 or post-2018 conversion timeline for improved tracking and filtering.

* **Database**
  * Extended five core property tables with new indexed ConversionEra columns and supporting migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->