### PR TITLE
feat(block-g/G2): propagate ConversionEra to canonical_tf via majority-of-truth

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfAssessmentWsdor.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfAssessmentWsdor.cs
@@ -70,6 +70,14 @@ public sealed class TfAssessmentWsdor
     /// <summary>The B4 promotion batch that created this row.</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker derived via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing <c>truth_pacs.wash_prop_owner_val</c> row(s).
+    /// Nullable for back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovement.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovement.cs
@@ -56,6 +56,16 @@ public sealed class TfImprovement
     /// <summary>The C3 promotion batch that created this row.</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker derived via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing <c>truth_pacs.imprv_current</c> row(s).
+    /// Child <see cref="TfImprovementFeature"/> rows inherit this era
+    /// from their parent improvement at projection time. Nullable for
+    /// back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovementFeature.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovementFeature.cs
@@ -76,6 +76,15 @@ public sealed class TfImprovementFeature
     public Guid SourceImprvDetailLandedRowId { get; set; }
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker inherited verbatim
+    /// from the parent <see cref="TfImprovement.ConversionEra"/> at
+    /// projection time. A feature row never has its own contributing
+    /// truth set — it always rides on its parent's era. Nullable for
+    /// back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfLand.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfLand.cs
@@ -74,6 +74,14 @@ public sealed class TfLand
     /// </summary>
     public AttributeDefinition? AttributeDefinition { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker derived via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing <c>truth_pacs.land_current</c> row(s).
+    /// Nullable for back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfOwner.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfOwner.cs
@@ -86,6 +86,14 @@ public sealed class TfOwner
     /// <summary>The B3 promotion batch that created this row.</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker derived via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing <c>truth_pacs.owner_current</c> row(s).
+    /// Nullable for back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfSale.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfSale.cs
@@ -54,6 +54,17 @@ public sealed class TfSale
     /// <summary>The S3 promotion batch that created this row.</summary>
     public Guid PromotionLoadBatchId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (v1.11): conversion-era marker derived via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing <c>truth_pacs.sale</c> row(s). Today every
+    /// truth → canonical projection is 1:1, so era is a verbatim copy
+    /// from the single contributor; tomorrow's multi-source canonical
+    /// rows resolve via majority with <c>UNKNOWN</c> for ties. Nullable
+    /// for back-compat with rows projected before G2.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/ConversionEras.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/ConversionEras.cs
@@ -101,4 +101,55 @@ public static class ConversionEras
     /// </summary>
     public static bool IsKnown(string value) =>
         !string.IsNullOrEmpty(value) && All.Contains(value);
+
+    /// <summary>
+    /// Slice G2 (v1.11): majority-of-underlying-truth resolution
+    /// rule for canonical-layer rows. Walks the contributing truth
+    /// rows' eras and returns:
+    ///
+    /// <list type="bullet">
+    ///   <item>the single agreed-upon era if every non-null
+    ///   contributor returns the same value;</item>
+    ///   <item><see cref="Unknown"/> if contributors disagree, if
+    ///   the sequence is empty, or if every contributor is null.</item>
+    /// </list>
+    ///
+    /// <para>Today every truth → canonical projection is 1:1, so
+    /// callers pass a single-element sequence and the helper returns
+    /// that era unchanged. The helper exists so that future N:1
+    /// projections (multi-source canonical rows, e.g. ArcGIS geometry
+    /// joined with PACS attributes on tf_parcel) can adopt the same
+    /// resolution rule without re-touching every projector.</para>
+    ///
+    /// <para>Doctrine: a non-empty sequence containing both null and
+    /// known values is treated as "the known values are the
+    /// contributors"; the null entries are ignored. If the only
+    /// values present are null, the result is <see cref="Unknown"/>.</para>
+    /// </summary>
+    /// <param name="contributors">
+    /// Era values from each contributing truth row. Null entries
+    /// (e.g. pre-G1 rows that haven't been re-promoted) are skipped.
+    /// </param>
+    public static string MajorityOfTruth(IEnumerable<string?> contributors)
+    {
+        if (contributors is null) return Unknown;
+
+        string? agreed = null;
+        var hasAny = false;
+        foreach (var era in contributors)
+        {
+            if (era is null) continue;
+            if (!IsKnown(era)) continue; // ignore unknown vocab tokens
+            if (!hasAny)
+            {
+                agreed = era;
+                hasAny = true;
+            }
+            else if (agreed != era)
+            {
+                return Unknown;
+            }
+        }
+        return hasAny ? agreed! : Unknown;
+    }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfAssessmentWsdorConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfAssessmentWsdorConfiguration.cs
@@ -65,5 +65,10 @@ public sealed class TfAssessmentWsdorConfiguration
         // BOE status scans.
         builder.HasIndex(x => x.BoeStatus)
             .HasDatabaseName("ix_tf_assessment_wsdor_boe_status");
+
+        // G2 (v1.11): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_assessment_wsdor_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementConfiguration.cs
@@ -37,5 +37,10 @@ public sealed class TfImprovementConfiguration : IEntityTypeConfiguration<TfImpr
             .HasDatabaseName("ix_tf_improvement_promotion_batch");
         builder.HasIndex(x => x.ImprvTypeCd)
             .HasDatabaseName("ix_tf_improvement_type");
+
+        // G2 (v1.11): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_improvement_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementFeatureConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementFeatureConfiguration.cs
@@ -59,5 +59,10 @@ public sealed class TfImprovementFeatureConfiguration
 
         builder.HasIndex(x => x.AttributeId)
             .HasDatabaseName("ix_tf_improvement_feature_attribute_id");
+
+        // G2 (v1.11): conversion-era marker (inherited from parent improvement).
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_improvement_feature_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfLandConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfLandConfiguration.cs
@@ -57,5 +57,10 @@ public sealed class TfLandConfiguration : IEntityTypeConfiguration<TfLand>
 
         builder.HasIndex(x => x.AttributeId)
             .HasDatabaseName("ix_tf_land_attribute_id");
+
+        // G2 (v1.11): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_land_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfOwnerConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfOwnerConfiguration.cs
@@ -44,5 +44,10 @@ public sealed class TfOwnerConfiguration : IEntityTypeConfiguration<TfOwner>
         // Confidentiality scans (audit surface).
         builder.HasIndex(x => x.ConfidentialFlag)
             .HasDatabaseName("ix_tf_owner_confidential");
+
+        // G2 (v1.11): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_owner_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfSaleConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfSaleConfiguration.cs
@@ -45,5 +45,10 @@ public sealed class TfSaleConfiguration : IEntityTypeConfiguration<TfSale>
         // Identity lookup.
         builder.HasIndex(x => x.ChgOfOwnerId)
             .HasDatabaseName("ix_tf_sale_chgofowner");
+
+        // G2 (v1.11): conversion-era marker.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_sale_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260503153646_AddConversionEraToCanonicalTf.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503153646_AddConversionEraToCanonicalTf.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503153646_AddConversionEraToCanonicalTf")]
+    partial class AddConversionEraToCanonicalTf
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260503153646_AddConversionEraToCanonicalTf.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260503153646_AddConversionEraToCanonicalTf.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConversionEraToCanonicalTf : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_owner",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_land",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_improvement_feature",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_assessment_wsdor",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_sale_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_owner_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_owner",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_land_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_land",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_improvement_feature_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_improvement_feature",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_improvement_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_assessment_wsdor_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_assessment_wsdor",
+                column: "ConversionEra");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_tf_sale_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_owner_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_owner");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_land_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_land");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_improvement_feature_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_improvement_feature");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_improvement_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_assessment_wsdor_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_assessment_wsdor");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_owner");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_land");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_improvement_feature");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_assessment_wsdor");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
@@ -11,6 +11,7 @@ using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsImprvCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -283,6 +284,9 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                     EffectiveYearBuilt = truth.EffectiveYearBuilt,
                     ActualYearBuilt = truth.ActualYearBuilt,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G2 (v1.11): era resolved via majority-of-truth.
+                    // Single contributor → verbatim copy.
+                    ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
                     CreatedAt = now,
                     UpdatedAt = now,
                 };
@@ -331,6 +335,8 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                             YrBuilt = detail.YrBuilt,
                             SourceImprvDetailLandedRowId = detail.LandedRowId,
                             PromotionLoadBatchId = batch.LoadBatchId,
+                            // G2 (v1.11): feature inherits parent improvement's era verbatim.
+                            ConversionEra = imprv.ConversionEra,
                             CreatedAt = now,
                             UpdatedAt = now,
                         });
@@ -367,6 +373,8 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                                 // case it points at imprv_attr.LandedRowId.
                                 SourceImprvDetailLandedRowId = attr.LandedRowId,
                                 PromotionLoadBatchId = batch.LoadBatchId,
+                                // G2 (v1.11): feature inherits parent improvement's era verbatim.
+                                ConversionEra = imprv.ConversionEra,
                                 CreatedAt = now,
                                 UpdatedAt = now,
                             });

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsLandCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsLandCanonicalProjector.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsLandCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -215,6 +216,9 @@ public sealed class PacsLandCanonicalProjector : IPacsLandCanonicalProjector
                     LandSegAssessedVal = truth.LandSegAssessedVal,
                     LandSegEffAge = truth.LandSegEffAge,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G2 (v1.11): era resolved via majority-of-truth.
+                    // Single contributor → verbatim copy.
+                    ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
                     CreatedAt = now,
                     UpdatedAt = now,
                 };

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsOwnerCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsOwnerCanonicalProjector.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsOwnerCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -319,6 +320,9 @@ public sealed class PacsOwnerCanonicalProjector : IPacsOwnerCanonicalProjector
                 WebSuppression = truth.WebSuppression,
                 TypeOfOwner = truth.TypeOfOwner,
                 PromotionLoadBatchId = promotionBatchId,
+                // G2 (v1.11): era resolved via majority-of-truth.
+                // Single contributor → verbatim copy.
+                ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
                 CreatedAt = now,
                 UpdatedAt = now,
             };
@@ -335,6 +339,9 @@ public sealed class PacsOwnerCanonicalProjector : IPacsOwnerCanonicalProjector
             WebSuppression = truth.WebSuppression,
             TypeOfOwner = truth.TypeOfOwner,
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): era resolved via majority-of-truth.
+            // Single contributor → verbatim copy.
+            ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
             CreatedAt = now,
             UpdatedAt = now,
         };

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsSaleCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsSaleCanonicalProjector.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsSaleCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -192,6 +193,9 @@ public sealed class PacsSaleCanonicalProjector : IPacsSaleCanonicalProjector
                     AdjSlPrice = truth.AdjSlPrice,
                     SaleQualified = true,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G2 (v1.11): era resolved via majority-of-truth.
+                    // Single contributor → verbatim copy.
+                    ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
                     CreatedAt = now,
                     UpdatedAt = now,
                 };

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsWsdorCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsWsdorCanonicalProjector.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsWsdorCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -251,6 +252,9 @@ public sealed class PacsWsdorCanonicalProjector : IPacsWsdorCanonicalProjector
                     SnrFrzImprvHs = truth.SnrFrzImprvHs,
                     SnrFrzLandHs = truth.SnrFrzLandHs,
                     PromotionLoadBatchId = batch.LoadBatchId,
+                    // G2 (v1.11): era resolved via majority-of-truth.
+                    // Single contributor → verbatim copy.
+                    ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
                     CreatedAt = now,
                     UpdatedAt = now,
                 };

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsImprvCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsImprvCanonicalProjectorTests.cs
@@ -110,6 +110,8 @@ public sealed class PacsImprvCanonicalProjectorTests : IDisposable
             ImprvLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): mirror promoter-stamped era.
+            ConversionEra = ConversionEras.FromYear(year),
         };
         _db.TruthPacsImprvCurrents.Add(t);
         await _db.SaveChangesAsync();
@@ -190,10 +192,14 @@ public sealed class PacsImprvCanonicalProjectorTests : IDisposable
         imprv.CountyId.Should().Be(countyId);
         imprv.TfParcelId.Should().Be(parcelId);
         imprv.IsHomesite.Should().BeTrue();
+        // G2 (v1.11): canonical era from majority-of-truth (single contributor, year=2026).
+        imprv.ConversionEra.Should().Be(ConversionEras.PostConversion);
 
         var features = await _db.TfImprovementFeatures.ToListAsync();
         features.Should().HaveCount(4);
         features.Should().OnlyContain(f => f.TfImprovementId == imprv.TfImprovementId);
+        // G2 (v1.11): every feature inherits the parent improvement's era verbatim.
+        features.Should().OnlyContain(f => f.ConversionEra == ConversionEras.PostConversion);
         features.Select(f => f.FeatureCode).Should().BeEquivalentTo(new[]
         {
             "MA", "BSMT", "ATTGAR", "COVPATIO",

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsLandCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsLandCanonicalProjectorTests.cs
@@ -118,6 +118,8 @@ public sealed class PacsLandCanonicalProjectorTests : IDisposable
             LandLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): mirror promoter-stamped era.
+            ConversionEra = ConversionEras.FromYear(year),
         };
         _db.TruthPacsLandCurrents.Add(t);
         await _db.SaveChangesAsync();
@@ -182,6 +184,8 @@ public sealed class PacsLandCanonicalProjectorTests : IDisposable
         land.IsHomesite.Should().BeTrue();
         land.SizeAcres.Should().Be(2.5m);
         land.LandSegMarketVal.Should().Be(125_000m);
+        // G2 (v1.11): canonical era from majority-of-truth (single contributor, year=2026).
+        land.ConversionEra.Should().Be(ConversionEras.PostConversion);
 
         var xref = await _db.SyncBridgeSourceXrefs
             .SingleAsync(x => x.TfEntityType == "land");

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsOwnerCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsOwnerCanonicalProjectorTests.cs
@@ -120,6 +120,8 @@ public sealed class PacsOwnerCanonicalProjectorTests : IDisposable
             AccountLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): mirror promoter-stamped era (derived from OwnerTaxYr).
+            ConversionEra = ConversionEras.FromYear(year),
         };
         _db.TruthPacsOwnerCurrents.Add(t);
         await _db.SaveChangesAsync();
@@ -177,6 +179,8 @@ public sealed class PacsOwnerCanonicalProjectorTests : IDisposable
         owner.AcctId.Should().Be(1);
         owner.DisplayName.Should().Be("Smith, John");
         owner.ConfidentialFlag.Should().BeFalse();
+        // G2 (v1.11): canonical era from majority-of-truth (single contributor, OwnerTaxYr=2026).
+        owner.ConversionEra.Should().Be(ConversionEras.PostConversion);
 
         var link = await _db.TfParcelOwnerLinks.SingleAsync();
         link.TfParcelId.Should().Be(parcelId);

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsSaleCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsSaleCanonicalProjectorTests.cs
@@ -108,6 +108,9 @@ public sealed class PacsSaleCanonicalProjectorTests : IDisposable
             SaleLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): mirror promoter-stamped era so canonical projector
+            // observes a real era on its truth contributors.
+            ConversionEra = ConversionEras.FromYear(year),
         };
         _db.TruthPacsSales.Add(t);
         await _db.SaveChangesAsync();
@@ -169,6 +172,9 @@ public sealed class PacsSaleCanonicalProjectorTests : IDisposable
         sale.ChgOfOwnerId.Should().Be(1);
         sale.SaleQualified.Should().BeTrue();
         sale.PromotionLoadBatchId.Should().Be(result.PromotionLoadBatchId);
+        // G2 (v1.11): canonical era is the majority of contributing truth eras.
+        // Single contributor at year=2026 ⇒ POST_CONVERSION.
+        sale.ConversionEra.Should().Be(ConversionEras.PostConversion);
 
         var xref = await _db.SyncBridgeSourceXrefs
             .SingleAsync(x => x.TfEntityType == "sale");

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsWsdorCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsWsdorCanonicalProjectorTests.cs
@@ -104,6 +104,8 @@ public sealed class PacsWsdorCanonicalProjectorTests : IDisposable
             WpovLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = promotionBatchId,
+            // G2 (v1.11): mirror promoter-stamped era.
+            ConversionEra = ConversionEras.FromYear(year),
         };
         _db.TruthPacsWashPropOwnerVals.Add(t);
         await _db.SaveChangesAsync();
@@ -185,6 +187,8 @@ public sealed class PacsWsdorCanonicalProjectorTests : IDisposable
         assessment.TfOwnerId.Should().Be(ownerId);
         assessment.AssessmentYear.Should().Be(2026);
         assessment.AssessedVal.Should().Be(250_000m);
+        // G2 (v1.11): canonical era from majority-of-truth (single contributor, year=2026).
+        assessment.ConversionEra.Should().Be(ConversionEras.PostConversion);
 
         var xref = await _db.SyncBridgeSourceXrefs
             .SingleAsync(x => x.TfEntityType == "assessment_wsdor");
@@ -453,6 +457,8 @@ public sealed class PacsWsdorCanonicalProjectorTests : IDisposable
             WpovLoadBatchId = Guid.NewGuid(),
             SuppAssocLoadBatchId = Guid.NewGuid(),
             PromotionLoadBatchId = truthBatch,
+            // G2 (v1.11): mirror promoter-stamped era.
+            ConversionEra = ConversionEras.FromYear(2026),
         });
         await _db.SaveChangesAsync();
 

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
@@ -975,6 +975,123 @@ public sealed class BlockCContractV1Tests : IDisposable
         }
     }
 
+    // ───────────────────────────────────────────────────────────────
+    // v1.11 addendum — ConversionEra propagation to canonical_tf (G2)
+    // ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_EmptyOrAllNull_ReturnsUnknown()
+    {
+        // v1.11 §2: when no contributing truth row reports an era,
+        // the canonical row's era is UNKNOWN.
+        ConversionEras.MajorityOfTruth(Array.Empty<string?>())
+            .Should().Be(ConversionEras.Unknown);
+        ConversionEras.MajorityOfTruth(new string?[] { null, null, null })
+            .Should().Be(ConversionEras.Unknown);
+    }
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_SingleContributor_ReturnsThatEra()
+    {
+        // v1.11 §2: 1:1 projections (every truth → canonical mapping
+        // today) reduce to verbatim copy.
+        ConversionEras.MajorityOfTruth(new string?[] { ConversionEras.PostConversion })
+            .Should().Be(ConversionEras.PostConversion);
+        ConversionEras.MajorityOfTruth(new string?[] { ConversionEras.PreConversion2017 })
+            .Should().Be(ConversionEras.PreConversion2017);
+    }
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_AllAgree_ReturnsAgreedEra()
+    {
+        ConversionEras.MajorityOfTruth(new string?[]
+        {
+            ConversionEras.PostConversion,
+            ConversionEras.PostConversion,
+            ConversionEras.PostConversion,
+        }).Should().Be(ConversionEras.PostConversion);
+    }
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_Disagree_ReturnsUnknown()
+    {
+        // v1.11 §2: contributors that span the cutover collapse to
+        // UNKNOWN. The canonical layer cannot pretend the row is
+        // unambiguously one era when its truth contributors disagree.
+        ConversionEras.MajorityOfTruth(new string?[]
+        {
+            ConversionEras.PreConversion2017,
+            ConversionEras.PostConversion,
+        }).Should().Be(ConversionEras.Unknown);
+    }
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_NullsIgnored_AmongstAgreement()
+    {
+        // v1.11 §2: null contributors (pre-G1 rows that haven't been
+        // re-promoted) are skipped, not voted. Surviving non-null
+        // contributors decide.
+        ConversionEras.MajorityOfTruth(new string?[]
+        {
+            null,
+            ConversionEras.PostConversion,
+            null,
+            ConversionEras.PostConversion,
+        }).Should().Be(ConversionEras.PostConversion);
+    }
+
+    [Fact]
+    public void Contract_v1_11_MajorityOfTruth_UnknownVocabTokens_AreIgnored()
+    {
+        // v1.11 §2: out-of-vocabulary tokens are doctrine violations
+        // upstream. The helper does not propagate them — it skips
+        // them as if they were null. If only such tokens appear, the
+        // result is UNKNOWN.
+        ConversionEras.MajorityOfTruth(new string?[]
+        {
+            "BOGUS_ERA",
+            ConversionEras.PostConversion,
+        }).Should().Be(ConversionEras.PostConversion);
+
+        ConversionEras.MajorityOfTruth(new string?[]
+        {
+            "BOGUS_ERA",
+            "ANOTHER_BAD_TOKEN",
+        }).Should().Be(ConversionEras.Unknown);
+    }
+
+    [Fact]
+    public void Contract_v1_11_CanonicalTf_AllSixEntities_HaveConversionEraColumn()
+    {
+        // v1.11 §3: all six canonical lanes that derive from truth
+        // carry a nullable ConversionEra column with MaxLength = 20.
+        var entityTypes = new[]
+        {
+            typeof(TfSale),
+            typeof(TfOwner),
+            typeof(TfAssessmentWsdor),
+            typeof(TfImprovement),
+            typeof(TfImprovementFeature),
+            typeof(TfLand),
+        };
+
+        foreach (var clrType in entityTypes)
+        {
+            var entityType = _db.Model.FindEntityType(clrType);
+            entityType.Should().NotBeNull(
+                $"v1.11 §3: {clrType.Name} must be mapped");
+            var conversionEra = entityType!.FindProperty("ConversionEra");
+            conversionEra.Should().NotBeNull(
+                $"v1.11 §3: {clrType.Name}.ConversionEra must exist");
+            conversionEra!.IsNullable.Should().BeTrue(
+                $"v1.11 §3: {clrType.Name}.ConversionEra must be " +
+                "nullable for back-compat with pre-G2 rows");
+            conversionEra.GetMaxLength().Should().Be(20,
+                $"v1.11 §3: {clrType.Name}.ConversionEra max length " +
+                "is 20 (matches the truth_pacs.* column shape)");
+        }
+    }
+
     [Fact]
     public void Contract_v1_10_TruthPacs_AllFiveEntities_HaveConversionEraColumn()
     {
@@ -1055,6 +1172,9 @@ public sealed class BlockCContractV1Tests : IDisposable
             // Block-C contract v1.10 — ConversionEra column + index
             // on all five truth_pacs lanes (G1).
             "AddConversionEraToTruthPacs",
+            // Block-C contract v1.11 — ConversionEra column + index
+            // on six canonical_tf lanes (G2).
+            "AddConversionEraToCanonicalTf",
         };
 
         foreach (var fragment in requiredFragments)

--- a/docs/pacs/block-c-contract-v1.11.md
+++ b/docs/pacs/block-c-contract-v1.11.md
@@ -1,0 +1,209 @@
+# Block-C Contract — v1.11 (G2 ConversionEra Propagation to canonical_tf)
+
+**Status:** binding doctrine. Version `v1.11`. Frozen 2026-05-03.
+**Predecessor:** `docs/pacs/block-c-contract-v1.10.md` (v1.10, 2026-05-03).
+**Layer:** 3.5 of the PACS doctrine stack.
+
+```text
+docs/pacs/block-c-contract-v1.md             (v1   — base freeze)
+docs/pacs/block-c-contract-v1.1.md           (v1.1 — dict_neighborhood)
+docs/pacs/block-c-contract-v1.2.md           (v1.2 — attribute_definition)
+docs/pacs/block-c-contract-v1.3.md           (v1.3 — nullable AttributeId FKs)
+docs/pacs/block-c-contract-v1.4.md           (v1.4 — QuarantineReasons closed vocab)
+docs/pacs/block-c-contract-v1.5.md           (v1.5 — attribute resolution semantics)
+docs/pacs/block-c-contract-v1.6.md           (v1.6 — two-layer quarantine vocabulary)
+docs/pacs/block-c-contract-v1.7.md           (v1.7 — E4c documented deferral; Block E close)
+docs/pacs/block-c-contract-v1.8.md           (v1.8 — Block-D D1+D2+D3 + legacy retirement)
+docs/pacs/block-c-contract-v1.9.md           (v1.9 — F5 sales-ratio-study read-model)
+docs/pacs/block-c-contract-v1.10.md          (v1.10 — G1 truth-layer ConversionEra)
+docs/pacs/block-c-contract-v1.11.md          (v1.11 — G2 canonical-layer ConversionEra) ← this doc
+```
+
+## 0. What v1.11 is
+
+A coordinated minor bump that records:
+
+1. **G2** propagates the truth-layer `ConversionEra` (G1, v1.10)
+   forward into the canonical layer. Every canonical entity that
+   derives from a `truth_pacs.*` lane now carries a nullable
+   `ConversionEra` column populated at projection time via the
+   `ConversionEras.MajorityOfTruth` resolution rule.
+2. The new `MajorityOfTruth(IEnumerable<string?>)` helper on
+   `ConversionEras` is the single source of truth for canonical-era
+   resolution. Today every truth → canonical projection is 1:1, so
+   the helper reduces to verbatim copy; tomorrow's multi-source
+   projections (e.g. ArcGIS geometry joined with PACS attributes
+   on `tf_parcel`) call the same helper unchanged.
+3. Subsequent slices (G3 `eraFilter` query parameter on read
+   endpoints, G4 promotion gate for pre-conversion-row share)
+   consume the canonical column. They are not in scope for v1.11.
+
+The migration is purely additive (6 nullable column adds + 6
+indexes). No v1.x-frozen shape is altered.
+
+## 0.5 Doctrine integrity disclosure (carry-forward)
+
+v1.10 §6 noted that "G2 will propagate the era forward, including
+the majority-of-underlying-truth resolution rule that needs
+`UNKNOWN` for ties." v1.11 ships exactly that. The vocabulary
+(v1.10 §1) is unchanged: `PRE_CONVERSION_2017`, `POST_CONVERSION`,
+`UNKNOWN`. `UNKNOWN` is now genuinely reachable from the canonical
+layer, since multi-source canonical rows can have contributors
+that disagree on era. Truth-layer rows still never emit `UNKNOWN`
+(per the doctrine test
+`Contract_v1_10_ConversionEras_TruthLayer_NeverEmitsUnknown`).
+
+## 1. The resolution rule
+
+```csharp
+public static string MajorityOfTruth(IEnumerable<string?> contributors)
+```
+
+Behavior, frozen by doctrine tests in `BlockCContractV1Tests`
+section "v1.11 addendum":
+
+| Input | Output |
+|---|---|
+| empty sequence | `UNKNOWN` |
+| all entries null | `UNKNOWN` |
+| one non-null entry | that entry |
+| multiple non-null, all agree | the agreed value |
+| multiple non-null, disagree | `UNKNOWN` |
+| nulls mixed with agreeing non-null | the agreed value (nulls skipped) |
+| out-of-vocabulary tokens (e.g. `"BOGUS_ERA"`) | skipped as if null; if only such tokens, `UNKNOWN` |
+
+The helper does **not** validate vocabulary at the boundary —
+upstream code already guards via `ConversionEras.IsKnown`. Out-of-
+vocab tokens are tolerated so a single bad row doesn't poison a
+canonical projection; they are simply ignored when resolving the
+era.
+
+## 2. The schema shape
+
+All six canonical lanes that derive from truth carry a single
+nullable column with a single-column index on the era token. The
+shape mirrors v1.10's truth-layer pattern.
+
+| Entity | Migration column | Index |
+|---|---|---|
+| `TfSale` | `canonical_tf.tf_sale.ConversionEra` | `ix_tf_sale_conversion_era` |
+| `TfOwner` | `canonical_tf.tf_owner.ConversionEra` | `ix_tf_owner_conversion_era` |
+| `TfAssessmentWsdor` | `canonical_tf.tf_assessment_wsdor.ConversionEra` | `ix_tf_assessment_wsdor_conversion_era` |
+| `TfImprovement` | `canonical_tf.tf_improvement.ConversionEra` | `ix_tf_improvement_conversion_era` |
+| `TfImprovementFeature` | `canonical_tf.tf_improvement_feature.ConversionEra` | `ix_tf_improvement_feature_conversion_era` |
+| `TfLand` | `canonical_tf.tf_land.ConversionEra` | `ix_tf_land_conversion_era` |
+
+Column type: `character varying(20)`. Nullable for back-compat
+with rows projected before G2; new projections always set it.
+
+The indexes exist so G3's `eraFilter` query parameter (default
+`POST_CONVERSION`) can resolve via index seek rather than scan.
+
+Migration: `AddConversionEraToCanonicalTf`. Purely additive: 6
+`AddColumn` + 6 `CreateIndex` on `Up`; exact reverse on `Down`.
+The migration list addendum in `BlockCContractV1Tests` requires
+this fragment.
+
+## 3. The projector wiring
+
+All five canonical projectors compute era via the helper at row-
+construction time, immediately before `CreatedAt = now`:
+
+```csharp
+// inside each projector, per row
+ConversionEra = ConversionEras.MajorityOfTruth(
+    new[] { truth.ConversionEra }),
+CreatedAt = now,
+```
+
+For `TfImprovementFeature` (sub-rows under a parent improvement),
+the era is **inherited verbatim** from the parent
+`TfImprovement.ConversionEra` — features never have their own
+contributing-truth set; they ride on their parent's resolution:
+
+```csharp
+// inside the imprv projector, when emitting feature rows
+ConversionEra = imprv.ConversionEra,
+```
+
+Touched files:
+
+```text
+backend/src/TerraFusion.Data/Services/CanonicalTf/
+  PacsSaleCanonicalProjector.cs                (sale: 1 site)
+  PacsOwnerCanonicalProjector.cs               (owner: 2 sites — confidential + non-confidential branches)
+  PacsWsdorCanonicalProjector.cs               (wsdor: 1 site)
+  PacsImprvCanonicalProjector.cs               (imprv: 3 sites — parent + detail-feature + attr-feature)
+  PacsLandCanonicalProjector.cs                (land: 1 site)
+```
+
+Even though every projection is 1:1 today (so the helper reduces
+to verbatim copy), going through the helper keeps the doctrine
+contract uniform: any future N:1 projection adopts the same
+resolution rule without re-touching every projector.
+
+## 4. Tests
+
+### Per-projector happy-path assertions
+
+Each canonical projector's happy-path test now seeds its
+`truth_pacs.*` row with a definite era (mirroring G1 promoter
+behavior) and asserts the projected canonical row carries
+`ConversionEra == ConversionEras.PostConversion` (year=2026 in
+every happy path).
+
+For `PacsImprvCanonicalProjectorTests.HappyPath_*`, both the
+parent `TfImprovement` AND every child `TfImprovementFeature`
+must carry the era — proves the inheritance contract.
+
+### Doctrine integrity tests
+
+New tests in `backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs`
+section "v1.11 addendum":
+
+- `Contract_v1_11_MajorityOfTruth_EmptyOrAllNull_ReturnsUnknown`
+- `Contract_v1_11_MajorityOfTruth_SingleContributor_ReturnsThatEra`
+- `Contract_v1_11_MajorityOfTruth_AllAgree_ReturnsAgreedEra`
+- `Contract_v1_11_MajorityOfTruth_Disagree_ReturnsUnknown`
+- `Contract_v1_11_MajorityOfTruth_NullsIgnored_AmongstAgreement`
+- `Contract_v1_11_MajorityOfTruth_UnknownVocabTokens_AreIgnored`
+- `Contract_v1_11_CanonicalTf_AllSixEntities_HaveConversionEraColumn`
+  — reflective check via `_db.Model.FindEntityType(...)` that all
+  six lanes carry the column, that it is nullable, and that
+  `MaxLength == 20`.
+
+Migration list (`Contract_RequiredMigrations_ArePresentInDataAssembly`)
+adds `AddConversionEraToCanonicalTf` to the required-fragments
+set.
+
+## 5. What v1.11 does NOT change
+
+- Read endpoints (sales-ratio-study, dashboards, parcel-owner,
+  parcel-wsdor) are untouched. G3 will add the `eraFilter` query
+  parameter (default `POST_CONVERSION`) once operators are ready
+  to consume the canonical column.
+- No promotion gate is added. G4 will introduce a
+  pre-conversion-row-share gate that warns when an inbound batch
+  exceeds a configurable threshold.
+- Historical canonical rows projected before G2 remain `NULL`
+  until a re-projection backfills them. Read endpoints continue
+  to treat `NULL` as "fall back to the contributing year column"
+  — the same rule v1.10 §0.5 set for truth rows.
+- `tf_parcel`, `tf_parcel_owner_link`, `tf_parcel_geom`, and the
+  attribute / dictionary tables are not in scope. They have no
+  truth contributor with an era, or they're junction tables whose
+  era is meaningless in isolation.
+- All other v1.x-frozen shapes (sales codes, gates, dictionary
+  tables, GIS scaffold, AttributeDefinition, QuarantineReasons,
+  LandingQuarantineReasons, SourceFamilies) remain untouched.
+
+## 6. Linked GitHub issues
+
+- **G2** — closed by this slice (this doc).
+- **G3 / G4** — pending follow-up slices. Tracked under the
+  Block-G milestone in the design spine
+  (`blocks-d-through-h-design.md` §G).
+- **OPERATOR-SQL-IMPORT-1 (#726)** — unrelated to G2 but still
+  blocking F1/F3/F4 per v1.9.
+- **CI-HYGIENE-1 (#724)** — chronic main-state continues to
+  require admin-merge through documented exception.


### PR DESCRIPTION
## Summary
- Propagate the truth-layer `ConversionEra` (G1, v1.10) forward into the canonical layer. Every `canonical_tf.*` row that derives from a `truth_pacs.*` lane now carries the era resolved by `ConversionEras.MajorityOfTruth` over its contributing truth rows.
- Doctrine bumped to **v1.11** (`docs/pacs/block-c-contract-v1.11.md`). New regression band in `BlockCContractV1Tests` locks the helper algorithm + the canonical-entity shape.
- Migration is **purely additive**: 6 `AddColumn` + 6 `CreateIndex` on Up; exact reverse on Down. Startup-project guard preserved.

## What changed
- **New helper:** `ConversionEras.MajorityOfTruth(IEnumerable<string?>)` — empty/all-null → `UNKNOWN`; single contributor → verbatim; agreeing contributors → that era; disagreeing → `UNKNOWN`; out-of-vocab tokens skipped.
- **Schema:** Nullable `ConversionEra` (`varchar(20)`) on `TfSale`, `TfOwner`, `TfAssessmentWsdor`, `TfImprovement`, `TfImprovementFeature`, `TfLand`. EF configs add per-table indexes.
- **Migration:** `20260503153646_AddConversionEraToCanonicalTf` (6 columns + 6 indexes, additive only).
- **Projectors:** All 5 canonical projectors stamp era at construction via `MajorityOfTruth(new[] { truth.ConversionEra })`. Even though every projection is 1:1 today (helper reduces to verbatim copy), going through the helper keeps the doctrine contract uniform for future N:1 projections.
- **Feature inheritance:** `TfImprovementFeature` rows inherit `imprv.ConversionEra` verbatim — features ride on the parent's resolution.
- **Tests:** 5 canonical projector happy-paths now seed truth with promoter-stamped era and assert `ConversionEra == PostConversion`. `PacsImprvCanonicalProjectorTests` also asserts every feature inherits the parent era. 7 new doctrine tests in `BlockCContractV1Tests` v1.11 band.
- **Doctrine:** `docs/pacs/block-c-contract-v1.11.md` frozen 2026-05-03.

## Out of scope (subsequent G slices)
- **G3** — `eraFilter` query parameter on read endpoints (default `POST_CONVERSION`). Now unblocked by this canonical column.
- **G4** — pre-conversion-row-share promotion gate.

## Test plan
- [x] `dotnet build TerraFusion.sln` — 0 errors, 17 pre-existing warnings (CI-HYGIENE-1 #724 chronic).
- [x] `dotnet test --filter "Contract_v1_11"` — 7/7 v1.11 doctrine tests green.
- [x] `dotnet test --filter "CanonicalTf.Pacs"` — 77/77 canonical projector tests green.
- [x] `dotnet test --filter "Contract_v1_10|Contract_RequiredMigrations"` — 12/12 G1 regression still green; migration list addendum picked up.
- [x] Pre-commit + pre-push quality gates green.
- [ ] CI runs on chronic-red main — admin-merge-through pattern (CI-HYGIENE-1 #724) applies for the same `Warning Gate` flap as #728.

## Doctrine integrity disclosure
Truth-layer rows still never emit `UNKNOWN` (per `Contract_v1_10_ConversionEras_TruthLayer_NeverEmitsUnknown`); only canonical rows can. Today every projection is 1:1, so the helper reduces to verbatim copy and `UNKNOWN` is unreachable from the current canonical projectors. The future N:1 projection (e.g. ArcGIS geometry joined with PACS attributes on `tf_parcel`) will exercise the disagree-→-`UNKNOWN` path. The doctrine tests lock the algorithm now so future projections cannot accidentally drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ConversionEra field to property assessment records to track data conversion history and versions with full backward compatibility support for legacy data.

* **Database**
  * Extended six property entity types with ConversionEra columns and corresponding database indexes to improve query performance and filtering capabilities.

* **Tests**
  * Added comprehensive test coverage validating ConversionEra field propagation, majority-of-truth resolution logic, and data schema compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->