### PR TITLE
chore(ci-hygiene-2): align Backend Tests connection_string with Postgres container password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,12 @@ jobs:
       dotnet_version: '8.0.x'
       configuration: Release
       solution: TerraFusion.sln
-      connection_string: 'Host=localhost;Database=terrafusion_test;Username=postgres;Password=postgres'
+      # CI-HYGIENE-2: align Password with the postgres service container's
+      # POSTGRES_PASSWORD env var declared in dotnet-test.yml
+      # (POSTGRES_PASSWORD: terrafusion_test). Latent mismatch: no current
+      # CI test in TerraFusion.sln connects to real Postgres, so this fix is
+      # defensive — but a future test that does would have hit auth failures.
+      connection_string: 'Host=localhost;Database=terrafusion_test;Username=postgres;Password=terrafusion_test'
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Vitest Full Suite (REQUIRED — merge gate)


### PR DESCRIPTION
## Summary
- Surgical defensive fix to `.github/workflows/ci.yml`: align the Backend .NET Tests `connection_string` Password with the Postgres service container's `POSTGRES_PASSWORD` from `dotnet-test.yml`. Latent mismatch — no test in the current CI scope connects to real Postgres, so this is defensive.
- **No code changes. No test changes. No solution changes.** Single-file workflow edit (+6/-1).

## What this PR DOES NOT do
The directive for CI-HYGIENE-2 was strict: "fix only CI/test-environment issues; no feature changes; no broad test rewrites." After diagnosis, the actual cleanup required for a fully green Backend Tests gate spans further than that directive permits. This PR therefore ships only the directive-faithful fix and files everything else as separate tracked work.

## Diagnosis (from local Release reproduction of CI scope)

```
TerraFusion.sln test scope (what CI runs):
  TerraFusion.Unit.SmokeTests       ✅ all pass
  TerraFusion.Integration.Tests     1490 pass / 3 fail / 1 skip / 1494 total

The 3 failures are all in AIDeStubTests, all in ConsciousnessEngineStub
production-code path. Real test/code regressions, not CI environment.
```

```
Test projects NOT in TerraFusion.sln (so CI never runs them):
  TerraFusion.Unit.Tests            ← Block G G1-G4 doctrine tests live HERE
  TerraFusion.Tests
  TerraFusion.Tests.Unit
  TerraFusion.Performance.Tests
```

This is how the G4 BeEquivalentTo regression (fixed in #732) reached `main` — those tests were never gated by CI.

## Tracking — separate issues filed

- **#733** — 3 ConsciousnessEngineStub regressions in AIDeStubTests. Real code/test work, requires its own slice.
- **#734** — Block G CI visibility gap. Adding `TerraFusion.Unit.Tests` to `TerraFusion.sln` is one line, but doing so without first fixing the ~276 pre-existing WebApplicationFactory failures would surface a worse red. Broad test triage needed first.

## Branch protection note

`Backend .NET Tests` is NOT a required status check (verified via `gh api repos/.../branches/main/protection/required_status_checks`). This PR's success or failure of that gate does NOT block PR merges. Until #733 closes, the gate will continue to show ❌ red on every PR — but it will not block merges.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml', encoding='utf-8'))"` — parses clean.
- [x] `git diff` — single logical change (+6/-1: the doctrine comment + the password swap on the same line).
- [x] No test execution path changes. The Postgres container still spins up with `terrafusion_test` password. The connection string now agrees.
- [ ] CI verification: WarningGate green (continues from #732), Backend Tests still ❌ from #733 failures (expected; not blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environment configuration to enhance test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->