### PR TITLE
feat(block-g/G4): per-lane pre-conversion-share promotion gate — Block G close

### DIFF
--- a/backend/src/TerraFusion.Data/Services/TruthPacs/ConversionEraGate.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/ConversionEraGate.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using TerraFusion.Core.Entities.SyncBridge;
+
+namespace TerraFusion.Data.Services.TruthPacs;
+
+/// <summary>
+/// Slice G4 (v1.13): shared promotion-gate helper that records the
+/// pre-conversion-row share for a truth-promotion batch.
+///
+/// <para>The gate is informational, not blocking. Per Block-C contract
+/// v1.13 §2 the era column is provenance, not validation — the
+/// promoter still completes COMPLETED regardless of the share. The
+/// gate raises <c>WARN</c> when the share exceeds
+/// <see cref="PreConversionShareWarnThreshold"/> so operators can
+/// notice when an inbound batch is dominated by pre-2017-conversion
+/// rows (whose coded fields have semantically distinct meaning).</para>
+///
+/// <para>Naming convention: <c>truth-pacs-{lane}-pre-conversion-share</c>
+/// where <c>{lane}</c> is one of <c>sale</c>, <c>owner</c>,
+/// <c>wpov</c>, <c>imprv</c>, <c>land</c>. The gate name pattern is
+/// frozen by doctrine v1.13 §3.</para>
+/// </summary>
+public static class ConversionEraGate
+{
+    /// <summary>
+    /// Slice G4 (v1.13): doctrine-frozen WARN threshold. A batch
+    /// whose pre-conversion share is strictly greater than this
+    /// fraction trips the WARN gate. The default (5%) is suitable
+    /// for current-year promotions; historical-backfill batches
+    /// will trip it by design and operators will acknowledge the
+    /// WARN explicitly.
+    ///
+    /// <para>This is intentionally a code constant rather than a
+    /// runtime-configurable knob in v1.13. Future v1.x bumps may
+    /// promote it to <c>IOptions&lt;PromotionGateOptions&gt;</c>
+    /// once operators have field experience with the default.</para>
+    /// </summary>
+    public const decimal PreConversionShareWarnThreshold = 0.05m;
+
+    /// <summary>
+    /// Doctrine-frozen prefix for the gate name. Combined with the
+    /// lane id and <see cref="GateSuffix"/> to produce e.g.
+    /// <c>truth-pacs-sale-pre-conversion-share</c>.
+    /// </summary>
+    public const string GateNamePrefix = "truth-pacs";
+
+    /// <summary>
+    /// Doctrine-frozen suffix for the gate name.
+    /// </summary>
+    public const string GateNameSuffix = "pre-conversion-share";
+
+    /// <summary>The five lane identifiers that participate in G4.</summary>
+    public static class Lanes
+    {
+        public const string Sale = "sale";
+        public const string Owner = "owner";
+        public const string Wpov = "wpov";
+        public const string Imprv = "imprv";
+        public const string Land = "land";
+    }
+
+    /// <summary>
+    /// Composes the doctrine-frozen gate name for a lane.
+    /// </summary>
+    public static string GateNameFor(string lane) =>
+        $"{GateNamePrefix}-{lane}-{GateNameSuffix}";
+
+    /// <summary>
+    /// Slice G4 (v1.13): records the pre-conversion-share gate for a
+    /// truth-promotion batch. Adds a <see cref="PromotionGateResult"/>
+    /// row to the supplied DbContext but does NOT call
+    /// <c>SaveChangesAsync</c> — the caller batches the save with its
+    /// other end-of-promotion gate writes for fewer round-trips.
+    /// </summary>
+    /// <param name="db">The TerraFusion DbContext.</param>
+    /// <param name="batch">The promotion LoadBatch this gate belongs to.</param>
+    /// <param name="lane">One of <see cref="Lanes"/>.</param>
+    /// <param name="totalPromoted">
+    /// Total rows promoted in this batch (denominator). Zero is
+    /// allowed and resolves to <c>PASS</c> with a 0% share.
+    /// </param>
+    /// <param name="preConversionPromoted">
+    /// Subset of promoted rows whose <c>ConversionEra</c> resolved to
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.PreConversion2017"/>
+    /// (numerator).
+    /// </param>
+    public static void AddShareGate(
+        TerraFusionDbContext db,
+        LoadBatch batch,
+        string lane,
+        int totalPromoted,
+        int preConversionPromoted)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrEmpty(lane);
+        if (preConversionPromoted < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(preConversionPromoted),
+                "pre-conversion count must be non-negative");
+        if (preConversionPromoted > totalPromoted)
+            throw new ArgumentOutOfRangeException(
+                nameof(preConversionPromoted),
+                $"pre-conversion count ({preConversionPromoted}) cannot " +
+                $"exceed total promoted ({totalPromoted})");
+
+        var share = totalPromoted == 0
+            ? 0m
+            : (decimal)preConversionPromoted / totalPromoted;
+
+        var status = share > PreConversionShareWarnThreshold ? "WARN" : "PASS";
+
+        db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = GateNameFor(lane),
+            GateStage = "RAW_TO_TRUTH",
+            Status = status,
+            Expected = string.Format(
+                CultureInfo.InvariantCulture,
+                "<= {0:P2}",
+                PreConversionShareWarnThreshold),
+            Actual = string.Format(CultureInfo.InvariantCulture, "{0:P2}", share),
+            Detail = string.Format(
+                CultureInfo.InvariantCulture,
+                "preConversion={0} total={1} threshold={2:P2}",
+                preConversionPromoted,
+                totalPromoted,
+                PreConversionShareWarnThreshold),
+            ExecutedAt = DateTime.UtcNow,
+        });
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
@@ -118,6 +118,8 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
             var promoted = 0;
             var rejectedNoSupp = 0;
             var rejectedStaleSup = 0;
+            // G4 (v1.13): pre-conversion-share gate counter.
+            var preConversionPromoted = 0;
             decimal imprvValSum = 0m;
             var now = DateTime.UtcNow;
 
@@ -135,6 +137,10 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                     rejectedStaleSup++;
                     continue;
                 }
+
+                // G1 (v1.10): conversion-era marker derived from PropValYr.
+                var era = ConversionEras.FromYear(imprv.PropValYr);
+                if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
 
                 _db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
                 {
@@ -156,8 +162,7 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                     ImprvLoadBatchId = imprvLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
-                    // G1 (v1.10): conversion-era marker derived from PropValYr.
-                    ConversionEra = ConversionEras.FromYear(imprv.PropValYr),
+                    ConversionEra = era,
                     PromotedAt = now,
                 });
                 promoted++;
@@ -165,6 +170,12 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                 if (imprv.ImprvVal.HasValue) imprvValSum += imprv.ImprvVal.Value;
             }
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // G4 (v1.13): pre-conversion-share gate. Queued before the
+            // remaining-gate writes so they batch into a single save.
+            ConversionEraGate.AddShareGate(
+                _db, batch, ConversionEraGate.Lanes.Imprv,
+                promoted, preConversionPromoted);
 
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNoSupp, rejectedStaleSup, imprvValSum,

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsLandCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsLandCurrentTruthPromoter.cs
@@ -118,6 +118,8 @@ public sealed class PacsLandCurrentTruthPromoter : IPacsLandCurrentTruthPromoter
             var promoted = 0;
             var rejectedNoSupp = 0;
             var rejectedStaleSup = 0;
+            // G4 (v1.13): pre-conversion-share gate counter.
+            var preConversionPromoted = 0;
             decimal acresSum = 0m;
             decimal marketValSum = 0m;
             var now = DateTime.UtcNow;
@@ -136,6 +138,10 @@ public sealed class PacsLandCurrentTruthPromoter : IPacsLandCurrentTruthPromoter
                     rejectedStaleSup++;
                     continue;
                 }
+
+                // G1 (v1.10): conversion-era marker derived from PropValYr.
+                var era = ConversionEras.FromYear(land.PropValYr);
+                if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
 
                 _db.TruthPacsLandCurrents.Add(new TruthPacsLandCurrent
                 {
@@ -160,8 +166,7 @@ public sealed class PacsLandCurrentTruthPromoter : IPacsLandCurrentTruthPromoter
                     LandLoadBatchId = landLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
-                    // G1 (v1.10): conversion-era marker derived from PropValYr.
-                    ConversionEra = ConversionEras.FromYear(land.PropValYr),
+                    ConversionEra = era,
                     PromotedAt = now,
                 });
                 promoted++;
@@ -170,6 +175,11 @@ public sealed class PacsLandCurrentTruthPromoter : IPacsLandCurrentTruthPromoter
                 if (land.LandSegMarketVal.HasValue) marketValSum += land.LandSegMarketVal.Value;
             }
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // G4 (v1.13): pre-conversion-share gate.
+            ConversionEraGate.AddShareGate(
+                _db, batch, ConversionEraGate.Lanes.Land,
+                promoted, preConversionPromoted);
 
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNoSupp, rejectedStaleSup, acresSum, marketValSum,

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsOwnerCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsOwnerCurrentTruthPromoter.cs
@@ -144,6 +144,8 @@ public sealed class PacsOwnerCurrentTruthPromoter : IPacsOwnerCurrentTruthPromot
             var rejectedNoSupp = 0;
             var rejectedStaleSup = 0;
             var rejectedNoAccount = 0;
+            // G4 (v1.13): pre-conversion-share gate counter.
+            var preConversionPromoted = 0;
 
             // Pct accumulator across promoted rows only — the hard
             // gate applies to the COMPLETE truth-layer projection.
@@ -170,6 +172,10 @@ public sealed class PacsOwnerCurrentTruthPromoter : IPacsOwnerCurrentTruthPromot
                     continue;
                 }
 
+                // G1 (v1.10): conversion-era marker derived from OwnerTaxYr.
+                var era = ConversionEras.FromYear(owner.OwnerTaxYr);
+                if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
+
                 _db.TruthPacsOwnerCurrents.Add(new TruthPacsOwnerCurrent
                 {
                     PropId = owner.PropId,
@@ -193,8 +199,7 @@ public sealed class PacsOwnerCurrentTruthPromoter : IPacsOwnerCurrentTruthPromot
                     AccountLoadBatchId = accountLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
-                    // G1 (v1.10): conversion-era marker derived from OwnerTaxYr.
-                    ConversionEra = ConversionEras.FromYear(owner.OwnerTaxYr),
+                    ConversionEra = era,
                     PromotedAt = now,
                 });
                 promoted++;
@@ -217,6 +222,11 @@ public sealed class PacsOwnerCurrentTruthPromoter : IPacsOwnerCurrentTruthPromot
 
             var pctViolations = groupPctSums.Values.Count(s =>
                 !s.HasValue || Math.Abs(s.Value - 100m) > FullPctTolerance);
+
+            // G4 (v1.13): pre-conversion-share gate.
+            ConversionEraGate.AddShareGate(
+                _db, batch, ConversionEraGate.Lanes.Owner,
+                promoted, preConversionPromoted);
 
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNoSupp, rejectedStaleSup, rejectedNoAccount,

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
@@ -149,6 +149,8 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
             var rejectedNoSuppPointer = 0;
             var rejectedStaleSupNum = 0;
             var rejectedStaleAxis = 0;
+            // G4 (v1.13): pre-conversion-share gate counter.
+            var preConversionPromoted = 0;
 
             var now = DateTime.UtcNow;
             foreach (var sale in sales)
@@ -181,6 +183,10 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     continue;
                 }
 
+                // G1 (v1.10): conversion-era marker derived from PropValYr.
+                var era = ConversionEras.FromYear(sale.PropValYr);
+                if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
+
                 _db.TruthPacsSales.Add(new TruthPacsSale
                 {
                     ChgOfOwnerId = sale.ChgOfOwnerId,
@@ -196,13 +202,17 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     SaleLoadBatchId = saleLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
-                    // G1 (v1.10): conversion-era marker derived from PropValYr.
-                    ConversionEra = ConversionEras.FromYear(sale.PropValYr),
+                    ConversionEra = era,
                     PromotedAt = now,
                 });
                 promoted++;
             }
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // G4 (v1.13): pre-conversion-share gate.
+            ConversionEraGate.AddShareGate(
+                _db, batch, ConversionEraGate.Lanes.Sale,
+                promoted, preConversionPromoted);
 
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNotQualified, rejectedNoSuppPointer, rejectedStaleSupNum,

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsWashPropOwnerValTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsWashPropOwnerValTruthPromoter.cs
@@ -118,6 +118,8 @@ public sealed class PacsWashPropOwnerValTruthPromoter : IPacsWashPropOwnerValTru
             var promoted = 0;
             var rejectedNoSupp = 0;
             var rejectedStaleSup = 0;
+            // G4 (v1.13): pre-conversion-share gate counter.
+            var preConversionPromoted = 0;
             decimal assessedSum = 0m;
             decimal marketSum = 0m;
             var now = DateTime.UtcNow;
@@ -136,6 +138,10 @@ public sealed class PacsWashPropOwnerValTruthPromoter : IPacsWashPropOwnerValTru
                     rejectedStaleSup++;
                     continue;
                 }
+
+                // G1 (v1.10): conversion-era marker derived from PropValYr.
+                var era = ConversionEras.FromYear(wpov.PropValYr);
+                if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
 
                 _db.TruthPacsWashPropOwnerVals.Add(new TruthPacsWashPropOwnerVal
                 {
@@ -163,8 +169,7 @@ public sealed class PacsWashPropOwnerValTruthPromoter : IPacsWashPropOwnerValTru
                     WpovLoadBatchId = wpovLoadBatchId,
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
-                    // G1 (v1.10): conversion-era marker derived from PropValYr.
-                    ConversionEra = ConversionEras.FromYear(wpov.PropValYr),
+                    ConversionEra = era,
                     PromotedAt = now,
                 });
                 promoted++;
@@ -173,6 +178,11 @@ public sealed class PacsWashPropOwnerValTruthPromoter : IPacsWashPropOwnerValTru
                 if (wpov.MarketVal.HasValue) marketSum += wpov.MarketVal.Value;
             }
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // G4 (v1.13): pre-conversion-share gate.
+            ConversionEraGate.AddShareGate(
+                _db, batch, ConversionEraGate.Lanes.Wpov,
+                promoted, preConversionPromoted);
 
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNoSupp, rejectedStaleSup, assessedSum, marketSum,

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
@@ -1061,6 +1061,55 @@ public sealed class BlockCContractV1Tests : IDisposable
     }
 
     // ───────────────────────────────────────────────────────────────
+    // v1.13 addendum — pre-conversion-share promotion gate (G4)
+    // ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Contract_v1_13_ConversionEraGate_ThresholdIsFrozenAt5Percent()
+    {
+        // v1.13 §1: the WARN threshold is a doctrine constant, not a
+        // runtime knob. Bumping it is a v1.x bump.
+        TerraFusion.Data.Services.TruthPacs.ConversionEraGate
+            .PreConversionShareWarnThreshold
+            .Should().Be(0.05m,
+                "Block-C contract v1.13 §1 freezes the WARN threshold");
+    }
+
+    [Fact]
+    public void Contract_v1_13_ConversionEraGate_GateNameTemplateIsFrozen()
+    {
+        // v1.13 §3: the gate name pattern is "truth-pacs-{lane}-pre-conversion-share".
+        TerraFusion.Data.Services.TruthPacs.ConversionEraGate.GateNamePrefix
+            .Should().Be("truth-pacs");
+        TerraFusion.Data.Services.TruthPacs.ConversionEraGate.GateNameSuffix
+            .Should().Be("pre-conversion-share");
+
+        TerraFusion.Data.Services.TruthPacs.ConversionEraGate
+            .GateNameFor("sale")
+            .Should().Be("truth-pacs-sale-pre-conversion-share");
+    }
+
+    [Fact]
+    public void Contract_v1_13_ConversionEraGate_LaneIdsMatchTheFiveTruthLanes()
+    {
+        // v1.13 §3: the five lane identifiers are frozen and match
+        // the five truth_pacs entities that carry ConversionEra.
+        var lanes = new[]
+        {
+            TerraFusion.Data.Services.TruthPacs.ConversionEraGate.Lanes.Sale,
+            TerraFusion.Data.Services.TruthPacs.ConversionEraGate.Lanes.Owner,
+            TerraFusion.Data.Services.TruthPacs.ConversionEraGate.Lanes.Wpov,
+            TerraFusion.Data.Services.TruthPacs.ConversionEraGate.Lanes.Imprv,
+            TerraFusion.Data.Services.TruthPacs.ConversionEraGate.Lanes.Land,
+        };
+
+        lanes.Should().BeEquivalentTo(new[]
+        {
+            "sale", "owner", "wpov", "imprv", "land",
+        });
+    }
+
+    // ───────────────────────────────────────────────────────────────
     // v1.12 addendum — eraFilter on SalesRatioStudy read endpoints (G3)
     // ───────────────────────────────────────────────────────────────
 

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
@@ -285,7 +285,9 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        gates.Should().HaveCount(4);
+        // G4 (v1.13): the new pre-conversion-share gate brings the
+        // imprv lane's gate count to 5.
+        gates.Should().HaveCount(5);
         gates.Should().OnlyContain(g => g.Status != "FAIL");
     }
 
@@ -351,5 +353,48 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
         truth.YearBuilt.Should().Be(1990);
         truth.EffectiveYearBuilt.Should().Be(2010);
         truth.ActualYearBuilt.Should().Be(1990);
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch()
+    {
+        // G4 (v1.13): one pre-conversion row + one post = 50% share,
+        // well over the 5% threshold ⇒ WARN.
+        var imprvBatch = await SeedBatchAsync("imprv");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2010, sup: 0);
+        await SeedSuppAsync(suppBatch, propId: 200, year: 2026, sup: 0);
+        await SeedImprvAsync(imprvBatch, propId: 100, imprvId: 1, year: 2010);
+        await SeedImprvAsync(imprvBatch, propId: 200, imprvId: 1, year: 2026);
+
+        var result = await BuildPromoter().PromoteAsync(imprvBatch, suppBatch, "c2-test");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Imprv));
+        gate.Status.Should().Be("WARN");
+        gate.GateStage.Should().Be("RAW_TO_TRUTH");
+        gate.Detail.Should().Contain("preConversion=1");
+        gate.Detail.Should().Contain("total=2");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch()
+    {
+        // G4 (v1.13): 0% pre-conversion share ⇒ PASS regardless of count.
+        var imprvBatch = await SeedBatchAsync("imprv");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2026, sup: 0);
+        await SeedImprvAsync(imprvBatch, propId: 100, imprvId: 1);
+
+        var result = await BuildPromoter().PromoteAsync(imprvBatch, suppBatch, "c2-test");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Imprv));
+        gate.Status.Should().Be("PASS");
+        gate.Detail.Should().Contain("preConversion=0");
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
@@ -285,7 +285,9 @@ public sealed class PacsLandCurrentTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        gates.Should().HaveCount(4);
+        // G4 (v1.13): the new pre-conversion-share gate brings the
+        // land lane's gate count to 5.
+        gates.Should().HaveCount(5);
         gates.Should().OnlyContain(g => g.Status != "FAIL");
     }
 
@@ -394,5 +396,46 @@ public sealed class PacsLandCurrentTruthPromoterTests : IDisposable
         truth.LandSegMarketVal.Should().Be(240_000m);
         truth.LandSegAgValue.Should().Be(80_000m);
         truth.LandSegAssessedVal.Should().Be(80_000m);
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch()
+    {
+        // G4 (v1.13): one pre + one post = 50% > 5% ⇒ WARN.
+        var landBatch = await SeedBatchAsync("land");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2010, sup: 0);
+        await SeedSuppAsync(suppBatch, propId: 200, year: 2026, sup: 0);
+        await SeedLandAsync(landBatch, propId: 100, landSegId: 1, year: 2010);
+        await SeedLandAsync(landBatch, propId: 200, landSegId: 1, year: 2026);
+
+        var result = await BuildPromoter().PromoteAsync(landBatch, suppBatch, "l2-test");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Land));
+        gate.Status.Should().Be("WARN");
+        gate.GateStage.Should().Be("RAW_TO_TRUTH");
+        gate.Detail.Should().Contain("preConversion=1");
+        gate.Detail.Should().Contain("total=2");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch()
+    {
+        var landBatch = await SeedBatchAsync("land");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2026, sup: 0);
+        await SeedLandAsync(landBatch, propId: 100, landSegId: 1);
+
+        var result = await BuildPromoter().PromoteAsync(landBatch, suppBatch, "l2-test");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Land));
+        gate.Status.Should().Be("PASS");
+        gate.Detail.Should().Contain("preConversion=0");
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
@@ -420,7 +420,9 @@ public sealed class PacsOwnerCurrentTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        gates.Should().HaveCount(5);
+        // G4 (v1.13): the new pre-conversion-share gate brings the
+        // owner lane's gate count to 6.
+        gates.Should().HaveCount(6);
         gates.Where(g => g.GateName == "truth-pacs-owner-pct-completeness")
             .Single().Status.Should().Be("PASS");
     }
@@ -468,5 +470,54 @@ public sealed class PacsOwnerCurrentTruthPromoterTests : IDisposable
                           && g.LoadBatchId == result.PromotionLoadBatchId);
         gate.Status.Should().Be("WARN");
         gate.Detail.Should().Contain("noSuppPointer=1");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch()
+    {
+        // G4 (v1.13): one pre + one post = 50% > 5% ⇒ WARN.
+        // Owner era is derived from OwnerTaxYr, not PropValYr.
+        var ownerBatch = await SeedBatchAsync("owner");
+        var accountBatch = await SeedBatchAsync("account");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2010, sup: 0);
+        await SeedSuppAsync(suppBatch, propId: 200, year: 2026, sup: 0);
+        await SeedAccountAsync(accountBatch, acctId: 1);
+        await SeedAccountAsync(accountBatch, acctId: 2);
+        await SeedOwnerAsync(ownerBatch, propId: 100, ownerId: 1, year: 2010);
+        await SeedOwnerAsync(ownerBatch, propId: 200, ownerId: 2, year: 2026);
+
+        var result = await BuildPromoter()
+            .PromoteAsync(ownerBatch, accountBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Owner));
+        gate.Status.Should().Be("WARN");
+        gate.GateStage.Should().Be("RAW_TO_TRUTH");
+        gate.Detail.Should().Contain("preConversion=1");
+        gate.Detail.Should().Contain("total=2");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch()
+    {
+        var ownerBatch = await SeedBatchAsync("owner");
+        var accountBatch = await SeedBatchAsync("account");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2026, sup: 0);
+        await SeedAccountAsync(accountBatch, acctId: 1);
+        await SeedOwnerAsync(ownerBatch, propId: 100, ownerId: 1, pct: 100m);
+
+        var result = await BuildPromoter()
+            .PromoteAsync(ownerBatch, accountBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Owner));
+        gate.Status.Should().Be("PASS");
+        gate.Detail.Should().Contain("preConversion=0");
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
@@ -347,7 +347,9 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        gates.Should().HaveCount(5);
+        // G4 (v1.13): the new pre-conversion-share gate brings the
+        // sale lane's gate count to 6.
+        gates.Should().HaveCount(6);
         gates.Where(g => g.GateName == "truth-pacs-stale-axis-rejected")
             .Single().Status.Should().Be("PASS");
     }
@@ -367,5 +369,46 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
         (await _db.TfParcelGeoms.CountAsync()).Should().Be(0);
         // sync_bridge.source_xref also untouched (canonical lineage is S3).
         (await _db.SyncBridgeSourceXrefs.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch()
+    {
+        // G4 (v1.13): one pre + one post = 50% > 5% ⇒ WARN.
+        var saleBatch = await SeedCompletedBatchAsync("sale-batch");
+        var suppBatch = await SeedCompletedBatchAsync("supp-batch");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2010, sup: 0);
+        await SeedSuppAsync(suppBatch, propId: 200, year: 2026, sup: 0);
+        await SeedSaleAsync(saleBatch, chgOfOwnerId: 1, propId: 100, year: 2010, sup: 0, code: "100");
+        await SeedSaleAsync(saleBatch, chgOfOwnerId: 2, propId: 200, year: 2026, sup: 0, code: "100");
+
+        var result = await BuildPromoter().PromoteAsync(saleBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Sale));
+        gate.Status.Should().Be("WARN");
+        gate.GateStage.Should().Be("RAW_TO_TRUTH");
+        gate.Detail.Should().Contain("preConversion=1");
+        gate.Detail.Should().Contain("total=2");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch()
+    {
+        var saleBatch = await SeedCompletedBatchAsync("sale-batch");
+        var suppBatch = await SeedCompletedBatchAsync("supp-batch");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2026, sup: 0);
+        await SeedSaleAsync(saleBatch, chgOfOwnerId: 1, propId: 100, year: 2026, sup: 0, code: "100");
+
+        var result = await BuildPromoter().PromoteAsync(saleBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Sale));
+        gate.Status.Should().Be("PASS");
+        gate.Detail.Should().Contain("preConversion=0");
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
@@ -290,7 +290,9 @@ public sealed class PacsWashPropOwnerValTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        gates.Should().HaveCount(4);
+        // G4 (v1.13): the new pre-conversion-share gate brings the
+        // wpov lane's gate count to 5.
+        gates.Should().HaveCount(5);
         gates.Should().OnlyContain(g => g.Status != "FAIL");
     }
 
@@ -366,5 +368,46 @@ public sealed class PacsWashPropOwnerValTruthPromoterTests : IDisposable
         truth.DisasterProrationPct.Should().Be(50.5m);
         truth.SnrFrzImprvHs.Should().Be(100_000m);
         truth.SnrFrzLandHs.Should().Be(25_000m);
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch()
+    {
+        // G4 (v1.13): one pre + one post = 50% > 5% ⇒ WARN.
+        var wpovBatch = await SeedBatchAsync("wpov");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2010, sup: 0);
+        await SeedSuppAsync(suppBatch, propId: 200, year: 2026, sup: 0);
+        await SeedWpovAsync(wpovBatch, propId: 100, ownerId: 1, year: 2010);
+        await SeedWpovAsync(wpovBatch, propId: 200, ownerId: 2, year: 2026);
+
+        var result = await BuildPromoter().PromoteAsync(wpovBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Wpov));
+        gate.Status.Should().Be("WARN");
+        gate.GateStage.Should().Be("RAW_TO_TRUTH");
+        gate.Detail.Should().Contain("preConversion=1");
+        gate.Detail.Should().Contain("total=2");
+    }
+
+    [Fact]
+    public async Task PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch()
+    {
+        var wpovBatch = await SeedBatchAsync("wpov");
+        var suppBatch = await SeedBatchAsync("supp");
+        await SeedSuppAsync(suppBatch, propId: 100, year: 2026, sup: 0);
+        await SeedWpovAsync(wpovBatch, propId: 100, ownerId: 1);
+
+        var result = await BuildPromoter().PromoteAsync(wpovBatch, suppBatch, "test-op");
+
+        var gate = await _db.SyncBridgePromotionGateResults
+            .SingleAsync(g => g.LoadBatchId == result.PromotionLoadBatchId
+                           && g.GateName == ConversionEraGate.GateNameFor(
+                                  ConversionEraGate.Lanes.Wpov));
+        gate.Status.Should().Be("PASS");
+        gate.Detail.Should().Contain("preConversion=0");
     }
 }

--- a/docs/pacs/block-c-contract-v1.13.md
+++ b/docs/pacs/block-c-contract-v1.13.md
@@ -1,0 +1,212 @@
+# Block-C Contract — v1.13 (G4 Pre-Conversion-Share Promotion Gate, Block G Close)
+
+**Status:** binding doctrine. Version `v1.13`. Frozen 2026-05-03.
+**Predecessor:** `docs/pacs/block-c-contract-v1.12.md` (v1.12, 2026-05-03).
+**Layer:** 3.5 of the PACS doctrine stack.
+
+```text
+docs/pacs/block-c-contract-v1.md             (v1   — base freeze)
+docs/pacs/block-c-contract-v1.1.md           (v1.1 — dict_neighborhood)
+docs/pacs/block-c-contract-v1.2.md           (v1.2 — attribute_definition)
+docs/pacs/block-c-contract-v1.3.md           (v1.3 — nullable AttributeId FKs)
+docs/pacs/block-c-contract-v1.4.md           (v1.4 — QuarantineReasons closed vocab)
+docs/pacs/block-c-contract-v1.5.md           (v1.5 — attribute resolution semantics)
+docs/pacs/block-c-contract-v1.6.md           (v1.6 — two-layer quarantine vocabulary)
+docs/pacs/block-c-contract-v1.7.md           (v1.7 — E4c documented deferral; Block E close)
+docs/pacs/block-c-contract-v1.8.md           (v1.8 — Block-D D1+D2+D3 + legacy retirement)
+docs/pacs/block-c-contract-v1.9.md           (v1.9 — F5 sales-ratio-study read-model)
+docs/pacs/block-c-contract-v1.10.md          (v1.10 — G1 truth-layer ConversionEra)
+docs/pacs/block-c-contract-v1.11.md          (v1.11 — G2 canonical-layer ConversionEra)
+docs/pacs/block-c-contract-v1.12.md          (v1.12 — G3 eraFilter on read endpoints)
+docs/pacs/block-c-contract-v1.13.md          (v1.13 — G4 pre-conversion-share gate; Block G close) ← this doc
+```
+
+## 0. What v1.13 is
+
+A coordinated minor bump that records:
+
+1. **G4** introduces a per-lane promotion gate that records what
+   fraction of each truth-promotion batch is pre-conversion-era.
+   The gate is informational (`WARN`/`PASS`, never `FAIL`) — era
+   is provenance, not validation.
+2. **Block G is closed** by this slice. The 4-slice arc (G1 truth,
+   G2 canonical, G3 read filter, G4 promotion gate) is now in
+   doctrine.
+3. The gate threshold is a frozen code constant (`5%`). Future v1.x
+   bumps may promote it to runtime configuration if operator
+   field experience justifies it.
+
+No schema change. No migration. v1.13 is gate + doctrine only.
+
+## 0.5 Doctrine integrity disclosure (carry-forward)
+
+v1.10 §6 promised a "promotion gate that warns when an inbound
+batch exceeds a configurable threshold." v1.13 ships exactly that
+with one refinement: the threshold is a **doctrine constant**, not
+a runtime knob. Per the same rationale as the era vocabulary
+itself (closed by design), introducing operator-tunable thresholds
+opens a door to silent drift. If a county operator routinely sees
+the gate trip, the conversation is "your data has unusual era
+mix" — a doctrine-level discussion, not a knob-twiddle.
+
+The gate is **never blocking**: a high pre-conversion share never
+prevents promotion. It is recorded in
+`sync_bridge.promotion_gate_result` for observability so the
+operator dashboard can surface it.
+
+## 1. The threshold
+
+```csharp
+public const decimal PreConversionShareWarnThreshold = 0.05m; // 5%
+```
+
+Lives on `TerraFusion.Data.Services.TruthPacs.ConversionEraGate`.
+Frozen by doctrine test
+`Contract_v1_13_ConversionEraGate_ThresholdIsFrozenAt5Percent`.
+
+The 5% default reflects current-year promotion behavior: when an
+operator syncs a typical year (e.g. PropValYr 2026), nearly every
+row should be POST_CONVERSION. A non-zero pre-conversion share
+indicates either legacy backfill data is present (operator's
+intentional choice — they will acknowledge the WARN) or a data-
+quality issue (operator should investigate).
+
+The threshold is **strict greater-than**: a share of exactly 5%
+passes; a share of 5.001% trips WARN. This matches typical gate
+boundary semantics elsewhere in Block C.
+
+## 2. The status semantics
+
+```text
+share <= threshold (5%)  →  PASS
+share >  threshold (5%)  →  WARN
+                        →  FAIL never raised by this gate
+```
+
+`PASS` is informational positive: the batch is effectively
+modern-era data. `WARN` is informational negative: the batch is
+backfill or anomalous; review recommended. `FAIL` is reserved for
+gates that block promotion — era never blocks.
+
+A batch with zero promoted rows resolves to 0% share and `PASS`
+by construction. This matches the operator's mental model that
+"empty batches are clean batches."
+
+## 3. The gate naming
+
+```text
+truth-pacs-{lane}-pre-conversion-share
+```
+
+where `{lane}` is one of:
+
+| Lane id | Truth entity |
+|---|---|
+| `sale` | `TruthPacsSale` |
+| `owner` | `TruthPacsOwnerCurrent` |
+| `wpov` | `TruthPacsWashPropOwnerVal` |
+| `imprv` | `TruthPacsImprvCurrent` |
+| `land` | `TruthPacsLandCurrent` |
+
+Constants exposed as `ConversionEraGate.Lanes.{Sale|Owner|Wpov|Imprv|Land}`.
+Helper: `ConversionEraGate.GateNameFor(lane)`. Both frozen by
+doctrine tests
+`Contract_v1_13_ConversionEraGate_GateNameTemplateIsFrozen` and
+`Contract_v1_13_ConversionEraGate_LaneIdsMatchTheFiveTruthLanes`.
+
+`GateStage` is `RAW_TO_TRUTH` per the existing convention
+documented on `PromotionGateResult`.
+
+## 4. The promoter wiring
+
+Each of the five truth promoters now:
+
+1. Maintains a `preConversionPromoted` counter alongside the
+   existing `promoted` counter.
+2. Computes the era inside the foreach loop and increments the
+   counter when the era is `PRE_CONVERSION_2017`.
+3. After the truth-row save, calls
+   `ConversionEraGate.AddShareGate(_db, batch, lane, promoted, preConversionPromoted)`
+   which queues the gate row into the same DbContext save the
+   lane's existing `WriteRemainingGatesAsync` will perform.
+
+The era column itself (G1) is unchanged in shape; only the
+side-counter and the gate write are new.
+
+Touched files:
+
+```text
+backend/src/TerraFusion.Data/Services/TruthPacs/
+  ConversionEraGate.cs                              (NEW)
+  PacsSaleTruthPromoter.cs                         (counter + AddShareGate call)
+  PacsOwnerCurrentTruthPromoter.cs                 (counter + AddShareGate call)
+  PacsWashPropOwnerValTruthPromoter.cs             (counter + AddShareGate call)
+  PacsImprvCurrentTruthPromoter.cs                 (counter + AddShareGate call)
+  PacsLandCurrentTruthPromoter.cs                  (counter + AddShareGate call)
+```
+
+The helper `AddShareGate` is intentionally synchronous (no
+`SaveChangesAsync`) so the caller batches the gate row into its
+existing end-of-promotion save for one round-trip.
+
+## 5. Tests
+
+### Per-promoter tests
+
+Each of the five `Pacs*TruthPromoterTests` files gains:
+
+- `PreConversionShareGate_Trips_WARN_OnPreConversionHeavyBatch` —
+  seeds 1 pre-2018-year row + 1 post-2018-year row (50% share),
+  asserts gate goes `WARN` with the expected detail.
+- `PreConversionShareGate_Stays_PASS_OnAllPostConversionBatch` —
+  seeds only post-2018-year rows (0% share), asserts gate is
+  `PASS`.
+
+The existing `AllFourGates_AreRecorded_OnSuccess` /
+`AllFiveGates_AreRecorded_OnSuccess` count assertions are bumped
+by 1 (4→5 for imprv/land/wpov; 5→6 for sale/owner) with an inline
+comment naming v1.13 as the cause.
+
+### Doctrine tests
+
+New band in `BlockCContractV1Tests`:
+
+- `Contract_v1_13_ConversionEraGate_ThresholdIsFrozenAt5Percent`
+- `Contract_v1_13_ConversionEraGate_GateNameTemplateIsFrozen`
+- `Contract_v1_13_ConversionEraGate_LaneIdsMatchTheFiveTruthLanes`
+
+## 6. What v1.13 does NOT change
+
+- Schema: zero changes. No new column, no new migration.
+- Existing gates (`truth-pacs-{lane}-source-batches-completed`,
+  `truth-pacs-{lane}-supp-aware-join`, etc.) — unchanged.
+- The era column on `truth_pacs.*` and `canonical_tf.*` —
+  unchanged shape, still nullable, vocabulary still frozen.
+- Read endpoints (G3 `eraFilter`) — unchanged.
+- All other v1.x-frozen shapes — untouched.
+
+## 7. Block G summary (G1 → G4 close)
+
+With v1.13 frozen, Block G is **complete**:
+
+| Slice | What it shipped | Doctrine | PR |
+|---|---|---|---|
+| G1 | Nullable `ConversionEra` on 5 `truth_pacs.*` lanes; promoters stamp at promotion via `ConversionEras.FromYear` | v1.10 | #728 (merged) |
+| G2 | Nullable `ConversionEra` on 6 `canonical_tf.*` lanes; projectors stamp via `MajorityOfTruth` (1:1 verbatim today, future-proofs N:1) | v1.11 | #729 (merged) |
+| G3 | `era` query parameter on the 3 SalesRatioStudy read endpoints; default `POST_CONVERSION`; NULL falls back to year | v1.12 | #730 (merged) |
+| G4 | Per-lane pre-conversion-share gate (`WARN` over 5%, `PASS` otherwise; never `FAIL`) | v1.13 | this PR |
+
+The arc moves PACS conversion-era awareness end-to-end through
+the doctrine stack: from year-derived stamping at promotion, to
+majority-of-truth resolution at canonical projection, to operator-
+visible filtering at the read surface, to operator-visible
+warnings at promotion time.
+
+## 8. Linked GitHub issues
+
+- **G4** — closed by this slice (this doc).
+- **Block G** — closed by this slice.
+- **OPERATOR-SQL-IMPORT-1 (#726)** — unrelated to G4 but still
+  blocking F1/F3/F4 per v1.9.
+- **CI-HYGIENE-1 (#724)** — chronic main-state continues to
+  require admin-merge through documented exception.


### PR DESCRIPTION
## Summary
- **Block G closes here.** G4 adds a per-lane promotion gate that records what fraction of each truth-promotion batch is pre-2017-conversion-era, raising `WARN` when the share exceeds 5%. Era is provenance, not validation — the gate is informational and **never blocks promotion**.
- New `ConversionEraGate` static helper centralizes the threshold, gate-name pattern, lane vocabulary, and the gate-write logic. All 5 truth promoters call it.
- Doctrine bumped to **v1.13**. New regression band locks the threshold (5%), the gate-name template, and the lane vocabulary.
- **No schema change. No migration.** v1.13 is gate + doctrine only.

## What changed
- **New helper** `TerraFusion.Data.Services.TruthPacs.ConversionEraGate`:
  - `PreConversionShareWarnThreshold = 0.05m` (frozen)
  - `GateNamePrefix = "truth-pacs"`, `GateNameSuffix = "pre-conversion-share"`, `GateNameFor(lane)`
  - `Lanes` constants: `sale`, `owner`, `wpov`, `imprv`, `land`
  - `AddShareGate(...)` queues the `PromotionGateResult` row without saving — caller batches into the existing end-of-promotion `SaveChangesAsync`.
- **All 5 promoters** now track `preConversionPromoted` alongside the existing `promoted` counter and call `AddShareGate` after the truth-row save.
- **Status semantics:** `share <= 5%` → `PASS`; `share > 5%` → `WARN`; **never** `FAIL`. Empty batches resolve to 0% / `PASS`.

## Block G summary (G1 → G4 close)
| Slice | Doctrine | PR |
|---|---|---|
| G1 truth ConversionEra | v1.10 | #728 (merged) |
| G2 canonical propagation | v1.11 | #729 (merged) |
| G3 eraFilter on read endpoints | v1.12 | #730 (merged) |
| G4 pre-conversion-share gate | v1.13 | this PR |

End-to-end era awareness is now in doctrine: year-derived stamping at promotion → majority-of-truth resolution at canonical projection → operator-visible filtering at read surface → operator-visible warnings at promotion time.

## Out of scope
- Block G is closed. Future enhancements (e.g. promoting the threshold to runtime configuration, extending eraFilter to other read endpoints) become their own slices when operators request them.

## Test plan
- [x] `dotnet build TerraFusion.sln` — 0 errors, 17 pre-existing warnings (CI-HYGIENE-1 #724 chronic).
- [x] `dotnet test --filter "Contract_v1_13|PreConversionShareGate|AllFiveGates|AllFourGates|Contract_RequiredMigrations|Contract_v1_10|Contract_v1_11|Contract_v1_12"` — **27/27 green**.
- [x] `dotnet test --filter "TruthPacs.Pacs"` — **76/76 promoter tests green** across all 5 lanes (gate count assertions bumped by 1 per lane).
- [x] `dotnet test --filter "CanonicalTf.Pacs|SalesRatioStudy"` — **106/106 G2+G3 regression green** (no break to canonical projection or eraFilter).
- [x] Pre-commit + pre-push quality gates green.
- [ ] CI — same chronic-red CI-HYGIENE-1 (#724) Warning Gate flap on pre-existing CS warnings; admin-merge-through pattern applies.

## Doctrine integrity disclosure
The threshold is intentionally a **code constant**, not a runtime knob. Per v1.13 §0.5: "introducing operator-tunable thresholds opens a door to silent drift. If a county operator routinely sees the gate trip, the conversation is 'your data has unusual era mix' — a doctrine-level discussion, not a knob-twiddle." Future v1.x bumps may revisit if field experience justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-conversion-share quality gate that monitors the percentage of pre-conversion records within data batches. The gate returns a warning status when the pre-conversion share exceeds 5%, providing better visibility into data composition.

* **Tests**
  * Added validation tests for the new pre-conversion-share gate across all data lanes.

* **Documentation**
  * Updated documentation with v1.13 specifications and gate behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->