### PR TITLE
fix(runtime): restore product data boundary after sync merges

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -1432,7 +1432,6 @@ public class CostForgeController : ControllerBase
   /// Reports source-ingestion status from TerraFusion runtime tables.
   /// </summary>
   [HttpPost("sync/source-status")]
-  [HttpPost("sync/harris-pacs")]
   [RequiresPermission("sync:external-systems")]
   public async Task<ActionResult<HarrisSyncResultDto>> SyncWithHarrisPACS([FromBody] HarrisSyncRequestDto request)
   {
@@ -1440,7 +1439,7 @@ public class CostForgeController : ControllerBase
     if (countyContext is null)
       return Forbid();
 
-    _logger.LogInformation("Harris PACS sync initiated for county {CountyId} by {UserId}",
+    _logger.LogInformation("Source ingestion status requested for county {CountyId} by {UserId}",
         countyContext.CountyId, User.FindFirst("sub")?.Value);
 
     var startTime = DateTime.UtcNow;
@@ -1451,9 +1450,9 @@ public class CostForgeController : ControllerBase
 
     var endTime = DateTime.UtcNow;
 
-    await _auditLogger.LogUserActionAsync("CostForge:HarrisPACSSync",
+    await _auditLogger.LogUserActionAsync("CostForge:SourceIngestionStatus",
         User.FindFirst("sub")?.Value ?? "anonymous",
-        $"Harris PACS sync status retrieved for county {countyContext.CountyName}. Properties: {propertyCount}");
+        $"Source ingestion status retrieved for county {countyContext.CountyName}. Properties: {propertyCount}");
 
     return Ok(new HarrisSyncResultDto
     {

--- a/backend/src/TerraFusion.API/Controllers/NamespaceExcludingControllerFeatureProvider.cs
+++ b/backend/src/TerraFusion.API/Controllers/NamespaceExcludingControllerFeatureProvider.cs
@@ -8,11 +8,21 @@ public sealed class NamespaceExcludingControllerFeatureProvider : ControllerFeat
 {
     private readonly string _namespacePrefix;
     private readonly HashSet<string> _includedControllerNames;
+    private readonly HashSet<string> _excludedControllerNames;
 
     public NamespaceExcludingControllerFeatureProvider(string namespacePrefix, params string[] includedControllerNames)
+        : this(namespacePrefix, includedControllerNames, Array.Empty<string>())
+    {
+    }
+
+    public NamespaceExcludingControllerFeatureProvider(
+        string namespacePrefix,
+        IEnumerable<string> includedControllerNames,
+        IEnumerable<string> excludedControllerNames)
     {
         _namespacePrefix = namespacePrefix ?? string.Empty;
         _includedControllerNames = new HashSet<string>(includedControllerNames ?? Array.Empty<string>(), StringComparer.Ordinal);
+        _excludedControllerNames = new HashSet<string>(excludedControllerNames ?? Array.Empty<string>(), StringComparer.Ordinal);
     }
 
     protected override bool IsController(TypeInfo typeInfo)
@@ -23,6 +33,11 @@ public sealed class NamespaceExcludingControllerFeatureProvider : ControllerFeat
         }
 
         var ns = typeInfo.Namespace ?? string.Empty;
+        if (_excludedControllerNames.Contains(typeInfo.Name))
+        {
+            return false;
+        }
+
         if (_includedControllerNames.Contains(typeInfo.Name))
         {
             return true;

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1112,7 +1112,10 @@ builder.Services.AddControllers()
       manager.FeatureProviders.Add(
           new TerraFusion.API.Controllers.NamespaceExcludingControllerFeatureProvider(
               "TerraFusion.AI.Controllers",
-              "Codex369Controller"));
+              new[] { "Codex369Controller" },
+              builder.Environment.IsDevelopment()
+                  ? Array.Empty<string>()
+                  : new[] { "CanonicalDebugController" }));
     })
     .AddJsonOptions(options =>
     {

--- a/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx18PermissionPolicyIntegrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/R1Week5/R1Week5Cx18PermissionPolicyIntegrationTests.cs
@@ -91,7 +91,7 @@ public sealed class R1Week5Cx18PermissionPolicyIntegrationTests
         yield return new object?[] { "CostForge_manage:ai-agents", "POST", "/api/CostForge/agents/scale",
             JsonSerializer.Serialize(new { TargetCount = 1 }) };
         yield return new object?[] { "CostForge_read:performance-metrics", "GET", "/api/CostForge/metrics", null };
-        yield return new object?[] { "CostForge_sync:external-systems", "POST", "/api/CostForge/sync/harris-pacs",
+        yield return new object?[] { "CostForge_sync:external-systems", "POST", "/api/CostForge/sync/source-status",
             JsonSerializer.Serialize(new { CountyId = "BENTON", FullSync = false }) };
 
         // ── DossierController (3) ────────────────────────────────────

--- a/scripts/truth/runtime-data-boundary-audit.mjs
+++ b/scripts/truth/runtime-data-boundary-audit.mjs
@@ -120,6 +120,15 @@ function safeRead(filePath) {
   }
 }
 
+function hasDevelopmentOnlyCanonicalDebugGate() {
+  const program = safeRead(path.join(repoRoot, 'backend', 'src', 'TerraFusion.API', 'Program.cs'));
+  return (
+    /\bCanonicalDebugController\b/.test(program) &&
+    /\.IsDevelopment\s*\(/.test(program) &&
+    /new\[\]\s*\{\s*"CanonicalDebugController"\s*\}/.test(program)
+  );
+}
+
 function matches(patterns, value) {
   return patterns.filter(pattern => pattern.test(value)).map(pattern => pattern.source);
 }
@@ -233,6 +242,11 @@ function zoneFor(filePath, content) {
   if (relative.includes('/tests/') || relative.startsWith('backend/tests/')) return 'allowed_tests';
   if (/#if\s+DEBUG/i.test(content) && /TestController\.cs$/i.test(relative)) return 'allowed_tests';
   if (/WorkbenchSyncReadinessController\.cs$/i.test(relative)) return 'allowed_admin_proof';
+  if (/CanonicalDebugController\.cs$/i.test(relative)) {
+    return hasDevelopmentOnlyCanonicalDebugGate()
+      ? 'allowed_admin_proof'
+      : 'forbidden_product_runtime';
+  }
 
   if (
     /(^|\/)(sync|etl|scrapers?|datamining)(\/|$)/i.test(relative) ||

--- a/scripts/truth/runtime-data-boundary-audit.test.mjs
+++ b/scripts/truth/runtime-data-boundary-audit.test.mjs
@@ -135,6 +135,92 @@ test('workbench sync readiness facade is classified as admin proof, not product 
   assert.equal(report.summary.syncAdminEndpointsScanned, 1);
 });
 
+test('canonical debug controller is allowed only when Program gates it to development', async () => {
+  const root = makeTempRepo('tf-boundary-canonical-debug-gated-');
+  fs.writeFileSync(
+    path.join(root, 'backend', 'src', 'TerraFusion.API', 'Program.cs'),
+    `
+      builder.Services.AddControllers()
+        .ConfigureApplicationPartManager(manager =>
+        {
+          manager.FeatureProviders.Add(
+            new NamespaceExcludingControllerFeatureProvider(
+              "TerraFusion.AI.Controllers",
+              new[] { "Codex369Controller" },
+              builder.Environment.IsDevelopment()
+                ? Array.Empty<string>()
+                : new[] { "CanonicalDebugController" }));
+        });
+    `
+  );
+  fs.writeFileSync(
+    path.join(
+      root,
+      'backend',
+      'src',
+      'TerraFusion.API',
+      'Controllers',
+      'CanonicalDebugController.cs'
+    ),
+    `
+      [Route("api/debug")]
+      public class CanonicalDebugController : ControllerBase
+      {
+        public IActionResult Counts() {
+          using var connection = new SqlConnection("Server=tf-mssql;Database=pacs_oltp");
+          return Ok(new { canonical = true });
+        }
+      }
+    `
+  );
+
+  const report = await runAudit(root);
+  const endpoint = report.backendEndpoints.find(item =>
+    item.filePath.endsWith('CanonicalDebugController.cs')
+  );
+  assert.equal(endpoint.zone, 'allowed_admin_proof');
+  assert.equal(endpoint.dataSourceClass, 'mixed_canonical_and_legacy');
+  assert.deepEqual(endpoint.blockers, []);
+  assert.equal(report.summary.productLegacyViolations, 0);
+});
+
+test('ungated canonical debug controller is blocked as product runtime', async () => {
+  const root = makeTempRepo('tf-boundary-canonical-debug-ungated-');
+  fs.writeFileSync(
+    path.join(
+      root,
+      'backend',
+      'src',
+      'TerraFusion.API',
+      'Controllers',
+      'CanonicalDebugController.cs'
+    ),
+    `
+      [Route("api/debug")]
+      public class CanonicalDebugController : ControllerBase
+      {
+        public IActionResult Counts() {
+          using var connection = new SqlConnection("Server=tf-mssql;Database=pacs_oltp");
+          return Ok(new { canonical = true });
+        }
+      }
+    `
+  );
+
+  const report = await runAudit(root);
+  const endpoint = report.backendEndpoints.find(item =>
+    item.filePath.endsWith('CanonicalDebugController.cs')
+  );
+  assert.equal(endpoint.zone, 'forbidden_product_runtime');
+  assert.equal(endpoint.dataSourceClass, 'mixed_canonical_and_legacy');
+  assert.ok(
+    endpoint.blockers.includes(
+      'Product runtime endpoint has direct legacy source dependency evidence.'
+    )
+  );
+  assert.equal(report.summary.productLegacyViolations, 1);
+});
+
 test('debug-only test controller is not counted as production product runtime', async () => {
   const root = makeTempRepo('tf-boundary-debug-test-controller-');
   fs.writeFileSync(


### PR DESCRIPTION
## Summary
- gate CanonicalDebugController out of non-development controller discovery
- remove the legacy-named CostForge source-status route alias
- update runtime data-boundary audit coverage for development-gated debug controllers

## Verification
- node --test scripts/truth/runtime-data-boundary-audit.test.mjs
- pnpm run truth:runtime-data-boundary-audit
- dotnet build backend/TerraFusion.sln -c Release /warnaserror
- dotnet build backend/TerraFusion.sln -c Release /warnaserror --no-restore
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- pre-push hook passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external-systems sync status endpoint that returns per-county property counts and is access-controlled.

* **Chores**
  * Controller discovery updated to support explicit exclusions; a debug controller is now gated to development-only in non-dev environments.

* **Tests**
  * Expanded runtime audit tests for the debug-controller gating and updated integration test to reflect the new sync endpoint route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->