### PR TITLE
fix: enforce permission gates on exposed controller surfaces (CI-HYGIENE-D AUTH, partial #739)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -23,7 +23,8 @@ namespace TerraFusion.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-[AllowAnonymous]
+[Authorize]
+[RequiresPermission("access:costforge")]
 public class CostForgeController : ControllerBase
 {
   private readonly ICostForgeService _costForgeService;
@@ -333,6 +334,7 @@ public class CostForgeController : ControllerBase
   /// Integrates with frontend EnhancedCostCalculator component
   /// </summary>
   [HttpPost("calculate")]
+  [RequiresPermission("calculate:property-cost")]
   public async Task<ActionResult<CostAnalysisDto>> CalculatePropertyCost([FromBody] PropertyCostCalculationRequest request)
   {
     var startTime = DateTime.UtcNow;
@@ -953,6 +955,7 @@ public class CostForgeController : ControllerBase
   /// Supports Washington State compliance and Harris PACS integration
   /// </summary>
   [HttpPost("batch-calculate")]
+  [RequiresPermission("calculate:batch-valuation")]
   public async Task<ActionResult<BatchValuationResultDto>> BatchCalculateValuations([FromBody] BatchValuationRequestDto request)
   {
     var countyContext = await ResolveCountyContextAsync();
@@ -1143,6 +1146,7 @@ public class CostForgeController : ControllerBase
   /// Powers EnhancedDataVisualization component charts
   /// </summary>
   [HttpGet("{propertyId}/breakdown")]
+  [RequiresPermission("read:cost-breakdown")]
   public async Task<ActionResult<CostBreakdownDto>> GetCostBreakdown(Guid propertyId)
   {
     try
@@ -1179,6 +1183,7 @@ public class CostForgeController : ControllerBase
   /// Enhanced analysis for property assessment validation
   /// </summary>
   [HttpGet("compare/{propertyId1}/{propertyId2}")]
+  [RequiresPermission("read:cost-comparison")]
   public async Task<ActionResult<CostComparisonDto>> CompareCosts(Guid propertyId1, Guid propertyId2)
   {
     try
@@ -1222,6 +1227,7 @@ public class CostForgeController : ControllerBase
   /// Supports multi-year assessment projections
   /// </summary>
   [HttpGet("{propertyId}/forecast")]
+  [RequiresPermission("read:cost-forecast")]
   public async Task<ActionResult<CostForecastDto>> GetCostForecast(Guid propertyId, [FromQuery] int years = 5)
   {
     try
@@ -1263,6 +1269,7 @@ public class CostForgeController : ControllerBase
   /// Washington State county-specific adjustments
   /// </summary>
   [HttpGet("factors/{region}")]
+  [RequiresPermission("read:cost-factors")]
   public async Task<ActionResult<IEnumerable<TerraFusion.Core.DTOs.CostFactorDto>>> GetCostFactors(string region)
   {
     try
@@ -1287,6 +1294,7 @@ public class CostForgeController : ControllerBase
   /// Powers calculation engine accuracy
   /// </summary>
   [HttpGet("matrix")]
+  [RequiresPermission("read:cost-matrix")]
   public async Task<ActionResult<CostMatrixDto>> GetCostMatrix([FromQuery] string buildingType, [FromQuery] string region)
   {
     try
@@ -1317,6 +1325,7 @@ public class CostForgeController : ControllerBase
   /// Powers CostForgeQuantumDashboard monitoring
   /// </summary>
   [HttpGet("status")]
+  [RequiresPermission("read:system-status")]
   public async Task<ActionResult> GetSystemStatus()
   {
     try
@@ -1344,6 +1353,7 @@ public class CostForgeController : ControllerBase
   /// Supports 50,000+ AI agents across 39+ counties
   /// </summary>
   [HttpGet("agents/status")]
+  [RequiresPermission("read:ai-agents")]
   public async Task<ActionResult<AIAgentStatusDto>> GetAIAgentStatus()
   {
     try
@@ -1367,6 +1377,7 @@ public class CostForgeController : ControllerBase
   /// Autonomous self-healing capability
   /// </summary>
   [HttpPost("agents/scale")]
+  [RequiresPermission("manage:ai-agents")]
   public async Task<ActionResult> ScaleAIAgents([FromBody] ScaleAgentsRequest request)
   {
     try
@@ -1400,6 +1411,7 @@ public class CostForgeController : ControllerBase
   /// Championship-level performance analytics
   /// </summary>
   [HttpGet("metrics")]
+  [RequiresPermission("read:performance-metrics")]
   public async Task<ActionResult<CostForgePerformanceMetricsDto>> GetPerformanceMetrics()
   {
     try
@@ -1420,6 +1432,7 @@ public class CostForgeController : ControllerBase
   /// Reports source-ingestion status from TerraFusion runtime tables.
   /// </summary>
   [HttpPost("sync/source-status")]
+  [RequiresPermission("sync:external-systems")]
   public async Task<ActionResult<HarrisSyncResultDto>> SyncWithHarrisPACS([FromBody] HarrisSyncRequestDto request)
   {
     var countyContext = await ResolveCountyContextAsync();

--- a/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
+++ b/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
@@ -10,7 +10,7 @@ namespace TerraFusion.API.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[AllowAnonymous]
+[Authorize]
 public class PropertiesController : ControllerBase
 {
     private readonly IPropertyService _propertyService;
@@ -25,6 +25,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<PagedResult<PropertyDto>>> GetProperties(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
@@ -50,6 +51,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet("{id}")]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<PropertyDto>> GetProperty(Guid id)
     {
         try
@@ -85,6 +87,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet("parcel/{parcelNumber}")]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<PropertyDto>> GetPropertyByParcel(string parcelNumber)
     {
         try
@@ -157,6 +160,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet("{id}/valuations")]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<IEnumerable<ValuationDto>>> GetPropertyValuations(Guid id)
     {
         try
@@ -180,6 +184,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpPost("{id}/valuations")]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<ValuationDto>> CreateValuation(Guid id, CreateValuationDto createDto)
     {
         try
@@ -204,6 +209,7 @@ public class PropertiesController : ControllerBase
     }
 
     [HttpGet("stats")]
+    [RequiresPermission("read:properties")]
     public async Task<ActionResult<PropertyStatsDto>> GetPropertyStats()
     {
         try
@@ -227,6 +233,7 @@ public class PropertiesController : ControllerBase
     /// Stub: returns empty list until activity tracking is implemented.
     /// </summary>
     [HttpGet("parcel/{parcelNumber}/activity")]
+    [AllowAnonymous]
     public IActionResult GetParcelActivity(string parcelNumber)
     {
         _logger.LogDebug("Activity requested for parcel {ParcelNumber} — returning stub empty list", parcelNumber);
@@ -240,6 +247,7 @@ public class PropertiesController : ControllerBase
     /// Returns empty buildings array (not 404) when parcel has no PACS improvements.
     /// </summary>
     [HttpGet("parcel/{parcelNumber}/sketch")]
+    [RequiresPermission("read:properties")]
     public async Task<IActionResult> GetParcelSketch(string parcelNumber)
     {
         try


### PR DESCRIPTION
## Summary

`PropertiesController` and `CostForgeController` carried `[AllowAnonymous]` at class level, short-circuiting the entire ASP.NET Core authorization pipeline before `DynamicModulePolicyProvider` and `PluginPermissionHandler` could fire. The 39 failing tests across Cx18 / Cx18D / DX04Gate / Cx19D1 / Cx16 all asserted the documented permission contract from `r1-week5-scope-lock.md`; production was wide open.

This PR replaces class-level `[AllowAnonymous]` with `[Authorize]` (and `[RequiresPermission("access:costforge")]` on CostForge for the two-gate pattern), then adds `[RequiresPermission(...)]` on the 7+12 actions named in the scope-lock matrix. The 21 existing explicit `[AllowAnonymous]` attributes on intentionally-public CostForge actions (reference data, calibration tools, batch status pollers, dev/OS-module hooks) are preserved.

`PropertiesController.GetParcelActivity` receives an explicit `[AllowAnonymous]` override because the stub returns an empty list (no PII) and is used by the OS-module surface.

This is the AUTH slice approved as Option A in the #739 sweep triage. **Real FISMA-relevant security debt** — controllers were accepting unauthenticated traffic on Properties and CostForge cores. Tests were correct; production was wrong.

Partial close on #739.

## Diff scope

2 files, +23/−2:
- `backend/src/TerraFusion.API/Controllers/PropertiesController.cs` (+10/−1)
- `backend/src/TerraFusion.API/Controllers/CostForgeController.cs` (+15/−1)

### Class-level changes
| Controller | Before | After |
|---|---|---|
| `PropertiesController` | `[AllowAnonymous]` | `[Authorize]` |
| `CostForgeController` | `[AllowAnonymous]` | `[Authorize] + [RequiresPermission("access:costforge")]` |

### Action-level additions

**PropertiesController** — 7 `[RequiresPermission("read:properties")]` + 1 `[AllowAnonymous]` override on stub `GetParcelActivity`.

**CostForgeController** — 12 `[RequiresPermission(...)]`:
| Action | Permission |
|---|---|
| `CalculatePropertyCost` | `calculate:property-cost` |
| `BatchCalculateValuations` | `calculate:batch-valuation` |
| `GetCostBreakdown(Guid)` | `read:cost-breakdown` |
| `CompareCosts` | `read:cost-comparison` |
| `GetCostForecast` | `read:cost-forecast` |
| `GetCostFactors` | `read:cost-factors` |
| `GetCostMatrix` | `read:cost-matrix` |
| `GetSystemStatus` | `read:system-status` |
| `GetAIAgentStatus` | `read:ai-agents` |
| `ScaleAIAgents` | `manage:ai-agents` |
| `GetPerformanceMetrics` | `read:performance-metrics` |
| `SyncWithHarrisPACS` | `sync:external-systems` |

The 21 existing explicit `[AllowAnonymous]` attributes on action methods (reference lookups, calibration tools, batch status pollers, etc.) are preserved.

## Verification

- API project build: 0 errors, 0 warnings
- Test project build: 0 errors, 0 warnings
- **Full solution build: 0 errors, 0 warnings**
- AUTH cluster: **91/94 pass** (was 0/39 of these previously failing)
- **Cx27 sibling regression: 11/11 pass** ← critical "must not break" verification
- **Cx16 RealLoginE2E sibling regression: 7/7 pass**

## Known residuals (out of scope for this PR)

3 failures remain after this lands:
1. `Cx18 Unauthenticated_Returns401(sync/harris-pacs)` — route mismatch: test expects `/api/CostForge/sync/harris-pacs` but controller routes `SyncWithHarrisPACS` to `sync/source-status`. Will be filed as a separate route-contract issue.
2. `Cx18 AuthenticatedWithoutPermission_Returns403(sync/harris-pacs)` — same route mismatch.
3. `Cx19D1 Authenticated_MissingCountyClaims_GetPropertyById_Returns403Or401` — `TryResolveCountyId` returns `BadRequest(400)` when countyId claim is null; test expects 401/403. Verified pre-existing on origin/main (not introduced by this commit). Will be addressed in a follow-up that converts the `BadRequest` to `Forbid()`.

Net delta this PR: **−36 fails** (39 expected − 3 residuals).

## Out of scope

- Route alias `sync/harris-pacs` (separate issue)
- `TryResolveCountyId` 400→403 conversion (separate issue)
- Frontend callers of `analytics/*`, `income-approach/*`, etc. without bearer tokens — these will now receive 401/403 (intended posture per scope-lock matrix)
- No middleware, no `Program.cs`, no `AuthenticationConfiguration`, no `RequiresPermissionAttribute` changes
- No test files modified

## Test plan

- [x] Full solution build clean
- [x] AUTH cluster 91/94 (3 known residuals, all out of scope)
- [x] Cx27 sibling regression 11/11
- [x] Cx16 sibling regression 7/7
- [ ] Required CI checks green (Tier-1 UI Harness, Seal Gate, governed-spine, phase85-tools, phase86-toolrunner)
- [ ] Backend Gate confirms 36 AUTH failures gone
- [ ] Auto-merge per locked rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Properties and CostForge API endpoints now require authentication and specific permissions to access sensitive data and operations.
  * Individual endpoints require targeted permissions for properties, cost calculations, system status, and AI agent management.
  * Parcel activity data remains publicly accessible.
  * Enhanced access controls restrict unauthorized access across data retrieval and system management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->