### PR TITLE
test: align R2Wave38 to county-only qualification contract (closes #752)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/SyncController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SyncController.cs
@@ -61,7 +61,10 @@ public class SyncController : ControllerBase
     ///
     /// Trigger this after PacsDataSeeder completes a new sync.
     /// Uses SaleQualificationService Layer 2 (county_ratio_code FK lookup) as the
-    /// primary driver; Layer 2b (sale_ratio_type), 3, 4, 5 apply in cascade.
+    /// primary driver; Layer 3 (exclude_calc_cd), Layer 4 (wac_cd subtype),
+    /// and Layer 5 (default) apply in cascade. DOR sl_ratio_type is state-reporting
+    /// metadata only and is NOT consulted by this engine — see commit 97f95f0f1
+    /// (April 17, 2026) which removed DOR ratio type from county qualification logic.
     ///
     /// Does NOT overwrite QualificationDecision — that belongs to the appraiser.
     /// Only QualificationRecommendation, RecommendationReason, RecommendationSource,

--- a/backend/tests/TerraFusion.Unit.Tests/R2Wave38/R2Wave38FkAwareQualificationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R2Wave38/R2Wave38FkAwareQualificationTests.cs
@@ -10,30 +10,41 @@ using Task = System.Threading.Tasks.Task;
 
 namespace TerraFusion.Unit.Tests.R2Wave38;
 
+// CI-HYGIENE-D (#752): tests rewritten to assert the county-only qualification
+// contract established by commit 97f95f0f1 (April 17, 2026):
+// "DOR ratio type (sl_ratio_type_cd) completely removed from county qualification
+//  logic. County ratio code and DOR ratio type are independent systems for
+//  independent purposes." RecommendationVersion bumped to 2.0 in the same commit.
+//  Tests previously asserted DOR-aware Layer 2b behavior + version "1.1" — both
+//  deprecated. Same stale-contract pattern as PR #745 / #758. SyncController.cs:64
+//  stale doc comment also fixed (was the source of test author confusion).
+
 /// <summary>
-/// R2Wave38 — FK-aware sale qualification via <see cref="SaleQualificationService.ComputeRecommendationsAsync"/>.
+/// R2Wave38 — county-only qualification via <see cref="SaleQualificationService.ComputeRecommendationsAsync"/>.
 ///
 /// Purpose:
-///   Verify that the service reads dbo.sale_ratio_type (invalid_sale flag) and
-///   dbo.county_ratio_code (ratio_desc) from the DB and uses them to qualify
-///   sales — instead of relying on hardcoded string guesses against raw codes.
+///   Verify the county-only cascade established by commit 97f95f0f1:
+///     Layer 1 — RawSaleQualifier (sl_qualifier)
+///     Layer 2 — RawCountyRatioCd (sl_county_ratio_cd) — keyword match against county_ratio_code.ratio_desc
+///     Layer 3 — RawExcludeCalcCd (sales_exclude_calc_cd)
+///     Layer 4 — RawWacCd (WAC 458-61A excise exemption)
+///     Layer 5 — Default qualified
+///
+///   DOR ratio type (RawRatioTypeCd / sl_ratio_type_cd) is intentionally NOT
+///   consulted: it is state-reporting metadata only.
 ///
 /// Invariants under test:
-///   WF38-01: sale_ratio_type.invalid_sale=true → non-arms-length regardless of descriptor
-///   WF38-02: sale_ratio_type.invalid_sale=false → qualified by DOR
-///   WF38-03: county_ratio_code.ratio_desc containing "QUAL" → qualified
-///   WF38-04: county_ratio_code.ratio_desc containing "UNQUAL" → non-arms-length
-///   WF38-05: county_ratio_code.ratio_desc containing "FORECLOS" → foreclosure
-///   WF38-06: county_ratio_code.ratio_desc containing "ESTATE" → estate
-///   WF38-07: county_ratio_code.ratio_desc containing "EXCLUDE" → excluded
-///   WF38-08: Layer priority — county code (Layer 2) wins over ratio type (Layer 2b)
-///   WF38-09: Empty lookup tables → falls through to Layer 3/4/5
-///   WF38-10: RecommendationVersion = "1.1" after FK-aware recompute
-///   WF38-11: RecommendationReason cites FK layers correctly
-///   WF38-12: unknown county ratio desc → conservative non-arms-length
+///   WF38-01: DOR-only input (invalid_sale=true) → falls to Layer 5 default "qualified"
+///   WF38-02: DOR-only input (invalid_sale=false) → Layer 5 default "qualified"
+///   WF38-03..07: county_ratio_code keyword cascade (VALID / LAND ONLY / OMIT / DARK / COMMERCIAL)
+///   WF38-08: County code present → Layer 2 wins; DOR is never consulted
+///   WF38-09: Empty lookup tables → Layer 3/4/5 cascade still operates
+///   WF38-10: RecommendationVersion = "2.0" (post-97f95f0f1)
+///   WF38-11: RecommendationReason format "L2: CountyRatioCd=…" (no "Layer 2b" anywhere)
+///   WF38-12: Unknown county code with non-keyword description → conservative non-arms-length
 /// </summary>
 [Trait("Category", "R2Wave38")]
-[Trait("Category", "FkAwareQualification")]
+[Trait("Category", "CountyOnlyQualification")]
 public sealed class R2Wave38FkAwareQualificationTests
 {
     private static readonly Guid BentonCountyId = Guid.NewGuid();
@@ -87,16 +98,19 @@ public sealed class R2Wave38FkAwareQualificationTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-01 / WF38-02 — sale_ratio_type.invalid_sale flag
+    // WF38-01 / WF38-02 — DOR sl_ratio_type is NOT consulted by county engine.
+    // Per commit 97f95f0f1, DOR ratio type is state-reporting metadata only.
+    // A sale with only RawRatioTypeCd set falls through to Layer 5 default.
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task WF38_01_InvalidSaleFlag_True_YieldsNonArmsLength()
+    public async Task WF38_01_DorRatioTypeOnly_FallsThroughToLayer5Default()
     {
-        using var db = CreateDbContext(nameof(WF38_01_InvalidSaleFlag_True_YieldsNonArmsLength));
+        using var db = CreateDbContext(nameof(WF38_01_DorRatioTypeOnly_FallsThroughToLayer5Default));
         await SeedCountyAsync(db);
 
-        // Seed a PACS ratio type with invalid_sale = true
+        // Seed a PACS DOR ratio type with invalid_sale = true. This MUST be ignored
+        // by the county engine — DOR ratio type is state-reporting metadata only.
         db.SaleRatioTypes.Add(new SaleRatioType
         {
             SlRatioTypeCd = "99",
@@ -105,7 +119,7 @@ public sealed class R2Wave38FkAwareQualificationTests
             RequiresReason = false,
         });
 
-        // Sale with this DOR code, no county code, no raw qualifier
+        // Sale with this DOR code only — no county code, no qualifier, no flags.
         var sale = await SeedSaleAsync(db, ratioTypeCd: "99");
         await db.SaveChangesAsync();
 
@@ -113,16 +127,17 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        refreshed!.QualificationRecommendation.Should().Be("non-arms-length");
+        refreshed!.QualificationRecommendation.Should().Be("qualified",
+            because: "DOR ratio type (sl_ratio_type_cd) is NOT consulted by the county engine; "
+                   + "with no other codes, the sale falls to Layer 5 default.");
     }
 
     [Fact]
-    public async Task WF38_02_InvalidSaleFlag_False_YieldsQualified()
+    public async Task WF38_02_DorRatioTypeOnly_InvalidSaleFalse_StillLayer5Default()
     {
-        using var db = CreateDbContext(nameof(WF38_02_InvalidSaleFlag_False_YieldsQualified));
+        using var db = CreateDbContext(nameof(WF38_02_DorRatioTypeOnly_InvalidSaleFalse_StillLayer5Default));
         await SeedCountyAsync(db);
 
-        // Seed a PACS ratio type with invalid_sale = false (DOR-approved qualified sale)
         db.SaleRatioTypes.Add(new SaleRatioType
         {
             SlRatioTypeCd = "00",
@@ -138,24 +153,33 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        refreshed!.QualificationRecommendation.Should().Be("qualified");
+        refreshed!.QualificationRecommendation.Should().Be("qualified",
+            because: "DOR ratio type is not consulted regardless of invalid_sale; "
+                   + "Layer 5 default applies when no county code/flag is set.");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-03..07 — county_ratio_code.ratio_desc classification
+    // WF38-03..07 — Layer 2 keyword cascade against county_ratio_code.ratio_desc.
+    // Production cascade (SaleQualificationService.QualifyForCounty):
+    //   description contains "VALID" (and not "INVALID")  → "qualified"
+    //   description contains "LAND ONLY"/"LAND-ONLY"      → "land-only"
+    //   description contains "OMIT"                       → "omitted"
+    //   description contains "DARK" or "COMMERCIAL"       → "dark-sale"
+    //   any other description with a county code          → "non-arms-length"
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Theory]
-    [InlineData("BC-Q",  "Qualified Sale",               "qualified")]
-    [InlineData("BC-U",  "Unqualified - Related Party",  "non-arms-length")]
-    [InlineData("BC-N",  "NON-QUALIFIED TRANSFER",       "non-arms-length")]
-    [InlineData("BC-F",  "FORECLOSURE / BANK OWNED",     "foreclosure")]
-    [InlineData("BC-E",  "ESTATE SALE",                  "estate")]
-    [InlineData("BC-X",  "EXCLUDED FROM STUDY",          "excluded")]
-    public async Task WF38_03_07_CountyRatioCodeDesc_ClassifiesCorrectly(
+    [InlineData("BC-V", "Valid Sale",                  "qualified")]
+    [InlineData("BC-I", "Invalid Sale",                "non-arms-length")]
+    [InlineData("BC-N", "NON-QUALIFIED TRANSFER",      "non-arms-length")]
+    [InlineData("BC-L", "LAND ONLY SALE",              "land-only")]
+    [InlineData("BC-O", "OMITTED — REVIEW",            "omitted")]
+    [InlineData("BC-D", "DARK COMMERCIAL",             "dark-sale")]
+    [InlineData("BC-X", "EXCLUDED FROM STUDY",         "non-arms-length")]
+    public async Task WF38_03_07_CountyRatioCodeDesc_ClassifiesByLayer2Keywords(
         string code, string desc, string expected)
     {
-        var testName = $"WF38_{code.Replace("-", "_")}_{expected}";
+        var testName = $"WF38_{code.Replace("-", "_")}_{expected.Replace("-", "_")}";
         using var db = CreateDbContext(testName);
         await SeedCountyAsync(db);
 
@@ -170,20 +194,22 @@ public sealed class R2Wave38FkAwareQualificationTests
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
         refreshed!.QualificationRecommendation.Should().Be(expected,
-            because: $"County code '{code}' has description '{desc}'");
+            because: $"County code '{code}' description '{desc}' should match Layer 2 keyword cascade");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-08 — Layer priority: county code (L2) wins over ratio type (L2b)
+    // WF38-08 — Layer 2 (county code) is the authority. DOR is not consulted.
+    // Even when a DOR ratio type is seeded with invalid_sale=true, the engine
+    // never reads it: Layer 2 alone determines the outcome.
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task WF38_08_Layer2_WinsOver_Layer2b()
+    public async Task WF38_08_Layer2_CountyCode_Wins_DorNeverConsulted()
     {
-        using var db = CreateDbContext(nameof(WF38_08_Layer2_WinsOver_Layer2b));
+        using var db = CreateDbContext(nameof(WF38_08_Layer2_CountyCode_Wins_DorNeverConsulted));
         await SeedCountyAsync(db);
 
-        // DOR says invalid, but county has its OWN "Qualified" code — L2 wins
+        // DOR table has an "invalid" entry — must be ignored by county engine.
         db.SaleRatioTypes.Add(new SaleRatioType
         {
             SlRatioTypeCd = "99",
@@ -191,13 +217,13 @@ public sealed class R2Wave38FkAwareQualificationTests
             InvalidSale   = true,
             RequiresReason = false,
         });
+        // County says "Valid Sale" — Layer 2 keyword cascade returns "qualified".
         db.CountyRatioCodes.Add(new CountyRatioCode
         {
             RatioCd   = "QC",
-            RatioDesc = "County Verified Qualified",
+            RatioDesc = "County Valid Sale (verified)",
         });
 
-        // Sale has both: county code QC AND DOR code 99 (invalid by DOR)
         var sale = await SeedSaleAsync(db, countyRatioCd: "QC", ratioTypeCd: "99");
         await db.SaveChangesAsync();
 
@@ -205,13 +231,12 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        // Layer 2 (county code) wins → "qualified", despite DOR saying invalid
         refreshed!.QualificationRecommendation.Should().Be("qualified",
-            because: "county_ratio_code (Layer 2) takes priority over sale_ratio_type (Layer 2b)");
+            because: "Layer 2 (county_ratio_code) is the authority; DOR ratio type is never consulted.");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-09 — Empty lookup tables → falls through to Layer 3/4/5
+    // WF38-09 — Empty lookup tables → cascade still works through Layer 3/4/5.
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Fact]
@@ -252,13 +277,14 @@ public sealed class R2Wave38FkAwareQualificationTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-10 — RecommendationVersion = "1.1" after FK-aware recompute
+    // WF38-10 — RecommendationVersion = "2.0" (bumped by commit 97f95f0f1)
+    // Previously "1.1" under the deprecated DOR-aware contract.
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task WF38_10_RecommendationVersion_Is_1_1_After_FkRecompute()
+    public async Task WF38_10_RecommendationVersion_Is_2_0_PostCountyOnlyContract()
     {
-        using var db = CreateDbContext(nameof(WF38_10_RecommendationVersion_Is_1_1_After_FkRecompute));
+        using var db = CreateDbContext(nameof(WF38_10_RecommendationVersion_Is_2_0_PostCountyOnlyContract));
         await SeedCountyAsync(db);
         var sale = await SeedSaleAsync(db);
         await db.SaveChangesAsync();
@@ -267,22 +293,24 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        refreshed!.RecommendationVersion.Should().Be("1.1",
-            because: "FK-aware recompute bumps version to 1.1");
+        refreshed!.RecommendationVersion.Should().Be("2.0",
+            because: "commit 97f95f0f1 (April 17, 2026) bumped RecommendationVersion to 2.0 "
+                   + "when DOR ratio type was removed from county qualification logic.");
         refreshed.RecommendationSource.Should().Be("TerraFusionRuleEngine");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-11 — RecommendationReason cites the correct FK layer
+    // WF38-11 — RecommendationReason format. Production emits "L2: CountyRatioCd=XX"
+    // (per BuildRecommendationReason). No "Layer 2b" path exists.
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task WF38_11_RecommendationReason_Cites_CountyRatioFk_ForLayer2()
+    public async Task WF38_11_RecommendationReason_Cites_L2_CountyRatioCd_ForLayer2()
     {
-        using var db = CreateDbContext(nameof(WF38_11_RecommendationReason_Cites_CountyRatioFk_ForLayer2));
+        using var db = CreateDbContext(nameof(WF38_11_RecommendationReason_Cites_L2_CountyRatioCd_ForLayer2));
         await SeedCountyAsync(db);
 
-        db.CountyRatioCodes.Add(new CountyRatioCode { RatioCd = "AQ", RatioDesc = "Qualified Arm's Length" });
+        db.CountyRatioCodes.Add(new CountyRatioCode { RatioCd = "AQ", RatioDesc = "Valid Sale (Arm's Length)" });
         var sale = await SeedSaleAsync(db, countyRatioCd: "AQ");
         await db.SaveChangesAsync();
 
@@ -290,16 +318,18 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        refreshed!.RecommendationReason.Should().Contain("Layer 2",
-            because: "Layer 2 (county_ratio_code FK) was the deciding factor");
+        refreshed!.RecommendationReason.Should().Contain("L2: CountyRatioCd=",
+            because: "BuildRecommendationReason emits the L2 prefix when only a county code is present.");
         refreshed.RecommendationReason.Should().Contain("AQ",
             because: "reason should include the code");
+        refreshed.RecommendationReason.Should().NotContain("Layer 2b",
+            because: "Layer 2b path was removed by commit 97f95f0f1.");
     }
 
     [Fact]
-    public async Task WF38_11b_RecommendationReason_Cites_DorRatioFk_ForLayer2b()
+    public async Task WF38_11b_DorRatioTypeOnly_ReasonFallsToLayer5Default_NeverCitesLayer2b()
     {
-        using var db = CreateDbContext(nameof(WF38_11b_RecommendationReason_Cites_DorRatioFk_ForLayer2b));
+        using var db = CreateDbContext(nameof(WF38_11b_DorRatioTypeOnly_ReasonFallsToLayer5Default_NeverCitesLayer2b));
         await SeedCountyAsync(db);
 
         db.SaleRatioTypes.Add(new SaleRatioType
@@ -316,9 +346,11 @@ public sealed class R2Wave38FkAwareQualificationTests
         await svc.ComputeRecommendationsAsync(BentonCountyId);
 
         var refreshed = await db.ComparableSales.FindAsync(sale.Id);
-        refreshed!.RecommendationReason.Should().Contain("Layer 2b",
-            because: "Layer 2b (sale_ratio_type.invalid_sale FK) was the deciding factor");
-        refreshed.RecommendationReason.Should().Contain("01");
+        refreshed!.RecommendationReason.Should().StartWith("L5",
+            because: "DOR ratio type is not in the county cascade; with only RawRatioTypeCd set, "
+                   + "BuildRecommendationReason falls through to the L5 default reason.");
+        refreshed.RecommendationReason.Should().NotContain("Layer 2b",
+            because: "Layer 2b doctrine was removed by commit 97f95f0f1; reason must never cite it.");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -349,28 +381,21 @@ public sealed class R2Wave38FkAwareQualificationTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Batch correctness — multiple sales, each gets the right classification
-    // ═══════════════════════════════════════════════════════════════════════════
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // WF38-13 — Sync-time fast path: live-confirmed Benton pacs_oltp codes
-    //
-    // Regression for the bug where the sync-time Qualify() fallback returned
-    // "non-arms-length" for ANY non-empty county ratio code when the lookup table
-    // was not loaded.
+    // WF38-13 — Sync-time fast path: live-confirmed Benton pacs_oltp codes.
     //
     // Live pacs_oltp query 2026-04-04 (GROUP BY sl_county_ratio_cd on 425,251 rows):
     //   '100' → 21,715 occurrences — county_ratio_code.ratio_desc = "Valid Sale"
     //   '0'   →    219 occurrences — county_ratio_code.ratio_desc = "VALID SALE"
     //   '200' → 10,445 occurrences — "Invalid Sale"
-    //   '01'+'02' DO NOT EXIST in live data (prior doc reference was wrong)
+    //   '300' →  3,363 occurrences — "Land Only Sale"  → "land-only"
+    //   '99'  → unknown            → "non-arms-length" (conservative fallback)
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Theory]
     [InlineData("100", "qualified")]           // Benton: Valid Sale (primary — 21,715 sales)
     [InlineData("0",   "qualified")]           // Benton: VALID SALE (legacy — 219 sales)
     [InlineData("200", "non-arms-length")]     // Invalid Sale
-    [InlineData("300", "non-arms-length")]     // Land Only Sale
+    [InlineData("300", "land-only")]           // Land Only Sale
     [InlineData("99",  "non-arms-length")]     // Unknown code → conservative fallback
     public void WF38_13_SyncTimeFastPath_BentonCountyCodes_QualifyCorrectly(
         string countyRatioCd, string expectedResult)
@@ -391,10 +416,15 @@ public sealed class R2Wave38FkAwareQualificationTests
             because: $"sl_county_ratio_cd='{countyRatioCd}' sync-time fast path should use known Benton codes");
     }
 
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Batch correctness — DOR-only inputs all fall to Layer 5 default. The DOR
+    // ratio type is not consulted, so per-input differentiation by DOR is gone.
+    // ═══════════════════════════════════════════════════════════════════════════
+
     [Fact]
-    public async Task WF38_Batch_MultipleRatioTypes_EachClassifiedCorrectly()
+    public async Task WF38_Batch_MultipleDorRatioTypes_AllFallToLayer5Default()
     {
-        using var db = CreateDbContext(nameof(WF38_Batch_MultipleRatioTypes_EachClassifiedCorrectly));
+        using var db = CreateDbContext(nameof(WF38_Batch_MultipleDorRatioTypes_AllFallToLayer5Default));
         await SeedCountyAsync(db);
 
         db.SaleRatioTypes.AddRange(
@@ -417,8 +447,12 @@ public sealed class R2Wave38FkAwareQualificationTests
         var related    = await db.ComparableSales.FindAsync(saleRelated.Id);
         var bank       = await db.ComparableSales.FindAsync(saleBank.Id);
 
+        // All three sales have only RawRatioTypeCd set → no county code, no flags →
+        // Layer 5 default applies uniformly. DOR is not consulted (per commit 97f95f0f1).
         armsLength!.QualificationRecommendation.Should().Be("qualified");
-        related!.QualificationRecommendation.Should().Be("non-arms-length");
-        bank!.QualificationRecommendation.Should().Be("non-arms-length");
+        related!.QualificationRecommendation.Should().Be("qualified",
+            because: "DOR invalid_sale=true is NOT consulted by the county engine; falls to Layer 5.");
+        bank!.QualificationRecommendation.Should().Be("qualified",
+            because: "DOR invalid_sale=true is NOT consulted by the county engine; falls to Layer 5.");
     }
 }


### PR DESCRIPTION
## Summary

R2Wave38 tests asserted a DOR-aware Layer 2b sale qualification contract + RecommendationVersion "1.1" that was deliberately retired by commit `97f95f0f1` (April 17, 2026):

> *"DOR ratio type (sl_ratio_type_cd) completely removed from county qualification logic. County ratio code and DOR ratio type are independent systems for independent purposes: county code drives the county ratio study; DOR type is state-reporting metadata only."*
> *"SaleRatioTypes DB query removed from ComputeRecommendationsAsync. RecommendationVersion bumped to 2.0."*

Production today has 4 doctrine markers across 3 files codifying this. The R2Wave38 test author wrote against a stale `SyncController.cs:64` doc comment that incorrectly claimed "Layer 2b (sale_ratio_type)" was in the cascade — that comment is also fixed in this PR.

Same stale-contract pattern as PR #745 / #758. Closes #752.

## Diff

2 files, 193 lines:
- `backend/tests/TerraFusion.Unit.Tests/R2Wave38/R2Wave38FkAwareQualificationTests.cs` — full rewrite, +110/-78
- `backend/src/TerraFusion.API/Controllers/SyncController.cs` — **comment-only** (5 lines): replaced stale "Layer 2b (sale_ratio_type)" doc with accurate cascade description

## Test rewrites

- DOR-only inputs (WF38_01/02): assert "qualified" Layer 5 default (DOR not consulted)
- WF38_03..07: theory rewritten to test actual Layer 2 keyword cascade (VALID/LAND ONLY/OMIT/DARK/COMMERCIAL)
- WF38_08: renamed `Layer2_CountyCode_Wins_DorNeverConsulted`; uses "County Valid Sale" desc
- WF38_10: expects `RecommendationVersion == "2.0"` (was "1.1")
- WF38_11: asserts production format `"L2: CountyRatioCd=AQ"` (production emits "L2:" not "Layer 2:" per `BuildRecommendationReason` lines 200-211)
- WF38_11b: with only `RawRatioTypeCd` set, reason falls to `"L5"` default
- WF38_13: code "300" expects "land-only" (production hardcoded fallback)

## Verification

- Build: 0 errors
- R2Wave38: **22/22 pass** (was 0/11)
- Wide regression (`SaleQualification|R2Wave42/39/43|Sync`): **835/835 pass**

## Out of scope

`SaleQualificationService.cs` is the doctrine-correct production code; this PR does not modify it. The SyncController change is comment-only — verified via `git diff` showing edits are entirely within the `///` doc block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation to clarify the qualification system's layer ordering, emphasizing that county-based lookup is the primary qualification driver and DOR ratio type serves as metadata only.

* **Tests**
  * Updated test suite to verify county-only qualification behavior and ensure compliance with recommendation version 2.0 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->