### PR TITLE
fix: close auth CI residual route and county-claim contracts (CI-HYGIENE-D epilogue, closes #756 #757)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -1432,6 +1432,7 @@ public class CostForgeController : ControllerBase
   /// Reports source-ingestion status from TerraFusion runtime tables.
   /// </summary>
   [HttpPost("sync/source-status")]
+  [HttpPost("sync/harris-pacs")]
   [RequiresPermission("sync:external-systems")]
   public async Task<ActionResult<HarrisSyncResultDto>> SyncWithHarrisPACS([FromBody] HarrisSyncRequestDto request)
   {

--- a/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
+++ b/backend/src/TerraFusion.API/Controllers/PropertiesController.cs
@@ -78,7 +78,7 @@ public class PropertiesController : ControllerBase
         countyId = Guid.Empty;
         var claim = User.FindFirst("countyId")?.Value?.Trim();
         if (string.IsNullOrWhiteSpace(claim) || !Guid.TryParse(claim, out countyId))
-            return BadRequest("County authentication required — include a valid countyId claim.");
+            return Forbid();
 
         if (requestedCountyId.HasValue && requestedCountyId.Value != countyId)
             return Forbid();


### PR DESCRIPTION
## Summary

Two micro-residuals from the AUTH hardening sweep (PR #755):

1. **CostForge `sync/harris-pacs` route alias** (closes #756)
   `SyncWithHarrisPACS` was exposed only on `/sync/source-status`, but the documented external Harris-PACS contract uses `/sync/harris-pacs`. Cx18 tests asserted the documented route. Added `[HttpPost("sync/harris-pacs")]` as a second route attribute on the existing action; the `[RequiresPermission("sync:external-systems")]` gate from #755 still applies.

2. **PropertiesController.TryResolveCountyId 400 → 403** (closes #757)
   Returned `BadRequest(400)` when an authenticated user lacked a `countyId` claim. Per Sovereign County Model, the correct contract is **Forbidden (403)**: the request is well-formed and authenticated, but the user lacks the claim required for county-scoped data. Changed `BadRequest(...)` → `Forbid()`.

Closes the last 3 fails from the #739 sweep:
- `Cx18.Unauthenticated_Returns401(.../sync/harris-pacs)`
- `Cx18.AuthenticatedWithoutPermission_Returns403(.../sync/harris-pacs)`
- `Cx19D1.Authenticated_MissingCountyClaims_GetPropertyById_Returns403Or401`

Partial close on #739.

## Diff scope

2 files, +2/−1:
- `backend/src/TerraFusion.API/Controllers/CostForgeController.cs` — added `[HttpPost("sync/harris-pacs")]`
- `backend/src/TerraFusion.API/Controllers/PropertiesController.cs` — `BadRequest(...)` → `Forbid()` in `TryResolveCountyId`

## Verification

- Build: 0 errors, 0 warnings
- Targeted (Cx18 + Cx19D1): **74/74 pass** (was 71/74). 3 newly green per the residuals listed above.
- Sibling regression: Cx27 + Cx16 RealLoginE2E + R14Phase2BRemainingP0Controller: **30/30 pass** (Failed: 0)
- Properties + CostForge full controller regression: 89 passed / 3 failed / 92 total. The 3 failures are NOT introduced by this PR — they are pre-existing on current main, originating from PR #755's `[AllowAnonymous]` removal hardening. They live in `R14Phase2P0ControllerIntegrationTests.cs` (a different file from the already-fixed `Phase2BRemainingP0`) and are stale-contract assertions of the deprecated insecure behavior. **Filed as #758** for proper test alignment in a follow-up. Zero new regressions introduced by this PR.

## Out of scope

- #758 R14Phase2P0 stale-contract tests (filed as separate issue per scope discipline)
- SVC clusters #751/#752/#753 (feature work)
- No middleware, Program.cs, AuthenticationConfiguration, RequiresPermissionAttribute, or any other production code beyond the 2 named edits

## Test plan

- [x] Local 3 newly-green residuals
- [x] Sibling regressions clean (Cx27 11/11, Cx16 7/7, R14Phase2BRemaining 12/12)
- [ ] Required CI checks green (Tier-1 UI Harness, Seal Gate, governed-spine, phase85-tools, phase86-toolrunner)
- [ ] Auto-merge per locked rule

The last auth crumbs left the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Harris PACS synchronization endpoint for enhanced data integration capabilities.

* **Bug Fixes**
  * Improved authorization error handling for county identification validation, returning appropriate security response codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->