### PR TITLE
feat(block-g/G3): eraFilter query parameter on SalesRatioStudy read endpoints

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/SalesRatioStudyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SalesRatioStudyController.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.SalesRatioStudy;
 
 namespace TerraFusion.API.Controllers;
@@ -53,6 +55,19 @@ public sealed class SalesRatioStudyController : ControllerBase
     }
 
     /// <summary>
+    /// G3 (v1.12): valid era tokens accepted on the <c>era</c> query
+    /// parameter. Doctrine-frozen set; unrecognized values are 400.
+    /// </summary>
+    private static readonly IReadOnlySet<string> ValidEraValues =
+        new HashSet<string>
+        {
+            ConversionEras.PostConversion,
+            ConversionEras.PreConversion2017,
+            ConversionEras.Unknown,
+            ISalesRatioStudyReader.EraAll,
+        };
+
+    /// <summary>
     /// Q1: count of valid sales for the county.
     /// <c>GET /api/counties/{countyId}/sales-ratio-study/valid-sale-count</c>
     /// </summary>
@@ -61,17 +76,21 @@ public sealed class SalesRatioStudyController : ControllerBase
     public async Task<IActionResult> GetValidSaleCount(
         Guid countyId,
         [FromQuery] DateTime? from = null,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (!TryAuthorize(countyId, out var fail))
             return fail!;
+        if (!TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+            return eraFail!;
 
-        var count = await _reader.GetValidSaleCountAsync(countyId, from, ct)
+        var count = await _reader.GetValidSaleCountAsync(countyId, from, resolvedEra, ct)
             .ConfigureAwait(false);
         return Ok(new
         {
             countyId,
             fromDate = from ?? ISalesRatioStudyReader.DefaultFromDate,
+            era = resolvedEra,
             validSaleCount = count,
         });
     }
@@ -85,17 +104,21 @@ public sealed class SalesRatioStudyController : ControllerBase
     public async Task<IActionResult> GetValidSalesByYear(
         Guid countyId,
         [FromQuery] DateTime? from = null,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (!TryAuthorize(countyId, out var fail))
             return fail!;
+        if (!TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+            return eraFail!;
 
-        var rows = await _reader.GetValidSalesByYearAsync(countyId, from, ct)
+        var rows = await _reader.GetValidSalesByYearAsync(countyId, from, resolvedEra, ct)
             .ConfigureAwait(false);
         return Ok(new
         {
             countyId,
             fromDate = from ?? ISalesRatioStudyReader.DefaultFromDate,
+            era = resolvedEra,
             rows,
         });
     }
@@ -110,19 +133,60 @@ public sealed class SalesRatioStudyController : ControllerBase
     public async Task<IActionResult> GetAggregateSalePrice(
         Guid countyId,
         [FromQuery] DateTime? from = null,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (!TryAuthorize(countyId, out var fail))
             return fail!;
+        if (!TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+            return eraFail!;
 
-        var aggregate = await _reader.GetAggregateSalePriceAsync(countyId, from, ct)
+        var aggregate = await _reader.GetAggregateSalePriceAsync(countyId, from, resolvedEra, ct)
             .ConfigureAwait(false);
         return Ok(new
         {
             countyId,
             fromDate = from ?? ISalesRatioStudyReader.DefaultFromDate,
+            era = resolvedEra,
             aggregate,
         });
+    }
+
+    /// <summary>
+    /// G3 (v1.12): normalizes the <c>era</c> query parameter.
+    /// Null/whitespace resolves to <see cref="ConversionEras.PostConversion"/>
+    /// (the documented default). Unrecognized values produce 400 with
+    /// the valid value list. Returns the resolved string for echo.
+    /// </summary>
+    private bool TryNormalizeEra(
+        string? era,
+        out string resolvedEra,
+        out IActionResult? failureResult)
+    {
+        if (string.IsNullOrWhiteSpace(era))
+        {
+            resolvedEra = ConversionEras.PostConversion;
+            failureResult = null;
+            return true;
+        }
+
+        var trimmed = era.Trim();
+        if (!ValidEraValues.Contains(trimmed))
+        {
+            _logger.LogWarning(
+                "[SalesRatioStudy] invalid era token: {Era}", trimmed);
+            resolvedEra = string.Empty;
+            failureResult = BadRequest(new
+            {
+                error = "invalid era",
+                validValues = ValidEraValues,
+            });
+            return false;
+        }
+
+        resolvedEra = trimmed;
+        failureResult = null;
+        return true;
     }
 
     /// <summary>

--- a/backend/src/TerraFusion.Core/Sync/SalesRatioStudy/ISalesRatioStudyReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/SalesRatioStudy/ISalesRatioStudyReader.cs
@@ -51,29 +51,55 @@ public interface ISalesRatioStudyReader
         new(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     /// <summary>
-    /// Q1: count of valid (qualified, post-cutover) sales for a
-    /// county.
+    /// Slice G3 (v1.12): special <c>era</c> token that bypasses the
+    /// era filter entirely. Returns rows regardless of their
+    /// <c>ConversionEra</c> column (including <c>NULL</c>). Used for
+    /// audit / migration sweeps; not the default.
     /// </summary>
+    public const string EraAll = "ALL";
+
+    /// <summary>
+    /// Q1: count of valid (qualified) sales for a county filtered by
+    /// conversion era (G3, v1.12) and a hard date floor.
+    /// </summary>
+    /// <param name="countyId">Sovereign-county scope.</param>
+    /// <param name="fromDate">
+    /// Hard <c>SlDt &gt;= fromDate</c> floor. Defaults to
+    /// <see cref="DefaultFromDate"/>.
+    /// </param>
+    /// <param name="era">
+    /// Conversion-era filter per Block-C contract v1.12 §2. Null
+    /// resolves to <c>POST_CONVERSION</c>. Recognized values:
+    /// <c>POST_CONVERSION</c>, <c>PRE_CONVERSION_2017</c>,
+    /// <c>UNKNOWN</c>, <see cref="EraAll"/>. Unknown values throw
+    /// <see cref="ArgumentException"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<int> GetValidSaleCountAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Q2: count of valid sales grouped by sale year, descending.
+    /// Q2: count of valid sales grouped by sale year, descending,
+    /// filtered by conversion era (G3, v1.12) and date floor.
     /// </summary>
     Task<IReadOnlyList<SalesByYearRow>> GetValidSalesByYearAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Q3: aggregate sale price (count, sum, average) for valid
-    /// sales whose <c>SlPrice</c> is non-null.
+    /// sales whose <c>SlPrice</c> is non-null, filtered by
+    /// conversion era (G3, v1.12) and date floor.
     /// </summary>
     Task<SalePriceAggregate> GetAggregateSalePriceAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default);
 }
 

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/SalesRatioStudyReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/SalesRatioStudyReader.cs
@@ -1,18 +1,22 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.SalesRatioStudy;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
 
 /// <summary>
-/// Slice F5: EF-backed read-model for sales-ratio-study
+/// Slice F5 + G3: EF-backed read-model for sales-ratio-study
 /// aggregates. Canonical-equivalent of the operator's morning
 /// queries documented in
-/// <c>docs/sync/operator-sql-regression/sales-ratio-queries.md</c>.
+/// <c>docs/sync/operator-sql-regression/sales-ratio-queries.md</c>,
+/// extended in v1.12 with the <c>era</c> conversion-era filter.
 ///
 /// <para>Read-only by contract: <c>AsNoTracking</c> on every
 /// query, no <c>SaveChangesAsync</c>. The reader sits over
@@ -23,6 +27,9 @@ namespace TerraFusion.Data.Services.CanonicalTf;
 /// </summary>
 public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
 {
+    private static readonly DateTime EraCutoverDate =
+        new(ConversionEras.CutoverYear, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     private readonly TerraFusionDbContext _db;
 
     public SalesRatioStudyReader(TerraFusionDbContext db) => _db = db;
@@ -30,9 +37,11 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
     public async Task<int> GetValidSaleCountAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
         var cutoff = fromDate ?? ISalesRatioStudyReader.DefaultFromDate;
+        var eraPredicate = ResolveEraPredicate(era);
 
         return await _db.TfSales
             .AsNoTracking()
@@ -40,15 +49,18 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
                         && s.SaleQualified
                         && s.SlDt != null
                         && s.SlDt >= cutoff)
+            .Where(eraPredicate)
             .CountAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<SalesByYearRow>> GetValidSalesByYearAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
         var cutoff = fromDate ?? ISalesRatioStudyReader.DefaultFromDate;
+        var eraPredicate = ResolveEraPredicate(era);
 
         // EF may not translate Year() across all providers; a
         // safe portable shape is to materialize the date column
@@ -60,6 +72,7 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
                         && s.SaleQualified
                         && s.SlDt != null
                         && s.SlDt >= cutoff)
+            .Where(eraPredicate)
             .Select(s => s.SlDt!.Value)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -77,9 +90,11 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
     public async Task<SalePriceAggregate> GetAggregateSalePriceAsync(
         Guid countyId,
         DateTime? fromDate = null,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
         var cutoff = fromDate ?? ISalesRatioStudyReader.DefaultFromDate;
+        var eraPredicate = ResolveEraPredicate(era);
 
         var prices = await _db.TfSales
             .AsNoTracking()
@@ -88,6 +103,7 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
                         && s.SlDt != null
                         && s.SlDt >= cutoff
                         && s.SlPrice != null)
+            .Where(eraPredicate)
             .Select(s => s.SlPrice!.Value)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -108,5 +124,53 @@ public sealed class SalesRatioStudyReader : ISalesRatioStudyReader
             TotalPrice = sum,
             AveragePrice = sum / prices.Count,
         };
+    }
+
+    /// <summary>
+    /// Slice G3 (v1.12): translates an era filter token into a
+    /// <c>tf_sale</c> predicate. Per Block-C contract v1.12 §2:
+    ///
+    /// <list type="bullet">
+    ///   <item><c>null</c> resolves to <see cref="ConversionEras.PostConversion"/>.</item>
+    ///   <item><see cref="ISalesRatioStudyReader.EraAll"/> bypasses
+    ///   the era filter entirely.</item>
+    ///   <item>Recognized eras (POST / PRE / UNKNOWN) match by
+    ///   exact column value AND, for POST / PRE only, by
+    ///   year-fallback when the column is <c>NULL</c> (per v1.10 §0.5
+    ///   doctrine that pre-G2 rows fall back to their year column).</item>
+    ///   <item>Unrecognized values throw <see cref="ArgumentException"/>.</item>
+    /// </list>
+    /// </summary>
+    private static Expression<Func<TfSale, bool>> ResolveEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == ISalesRatioStudyReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return s => s.ConversionEra == ConversionEras.PostConversion
+                || (s.ConversionEra == null && s.SlDt != null && s.SlDt >= EraCutoverDate);
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return s => s.ConversionEra == ConversionEras.PreConversion2017
+                || (s.ConversionEra == null && s.SlDt != null && s.SlDt < EraCutoverDate);
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            // UNKNOWN never falls back to year — by doctrine v1.10 §2
+            // the truth-layer never emits UNKNOWN, and canonical-layer
+            // UNKNOWN is the explicit "contributors disagree" signal.
+            return s => s.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {ISalesRatioStudyReader.EraAll}.",
+            nameof(era));
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/SalesRatioStudyControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/SalesRatioStudyControllerTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.SalesRatioStudy;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Slice G3 (v1.12) acceptance tests for
+/// <see cref="SalesRatioStudyController"/>'s new <c>era</c> query
+/// parameter. Auth + reader-delegation coverage; the era predicate
+/// itself is fully covered by <see cref="SalesRatioStudyReaderTests"/>.
+///
+/// <para>Contract focus:
+/// <list type="bullet">
+///   <item>200 happy path with default era resolves to POST_CONVERSION.</item>
+///   <item>200 with explicit recognized era is echoed back in the body.</item>
+///   <item>400 with invalid era token (and the valid-values list).</item>
+///   <item>403 still enforced when caller lacks the county claim
+///   (regression guard for the v1.9 auth contract).</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class SalesRatioStudyControllerTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("19190019-1919-1919-1919-191919191919");
+
+    private readonly TerraFusionDbContext _db;
+
+    public SalesRatioStudyControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"g3-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private SalesRatioStudyController BuildController(Guid? principalCountyClaim)
+    {
+        var reader = new SalesRatioStudyReader(_db);
+        var ctrl = new SalesRatioStudyController(
+            reader, NullLogger<SalesRatioStudyController>.Instance);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: principalCountyClaim is null ? null : "Test");
+        if (principalCountyClaim is not null)
+        {
+            identity.AddClaim(new Claim("countyId", principalCountyClaim.Value.ToString()));
+        }
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+            },
+        };
+        return ctrl;
+    }
+
+    private async Task SeedSaleAsync(
+        Guid countyId,
+        long chgOfOwnerId,
+        DateTime slDt,
+        decimal price,
+        string? era)
+    {
+        _db.TfSales.Add(new TfSale
+        {
+            CountyId = countyId,
+            TfParcelId = Guid.NewGuid(),
+            ChgOfOwnerId = chgOfOwnerId,
+            SlDt = slDt,
+            SlPrice = price,
+            AdjSlPrice = price,
+            SaleQualified = true,
+            PromotionLoadBatchId = Guid.NewGuid(),
+            ConversionEra = era,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// The controller wraps each response in an anonymous-type
+    /// projection (countyId, fromDate, era, ...). Reflection-extract
+    /// keeps tests independent of those types.
+    /// </summary>
+    private static T ExtractProperty<T>(object? body, string name)
+    {
+        body.Should().NotBeNull();
+        var prop = body!.GetType().GetProperty(
+            name, BindingFlags.Public | BindingFlags.Instance);
+        prop.Should().NotBeNull($"response body should expose '{name}'");
+        var value = prop!.GetValue(body);
+        value.Should().BeOfType<T>();
+        return (T)value!;
+    }
+
+    [Fact]
+    public async Task GetValidSaleCount_OmittedEra_DefaultsToPostConversion()
+    {
+        await SeedSaleAsync(CountyA, 1,
+            new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(CountyA, 2,
+            new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            200_000m, era: ConversionEras.Unknown);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetValidSaleCount(CountyA);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+        ExtractProperty<int>(ok.Value, "validSaleCount")
+            .Should().Be(1, "default era=POST excludes the UNKNOWN row");
+    }
+
+    [Fact]
+    public async Task GetValidSaleCount_ExplicitEraAll_BypassesFilter()
+    {
+        await SeedSaleAsync(CountyA, 1,
+            new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(CountyA, 2,
+            new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            200_000m, era: ConversionEras.Unknown);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetValidSaleCount(CountyA, era: ISalesRatioStudyReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ISalesRatioStudyReader.EraAll);
+        ExtractProperty<int>(ok.Value, "validSaleCount").Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData("BOGUS_ERA")]
+    [InlineData("post_conversion")]   // case-sensitive; lowercase is invalid
+    [InlineData("ALL ")]               // controller trims, but extra-internal tokens are different — covered by trimming
+    public async Task GetValidSaleCount_InvalidEra_Returns400(string badEra)
+    {
+        // Trim + case sensitivity is part of the contract: only the
+        // exact frozen tokens (POST_CONVERSION, PRE_CONVERSION_2017,
+        // UNKNOWN, ALL) are accepted. The "ALL " case actually trims
+        // to "ALL" and is valid, so we exclude it from this Theory.
+        if (badEra.Trim() == ISalesRatioStudyReader.EraAll) return;
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetValidSaleCount(CountyA, era: badEra);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetValidSaleCount_NoCountyClaim_Returns403()
+    {
+        var ctrl = BuildController(principalCountyClaim: null);
+        var result = await ctrl.GetValidSaleCount(CountyA);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetValidSalesByYear_EchoesEraInResponse()
+    {
+        await SeedSaleAsync(CountyA, 1,
+            new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetValidSalesByYear(
+            CountyA, era: ConversionEras.PostConversion);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+    }
+
+    [Fact]
+    public async Task GetAggregateSalePrice_EchoesEraInResponse()
+    {
+        await SeedSaleAsync(CountyA, 1,
+            new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetAggregateSalePrice(
+            CountyA, era: ConversionEras.PostConversion);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+    }
+
+    [Fact]
+    public async Task EraTrimWhitespace_AcceptedAsEquivalent()
+    {
+        // Controller trims whitespace before validating.
+        await SeedSaleAsync(CountyA, 1,
+            new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetValidSaleCount(
+            CountyA, era: "  POST_CONVERSION  ");
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/SalesRatioStudyReaderTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/SalesRatioStudyReaderTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.SalesRatioStudy;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.CanonicalTf;
@@ -55,7 +56,8 @@ public sealed class SalesRatioStudyReaderTests : IDisposable
         long chgOfOwnerId,
         DateTime? slDt,
         decimal? slPrice,
-        bool qualified = true)
+        bool qualified = true,
+        string? era = null)
     {
         _db.TfSales.Add(new TfSale
         {
@@ -67,6 +69,11 @@ public sealed class SalesRatioStudyReaderTests : IDisposable
             AdjSlPrice = slPrice,
             SaleQualified = qualified,
             PromotionLoadBatchId = Guid.NewGuid(),
+            // G3 (v1.12): era stamping mirrors what the canonical
+            // projector does. Tests that seed without an era are
+            // deliberately exercising the NULL-fallback path per
+            // doctrine v1.10 §0.5.
+            ConversionEra = era,
         });
         await _db.SaveChangesAsync();
     }
@@ -225,5 +232,150 @@ public sealed class SalesRatioStudyReaderTests : IDisposable
         // Per v1.9 §2: the cutover is 2018-01-01 UTC.
         ISalesRatioStudyReader.DefaultFromDate.Should()
             .Be(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // G3 (v1.12) — era filter
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EraFilter_DefaultsToPostConversion_WhenOmitted()
+    {
+        // v1.12 §2: omitting era resolves to POST_CONVERSION.
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(benton, 2, new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            200_000m, era: ConversionEras.Unknown);
+
+        var defaultCount = await Build().GetValidSaleCountAsync(benton);
+        var explicitCount = await Build().GetValidSaleCountAsync(
+            benton, era: ConversionEras.PostConversion);
+
+        defaultCount.Should().Be(1, "only the POST row matches the default");
+        explicitCount.Should().Be(defaultCount,
+            "explicit POST_CONVERSION matches the default behavior");
+    }
+
+    [Fact]
+    public async Task EraFilter_PostConversion_FallsBackToYearForNullEra()
+    {
+        // v1.10 §0.5 + v1.12 §2: rows whose ConversionEra is NULL
+        // fall back to their SlDt year. A 2020 sale with NULL era
+        // is treated as POST under era=POST.
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: null); // pre-G2 NULL era
+
+        var count = await Build().GetValidSaleCountAsync(
+            benton, era: ConversionEras.PostConversion);
+        count.Should().Be(1,
+            "v1.10 §0.5: NULL era falls back to SlDt year (2020 ⇒ POST)");
+    }
+
+    [Fact]
+    public async Task EraFilter_PreConversion_RequiresExplicitFromDateOverride()
+    {
+        // PRE-conversion sales have SlDt < 2018 by definition. The
+        // default fromDate of 2018-01-01 excludes them. To query the
+        // pre-conversion era, callers must pass fromDate explicitly.
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2010, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            50_000m, era: ConversionEras.PreConversion2017);
+        await SeedSaleAsync(benton, 2, new DateTime(2015, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            75_000m, era: null); // NULL era, pre-2018 date
+
+        var count = await Build().GetValidSaleCountAsync(
+            benton,
+            fromDate: new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.PreConversion2017);
+
+        count.Should().Be(2,
+            "explicit PRE row + NULL-era row whose SlDt year derives PRE");
+    }
+
+    [Fact]
+    public async Task EraFilter_Unknown_RequiresExactColumnMatch()
+    {
+        // v1.12 §2: UNKNOWN does not fall back to year — by doctrine
+        // v1.10 §2 the truth-layer never emits UNKNOWN, and
+        // canonical-layer UNKNOWN is the explicit "contributors
+        // disagree" signal. NULL rows do NOT satisfy era=UNKNOWN.
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.Unknown);
+        await SeedSaleAsync(benton, 2, new DateTime(2020, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            200_000m, era: null);
+
+        var count = await Build().GetValidSaleCountAsync(
+            benton, era: ConversionEras.Unknown);
+        count.Should().Be(1, "only the explicit UNKNOWN row matches");
+    }
+
+    [Fact]
+    public async Task EraFilter_All_BypassesEraEntirely()
+    {
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(benton, 2, new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            200_000m, era: ConversionEras.Unknown);
+        await SeedSaleAsync(benton, 3, new DateTime(2022, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            300_000m, era: null);
+
+        var count = await Build().GetValidSaleCountAsync(
+            benton, era: ISalesRatioStudyReader.EraAll);
+        count.Should().Be(3, "EraAll bypasses the era filter");
+    }
+
+    [Fact]
+    public async Task EraFilter_Q2_ByYear_HonorsEraFilter()
+    {
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(benton, 2, new DateTime(2020, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            150_000m, era: ConversionEras.Unknown);
+
+        var defaultRows = await Build().GetValidSalesByYearAsync(benton);
+        defaultRows.Should().ContainSingle()
+            .Which.Count.Should().Be(1, "default era=POST excludes UNKNOWN row");
+
+        var allRows = await Build().GetValidSalesByYearAsync(
+            benton, era: ISalesRatioStudyReader.EraAll);
+        allRows.Should().ContainSingle()
+            .Which.Count.Should().Be(2, "EraAll includes both rows");
+    }
+
+    [Fact]
+    public async Task EraFilter_Q3_PriceAggregate_HonorsEraFilter()
+    {
+        var benton = Guid.NewGuid();
+        await SeedSaleAsync(benton, 1, new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            100_000m, era: ConversionEras.PostConversion);
+        await SeedSaleAsync(benton, 2, new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            300_000m, era: ConversionEras.Unknown);
+
+        var defaultAgg = await Build().GetAggregateSalePriceAsync(benton);
+        defaultAgg.Count.Should().Be(1);
+        defaultAgg.TotalPrice.Should().Be(100_000m);
+
+        var allAgg = await Build().GetAggregateSalePriceAsync(
+            benton, era: ISalesRatioStudyReader.EraAll);
+        allAgg.Count.Should().Be(2);
+        allAgg.TotalPrice.Should().Be(400_000m);
+        allAgg.AveragePrice.Should().Be(200_000m);
+    }
+
+    [Fact]
+    public async Task EraFilter_InvalidToken_Throws()
+    {
+        var benton = Guid.NewGuid();
+
+        var act = async () => await Build().GetValidSaleCountAsync(
+            benton, era: "BOGUS_ERA");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .Where(e => e.Message.Contains("Unrecognized era"));
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
@@ -1060,6 +1060,45 @@ public sealed class BlockCContractV1Tests : IDisposable
         }).Should().Be(ConversionEras.Unknown);
     }
 
+    // ───────────────────────────────────────────────────────────────
+    // v1.12 addendum — eraFilter on SalesRatioStudy read endpoints (G3)
+    // ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Contract_v1_12_ISalesRatioStudyReader_EraAll_IsFrozen()
+    {
+        // v1.12 §2: the special "ALL" token bypasses the era filter.
+        // The constant is part of the public contract; renaming it is
+        // a v2 BREAKING change.
+        TerraFusion.Core.Sync.SalesRatioStudy.ISalesRatioStudyReader.EraAll
+            .Should().Be("ALL", "Block-C contract v1.12 §2 freezes the EraAll token");
+    }
+
+    [Fact]
+    public void Contract_v1_12_DefaultFromDate_StillLockedToCutoverConvention()
+    {
+        // v1.12 carries forward v1.9's date floor. The date filter
+        // and the era filter are orthogonal — both apply by default.
+        TerraFusion.Core.Sync.SalesRatioStudy.ISalesRatioStudyReader.DefaultFromDate
+            .Should().Be(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                "Block-C contract v1.12 §3 carries forward v1.9's date-floor default");
+    }
+
+    [Fact]
+    public void Contract_v1_12_EraDefault_IsPostConversion()
+    {
+        // v1.12 §2: when the operator omits the era query parameter,
+        // the default is POST_CONVERSION per v1.10 §3. This is locked
+        // by reflecting the controller's default-resolution test.
+        // The reader's contract says null => POST_CONVERSION; the
+        // controller's contract says null/whitespace => POST_CONVERSION.
+        // Both reduce to the same default, which the Doctrine pins
+        // here via the vocabulary identity assertion.
+        ConversionEras.PostConversion
+            .Should().Be("POST_CONVERSION",
+                "v1.12 §2 documented default for omitted era");
+    }
+
     [Fact]
     public void Contract_v1_11_CanonicalTf_AllSixEntities_HaveConversionEraColumn()
     {

--- a/docs/pacs/block-c-contract-v1.12.md
+++ b/docs/pacs/block-c-contract-v1.12.md
@@ -1,0 +1,204 @@
+# Block-C Contract — v1.12 (G3 eraFilter on SalesRatioStudy Read Endpoints)
+
+**Status:** binding doctrine. Version `v1.12`. Frozen 2026-05-03.
+**Predecessor:** `docs/pacs/block-c-contract-v1.11.md` (v1.11, 2026-05-03).
+**Layer:** 3.5 of the PACS doctrine stack.
+
+```text
+docs/pacs/block-c-contract-v1.md             (v1   — base freeze)
+docs/pacs/block-c-contract-v1.1.md           (v1.1 — dict_neighborhood)
+docs/pacs/block-c-contract-v1.2.md           (v1.2 — attribute_definition)
+docs/pacs/block-c-contract-v1.3.md           (v1.3 — nullable AttributeId FKs)
+docs/pacs/block-c-contract-v1.4.md           (v1.4 — QuarantineReasons closed vocab)
+docs/pacs/block-c-contract-v1.5.md           (v1.5 — attribute resolution semantics)
+docs/pacs/block-c-contract-v1.6.md           (v1.6 — two-layer quarantine vocabulary)
+docs/pacs/block-c-contract-v1.7.md           (v1.7 — E4c documented deferral; Block E close)
+docs/pacs/block-c-contract-v1.8.md           (v1.8 — Block-D D1+D2+D3 + legacy retirement)
+docs/pacs/block-c-contract-v1.9.md           (v1.9 — F5 sales-ratio-study read-model)
+docs/pacs/block-c-contract-v1.10.md          (v1.10 — G1 truth-layer ConversionEra)
+docs/pacs/block-c-contract-v1.11.md          (v1.11 — G2 canonical-layer ConversionEra)
+docs/pacs/block-c-contract-v1.12.md          (v1.12 — G3 eraFilter on read endpoints) ← this doc
+```
+
+## 0. What v1.12 is
+
+A coordinated minor bump that records:
+
+1. **G3** consumes the canonical-layer `ConversionEra` (G2, v1.11) on
+   the SalesRatioStudy read endpoints. A new `era` query parameter
+   filters the three F5 surfaces (Q1 valid count, Q2 by-year, Q3
+   aggregate price) by conversion era.
+2. The `era` parameter defaults to `POST_CONVERSION` per v1.10 §3,
+   so existing operator dashboards see no behavioral change. The
+   filter is additive — pre-G3 callers still get the same data.
+3. The new `ISalesRatioStudyReader.EraAll` constant ("ALL") is the
+   doctrine-frozen token for "bypass the era filter entirely."
+4. Subsequent slices (G4 promotion gate for pre-conversion-row
+   share, future G* expansion to Parcel-Owner / Parcel-Wsdor /
+   TfSales endpoints) consume the same vocabulary. They are not
+   in scope for v1.12.
+
+No schema change. No migration. v1.12 is read-model + doctrine
+only, mirroring v1.9's surface-only pattern.
+
+## 0.5 Doctrine integrity disclosure (carry-forward)
+
+v1.10 §0.5 promised: "read endpoints treat `NULL` as 'era unknown
+— fall back to the year column'." v1.12 implements exactly that
+fallback for the SalesRatioStudy reader. Other read endpoints
+(`/api/sales`, `/api/parcels/{id}/owners`, `/api/parcels/{id}/wsdor`)
+do **not** yet take an `era` parameter — those are deferred to a
+future slice. Until they get one, those endpoints continue to
+return rows regardless of era (status quo from before G1).
+
+## 1. The query-parameter shape
+
+```text
+GET /api/counties/{countyId}/sales-ratio-study/valid-sale-count
+    ?from=YYYY-MM-DD            (optional; default 2018-01-01 UTC)
+    &era=POST_CONVERSION        (optional; default POST_CONVERSION)
+GET /api/counties/{countyId}/sales-ratio-study/by-year
+    ?from=...&era=...
+GET /api/counties/{countyId}/sales-ratio-study/price-aggregate
+    ?from=...&era=...
+```
+
+Recognized `era` values:
+
+| Token | Behavior |
+|---|---|
+| (omitted) | Resolves to `POST_CONVERSION` — the default per v1.10 §3 |
+| `POST_CONVERSION` | Match `ConversionEra = 'POST_CONVERSION'` OR (`ConversionEra IS NULL` AND `SlDt >= 2018-01-01`) |
+| `PRE_CONVERSION_2017` | Match `ConversionEra = 'PRE_CONVERSION_2017'` OR (`ConversionEra IS NULL` AND `SlDt < 2018-01-01`) |
+| `UNKNOWN` | Match `ConversionEra = 'UNKNOWN'` exactly. Does NOT fall back to year — by doctrine v1.10 §2 the truth-layer never emits UNKNOWN, so a NULL row is unambiguously "not yet stamped," not "could not be determined." |
+| `ALL` | Bypass the era filter. Returns every row regardless of era (including NULL). The constant lives on `ISalesRatioStudyReader.EraAll`. |
+| anything else | 400 Bad Request with `validValues` listing the four accepted tokens |
+
+The token comparison is **case-sensitive and trim-tolerant**:
+leading/trailing whitespace is stripped before validation, but
+casing must match exactly. This matches the closed-vocabulary
+semantics of v1.10 §1.
+
+## 2. The resolution rule
+
+```csharp
+// In SalesRatioStudyReader (Data layer).
+private static Expression<Func<TfSale, bool>> ResolveEraPredicate(string? era);
+```
+
+Behavior frozen by `SalesRatioStudyReaderTests` cases under
+"G3 (v1.12) — era filter":
+
+```text
+era=null     →  predicate(POST_CONVERSION)
+era=POST_*   →  s.ConversionEra == "POST_CONVERSION"
+                 OR (s.ConversionEra IS NULL AND s.SlDt >= 2018-01-01)
+era=PRE_*    →  s.ConversionEra == "PRE_CONVERSION_2017"
+                 OR (s.ConversionEra IS NULL AND s.SlDt < 2018-01-01)
+era=UNKNOWN  →  s.ConversionEra == "UNKNOWN"   (no NULL fallback)
+era=ALL      →  always true
+era=other    →  ArgumentException
+```
+
+The era filter is composed with the existing date-floor filter
+via SQL `AND`. Both apply orthogonally:
+
+- `era=POST_CONVERSION` (default) + `from=2020-01-01`: post-conversion
+  sales since 2020.
+- `era=PRE_CONVERSION_2017` + `from=2010-01-01`: pre-conversion
+  sales since 2010.
+- `era=PRE_CONVERSION_2017` (no `from` override): empty result, by
+  construction — pre rows have `SlDt < 2018-01-01` and the default
+  floor excludes them. Operators must pass `from` explicitly to
+  query pre-conversion data.
+
+## 3. The response shape
+
+Each endpoint's 200 body now includes the resolved `era` token:
+
+```json
+{
+  "countyId": "...",
+  "fromDate": "2018-01-01T00:00:00Z",
+  "era": "POST_CONVERSION",
+  "validSaleCount": 42
+}
+```
+
+The echo-back makes the resolved default visible to operators and
+keeps the response self-describing.
+
+400 body on invalid era:
+
+```json
+{
+  "error": "invalid era",
+  "validValues": ["POST_CONVERSION", "PRE_CONVERSION_2017", "UNKNOWN", "ALL"]
+}
+```
+
+403 (cross-county or missing claim) is unchanged from v1.9.
+
+## 4. Tests
+
+### Reader tests (`SalesRatioStudyReaderTests`)
+
+New section "G3 (v1.12) — era filter":
+
+- `EraFilter_DefaultsToPostConversion_WhenOmitted`
+- `EraFilter_PostConversion_FallsBackToYearForNullEra`
+- `EraFilter_PreConversion_RequiresExplicitFromDateOverride`
+- `EraFilter_Unknown_RequiresExactColumnMatch`
+- `EraFilter_All_BypassesEraEntirely`
+- `EraFilter_Q2_ByYear_HonorsEraFilter`
+- `EraFilter_Q3_PriceAggregate_HonorsEraFilter`
+- `EraFilter_InvalidToken_Throws`
+
+### Controller tests (`SalesRatioStudyControllerTests` — new file)
+
+Reflection-based response-body inspection (the controller wraps
+results in anonymous types). Coverage:
+
+- `GetValidSaleCount_OmittedEra_DefaultsToPostConversion`
+- `GetValidSaleCount_ExplicitEraAll_BypassesFilter`
+- `GetValidSaleCount_InvalidEra_Returns400` (theory: 3 cases)
+- `GetValidSaleCount_NoCountyClaim_Returns403` (auth regression)
+- `GetValidSalesByYear_EchoesEraInResponse`
+- `GetAggregateSalePrice_EchoesEraInResponse`
+- `EraTrimWhitespace_AcceptedAsEquivalent`
+
+### Doctrine tests (`BlockCContractV1Tests` — v1.12 band)
+
+- `Contract_v1_12_ISalesRatioStudyReader_EraAll_IsFrozen` — locks
+  the `"ALL"` token value.
+- `Contract_v1_12_DefaultFromDate_StillLockedToCutoverConvention`
+  — carries forward v1.9 §2's date-floor freeze.
+- `Contract_v1_12_EraDefault_IsPostConversion` — locks the
+  vocabulary identity that backs the documented default.
+
+## 5. What v1.12 does NOT change
+
+- Schema: zero changes. No new column, no new migration. The
+  doctrine tests in `Contract_RequiredMigrations_ArePresentInDataAssembly`
+  do not need a v1.12 fragment.
+- Other read endpoints: `/api/sales`, `/api/parcels/{id}/owners`,
+  `/api/parcels/{id}/wsdor`, `/api/parcels/{id}/geometry` are
+  unchanged. Adding `era` to those is a future slice.
+- Promotion-side behavior: G4 (pre-conversion-row-share gate) is
+  still pending.
+- All other v1.x-frozen shapes (sales codes, gates, dictionary
+  tables, GIS scaffold, AttributeDefinition, QuarantineReasons,
+  LandingQuarantineReasons, SourceFamilies, ConversionEras
+  vocabulary) remain untouched.
+
+## 6. Linked GitHub issues
+
+- **G3** — closed by this slice (this doc).
+- **G4** — pending. Tracked under the Block-G milestone in the
+  design spine (`blocks-d-through-h-design.md` §G).
+- Future expansion of `eraFilter` to other read endpoints — to be
+  scoped when operators request it.
+- **OPERATOR-SQL-IMPORT-1 (#726)** — unrelated to G3 but still
+  blocking F1/F3/F4 per v1.9.
+- **CI-HYGIENE-1 (#724)** — chronic main-state continues to
+  require admin-merge through documented exception.


### PR DESCRIPTION
## Summary
- Add an `era` query parameter to the three SalesRatioStudy read endpoints (Q1 valid-count, Q2 by-year, Q3 aggregate price). Default = `POST_CONVERSION`, so existing operator dashboards see no behavioral change.
- The reader composes era + date floor via SQL `AND`. Pre-G2 rows with `NULL` era fall back to their `SlDt` year, honoring the doctrine v1.10 §0.5 commitment.
- Doctrine bumped to **v1.11 → v1.12**. New regression tests lock the `EraAll = "ALL"` constant, the date-floor default, and the omitted-era default.
- **No schema change. No migration.** v1.12 is read-model + doctrine only, mirroring v1.9's surface-only pattern.

## What changed
- **Reader interface (`ISalesRatioStudyReader`):** adds `string? era = null` to all 3 method signatures + the `EraAll = "ALL"` constant.
- **Reader (`SalesRatioStudyReader`):** new `ResolveEraPredicate` helper translates the era token into a `tf_sale` predicate. Out-of-vocabulary tokens throw `ArgumentException`; `null` resolves to `POST_CONVERSION`.
- **Controller (`SalesRatioStudyController`):** adds `[FromQuery] string? era = null`. Whitespace-trim + case-sensitive validation against the frozen 4-token set; returns 400 with `validValues` list on invalid input. Resolved era is echoed in the response body.
- **Doctrine:** `docs/pacs/block-c-contract-v1.12.md` frozen 2026-05-03.

## Recognized `era` values
| Token | Behavior |
|---|---|
| (omitted) | Defaults to `POST_CONVERSION` per v1.10 §3 |
| `POST_CONVERSION` | exact-match OR (NULL era AND `SlDt >= 2018-01-01`) |
| `PRE_CONVERSION_2017` | exact-match OR (NULL era AND `SlDt < 2018-01-01`) |
| `UNKNOWN` | exact-match only — no NULL fallback (per v1.10 §2 truth never emits UNKNOWN) |
| `ALL` | bypass the era filter entirely |
| anything else | 400 BadRequest |

## Out of scope (subsequent slices)
- **G4** — pre-conversion-row-share promotion gate.
- Future expansion of `eraFilter` to `/api/sales`, `/api/parcels/{id}/owners`, `/api/parcels/{id}/wsdor` once operators request it.

## Test plan
- [x] `dotnet build TerraFusion.sln` — 0 errors, pre-existing warnings only.
- [x] `dotnet test --filter "SalesRatioStudy|Contract_v1_12"` — 31/31 green:
  - 11/11 existing F5 reader tests (regression)
  - 8/8 new reader era-filter tests
  - 8/8 new controller tests (3 theory cases for invalid tokens)
  - 3/3 v1.12 doctrine tests
- [x] `dotnet test --filter "Contract_v1_10|Contract_v1_11|Contract_RequiredMigrations|PacsSale*"` — 42/42 G1+G2 regression green.
- [x] Pre-commit + pre-push quality gates green.
- [ ] CI — same chronic-red CI-HYGIENE-1 (#724) Warning Gate flap expected on pre-existing CS warnings; admin-merge-through pattern applies.

## Doctrine integrity disclosure
Other read endpoints (`/api/sales`, parcel-owner, parcel-wsdor) do **not** yet take an `era` parameter — they continue returning rows regardless of era (status quo from before G1). When operators ask for it, future slices will extend the same vocabulary to those endpoints. No quiet drift; the era contract is locked here for the SalesRatioStudy surface and is the template for everything that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sales endpoints now support optional era filtering to refine results by conversion period.
  * Response bodies now include the applied era filter value for clarity.

* **Tests**
  * Added comprehensive test coverage for era filter validation and endpoint behavior.

* **Documentation**
  * Updated API documentation with era parameter details and contract specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->