### PR TITLE
chore(ci-hygiene-3): split build and test in dotnet-test.yml (closes #737)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -123,6 +123,19 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ${{ inputs.solution }}
 
+      # CI-HYGIENE-3 (#737): build once, test with --no-build.
+      # Rationale: every prior `dotnet test` invocation re-built the
+      # whole Release solution because `--no-build` was not passed.
+      # On the GH-shared runner this cost ~4–5 minutes of CPU per
+      # job, pushing the test step past the ~8 minute soft cap that
+      # was killing Backend Tests on every PR since 2026-04-28.
+      # Splitting build and test cleanly separates which step fails
+      # and lets the test step run in roughly local time.
+      - name: Build (Release)
+        run: |
+          BUILD_TARGET="${{ inputs.test_project || inputs.solution }}"
+          dotnet build "$BUILD_TARGET" -c "${{ inputs.configuration }}" --no-restore -v:minimal /nologo
+
       - name: Canonical tests (Release)
         if: ${{ !inputs.enable_coverage }}
         env:
@@ -133,7 +146,12 @@ jobs:
           if [ -n "${{ inputs.test_filter }}" ]; then
             ARGS+=(--filter "${{ inputs.test_filter }}")
           fi
-          dotnet test "$TEST_TARGET" -c "${{ inputs.configuration }}" -v:minimal /nologo "${ARGS[@]}"
+          # --blame-hang-timeout: surface which test hangs if the run
+          # ever times out again (defensive diagnostic — 8 min hang
+          # cap is well above local 4 min runtime).
+          dotnet test "$TEST_TARGET" -c "${{ inputs.configuration }}" --no-build -v:minimal /nologo \
+            --blame-hang-timeout 8m --blame-hang-dump-type none \
+            "${ARGS[@]}"
 
       - name: Tests with coverage (Release)
         if: ${{ inputs.enable_coverage }}
@@ -145,7 +163,8 @@ jobs:
           if [ -n "${{ inputs.test_filter }}" ]; then
             ARGS+=(--filter "${{ inputs.test_filter }}")
           fi
-          dotnet test "$TEST_TARGET" -c "${{ inputs.configuration }}" -v:minimal /nologo "${ARGS[@]}" \
+          dotnet test "$TEST_TARGET" -c "${{ inputs.configuration }}" --no-build -v:minimal /nologo "${ARGS[@]}" \
+            --blame-hang-timeout 8m --blame-hang-dump-type none \
             --collect:"XPlat Code Coverage" \
             --logger "trx;LogFileName=test-results.trx" \
             --results-directory ./artifacts/test-results


### PR DESCRIPTION
## Summary
- The reusable `.github/workflows/dotnet-test.yml` test step was running `dotnet test` **without `--no-build`**, so every Backend .NET Tests CI run rebuilt the entire Release solution from scratch (~4–5 min on the GH-shared runner) before any test ran. Adding the actual test runtime pushed the step into the ~8-minute wall that's been killing it on every PR since 2026-04-28.
- Fix: explicit `Build (Release)` step between Restore and the test step + `--no-build` on the test step. Also adds `--blame-hang-timeout 8m --blame-hang-dump-type none` as a defensive diagnostic so any future hang is named, not opaque.
- **Closes #737.** No product code changes. No solution changes. No test changes.

## Diff scope
```
.github/workflows/dotnet-test.yml | 23 +++++++++++++++++++++--
1 file changed, 21 insertions(+), 2 deletions(-)
```

## Why this fix matches the failure pattern
| Observation | Explanation |
|---|---|
| Backend Tests fails on every PR since 2026-04-28 | Pre-existing; not introduced by Block G |
| Step duration: 7m 30s – 13m 30s, then killed | Runtime grows with test count; no `--no-build` means rebuild dominates |
| API reports step status=in_progress, conclusion=null while job=failure | Runner agent termination, not graceful test-failure exit |
| Local run with `--no-build`: ~4 min, all green | Matches CI step time minus the redundant rebuild |
| Warning Gate (just builds): 449s in CI | Build alone is half the test step's wall time |

## Reusable workflow contract
The reusable `dotnet-test.yml` is consumed by other workflows per the Drift Guard. The contract is preserved:
- `solution`, `test_project`, `test_filter`, `connection_string`, etc. inputs unchanged.
- The added Build step honors the same `test_project || solution` selector the test step already uses.
- Coverage path (`--collect:"XPlat Code Coverage"` / trx logger) untouched in shape — just gains `--no-build` and `--blame-hang-timeout`.

## Test plan
- [x] `python3 yaml.safe_load` on the modified workflow — parses clean.
- [x] Local reproduction of the new 3-step pattern:
  - Restore: ~2.5s (cached)
  - Build (Release, `--no-restore`): ~60s
  - Test (`--no-build`, `--blame-hang-timeout 8m`): ~175s
  - Total: ~4 min (vs prior CI step of 7m 30s+)
- [x] `git diff` is one logical change: insert Build step, add `--no-build` to two test commands, add `--blame-hang-timeout 8m --blame-hang-dump-type none`.
- [ ] **CI proof**: this PR's own CI run is the real test. Backend Tests should go naturally green (or at minimum, fail with named tests instead of opaque kill).

## Note: separate flaky test surfaced during local repro
Local reproduction showed `OpenTelemetryDistributedTracingTests.Performance_BatchExport_DoesNotBlockMainThread` failing intermittently — a timing-sensitive `"near-instant"` assertion. **This is its own concern, not in scope for #737.** If CI continues to flag this one test red after #737's infra fix lands, it gets its own slice (likely a tolerance widening or a `[Trait("Category", "Flaky")]` quarantine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test diagnostics with improved hang detection and timeout handling. Optimized build and test workflow execution for more reliable CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->