### PR TITLE
test: align R14Phase2P0 tests to evidence-only + permission-gated contract (closes #758)

### DIFF
--- a/backend/tests/TerraFusion.Unit.Tests/R14/R14Phase2P0ControllerIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R14/R14Phase2P0ControllerIntegrationTests.cs
@@ -83,11 +83,28 @@ public sealed class R14Phase2P0ControllerIntegrationTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    // CI-HYGIENE-D (#758): the original test name asserted the deprecated
+    // "controller allows claims without policy permission, returns 200"
+    // contract — literally the [AllowAnonymous]-style permissive behavior
+    // PR #755 deliberately removed when CostForgeController was hardened
+    // with [Authorize] + [RequiresPermission("access:costforge")] at the
+    // class gate and [RequiresPermission("calculate:property-cost")] at
+    // the action gate. The contract is now: presenting valid claims
+    // WITHOUT the per-action permission must be denied. This rewrite
+    // preserves the test intent (verifying the gate works) and updates
+    // the assertion to the post-#755 evidence-only + per-action contract.
+    // See backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+    // ~line 26 (class gate) and ~line 337 (action gate).
     [Fact]
-    public async Task CostForge_Calculate_ControllerAllowsClaimsWithoutPolicyPermission_Returns200()
+    public async Task CostForge_Calculate_ClaimsWithoutPolicyPermission_Returns403()
     {
         using var factory = await CreateFactoryAsync();
-        using var client = factory.CreateAuthenticatedClient(roles: ["Assessor"]);
+        // Authenticated with the class-level gate (access:costforge) but
+        // WITHOUT the action-level gate (calculate:property-cost) — this
+        // must be denied by the RequiresPermission policy handler.
+        using var client = factory.CreateAuthenticatedClient(
+            roles: ["Assessor"],
+            perms: ["access:costforge"]);
 
         var response = await client.PostAsJsonAsync("/api/costforge/calculate", new
         {
@@ -97,7 +114,7 @@ public sealed class R14Phase2P0ControllerIntegrationTests
             BuildingType = "SFR",
         });
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -203,11 +220,25 @@ public sealed class R14Phase2P0ControllerIntegrationTests
         payload!.ParcelNumber.Should().Be(R14Phase2ControllerFactory.BentonParcelId);
     }
 
+    // CI-HYGIENE-D (#758): pre-#755, the [Authorize] + RequiresPermission
+    // gates on PropertiesController did not intercept this unauthenticated
+    // POST before model validation, so a malformed body reached the model
+    // binder and produced a 400. After #755 hardened the controller, the
+    // auth pipeline returns 401/403 BEFORE validation runs, so the test
+    // never reached the validation path it was asserting against. The fix
+    // is to AUTHENTICATE the client with read:properties (class gate is
+    // [Authorize]; action declares [RequiresPermission("read:properties")]
+    // for the valuations endpoint per controller convention) so the
+    // request reaches model validation, where the malformed body
+    // (EstimatedValue=-1, Confidence=2) still produces the genuine 400
+    // this test was designed to verify.
     [Fact]
     public async Task Properties_CreateValuation_ValidationFailure_Returns400()
     {
         using var factory = await CreateFactoryAsync();
-        using var client = factory.CreateAuthenticatedClient(roles: ["Assessor"]);
+        using var client = factory.CreateAuthenticatedClient(
+            roles: ["Assessor"],
+            perms: ["read:properties"]);
 
         var response = await client.PostAsJsonAsync(
             $"/api/properties/{R14Phase2ControllerFactory.BentonPropertyId}/valuations",
@@ -220,8 +251,18 @@ public sealed class R14Phase2P0ControllerIntegrationTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    // CI-HYGIENE-D (#758): pre-#755 the missing-countyId path returned
+    // BadRequest(400). After the AUTH hardening (#755), follow-up #757,
+    // and the Sovereign County Model alignment in #759, PropertiesController
+    // .TryResolveCountyId now returns Forbid() (403) when the countyId
+    // claim is missing or unparseable. This is the correct semantics:
+    // the user is authenticated but lacks a valid county scope, so the
+    // request is forbidden, not malformed. See
+    // backend/src/TerraFusion.API/Controllers/PropertiesController.cs
+    // ~lines 76-87 (TryResolveCountyId returns Forbid() on missing/bad
+    // countyId claim).
     [Fact]
-    public async Task Properties_GetById_MissingCountyClaim_Returns400()
+    public async Task Properties_GetById_MissingCountyClaim_Returns403()
     {
         using var factory = await CreateFactoryAsync();
         using var client = factory.CreateAuthenticatedClient(
@@ -231,7 +272,7 @@ public sealed class R14Phase2P0ControllerIntegrationTests
 
         var response = await client.GetAsync($"/api/properties/{R14Phase2ControllerFactory.BentonPropertyId}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Three tests in `R14Phase2P0ControllerIntegrationTests` (the `Phase2P0` file, distinct from `Phase2BRemainingP0` already fixed in PR #745) asserted the pre-#755 contract:

- `BadRequest(400)` for missing county claim
- Pre-validation 400 on unauthenticated POST
- "controller allows claims without policy permission, returns 200" — literally the `[AllowAnonymous]` behavior PR #755 deliberately removed

All three are stale-contract artifacts of the AUTH hardening sweep, **same pattern as PR #745** fixed for `R14Phase2BRemainingP0`. This PR aligns them to the new (correct) contract.

Closes #758. Final partial close on #739's residual list.

## Diff scope

`backend/tests/TerraFusion.Unit.Tests/R14/R14Phase2P0ControllerIntegrationTests.cs` only — 1 file, +47/−6.

## Test rewrites

| Test (before → after) | Resolution |
|---|---|
| `Properties_GetById_MissingCountyClaim_Returns400` → `_Returns403` | Renamed; assertion changed `BadRequest` → `Forbidden` per Sovereign County Model. `TryResolveCountyId` returns `Forbid()` since #759. |
| `Properties_CreateValuation_ValidationFailure_Returns400` (name kept) | Now grants `read:properties` permission so auth pipeline allows the request to reach model validation, where the original 400 path still applies. |
| `CostForge_Calculate_ControllerAllowsClaimsWithoutPolicyPermission_Returns200` → `_Returns403` | Renamed and rewritten. Authenticates with `access:costforge` (class gate) only — no `calculate:property-cost` — expects 403. Asserts the inverted contract: gate works. |

Each test carries a `CI-HYGIENE-D (#758)` doctrine comment citing #755, #757, #759 and the relevant controller line numbers.

## Verification

- Build: 0 warnings, 0 errors
- `R14Phase2P0ControllerIntegrationTests`: **20/20 pass** (3 newly green + 17 already green)
- `R14Phase2BRemaining + R1Week5Cx27` regression: **23/23 pass** (Failed: 0)
- Broad regression `R14|Cx18|Cx19D1|Cx16`: **142/142 pass** (Failed: 0)

The broader regression filter was added per a lesson learned from #755, where the original Phase2P0 regression went unnoticed because the verification scope was too narrow.

## Out of scope

- No `backend/src/**` changes
- No factory class changes (`R14Phase2ControllerFactory.CreateAuthenticatedClient` already supports per-permission auth grants and county-claim suppression — same factory referenced by #745)
- No middleware, no Program.cs, no other test files

## Test plan

- [x] Local 20/20 R14Phase2P0
- [x] Local 23/23 sibling regression (R14Phase2BRemaining + Cx27)
- [x] Local 142/142 broad regression (R14|Cx18|Cx19D1|Cx16)
- [ ] Required CI checks green (Tier-1 UI Harness, Seal Gate, governed-spine, phase85-tools, phase86-toolrunner)
- [ ] Auto-merge per locked rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authorization tests to verify API endpoints properly deny access (403 Forbidden) when required permissions are missing.
  * Adjusted validation tests to confirm model validation occurs when proper authentication is present.
  * Enhanced test coverage for permission scoping behavior across controller endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->