### PR TITLE
fix(consciousness): pin AIDeStubTests to governed-lane-unavailable contract (closes #733)

### DIFF
--- a/backend/tests/TerraFusion.Integration.Tests/AIDeStubTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/AIDeStubTests.cs
@@ -94,8 +94,21 @@ public class AIDeStubTests
         status.HealthScore.Should().Be(0);
     }
 
+    // Issue #733: ConsciousnessEngineStub.InitializeSwarmAsync and
+    // ExecuteQuantumOptimizationAsync are intentionally compatibility-
+    // surface-only per the v1 governed-quantum-lane policy. They MUST
+    // NOT actually provision agents or run quantum optimization in this
+    // build profile. The stub source documents this with:
+    //   "Governed swarm provisioning and quantum optimization are
+    //    unavailable; compatibility surface only."
+    // and `backend/CLAUDE.md` reinforces it: "DO NOT interfere with
+    // production AI swarm." The tests below pin the unavailable
+    // contract — flipping these assertions back to BeTrue would mean
+    // someone has un-stubbed the governed lane, and that needs to be
+    // a doctrine-level conversation, not a quiet code change.
+
     [Fact]
-    public async System.Threading.Tasks.Task ConsciousnessEngine_InitializeSwarm_CreatesNewAgents()
+    public async System.Threading.Tasks.Task ConsciousnessEngine_InitializeSwarm_ReturnsFalse_GovernedLaneUnavailable()
     {
         await using var ctx = CreateDbContext("CE_InitSwarm");
 
@@ -104,18 +117,21 @@ public class AIDeStubTests
 
         var result = await engine.InitializeSwarmAsync(20, "BENTON");
 
-        result.Should().BeTrue();
-        var agentCount = await ctx.AIAgents.CountAsync();
-        agentCount.Should().Be(20);
+        // #733: stub MUST return false (governed lane unavailable).
+        result.Should().BeFalse(
+            "ConsciousnessEngineStub.InitializeSwarmAsync is a " +
+            "compatibility surface only; agent provisioning is " +
+            "deliberately unavailable in this build profile.");
 
-        var bentonAgents = await ctx.AIAgents
-            .Where(a => a.AssignedCounty == "BENTON")
-            .CountAsync();
-        bentonAgents.Should().Be(20);
+        // And it MUST NOT have created any rows.
+        var agentCount = await ctx.AIAgents.CountAsync();
+        agentCount.Should().Be(0,
+            "stub does not actually provision agents — empty input " +
+            "stays empty.");
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task ConsciousnessEngine_InitializeSwarm_DoesNotDuplicateExisting()
+    public async System.Threading.Tasks.Task ConsciousnessEngine_InitializeSwarm_ReturnsFalse_AndDoesNotMutateExistingAgents()
     {
         await using var ctx = CreateDbContext("CE_InitSwarm_NoDup");
         await SeedAgents(ctx, 15, "Active", "BENTON");
@@ -125,9 +141,16 @@ public class AIDeStubTests
 
         var result = await engine.InitializeSwarmAsync(20, "BENTON");
 
-        result.Should().BeTrue();
+        // #733: stub MUST return false (governed lane unavailable).
+        result.Should().BeFalse();
+
+        // Pre-seeded agents must remain untouched — stub never adds,
+        // never removes, never edits. This is the strongest contract
+        // for a compatibility surface.
         var agentCount = await ctx.AIAgents.CountAsync();
-        agentCount.Should().Be(20, "should only create 5 new agents to reach 20");
+        agentCount.Should().Be(15,
+            "stub does not provision; pre-seeded rows remain " +
+            "exactly as seeded.");
     }
 
     [Fact]
@@ -175,7 +198,7 @@ public class AIDeStubTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task ConsciousnessEngine_QuantumOptimization_RecordsMetric()
+    public async System.Threading.Tasks.Task ConsciousnessEngine_QuantumOptimization_ReturnsFailure_AndPersistsNothing()
     {
         await using var ctx = CreateDbContext("CE_Quantum");
         await SeedAgents(ctx, 5, "Active");
@@ -191,16 +214,27 @@ public class AIDeStubTests
 
         var result = await engine.ExecuteQuantumOptimizationAsync(request);
 
-        result.Success.Should().BeTrue();
-        result.QuantumFactor.Should().Be(949);
-        result.OptimizationScore.Should().BeGreaterThan(0);
+        // #733: governed-quantum-lane is unavailable per stub doctrine.
+        result.Success.Should().BeFalse(
+            "ConsciousnessEngineStub.ExecuteQuantumOptimizationAsync " +
+            "is a compatibility surface only.");
+        result.OptimizationScore.Should().Be(0m);
+        result.Results.Should().ContainKey("governed_quantum_lane_available")
+            .WhoseValue.Should().Be(false);
+        result.Results.Should().ContainKey("requested_quantum_factor")
+            .WhoseValue.Should().Be(949,
+                "the requested factor is echoed in the result for " +
+                "operator-side traceback even though no optimization " +
+                "actually ran.");
 
-        // Verify metric was persisted
+        // The stub MUST NOT have persisted a PerformanceMetric row —
+        // recording a fake metric would lie about what happened.
         var metric = await ctx.PerformanceMetrics
             .Where(m => m.MetricName == "QuantumOptimization")
             .FirstOrDefaultAsync();
-        metric.Should().NotBeNull("optimization should record a performance metric");
-        metric!.Source.Should().Be("ConsciousnessEngine");
+        metric.Should().BeNull(
+            "stub does not actually run optimization, therefore must " +
+            "not persist a metric for it.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- The 3 failing `AIDeStubTests` pre-date the deliberate neutering of `ConsciousnessEngineStub.{InitializeSwarmAsync, ExecuteQuantumOptimizationAsync}`. The stub source documents itself as a "compatibility surface only" — `backend/CLAUDE.md` reinforces with "DO NOT interfere with production AI swarm." The tests still asserted the pre-neutering `Success=true` behavior.
- This PR pins the tests to the stub's intentional unavailable contract. **No changes to the stub itself. No changes to any other production code. No changes to any other test.**
- **Closes #733.**

## Changes
| Old name | New name | New contract |
|---|---|---|
| `_InitializeSwarm_CreatesNewAgents` | `_InitializeSwarm_ReturnsFalse_GovernedLaneUnavailable` | `result==false`, `0 agents provisioned` |
| `_InitializeSwarm_DoesNotDuplicateExisting` | `_InitializeSwarm_ReturnsFalse_AndDoesNotMutateExistingAgents` | `result==false`, pre-seeded `15` stays `15` |
| `_QuantumOptimization_RecordsMetric` | `_QuantumOptimization_ReturnsFailure_AndPersistsNothing` | `Success==false`, `OptimizationScore==0`, `governed_quantum_lane_available==false`, `requested_quantum_factor` echoed, **no** `PerformanceMetric` row |

A doctrine comment block above the rewritten tests cites #733, the stub's own `UnavailableReason` text, and `backend/CLAUDE.md`. Future engineers who see `BeFalse` and want to "fix" the stub now know they need to start a doctrine-level conversation, not a quiet code change.

## What this PR DOES NOT do
- No edits to `ConsciousnessEngineStub.cs` (the stub stays correct).
- No edits to the 18 other passing tests in `AIDeStubTests`.
- No edits to other test files.
- No solution membership changes — issue #734 (Block G CI visibility gap) stays open and tracks separately.

## Test plan
- [x] `dotnet build TerraFusion.sln -c Release`: 0 errors, 0 warnings (continues from #732/#735 green baseline).
- [x] `dotnet test --filter "FullyQualifiedName~AIDeStubTests" -c Release`: **21/21 green** (was 18/21).
- [x] `dotnet test tests/TerraFusion.Integration.Tests/... -c Release`: **1494/1494 green** (was 1490 pass / 3 fail / 1 skip).
- [x] `dotnet test TerraFusion.sln -c Release`: all green (TerraFusion.AI 5/5 + Integration 1494/1494).
- [x] **Block G spine regression** (Doctrine.BlockCContractV1Tests + TruthPacs.Pacs + CanonicalTf.Pacs + SalesRatioStudy): **262/262 green**.
- [x] Pre-commit + pre-push gates green.
- [ ] CI: this should turn `Backend .NET Tests / Canonical .NET Test Run` naturally green for the first time since #732 unmasked it. Required-checks-only merge rule continues to apply.

## Doctrine note
The renamed tests now make the stub's contract explicit at the test name level. Anyone scanning `dotnet test` output sees `_ReturnsFalse_GovernedLaneUnavailable` and immediately understands what's being verified. This is doctrine-as-test-name, the same pattern the Block G doctrine tests use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to verify that quantum-lane provisioning returns false and does not create agents.
  * Updated test suite to confirm that quantum optimization returns failure with zero score and does not persist performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->