### PR TITLE
test: provide ControllerContext.HttpContext in R2Wave43 regression endpoint tests (CI-HYGIENE-D)

### DIFF
--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave43/R2Wave43RegressionEndpointTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave43/R2Wave43RegressionEndpointTests.cs
@@ -1,9 +1,11 @@
 using FluentAssertions;
 using Moq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Security.Claims;
 using TerraFusion.API.Controllers;
 using TerraFusion.API.Services;
 using TerraFusion.Core.Entities;
@@ -49,6 +51,13 @@ public sealed class R2Wave43RegressionEndpointTests
         return new DataDbContext(options, config);
     }
 
+    private static ClaimsPrincipal CreatePrincipal() =>
+        new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("countyId", BentonCountyId.ToString()),
+            new Claim("sub", "w43-test-user"),
+        ], "TestAuth"));
+
     // Real OlsRegressionService — pure math, no dependencies.
     private static TerraForgeController CreateController(DataDbContext db)
     {
@@ -60,12 +69,20 @@ public sealed class R2Wave43RegressionEndpointTests
             .Setup(x => x.TryResolveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(BentonCountyId);
 
-        return new TerraForgeController(
+        var ctrl = new TerraForgeController(
             db,
             NullLogger<TerraForgeController>.Instance,
             new OlsRegressionService(),
             Mock.Of<ISaleQualificationService>(),
             countyResolver.Object);
+
+        // CI-HYGIENE-D (#739): provide ControllerContext.HttpContext so ResolveCountyScopeToken's Request.Headers access does not throw
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = CreatePrincipal() },
+        };
+
+        return ctrl;
     }
 
     private static async Task SeedCountyAsync(DataDbContext db)


### PR DESCRIPTION
## Summary

All 12 R2Wave43 tests failed with `InvalidOperationException: HttpContext must not be null` thrown from `TerraForgeController.ResolveCountyScopeToken` (line 42), which reads `Request.Headers["x-county-id"]`. The test's `CreateController` helper instantiated the controller but never assigned a `ControllerContext` / `DefaultHttpContext`, so the very first call to `Request` threw — the `ICountyResolver` mock setup was irrelevant because the throw happened before resolver was reached.

Production code is correct. Pure test fixture gap. Identical pattern to R2Wave26, R2Wave27, R2Wave33 — all of which set up `DefaultHttpContext` + `ClaimsPrincipal` correctly. R2Wave43 was the outlier.

Fix follows the proven shape used elsewhere in the same test project: `CreatePrincipal()` static carrying `countyId` claim + `ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = ... } }` immediately after `new TerraForgeController(...)`.

Partial close on #739.

## Diff scope

`backend/tests/TerraFusion.Unit.Tests/R2Wave43/R2Wave43RegressionEndpointTests.cs` only — +18/−1.

## Verification

- Build: 0 errors
- `R2Wave43`: **12/12 pass** (was 0/12)
- Sibling regression on `~R2Wave`: zero new regressions (R2Wave32/38/39 still failing as expected — those clusters are escalated separately, see triage at #739)

## Out of scope

No `backend/src/**` changes. R2Wave32/38/39 service-body issues escalated separately.

## Test plan

- [x] Local 12/12
- [ ] Required CI checks green
- [ ] Backend Gate confirms 12 R2Wave43 failures gone
- [ ] Standard merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression endpoint tests with proper authentication and HTTP context configuration to improve security scenario validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->