### PR TITLE
test: seed CamaCharacteristics in Cx8 proof harness factory (CI-HYGIENE-D)

### DIFF
--- a/backend/tests/TerraFusion.Unit.Tests/R1Week2/R1Week2Cx8CostForgeRealOutputTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week2/R1Week2Cx8CostForgeRealOutputTests.cs
@@ -243,9 +243,11 @@ public sealed class R1Week2Cx8CostForgeRealOutputTests
     public async Task CostForge_MissingRequestInputs_Returns422InsteadOfGeneric500()
     {
         using var client = CreateBentonClient();
+        // CI-HYGIENE-D (#739): use PropertyNoCamaId — it has no CamaCharacteristic row,
+        // so AnalyzeCostAsync hits the "No CAMA characteristics found" path that this test asserts.
         var payload = JsonSerializer.Serialize(new
         {
-            PropertyId = Cx8CostForgeRealFactory.PropertyAId,
+            PropertyId = Cx8CostForgeRealFactory.PropertyNoCamaId,
             CountyCode = "BENTON",
             Region = "Reval 1",
             BuildingType = "RESIDENTIAL",
@@ -318,10 +320,13 @@ public sealed class Cx8CostForgeRealFactory : WebApplicationFactory<ApiProgram>
     // ── Property IDs ─────────────────────────────────────────────────────
     public static readonly Guid PropertyAId = Guid.Parse("c8c8c8c8-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     public static readonly Guid PropertyBId = Guid.Parse("c8c8c8c8-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    // CI-HYGIENE-D (#739): property with no CAMA row, used by the 422 "no CAMA" assertion test
+    public static readonly Guid PropertyNoCamaId = Guid.Parse("c8c8c8c8-cccc-cccc-cccc-cccccccccccc");
 
     // ── Parcel identifiers ──────────────────────────────────────────────
     public const string PropertyAParcelNumber = "CX8-BN-SMALL-001";
     public const string PropertyBParcelNumber = "CX8-BN-LARGE-002";
+    public const string PropertyNoCamaParcelNumber = "CX8-BN-NOCAMA-003";
 
     // ── Plugin for permission pass-through ───────────────────────────────
     public static readonly Guid PluginAllPermsId = Guid.Parse("c8c8c8c8-ffff-ffff-ffff-ffffffffffff");
@@ -469,6 +474,69 @@ public sealed class Cx8CostForgeRealFactory : WebApplicationFactory<ApiProgram>
                     TaxYear = 2026,
                     AssessmentDate = DateTime.UtcNow,
                     LastUpdated = DateTime.UtcNow,
+                });
+
+                // CI-HYGIENE-D (#739): Property with no matching CamaCharacteristic row,
+                // used to prove the 422 "No CAMA characteristics found" error path.
+                db.Properties.Add(new Property
+                {
+                    Id = PropertyNoCamaId,
+                    PropertyId = "CX8-BENTON-NOCAMA",
+                    ParcelId = "CX8-BN-NOCAMA-PID",
+                    ParcelNumber = PropertyNoCamaParcelNumber,
+                    Address = "999 Missing CAMA Ln, Kennewick, WA",
+                    CountyId = BentonCountyId,
+                    AssessedValue = 100000m,
+                    LandValue = 50000m,
+                    ImprovementValue = 50000m,
+                    MarketValue = 100000m,
+                    TaxYear = 2026,
+                    AssessmentDate = DateTime.UtcNow,
+                    LastUpdated = DateTime.UtcNow,
+                });
+
+                await db.SaveChangesAsync();
+            }
+
+            // CI-HYGIENE-D (#739): seed CamaCharacteristics so AnalyzeCostAsync resolves real cost matrix path
+            // CostForgeService.AnalyzeCostAsync queries CamaCharacteristics by ParcelId == Property.ParcelNumber
+            // && CountyId. Without these rows, the service throws InvalidOperationException → 422 → test fails.
+            // SquareFeet differs between A and B so Cx8ProofHarness.Proof_TwoParcels_DifferentOutputs sees
+            // totalA != totalB through the cost matrix path.
+            if (!await db.CamaCharacteristics.AnyAsync(c => c.ParcelId == PropertyAParcelNumber && c.CountyId == BentonCountyId))
+            {
+                db.CamaCharacteristics.Add(new CamaCharacteristic
+                {
+                    Id = Guid.NewGuid(),
+                    ParcelId = PropertyAParcelNumber,
+                    CountyId = BentonCountyId,
+                    TaxYear = 2026,
+                    BuildingType = "R1",
+                    Region = "Reval 1",
+                    SquareFeet = 1800m,
+                    YearBuilt = 2000,
+                    QualityGrade = "STANDARD",
+                    ConditionGrade = "GOOD",
+                    ComplexityGrade = "STANDARD",
+                    UpdatedBy = "cx8-test-seed",
+                    UpdatedAt = DateTime.UtcNow,
+                });
+
+                db.CamaCharacteristics.Add(new CamaCharacteristic
+                {
+                    Id = Guid.NewGuid(),
+                    ParcelId = PropertyBParcelNumber,
+                    CountyId = BentonCountyId,
+                    TaxYear = 2026,
+                    BuildingType = "R1",
+                    Region = "Reval 1",
+                    SquareFeet = 3400m,
+                    YearBuilt = 1995,
+                    QualityGrade = "CUSTOM",
+                    ConditionGrade = "GOOD",
+                    ComplexityGrade = "STANDARD",
+                    UpdatedBy = "cx8-test-seed",
+                    UpdatedAt = DateTime.UtcNow,
                 });
 
                 await db.SaveChangesAsync();


### PR DESCRIPTION
## Summary

The Cx8 proof harness payload omits `SquareFeet`, so `CostForgeController.CalculatePropertyCost` routes to `CostForgeService.AnalyzeCostAsync`, which queries `CamaCharacteristics` by `ParcelId == Property.ParcelNumber`. The factory's `EnsureSeedDataAsync` only seeded `County` + `Property` rows — no CAMA — so the service threw `InvalidOperationException("No CAMA characteristics found...")` → 422 → `EnsureSuccessStatusCode()` raised.

This PR seeds 2 `CamaCharacteristic` rows (PropertyA = 1800 sqft, PropertyB = 3400 sqft, `BuildingType=R1`, `Region="Reval 1"`, `TaxYear=2026`) so `AnalyzeCostAsync` resolves the real Benton 2025 cost matrix path with distinct outputs (proves `totalA != totalB`).

Sibling test `CostForge_MissingRequestInputs_Returns422InsteadOfGeneric500` previously relied on PropertyA having no CAMA — added a third `PropertyNoCamaId` (no CAMA seeded) and rewired that test to use it, preserving its 422 assertion.

Partial close on #739.

## Diff scope

`backend/tests/TerraFusion.Unit.Tests/R1Week2/R1Week2Cx8CostForgeRealOutputTests.cs` only — +69/−1.

## Verification

- Build clean
- Cx8 filter: **8/8 pass** (was 7 pass + 1 fail)
- R1Week2 sibling regression: clean

## Out of scope

No `backend/src/**` changes.

## Test plan

- [x] Local 8/8
- [ ] Required CI checks green
- [ ] Standard merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for improved error handling when CAMA characteristics are missing, now returning a 422 response with specific error messaging instead of a generic 500 error.
  * Enhanced test data seeding to support comprehensive validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->