### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V2 — escape-hatch precedence + ag_apply guard relaxation

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/DoctrinePropertyUniverseSeederTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/DoctrinePropertyUniverseSeederTests.cs
@@ -31,7 +31,7 @@ public class DoctrinePropertyUniverseSeederTests
     }
 
     [Fact]
-    public async Task First_run_inserts_six_rules_with_locked_precedence()
+    public async Task First_run_inserts_six_V2_rules_with_escape_hatch_precedence()
     {
         var sp = BuildSp();
         using var scope = sp.CreateScope();
@@ -42,16 +42,71 @@ public class DoctrinePropertyUniverseSeederTests
         var added = await seeder.SeedAsync();
 
         Assert.Equal(6, added);
-        var rules = await db.TfDoctrinePropertyUniverses.OrderBy(r => r.Precedence).ToListAsync();
+        var rules = await db.TfDoctrinePropertyUniverses
+            .Where(r => r.ActiveFlag)
+            .OrderBy(r => r.Precedence)
+            .ToListAsync();
         Assert.Equal(6, rules.Count);
 
-        // Locked precedence per design doc §"Locked precedence".
-        Assert.Equal((1, UniverseCodes.ConversionLegacy), (rules[0].Precedence, rules[0].UniverseCode));
-        Assert.Equal((2, UniverseCodes.AgCurrentUse), (rules[1].Precedence, rules[1].UniverseCode));
-        Assert.Equal((3, UniverseCodes.PersonalProperty), (rules[2].Precedence, rules[2].UniverseCode));
-        Assert.Equal((4, UniverseCodes.MobileHome), (rules[3].Precedence, rules[3].UniverseCode));
-        Assert.Equal((5, UniverseCodes.RealCommercial), (rules[4].Precedence, rules[4].UniverseCode));
-        Assert.Equal((6, UniverseCodes.RealResidential), (rules[5].Precedence, rules[5].UniverseCode));
+        // SYNC-DOCTRINE-4-IMPL-V2 precedence: CONVERSION_LEGACY moved
+        // to escape hatch (last). Modern rules go first.
+        Assert.Equal((1, UniverseCodes.AgCurrentUse), (rules[0].Precedence, rules[0].UniverseCode));
+        Assert.Equal((2, UniverseCodes.PersonalProperty), (rules[1].Precedence, rules[1].UniverseCode));
+        Assert.Equal((3, UniverseCodes.MobileHome), (rules[2].Precedence, rules[2].UniverseCode));
+        Assert.Equal((4, UniverseCodes.RealCommercial), (rules[3].Precedence, rules[3].UniverseCode));
+        Assert.Equal((5, UniverseCodes.RealResidential), (rules[4].Precedence, rules[4].UniverseCode));
+        Assert.Equal((7, UniverseCodes.ConversionLegacy), (rules[5].Precedence, rules[5].UniverseCode));
+    }
+
+    [Fact]
+    public async Task Seeder_deactivates_V1_rules_when_present()
+    {
+        var sp = BuildSp();
+        using (var scope = sp.CreateScope())
+        {
+            // Seed a V1 rule (with V1 GUID) as if it had been inserted
+            // by the V1 seeder.
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.TfDoctrinePropertyUniverses.Add(new TerraFusion.Core.Entities.DoctrineTf.TfDoctrinePropertyUniverse
+            {
+                RuleId = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010"),
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                Precedence = 1,
+                UniverseCode = UniverseCodes.ConversionLegacy,
+                RequiresLegacyMarker = true,
+                LegacyMarkerType = "CREATED_DT_PRE_2017",
+                ActiveFlag = true,
+                Reason = "V1",
+                EvidenceSource = "V1",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // Run V2 seeder.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var seeder = new DoctrinePropertyUniverseSeeder(
+                db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+            await seeder.SeedAsync();
+        }
+
+        // V1 row should be deactivated; V2 rows should be active.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var v1 = await db.TfDoctrinePropertyUniverses.FindAsync(
+                Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010"));
+            Assert.NotNull(v1);
+            Assert.False(v1!.ActiveFlag);
+            Assert.Contains("DEACTIVATED 2026-05-06", v1.Notes ?? string.Empty);
+
+            var v2Active = await db.TfDoctrinePropertyUniverses
+                .Where(r => r.ActiveFlag)
+                .CountAsync();
+            Assert.Equal(6, v2Active);
+        }
     }
 
     [Fact]

--- a/backend/TerraFusion.API.Tests/Doctrine/PropertyUniverseClassifierTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PropertyUniverseClassifierTests.cs
@@ -95,20 +95,36 @@ public class PropertyUniverseClassifierTests
     public async Task CONVERSION_LEGACY_does_not_fire_without_explicit_legacy_marker()
     {
         var classifier = BuildClassifier();
-        // R / F / no legacy marker → REAL_RESIDENTIAL (precedence 6).
+        // R / F / no legacy marker → REAL_RESIDENTIAL (precedence 5
+        // under V2, after AG/PP/MH/COMMERCIAL).
         var result = await classifier.ClassifyAsync(
             Input(propTypeCd: "R", agApply: "F", hasLegacyMarker: false));
         Assert.Equal(UniverseCodes.RealResidential, result.UniverseCode);
     }
 
     [Fact]
-    public async Task CONVERSION_LEGACY_beats_other_buckets_when_marker_is_present()
+    public async Task CONVERSION_LEGACY_does_not_beat_REAL_RESIDENTIAL_under_V2_escape_hatch_ordering()
     {
+        // V2 reordering: CONVERSION_LEGACY moves from precedence 1
+        // (V1) to precedence 7 (V2 last). A row with prop_type_cd='R'
+        // that ALSO carries the legacy marker classifies as
+        // REAL_RESIDENTIAL — modern rule wins, marker is observed but
+        // not used because the row already fits a modern bucket. This
+        // is the design doc's stated intent finally realized.
         var classifier = BuildClassifier();
-        // Same R / F shape as above, but legacy marker is present.
-        // CONVERSION_LEGACY (precedence 1) wins.
         var result = await classifier.ClassifyAsync(
             Input(propTypeCd: "R", agApply: "F", hasLegacyMarker: true));
+        Assert.Equal(UniverseCodes.RealResidential, result.UniverseCode);
+    }
+
+    [Fact]
+    public async Task CONVERSION_LEGACY_fires_when_no_modern_rule_matches_AND_marker_present()
+    {
+        // V2 escape hatch semantic: a row with no prop_type match AND
+        // a legacy marker drops to CONVERSION_LEGACY at precedence 7.
+        var classifier = BuildClassifier();
+        var result = await classifier.ClassifyAsync(
+            Input(propTypeCd: "X", agApply: null, hasLegacyMarker: true));
         Assert.Equal(UniverseCodes.ConversionLegacy, result.UniverseCode);
     }
 

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeeder.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrinePropertyUniverseSeeder.cs
@@ -36,6 +36,18 @@ public sealed class DoctrinePropertyUniverseSeeder
 
     public async Task<int> SeedAsync(CancellationToken cancellationToken = default)
     {
+        // SYNC-DOCTRINE-4-IMPL-V2: deactivate V1 seed rules first, then
+        // insert V2 rules. Live replay of V1 surfaced that the locked
+        // CREATED_DT_PRE_2017 marker fires for 100 % of Benton rows
+        // because PACS PropCreateDt is a 1980-01-01 sentinel from the
+        // 2017 ProVal conversion. V2 reorders CONVERSION_LEGACY to the
+        // last precedence (escape hatch) and relaxes REAL_RESIDENTIAL
+        // / REAL_COMMERCIAL ag_apply guards to wildcard so the modern
+        // rules can fire without land_detail joins (which arrive in a
+        // separate slice).
+        var deactivated = await DeactivateLegacyV1RulesAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var seedRules = BuildBentonSeed();
 
         var existingIds = await _db.TfDoctrinePropertyUniverses
@@ -52,17 +64,17 @@ public sealed class DoctrinePropertyUniverseSeeder
             added++;
         }
 
-        if (added > 0)
+        if (added > 0 || deactivated > 0)
         {
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogInformation(
-                "DoctrinePropertyUniverseSeeder: inserted {Added} rule(s); existing {Existing}",
-                added, existingSet.Count);
+                "DoctrinePropertyUniverseSeeder: inserted {Added} V2 rule(s); deactivated {Deactivated} V1 rule(s); existing {Existing}",
+                added, deactivated, existingSet.Count);
         }
         else
         {
             _logger.LogDebug(
-                "DoctrinePropertyUniverseSeeder: no new rules; {Existing} already present",
+                "DoctrinePropertyUniverseSeeder: no changes; {Existing} already present",
                 existingSet.Count);
         }
 
@@ -70,58 +82,95 @@ public sealed class DoctrinePropertyUniverseSeeder
     }
 
     /// <summary>
-    /// Six locked seed rules, all evidence-cited. Precedence values
-    /// match the design doc §"Locked precedence" exactly.
+    /// SYNC-DOCTRINE-4-IMPL-V2: mark V1 seed rules inactive.
+    /// V1 GUIDs are preserved (audit trail) but the classifier
+    /// excludes them via <see cref="TfDoctrinePropertyUniverse.ActiveFlag"/>.
+    /// Idempotent: setting an already-inactive row's flag to false
+    /// is a no-op via EF change-tracking.
+    /// </summary>
+    private async Task<int> DeactivateLegacyV1RulesAsync(CancellationToken cancellationToken)
+    {
+        var v1RuleIds = LegacyV1RuleIds();
+        var rows = await _db.TfDoctrinePropertyUniverses
+            .Where(r => v1RuleIds.Contains(r.RuleId) && r.ActiveFlag)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var row in rows)
+        {
+            row.ActiveFlag = false;
+            row.Notes = (row.Notes is null ? string.Empty : row.Notes + " | ") +
+                "DEACTIVATED 2026-05-06 by SYNC-DOCTRINE-4-IMPL-V2 (live replay surfaced " +
+                "PropCreateDt sentinel; V2 reorders CONVERSION_LEGACY to last precedence " +
+                "and relaxes ag_apply guards on REAL_RESIDENTIAL/REAL_COMMERCIAL).";
+        }
+        return rows.Count;
+    }
+
+    private static Guid[] LegacyV1RuleIds() => new[]
+    {
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010"),  // V1 CONVERSION_LEGACY
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005020"),  // V1 AG_CURRENT_USE
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005030"),  // V1 PERSONAL_PROPERTY
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005040"),  // V1 MOBILE_HOME
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005050"),  // V1 REAL_COMMERCIAL
+        Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005060"),  // V1 REAL_RESIDENTIAL
+    };
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4-IMPL-V2 seed (six rules + UNKNOWN sentinel).
+    ///
+    /// <para>Differences from V1 (deactivated by
+    /// <see cref="DeactivateLegacyV1RulesAsync"/> at boot):</para>
+    /// <list type="bullet">
+    ///   <item><b>CONVERSION_LEGACY moved from precedence 1 to
+    ///   precedence 7 (escape hatch).</b> The locked
+    ///   <c>CREATED_DT_PRE_2017</c> marker fires for 100 % of Benton
+    ///   rows because PACS PropCreateDt is a 1980-01-01 sentinel
+    ///   from the 2017 ProVal conversion. Putting CONVERSION_LEGACY
+    ///   first meant every row classified legacy regardless of
+    ///   actual prop_type_cd. V2 makes it a true last-resort: only
+    ///   fires when no modern rule matches AND a legacy marker is
+    ///   present. Realizes the design doc's stated intent.</item>
+    ///   <item><b>REAL_RESIDENTIAL ag_apply guard relaxed to
+    ///   wildcard.</b> Until <c>land_detail</c> joins land in the
+    ///   promoter (separate slice), <c>ag_apply</c> is always NULL
+    ///   in the classifier input. The V1 <c>ag_apply='F'</c> guard
+    ///   prevented RESIDENTIAL from firing on any row. V2 accepts
+    ///   any ag_apply for the residential default — when
+    ///   land_detail wiring lands, AG_CURRENT_USE (precedence 2)
+    ///   will siphon ag_apply='T' rows BEFORE this rule sees them.</item>
+    ///   <item><b>REAL_COMMERCIAL ag_apply guard also relaxed to
+    ///   wildcard.</b> Same reasoning. The PropertyUseMode=EXCLUDE
+    ///   guard against residential property_use_cd values still
+    ///   discriminates commercial vs residential when
+    ///   property_use_cd is non-null; with NULL property_use_cd the
+    ///   EXCLUDE rule short-circuits to false (per classifier
+    ///   semantics) and falls through to RESIDENTIAL.</item>
+    /// </list>
     /// </summary>
     private static TfDoctrinePropertyUniverse[] BuildBentonSeed()
     {
-        // Deterministic GUIDs — d0c7d0c7 = "doctrine seed", 0040 = SYNC-DOCTRINE-4,
-        // final group encodes county-fips '53005' (Benton WA).
-        var ruleConvLegacy   = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010");
-        var ruleAgCurrentUse = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005020");
-        var rulePersonalProp = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005030");
-        var ruleMobileHome   = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005040");
-        var ruleRealComm     = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005050");
-        var ruleRealResid    = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005060");
+        // V2 deterministic GUIDs — d0c7d0c7 = "doctrine seed",
+        // 4002 = SYNC-DOCTRINE-4 V2, final group encodes county-fips
+        // '53005' (Benton WA).
+        var ruleConvLegacy   = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005010");
+        var ruleAgCurrentUse = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005020");
+        var rulePersonalProp = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005030");
+        var ruleMobileHome   = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005040");
+        var ruleRealComm     = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005050");
+        var ruleRealResid    = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005060");
 
-        var approvedAt = new DateTime(2026, 5, 6, 0, 0, 0, DateTimeKind.Utc);
+        var approvedAt = new DateTime(2026, 5, 6, 14, 30, 0, DateTimeKind.Utc);
         var approver = "operator-bsval";
 
         return new[]
         {
             new TfDoctrinePropertyUniverse
             {
-                RuleId = ruleConvLegacy,
-                County = "benton-wa",
-                EffectiveStartYear = 1990,
-                EffectiveEndYear = null,
-                Precedence = 1,
-                UniverseCode = UniverseCodes.ConversionLegacy,
-                PropTypeCdCsv = null,
-                PropertyUseMode = "ANY",
-                PropertyUseCdCsv = null,
-                AgApplyValue = null,
-                AgUseCdCsv = null,
-                RequiresLegacyMarker = true,
-                LegacyMarkerType = "CREATED_DT_PRE_2017",
-                LegacyMarkerValue = null,
-                Reason = "CONVERSION_LEGACY: only fires when current PACS domain rules can't " +
-                         "classify confidently AND a legacy marker is present. Conservative.",
-                EvidenceSource = "design doc §Locked precedence; PACS conversion 2017 historical fact",
-                Confidence = "MED",
-                ApprovedBy = approver,
-                ApprovedAt = approvedAt,
-                Notes = "Initial marker = CREATED_DT_PRE_2017. SOURCE_SYSTEM and IMPORT_BATCH " +
-                        "variants reserved for future tightening.",
-            },
-
-            new TfDoctrinePropertyUniverse
-            {
                 RuleId = ruleAgCurrentUse,
                 County = "benton-wa",
                 EffectiveStartYear = 1990,
                 EffectiveEndYear = null,
-                Precedence = 2,
+                Precedence = 1,
                 UniverseCode = UniverseCodes.AgCurrentUse,
                 PropTypeCdCsv = null,
                 PropertyUseMode = "ANY",
@@ -136,8 +185,10 @@ public sealed class DoctrinePropertyUniverseSeeder
                 Confidence = "HIGH",
                 ApprovedBy = approver,
                 ApprovedAt = approvedAt,
-                Notes = "Single AG_CURRENT_USE bucket per design doc §Out of scope. Future " +
-                        "split into AG/OSP/CNV deferred until profiling.",
+                Notes = "V2 precedence 1 (was V1 precedence 2). Single AG_CURRENT_USE bucket " +
+                        "per design doc §Out of scope. Future split into AG/OSP/CNV deferred " +
+                        "until profiling. Won't fire from promoter wiring until land_detail " +
+                        "joins land in a separate slice (ag_apply currently passed as NULL).",
             },
 
             new TfDoctrinePropertyUniverse
@@ -146,7 +197,7 @@ public sealed class DoctrinePropertyUniverseSeeder
                 County = "benton-wa",
                 EffectiveStartYear = 1990,
                 EffectiveEndYear = null,
-                Precedence = 3,
+                Precedence = 2,
                 UniverseCode = UniverseCodes.PersonalProperty,
                 PropTypeCdCsv = "P,B",
                 PropertyUseMode = "ANY",
@@ -161,8 +212,8 @@ public sealed class DoctrinePropertyUniverseSeeder
                 Confidence = "HIGH",
                 ApprovedBy = approver,
                 ApprovedAt = approvedAt,
-                Notes = "Widening beyond {P,B} deferred until Benton-specific evidence " +
-                        "supports more types.",
+                Notes = "V2 precedence 2 (was V1 precedence 3). Widening beyond {P,B} deferred " +
+                        "until Benton-specific evidence supports more types.",
             },
 
             new TfDoctrinePropertyUniverse
@@ -171,7 +222,7 @@ public sealed class DoctrinePropertyUniverseSeeder
                 County = "benton-wa",
                 EffectiveStartYear = 1990,
                 EffectiveEndYear = null,
-                Precedence = 4,
+                Precedence = 3,
                 UniverseCode = UniverseCodes.MobileHome,
                 PropTypeCdCsv = "MH",
                 PropertyUseMode = "ANY",
@@ -185,6 +236,7 @@ public sealed class DoctrinePropertyUniverseSeeder
                 Confidence = "HIGH",
                 ApprovedBy = approver,
                 ApprovedAt = approvedAt,
+                Notes = "V2 precedence 3 (was V1 precedence 4).",
             },
 
             new TfDoctrinePropertyUniverse
@@ -193,14 +245,14 @@ public sealed class DoctrinePropertyUniverseSeeder
                 County = "benton-wa",
                 EffectiveStartYear = 1990,
                 EffectiveEndYear = null,
-                Precedence = 5,
+                Precedence = 4,
                 UniverseCode = UniverseCodes.RealCommercial,
                 PropTypeCdCsv = "R",
                 PropertyUseMode = "EXCLUDE",
                 // EXCLUDE: residential property_use codes excluded from this rule;
                 // remaining codes route to commercial. Tighten after profiling drain.
                 PropertyUseCdCsv = "11,12,13,14,18",
-                AgApplyValue = "F",
+                AgApplyValue = null,  // V2: relaxed from 'F' to wildcard
                 AgUseCdCsv = null,
                 RequiresLegacyMarker = false,
                 Reason = "REAL_COMMERCIAL: broad non-residential real-property bucket. Tighten " +
@@ -211,8 +263,12 @@ public sealed class DoctrinePropertyUniverseSeeder
                 Confidence = "MED",
                 ApprovedBy = approver,
                 ApprovedAt = approvedAt,
-                Notes = "EXCLUDE mode is the broad first-pass approach. Replace with INCLUDE " +
-                        "when commercial property_use_cd distribution is known.",
+                Notes = "V2 precedence 4 (was V1 precedence 5). ag_apply guard relaxed from " +
+                        "'F' to wildcard so it can fire without land_detail joins. EXCLUDE " +
+                        "with NULL property_use_cd evaluates to false in classifier (no value " +
+                        "to compare), so this rule defaults out and falls through to " +
+                        "REAL_RESIDENTIAL — that's correct for now since property_use_cd is " +
+                        "always NULL in promoter input.",
             },
 
             new TfDoctrinePropertyUniverse
@@ -221,25 +277,58 @@ public sealed class DoctrinePropertyUniverseSeeder
                 County = "benton-wa",
                 EffectiveStartYear = 1990,
                 EffectiveEndYear = null,
-                Precedence = 6,
+                Precedence = 5,
                 UniverseCode = UniverseCodes.RealResidential,
                 PropTypeCdCsv = "R",
                 PropertyUseMode = "ANY",
                 PropertyUseCdCsv = null,
-                AgApplyValue = "F",
+                AgApplyValue = null,  // V2: relaxed from 'F' to wildcard
                 AgUseCdCsv = null,
                 RequiresLegacyMarker = false,
-                Reason = "REAL_RESIDENTIAL: default real-property residential bucket after higher-" +
-                         "precedence rules resolve.",
+                Reason = "REAL_RESIDENTIAL: default real-property residential bucket. After " +
+                         "higher-precedence rules (AG/PP/MH/COMMERCIAL) resolve, any " +
+                         "prop_type_cd='R' row routes here.",
                 EvidenceSource = "PACS prop_type_cd='R' distribution audit; ~61% of rows; " +
                                  "remainder after AG/MH/PP/COMMERCIAL filtered",
                 Confidence = "MED",
                 ApprovedBy = approver,
                 ApprovedAt = approvedAt,
-                Notes = "MED rather than HIGH because the ag_apply='F' guard is conservative; " +
-                        "a row with ag_apply=NULL (genuinely missing land row) won't match " +
-                        "this rule and will fall through to UNKNOWN. That's intentional — " +
-                        "reflect the data faithfully.",
+                Notes = "V2 precedence 5 (was V1 precedence 6). ag_apply guard relaxed from " +
+                        "'F' to wildcard so this fires as the genuine 'R' catchall today, even " +
+                        "without land_detail joins. When AG_CURRENT_USE wiring lands, ag_apply='T' " +
+                        "rows are siphoned at precedence 1 before reaching this rule.",
+            },
+
+            new TfDoctrinePropertyUniverse
+            {
+                RuleId = ruleConvLegacy,
+                County = "benton-wa",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = null,
+                Precedence = 7,  // V2: moved from 1 to last (escape hatch)
+                UniverseCode = UniverseCodes.ConversionLegacy,
+                PropTypeCdCsv = null,
+                PropertyUseMode = "ANY",
+                PropertyUseCdCsv = null,
+                AgApplyValue = null,
+                AgUseCdCsv = null,
+                RequiresLegacyMarker = true,
+                LegacyMarkerType = "CREATED_DT_PRE_2017",
+                LegacyMarkerValue = null,
+                Reason = "CONVERSION_LEGACY: escape hatch. Fires only when no modern rule " +
+                         "matches AND a legacy marker is present. Realizes the design doc's " +
+                         "stated intent: 'only when current PACS domain rules can't classify " +
+                         "confidently AND a legacy marker is present.'",
+                EvidenceSource = "design doc §Locked precedence (intent); SYNC-DOCTRINE-4 live " +
+                                 "replay 2026-05-06 surfaced V1 over-classification (100% of " +
+                                 "rows hit at precedence 1 due to PropCreateDt 1980-01-01 sentinel)",
+                Confidence = "MED",
+                ApprovedBy = approver,
+                ApprovedAt = approvedAt,
+                Notes = "V2 precedence 7 — last (escape hatch), was V1 precedence 1. Marker " +
+                        "remains CREATED_DT_PRE_2017 but its over-fire risk is structurally " +
+                        "neutralized by ordering. Future tightening (SOURCE_SYSTEM / " +
+                        "IMPORT_BATCH variants) optional, no longer urgent.",
             },
         };
     }


### PR DESCRIPTION
## Why

Live replay of SYNC-DOCTRINE-4-IMPL (PR #790, commit `f5110f778`) against Harris PACS surfaced that the locked `CREATED_DT_PRE_2017` marker fires for **100 % of Benton rows** because PACS `PropCreateDt` is a `1980-01-01` sentinel from the 2017 ProVal conversion. With CONVERSION_LEGACY at precedence 1, every parcel classified legacy regardless of actual `prop_type_cd`. Documented in `artifacts/sync-doctrine-4/` + `project_sync_doctrine_4_seal.md`.

V2 fixes the over-classification with two coordinated changes.

## Changes

### 1. CONVERSION_LEGACY moved from precedence 1 → 7 (escape hatch)

Realizes the design doc's stated intent: the rule fires only when **no modern rule matches AND a legacy marker is present**. Marker semantic preserved (`CREATED_DT_PRE_2017`); the over-fire risk is structurally neutralized by ordering rather than by tightening the marker. Future SOURCE_SYSTEM / IMPORT_BATCH variants remain optional, no longer urgent.

### 2. REAL_RESIDENTIAL + REAL_COMMERCIAL `ag_apply` guards relaxed `'F'` → wildcard

Until `LegacyPacsRawLandDetail.ag_apply` lands in the promoter (separate slice), `ag_apply` is always NULL in the classifier input. The V1 `ag_apply='F'` guard prevented modern rules from firing altogether — which is what allowed CONVERSION_LEGACY to dominate. With wildcard, REAL_RESIDENTIAL fires as the genuine `R` catchall today; AG_CURRENT_USE (precedence 1) will siphon `ag_apply='T'` rows ahead of it once `land_detail` wiring lands.

## Implementation

- `DoctrinePropertyUniverseSeeder`: V2 seed rules with new GUIDs (`4002` series, distinct from `4001` V1). On boot, the seeder marks the six V1 GUIDs `ActiveFlag=false` (audit trail preserved) before inserting V2 rules. Idempotent. Notes column carries the deactivation rationale.
- `PropertyUniverseClassifier` already filters by `ActiveFlag`, so V1 rules cease to participate immediately on first V2 boot. No code change to the classifier.
- No EF migration needed (data-only doctrine evolution).

## Tests

- `CONVERSION_LEGACY_does_not_beat_REAL_RESIDENTIAL_under_V2_escape_hatch_ordering` — locks the new semantic.
- `CONVERSION_LEGACY_fires_when_no_modern_rule_matches_AND_marker_present` — locks escape-hatch fallback.
- `First_run_inserts_six_V2_rules_with_escape_hatch_precedence` — V2 ordering (AG=1, PP=2, MH=3, COMMERCIAL=4, RESIDENTIAL=5, CONVERSION_LEGACY=7).
- `Seeder_deactivates_V1_rules_when_present` — idempotent V1→V2 transition.

Solution: 0 errors / 0 warnings. Tests: 29/29 SYNC-DOCTRINE-4 specific + 46/46 imprv regression.

## Live verification

Same TopN=200 sample, same `prop_type_cd='R'` rows, same legacy markers:

| | V1 (PR #790) | V2 (this PR) |
|---|---|---|
| Truth `UniverseCode` | `CONVERSION_LEGACY=241` | `REAL_RESIDENTIAL=241` |
| Canonical `UniverseCode` | `CONVERSION_LEGACY=241` | `REAL_RESIDENTIAL=241` |
| Universe distribution gate | PASS | PASS |

V2 evidence captured in `artifacts/sync-doctrine-4/v2-*.{txt,json}`.

## Out of scope (future)

- `LegacyPacsRawLandDetail.ag_apply` column landing — would let AG_CURRENT_USE / REAL_COMMERCIAL / MOBILE_HOME fire from real PACS data.
- `LegacyPacsRawPropertyVal` for `property_use_cd` — would let REAL_COMMERCIAL EXCLUDE rule discriminate against residential use codes.
- Backfill of pre-V2 truth rows currently carrying `NULL UniverseCode` or stale CONVERSION_LEGACY classification.

## Reference commits

- V1 on main: PR #790 commit `f5110f778`.
- V1 replay seal: `project_sync_doctrine_4_seal.md` (live replay surfaced the over-classification).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated seeder test suite to align with V2 behavior and rule precedence ordering
  * Added new tests for V2-specific rule precedence and legacy marker handling scenarios
  * Enhanced test coverage for rule classification

* **Chores**
  * Improved legacy rule handling in the seeding process with updated configuration management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->