### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL — six-universe improvement classifier + per-universe attribute dictionary

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/DoctrinePropertyUniverseSeederTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/DoctrinePropertyUniverseSeederTests.cs
@@ -1,0 +1,106 @@
+// SYNC-DOCTRINE-4 — seeder contract tests.
+//
+// Validates that the universe seeder is idempotent and produces the
+// six locked seed rules with the locked precedence values.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class DoctrinePropertyUniverseSeederTests
+{
+    private static IServiceProvider BuildSp()
+    {
+        var dbName = $"PuSeederTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task First_run_inserts_six_rules_with_locked_precedence()
+    {
+        var sp = BuildSp();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var seeder = new DoctrinePropertyUniverseSeeder(
+            db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+
+        var added = await seeder.SeedAsync();
+
+        Assert.Equal(6, added);
+        var rules = await db.TfDoctrinePropertyUniverses.OrderBy(r => r.Precedence).ToListAsync();
+        Assert.Equal(6, rules.Count);
+
+        // Locked precedence per design doc §"Locked precedence".
+        Assert.Equal((1, UniverseCodes.ConversionLegacy), (rules[0].Precedence, rules[0].UniverseCode));
+        Assert.Equal((2, UniverseCodes.AgCurrentUse), (rules[1].Precedence, rules[1].UniverseCode));
+        Assert.Equal((3, UniverseCodes.PersonalProperty), (rules[2].Precedence, rules[2].UniverseCode));
+        Assert.Equal((4, UniverseCodes.MobileHome), (rules[3].Precedence, rules[3].UniverseCode));
+        Assert.Equal((5, UniverseCodes.RealCommercial), (rules[4].Precedence, rules[4].UniverseCode));
+        Assert.Equal((6, UniverseCodes.RealResidential), (rules[5].Precedence, rules[5].UniverseCode));
+    }
+
+    [Fact]
+    public async Task Second_run_is_idempotent()
+    {
+        var sp = BuildSp();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var seeder = new DoctrinePropertyUniverseSeeder(
+            db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+
+        await seeder.SeedAsync();
+        var added2 = await seeder.SeedAsync();
+
+        Assert.Equal(0, added2);
+        Assert.Equal(6, await db.TfDoctrinePropertyUniverses.CountAsync());
+    }
+
+    [Fact]
+    public async Task Every_seeded_rule_carries_evidence_source_and_approval()
+    {
+        var sp = BuildSp();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var seeder = new DoctrinePropertyUniverseSeeder(
+            db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+        await seeder.SeedAsync();
+
+        var rules = await db.TfDoctrinePropertyUniverses.ToListAsync();
+        Assert.All(rules, r =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(r.EvidenceSource));
+            Assert.False(string.IsNullOrWhiteSpace(r.Reason));
+            Assert.False(string.IsNullOrWhiteSpace(r.ApprovedBy));
+            Assert.NotNull(r.ApprovedAt);
+        });
+    }
+
+    [Fact]
+    public async Task UNKNOWN_is_never_seeded_as_a_rule()
+    {
+        var sp = BuildSp();
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var seeder = new DoctrinePropertyUniverseSeeder(
+            db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+        await seeder.SeedAsync();
+
+        var rules = await db.TfDoctrinePropertyUniverses.ToListAsync();
+        Assert.DoesNotContain(rules, r => r.UniverseCode == UniverseCodes.Unknown);
+    }
+}

--- a/backend/TerraFusion.API.Tests/Doctrine/PerUniverseAttributeDictionaryTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PerUniverseAttributeDictionaryTests.cs
@@ -1,0 +1,240 @@
+// SYNC-DOCTRINE-4 — Test Plans B + C: dictionary evaluation +
+// false-global-quarantine regression.
+//
+// Validates that per-universe dictionary lookups are scoped strictly
+// to the row's universe — a code present in REAL_RESIDENTIAL must not
+// be visible to a REAL_COMMERCIAL lookup, and vice versa. Regression
+// against the pre-SYNC-DOCTRINE-4 single-global-bucket contamination.
+// See docs/sync/sync-doctrine-4-improvement-universe-design.md
+// §"Test plan B" + §"Test plan C".
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class PerUniverseAttributeDictionaryTests
+{
+    private const string County = "benton-wa";
+
+    private static (PerUniverseAttributeDictionary svc, IServiceProvider sp)
+        Build(params TfDoctrineAttributeDictionary[] entries)
+    {
+        var dbName = $"PuDictTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        if (entries.Length > 0)
+        {
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.TfDoctrineAttributeDictionaries.AddRange(entries);
+            db.SaveChanges();
+        }
+
+        var svc = new PerUniverseAttributeDictionary(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PerUniverseAttributeDictionary>.Instance);
+        return (svc, sp);
+    }
+
+    private static TfDoctrineAttributeDictionary Entry(
+        string universe, string attrId, string val,
+        string ctyName = "benton-wa", int startYear = 1990) =>
+        new()
+        {
+            County = ctyName,
+            UniverseCode = universe,
+            EffectiveStartYear = startYear,
+            ImprvAttrId = attrId,
+            IAttrValCd = val,
+            ActiveFlag = true,
+            Reason = "test",
+            EvidenceSource = "test",
+        };
+
+    // ── Test Plan B: dictionary evaluation ─────────────────────────
+
+    [Fact]
+    public async Task Code_known_in_REAL_RESIDENTIAL_is_not_unknown_in_that_universe()
+    {
+        var (svc, _) = Build(Entry(UniverseCodes.RealResidential, "100", "GR1"));
+        var result = await svc.LookupAsync(County, UniverseCodes.RealResidential, 2026, "100", "GR1");
+        Assert.Equal(DictionaryLookupOutcome.Known, result.Outcome);
+        Assert.NotNull(result.MatchedRowId);
+        Assert.Null(result.QuarantineReason);
+    }
+
+    [Fact]
+    public async Task Same_code_missing_in_REAL_COMMERCIAL_is_quarantined_only_for_that_universe()
+    {
+        var (svc, _) = Build(
+            Entry(UniverseCodes.RealResidential, "100", "GR1"),
+            // Distinct entry on commercial so its dictionary is non-empty.
+            Entry(UniverseCodes.RealCommercial, "200", "C1"));
+
+        // Code "100/GR1" exists for residential. Lookup against commercial
+        // must NOT find it.
+        var commercial = await svc.LookupAsync(
+            County, UniverseCodes.RealCommercial, 2026, "100", "GR1");
+        Assert.Equal(DictionaryLookupOutcome.UnknownForUniverse, commercial.Outcome);
+        Assert.Equal(UniverseQuarantineReasons.UnknownForUniverseDictionary,
+            commercial.QuarantineReason);
+
+        // Same code IS known under residential — confirms isolation.
+        var residential = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2026, "100", "GR1");
+        Assert.Equal(DictionaryLookupOutcome.Known, residential.Outcome);
+    }
+
+    [Fact]
+    public async Task Code_known_in_MOBILE_HOME_does_not_require_presence_in_REAL_RESIDENTIAL()
+    {
+        var (svc, _) = Build(
+            Entry(UniverseCodes.MobileHome, "300", "MH1"),
+            Entry(UniverseCodes.RealResidential, "999", "X"));
+        var mh = await svc.LookupAsync(County, UniverseCodes.MobileHome, 2026, "300", "MH1");
+        Assert.Equal(DictionaryLookupOutcome.Known, mh.Outcome);
+    }
+
+    [Fact]
+    public async Task Code_known_in_AG_CURRENT_USE_does_not_require_presence_in_PERSONAL_PROPERTY()
+    {
+        var (svc, _) = Build(
+            Entry(UniverseCodes.AgCurrentUse, "400", "AG1"),
+            // PP dictionary is non-empty but with a different code.
+            Entry(UniverseCodes.PersonalProperty, "500", "PP1"));
+        var ag = await svc.LookupAsync(County, UniverseCodes.AgCurrentUse, 2026, "400", "AG1");
+        Assert.Equal(DictionaryLookupOutcome.Known, ag.Outcome);
+    }
+
+    [Fact]
+    public async Task Dictionary_not_loaded_for_universe_yields_DictionaryNotLoadedForUniverse_not_unknown_code()
+    {
+        // Seed only RESIDENTIAL — COMMERCIAL stays empty.
+        var (svc, _) = Build(Entry(UniverseCodes.RealResidential, "100", "GR1"));
+        var result = await svc.LookupAsync(
+            County, UniverseCodes.RealCommercial, 2026, "anything", "anything");
+        Assert.Equal(DictionaryLookupOutcome.DictionaryNotLoaded, result.Outcome);
+        Assert.Equal(UniverseQuarantineReasons.DictionaryNotLoadedForUniverse,
+            result.QuarantineReason);
+    }
+
+    // ── Test Plan C: false-global-quarantine regression ────────────
+
+    [Fact]
+    public async Task One_universe_missing_code_does_not_poison_other_universes()
+    {
+        // Code "200/C1" is known in COMMERCIAL only. A residential
+        // row whose attribute is "100/GR1" must still resolve known
+        // — proving the universes don't share a global namespace.
+        var (svc, _) = Build(
+            Entry(UniverseCodes.RealResidential, "100", "GR1"),
+            Entry(UniverseCodes.RealCommercial, "200", "C1"));
+
+        var residential = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2026, "100", "GR1");
+        Assert.Equal(DictionaryLookupOutcome.Known, residential.Outcome);
+
+        // The commercial code IS unknown against residential dictionary;
+        // that's per-universe quarantine, not "global".
+        var residentialAgainstCommercialCode = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2026, "200", "C1");
+        Assert.Equal(DictionaryLookupOutcome.UnknownForUniverse,
+            residentialAgainstCommercialCode.Outcome);
+    }
+
+    [Fact]
+    public async Task Previously_reported_unknown_code_resolves_when_universe_dictionary_contains_it()
+    {
+        // Pre-SYNC-DOCTRINE-4 behavior: a code missing from a single
+        // global dictionary always quarantined. Post-SYNC-DOCTRINE-4:
+        // if the code is in THE row's universe dictionary, it
+        // resolves regardless of any other universe's contents.
+        var (svc, _) = Build(Entry(UniverseCodes.MobileHome, "MH-grade", "Q3"));
+
+        var result = await svc.LookupAsync(
+            County, UniverseCodes.MobileHome, 2026, "MH-grade", "Q3");
+        Assert.Equal(DictionaryLookupOutcome.Known, result.Outcome);
+    }
+
+    // ── Sentinel + edge cases ──────────────────────────────────────
+
+    [Fact]
+    public async Task UNKNOWN_universe_yields_UniverseNotEvaluated()
+    {
+        var (svc, _) = Build();
+        var result = await svc.LookupAsync(County, UniverseCodes.Unknown, 2026, "x", "y");
+        Assert.Equal(DictionaryLookupOutcome.UniverseNotEvaluated, result.Outcome);
+        Assert.Equal(UniverseQuarantineReasons.UniverseNotEvaluated, result.QuarantineReason);
+    }
+
+    [Fact]
+    public async Task Empty_universe_is_treated_as_NotEvaluated()
+    {
+        var (svc, _) = Build();
+        var result = await svc.LookupAsync(County, "", 2026, "x", "y");
+        Assert.Equal(DictionaryLookupOutcome.UniverseNotEvaluated, result.Outcome);
+    }
+
+    [Fact]
+    public async Task Year_window_filtering_excludes_out_of_window_entries()
+    {
+        var (svc, _) = Build(new TfDoctrineAttributeDictionary
+        {
+            County = County,
+            UniverseCode = UniverseCodes.RealResidential,
+            EffectiveStartYear = 2010,
+            EffectiveEndYear = 2015,
+            ImprvAttrId = "100",
+            IAttrValCd = "X",
+            ActiveFlag = true,
+            Reason = "test", EvidenceSource = "test",
+        });
+
+        var inWindow = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2012, "100", "X");
+        Assert.Equal(DictionaryLookupOutcome.Known, inWindow.Outcome);
+
+        var outOfWindow = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2026, "100", "X");
+        Assert.Equal(DictionaryLookupOutcome.UnknownForUniverse, outOfWindow.Outcome);
+    }
+
+    [Fact]
+    public async Task Inactive_entries_are_ignored()
+    {
+        var entry = Entry(UniverseCodes.RealResidential, "100", "X");
+        entry.ActiveFlag = false;
+        var (svc, _) = Build(entry);
+
+        var result = await svc.LookupAsync(
+            County, UniverseCodes.RealResidential, 2026, "100", "X");
+        // Active=false entries are excluded entirely → empty dictionary.
+        Assert.Equal(DictionaryLookupOutcome.DictionaryNotLoaded, result.Outcome);
+    }
+
+    [Fact]
+    public async Task Count_for_universe_reports_active_entries()
+    {
+        var (svc, _) = Build(
+            Entry(UniverseCodes.RealResidential, "100", "X"),
+            Entry(UniverseCodes.RealResidential, "200", "Y"));
+        var count = await svc.CountForUniverseAsync(County, UniverseCodes.RealResidential);
+        Assert.Equal(2, count);
+    }
+}

--- a/backend/TerraFusion.API.Tests/Doctrine/PropertyUniverseClassifierTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PropertyUniverseClassifierTests.cs
@@ -1,0 +1,206 @@
+// SYNC-DOCTRINE-4 — Test Plan A: universe-precedence tests.
+//
+// Validates the locked precedence of the six-universe classifier:
+//   1=CONVERSION_LEGACY, 2=AG_CURRENT_USE, 3=PERSONAL_PROPERTY,
+//   4=MOBILE_HOME, 5=REAL_COMMERCIAL, 6=REAL_RESIDENTIAL,
+//   7=UNKNOWN (sentinel; never seeded).
+// See docs/sync/sync-doctrine-4-improvement-universe-design.md
+// §"Test plan A".
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class PropertyUniverseClassifierTests
+{
+    private const string County = "benton-wa";
+
+    private static PropertyUniverseClassifier BuildClassifier()
+    {
+        var dbName = $"PuTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        // Seed using the production seeder so the test exercises the
+        // exact rule set that ships in production.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var seeder = new DoctrinePropertyUniverseSeeder(db,
+                NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+            seeder.SeedAsync().GetAwaiter().GetResult();
+        }
+
+        return new PropertyUniverseClassifier(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PropertyUniverseClassifier>.Instance);
+    }
+
+    private static UniverseClassifierInput Input(
+        string? propTypeCd = null,
+        string? propertyUseCd = null,
+        string? agApply = null,
+        string? agUseCd = null,
+        bool hasLegacyMarker = false,
+        int year = 2026) =>
+        new(County, year, propTypeCd, propertyUseCd, agApply, agUseCd, hasLegacyMarker);
+
+    [Fact]
+    public async Task AG_CURRENT_USE_beats_REAL_RESIDENTIAL_when_ag_apply_is_T()
+    {
+        var classifier = BuildClassifier();
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "R", agApply: "T"));
+        Assert.Equal(UniverseCodes.AgCurrentUse, result.UniverseCode);
+        Assert.NotNull(result.RuleId);
+    }
+
+    [Fact]
+    public async Task MOBILE_HOME_beats_real_property_buckets_when_prop_type_is_MH()
+    {
+        var classifier = BuildClassifier();
+        // ag_apply='F' means AG rule (precedence 2) skips. MH then wins.
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "MH", agApply: "F"));
+        Assert.Equal(UniverseCodes.MobileHome, result.UniverseCode);
+    }
+
+    [Theory]
+    [InlineData("P")]
+    [InlineData("B")]
+    public async Task PERSONAL_PROPERTY_beats_real_property_buckets_for_P_and_B(string code)
+    {
+        var classifier = BuildClassifier();
+        var result = await classifier.ClassifyAsync(Input(propTypeCd: code));
+        Assert.Equal(UniverseCodes.PersonalProperty, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task CONVERSION_LEGACY_does_not_fire_without_explicit_legacy_marker()
+    {
+        var classifier = BuildClassifier();
+        // R / F / no legacy marker → REAL_RESIDENTIAL (precedence 6).
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "R", agApply: "F", hasLegacyMarker: false));
+        Assert.Equal(UniverseCodes.RealResidential, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task CONVERSION_LEGACY_beats_other_buckets_when_marker_is_present()
+    {
+        var classifier = BuildClassifier();
+        // Same R / F shape as above, but legacy marker is present.
+        // CONVERSION_LEGACY (precedence 1) wins.
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "R", agApply: "F", hasLegacyMarker: true));
+        Assert.Equal(UniverseCodes.ConversionLegacy, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task REAL_COMMERCIAL_beats_REAL_RESIDENTIAL_when_property_use_is_excluded()
+    {
+        var classifier = BuildClassifier();
+        // R / F / property_use_cd outside residential set → COMMERCIAL.
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "R", agApply: "F", propertyUseCd: "60"));
+        Assert.Equal(UniverseCodes.RealCommercial, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task REAL_RESIDENTIAL_is_default_real_bucket_after_higher_precedence_rules_fail()
+    {
+        var classifier = BuildClassifier();
+        // R / F / residential property_use code → COMMERCIAL excluded,
+        // RESIDENTIAL fires.
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "R", agApply: "F", propertyUseCd: "11"));
+        Assert.Equal(UniverseCodes.RealResidential, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task UNKNOWN_is_returned_when_no_rule_matches()
+    {
+        var classifier = BuildClassifier();
+        // ag_apply NULL means all rules with explicit ag_apply='F'
+        // (commercial, residential) skip. prop_type 'X' isn't in any
+        // CSV. No rule fires → UNKNOWN.
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "X", agApply: null));
+        Assert.Equal(UniverseCodes.Unknown, result.UniverseCode);
+        Assert.Equal(UniverseQuarantineReasons.UnknownUniverse, result.QuarantineReasonHint);
+        Assert.Null(result.RuleId);
+    }
+
+    [Fact]
+    public async Task Cache_can_be_invalidated_per_county()
+    {
+        var classifier = BuildClassifier();
+        // Warm cache.
+        await classifier.ClassifyAsync(Input(propTypeCd: "MH", agApply: "F"));
+
+        classifier.InvalidateCache(County);
+
+        // Re-classify after invalidation; behaviour unchanged because
+        // seeded rules still in DB. The contract asserts no exception
+        // and consistent result.
+        var result = await classifier.ClassifyAsync(Input(propTypeCd: "MH", agApply: "F"));
+        Assert.Equal(UniverseCodes.MobileHome, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task Inactive_rules_are_skipped()
+    {
+        var dbName = $"PuInactiveTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            // Seed an inactive rule that would otherwise match MH.
+            db.TfDoctrinePropertyUniverses.Add(new TfDoctrinePropertyUniverse
+            {
+                County = County,
+                EffectiveStartYear = 1990,
+                Precedence = 4,
+                UniverseCode = UniverseCodes.MobileHome,
+                PropTypeCdCsv = "MH",
+                ActiveFlag = false,
+                Reason = "test inactive rule",
+                EvidenceSource = "test",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var classifier = new PropertyUniverseClassifier(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PropertyUniverseClassifier>.Instance);
+
+        // No active rules → UNKNOWN.
+        var result = await classifier.ClassifyAsync(Input(propTypeCd: "MH"));
+        Assert.Equal(UniverseCodes.Unknown, result.UniverseCode);
+    }
+}

--- a/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
@@ -132,4 +132,156 @@ public class DoctrinePolicyController : ControllerBase
                 : $"Inserted {added} new rule(s); cache invalidated.",
         });
     }
+
+    // ────────────────────────────────────────────────────────────────
+    // SYNC-DOCTRINE-4: property-universe doctrine endpoints.
+    // ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// List property-universe rules. Optional filters by county and
+    /// universe code. Mirrors the ratio endpoint shape.
+    /// </summary>
+    [HttpGet("universe")]
+    public async Task<IActionResult> ListUniverseRules(
+        [FromQuery] string? county,
+        [FromQuery] string? universe,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _db.TfDoctrinePropertyUniverses.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(county))
+            query = query.Where(r => r.County == county);
+        if (!string.IsNullOrWhiteSpace(universe))
+            query = query.Where(r => r.UniverseCode == universe);
+
+        var rules = await query
+            .OrderBy(r => r.County)
+            .ThenBy(r => r.Precedence)
+            .Select(r => new
+            {
+                r.RuleId,
+                r.County,
+                r.EffectiveStartYear,
+                r.EffectiveEndYear,
+                r.Precedence,
+                r.UniverseCode,
+                r.PropTypeCdCsv,
+                r.PropertyUseCdCsv,
+                r.PropertyUseMode,
+                r.AgApplyValue,
+                r.AgUseCdCsv,
+                r.RequiresLegacyMarker,
+                r.LegacyMarkerType,
+                r.LegacyMarkerValue,
+                r.Reason,
+                r.EvidenceSource,
+                r.Confidence,
+                r.ActiveFlag,
+                r.ApprovedBy,
+                r.ApprovedAt,
+                r.Notes,
+            })
+            .ToListAsync(cancellationToken);
+
+        return Ok(new { count = rules.Count, rules });
+    }
+
+    /// <summary>
+    /// Spot-check the universe classifier. Pass the same property-
+    /// level signals the truth promoter would consult and observe
+    /// which rule fires.
+    /// </summary>
+    [HttpGet("universe/classify")]
+    public async Task<IActionResult> ClassifyUniverse(
+        [FromServices] IPropertyUniverseClassifier classifier,
+        [FromQuery] string county,
+        [FromQuery] int year,
+        [FromQuery(Name = "prop_type_cd")] string? propTypeCd,
+        [FromQuery(Name = "property_use_cd")] string? propertyUseCd,
+        [FromQuery(Name = "ag_apply")] string? agApply,
+        [FromQuery(Name = "ag_use_cd")] string? agUseCd,
+        [FromQuery(Name = "has_legacy_marker")] bool hasLegacyMarker = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(county))
+            return BadRequest(new { error = "Query parameter 'county' is required." });
+        if (year <= 0)
+            return BadRequest(new { error = "Query parameter 'year' must be positive." });
+
+        var input = new UniverseClassifierInput(
+            county, year, propTypeCd, propertyUseCd, agApply, agUseCd, hasLegacyMarker);
+        var result = await classifier.ClassifyAsync(input, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// List per-universe attribute-dictionary entries. Optional
+    /// filters by county and universe.
+    /// </summary>
+    [HttpGet("universe/attribute-dictionary")]
+    public async Task<IActionResult> ListAttributeDictionary(
+        [FromQuery] string? county,
+        [FromQuery] string? universe,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _db.TfDoctrineAttributeDictionaries.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(county))
+            query = query.Where(e => e.County == county);
+        if (!string.IsNullOrWhiteSpace(universe))
+            query = query.Where(e => e.UniverseCode == universe);
+
+        var entries = await query
+            .OrderBy(e => e.County)
+            .ThenBy(e => e.UniverseCode)
+            .ThenBy(e => e.ImprvAttrId)
+            .ThenBy(e => e.IAttrValCd)
+            .Select(e => new
+            {
+                e.DictionaryRowId,
+                e.County,
+                e.UniverseCode,
+                e.EffectiveStartYear,
+                e.EffectiveEndYear,
+                e.ImprvAttrId,
+                e.IAttrValCd,
+                e.AttributeDescription,
+                e.AttributeGroup,
+                e.SourceTable,
+                e.SourceKey,
+                e.Reason,
+                e.EvidenceSource,
+                e.Confidence,
+                e.ActiveFlag,
+                e.ApprovedBy,
+                e.ApprovedAt,
+            })
+            .ToListAsync(cancellationToken);
+
+        return Ok(new { count = entries.Count, entries });
+    }
+
+    /// <summary>
+    /// Re-run the idempotent universe + attribute-dictionary seeders.
+    /// Invalidates the classifier and per-universe dictionary caches.
+    /// </summary>
+    [HttpPost("universe/seed")]
+    public async Task<IActionResult> SeedUniverse(
+        [FromServices] DoctrinePropertyUniverseSeeder universeSeeder,
+        [FromServices] DoctrineAttributeDictionarySeeder dictSeeder,
+        [FromServices] IPropertyUniverseClassifier classifier,
+        [FromServices] IPerUniverseAttributeDictionary dictionary,
+        CancellationToken cancellationToken = default)
+    {
+        var universeAdded = await universeSeeder.SeedAsync(cancellationToken);
+        var dictAdded = await dictSeeder.SeedAsync(cancellationToken);
+
+        if (classifier is PropertyUniverseClassifier puc) puc.InvalidateCache();
+        if (dictionary is PerUniverseAttributeDictionary pad) pad.InvalidateCache();
+
+        return Ok(new
+        {
+            universeRulesInserted = universeAdded,
+            attributeDictionaryEntriesInserted = dictAdded,
+            note = "Caches invalidated; classifier reads next call rebuild from DB.",
+        });
+    }
 }

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1778,6 +1778,29 @@ builder.Services.AddScoped<
 builder.Services.AddHostedService<
     TerraFusion.Data.Services.Doctrine.DoctrineRatioPolicySeederHostedService>();
 
+// SYNC-DOCTRINE-4: property-universe classifier. Singleton with
+// ConcurrentDictionary cache; loads rules from
+// doctrine_tf.tf_doctrine_property_universe via IServiceScopeFactory.
+// Mirrors B1's RatioQualificationPolicy lifetime/cache pattern.
+builder.Services.AddSingleton<
+    TerraFusion.Core.Sync.Doctrine.IPropertyUniverseClassifier,
+    TerraFusion.Data.Services.Doctrine.PropertyUniverseClassifier>();
+// SYNC-DOCTRINE-4: per-universe imprv_attr dictionary. Singleton
+// keyed by (county, universe). Replaces the global
+// RefreshableImprvAttrDictionary for universe-aware lookups.
+builder.Services.AddSingleton<
+    TerraFusion.Core.Sync.Doctrine.IPerUniverseAttributeDictionary,
+    TerraFusion.Data.Services.Doctrine.PerUniverseAttributeDictionary>();
+builder.Services.AddScoped<
+    TerraFusion.Data.Services.Doctrine.DoctrinePropertyUniverseSeeder>();
+builder.Services.AddScoped<
+    TerraFusion.Data.Services.Doctrine.DoctrineAttributeDictionarySeeder>();
+// SYNC-DOCTRINE-4: hosted service runs both seeders at startup.
+// Idempotent; non-fatal on failure (classifier emits UNKNOWN until
+// successful seed).
+builder.Services.AddHostedService<
+    TerraFusion.Data.Services.Doctrine.DoctrinePropertyUniverseSeederHostedService>();
+
 // Slice L1: PACS land_detail raw landing — Block C's land lane
 // per-segment table. Four gates: distribution, 4-key-uniqueness,
 // provenance-coverage, aggregate.

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovement.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfImprovement.cs
@@ -66,6 +66,28 @@ public sealed class TfImprovement
     /// </summary>
     public string? ConversionEra { get; set; }
 
+    // ── SYNC-DOCTRINE-4: universe classification (forwarded from truth) ─
+    /// <summary>
+    /// Forwarded verbatim from <c>truth_pacs.imprv_current.UniverseCode</c>
+    /// at projection time. One of
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// Nullable for back-compat with rows projected before
+    /// SYNC-DOCTRINE-4-IMPL.
+    /// </summary>
+    public string? UniverseCode { get; set; }
+
+    /// <summary>
+    /// FK to <c>doctrine_tf.tf_doctrine_property_universe.rule_id</c>,
+    /// forwarded from truth.
+    /// </summary>
+    public Guid? UniverseRuleId { get; set; }
+
+    /// <summary>HIGH | MED | LOW. Forwarded from truth.</summary>
+    public string? UniverseConfidence { get; set; }
+
+    /// <summary>Forwarded from truth.</summary>
+    public string? UniverseReason { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrineAttributeDictionary.cs
+++ b/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrineAttributeDictionary.cs
@@ -1,0 +1,92 @@
+using System;
+
+namespace TerraFusion.Core.Entities.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: per-universe, year-aware, evidence-backed
+/// imprv_attr dictionary. Replaces the single global in-memory
+/// <see cref="TerraFusion.Core.Sync.PacsImprvAttr.RefreshableImprvAttrDictionary"/>
+/// which collapsed real / mobile-home / ag / personal-property /
+/// legacy attribute namespaces into one bucket.
+///
+/// <para>One row per (county, universe, year, imprv_attr_id,
+/// i_attr_val_cd) tuple. Quarantine semantics become per-universe:
+/// <c>UNKNOWN_FOR_UNIVERSE_DICTIONARY</c> only fires when the code
+/// is missing from THAT row's universe — not from any other
+/// universe's dictionary.</para>
+///
+/// <para>Initial seed is intentionally empty (per design doc
+/// §"Out of scope"): per-universe code distributions need a
+/// profiling drain against live PACS before tightening.</para>
+/// </summary>
+public sealed class TfDoctrineAttributeDictionary
+{
+    /// <summary>Surrogate primary key.</summary>
+    public Guid DictionaryRowId { get; set; } = Guid.NewGuid();
+
+    /// <summary>County scope, lowercase-hyphenated. e.g. "benton-wa".</summary>
+    public string County { get; set; } = string.Empty;
+
+    /// <summary>First PropValYr the entry applies to (inclusive).</summary>
+    public int EffectiveStartYear { get; set; }
+
+    /// <summary>Last PropValYr the entry applies to (inclusive). NULL = "still in effect".</summary>
+    public int? EffectiveEndYear { get; set; }
+
+    /// <summary>
+    /// Closed vocabulary from <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// Never <c>UNKNOWN</c> — by definition no dictionary entries
+    /// exist for an unclassified row.
+    /// </summary>
+    public string UniverseCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// PACS <c>imprv_attr_id</c> (column reference). Stored as string
+    /// to match the ad-hoc-keyed nature of the legacy dictionary;
+    /// real values are integers but the doctrine surface keeps the
+    /// option open.
+    /// </summary>
+    public string ImprvAttrId { get; set; } = string.Empty;
+
+    /// <summary>The PACS value-code being recognized (e.g. a quality grade or finish code).</summary>
+    public string IAttrValCd { get; set; } = string.Empty;
+
+    /// <summary>Human-friendly description, when known.</summary>
+    public string? AttributeDescription { get; set; }
+
+    /// <summary>Optional grouping for reporting (e.g. "QUALITY", "EXTERIOR").</summary>
+    public string? AttributeGroup { get; set; }
+
+    /// <summary>Source table the entry was learned from (e.g. <c>dbo.imprv_attr_val</c>).</summary>
+    public string? SourceTable { get; set; }
+
+    /// <summary>Source key in the source table (e.g. composite of imprv_attr_id + i_attr_val_cd).</summary>
+    public string? SourceKey { get; set; }
+
+    /// <summary>Why this entry exists. Free-text.</summary>
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>Citation supporting the entry. Required for HIGH confidence.</summary>
+    public string EvidenceSource { get; set; } = string.Empty;
+
+    /// <summary>Closed vocab: <c>'HIGH'</c> | <c>'MED'</c> | <c>'LOW'</c>.</summary>
+    public string Confidence { get; set; } = "MED";
+
+    /// <summary>Free-text notes for future maintainers.</summary>
+    public string? Notes { get; set; }
+
+    /// <summary>Soft-disable; lookups ignore entries with <c>ActiveFlag = false</c>.</summary>
+    public bool ActiveFlag { get; set; } = true;
+
+    /// <summary>Operator who signed off.</summary>
+    public string? ApprovedBy { get; set; }
+
+    /// <summary>Timestamp of operator sign-off.</summary>
+    public DateTime? ApprovedAt { get; set; }
+
+    // ── Audit fields (auto-populated) ─────────────────────────────────
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrinePropertyUniverse.cs
+++ b/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrinePropertyUniverse.cs
@@ -1,0 +1,148 @@
+using System;
+
+namespace TerraFusion.Core.Entities.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: year-aware, evidence-backed property-universe
+/// classification rule. The doctrine layer that replaces the
+/// implicit "real-residential by default" assumption baked into the
+/// previous improvement promoter.
+///
+/// <para>Each row represents one rule that maps a tuple of PACS
+/// property-level signals (<c>prop_type_cd</c>, <c>property_use_cd</c>,
+/// <c>ag_apply</c>, <c>ag_use_cd</c>, optional legacy marker) onto
+/// one of the seven universe codes. Rules are ranked by
+/// <see cref="Precedence"/> (lower number = higher priority); the
+/// first matching rule wins.</para>
+///
+/// <para>Six universes + UNKNOWN sentinel are locked in
+/// <c>docs/sync/sync-doctrine-4-improvement-universe-design.md</c>:
+/// REAL_RESIDENTIAL, REAL_COMMERCIAL, MOBILE_HOME, AG_CURRENT_USE,
+/// PERSONAL_PROPERTY, CONVERSION_LEGACY, UNKNOWN. UNKNOWN is never
+/// seeded; the classifier writes it when no rule matches.</para>
+///
+/// <para>Constitutional principle (operator, 2026-05-06):
+/// "Transport gates can be green. Doctrine gates are not green
+/// until policy is explicit, versioned, and evidence-backed."
+/// Every row in this table MUST carry <see cref="EvidenceSource"/>,
+/// <see cref="Confidence"/>, and (for production-active rules)
+/// <see cref="ApprovedBy"/>.</para>
+/// </summary>
+public sealed class TfDoctrinePropertyUniverse
+{
+    /// <summary>Surrogate primary key.</summary>
+    public Guid RuleId { get; set; } = Guid.NewGuid();
+
+    /// <summary>County scope, lowercase-hyphenated. e.g. "benton-wa".</summary>
+    public string County { get; set; } = string.Empty;
+
+    /// <summary>First PropValYr the rule applies to (inclusive).</summary>
+    public int EffectiveStartYear { get; set; }
+
+    /// <summary>Last PropValYr the rule applies to (inclusive). NULL = "still in effect".</summary>
+    public int? EffectiveEndYear { get; set; }
+
+    /// <summary>
+    /// Lower number = higher priority. The classifier walks
+    /// active rules ordered by Precedence ASC and returns the
+    /// first match. Locked precedence values (per design doc):
+    /// 1=CONVERSION_LEGACY, 2=AG_CURRENT_USE, 3=PERSONAL_PROPERTY,
+    /// 4=MOBILE_HOME, 5=REAL_COMMERCIAL, 6=REAL_RESIDENTIAL.
+    /// </summary>
+    public int Precedence { get; set; }
+
+    /// <summary>
+    /// Closed vocabulary from <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// Never <c>UNKNOWN</c> — that sentinel is reserved for the
+    /// classifier's no-match output, not for stored rules.
+    /// </summary>
+    public string UniverseCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Comma-separated <c>prop_type_cd</c> values this rule matches.
+    /// Empty / NULL = wildcard (any prop_type_cd). e.g. "R" or "P,B".
+    /// </summary>
+    public string? PropTypeCdCsv { get; set; }
+
+    /// <summary>
+    /// Comma-separated <c>property_use_cd</c> values relevant to
+    /// <see cref="PropertyUseMode"/>. Free-text length to allow long
+    /// CSV lists when tightening commercial / residential boundaries
+    /// after profiling.
+    /// </summary>
+    public string? PropertyUseCdCsv { get; set; }
+
+    /// <summary>
+    /// How <see cref="PropertyUseCdCsv"/> participates in matching:
+    /// <c>"ANY"</c> (column ignored — anything matches),
+    /// <c>"INCLUDE"</c> (row's property_use_cd must be in the CSV),
+    /// <c>"EXCLUDE"</c> (row's property_use_cd must NOT be in the
+    /// CSV, used by the broad commercial seed rule to exclude
+    /// residential codes).
+    /// </summary>
+    public string PropertyUseMode { get; set; } = "ANY";
+
+    /// <summary>
+    /// Required <c>ag_apply</c> value. <c>"T"</c> | <c>"F"</c> |
+    /// NULL (= wildcard).
+    /// </summary>
+    public string? AgApplyValue { get; set; }
+
+    /// <summary>
+    /// Comma-separated <c>ag_use_cd</c> values (e.g. "AG,OSP,CNV").
+    /// Reserved for future tightening of AG_CURRENT_USE; ignored at
+    /// initial seed.
+    /// </summary>
+    public string? AgUseCdCsv { get; set; }
+
+    /// <summary>
+    /// True iff the rule requires a legacy marker to be present on
+    /// the row before firing. Only true on the CONVERSION_LEGACY
+    /// rule.
+    /// </summary>
+    public bool RequiresLegacyMarker { get; set; }
+
+    /// <summary>
+    /// Closed vocabulary identifying which legacy marker the rule
+    /// looks for: <c>CREATED_DT_PRE_2017</c> | <c>SOURCE_SYSTEM</c> |
+    /// <c>IMPORT_BATCH</c>. NULL when <see cref="RequiresLegacyMarker"/>
+    /// is false.
+    /// </summary>
+    public string? LegacyMarkerType { get; set; }
+
+    /// <summary>
+    /// Optional value the legacy marker must equal (for SOURCE_SYSTEM
+    /// or IMPORT_BATCH variants). NULL for date-based markers.
+    /// </summary>
+    public string? LegacyMarkerValue { get; set; }
+
+    /// <summary>Why this rule exists. Free-text.</summary>
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Citation: where the rule comes from. Required for HIGH
+    /// confidence rules. Mirrors <see cref="TfDoctrineRatioPolicy.EvidenceSource"/>.
+    /// </summary>
+    public string EvidenceSource { get; set; } = string.Empty;
+
+    /// <summary>Closed vocab: <c>'HIGH'</c> | <c>'MED'</c> | <c>'LOW'</c>.</summary>
+    public string Confidence { get; set; } = "MED";
+
+    /// <summary>Free-text notes for future maintainers.</summary>
+    public string? Notes { get; set; }
+
+    /// <summary>Soft-disable knob; classifier ignores rules with <c>ActiveFlag = false</c>.</summary>
+    public bool ActiveFlag { get; set; } = true;
+
+    /// <summary>Operator who signed off. e.g. "operator-bsval".</summary>
+    public string? ApprovedBy { get; set; }
+
+    /// <summary>Timestamp of operator sign-off.</summary>
+    public DateTime? ApprovedAt { get; set; }
+
+    // ── Audit fields (auto-populated by AuditableEntityInterceptor) ────
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/LegacyTfUnproven/LegacyTfUnprovenImprvAttr.cs
+++ b/backend/src/TerraFusion.Core/Entities/LegacyTfUnproven/LegacyTfUnprovenImprvAttr.cs
@@ -55,5 +55,33 @@ public sealed class LegacyTfUnprovenImprvAttr
     /// </summary>
     public string QuarantineReason { get; set; } = string.Empty;
 
+    // ── SYNC-DOCTRINE-4: universe-aware quarantine context ──────────
+    /// <summary>
+    /// The universe classification for the parent improvement at the
+    /// time this row was quarantined. One of
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// Nullable for back-compat with rows quarantined before
+    /// SYNC-DOCTRINE-4-IMPL.
+    /// </summary>
+    public string? UniverseCode { get; set; }
+
+    /// <summary>
+    /// FK to <c>doctrine_tf.tf_doctrine_property_universe.rule_id</c>
+    /// — the rule that produced <see cref="UniverseCode"/>. NULL when
+    /// the universe is <c>UNKNOWN</c> or unclassified.
+    /// </summary>
+    public Guid? UniverseRuleId { get; set; }
+
+    /// <summary>
+    /// One of
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseQuarantineReasons"/>.
+    /// Replaces the muddier
+    /// <see cref="QuarantineReason"/> = <c>UNKNOWN_ATTRIBUTE</c> with
+    /// a five-named-reason taxonomy that distinguishes classification
+    /// failure from dictionary-load failure from genuine unknown
+    /// code-within-known-universe.
+    /// </summary>
+    public string? QuarantineReasonDetail { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsImprvCurrent.cs
+++ b/backend/src/TerraFusion.Core/Entities/TruthPacs/TruthPacsImprvCurrent.cs
@@ -67,5 +67,30 @@ public sealed class TruthPacsImprvCurrent
     /// </summary>
     public string? ConversionEra { get; set; }
 
+    // ── SYNC-DOCTRINE-4: universe classification surface ─────────
+    /// <summary>
+    /// Closed vocabulary from
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// Written by the truth promoter via
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.IPropertyUniverseClassifier"/>.
+    /// Nullable for back-compat with rows promoted before
+    /// SYNC-DOCTRINE-4-IMPL.
+    /// </summary>
+    public string? UniverseCode { get; set; }
+
+    /// <summary>
+    /// FK to <c>doctrine_tf.tf_doctrine_property_universe.rule_id</c>
+    /// — the rule that classified this row. NULL when
+    /// <see cref="UniverseCode"/> is <c>UNKNOWN</c> (sentinel) or
+    /// when the row was promoted before SYNC-DOCTRINE-4-IMPL.
+    /// </summary>
+    public Guid? UniverseRuleId { get; set; }
+
+    /// <summary>HIGH | MED | LOW. Mirrors the matching rule's confidence.</summary>
+    public string? UniverseConfidence { get; set; }
+
+    /// <summary>Operator-readable explanation: matching rule's reason or "no rule matched (...)".</summary>
+    public string? UniverseReason { get; set; }
+
     public DateTime PromotedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IPerUniverseAttributeDictionary.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IPerUniverseAttributeDictionary.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: per-universe imprv_attr code dictionary. Replaces
+/// the global <see cref="TerraFusion.Core.Sync.PacsImprvAttr.IImprvAttrDictionary"/>
+/// for universe-aware lookups.
+///
+/// <para>A code is "known" if and only if it appears in
+/// <c>doctrine_tf.tf_doctrine_attribute_dictionary</c> for THE row's
+/// universe + county + year window. Quarantine semantics become
+/// per-universe: <c>UNKNOWN_FOR_UNIVERSE_DICTIONARY</c> only fires
+/// when the code is missing from THAT row's universe — not from any
+/// other universe's dictionary.</para>
+/// </summary>
+public interface IPerUniverseAttributeDictionary
+{
+    /// <summary>
+    /// Look up an imprv_attr code under a specific universe.
+    /// </summary>
+    /// <param name="county">Lowercase-hyphenated county slug.</param>
+    /// <param name="universeCode">
+    /// One of <see cref="UniverseCodes"/>. Calling with
+    /// <c>UNKNOWN</c> always returns
+    /// <see cref="DictionaryLookupResult.NotEvaluated"/>.
+    /// </param>
+    /// <param name="year">PropValYr for effective-window matching.</param>
+    /// <param name="imprvAttrId">PACS imprv_attr_id (column id).</param>
+    /// <param name="iAttrValCd">PACS i_attr_val_cd (the value being recognized).</param>
+    Task<DictionaryLookupResult> LookupAsync(
+        string county,
+        string universeCode,
+        int year,
+        string imprvAttrId,
+        string iAttrValCd,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the number of dictionary rows currently loaded for
+    /// <paramref name="county"/> + <paramref name="universeCode"/>.
+    /// Used by the gate writer to record per-universe dictionary
+    /// load state.
+    /// </summary>
+    Task<int> CountForUniverseAsync(
+        string county,
+        string universeCode,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Drop the cached entries for the given county (or all when null).</summary>
+    void InvalidateCache(string? county = null);
+}
+
+/// <summary>
+/// Outcome of <see cref="IPerUniverseAttributeDictionary.LookupAsync"/>.
+/// </summary>
+public enum DictionaryLookupOutcome
+{
+    /// <summary>The code is present in the per-universe dictionary.</summary>
+    Known = 1,
+
+    /// <summary>The universe is loaded; the code is genuinely absent.</summary>
+    UnknownForUniverse = 2,
+
+    /// <summary>The universe has zero active dictionary rows; cannot evaluate.</summary>
+    DictionaryNotLoaded = 3,
+
+    /// <summary>The universe was UNKNOWN at the call site; no lookup attempted.</summary>
+    UniverseNotEvaluated = 4,
+}
+
+/// <summary>
+/// Result of <see cref="IPerUniverseAttributeDictionary.LookupAsync"/>.
+/// </summary>
+/// <param name="Outcome">Categorical outcome (see <see cref="DictionaryLookupOutcome"/>).</param>
+/// <param name="MatchedRowId">
+/// The matching dictionary row's id when
+/// <see cref="Outcome"/> = <see cref="DictionaryLookupOutcome.Known"/>;
+/// NULL otherwise.
+/// </param>
+/// <param name="QuarantineReason">
+/// The reason to write on a quarantine row when
+/// <see cref="Outcome"/> != <see cref="DictionaryLookupOutcome.Known"/>.
+/// One of <see cref="UniverseQuarantineReasons"/>. NULL when known.
+/// </param>
+public sealed record DictionaryLookupResult(
+    DictionaryLookupOutcome Outcome,
+    Guid? MatchedRowId,
+    string? QuarantineReason)
+{
+    /// <summary>True iff the code resolved successfully.</summary>
+    public bool IsKnown => Outcome == DictionaryLookupOutcome.Known;
+
+    public static DictionaryLookupResult Known(Guid rowId)
+        => new(DictionaryLookupOutcome.Known, rowId, null);
+
+    public static DictionaryLookupResult UnknownForUniverse()
+        => new(DictionaryLookupOutcome.UnknownForUniverse, null,
+               UniverseQuarantineReasons.UnknownForUniverseDictionary);
+
+    public static DictionaryLookupResult DictionaryNotLoaded()
+        => new(DictionaryLookupOutcome.DictionaryNotLoaded, null,
+               UniverseQuarantineReasons.DictionaryNotLoadedForUniverse);
+
+    public static DictionaryLookupResult NotEvaluated()
+        => new(DictionaryLookupOutcome.UniverseNotEvaluated, null,
+               UniverseQuarantineReasons.UniverseNotEvaluated);
+}

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IPropertyUniverseClassifier.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IPropertyUniverseClassifier.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: classify an improvement row's property-level
+/// signals into one of the seven universe codes
+/// (<see cref="UniverseCodes"/>).
+///
+/// <para>The classifier is the doctrine layer between raw PACS
+/// fields and the per-universe attribute dictionary. Implementations
+/// load rules from <c>doctrine_tf.tf_doctrine_property_universe</c>
+/// scoped by county, walk them ordered by
+/// <c>Precedence ASC</c>, and return the first match. If no rule
+/// fires the result is <see cref="UniverseCodes.Unknown"/> with a
+/// reason citing the input tuple.</para>
+///
+/// <para>The classifier is pure with respect to the input
+/// signals — same input always yields the same output for a given
+/// county + rule snapshot. Cache invalidation happens via
+/// <see cref="InvalidateCache"/> after a re-seed.</para>
+/// </summary>
+public interface IPropertyUniverseClassifier
+{
+    /// <summary>
+    /// Classify a single improvement row. <paramref name="input"/>
+    /// carries the property-level signals already joined from raw
+    /// PACS; the classifier never reads from the raw tables itself.
+    /// </summary>
+    Task<UniverseClassification> ClassifyAsync(
+        UniverseClassifierInput input,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Drop the cached rule list for the given county.</summary>
+    void InvalidateCache(string? county = null);
+}
+
+/// <summary>
+/// Inputs to <see cref="IPropertyUniverseClassifier.ClassifyAsync"/>.
+/// </summary>
+/// <param name="County">Lowercase-hyphenated county slug.</param>
+/// <param name="PropValYr">Year axis used for effective-window matching.</param>
+/// <param name="PropTypeCd">PACS <c>dbo.property.prop_type_cd</c>. NULL allowed.</param>
+/// <param name="PropertyUseCd">PACS <c>dbo.property_val.property_use_cd</c>. NULL allowed.</param>
+/// <param name="AgApply">PACS <c>dbo.land_detail.ag_apply</c> ('T'/'F'). NULL allowed.</param>
+/// <param name="AgUseCd">PACS <c>dbo.land_detail.ag_use_cd</c>. NULL allowed.</param>
+/// <param name="HasLegacyMarker">
+/// True iff the calling promoter has confirmed an explicit legacy
+/// marker on the row (e.g. <c>property.prop_create_dt &lt; 2017-01-01</c>).
+/// Only consulted by rules with <c>RequiresLegacyMarker = true</c>.
+/// </param>
+public sealed record UniverseClassifierInput(
+    string County,
+    int PropValYr,
+    string? PropTypeCd,
+    string? PropertyUseCd,
+    string? AgApply,
+    string? AgUseCd,
+    bool HasLegacyMarker);
+
+/// <summary>
+/// Result of <see cref="IPropertyUniverseClassifier.ClassifyAsync"/>.
+/// </summary>
+/// <param name="UniverseCode">
+/// One of <see cref="UniverseCodes"/>. <c>UNKNOWN</c> when no rule
+/// matched.
+/// </param>
+/// <param name="RuleId">
+/// The matching rule's id, or NULL when no rule fired.
+/// </param>
+/// <param name="Confidence">The matching rule's confidence, or "LOW" for UNKNOWN.</param>
+/// <param name="Reason">
+/// Free-text explanation copied from the matching rule, or a
+/// generated "no rule matched (...)" string for UNKNOWN. Operator-
+/// readable.
+/// </param>
+/// <param name="QuarantineReasonHint">
+/// Hint for the caller: when <see cref="UniverseCode"/> is
+/// <c>UNKNOWN</c>, set to <see cref="UniverseQuarantineReasons.UnknownUniverse"/>.
+/// When CONVERSION_LEGACY fires on a weak marker, set to
+/// <see cref="UniverseQuarantineReasons.LegacyClassificationUncertain"/>.
+/// NULL otherwise (no quarantine implication).
+/// </param>
+public sealed record UniverseClassification(
+    string UniverseCode,
+    Guid? RuleId,
+    string Confidence,
+    string Reason,
+    string? QuarantineReasonHint);

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/UniverseCodes.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/UniverseCodes.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: closed vocabulary for the
+/// <c>UniverseCode</c> column on <c>truth_pacs.imprv_current</c>,
+/// <c>canonical_tf.tf_improvement</c>, and any per-universe lookup
+/// in <c>doctrine_tf.tf_doctrine_attribute_dictionary</c>.
+///
+/// <para>Six real universes plus the <c>UNKNOWN</c> sentinel. The
+/// classifier never silently coerces an unmatched row into
+/// <c>REAL_RESIDENTIAL</c> — it returns <see cref="Unknown"/> with a
+/// quarantine-reason detail. See
+/// <c>docs/sync/sync-doctrine-4-improvement-universe-design.md</c>
+/// §"Locked universe set".</para>
+///
+/// <para>Adding a new universe is intentionally a code change. The
+/// classifier, dictionary, and quarantine taxonomy must be reviewed
+/// jointly before a new universe lands; there is no runtime
+/// extensibility hook.</para>
+/// </summary>
+public static class UniverseCodes
+{
+    /// <summary>
+    /// Real-property residential improvements. The default real bucket
+    /// after higher-precedence rules fail. <c>prop_type_cd = 'R'</c>
+    /// AND <c>ag_apply &lt;&gt; 'T'</c>.
+    /// </summary>
+    public const string RealResidential = "REAL_RESIDENTIAL";
+
+    /// <summary>
+    /// Real-property non-residential. Broad commercial bucket for
+    /// initial seed; tighten <c>property_use_cd</c> against profiling
+    /// distribution after first drain.
+    /// </summary>
+    public const string RealCommercial = "REAL_COMMERCIAL";
+
+    /// <summary>
+    /// Mobile-home universe. <c>prop_type_cd = 'MH'</c>. Real but not
+    /// stick-built; PACS attribute namespace genuinely diverges from
+    /// stick-built residential.
+    /// </summary>
+    public const string MobileHome = "MOBILE_HOME";
+
+    /// <summary>
+    /// Agricultural / current-use / open-space / conversion. Wins over
+    /// residential / commercial when <c>ag_apply = 'T'</c> regardless
+    /// of prop_type_cd. Future split into AG/OSP/CNV is out of scope
+    /// per design doc §"Out of scope".
+    /// </summary>
+    public const string AgCurrentUse = "AG_CURRENT_USE";
+
+    /// <summary>
+    /// Business personal property. <c>prop_type_cd ∈ {'P', 'B'}</c>.
+    /// Distinct attribute schedules from real property.
+    /// </summary>
+    public const string PersonalProperty = "PERSONAL_PROPERTY";
+
+    /// <summary>
+    /// Pre-2017 PACS conversion-legacy rows. Conservative: only fires
+    /// when current PACS domain rules can't classify confidently AND
+    /// an explicit legacy marker is present. Wins over all other
+    /// universes when fired.
+    /// </summary>
+    public const string ConversionLegacy = "CONVERSION_LEGACY";
+
+    /// <summary>
+    /// Sentinel for rows that match no rule. NEVER seeded; only
+    /// written by the classifier when no rule fires. Paired with a
+    /// <see cref="UniverseQuarantineReasons"/> detail.
+    /// </summary>
+    public const string Unknown = "UNKNOWN";
+
+    /// <summary>
+    /// All six real universes (excludes <see cref="Unknown"/>). Use
+    /// for seeding loops, distribution audits, and dictionary
+    /// per-universe queries.
+    /// </summary>
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>
+    {
+        RealResidential,
+        RealCommercial,
+        MobileHome,
+        AgCurrentUse,
+        PersonalProperty,
+        ConversionLegacy,
+    };
+
+    /// <summary>
+    /// All universes including the UNKNOWN sentinel. Use at boundaries
+    /// validating input from external callers.
+    /// </summary>
+    public static IReadOnlySet<string> AllIncludingUnknown { get; } = new HashSet<string>
+    {
+        RealResidential,
+        RealCommercial,
+        MobileHome,
+        AgCurrentUse,
+        PersonalProperty,
+        ConversionLegacy,
+        Unknown,
+    };
+
+    /// <summary>True iff <paramref name="value"/> is a recognized universe code (any of the seven).</summary>
+    public static bool IsKnown(string? value) =>
+        !string.IsNullOrEmpty(value) && AllIncludingUnknown.Contains(value);
+}

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/UniverseQuarantineReasons.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/UniverseQuarantineReasons.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: closed vocabulary for the
+/// <c>QuarantineReasonDetail</c> column on
+/// <c>legacy_tf_unproven.imprv_attr</c>. Replaces the single muddy
+/// <c>UNKNOWN_I_ATTR_VAL_CD</c> / <c>UNKNOWN_ATTRIBUTE</c> bucket
+/// with five named reasons that tell the operator WHICH stage of the
+/// pipeline failed.
+///
+/// <para>This vocabulary is orthogonal to the legacy
+/// <see cref="TerraFusion.Core.Entities.SyncBridge.QuarantineReasons"/>
+/// (NoParcelXref / NoOwnerXref / BothMissing / UnknownAttribute) which
+/// remain in use for canonical-layer parcel-xref failures. The
+/// universe-aware reasons here surface only on attribute-side
+/// quarantines.</para>
+///
+/// <para>See <c>docs/sync/sync-doctrine-4-improvement-universe-design.md</c>
+/// §"Quarantine reason taxonomy".</para>
+/// </summary>
+public static class UniverseQuarantineReasons
+{
+    /// <summary>
+    /// Universe classification ran but no rule matched. The row's
+    /// universe is <c>UNKNOWN</c> and there is nothing to look up
+    /// in the per-universe dictionary. Operator action: review the
+    /// universe rule set; either a new rule is needed or an existing
+    /// rule's predicates need widening.
+    /// </summary>
+    public const string UnknownUniverse = "UNKNOWN_UNIVERSE";
+
+    /// <summary>
+    /// Universe was classified successfully but the imprv_attr code
+    /// is missing from THAT universe's dictionary entries. Operator
+    /// action: add the code to the per-universe dictionary, or
+    /// confirm the row is genuinely outside the dictionary.
+    /// </summary>
+    public const string UnknownForUniverseDictionary = "UNKNOWN_FOR_UNIVERSE_DICTIONARY";
+
+    /// <summary>
+    /// Defensive: the classifier did not run for this row at all.
+    /// Should be rare; emitted when the property-level signals
+    /// (prop_type_cd, property_use_cd, ag_apply) couldn't be loaded
+    /// (e.g. raw property table missing the prop_id). Operator
+    /// action: ensure SYNC-POP-4a property landing has run for this
+    /// batch's prop_ids.
+    /// </summary>
+    public const string UniverseNotEvaluated = "UNIVERSE_NOT_EVALUATED";
+
+    /// <summary>
+    /// Universe was classified, but the per-universe dictionary
+    /// table contains zero active rows for that universe. Operator
+    /// action: run the attribute-dictionary refresh / seeder for
+    /// that universe before re-draining.
+    /// </summary>
+    public const string DictionaryNotLoadedForUniverse = "DICTIONARY_NOT_LOADED_FOR_UNIVERSE";
+
+    /// <summary>
+    /// CONVERSION_LEGACY rule fired but the legacy marker is weak
+    /// evidence (e.g. missing PropCreateDt; deduced rather than
+    /// explicit). Operator action: review the legacy marker logic
+    /// and either tighten the rule or accept the deduced
+    /// classification.
+    /// </summary>
+    public const string LegacyClassificationUncertain = "LEGACY_CLASSIFICATION_UNCERTAIN";
+
+    /// <summary>All five recognized universe-aware quarantine reasons.</summary>
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>
+    {
+        UnknownUniverse,
+        UnknownForUniverseDictionary,
+        UniverseNotEvaluated,
+        DictionaryNotLoadedForUniverse,
+        LegacyClassificationUncertain,
+    };
+
+    /// <summary>True iff <paramref name="value"/> is a recognized universe-aware quarantine reason.</summary>
+    public static bool IsKnown(string? value) =>
+        !string.IsNullOrEmpty(value) && All.Contains(value);
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfImprovementConfiguration.cs
@@ -42,5 +42,13 @@ public sealed class TfImprovementConfiguration : IEntityTypeConfiguration<TfImpr
         builder.Property(x => x.ConversionEra).HasMaxLength(20);
         builder.HasIndex(x => x.ConversionEra)
             .HasDatabaseName("ix_tf_improvement_conversion_era");
+
+        // SYNC-DOCTRINE-4: universe classification (forwarded from truth).
+        builder.Property(x => x.UniverseCode).HasMaxLength(50);
+        builder.Property(x => x.UniverseRuleId);
+        builder.Property(x => x.UniverseConfidence).HasMaxLength(8);
+        builder.Property(x => x.UniverseReason).HasMaxLength(1024);
+        builder.HasIndex(x => x.UniverseCode)
+            .HasDatabaseName("ix_tf_improvement_universe");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrineAttributeDictionaryConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrineAttributeDictionaryConfiguration.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.DoctrineTf;
+
+namespace TerraFusion.Data.Configurations.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: EF configuration for
+/// <see cref="TfDoctrineAttributeDictionary"/>.
+/// Schema <c>doctrine_tf</c>; table
+/// <c>tf_doctrine_attribute_dictionary</c>.
+/// </summary>
+public sealed class TfDoctrineAttributeDictionaryConfiguration
+    : IEntityTypeConfiguration<TfDoctrineAttributeDictionary>
+{
+    public void Configure(EntityTypeBuilder<TfDoctrineAttributeDictionary> builder)
+    {
+        builder.ToTable("tf_doctrine_attribute_dictionary", schema: "doctrine_tf");
+
+        builder.HasKey(x => x.DictionaryRowId);
+        builder.Property(x => x.DictionaryRowId).IsRequired();
+
+        builder.Property(x => x.County).IsRequired().HasMaxLength(64);
+
+        builder.Property(x => x.EffectiveStartYear).IsRequired();
+        builder.Property(x => x.EffectiveEndYear);
+
+        builder.Property(x => x.UniverseCode).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.ImprvAttrId).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.IAttrValCd).IsRequired().HasMaxLength(200);
+
+        builder.Property(x => x.AttributeDescription).HasMaxLength(500);
+        builder.Property(x => x.AttributeGroup).HasMaxLength(100);
+        builder.Property(x => x.SourceTable).HasMaxLength(200);
+        builder.Property(x => x.SourceKey).HasMaxLength(200);
+
+        builder.Property(x => x.Reason).IsRequired().HasMaxLength(1024);
+        builder.Property(x => x.EvidenceSource).IsRequired().HasMaxLength(1024);
+
+        builder.Property(x => x.Confidence)
+            .IsRequired()
+            .HasMaxLength(8)
+            .HasDefaultValue("MED");
+
+        builder.Property(x => x.Notes).HasMaxLength(2048);
+
+        builder.Property(x => x.ActiveFlag).IsRequired().HasDefaultValue(true);
+
+        builder.Property(x => x.ApprovedBy).HasMaxLength(128);
+        builder.Property(x => x.ApprovedAt);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(128);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(128);
+
+        // Uniqueness: one entry per (county, universe, code, value, year).
+        // Per design doc §"tf_doctrine_attribute_dictionary".
+        builder.HasIndex(x => new
+            {
+                x.County, x.UniverseCode, x.ImprvAttrId, x.IAttrValCd, x.EffectiveStartYear,
+            })
+            .IsUnique()
+            .HasDatabaseName("uq_tf_doctrine_attribute_dictionary");
+
+        // Lookup: per-universe scan for the in-memory cache build.
+        builder.HasIndex(x => new { x.County, x.UniverseCode, x.ActiveFlag })
+            .HasDatabaseName("ix_tf_doctrine_attribute_dictionary_lookup");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrinePropertyUniverseConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrinePropertyUniverseConfiguration.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.DoctrineTf;
+
+namespace TerraFusion.Data.Configurations.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: EF configuration for
+/// <see cref="TfDoctrinePropertyUniverse"/>.
+/// Schema <c>doctrine_tf</c>; table
+/// <c>tf_doctrine_property_universe</c>.
+/// </summary>
+public sealed class TfDoctrinePropertyUniverseConfiguration
+    : IEntityTypeConfiguration<TfDoctrinePropertyUniverse>
+{
+    public void Configure(EntityTypeBuilder<TfDoctrinePropertyUniverse> builder)
+    {
+        builder.ToTable("tf_doctrine_property_universe", schema: "doctrine_tf");
+
+        builder.HasKey(x => x.RuleId);
+        builder.Property(x => x.RuleId).IsRequired();
+
+        builder.Property(x => x.County).IsRequired().HasMaxLength(64);
+
+        builder.Property(x => x.EffectiveStartYear).IsRequired();
+        builder.Property(x => x.EffectiveEndYear);
+
+        builder.Property(x => x.Precedence).IsRequired();
+
+        // Closed vocab from UniverseCodes; widest is "PERSONAL_PROPERTY" (17 chars).
+        builder.Property(x => x.UniverseCode).IsRequired().HasMaxLength(50);
+
+        builder.Property(x => x.PropTypeCdCsv).HasMaxLength(200);
+        // Property-use codes can grow long when tightening commercial/residential
+        // boundaries against profiling data. Allow generous room.
+        builder.Property(x => x.PropertyUseCdCsv).HasMaxLength(2000);
+
+        builder.Property(x => x.PropertyUseMode)
+            .IsRequired()
+            .HasMaxLength(20)
+            .HasDefaultValue("ANY");
+
+        builder.Property(x => x.AgApplyValue).HasMaxLength(10);
+        builder.Property(x => x.AgUseCdCsv).HasMaxLength(200);
+
+        builder.Property(x => x.RequiresLegacyMarker).IsRequired();
+        builder.Property(x => x.LegacyMarkerType).HasMaxLength(50);
+        builder.Property(x => x.LegacyMarkerValue).HasMaxLength(200);
+
+        builder.Property(x => x.Reason).IsRequired().HasMaxLength(1024);
+        builder.Property(x => x.EvidenceSource).IsRequired().HasMaxLength(1024);
+
+        builder.Property(x => x.Confidence)
+            .IsRequired()
+            .HasMaxLength(8)
+            .HasDefaultValue("MED");
+
+        builder.Property(x => x.Notes).HasMaxLength(2048);
+
+        builder.Property(x => x.ActiveFlag).IsRequired().HasDefaultValue(true);
+
+        builder.Property(x => x.ApprovedBy).HasMaxLength(128);
+        builder.Property(x => x.ApprovedAt);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(128);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(128);
+
+        // Primary lookup index: classifier walks active rules for a
+        // county ordered by precedence ASC.
+        builder.HasIndex(x => new { x.County, x.ActiveFlag, x.Precedence })
+            .HasDatabaseName("ix_tf_doctrine_property_universe_county_active_prec");
+
+        // Secondary: per-universe effective-window scan for audits and
+        // admin endpoints.
+        builder.HasIndex(x => new { x.County, x.UniverseCode, x.EffectiveStartYear })
+            .HasDatabaseName("ix_tf_doctrine_property_universe_county_universe_start");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/LegacyTfUnproven/LegacyTfUnprovenImprvAttrConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/LegacyTfUnproven/LegacyTfUnprovenImprvAttrConfiguration.cs
@@ -44,5 +44,14 @@ public sealed class LegacyTfUnprovenImprvAttrConfiguration
 
         builder.HasIndex(x => x.LandingLoadBatchId)
             .HasDatabaseName("ix_legacy_tf_unproven_imprv_attr_landingbatch");
+
+        // SYNC-DOCTRINE-4: universe-aware quarantine context.
+        builder.Property(x => x.UniverseCode).HasMaxLength(50);
+        builder.Property(x => x.UniverseRuleId);
+        builder.Property(x => x.QuarantineReasonDetail).HasMaxLength(50);
+        builder.HasIndex(x => x.UniverseCode)
+            .HasDatabaseName("ix_legacy_tf_unproven_imprv_attr_universe");
+        builder.HasIndex(x => x.QuarantineReasonDetail)
+            .HasDatabaseName("ix_legacy_tf_unproven_imprv_attr_reason_detail");
     }
 }

--- a/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsImprvCurrentConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/TruthPacs/TruthPacsImprvCurrentConfiguration.cs
@@ -58,5 +58,13 @@ public sealed class TruthPacsImprvCurrentConfiguration
         builder.Property(x => x.ConversionEra).HasMaxLength(20);
         builder.HasIndex(x => x.ConversionEra)
             .HasDatabaseName("ix_truth_pacs_imprv_conversion_era");
+
+        // SYNC-DOCTRINE-4: universe classification surface.
+        builder.Property(x => x.UniverseCode).HasMaxLength(50);
+        builder.Property(x => x.UniverseRuleId);
+        builder.Property(x => x.UniverseConfidence).HasMaxLength(8);
+        builder.Property(x => x.UniverseReason).HasMaxLength(1024);
+        builder.HasIndex(x => x.UniverseCode)
+            .HasDatabaseName("ix_truth_pacs_imprv_universe");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260506073029_SyncDoctrine4PropertyUniverseAndAttributeDictionary.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506073029_SyncDoctrine4PropertyUniverseAndAttributeDictionary.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506073029_SyncDoctrine4PropertyUniverseAndAttributeDictionary")]
+    partial class SyncDoctrine4PropertyUniverseAndAttributeDictionary
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260506073029_SyncDoctrine4PropertyUniverseAndAttributeDictionary.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506073029_SyncDoctrine4PropertyUniverseAndAttributeDictionary.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncDoctrine4PropertyUniverseAndAttributeDictionary : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "QuarantineReasonDetail",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseCode",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UniverseRuleId",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseCode",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseConfidence",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseReason",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UniverseRuleId",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseCode",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseConfidence",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniverseReason",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "UniverseRuleId",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "tf_doctrine_attribute_dictionary",
+                schema: "doctrine_tf",
+                columns: table => new
+                {
+                    DictionaryRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    County = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    EffectiveStartYear = table.Column<int>(type: "integer", nullable: false),
+                    EffectiveEndYear = table.Column<int>(type: "integer", nullable: true),
+                    UniverseCode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ImprvAttrId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IAttrValCd = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AttributeDescription = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    AttributeGroup = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    SourceTable = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    SourceKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Reason = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    EvidenceSource = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    Confidence = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false, defaultValue: "MED"),
+                    Notes = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    ActiveFlag = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    ApprovedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    ApprovedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tf_doctrine_attribute_dictionary", x => x.DictionaryRowId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "tf_doctrine_property_universe",
+                schema: "doctrine_tf",
+                columns: table => new
+                {
+                    RuleId = table.Column<Guid>(type: "uuid", nullable: false),
+                    County = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    EffectiveStartYear = table.Column<int>(type: "integer", nullable: false),
+                    EffectiveEndYear = table.Column<int>(type: "integer", nullable: true),
+                    Precedence = table.Column<int>(type: "integer", nullable: false),
+                    UniverseCode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    PropTypeCdCsv = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PropertyUseCdCsv = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    PropertyUseMode = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "ANY"),
+                    AgApplyValue = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true),
+                    AgUseCdCsv = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    RequiresLegacyMarker = table.Column<bool>(type: "boolean", nullable: false),
+                    LegacyMarkerType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    LegacyMarkerValue = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Reason = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    EvidenceSource = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    Confidence = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false, defaultValue: "MED"),
+                    Notes = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    ActiveFlag = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    ApprovedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    ApprovedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tf_doctrine_property_universe", x => x.RuleId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_tf_unproven_imprv_attr_reason_detail",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr",
+                column: "QuarantineReasonDetail");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_tf_unproven_imprv_attr_universe",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr",
+                column: "UniverseCode");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_improvement_universe",
+                schema: "canonical_tf",
+                table: "tf_improvement",
+                column: "UniverseCode");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_truth_pacs_imprv_universe",
+                schema: "truth_pacs",
+                table: "imprv_current",
+                column: "UniverseCode");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_attribute_dictionary_lookup",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_attribute_dictionary",
+                columns: new[] { "County", "UniverseCode", "ActiveFlag" });
+
+            migrationBuilder.CreateIndex(
+                name: "uq_tf_doctrine_attribute_dictionary",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_attribute_dictionary",
+                columns: new[] { "County", "UniverseCode", "ImprvAttrId", "IAttrValCd", "EffectiveStartYear" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_property_universe_county_active_prec",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_property_universe",
+                columns: new[] { "County", "ActiveFlag", "Precedence" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_property_universe_county_universe_start",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_property_universe",
+                columns: new[] { "County", "UniverseCode", "EffectiveStartYear" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tf_doctrine_attribute_dictionary",
+                schema: "doctrine_tf");
+
+            migrationBuilder.DropTable(
+                name: "tf_doctrine_property_universe",
+                schema: "doctrine_tf");
+
+            migrationBuilder.DropIndex(
+                name: "ix_legacy_tf_unproven_imprv_attr_reason_detail",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr");
+
+            migrationBuilder.DropIndex(
+                name: "ix_legacy_tf_unproven_imprv_attr_universe",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_improvement_universe",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropIndex(
+                name: "ix_truth_pacs_imprv_universe",
+                schema: "truth_pacs",
+                table: "imprv_current");
+
+            migrationBuilder.DropColumn(
+                name: "QuarantineReasonDetail",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseCode",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseRuleId",
+                schema: "legacy_tf_unproven",
+                table: "unresolved_imprv_attr");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseCode",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseConfidence",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseReason",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseRuleId",
+                schema: "canonical_tf",
+                table: "tf_improvement");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseCode",
+                schema: "truth_pacs",
+                table: "imprv_current");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseConfidence",
+                schema: "truth_pacs",
+                table: "imprv_current");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseReason",
+                schema: "truth_pacs",
+                table: "imprv_current");
+
+            migrationBuilder.DropColumn(
+                name: "UniverseRuleId",
+                schema: "truth_pacs",
+                table: "imprv_current");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
@@ -12,6 +12,7 @@ using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.LegacyTfUnproven;
 using TerraFusion.Core.Entities.SyncBridge;
 using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
 using TerraFusion.Core.Sync.PacsImprvCanonical;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
@@ -42,17 +43,21 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
 {
     private const string EntityType = "improvement";
     private const string ParcelEntityType = "parcel";
+    private const string DefaultCountyTag = "benton-wa";
     // E4a (v1.4): quarantine reasons live in QuarantineReasons —
     // see docs/pacs/block-c-contract-v1.4.md.
 
     private readonly TerraFusionDbContext _db;
+    private readonly IPerUniverseAttributeDictionary _universeAttributeDictionary;
     private readonly ILogger<PacsImprvCanonicalProjector> _logger;
 
     public PacsImprvCanonicalProjector(
         TerraFusionDbContext db,
+        IPerUniverseAttributeDictionary universeAttributeDictionary,
         ILogger<PacsImprvCanonicalProjector> logger)
     {
         _db = db;
+        _universeAttributeDictionary = universeAttributeDictionary;
         _logger = logger;
     }
 
@@ -287,6 +292,11 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                     // G2 (v1.11): era resolved via majority-of-truth.
                     // Single contributor → verbatim copy.
                     ConversionEra = ConversionEras.MajorityOfTruth(new[] { truth.ConversionEra }),
+                    // SYNC-DOCTRINE-4: forward universe classification verbatim.
+                    UniverseCode = truth.UniverseCode,
+                    UniverseRuleId = truth.UniverseRuleId,
+                    UniverseConfidence = truth.UniverseConfidence,
+                    UniverseReason = truth.UniverseReason,
                     CreatedAt = now,
                     UpdatedAt = now,
                 };
@@ -387,6 +397,15 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                             // (distinct from landing-layer quarantine
                             // which uses UNKNOWN_I_ATTR_VAL_CD). See
                             // v1.5 §2.2 step 4.
+                            //
+                            // SYNC-DOCTRINE-4: enrich the quarantine row
+                            // with universe context so the operator can
+                            // distinguish classification failure from
+                            // dictionary-not-loaded from genuine
+                            // unknown-code-within-known-universe.
+                            var detailReason = await ResolveQuarantineReasonDetailAsync(
+                                truth, attr, cancellationToken).ConfigureAwait(false);
+
                             _db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
                             {
                                 PropValYr = attr.PropValYr,
@@ -404,6 +423,9 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                                 // awkwardness flagged for v1.6+ cleanup.
                                 LandingLoadBatchId = batch.LoadBatchId,
                                 QuarantineReason = QuarantineReasons.UnknownAttribute,
+                                UniverseCode = truth.UniverseCode,
+                                UniverseRuleId = truth.UniverseRuleId,
+                                QuarantineReasonDetail = detailReason,
                                 CreatedAt = now,
                             });
                             attributesQuarantined++;
@@ -476,6 +498,42 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
                 ErrorSummary = summary,
             };
         }
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4: derive a universe-aware quarantine-reason
+    /// detail for an attribute that the global AttributeDefinition
+    /// lookup couldn't resolve.
+    ///
+    /// <para>Five possible reasons (closed vocabulary in
+    /// <see cref="UniverseQuarantineReasons"/>): UniverseNotEvaluated
+    /// (truth row's universe is unclassified or UNKNOWN), then any of
+    /// DictionaryNotLoadedForUniverse / UnknownForUniverseDictionary
+    /// returned by the per-universe dictionary lookup. The
+    /// LegacyClassificationUncertain reason is reserved for the
+    /// classifier's hint surface and is not produced from the
+    /// quarantine path.</para>
+    /// </summary>
+    private async Task<string> ResolveQuarantineReasonDetailAsync(
+        TruthPacsImprvCurrent truth,
+        LegacyPacsRawImprvAttr attr,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(truth.UniverseCode)
+            || string.Equals(truth.UniverseCode, UniverseCodes.Unknown, StringComparison.OrdinalIgnoreCase))
+        {
+            return UniverseQuarantineReasons.UniverseNotEvaluated;
+        }
+
+        var lookup = await _universeAttributeDictionary.LookupAsync(
+            DefaultCountyTag,
+            truth.UniverseCode,
+            truth.PropValYr,
+            attr.IAttrValId.ToString(CultureInfo.InvariantCulture),
+            attr.IAttrValCd,
+            cancellationToken).ConfigureAwait(false);
+
+        return lookup.QuarantineReason ?? UniverseQuarantineReasons.UnknownForUniverseDictionary;
     }
 
     private async Task<IReadOnlyDictionary<int, ParcelLookup>> BuildParcelIndexAsync(

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineAttributeDictionarySeeder.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineAttributeDictionarySeeder.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: per-universe attribute-dictionary seeder.
+///
+/// <para>Initial seed is intentionally empty per the design doc
+/// §"Out of scope": "initial seed deferred until a profiling drain
+/// produces per-universe code distributions". The seeder is wired
+/// up so the operator can populate per-universe entries via a
+/// future POST endpoint or by editing
+/// <see cref="BuildSeedEntries"/> directly.</para>
+///
+/// <para>Idempotent over deterministic
+/// <see cref="TfDoctrineAttributeDictionary.DictionaryRowId"/>.
+/// Inserting zero rows is the expected initial outcome.</para>
+/// </summary>
+public sealed class DoctrineAttributeDictionarySeeder
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<DoctrineAttributeDictionarySeeder> _logger;
+
+    public DoctrineAttributeDictionarySeeder(
+        TerraFusionDbContext db,
+        ILogger<DoctrineAttributeDictionarySeeder> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<int> SeedAsync(CancellationToken cancellationToken = default)
+    {
+        var seed = BuildSeedEntries();
+        if (seed.Count == 0)
+        {
+            _logger.LogDebug(
+                "DoctrineAttributeDictionarySeeder: no entries seeded (initial empty seed); " +
+                "operator will populate after profiling drain.");
+            return 0;
+        }
+
+        var existingIds = await _db.TfDoctrineAttributeDictionaries
+            .Select(e => e.DictionaryRowId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var existingSet = new HashSet<Guid>(existingIds);
+
+        var added = 0;
+        foreach (var entry in seed)
+        {
+            if (existingSet.Contains(entry.DictionaryRowId)) continue;
+            _db.TfDoctrineAttributeDictionaries.Add(entry);
+            added++;
+        }
+
+        if (added > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "DoctrineAttributeDictionarySeeder: inserted {Added} entries; existing {Existing}",
+                added, existingSet.Count);
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// Empty by design. Tighten by adding deterministic-GUID
+    /// entries here once a profiling drain produces per-universe
+    /// code distributions; or the operator can drive population
+    /// through a future admin endpoint.
+    /// </summary>
+    private static IReadOnlyList<TfDoctrineAttributeDictionary> BuildSeedEntries() =>
+        Array.Empty<TfDoctrineAttributeDictionary>();
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeeder.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeeder.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: seed the six initial universe rules for Benton.
+///
+/// <para>Idempotent. Each rule has a deterministic
+/// <see cref="TfDoctrinePropertyUniverse.RuleId"/> so repeat
+/// invocations are no-ops.</para>
+///
+/// <para>Per design doc §"Initial seed-rule design": broad first
+/// pass — no overfitting. Tightening property_use_cd coverage waits
+/// on a profiling drain that captures live distributions.</para>
+/// </summary>
+public sealed class DoctrinePropertyUniverseSeeder
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<DoctrinePropertyUniverseSeeder> _logger;
+
+    public DoctrinePropertyUniverseSeeder(
+        TerraFusionDbContext db,
+        ILogger<DoctrinePropertyUniverseSeeder> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<int> SeedAsync(CancellationToken cancellationToken = default)
+    {
+        var seedRules = BuildBentonSeed();
+
+        var existingIds = await _db.TfDoctrinePropertyUniverses
+            .Select(r => r.RuleId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var existingSet = new HashSet<Guid>(existingIds);
+
+        var added = 0;
+        foreach (var rule in seedRules)
+        {
+            if (existingSet.Contains(rule.RuleId)) continue;
+            _db.TfDoctrinePropertyUniverses.Add(rule);
+            added++;
+        }
+
+        if (added > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "DoctrinePropertyUniverseSeeder: inserted {Added} rule(s); existing {Existing}",
+                added, existingSet.Count);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "DoctrinePropertyUniverseSeeder: no new rules; {Existing} already present",
+                existingSet.Count);
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// Six locked seed rules, all evidence-cited. Precedence values
+    /// match the design doc §"Locked precedence" exactly.
+    /// </summary>
+    private static TfDoctrinePropertyUniverse[] BuildBentonSeed()
+    {
+        // Deterministic GUIDs — d0c7d0c7 = "doctrine seed", 0040 = SYNC-DOCTRINE-4,
+        // final group encodes county-fips '53005' (Benton WA).
+        var ruleConvLegacy   = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010");
+        var ruleAgCurrentUse = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005020");
+        var rulePersonalProp = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005030");
+        var ruleMobileHome   = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005040");
+        var ruleRealComm     = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005050");
+        var ruleRealResid    = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005060");
+
+        var approvedAt = new DateTime(2026, 5, 6, 0, 0, 0, DateTimeKind.Utc);
+        var approver = "operator-bsval";
+
+        return new[]
+        {
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleConvLegacy,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 1,
+                UniverseCode = UniverseCodes.ConversionLegacy,
+                PropTypeCdCsv = null,
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = null,
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = true,
+                LegacyMarkerType = "CREATED_DT_PRE_2017",
+                LegacyMarkerValue = null,
+                Reason = "CONVERSION_LEGACY: only fires when current PACS domain rules can't " +
+                         "classify confidently AND a legacy marker is present. Conservative.",
+                EvidenceSource = "design doc §Locked precedence; PACS conversion 2017 historical fact",
+                Confidence = "MED",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "Initial marker = CREATED_DT_PRE_2017. SOURCE_SYSTEM and IMPORT_BATCH " +
+                        "variants reserved for future tightening.",
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleAgCurrentUse,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 2,
+                UniverseCode = UniverseCodes.AgCurrentUse,
+                PropTypeCdCsv = null,
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = "T",
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = false,
+                Reason = "AG_CURRENT_USE: ag/current-use/open-space valuation universe overrides " +
+                         "normal R/commercial splits when ag_apply='T'.",
+                EvidenceSource = "dbo.land_detail.ag_apply distributions audited 2026-05-06; " +
+                                 "T/AG=27381 attr-rows, T/OSP=65, T/CNV=23",
+                Confidence = "HIGH",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "Single AG_CURRENT_USE bucket per design doc §Out of scope. Future " +
+                        "split into AG/OSP/CNV deferred until profiling.",
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = rulePersonalProp,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 3,
+                UniverseCode = UniverseCodes.PersonalProperty,
+                PropTypeCdCsv = "P,B",
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = null,
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = false,
+                Reason = "PERSONAL_PROPERTY: BPP / business-personal schedules have distinct " +
+                         "attribute semantics from real property.",
+                EvidenceSource = "Benton personal-property monitor (operator-supplied); " +
+                                 "PACS prop_type_cd ∈ {P,B} for business personal property",
+                Confidence = "HIGH",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "Widening beyond {P,B} deferred until Benton-specific evidence " +
+                        "supports more types.",
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleMobileHome,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 4,
+                UniverseCode = UniverseCodes.MobileHome,
+                PropTypeCdCsv = "MH",
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = null,
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = false,
+                Reason = "MOBILE_HOME: real-but-not-stick-built; PACS attribute namespace " +
+                         "diverges from stick-built residential.",
+                EvidenceSource = "PACS prop_type_cd='MH' distribution audit; ~1% of rows",
+                Confidence = "HIGH",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleRealComm,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 5,
+                UniverseCode = UniverseCodes.RealCommercial,
+                PropTypeCdCsv = "R",
+                PropertyUseMode = "EXCLUDE",
+                // EXCLUDE: residential property_use codes excluded from this rule;
+                // remaining codes route to commercial. Tighten after profiling drain.
+                PropertyUseCdCsv = "11,12,13,14,18",
+                AgApplyValue = "F",
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = false,
+                Reason = "REAL_COMMERCIAL: broad non-residential real-property bucket. Tighten " +
+                         "PropertyUseCdCsv against observed commercial distribution after first " +
+                         "profiling drain.",
+                EvidenceSource = "Operator audit of property_use_cd dominant cells (R/11,12,13,14,18 " +
+                                 "are residential majority — exclude → commercial)",
+                Confidence = "MED",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "EXCLUDE mode is the broad first-pass approach. Replace with INCLUDE " +
+                        "when commercial property_use_cd distribution is known.",
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleRealResid,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 6,
+                UniverseCode = UniverseCodes.RealResidential,
+                PropTypeCdCsv = "R",
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = "F",
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = false,
+                Reason = "REAL_RESIDENTIAL: default real-property residential bucket after higher-" +
+                         "precedence rules resolve.",
+                EvidenceSource = "PACS prop_type_cd='R' distribution audit; ~61% of rows; " +
+                                 "remainder after AG/MH/PP/COMMERCIAL filtered",
+                Confidence = "MED",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "MED rather than HIGH because the ag_apply='F' guard is conservative; " +
+                        "a row with ag_apply=NULL (genuinely missing land row) won't match " +
+                        "this rule and will fall through to UNKNOWN. That's intentional — " +
+                        "reflect the data faithfully.",
+            },
+        };
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeederHostedService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeederHostedService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: hosted service that runs the universe seeder
+/// (always) and the attribute-dictionary seeder (no-op on initial
+/// empty seed) once at backend startup.
+///
+/// <para>Idempotent. Failure is non-fatal: if seeding throws (e.g.
+/// migration not applied yet), the host logs a warning and proceeds.
+/// The classifier will still operate; with zero rules it will
+/// classify everything as UNKNOWN with reason
+/// <c>UNKNOWN_UNIVERSE</c>, which is the correct safe default.</para>
+/// </summary>
+public sealed class DoctrinePropertyUniverseSeederHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<DoctrinePropertyUniverseSeederHostedService> _logger;
+
+    public DoctrinePropertyUniverseSeederHostedService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<DoctrinePropertyUniverseSeederHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+
+            var universeSeeder = scope.ServiceProvider
+                .GetRequiredService<DoctrinePropertyUniverseSeeder>();
+            var universeAdded = await universeSeeder.SeedAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var dictSeeder = scope.ServiceProvider
+                .GetRequiredService<DoctrineAttributeDictionarySeeder>();
+            var dictAdded = await dictSeeder.SeedAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "DoctrinePropertyUniverseSeederHostedService: startup ran; " +
+                "universe rules added={Universe} dictionary entries added={Dict}",
+                universeAdded, dictAdded);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: doctrine tables may not exist yet (migration
+            // pending). Classifier will treat everything as UNKNOWN
+            // until the seeder runs successfully.
+            _logger.LogWarning(ex,
+                "DoctrinePropertyUniverseSeederHostedService: startup seed failed; " +
+                "operator may need to run POST /api/sync/doctrine/policy/universe/seed manually");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/PerUniverseAttributeDictionary.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/PerUniverseAttributeDictionary.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: default <see cref="IPerUniverseAttributeDictionary"/>
+/// backed by <c>doctrine_tf.tf_doctrine_attribute_dictionary</c>.
+///
+/// <para>Registered Singleton; cached per <c>(county, universe)</c>.
+/// Cache contains a <see cref="HashSet{T}"/> of
+/// <c>(imprv_attr_id || '|' || i_attr_val_cd)</c> pairs alongside
+/// the matching <see cref="TfDoctrineAttributeDictionary"/> row for
+/// returning the dictionary row id.</para>
+///
+/// <para>Empty cache for a known universe yields
+/// <see cref="DictionaryLookupResult.DictionaryNotLoaded"/> rather
+/// than <see cref="DictionaryLookupResult.UnknownForUniverse"/>;
+/// this lets the operator distinguish "code is genuinely absent"
+/// from "we haven't seeded this universe's dictionary yet".</para>
+/// </summary>
+public sealed class PerUniverseAttributeDictionary : IPerUniverseAttributeDictionary
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PerUniverseAttributeDictionary> _logger;
+
+    // (county, universe) → dictionary entries (active only).
+    private readonly ConcurrentDictionary<(string County, string Universe),
+        IReadOnlyList<TfDoctrineAttributeDictionary>> _cache =
+            new(new CountyUniverseKeyComparer());
+
+    public PerUniverseAttributeDictionary(
+        IServiceScopeFactory scopeFactory,
+        ILogger<PerUniverseAttributeDictionary> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<DictionaryLookupResult> LookupAsync(
+        string county,
+        string universeCode,
+        int year,
+        string imprvAttrId,
+        string iAttrValCd,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(county))
+            throw new ArgumentException("County is required.", nameof(county));
+        if (string.IsNullOrWhiteSpace(universeCode))
+            return DictionaryLookupResult.NotEvaluated();
+
+        // UNKNOWN sentinel never has dictionary entries by definition.
+        if (string.Equals(universeCode, UniverseCodes.Unknown, StringComparison.OrdinalIgnoreCase))
+            return DictionaryLookupResult.NotEvaluated();
+
+        var entries = await GetEntriesAsync(county, universeCode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entries.Count == 0)
+            return DictionaryLookupResult.DictionaryNotLoaded();
+
+        var match = entries
+            .Where(e => year >= e.EffectiveStartYear
+                     && (e.EffectiveEndYear == null || year <= e.EffectiveEndYear))
+            .Where(e => string.Equals(e.ImprvAttrId, imprvAttrId, StringComparison.Ordinal)
+                     && string.Equals(e.IAttrValCd, iAttrValCd, StringComparison.Ordinal))
+            .OrderByDescending(e => e.ApprovedAt ?? e.CreatedAt)
+            .FirstOrDefault();
+
+        return match is null
+            ? DictionaryLookupResult.UnknownForUniverse()
+            : DictionaryLookupResult.Known(match.DictionaryRowId);
+    }
+
+    public async Task<int> CountForUniverseAsync(
+        string county, string universeCode, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(county) || string.IsNullOrWhiteSpace(universeCode)) return 0;
+        if (string.Equals(universeCode, UniverseCodes.Unknown, StringComparison.OrdinalIgnoreCase))
+            return 0;
+
+        var entries = await GetEntriesAsync(county, universeCode, cancellationToken)
+            .ConfigureAwait(false);
+        return entries.Count;
+    }
+
+    public void InvalidateCache(string? county = null)
+    {
+        if (county is null) { _cache.Clear(); return; }
+        var keys = _cache.Keys.Where(k =>
+            string.Equals(k.County, county, StringComparison.OrdinalIgnoreCase)).ToList();
+        foreach (var k in keys) _cache.TryRemove(k, out _);
+    }
+
+    // ── private ────────────────────────────────────────────────────────
+
+    private async Task<IReadOnlyList<TfDoctrineAttributeDictionary>> GetEntriesAsync(
+        string county, string universeCode, CancellationToken cancellationToken)
+    {
+        var key = (county, universeCode);
+        if (_cache.TryGetValue(key, out var cached)) return cached;
+
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        var entries = await db.TfDoctrineAttributeDictionaries
+            .AsNoTracking()
+            .Where(e => e.County == county
+                     && e.UniverseCode == universeCode
+                     && e.ActiveFlag)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "PerUniverseAttributeDictionary: loaded {Count} entries for ({County}, {Universe})",
+            entries.Count, county, universeCode);
+
+        _cache[key] = entries;
+        return entries;
+    }
+
+    private sealed class CountyUniverseKeyComparer
+        : IEqualityComparer<(string County, string Universe)>
+    {
+        public bool Equals(
+            (string County, string Universe) x,
+            (string County, string Universe) y) =>
+            StringComparer.OrdinalIgnoreCase.Equals(x.County, y.County)
+            && StringComparer.OrdinalIgnoreCase.Equals(x.Universe, y.Universe);
+
+        public int GetHashCode((string County, string Universe) obj) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.County ?? string.Empty),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Universe ?? string.Empty));
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/PropertyUniverseClassifier.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/PropertyUniverseClassifier.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4: default <see cref="IPropertyUniverseClassifier"/>
+/// backed by <c>doctrine_tf.tf_doctrine_property_universe</c>.
+///
+/// <para>Registered Singleton; uses <see cref="IServiceScopeFactory"/>
+/// to read the rule table on cache miss. Same lifetime/cache pattern
+/// as <see cref="RatioQualificationPolicy"/> (B1).</para>
+///
+/// <para>Match algorithm (per design doc §"Locked precedence"):
+/// for each county, walk active rules whose effective year window
+/// covers <c>input.PropValYr</c>, ordered by <c>Precedence ASC</c>;
+/// return the first rule whose predicates all match. If
+/// <c>RequiresLegacyMarker</c> is true the rule fires only when
+/// <c>input.HasLegacyMarker</c> is also true.</para>
+/// </summary>
+public sealed class PropertyUniverseClassifier : IPropertyUniverseClassifier
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PropertyUniverseClassifier> _logger;
+
+    private readonly ConcurrentDictionary<string, IReadOnlyList<TfDoctrinePropertyUniverse>>
+        _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public PropertyUniverseClassifier(
+        IServiceScopeFactory scopeFactory,
+        ILogger<PropertyUniverseClassifier> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task<UniverseClassification> ClassifyAsync(
+        UniverseClassifierInput input,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (string.IsNullOrWhiteSpace(input.County))
+            throw new ArgumentException("County is required.", nameof(input));
+
+        var rules = await GetRulesAsync(input.County, cancellationToken).ConfigureAwait(false);
+
+        // Filter: active, year window covers input.PropValYr.
+        var candidates = rules
+            .Where(r => r.ActiveFlag)
+            .Where(r => input.PropValYr >= r.EffectiveStartYear
+                     && (r.EffectiveEndYear == null || input.PropValYr <= r.EffectiveEndYear))
+            .OrderBy(r => r.Precedence)
+            .ThenBy(r => r.RuleId);
+
+        foreach (var rule in candidates)
+        {
+            if (!RuleMatches(rule, input)) continue;
+
+            // Conversion-legacy uncertainty: rule fired but the marker
+            // is the weakest available form (HasLegacyMarker = true is
+            // currently the only signal we accept; future revisions
+            // could downgrade based on marker source).
+            string? quarantineHint = null;
+            if (rule.UniverseCode == UniverseCodes.ConversionLegacy
+                && rule.Confidence == "LOW")
+            {
+                quarantineHint = UniverseQuarantineReasons.LegacyClassificationUncertain;
+            }
+
+            return new UniverseClassification(
+                UniverseCode: rule.UniverseCode,
+                RuleId: rule.RuleId,
+                Confidence: rule.Confidence,
+                Reason: rule.Reason,
+                QuarantineReasonHint: quarantineHint);
+        }
+
+        // No rule fired → UNKNOWN sentinel.
+        var diagnostic = $"no rule matched (prop_type_cd={input.PropTypeCd ?? "NULL"}, " +
+                         $"property_use_cd={input.PropertyUseCd ?? "NULL"}, " +
+                         $"ag_apply={input.AgApply ?? "NULL"}, year={input.PropValYr})";
+        return new UniverseClassification(
+            UniverseCode: UniverseCodes.Unknown,
+            RuleId: null,
+            Confidence: "LOW",
+            Reason: diagnostic,
+            QuarantineReasonHint: UniverseQuarantineReasons.UnknownUniverse);
+    }
+
+    public void InvalidateCache(string? county = null)
+    {
+        if (county is null) _cache.Clear();
+        else _cache.TryRemove(county, out _);
+    }
+
+    // ── private ────────────────────────────────────────────────────────
+
+    private async Task<IReadOnlyList<TfDoctrinePropertyUniverse>> GetRulesAsync(
+        string county, CancellationToken cancellationToken)
+    {
+        if (_cache.TryGetValue(county, out var cached)) return cached;
+
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        var rules = await db.TfDoctrinePropertyUniverses
+            .AsNoTracking()
+            .Where(r => r.County == county)
+            .OrderBy(r => r.Precedence)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "PropertyUniverseClassifier: loaded {Count} rules for county {County}",
+            rules.Count, county);
+
+        _cache[county] = rules;
+        return rules;
+    }
+
+    private static bool RuleMatches(TfDoctrinePropertyUniverse rule, UniverseClassifierInput input)
+    {
+        // Legacy marker gate.
+        if (rule.RequiresLegacyMarker && !input.HasLegacyMarker) return false;
+
+        // prop_type_cd: CSV match (wildcard if CSV null/empty).
+        if (!CsvMatches(rule.PropTypeCdCsv, input.PropTypeCd, includeOnEmpty: true)) return false;
+
+        // property_use_cd: respect PropertyUseMode.
+        if (!PropertyUseMatches(rule.PropertyUseMode, rule.PropertyUseCdCsv, input.PropertyUseCd))
+            return false;
+
+        // ag_apply: NULL on rule = wildcard. Otherwise exact match.
+        if (!string.IsNullOrEmpty(rule.AgApplyValue))
+        {
+            if (!string.Equals(rule.AgApplyValue, input.AgApply, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        // ag_use_cd: CSV match (wildcard if CSV null/empty).
+        if (!CsvMatches(rule.AgUseCdCsv, input.AgUseCd, includeOnEmpty: true)) return false;
+
+        return true;
+    }
+
+    private static bool PropertyUseMatches(string mode, string? csv, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(mode) || string.Equals(mode, "ANY", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var codes = SplitCsv(csv);
+        if (codes.Length == 0) return true; // empty CSV = wildcard regardless of mode
+
+        // INCLUDE/EXCLUDE require a non-null value to compare against
+        // the CSV. NULL value → rule does not match (defensive). This
+        // matters for the broad commercial seed rule: a row whose
+        // property_use_cd is missing must NOT be silently labelled
+        // commercial just because EXCLUDE tested NULL ∉ residential
+        // codes. The classifier falls through to the broader residential
+        // rule (which uses PropertyUseMode='ANY') instead.
+        if (string.IsNullOrEmpty(value)) return false;
+
+        var present = codes.Any(c => string.Equals(c, value, StringComparison.OrdinalIgnoreCase));
+
+        return mode.Equals("INCLUDE", StringComparison.OrdinalIgnoreCase) ? present
+             : mode.Equals("EXCLUDE", StringComparison.OrdinalIgnoreCase) ? !present
+             : true; // unknown mode = treat as ANY (defensive)
+    }
+
+    private static bool CsvMatches(string? csv, string? value, bool includeOnEmpty)
+    {
+        var codes = SplitCsv(csv);
+        if (codes.Length == 0) return includeOnEmpty;
+        if (string.IsNullOrEmpty(value)) return false;
+        return codes.Any(c => string.Equals(c, value, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] SplitCsv(string? csv) =>
+        string.IsNullOrWhiteSpace(csv)
+            ? Array.Empty<string>()
+            : csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
 using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
 using TerraFusion.Core.Sync.PacsImprvTruth;
 
 namespace TerraFusion.Data.Services.TruthPacs;
@@ -29,14 +32,30 @@ namespace TerraFusion.Data.Services.TruthPacs;
 /// </summary>
 public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromoter
 {
+    /// <summary>
+    /// Default county tag used by the universe classifier when the
+    /// promoter has no explicit county context. Matches the seed
+    /// rules' County field. Multi-county hosts will need to surface
+    /// a county tag through the orchestrator (out of scope for
+    /// SYNC-DOCTRINE-4-IMPL).
+    /// </summary>
+    private const string DefaultCountyTag = "benton-wa";
+
+    /// <summary>Year boundary for CONVERSION_LEGACY's CREATED_DT_PRE_2017 marker.</summary>
+    private static readonly DateTime LegacyMarkerCutoff =
+        new(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     private readonly TerraFusionDbContext _db;
+    private readonly IPropertyUniverseClassifier _universeClassifier;
     private readonly ILogger<PacsImprvCurrentTruthPromoter> _logger;
 
     public PacsImprvCurrentTruthPromoter(
         TerraFusionDbContext db,
+        IPropertyUniverseClassifier universeClassifier,
         ILogger<PacsImprvCurrentTruthPromoter> logger)
     {
         _db = db;
+        _universeClassifier = universeClassifier;
         _logger = logger;
     }
 
@@ -114,12 +133,31 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                 .Where(i => i.LoadBatchId == imprvLoadBatchId)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
+            // SYNC-DOCTRINE-4: build a property-row index for universe
+            // classification. Latest LandedAt per prop_id wins. Property
+            // rows live in legacy_pacs_raw.property and are populated by
+            // the SYNC-POP-4a property landing slice; rows arriving here
+            // without a matching property row classify as UNKNOWN /
+            // UniverseNotEvaluated, which the operator can use as a
+            // signal to run the property landing first.
+            var imprvPropIds = imprvRows.Select(i => i.PropId).Distinct().ToList();
+            var propertyIndex = await _db.LegacyPacsRawProperties
+                .Where(p => imprvPropIds.Contains(p.PropId))
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var latestPropertyByPropId = propertyIndex
+                .GroupBy(p => p.PropId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(p => p.LandedAt).First());
+
             var considered = imprvRows.Count;
             var promoted = 0;
             var rejectedNoSupp = 0;
             var rejectedStaleSup = 0;
             // G4 (v1.13): pre-conversion-share gate counter.
             var preConversionPromoted = 0;
+            // SYNC-DOCTRINE-4: per-batch universe distribution counter.
+            var universeCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             decimal imprvValSum = 0m;
             var now = DateTime.UtcNow;
 
@@ -142,6 +180,12 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                 var era = ConversionEras.FromYear(imprv.PropValYr);
                 if (era == ConversionEras.PreConversion2017) preConversionPromoted++;
 
+                // SYNC-DOCTRINE-4: classify universe.
+                var universe = await ClassifyUniverseAsync(
+                    imprv, latestPropertyByPropId, cancellationToken).ConfigureAwait(false);
+                if (!universeCounts.TryAdd(universe.UniverseCode, 1))
+                    universeCounts[universe.UniverseCode]++;
+
                 _db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
                 {
                     PropValYr = imprv.PropValYr,
@@ -163,6 +207,10 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                     SuppAssocLoadBatchId = suppAssocLoadBatchId,
                     PromotionLoadBatchId = batch.LoadBatchId,
                     ConversionEra = era,
+                    UniverseCode = universe.UniverseCode,
+                    UniverseRuleId = universe.RuleId,
+                    UniverseConfidence = universe.Confidence,
+                    UniverseReason = universe.Reason,
                     PromotedAt = now,
                 });
                 promoted++;
@@ -180,6 +228,10 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
             await WriteRemainingGatesAsync(batch, considered, promoted,
                 rejectedNoSupp, rejectedStaleSup, imprvValSum,
                 cancellationToken).ConfigureAwait(false);
+
+            // SYNC-DOCTRINE-4: informational per-batch universe distribution gate.
+            await WriteUniverseDistributionGateAsync(batch, universeCounts, cancellationToken)
+                .ConfigureAwait(false);
 
             batch.Status = "COMPLETED";
             batch.CompletedAt = DateTime.UtcNow;
@@ -324,6 +376,77 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
             ExecutedAt = now,
         });
 
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4: classify a single improvement row's universe.
+    /// Looks up the latest property row for the prop_id; if missing,
+    /// returns UNKNOWN with reason UniverseNotEvaluated. land_detail
+    /// signals (ag_apply, ag_use_cd) and per-year property_use_cd are
+    /// not consulted in this slice — they require additional joins
+    /// outside the current promoter contract. Future enhancement.
+    /// </summary>
+    private async Task<UniverseClassification> ClassifyUniverseAsync(
+        LegacyPacsRawImprv imprv,
+        IReadOnlyDictionary<int, LegacyPacsRawProperty> propertyIndex,
+        CancellationToken cancellationToken)
+    {
+        if (!propertyIndex.TryGetValue(imprv.PropId, out var property))
+        {
+            return new UniverseClassification(
+                UniverseCode: UniverseCodes.Unknown,
+                RuleId: null,
+                Confidence: "LOW",
+                Reason: $"property row not landed for prop_id={imprv.PropId}; cannot classify universe",
+                QuarantineReasonHint: UniverseQuarantineReasons.UniverseNotEvaluated);
+        }
+
+        var hasLegacyMarker = property.PropCreateDt.HasValue
+                              && property.PropCreateDt.Value < LegacyMarkerCutoff;
+
+        var input = new UniverseClassifierInput(
+            County: DefaultCountyTag,
+            PropValYr: imprv.PropValYr,
+            PropTypeCd: property.PropTypeCd,
+            PropertyUseCd: null,   // future: join dbo.property_val per (prop_id, prop_val_yr, sup_num)
+            AgApply: null,         // future: join dbo.land_detail per prop_id
+            AgUseCd: null,
+            HasLegacyMarker: hasLegacyMarker);
+
+        return await _universeClassifier.ClassifyAsync(input, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4: per-batch universe distribution gate.
+    /// Informational; never FAIL (the universe column itself is the
+    /// signal an operator inspects).
+    /// </summary>
+    private async Task WriteUniverseDistributionGateAsync(
+        LoadBatch batch,
+        IReadOnlyDictionary<string, int> counts,
+        CancellationToken cancellationToken)
+    {
+        var detail = counts.Count == 0
+            ? "no rows promoted"
+            : string.Join(" ", counts
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => $"{kv.Key}={kv.Value}"));
+
+        var totalRows = counts.Values.Sum();
+
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "truth-pacs-imprv-universe-distribution",
+            GateStage = "RAW_TO_TRUTH",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = totalRows.ToString(CultureInfo.InvariantCulture),
+            Detail = detail,
+            ExecutedAt = DateTime.UtcNow,
+        });
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -344,6 +344,18 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.DoctrineTf.TfDoctrineRatioPolicy>
     TfDoctrineRatioPolicies { get; set; } = null!;
 
+  // SYNC-DOCTRINE-4: doctrine_tf.tf_doctrine_property_universe.
+  // Year-aware, evidence-backed property-universe classification
+  // rules. Six universes + UNKNOWN sentinel.
+  public DbSet<TerraFusion.Core.Entities.DoctrineTf.TfDoctrinePropertyUniverse>
+    TfDoctrinePropertyUniverses { get; set; } = null!;
+
+  // SYNC-DOCTRINE-4: doctrine_tf.tf_doctrine_attribute_dictionary.
+  // Per-universe imprv_attr code dictionary. Replaces the global
+  // RefreshableImprvAttrDictionary for universe-aware lookups.
+  public DbSet<TerraFusion.Core.Entities.DoctrineTf.TfDoctrineAttributeDictionary>
+    TfDoctrineAttributeDictionaries { get; set; } = null!;
+
   // Slice D1: legacy_arcgis_raw.parcel_geom — first stop in the
   // 5-schema doctrine for ArcGIS-sourced geometry. Per Block-D
   // execution plan (docs/pacs/block-d-execution-plan.md §3.1).
@@ -1090,6 +1102,14 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // Year-aware sales-ratio qualification rule rows.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrineRatioPolicyConfiguration());
+
+    // SYNC-DOCTRINE-4: doctrine_tf.tf_doctrine_property_universe and
+    // doctrine_tf.tf_doctrine_attribute_dictionary. Six-universe
+    // classification + per-universe code dictionary.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrinePropertyUniverseConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrineAttributeDictionaryConfiguration());
 
     // Slice D1: legacy_arcgis_raw.parcel_geom — raw FeatureService
     // landing. Per docs/pacs/block-d-execution-plan.md §3.1.

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsImprvCanonicalProjectorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/PacsImprvCanonicalProjectorTests.cs
@@ -11,6 +11,7 @@ using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsImprvCanonical;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.CanonicalTf;
+using TerraFusion.Unit.Tests.Doctrine;
 using Xunit;
 
 namespace TerraFusion.Unit.Tests.CanonicalTf;
@@ -48,7 +49,9 @@ public sealed class PacsImprvCanonicalProjectorTests : IDisposable
     public void Dispose() => _db.Dispose();
 
     private PacsImprvCanonicalProjector BuildProjector()
-        => new(_db, NullLogger<PacsImprvCanonicalProjector>.Instance);
+        => new(_db,
+               new NullPerUniverseAttributeDictionary(),
+               NullLogger<PacsImprvCanonicalProjector>.Instance);
 
     private async Task<Guid> SeedCompletedBatchAsync(string label)
     {

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCReplayHarnessTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCReplayHarnessTests.cs
@@ -198,7 +198,9 @@ public sealed class BlockCReplayHarnessTests : IDisposable
         await SeedRawDetailAsync(propId: 100, imprvId: 1, imprvDetId: 11, typeCd: "BSMT");
 
         var projector = new PacsImprvCanonicalProjector(
-            _db, NullLogger<PacsImprvCanonicalProjector>.Instance);
+            _db,
+            new NullPerUniverseAttributeDictionary(),
+            NullLogger<PacsImprvCanonicalProjector>.Instance);
 
         var run1 = await projector.ProjectAsync(truthBatch, "h3-run1");
         run1.Status.Should().Be("COMPLETED");
@@ -240,7 +242,9 @@ public sealed class BlockCReplayHarnessTests : IDisposable
         // No parcel xref for prop 100 → row goes to quarantine.
 
         var projector = new PacsImprvCanonicalProjector(
-            _db, NullLogger<PacsImprvCanonicalProjector>.Instance);
+            _db,
+            new NullPerUniverseAttributeDictionary(),
+            NullLogger<PacsImprvCanonicalProjector>.Instance);
 
         var run1 = await projector.ProjectAsync(truthBatch, "h3-quar-run1");
         run1.ImprovementsProjected.Should().Be(0);

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/NullPerUniverseAttributeDictionary.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/NullPerUniverseAttributeDictionary.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Unit.Tests.Doctrine;
+
+/// <summary>
+/// Test double for <see cref="IPerUniverseAttributeDictionary"/> that
+/// behaves as if no universe-aware dictionary entries exist. Every
+/// known-universe lookup returns
+/// <see cref="DictionaryLookupOutcome.DictionaryNotLoaded"/>; every
+/// unknown-universe call returns
+/// <see cref="DictionaryLookupOutcome.UniverseNotEvaluated"/>.
+///
+/// <para>Use this double when a test asserts on universe-aware
+/// quarantine context but does not need to populate a per-universe
+/// dictionary itself.</para>
+/// </summary>
+public sealed class NullPerUniverseAttributeDictionary : IPerUniverseAttributeDictionary
+{
+    public Task<DictionaryLookupResult> LookupAsync(
+        string county,
+        string universeCode,
+        int year,
+        string imprvAttrId,
+        string iAttrValCd,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(universeCode)
+            || universeCode.Equals(UniverseCodes.Unknown, System.StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(DictionaryLookupResult.NotEvaluated());
+        }
+
+        return Task.FromResult(DictionaryLookupResult.DictionaryNotLoaded());
+    }
+
+    public Task<int> CountForUniverseAsync(
+        string county, string universeCode, CancellationToken cancellationToken = default) =>
+        Task.FromResult(0);
+
+    public void InvalidateCache(string? county = null) { /* no-op */ }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/NullPropertyUniverseClassifier.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/NullPropertyUniverseClassifier.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Unit.Tests.Doctrine;
+
+/// <summary>
+/// Test double for <see cref="IPropertyUniverseClassifier"/> that
+/// always returns <see cref="UniverseCodes.Unknown"/> with the
+/// <see cref="UniverseQuarantineReasons.UniverseNotEvaluated"/>
+/// hint. Mirrors the production behavior when a property row is
+/// missing for the given prop_id.
+///
+/// <para>Use this double when a test does not need to exercise
+/// universe classification rules but must satisfy the constructor
+/// dependency.</para>
+/// </summary>
+public sealed class NullPropertyUniverseClassifier : IPropertyUniverseClassifier
+{
+    public Task<UniverseClassification> ClassifyAsync(
+        UniverseClassifierInput input,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new UniverseClassification(
+            UniverseCode: UniverseCodes.Unknown,
+            RuleId: null,
+            Confidence: "LOW",
+            Reason: "test double: classifier disabled",
+            QuarantineReasonHint: UniverseQuarantineReasons.UniverseNotEvaluated));
+
+    public void InvalidateCache(string? county = null) { /* no-op */ }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/TruthPacs/PacsImprvCurrentTruthPromoterTests.cs
@@ -5,9 +5,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
 using TerraFusion.Core.Entities.SyncBridge;
 using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
 using TerraFusion.Core.Sync.PacsImprvTruth;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.TruthPacs;
+using TerraFusion.Unit.Tests.Doctrine;
 using Xunit;
 
 namespace TerraFusion.Unit.Tests.TruthPacs;
@@ -39,7 +41,9 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
     public void Dispose() => _db.Dispose();
 
     private PacsImprvCurrentTruthPromoter BuildPromoter()
-        => new(_db, NullLogger<PacsImprvCurrentTruthPromoter>.Instance);
+        => new(_db,
+               new NullPropertyUniverseClassifier(),
+               NullLogger<PacsImprvCurrentTruthPromoter>.Instance);
 
     private async Task<Guid> SeedBatchAsync(string label, string status = "COMPLETED")
     {
@@ -248,6 +252,8 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
             "truth-pacs-imprv-aggregate",
             // G4 (v1.13): pre-conversion-share gate.
             "truth-pacs-imprv-pre-conversion-share",
+            // SYNC-DOCTRINE-4: per-batch universe distribution gate.
+            "truth-pacs-imprv-universe-distribution",
         });
     }
 
@@ -289,7 +295,9 @@ public sealed class PacsImprvCurrentTruthPromoterTests : IDisposable
             .ToListAsync();
         // G4 (v1.13): the new pre-conversion-share gate brings the
         // imprv lane's gate count to 5.
-        gates.Should().HaveCount(5);
+        // SYNC-DOCTRINE-4: per-batch universe distribution gate brings
+        // the imprv lane's gate count to 6.
+        gates.Should().HaveCount(6);
         gates.Should().OnlyContain(g => g.Status != "FAIL");
     }
 


### PR DESCRIPTION
The fireplace finally got the right zip code (and now compiles).

## What

Translates the SYNC-DOCTRINE-4 design (`docs/sync/sync-doctrine-4-improvement-universe-design.md`, design commit `4ba0d5522`) into production code. Six universes + UNKNOWN sentinel, locked precedence, per-universe attribute dictionary, five-reason quarantine taxonomy.

## Why

The improvement quarantine in SYNC-COMPLETE-3 surfaced 1,584 "unknown imprv_attr" rows — collapsed into one bucket because the global dictionary couldn't be right for real-residential, real-commercial, mobile-home, ag/current-use, business personal property, and conversion-legacy improvements simultaneously. SYNC-DOCTRINE-4-IMPL gives each universe its own dictionary lane and replaces the muddier `UNKNOWN_ATTRIBUTE` bucket with five named reasons that tell the operator which stage of the pipeline failed.

## Schema (single EF migration)

- `doctrine_tf.tf_doctrine_property_universe` — six locked universes + UNKNOWN sentinel; precedence-ranked rules with year-aware effective windows, evidence citations, confidence markers.
- `doctrine_tf.tf_doctrine_attribute_dictionary` — per-universe imprv_attr code dictionary (replaces global single-bucket lookup for universe-aware semantics).
- `truth_pacs.imprv_current` + `canonical_tf.tf_improvement` — added `UniverseCode`, `UniverseRuleId`, `UniverseConfidence`, `UniverseReason`.
- `legacy_tf_unproven.unresolved_imprv_attr` — added `UniverseCode`, `UniverseRuleId`, `QuarantineReasonDetail`.

## Services (Singleton + IServiceScopeFactory pattern, mirrors B1)

- `IPropertyUniverseClassifier` / `PropertyUniverseClassifier`
- `IPerUniverseAttributeDictionary` / `PerUniverseAttributeDictionary`
- `DoctrinePropertyUniverseSeeder` (six locked seed rules, deterministic GUIDs, idempotent)
- `DoctrineAttributeDictionarySeeder` (empty initial seed by design — per-universe distributions wait on a profiling drain)
- `DoctrinePropertyUniverseSeederHostedService` (idempotent + non-fatal on failure)

## Promoter / projector wiring

- `PacsImprvCurrentTruthPromoter` joins `LegacyPacsRawProperty` for `prop_type_cd`, classifies universe, writes 4 universe columns onto `truth_pacs.imprv_current`. Missing property row → UNKNOWN with `UniverseNotEvaluated`. New informational gate: `truth-pacs-imprv-universe-distribution`.
- `PacsImprvCanonicalProjector` forwards universe fields verbatim to `canonical_tf.tf_improvement`. On attribute quarantine, consults `PerUniverseAttributeDictionary` to write a precise `QuarantineReasonDetail`:
  - `UniverseNotEvaluated` (truth.UniverseCode is null/UNKNOWN)
  - `DictionaryNotLoadedForUniverse` (universe known, dictionary empty)
  - `UnknownForUniverseDictionary` (universe known, code genuinely missing)

## Closed vocabularies

- `UniverseCodes` — six + UNKNOWN sentinel.
- `UniverseQuarantineReasons` — five named reasons replacing the muddier global `UNKNOWN_ATTRIBUTE`-only bucket.

## Endpoints

- `GET  /api/sync/doctrine/policy/universe`
- `GET  /api/sync/doctrine/policy/universe/classify` — operator spot-check
- `GET  /api/sync/doctrine/policy/universe/attribute-dictionary`
- `POST /api/sync/doctrine/policy/universe/seed` — re-run seeders + invalidate caches

## Tests (per design doc test plan A/B/C/D)

- `PropertyUniverseClassifierTests` — 10 tests, **plan A** (precedence)
- `PerUniverseAttributeDictionaryTests` — 12 tests, **plan B** (dictionary) + **plan C** (false-global-quarantine regression)
- `DoctrinePropertyUniverseSeederTests` — 4 tests (seed contract, idempotency, evidence presence, no-UNKNOWN-as-rule)
- Existing `PacsImprvCurrentTruthPromoterTests` / `BlockCReplayHarnessTests` / `PacsImprvCanonicalProjectorTests` updated for new constructor signature + new universe gate.

## Verification

- `dotnet build TerraFusion.sln` — **0 errors, 0 warnings**
- `dotnet test TerraFusion.Unit.Tests` — **3028 / 3028 passing**
- `dotnet test TerraFusion.API.Tests` filter SYNC-DOCTRINE-4 — **27 / 27 passing**
- Two pre-existing API.Tests failures (`Phase14.ControllerSecurityBoundaryTests.PropertiesController_GetProperties_ReturnsBadRequest_WhenCountyClaimMissing` + `Integration.CountyStudioSmokeTests.CountyStudio_FullWorkflow_Smoke`) are unrelated to this slice — they touch controllers and county-studio integration paths this PR does not modify.

## Out of scope (per design doc §"Out of scope" + future enhancements)

- **Promoter wiring of `property_use_cd`** (from `dbo.property_val`) and **`ag_apply` / `ag_use_cd`** (from `dbo.land_detail`). The classifier accepts them via input contract; the promoter passes NULL today. AG_CURRENT_USE rule is correctly seeded but won't fire from the promoter wiring until those joins land in a follow-up.
- **Initial per-universe attribute-dictionary seed** — empty by design; operator populates after a profiling drain produces per-universe code distributions.
- **AG_CURRENT_USE → AG/OSP/CNV split** — single bucket for now.
- **Aggressive global-rescue path** — if a code is in the per-universe dictionary, the projector will eventually short-circuit the existing global `AttributeDefinition` quarantine. This slice only enriches the QUARANTINE row with universe context; the rescue logic is dormant until the dictionary is populated.

## Reference commits

- Predecessor on main: SYNC-DOCTRINE-2 (B2, dual-surface sale promoter): `2a61f9ab7` (PR #788)
- Predecessor on main: SYNC-DOCTRINE-1 (B1, year-aware ratio policy): `07471455d` (PR #787)
- Design doc: `4ba0d5522` (`docs/sync/sync-doctrine-4-improvement-universe-design.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added property universe classification endpoints to categorize improvements across six property universes.
  * Added API endpoints to list universe rules and query per-universe attribute dictionaries.
  * Implemented per-universe scoped attribute dictionary lookups.

* **Tests**
  * Added comprehensive test coverage for universe classification logic, idempotency, and attribute dictionary isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->