### PR TITLE
chore(ci-hygiene-1): clear chronic Warning Gate blockers + latent G4 test regression

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,0 +1,31 @@
+<Project>
+  <!--
+    CI-HYGIENE-1: per-advisory NuGet audit suppressions.
+
+    Three OpenTelemetry packages emit moderate-severity NU1902 CVE
+    warnings at restore time. The packages are pinned in
+    Directory.Packages.props (Api 1.9.0, Exporter.OpenTelemetryProtocol
+    1.9.0, Exporter.Jaeger 1.6.0-rc.1). The Snyk Drift Guard CI job
+    remains the authoritative CVE tracker for these dependencies; this
+    file only silences the per-build warning so the WarningGate (0
+    warnings tolerance, /warnaserror in CI) stays green.
+
+    Per-advisory suppressions (not a blanket NoWarn=NU1902) ensure any
+    NEW CVE on any other package still trips the WarningGate. To
+    re-introduce a tracked CVE here you must explicitly add its
+    advisory URL — silent drift is impossible by construction.
+
+    Lift these once the underlying OpenTelemetry packages are bumped
+    to non-vulnerable versions in Directory.Packages.props. Tracked
+    under CI-HYGIENE-1 (#724); the cleanup of this file IS the close
+    signal for that issue.
+  -->
+  <ItemGroup>
+    <!-- OpenTelemetry.Api 1.9.0 — moderate. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g94r-2vxg-569j" />
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 — moderate. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+    <!-- OpenTelemetry.Exporter.OpenTelemetryProtocol 1.9.0 — moderate. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-4625-4j76-fww9" />
+  </ItemGroup>
+</Project>

--- a/backend/src/TerraFusion.API/Controllers/SyncController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SyncController.cs
@@ -471,41 +471,6 @@ public class SyncController : ControllerBase
 
     // ── Comp-eligibility read (Slice C38-B) ─────────────────────────────────
 
-    /// <summary>
-    /// Slice C38-B: read-side HTTP exposure of the C37-B
-    /// <c>ISalesCompEligibilityReader</c> per the C38-A policy.
-    ///
-    /// <para>Returns the comp pool for a county. Single selection rule
-    /// (inherited from C37-A): <c>ComputedDecision = Qualified</c>.
-    /// <c>Excluded</c> and <c>Inconclusive</c> rows are NOT returned.
-    /// This is the WacCd-bug containment surface exposed over HTTP —
-    /// pre-conversion / unmapped / problematic <c>wac_cd</c> codes
-    /// never reach the comp pool by construction.</para>
-    ///
-    /// <para>Authentication required (per C38-A Hard Guard 2).
-    /// County-isolation guard fires server-side (Hard Guard 3): the
-    /// authenticated principal's <c>countyId</c> claim must match the
-    /// requested <paramref name="countyId"/>; cross-county callers
-    /// receive 403 with no row data.</para>
-    ///
-    /// <para>Workbook-pin is opt-in (Hard Guard 7). When
-    /// <paramref name="workbookId"/> is omitted or empty, all
-    /// Qualified rows for the county are returned regardless of
-    /// which workbook produced them. There is no implicit "most
-    /// recent workbook" default — that would silently mask
-    /// workbook drift.</para>
-    /// </summary>
-    /// <param name="countyId">Sovereign-county scope (required).</param>
-    /// <param name="workbookId">
-    /// Optional workbook-pin. Empty / omitted means "all qualified
-    /// rows for this county."
-    /// </param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>
-    /// 200 OK with a (possibly empty) JSON array of
-    /// <see cref="CompEligibleSaleDto"/>. The array is ordered by
-    /// <c>ChgOfOwnerId</c> ascending for deterministic consumption.
-    /// </returns>
     // ── C45-B caching constants per the C45-A policy ───────────────────────
     // Comp endpoints: 60-second window (canonical only changes on C36 writes).
     // Active-workbook: 5-second window (operator promote/clear should reflect fast).
@@ -546,6 +511,45 @@ public class SyncController : ControllerBase
     /// </summary>
     private const int MaxPageSize = 500;
 
+    /// <summary>
+    /// Slice C38-B: read-side HTTP exposure of the C37-B
+    /// <c>ISalesCompEligibilityReader</c> per the C38-A policy.
+    ///
+    /// <para>Returns the comp pool for a county. Single selection rule
+    /// (inherited from C37-A): <c>ComputedDecision = Qualified</c>.
+    /// <c>Excluded</c> and <c>Inconclusive</c> rows are NOT returned.
+    /// This is the WacCd-bug containment surface exposed over HTTP —
+    /// pre-conversion / unmapped / problematic <c>wac_cd</c> codes
+    /// never reach the comp pool by construction.</para>
+    ///
+    /// <para>Authentication required (per C38-A Hard Guard 2).
+    /// County-isolation guard fires server-side (Hard Guard 3): the
+    /// authenticated principal's <c>countyId</c> claim must match the
+    /// requested <paramref name="countyId"/>; cross-county callers
+    /// receive 403 with no row data.</para>
+    ///
+    /// <para>Workbook-pin is opt-in (Hard Guard 7). When
+    /// <paramref name="workbookId"/> is omitted or empty, all
+    /// Qualified rows for the county are returned regardless of
+    /// which workbook produced them. There is no implicit "most
+    /// recent workbook" default — that would silently mask
+    /// workbook drift.</para>
+    /// </summary>
+    /// <param name="countyId">Sovereign-county scope (required).</param>
+    /// <param name="workbookId">
+    /// Optional workbook-pin. Empty / omitted means "all qualified
+    /// rows for this county."
+    /// </param>
+    /// <param name="page">Optional 1-based page index (defaults to 1).</param>
+    /// <param name="pageSize">
+    /// Optional page size; capped by <c>MaxPageSize</c>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// 200 OK with a (possibly empty) JSON array of
+    /// <see cref="CompEligibleSaleDto"/>. The array is ordered by
+    /// <c>ChgOfOwnerId</c> ascending for deterministic consumption.
+    /// </returns>
     [HttpGet("comps/eligible")]
     [HttpHead("comps/eligible")]
     [Authorize]

--- a/backend/src/TerraFusion.API/Services/ModuleLoaderService.cs
+++ b/backend/src/TerraFusion.API/Services/ModuleLoaderService.cs
@@ -41,8 +41,11 @@ public class ModuleLoaderService : BackgroundService, IModuleLoaderService
 
     /// <summary>
     /// Latest intent-filter-out count; updated each <see cref="RefreshModulesAsync"/>
-    /// pass. Volatile because <see cref="SystemHealthController.GetSystemHealth"/>
-    /// can read it from a different thread than the one that wrote it.
+    /// pass. Volatile because <c>SystemHealthController.GetSystemHealth</c>
+    /// can read it from a different thread than the one that wrote it
+    /// (the cref is a <c>code</c> tag rather than a typed reference so this
+    /// file does not need a using on a controller type that may not exist
+    /// in every build profile).
     /// </summary>
     private volatile int _lastFilteredOutCount;
     public int LastFilteredOutCount => _lastFilteredOutCount;

--- a/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsImprvAttrLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsImprvAttrLandingService.cs
@@ -100,7 +100,16 @@ public sealed class PacsImprvAttrLandingService : IPacsImprvAttrLandingService
                 var key = (src.PropValYr, src.SupNum, src.PropId, src.ImprvId, src.ImprvDetId, src.IAttrValId);
                 keyCounts[key] = keyCounts.TryGetValue(key, out var c) ? c + 1 : 1;
 
-                if (_dictionary.Contains(src.IAttrValCd))
+                // Source records declare IAttrValCd as non-null but the
+                // streaming source can yield null on bad rows. Hoist
+                // into a local non-null `iAttrValCd` (empty string for
+                // null inputs) so all downstream uses — dictionary
+                // probe, entity write, histogram key — share the
+                // null-collapsed shape. The unknown / quarantine
+                // branch keeps the literal "<NULL>" histogram key so
+                // operators can distinguish null from empty input.
+                var iAttrValCd = src.IAttrValCd ?? string.Empty;
+                if (_dictionary.Contains(iAttrValCd))
                 {
                     _db.LegacyPacsRawImprvAttrs.Add(new LegacyPacsRawImprvAttr
                     {
@@ -110,7 +119,7 @@ public sealed class PacsImprvAttrLandingService : IPacsImprvAttrLandingService
                         ImprvId = src.ImprvId,
                         ImprvDetId = src.ImprvDetId,
                         IAttrValId = src.IAttrValId,
-                        IAttrValCd = src.IAttrValCd,
+                        IAttrValCd = iAttrValCd,
                         AttrValueText = src.AttrValueText,
                         AttrValueNumeric = src.AttrValueNumeric,
                         LoadBatchId = batch.LoadBatchId,
@@ -119,8 +128,8 @@ public sealed class PacsImprvAttrLandingService : IPacsImprvAttrLandingService
                         LandedAt = DateTime.UtcNow,
                     });
                     landed++;
-                    knownHistogram[src.IAttrValCd] =
-                        knownHistogram.TryGetValue(src.IAttrValCd, out var kc) ? kc + 1 : 1;
+                    knownHistogram[iAttrValCd] =
+                        knownHistogram.TryGetValue(iAttrValCd, out var kc) ? kc + 1 : 1;
                 }
                 else
                 {
@@ -132,7 +141,7 @@ public sealed class PacsImprvAttrLandingService : IPacsImprvAttrLandingService
                         ImprvId = src.ImprvId,
                         ImprvDetId = src.ImprvDetId,
                         IAttrValId = src.IAttrValId,
-                        IAttrValCd = src.IAttrValCd ?? string.Empty,
+                        IAttrValCd = iAttrValCd,
                         AttrValueText = src.AttrValueText,
                         AttrValueNumeric = src.AttrValueNumeric,
                         LandingLoadBatchId = batch.LoadBatchId,

--- a/backend/src/TerraFusion.Sync/Workbench/Mapping/SyncMappingWorkbookBatchEditService.cs
+++ b/backend/src/TerraFusion.Sync/Workbench/Mapping/SyncMappingWorkbookBatchEditService.cs
@@ -353,13 +353,18 @@ public sealed class SyncMappingWorkbookBatchEditService : ISyncMappingWorkbookBa
                     $"canonical_value_null must be 'true' or empty. Got '{row.CanonicalValueNullRaw}'."));
                 continue;
             }
-            bool? isExcluded = null;
+            // Validation-only: shape-check is_excluded. The parsed bool
+            // is intentionally discarded — the apply phase re-parses
+            // from row.IsExcludedRaw via the same helper rather than
+            // pass a parsed value through ResolvedRow (per the
+            // doctrine note below at the end of this loop).
             if (row.IsExcludedRaw is not null)
             {
                 var trimmed = row.IsExcludedRaw.Trim();
-                if (string.Equals(trimmed, "true", StringComparison.OrdinalIgnoreCase))      isExcluded = true;
-                else if (string.Equals(trimmed, "false", StringComparison.OrdinalIgnoreCase)) isExcluded = false;
-                else
+                var isValidIsExcluded =
+                    string.Equals(trimmed, "true", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(trimmed, "false", StringComparison.OrdinalIgnoreCase);
+                if (!isValidIsExcluded)
                 {
                     errors.Add(new BatchEditValidationError(row.LineNumber, row.Scope, sourceLabel,
                         $"is_excluded must be 'true' or 'false'. Got '{row.IsExcludedRaw}'."));

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
@@ -246,6 +246,8 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
             "truth-pacs-imprv-supp-aware-join",
             "truth-pacs-imprv-promotion-coverage",
             "truth-pacs-imprv-aggregate",
+            // G4 (v1.13): pre-conversion-share gate.
+            "truth-pacs-imprv-pre-conversion-share",
         });
     }
 

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsLandCurrentTruthPromoterTests.cs
@@ -247,6 +247,8 @@ public sealed class PacsLandCurrentTruthPromoterTests : IDisposable
             "truth-pacs-land-supp-aware-join",
             "truth-pacs-land-promotion-coverage",
             "truth-pacs-land-aggregate",
+            // G4 (v1.13): pre-conversion-share gate.
+            "truth-pacs-land-pre-conversion-share",
         });
     }
 

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsOwnerCurrentTruthPromoterTests.cs
@@ -400,6 +400,8 @@ public sealed class PacsOwnerCurrentTruthPromoterTests : IDisposable
             "truth-pacs-owner-account-link",
             "truth-pacs-owner-pct-completeness",
             "truth-pacs-owner-promotion-coverage",
+            // G4 (v1.13): pre-conversion-share gate.
+            "truth-pacs-owner-pre-conversion-share",
         });
     }
 

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
@@ -299,6 +299,8 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
             "truth-pacs-supp-aware-join",
             "truth-pacs-stale-axis-rejected",
             "truth-pacs-promotion-coverage",
+            // G4 (v1.13): pre-conversion-share gate.
+            "truth-pacs-sale-pre-conversion-share",
         });
         gates.Where(g => g.GateName == "truth-pacs-source-batch-completed")
             .Single().Status.Should().Be("PASS");

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsWashPropOwnerValTruthPromoterTests.cs
@@ -250,6 +250,8 @@ public sealed class PacsWashPropOwnerValTruthPromoterTests : IDisposable
             "truth-pacs-wpov-supp-aware-join",
             "truth-pacs-wpov-promotion-coverage",
             "truth-pacs-wpov-aggregate",
+            // G4 (v1.13): pre-conversion-share gate.
+            "truth-pacs-wpov-pre-conversion-share",
         });
     }
 


### PR DESCRIPTION
## Summary
- Clear the 8 pre-existing CS warnings + 3 OpenTelemetry NU1902 CVE warnings that have made the WarningGate (Release `/warnaserror`) chronic-red since at least #728. **Future PRs should pass WarningGate naturally without admin override.**
- Fix a latent G4 regression in 5 `Pacs*PromoterTests` that #731's CI couldn't catch (Backend Tests was skipped by upstream WarningGate flap — the same flap this PR is fixing).
- **No feature work. No schema changes. No migrations. No frontend.** Closes **CI-HYGIENE-1 (#724)**.

## Changes — warning fixes
| Site | Warning | Fix |
|---|---|---|
| `PacsImprvAttrLandingService.cs` | CS8604 + CS8601 | Hoisted `var iAttrValCd = src.IAttrValCd ?? string.Empty` so all 3 downstream uses share the null-collapsed local. Behavior unchanged. |
| `SyncMappingWorkbookBatchEditService.cs` | CS0219 (`isExcluded` unused) | Replaced parsed-bool pattern with `isValidIsExcluded` boolean that's actually consumed. The doctrine note already in the file documented why the parsed value was discarded; the validation logic is preserved. |
| `SyncController.cs` | CS1734×2 + CS1572×3 | An XML doc block describing `GetEligibleComps` had drifted upward, ending up as the doc on the `CompMaxAge` field. Moved to its rightful place above the method's `[HttpGet]` attribute. Added missing `<param>` entries for `page`/`pageSize` while there. |
| `ModuleLoaderService.cs` | CS1574 | Demoted unresolvable cref to `<c>` tag with a doctrine comment explaining the build-profile rationale. |

## Changes — NU1902 OpenTelemetry CVEs
New `backend/Directory.Build.props` adds **per-advisory** `NuGetAuditSuppress` entries (NOT a blanket `NoWarn=NU1902`):
- `GHSA-g94r-2vxg-569j` — `OpenTelemetry.Api 1.9.0` (moderate)
- `GHSA-38h3-2333-qx47` — `OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1` (moderate)
- `GHSA-4625-4j76-fww9` — `OpenTelemetry.Exporter.OpenTelemetryProtocol 1.9.0` (moderate)

Per-advisory ensures any NEW CVE on any other package still trips WarningGate. The Snyk Drift Guard CI job remains the authoritative CVE tracker. This file's eventual removal IS the close signal for #724 once the OpenTelemetry packages are bumped to non-vulnerable versions.

## Changes — latent G4 regression
5 `AllFour/FiveGates_AreRecorded_OnSuccess` tests in `Pacs*TruthPromoterTests` had inline `BeEquivalentTo` gate-name lists that #731 (G4) didn't update when adding the `truth-pacs-{lane}-pre-conversion-share` gate. `HaveCount` was bumped in #731 but `BeEquivalentTo` was not. #731's CI couldn't catch this because Backend Tests was skipped by the same upstream WarningGate flap this PR fixes. Added the missing G4 gate name to all 5 lists.

## Verification
- [x] `dotnet build TerraFusion.sln -c Release -p:TreatWarningsAsErrors=true` — **0 Warning(s), 0 Error(s)**.
- [x] **71/71 doctrine** (`BlockCContractV1Tests`) green in Release.
- [x] **86/86 truth promoters** (`TruthPacs.Pacs*`) green in Release — was 81/86 before the `BeEquivalentTo` fix.
- [x] **106/106 canonical + SalesRatioStudy** (`CanonicalTf.Pacs*` + `SalesRatioStudy`) green in Release.
- [x] **124/124** across the 4 modified service files in Release.
- [x] **Total spine regression: 387/387 green under `/warnaserror`.**
- [x] Pre-commit + pre-push quality gates green.
- [ ] CI — **expected to be the first PR since #728 to pass WarningGate naturally** (no admin override needed).

## Doctrine integrity disclosure
The 276-test failure count we saw on the broader `dotnet test` run is pre-existing infrastructure (`WebApplicationFactory`-backed `R1Week5` tests with seed-data dependencies) — unrelated to anything this PR touches. Those failures predate Block G entirely and are tracked separately.

This PR keeps a clean kill-zone:
- Only the documented warning sites are touched.
- Only the 5 `BeEquivalentTo` lists that #731 missed are updated.
- No feature code, no schema, no migrations, no frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of attribute value normalization during data processing.
  * Enhanced CSV validation for the excluded field during batch uploads.

* **Tests**
  * Added validation tests for pre-conversion share gates across PACS data processors (improvements, land, owner, sale, and property owner value data).

* **Documentation**
  * Updated API endpoint documentation for query parameters.
  * Clarified service documentation for cross-thread data access.

* **Chores**
  * Added build configuration to suppress specific known security advisory warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->