### PR TITLE
feat(sync): SYNC-DOCTRINE-2 (B2) — promoter consumes doctrine, emits dual qualification surfaces

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/PacsSaleTruthPromoterDualSurfaceTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PacsSaleTruthPromoterDualSurfaceTests.cs
@@ -1,0 +1,346 @@
+// SYNC-DOCTRINE-2 (B2) tests
+//
+// Validates that PacsSaleTruthPromoter:
+//   - removes the hardcoded sl_county_ratio_cd='100' filter
+//   - evaluates BOTH ratio studies (DOR_RATIO + COUNTY_INTERNAL_RATIO)
+//     per sale via IRatioQualificationPolicy
+//   - writes the five new dual-surface fields onto every promoted row
+//   - promotes a sale iff at least one study qualifies it
+//   - preserves the stale-axis ('01'/'02') and FK gates unchanged
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using TerraFusion.Data.Services.TruthPacs;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class PacsSaleTruthPromoterDualSurfaceTests
+{
+    private const string CountySlug = "benton-wa";
+
+    private static (PacsSaleTruthPromoter promoter,
+                    Func<TerraFusionDbContext> dbFactory)
+        Build(params TfDoctrineRatioPolicy[] seedRules)
+    {
+        var dbName = $"PromoterTest_{Guid.NewGuid():N}";
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+                ["Logging:EnableSensitiveDataLogging"] = "false",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(config);
+        services.AddDbContext<TerraFusionDbContext>(o => o.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        // Seed the policy rules.
+        using (var scope = sp.CreateScope())
+        {
+            var seedDb = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            if (seedRules.Length > 0)
+            {
+                seedDb.TfDoctrineRatioPolicies.AddRange(seedRules);
+                seedDb.SaveChanges();
+            }
+        }
+
+        var policy = new RatioQualificationPolicy(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<RatioQualificationPolicy>.Instance);
+
+        // The promoter is Scoped + reads/writes EF — give it a fresh
+        // context per test invocation. Return a factory so the test
+        // can also inspect / seed sales.
+        Func<TerraFusionDbContext> dbFactory = () =>
+            sp.CreateScope().ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        var promoter = new PacsSaleTruthPromoter(
+            dbFactory(),
+            policy,
+            NullLogger<PacsSaleTruthPromoter>.Instance);
+
+        return (promoter, dbFactory);
+    }
+
+    private static TfDoctrineRatioPolicy DorRule() => new()
+    {
+        RuleId = Guid.NewGuid(),
+        County = CountySlug,
+        EffectiveStartYear = 1990,
+        EffectiveEndYear = null,
+        StudyName = "DOR_RATIO",
+        SourceField = "sale.sl_ratio_type_cd",
+        QualifiedCodesCsv = "00",
+        ExcludedCodesCsv = string.Empty,
+        Confidence = "HIGH",
+    };
+
+    private static TfDoctrineRatioPolicy CountyModernRule() => new()
+    {
+        RuleId = Guid.NewGuid(),
+        County = CountySlug,
+        EffectiveStartYear = 2018,
+        EffectiveEndYear = null,
+        StudyName = "COUNTY_INTERNAL_RATIO",
+        SourceField = "sale.sl_county_ratio_cd",
+        QualifiedCodesCsv = "100",
+        ExcludedCodesCsv = "200,300,400,500",
+        Confidence = "HIGH",
+    };
+
+    /// <summary>
+    /// Seed two source batches: a sale batch with N rows + a matching
+    /// supp_assoc batch with one entry per (PropId, PropValYr).
+    /// </summary>
+    private static (Guid saleBatch, Guid suppBatch) SeedSourceBatches(
+        TerraFusionDbContext db,
+        IEnumerable<(int PropId, short PropValYr, short SupNum, string? RatioTypeCd, string? CountyRatioCd, DateTime? SlDt)> sales)
+    {
+        var saleBatchId = Guid.NewGuid();
+        var suppBatchId = Guid.NewGuid();
+
+        db.SyncBridgeLoadBatches.AddRange(
+            new LoadBatch
+            {
+                LoadBatchId = saleBatchId,
+                SourceFamily = SourceFamilies.PacsOltp,
+                SourceSystem = "JCHARRISPACS",
+                SourceFileOrDatabase = "pacs_oltp",
+                SourceQueryHash = "test",
+                Operator = "test",
+                Status = "COMPLETED",
+                StartedAt = DateTime.UtcNow,
+                CompletedAt = DateTime.UtcNow,
+            },
+            new LoadBatch
+            {
+                LoadBatchId = suppBatchId,
+                SourceFamily = SourceFamilies.PacsOltp,
+                SourceSystem = "JCHARRISPACS",
+                SourceFileOrDatabase = "pacs_oltp",
+                SourceQueryHash = "test-supp",
+                Operator = "test",
+                Status = "COMPLETED",
+                StartedAt = DateTime.UtcNow,
+                CompletedAt = DateTime.UtcNow,
+            });
+
+        var coId = 1L;
+        foreach (var s in sales)
+        {
+            db.LegacyPacsRawSales.Add(new LegacyPacsRawSale
+            {
+                LandedRowId = Guid.NewGuid(),
+                ChgOfOwnerId = coId++,
+                PropId = s.PropId,
+                PropValYr = s.PropValYr,
+                SupNum = s.SupNum,
+                SlRatioTypeCd = s.RatioTypeCd,
+                SlCountyRatioCd = s.CountyRatioCd,
+                SlDt = s.SlDt,
+                SlPrice = 100_000m,
+                AdjSlPrice = 100_000m,
+                LoadBatchId = saleBatchId,
+                SourceQueryHash = "test",
+                SourceRowHash = Guid.NewGuid().ToString(),
+                LandedAt = DateTime.UtcNow,
+            });
+
+            // unique supp pointer per (PropId, PropValYr).
+            db.LegacyPacsRawPropSuppAssocs.Add(new LegacyPacsRawPropSuppAssoc
+            {
+                LandedRowId = Guid.NewGuid(),
+                PropId = s.PropId,
+                PropValYr = s.PropValYr,
+                SupNum = s.SupNum,
+                LoadBatchId = suppBatchId,
+                SourceQueryHash = "test-supp",
+                SourceRowHash = Guid.NewGuid().ToString(),
+                LandedAt = DateTime.UtcNow,
+            });
+        }
+        db.SaveChanges();
+        return (saleBatchId, suppBatchId);
+    }
+
+    [Fact]
+    public async Task DorOnlySale_Promoted_DorTrue_CountyFalse()
+    {
+        // sl_ratio_type_cd='00' → DOR qualified
+        // sl_county_ratio_cd=NULL → county not reviewed
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)"00", (string?)null, (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1, result.SalesPromoted);
+
+        using var verifyDb = dbFactory();
+        var truth = await verifyDb.TruthPacsSales.SingleAsync(t => t.SaleLoadBatchId == saleBatch);
+        Assert.True(truth.DorRatioQualified);
+        Assert.False(truth.CountyRatioReviewed);
+        Assert.False(truth.CountyRatioQualified);
+        Assert.Null(truth.CountyRatioCode);
+        Assert.Null(truth.CountyRatioDescription);
+    }
+
+    [Fact]
+    public async Task CountyOnlySale_Promoted_DorFalse_CountyTrue()
+    {
+        // sl_ratio_type_cd=NULL → DOR not qualified
+        // sl_county_ratio_cd='100' (year 2024) → county qualified
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)null, (string?)"100", (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1, result.SalesPromoted);
+
+        using var verifyDb = dbFactory();
+        var truth = await verifyDb.TruthPacsSales.SingleAsync(t => t.SaleLoadBatchId == saleBatch);
+        Assert.False(truth.DorRatioQualified);
+        Assert.True(truth.CountyRatioReviewed);
+        Assert.True(truth.CountyRatioQualified);
+        Assert.Equal("100", truth.CountyRatioCode);
+        Assert.Equal("Valid Sale", truth.CountyRatioDescription);
+    }
+
+    [Fact]
+    public async Task BothStudiesQualified_PromotedWithBothFlags()
+    {
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)"00", (string?)"100", (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal(1, result.SalesPromoted);
+
+        using var verifyDb = dbFactory();
+        var truth = await verifyDb.TruthPacsSales.SingleAsync(t => t.SaleLoadBatchId == saleBatch);
+        Assert.True(truth.DorRatioQualified);
+        Assert.True(truth.CountyRatioReviewed);
+        Assert.True(truth.CountyRatioQualified);
+    }
+
+    [Fact]
+    public async Task NeitherStudyQualified_NotPromoted()
+    {
+        // sl_ratio_type_cd=NULL → not DOR
+        // sl_county_ratio_cd='200' → reviewed but not qualified
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)null, (string?)"200", (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(0, result.SalesPromoted);
+        Assert.Equal(1, result.RejectedNotQualified);
+
+        using var verifyDb = dbFactory();
+        Assert.Empty(verifyDb.TruthPacsSales.Where(t => t.SaleLoadBatchId == saleBatch));
+    }
+
+    [Fact]
+    public async Task PreConversion_DorOnly_Promoted_CountyAlwaysFalse()
+    {
+        // 2015 sale: county study didn't exist as a formal program;
+        // the COUNTY_INTERNAL_RATIO rule only covers 2018+.
+        // So even with sl_county_ratio_cd='100' (rare pre-2018) the
+        // promoter writes county_ratio_qualified=false because no rule
+        // covers the year.
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2015, (short)0, (string?)"00", (string?)"100", (DateTime?)new DateTime(2015, 3, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal(1, result.SalesPromoted);
+
+        using var verifyDb = dbFactory();
+        var truth = await verifyDb.TruthPacsSales.SingleAsync(t => t.SaleLoadBatchId == saleBatch);
+        Assert.True(truth.DorRatioQualified, "DOR rule covers 1990+ → qualified");
+        Assert.False(truth.CountyRatioReviewed,
+            "No COUNTY_INTERNAL_RATIO rule covers 2015 → not reviewed by the active program");
+        Assert.False(truth.CountyRatioQualified);
+        Assert.Equal("100", truth.CountyRatioCode);
+        Assert.Equal("Valid Sale", truth.CountyRatioDescription);
+    }
+
+    [Fact]
+    public async Task StaleAxisCode_RejectedUnchanged_NotPromoted()
+    {
+        // '01' is stale-axis pre-conversion; rejected unconditionally
+        // regardless of dual-surface evaluation.
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)"00", (string?)"01", (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        var result = await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        Assert.Equal(0, result.SalesPromoted);
+        Assert.Equal(1, result.RejectedStaleAxis);
+    }
+
+    [Fact]
+    public async Task CountyCode_DescriptionResolvesFromCodebook()
+    {
+        // Verify several codes hit the codebook correctly.
+        var (promoter, dbFactory) = Build(DorRule(), CountyModernRule());
+        using var db = dbFactory();
+        var (saleBatch, suppBatch) = SeedSourceBatches(db, new[]
+        {
+            ((int)1, (short)2024, (short)0, (string?)"00", (string?)"100", (DateTime?)new DateTime(2024, 6, 1)),
+            ((int)2, (short)2024, (short)0, (string?)"00", (string?)"200", (DateTime?)new DateTime(2024, 6, 1)),
+            ((int)3, (short)2024, (short)0, (string?)"00", (string?)"300", (DateTime?)new DateTime(2024, 6, 1)),
+        });
+
+        await promoter.PromoteAsync(saleBatch, suppBatch, "test");
+
+        using var verifyDb = dbFactory();
+        var rows = await verifyDb.TruthPacsSales
+            .Where(t => t.SaleLoadBatchId == saleBatch)
+            .OrderBy(t => t.PropId)
+            .ToListAsync();
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal("Valid Sale", rows[0].CountyRatioDescription);
+        Assert.Equal("Invalid Sale", rows[1].CountyRatioDescription);
+        Assert.Equal("Land Only Sale", rows[2].CountyRatioDescription);
+    }
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1772,6 +1772,11 @@ builder.Services.AddSingleton<
     TerraFusion.Data.Services.Doctrine.RatioQualificationPolicy>();
 builder.Services.AddScoped<
     TerraFusion.Data.Services.Doctrine.DoctrineRatioPolicySeeder>();
+// SYNC-DOCTRINE-2 (B2): hosted service runs the seeder once at
+// startup so the doctrine table is populated before the first sale
+// truth-promotion call. Idempotent + non-fatal on failure.
+builder.Services.AddHostedService<
+    TerraFusion.Data.Services.Doctrine.DoctrineRatioPolicySeederHostedService>();
 
 // Slice L1: PACS land_detail raw landing — Block C's land lane
 // per-segment table. Four gates: distribution, 4-key-uniqueness,

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfSale.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfSale.cs
@@ -45,11 +45,56 @@ public sealed class TfSale
     public decimal? AdjSlPrice { get; set; }
 
     /// <summary>
-    /// True by construction: only sales that survived the truth-pacs
-    /// '100' filter reach <c>canonical_tf.tf_sale</c>. Surfaced as a
-    /// column for client-side invariant checks.
+    /// SYNC-DOCTRINE-2 (B2): legacy column. Pre-DOCTRINE-2 this was
+    /// "true by construction" because only county-ratio-100 sales
+    /// reached canonical. With dual-surface qualification it's now
+    /// derived from the new fields per a documented policy:
+    /// <c>SaleQualified = DorRatioQualified || CountyRatioQualified</c>
+    /// (a sale is qualified if EITHER study qualifies it). Kept for
+    /// back-compat with existing canonical consumers; new consumers
+    /// should read the two surface fields directly.
     /// </summary>
-    public bool SaleQualified { get; set; } = true;
+    public bool SaleQualified { get; set; }
+
+    // ── SYNC-DOCTRINE-2 (B2): dual-surface qualification ──────────
+    /// <summary>
+    /// Qualified for the Washington DoR ratio study per
+    /// <c>tf_doctrine_ratio_policy[StudyName='DOR_RATIO']</c>.
+    /// Source: <c>sale.sl_ratio_type_cd='00'</c> always-on rule.
+    /// </summary>
+    public bool DorRatioQualified { get; set; }
+
+    /// <summary>
+    /// True if the county has assigned ANY <c>sl_county_ratio_cd</c>
+    /// for this sale (the COUNTY_INTERNAL_RATIO study has reviewed
+    /// the sale). NULL codes = "not yet reviewed". A reviewed sale
+    /// can still be NOT-qualified (codes 200/300/400/500).
+    /// </summary>
+    public bool CountyRatioReviewed { get; set; }
+
+    /// <summary>
+    /// Qualified for the Benton internal ratio study per
+    /// <c>tf_doctrine_ratio_policy[StudyName='COUNTY_INTERNAL_RATIO']</c>.
+    /// Effective 2018+; pre-2018 sales always have this false (the
+    /// study did not exist as a formal program before then; legacy
+    /// codebook semantics live in LEGACY_CODEBOOK_VALID, which the
+    /// promoter does not consult for canonical output).
+    /// </summary>
+    public bool CountyRatioQualified { get; set; }
+
+    /// <summary>
+    /// Raw <c>sl_county_ratio_cd</c> verbatim from PACS. Preserved
+    /// so canonical consumers can apply ad-hoc policies without
+    /// re-querying PACS or the truth layer.
+    /// </summary>
+    public string? CountyRatioCode { get; set; }
+
+    /// <summary>
+    /// Human-readable description from <c>dbo.county_ratio_code</c>
+    /// (snapshot 2026-05-06 in <c>CountyRatioCodebook</c>). e.g.
+    /// "Valid Sale", "Invalid Sale", "Land Only Sale".
+    /// </summary>
+    public string? CountyRatioDescription { get; set; }
 
     /// <summary>The S3 promotion batch that created this row.</summary>
     public Guid PromotionLoadBatchId { get; set; }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsSale.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsSale.cs
@@ -3,14 +3,33 @@ using System;
 namespace TerraFusion.Core.Entities.TruthPacs;
 
 /// <summary>
-/// Slice S2-B: supp-aware-validated, qualification-filtered PACS
-/// sale row. The middle layer of the doctrine —
-/// <c>legacy_pacs_raw.sale</c> JOIN <c>legacy_pacs_raw.prop_supp_assoc</c>
-/// FILTER <c>sl_county_ratio_cd = '100'</c>.
+/// Slice S2-B: supp-aware-validated PACS sale row. The middle
+/// layer of the doctrine —
+/// <c>legacy_pacs_raw.sale</c> JOIN <c>legacy_pacs_raw.prop_supp_assoc</c>.
 ///
-/// <para>Three invariants hold by construction:
+/// <para>SYNC-DOCTRINE-2 (B2): the qualification filter is no longer
+/// a single hardcoded constant. Two parallel ratio studies are
+/// modeled, both written to every truth row:</para>
+/// <list type="bullet">
+///   <item><see cref="DorRatioQualified"/> — qualified for the
+///   Washington DoR ratio study (<c>sale.sl_ratio_type_cd='00'</c>
+///   per <c>tf_doctrine_ratio_policy</c>).</item>
+///   <item><see cref="CountyRatioReviewed"/> /
+///   <see cref="CountyRatioQualified"/> — Benton internal ratio
+///   study (started ~2018; uses <c>sale.sl_county_ratio_cd</c>).</item>
+/// </list>
+/// <para>The raw <see cref="CountyRatioCode"/> and
+/// <see cref="CountyRatioDescription"/> from
+/// <c>dbo.county_ratio_code</c> are preserved verbatim so canonical
+/// consumers can apply ad-hoc policies without re-querying PACS.</para>
+///
+/// <para>Pre-DOCTRINE-2 invariant — that <see cref="SlCountyRatioCd"/>
+/// was always <c>"100"</c> by construction — is REMOVED. Truth rows
+/// now exist for sales that fail one or both qualification surfaces;
+/// canonical projection (S3) decides what to do with them.</para>
+///
+/// <para>Two invariants still hold:
 /// <list type="number">
-///   <item><see cref="SlCountyRatioCd"/> is always <c>"100"</c>.</item>
 ///   <item><see cref="SupNum"/> matches the active supplement pointer
 ///   for <see cref="PropId"/> / <see cref="PropValYr"/> at promotion
 ///   time.</item>
@@ -39,8 +58,55 @@ public sealed class TruthPacsSale
     public short PropValYr { get; set; }
     public short SupNum { get; set; }
 
-    // ── Qualification (always '100' by construction) ─────────────
-    public string SlCountyRatioCd { get; set; } = "100";
+    /// <summary>
+    /// Raw <c>sale.sl_county_ratio_cd</c> verbatim from PACS. NULL
+    /// allowed (most-recent sales sit at NULL until the county
+    /// reviews them). Pre-DOCTRINE-2 this column was always
+    /// <c>"100"</c> by construction; with the policy table in B1 +
+    /// promoter rewire in B2 this is now the unfiltered raw value.
+    /// </summary>
+    public string? SlCountyRatioCd { get; set; }
+
+    // ── SYNC-DOCTRINE-2: dual-surface qualification ───────────────
+    /// <summary>
+    /// True if the sale qualifies for the Washington DoR ratio study
+    /// per <c>tf_doctrine_ratio_policy</c> (<c>StudyName='DOR_RATIO'</c>,
+    /// effective always, qualifier <c>sl_ratio_type_cd='00'</c>).
+    /// </summary>
+    public bool DorRatioQualified { get; set; }
+
+    /// <summary>
+    /// True if the county has assigned ANY <c>sl_county_ratio_cd</c>
+    /// value (i.e. the county study has reviewed this sale). NULL
+    /// codes mean "not yet reviewed". Independent of
+    /// <see cref="CountyRatioQualified"/>: a sale can be reviewed
+    /// and rejected ('200', '300', etc.).
+    /// </summary>
+    public bool CountyRatioReviewed { get; set; }
+
+    /// <summary>
+    /// True if the sale qualifies for the Benton internal ratio
+    /// study per <c>tf_doctrine_ratio_policy</c>
+    /// (<c>StudyName='COUNTY_INTERNAL_RATIO'</c>, effective 2018+,
+    /// qualifier <c>sl_county_ratio_cd='100'</c>; excluded codes
+    /// 200/300/400/500). False for pre-2018 sales by design — the
+    /// county study did not exist as a formal program before then.
+    /// </summary>
+    public bool CountyRatioQualified { get; set; }
+
+    /// <summary>
+    /// Raw county ratio code. Same as <see cref="SlCountyRatioCd"/>
+    /// (denormalized for canonical-consumer convenience).
+    /// </summary>
+    public string? CountyRatioCode { get; set; }
+
+    /// <summary>
+    /// Human-readable description joined from
+    /// <c>dbo.county_ratio_code.ratio_desc</c>. e.g. <c>"Valid Sale"</c>,
+    /// <c>"Invalid Sale"</c>, <c>"Land Only Sale"</c>. NULL when
+    /// the code itself is unknown or NULL.
+    /// </summary>
+    public string? CountyRatioDescription { get; set; }
 
     // ── Sale economics ────────────────────────────────────────────
     public DateTime? SlDt { get; set; }

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/CountyRatioCodebook.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/CountyRatioCodebook.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-2 (B2): static snapshot of Benton County's
+/// <c>dbo.county_ratio_code</c> dictionary. Used by the sale truth
+/// promoter to populate
+/// <see cref="TerraFusion.Core.Entities.TruthPacs.TruthPacsSale.CountyRatioDescription"/>
+/// without re-querying PACS per row.
+///
+/// <para>Snapshot taken 2026-05-06 against tf-mssql / pacs_oltp:</para>
+/// <code>
+/// SELECT ratio_cd, ratio_desc FROM dbo.county_ratio_code ORDER BY ratio_cd
+/// </code>
+///
+/// <para>Per the operator's "no doctrine widening in B2" directive,
+/// this is a code constant rather than a doctrine table. If the PACS
+/// dictionary changes upstream, update this constant and ship a
+/// new build. A future SYNC-DOCTRINE-3 may move this to a governed
+/// doctrine table; not in B2 scope.</para>
+/// </summary>
+public static class CountyRatioCodebook
+{
+    private static readonly IReadOnlyDictionary<string, string> Codes =
+        new Dictionary<string, string>(System.StringComparer.Ordinal)
+        {
+            // Legacy ALL-CAPS codebook (pre-2017 conversion era).
+            ["0"] = "VALID SALE",
+            ["1"] = "FAMILY-SALE BETWEEN RELATIVES",
+            ["3"] = "ADMIN/GRDN/EXECUTOR OF ESTATE",
+            ["6"] = "TAX DEED",
+            ["9"] = "QUIT CLAIM DEED",
+            ["10"] = "GIFT DEED, LOVE & AFFECTION",
+            ["11"] = "PACD OR SACD TRANSFER OF INT",
+            ["12"] = "CORRECTION DEED",
+            ["14"] = "DEEDS INVOLVING PARTIAL INT",
+            ["15"] = "FORCED SALE",
+            ["16"] = "EASEMENTS OR RIGHT OF WAYS",
+            ["18"] = "PROP PHYSICALLY IMP AFTER SALE",
+            ["23"] = "LEASE-ASSIGNMENT,OPTION,LSHLD",
+            ["24"] = "DESIGNATED O/S(AS OF SALE DT)",
+            ["27"] = "OTHER",
+            ["28"] = "MULTI-PARCELS",
+            ["30"] = "NOT VERIFIED",
+
+            // Modern mixed-case codebook (post-2017 conversion era).
+            ["100"] = "Valid Sale",
+            ["200"] = "Invalid Sale",
+            ["300"] = "Land Only Sale",
+            ["400"] = "Omitted Current Year; Review",
+            ["500"] = "Dark Sales (Commercial)",
+        };
+
+    /// <summary>
+    /// Look up the human-readable description for a county ratio
+    /// code. Returns NULL if the code is null/empty/unknown — the
+    /// promoter writes that NULL through to truth_pacs.sale verbatim.
+    /// </summary>
+    public static string? Describe(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code)) return null;
+        return Codes.TryGetValue(code.Trim(), out var desc) ? desc : null;
+    }
+
+    /// <summary>Total codes in this snapshot (22 as of 2026-05-06).</summary>
+    public static int Count => Codes.Count;
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfSaleConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfSaleConfiguration.cs
@@ -50,5 +50,20 @@ public sealed class TfSaleConfiguration : IEntityTypeConfiguration<TfSale>
         builder.Property(x => x.ConversionEra).HasMaxLength(20);
         builder.HasIndex(x => x.ConversionEra)
             .HasDatabaseName("ix_tf_sale_conversion_era");
+
+        // SYNC-DOCTRINE-2 (B2): dual-surface qualification fields.
+        // SaleQualified is a derived back-compat column (DOR OR County).
+        builder.Property(x => x.SaleQualified).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.DorRatioQualified).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioReviewed).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioQualified).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioCode).HasMaxLength(8);
+        builder.Property(x => x.CountyRatioDescription).HasMaxLength(64);
+
+        // Qualification-aware reads.
+        builder.HasIndex(x => x.DorRatioQualified)
+            .HasDatabaseName("ix_tf_sale_dor_qualified");
+        builder.HasIndex(x => new { x.CountyRatioReviewed, x.CountyRatioQualified })
+            .HasDatabaseName("ix_tf_sale_county_review_qual");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsSaleConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsSaleConfiguration.cs
@@ -22,7 +22,18 @@ public sealed class TruthPacsSaleConfiguration : IEntityTypeConfiguration<TruthP
         builder.Property(x => x.PropValYr).IsRequired();
         builder.Property(x => x.SupNum).IsRequired();
 
-        builder.Property(x => x.SlCountyRatioCd).HasMaxLength(8).IsRequired();
+        // SYNC-DOCTRINE-2 (B2): SlCountyRatioCd is now the verbatim
+        // raw value from PACS (NULL allowed). Pre-DOCTRINE-2 it was
+        // always '100' by construction; the qualification filter has
+        // moved to tf_doctrine_ratio_policy + the dual-surface fields.
+        builder.Property(x => x.SlCountyRatioCd).HasMaxLength(8);
+
+        // SYNC-DOCTRINE-2 (B2): dual-surface qualification fields.
+        builder.Property(x => x.DorRatioQualified).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioReviewed).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioQualified).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CountyRatioCode).HasMaxLength(8);
+        builder.Property(x => x.CountyRatioDescription).HasMaxLength(64);
 
         builder.Property(x => x.SlPrice).HasPrecision(18, 2);
         builder.Property(x => x.AdjSlPrice).HasPrecision(18, 2);
@@ -58,5 +69,13 @@ public sealed class TruthPacsSaleConfiguration : IEntityTypeConfiguration<TruthP
         builder.Property(x => x.ConversionEra).HasMaxLength(20);
         builder.HasIndex(x => x.ConversionEra)
             .HasDatabaseName("ix_truth_pacs_sale_conversion_era");
+
+        // SYNC-DOCTRINE-2 (B2): qualification-aware reads.
+        // "show me all DOR-qualified sales" / "show me sales reviewed
+        // but not qualified by the county study" should be index-fast.
+        builder.HasIndex(x => x.DorRatioQualified)
+            .HasDatabaseName("ix_truth_pacs_sale_dor_qualified");
+        builder.HasIndex(x => new { x.CountyRatioReviewed, x.CountyRatioQualified })
+            .HasDatabaseName("ix_truth_pacs_sale_county_review_qual");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260506042453_SyncDoctrine2DualSurfaceSale.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506042453_SyncDoctrine2DualSurfaceSale.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506042453_SyncDoctrine2DualSurfaceSale")]
+    partial class SyncDoctrine2DualSurfaceSale
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260506042453_SyncDoctrine2DualSurfaceSale.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506042453_SyncDoctrine2DualSurfaceSale.cs
@@ -1,0 +1,236 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncDoctrine2DualSurfaceSale : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "SaleQualified",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountyRatioCode",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountyRatioDescription",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CountyRatioQualified",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CountyRatioReviewed",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DorRatioQualified",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SlCountyRatioCd",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountyRatioCode",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountyRatioDescription",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CountyRatioQualified",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CountyRatioReviewed",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DorRatioQualified",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_sale_county_review_qual",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                columns: new[] { "CountyRatioReviewed", "CountyRatioQualified" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_sale_dor_qualified",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                column: "DorRatioQualified");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_sale_county_review_qual",
+                schema: "truth_pacs",
+                table: "sale",
+                columns: new[] { "CountyRatioReviewed", "CountyRatioQualified" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_sale_dor_qualified",
+                schema: "truth_pacs",
+                table: "sale",
+                column: "DorRatioQualified");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_tf_sale_county_review_qual",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_sale_dor_qualified",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_sale_county_review_qual",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_sale_dor_qualified",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioCode",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioDescription",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioQualified",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioReviewed",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "DorRatioQualified",
+                schema: "canonical_tf",
+                table: "tf_sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioCode",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioDescription",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioQualified",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "CountyRatioReviewed",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.DropColumn(
+                name: "DorRatioQualified",
+                schema: "truth_pacs",
+                table: "sale");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "SaleQualified",
+                schema: "canonical_tf",
+                table: "tf_sale",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SlCountyRatioCd",
+                schema: "truth_pacs",
+                table: "sale",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8,
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsSaleCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsSaleCanonicalProjector.cs
@@ -191,7 +191,19 @@ public sealed class PacsSaleCanonicalProjector : IPacsSaleCanonicalProjector
                     SlDt = truth.SlDt,
                     SlPrice = truth.SlPrice,
                     AdjSlPrice = truth.AdjSlPrice,
-                    SaleQualified = true,
+                    // SYNC-DOCTRINE-2 (B2): forward the dual-surface
+                    // qualification fields verbatim from truth.
+                    DorRatioQualified = truth.DorRatioQualified,
+                    CountyRatioReviewed = truth.CountyRatioReviewed,
+                    CountyRatioQualified = truth.CountyRatioQualified,
+                    CountyRatioCode = truth.CountyRatioCode,
+                    CountyRatioDescription = truth.CountyRatioDescription,
+                    // Legacy single-bool: derived as
+                    // DorRatioQualified || CountyRatioQualified.
+                    // Existing canonical consumers can keep reading
+                    // SaleQualified; new consumers should read the
+                    // two surface booleans directly.
+                    SaleQualified = truth.DorRatioQualified || truth.CountyRatioQualified,
                     PromotionLoadBatchId = batch.LoadBatchId,
                     // G2 (v1.11): era resolved via majority-of-truth.
                     // Single contributor → verbatim copy.

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineRatioPolicySeederHostedService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineRatioPolicySeederHostedService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-2 (B2): hosted service that runs the ratio-policy
+/// seeder once at backend startup so the doctrine table is populated
+/// before the first sale truth-promotion call.
+///
+/// <para>Idempotent — DoctrineRatioPolicySeeder skips rules whose
+/// deterministic RuleIds already exist. The hosted service is safe
+/// to leave registered in all environments; in tests with in-memory
+/// providers it just inserts the seed and proceeds.</para>
+///
+/// <para>Failure is non-fatal: if seeding throws (e.g. migration
+/// not applied yet), the host logs a warning and proceeds. The
+/// promoter will still operate; it'll just see no rules and treat
+/// every sale as "not reviewed / not qualified" (the safe default).
+/// Operators can re-seed manually via
+/// <c>POST /api/sync/doctrine/policy/ratio/seed</c>.</para>
+/// </summary>
+public sealed class DoctrineRatioPolicySeederHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<DoctrineRatioPolicySeederHostedService> _logger;
+
+    public DoctrineRatioPolicySeederHostedService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<DoctrineRatioPolicySeederHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var seeder = scope.ServiceProvider
+                .GetRequiredService<DoctrineRatioPolicySeeder>();
+            var inserted = await seeder.SeedAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "DoctrineRatioPolicySeederHostedService: startup seed ran; {Inserted} new rule(s) inserted",
+                inserted);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: doctrine table may not exist yet (migration
+            // pending). The promoter will treat sales as not-reviewed
+            // until the seeder runs successfully.
+            _logger.LogWarning(ex,
+                "DoctrineRatioPolicySeederHostedService: startup seed failed; " +
+                "operator may need to run POST /api/sync/doctrine/policy/ratio/seed manually");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsSaleTruthPromoter.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.SyncBridge;
 using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
 using TerraFusion.Core.Sync.PacsSaleTruth;
 
 namespace TerraFusion.Data.Services.TruthPacs;
@@ -33,18 +34,29 @@ namespace TerraFusion.Data.Services.TruthPacs;
 /// </summary>
 public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
 {
-    private const string ValidSaleCode = "100";
+    // SYNC-DOCTRINE-2 (B2): the hardcoded ValidSaleCode = "100" filter
+    // is REMOVED. Qualification is now per-sale evaluation against
+    // tf_doctrine_ratio_policy via IRatioQualificationPolicy. A sale
+    // is promoted to truth_pacs.sale if it qualifies for AT LEAST ONE
+    // of the two ratio studies (DOR_RATIO or COUNTY_INTERNAL_RATIO).
     private static readonly HashSet<string> StaleValidSaleCodes =
         new(StringComparer.OrdinalIgnoreCase) { "01", "02" };
 
+    // SYNC-DOCTRINE-2 (B2): single-county Benton hardcode. Multi-county
+    // future will inject this via an IOperatorContext or similar.
+    private const string CountySlug = "benton-wa";
+
     private readonly TerraFusionDbContext _db;
+    private readonly IRatioQualificationPolicy _policy;
     private readonly ILogger<PacsSaleTruthPromoter> _logger;
 
     public PacsSaleTruthPromoter(
         TerraFusionDbContext db,
+        IRatioQualificationPolicy policy,
         ILogger<PacsSaleTruthPromoter> logger)
     {
         _db = db;
+        _policy = policy;
         _logger = logger;
     }
 
@@ -151,13 +163,18 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
             var rejectedStaleAxis = 0;
             // G4 (v1.13): pre-conversion-share gate counter.
             var preConversionPromoted = 0;
+            // SYNC-DOCTRINE-2 (B2): dual-surface telemetry counters.
+            var promotedDorOnly = 0;
+            var promotedCountyOnly = 0;
+            var promotedBothStudies = 0;
 
             var now = DateTime.UtcNow;
             foreach (var sale in sales)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // Defense-in-depth stale-axis rejection.
+                // Defense-in-depth stale-axis rejection (pre-conversion
+                // legacy '01'/'02' codes are unconditionally dropped).
                 if (sale.SlCountyRatioCd is not null
                     && StaleValidSaleCodes.Contains(sale.SlCountyRatioCd))
                 {
@@ -165,12 +182,8 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     continue;
                 }
 
-                if (!string.Equals(sale.SlCountyRatioCd, ValidSaleCode, StringComparison.Ordinal))
-                {
-                    rejectedNotQualified++;
-                    continue;
-                }
-
+                // FK gates (sup-aware-validated identity) MUST hold
+                // regardless of qualification.
                 if (!suppIndex.TryGetValue((sale.PropId, sale.PropValYr), out var suppPtr))
                 {
                     rejectedNoSuppPointer++;
@@ -183,6 +196,38 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     continue;
                 }
 
+                // SYNC-DOCTRINE-2 (B2): dual-surface qualification
+                // evaluation. Replaces the hardcoded sl_county_ratio_cd='100'
+                // filter. The promoter evaluates BOTH studies and writes
+                // both booleans to truth_pacs.sale; promotion happens iff
+                // at least one study qualifies the sale.
+                var saleYear = sale.SlDt?.Year
+                    ?? (sale.PropValYr > 0 ? (int)sale.PropValYr : 0);
+
+                var dorEval = await _policy.EvaluateAsync(
+                    CountySlug,
+                    "DOR_RATIO",
+                    saleYear,
+                    sale.SlRatioTypeCd,
+                    cancellationToken).ConfigureAwait(false);
+
+                var countyEval = await _policy.EvaluateAsync(
+                    CountySlug,
+                    "COUNTY_INTERNAL_RATIO",
+                    saleYear,
+                    sale.SlCountyRatioCd,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (!dorEval.Qualified && !countyEval.Qualified)
+                {
+                    rejectedNotQualified++;
+                    continue;
+                }
+
+                if (dorEval.Qualified && countyEval.Qualified) promotedBothStudies++;
+                else if (dorEval.Qualified) promotedDorOnly++;
+                else promotedCountyOnly++;
+
                 // G1 (v1.10): conversion-era marker derived from PropValYr.
                 var era = ConversionEras.FromYear(sale.PropValYr);
                 if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
@@ -193,7 +238,15 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                     PropId = sale.PropId,
                     PropValYr = sale.PropValYr,
                     SupNum = sale.SupNum,
-                    SlCountyRatioCd = ValidSaleCode,
+                    // Verbatim: pre-DOCTRINE-2 this was forced to '100';
+                    // now it's the raw value (may be NULL or any code).
+                    SlCountyRatioCd = sale.SlCountyRatioCd,
+                    DorRatioQualified = dorEval.Qualified,
+                    CountyRatioReviewed = countyEval.Reviewed,
+                    CountyRatioQualified = countyEval.Qualified,
+                    CountyRatioCode = sale.SlCountyRatioCd,
+                    CountyRatioDescription =
+                        CountyRatioCodebook.Describe(sale.SlCountyRatioCd),
                     SlDt = sale.SlDt,
                     SlPrice = sale.SlPrice,
                     AdjSlPrice = sale.AdjSlPrice,
@@ -208,6 +261,11 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
                 promoted++;
             }
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // SYNC-DOCTRINE-2 (B2): dual-surface summary gate.
+            await RecordDualSurfaceGateAsync(
+                batch, promoted, promotedDorOnly, promotedCountyOnly,
+                promotedBothStudies, cancellationToken).ConfigureAwait(false);
 
             // G4 (v1.13): pre-conversion-share gate.
             ConversionEraGate.AddShareGate(
@@ -284,6 +342,35 @@ public sealed class PacsSaleTruthPromoter : IPacsSaleTruthPromoter
             Expected = "both COMPLETED",
             Actual = status,
             Detail = detail,
+            ExecutedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-2 (B2): informational gate recording how many
+    /// promoted truth rows qualified for DOR only, county only, or
+    /// both studies. Always PASS (data observation, not pass/fail).
+    /// </summary>
+    private async Task RecordDualSurfaceGateAsync(
+        LoadBatch batch,
+        int promoted,
+        int dorOnly,
+        int countyOnly,
+        int bothStudies,
+        CancellationToken cancellationToken)
+    {
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "truth-pacs-dual-surface-summary",
+            GateStage = "RAW_TO_TRUTH",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = promoted.ToString(CultureInfo.InvariantCulture),
+            Detail =
+                $"promoted={promoted} dorOnly={dorOnly} " +
+                $"countyOnly={countyOnly} bothStudies={bothStudies}",
             ExecutedAt = DateTime.UtcNow,
         });
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsSaleCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsSaleCanonicalProjectorTests.cs
@@ -100,6 +100,18 @@ public sealed class PacsSaleCanonicalProjectorTests : IDisposable
             PropValYr = year,
             SupNum = sup,
             SlCountyRatioCd = "100",
+            // SYNC-DOCTRINE-2 (B2): the truth row carries the dual-surface
+            // qualification booleans the promoter computed. Happy-path
+            // helper marks the sale as county-qualified per the post-B2
+            // doctrine (sl_county_ratio_cd='100' on a 2018+ year matches
+            // the COUNTY_INTERNAL_RATIO rule). The canonical projector
+            // forwards these verbatim and derives SaleQualified =
+            // DorRatioQualified || CountyRatioQualified.
+            DorRatioQualified = false,
+            CountyRatioReviewed = true,
+            CountyRatioQualified = true,
+            CountyRatioCode = "100",
+            CountyRatioDescription = "Valid Sale",
             SlDt = saleDt ?? new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
             SlPrice = price,
             AdjSlPrice = price,

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsSaleTruthPromoterTests.cs
@@ -5,12 +5,45 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
 using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
 using TerraFusion.Core.Sync.PacsSaleTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
 using Xunit;
 
 namespace TerraFusion.Unit.Tests.TruthPacs;
+
+/// <summary>
+/// SYNC-DOCTRINE-2 (B2): test-double IRatioQualificationPolicy that
+/// mirrors the pre-B2 single-code filter behavior so the legacy
+/// PacsSaleTruthPromoter tests continue to assert their original
+/// invariants without rewriting them. Returns Qualified=true on
+/// COUNTY_INTERNAL_RATIO code='100' across all years; false
+/// otherwise. DOR_RATIO always returns false here — these tests
+/// cover the county-side filter only.
+/// </summary>
+internal sealed class CountyOnly100QualifierPolicy : IRatioQualificationPolicy
+{
+    public Task<RatioPolicyEvaluation> EvaluateAsync(
+        string county, string studyName, int saleYear, string? code,
+        CancellationToken cancellationToken = default)
+    {
+        if (studyName == "COUNTY_INTERNAL_RATIO")
+        {
+            var qualified = string.Equals(code, "100", StringComparison.Ordinal);
+            return Task.FromResult(new RatioPolicyEvaluation(
+                Reviewed: !string.IsNullOrEmpty(code),
+                Qualified: qualified,
+                Code: code,
+                StudyName: studyName,
+                RuleId: Guid.Empty,
+                EvidenceSource: "test-double"));
+        }
+        return Task.FromResult(new RatioPolicyEvaluation(
+            Reviewed: false, Qualified: false, Code: code,
+            StudyName: studyName, RuleId: null, EvidenceSource: null));
+    }
+}
 
 /// <summary>
 /// Slice S2-B acceptance tests. Proves the five T-* gates and the
@@ -48,7 +81,8 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
     public void Dispose() => _db.Dispose();
 
     private PacsSaleTruthPromoter BuildPromoter()
-        => new(_db, NullLogger<PacsSaleTruthPromoter>.Instance);
+        => new(_db, new CountyOnly100QualifierPolicy(),
+               NullLogger<PacsSaleTruthPromoter>.Instance);
 
     /// <summary>Helper: seed a COMPLETED LoadBatch and return its id.</summary>
     private async Task<Guid> SeedCompletedBatchAsync(string label)
@@ -301,6 +335,8 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
             "truth-pacs-promotion-coverage",
             // G4 (v1.13): pre-conversion-share gate.
             "truth-pacs-sale-pre-conversion-share",
+            // SYNC-DOCTRINE-2 (B2): dual-surface telemetry gate.
+            "truth-pacs-dual-surface-summary",
         });
         gates.Where(g => g.GateName == "truth-pacs-source-batch-completed")
             .Single().Status.Should().Be("PASS");
@@ -349,9 +385,9 @@ public sealed class PacsSaleTruthPromoterTests : IDisposable
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.PromotionLoadBatchId)
             .ToListAsync();
-        // G4 (v1.13): the new pre-conversion-share gate brings the
-        // sale lane's gate count to 6.
-        gates.Should().HaveCount(6);
+        // G4 (v1.13): pre-conversion-share gate → 6.
+        // SYNC-DOCTRINE-2 (B2): dual-surface summary gate → 7.
+        gates.Should().HaveCount(7);
         gates.Where(g => g.GateName == "truth-pacs-stale-axis-rejected")
             .Single().Status.Should().Be("PASS");
     }


### PR DESCRIPTION
## Summary

- Rewires `PacsSaleTruthPromoter` to consume `IRatioQualificationPolicy` (shipped on main in #787) instead of the hardcoded `ValidSaleCode = \"100\"` constant.
- Adds five dual-surface qualification fields to `truth_pacs.sale` and `canonical_tf.tf_sale`: `DorRatioQualified`, `CountyRatioReviewed`, `CountyRatioQualified`, `CountyRatioCode`, `CountyRatioDescription`. **No single `ValidSale` boolean** — the two studies stay independent per operator directive.
- 7/7 dual-surface promoter tests + 11/11 B1 doctrine tests pass.

## What ships

- `truth_pacs.sale` + `canonical_tf.tf_sale` get 5 new columns (additive, non-breaking; old `SaleQualified` becomes `DOR ∨ County` for back-compat)
- `PacsSaleTruthPromoter` evaluates BOTH studies per sale; promotes iff at least one qualifies; writes both booleans to truth row
- New informational gate `truth-pacs-dual-surface-summary` reports `dorOnly` / `countyOnly` / `bothStudies` counters per batch
- `CountyRatioCodebook` — 22-code static snapshot of `dbo.county_ratio_code` (no new doctrine table, per \"no doctrine widening in B2\")
- `DoctrineRatioPolicySeederHostedService` — runs the seeder once at backend startup so the doctrine table is populated before the first drain
- EF migration `SyncDoctrine2DualSurfaceSale` adds the columns + 4 indexes (DOR-qualified scan, County-review-qual scan on each table)

## What does NOT ship

- No backfill of historical rows (next drain re-promotes via UPSERT and populates the new columns)
- No new doctrine tables (`tf_doctrine_improvement` / `tf_doctrine_property_universe` are separate slices)
- No promoter changes for non-sale lanes
- No multi-county lane support (still hardcoded to `\"benton-wa\"`; multi-county future will inject via an operator context)

## Operator-required contract held

> No single Benton ValidSale boolean is allowed. The two studies stay on separate columns. B2 is promoter-and-schema scope only — no doctrine widening, no collapse.

- ✅ Two booleans (`DorRatioQualified`, `CountyRatioQualified`) plus the reviewed signal (`CountyRatioReviewed`) — never collapsed.
- ✅ Promoter does NOT consult `LEGACY_CODEBOOK_VALID`; that rule stays in the doctrine table for audit/historical reference only.
- ✅ No new doctrine tables. Codebook is a static C# constant.
- ✅ Schema additions only; no destructive change.

## Test plan

- [x] `dotnet build TerraFusion.sln -c Debug` — 0 errors / 0 warnings (excluding 30 pre-existing test-project warnings)
- [x] `dotnet test --filter PacsSaleTruthPromoterDualSurfaceTests` — 7/7 PASS
- [x] `dotnet test --filter RatioQualificationPolicyTests` — 11/11 PASS (no B1 regression)
- [ ] CI green on Backend Gate, Frontend Gate, UI Token Contract Gen2
- [ ] After migration applies on dev DB: operator runs sales lane drain at TopN=200 → expects truth rows now have `DorRatioQualified=true` for ~95%+ of recent sales (DESC seed gets unqualified-by-county recent sales which were 0/200 before — now they should be DOR-qualified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sales qualification now evaluates two policy-driven ratio surfaces and promotes sales when at least one qualifies.
  * County ratio codes resolve to human-readable descriptions from an in-memory codebook.

* **Database Updates**
  * Added fields and indexes to track dual-surface qualification flags, ratio code, and description metadata.

* **Infrastructure**
  * Ratio policies are seeded automatically at application startup.

* **Tests**
  * New and updated tests cover single-, dual-, and non-qualification scenarios, pre-conversion and stale-axis handling, and gate/telemetry changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->