### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V3 — land ag_apply/ag_use_cd, wire promoter join, AG_CURRENT_USE fires from real PACS

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/LegacyPacsRaw/LegacyPacsRawLandDetail.cs
+++ b/backend/src/TerraFusion.Core/Entities/LegacyPacsRaw/LegacyPacsRawLandDetail.cs
@@ -66,6 +66,24 @@ public sealed class LegacyPacsRawLandDetail
     /// <summary>Effective age (depreciation/accrual basis).</summary>
     public short? LandSegEffAge { get; set; }
 
+    // ── SYNC-DOCTRINE-4-IMPL-V3: ag-program participation ────────
+    /// <summary>
+    /// PACS <c>dbo.land_detail.ag_apply</c> column. Y/T or F/N
+    /// (PACS character coding for boolean). Indicates whether this
+    /// land segment participates in the agricultural / current-use /
+    /// open-space valuation program. Used by SYNC-DOCTRINE-4
+    /// AG_CURRENT_USE rule.
+    /// </summary>
+    public string? AgApply { get; set; }
+
+    /// <summary>
+    /// PACS <c>dbo.land_detail.ag_use_cd</c>. Closed vocabulary:
+    /// 'AG' (agriculture), 'OSP' (open space), 'CNV' (current-use
+    /// converted), etc. Used to subdivide AG_CURRENT_USE into
+    /// AG/OSP/CNV in a future doctrine slice.
+    /// </summary>
+    public string? AgUseCd { get; set; }
+
     // ── Provenance (the doctrine's non-negotiable surface) ────────
     public Guid LoadBatchId { get; set; }
     public string SourceQueryHash { get; set; } = string.Empty;

--- a/backend/src/TerraFusion.Core/Sync/PacsLandDetail/PacsSourceLandDetail.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsLandDetail/PacsSourceLandDetail.cs
@@ -1,6 +1,12 @@
 namespace TerraFusion.Core.Sync.PacsLandDetail;
 
 /// <summary>Slice L1: source-shaped PACS <c>land_detail</c> row.</summary>
+/// <remarks>
+/// SYNC-DOCTRINE-4-IMPL-V3 added <see cref="AgApply"/> and
+/// <see cref="AgUseCd"/> so the truth promoter can pass real
+/// agricultural-program signals into the universe classifier
+/// instead of always-NULL inputs.
+/// </remarks>
 public sealed record PacsSourceLandDetail(
     short PropValYr,
     short SupNum,
@@ -17,4 +23,6 @@ public sealed record PacsSourceLandDetail(
     decimal? LandSegMarketVal,
     decimal? LandSegAgValue,
     decimal? LandSegAssessedVal,
-    short? LandSegEffAge);
+    short? LandSegEffAge,
+    string? AgApply = null,
+    string? AgUseCd = null);

--- a/backend/src/TerraFusion.Data/Configurations/LegacyPacsRaw/LegacyPacsRawLandDetailConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/LegacyPacsRaw/LegacyPacsRawLandDetailConfiguration.cs
@@ -31,6 +31,11 @@ public sealed class LegacyPacsRawLandDetailConfiguration
         builder.Property(x => x.SoilCd).HasMaxLength(16);
         builder.Property(x => x.LandSegHomesite).HasMaxLength(2);
 
+        // SYNC-DOCTRINE-4-IMPL-V3: ag-program signals.
+        // Width 4 covers PACS Y/T/F/N variants plus headroom.
+        builder.Property(x => x.AgApply).HasMaxLength(4);
+        builder.Property(x => x.AgUseCd).HasMaxLength(16);
+
         builder.Property(x => x.SizeAcres).HasPrecision(18, 4);
         builder.Property(x => x.SizeSquareFeet).HasPrecision(18, 2);
         builder.Property(x => x.LandSegMarketVal).HasPrecision(18, 2);
@@ -58,5 +63,12 @@ public sealed class LegacyPacsRawLandDetailConfiguration
         // Re-runs / rollback.
         builder.HasIndex(x => x.LoadBatchId)
             .HasDatabaseName("ix_legacy_pacs_raw_land_detail_loadbatch");
+
+        // SYNC-DOCTRINE-4-IMPL-V3: hot read path for the truth-promoter
+        // join — given a (prop_id, prop_val_yr) the promoter aggregates
+        // ag_apply across all land segments to feed the universe
+        // classifier.
+        builder.HasIndex(x => new { x.PropId, x.PropValYr, x.AgApply })
+            .HasDatabaseName("ix_legacy_pacs_raw_land_detail_prop_year_agapply");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260506162612_SyncDoctrine4V3LandDetailAgApply.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506162612_SyncDoctrine4V3LandDetailAgApply.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506162612_SyncDoctrine4V3LandDetailAgApply")]
+    partial class SyncDoctrine4V3LandDetailAgApply
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260506162612_SyncDoctrine4V3LandDetailAgApply.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506162612_SyncDoctrine4V3LandDetailAgApply.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncDoctrine4V3LandDetailAgApply : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AgApply",
+                schema: "legacy_pacs_raw",
+                table: "land_detail",
+                type: "character varying(4)",
+                maxLength: 4,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AgUseCd",
+                schema: "legacy_pacs_raw",
+                table: "land_detail",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_pacs_raw_land_detail_prop_year_agapply",
+                schema: "legacy_pacs_raw",
+                table: "land_detail",
+                columns: new[] { "PropId", "PropValYr", "AgApply" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_legacy_pacs_raw_land_detail_prop_year_agapply",
+                schema: "legacy_pacs_raw",
+                table: "land_detail");
+
+            migrationBuilder.DropColumn(
+                name: "AgApply",
+                schema: "legacy_pacs_raw",
+                table: "land_detail");
+
+            migrationBuilder.DropColumn(
+                name: "AgUseCd",
+                schema: "legacy_pacs_raw",
+                table: "land_detail");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsLandDetailLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsLandDetailLandingService.cs
@@ -107,6 +107,8 @@ public sealed class PacsLandDetailLandingService : IPacsLandDetailLandingService
                     LandSegAgValue = src.LandSegAgValue,
                     LandSegAssessedVal = src.LandSegAssessedVal,
                     LandSegEffAge = src.LandSegEffAge,
+                    AgApply = src.AgApply,
+                    AgUseCd = src.AgUseCd,
                     LoadBatchId = batch.LoadBatchId,
                     SourceQueryHash = queryHash,
                     SourceRowHash = ComputeRowHash(src),
@@ -299,7 +301,9 @@ public sealed class PacsLandDetailLandingService : IPacsLandDetailLandingService
             src.LandSegMarketVal?.ToString(CultureInfo.InvariantCulture) ?? "",
             src.LandSegAgValue?.ToString(CultureInfo.InvariantCulture) ?? "",
             src.LandSegAssessedVal?.ToString(CultureInfo.InvariantCulture) ?? "",
-            src.LandSegEffAge?.ToString(CultureInfo.InvariantCulture) ?? "");
+            src.LandSegEffAge?.ToString(CultureInfo.InvariantCulture) ?? "",
+            src.AgApply ?? "",
+            src.AgUseCd ?? "");
         return ComputeStableHash(seed);
     }
 }

--- a/backend/src/TerraFusion.Data/Services/PacsSources/KeyedSqlServerPacsLandDetailSource.cs
+++ b/backend/src/TerraFusion.Data/Services/PacsSources/KeyedSqlServerPacsLandDetailSource.cs
@@ -45,6 +45,9 @@ public sealed class KeyedSqlServerPacsLandDetailSource : IPacsLandDetailSource
     //   land_seg_ag_value          | ag_val
     //   land_seg_assessed_val      | (no equivalent — project NULL)
     //   land_seg_eff_age           | (no equivalent — project NULL)
+    // SYNC-DOCTRINE-4-IMPL-V3: ag_apply + ag_use_cd projected
+    // verbatim from dbo.land_detail. Both columns are nullable on
+    // the source side so the projection is a straight pass-through.
     public string SourceQueryText =>
         $"SELECT CAST(prop_val_yr AS smallint) AS prop_val_yr, CAST(sup_num AS smallint) AS sup_num, " +
         $"prop_id, land_seg_id, " +
@@ -54,7 +57,8 @@ public sealed class KeyedSqlServerPacsLandDetailSource : IPacsLandDetailSource
         $"land_seg_homesite, size_acres, size_square_feet, " +
         $"land_seg_mkt_val AS land_seg_market_val, ag_val AS land_seg_ag_value, " +
         $"CAST(NULL AS decimal(18,2)) AS land_seg_assessed_val, " +
-        $"CAST(NULL AS smallint) AS land_seg_eff_age " +
+        $"CAST(NULL AS smallint) AS land_seg_eff_age, " +
+        $"ag_apply, ag_use_cd " +
         $"FROM dbo.land_detail " +
         $"WHERE sup_num = 0 AND (prop_id, prop_val_yr) IN ({_keys.Count} keyed pairs)";
 
@@ -83,7 +87,8 @@ public sealed class KeyedSqlServerPacsLandDetailSource : IPacsLandDetailSource
             sb.AppendLine("       land_seg_mkt_val AS land_seg_market_val,");
             sb.AppendLine("       ag_val AS land_seg_ag_value,");
             sb.AppendLine("       CAST(NULL AS decimal(18,2)) AS land_seg_assessed_val,");
-            sb.AppendLine("       CAST(NULL AS smallint) AS land_seg_eff_age");
+            sb.AppendLine("       CAST(NULL AS smallint) AS land_seg_eff_age,");
+            sb.AppendLine("       ag_apply, ag_use_cd");
             sb.AppendLine("FROM dbo.land_detail");
             sb.AppendLine("WHERE sup_num = 0 AND (");
 
@@ -115,6 +120,8 @@ public sealed class KeyedSqlServerPacsLandDetailSource : IPacsLandDetailSource
             var oAgValue    = rdr.GetOrdinal("land_seg_ag_value");
             var oAssessedVal= rdr.GetOrdinal("land_seg_assessed_val");
             var oEffAge     = rdr.GetOrdinal("land_seg_eff_age");
+            var oAgApply    = rdr.GetOrdinal("ag_apply");
+            var oAgUseCd    = rdr.GetOrdinal("ag_use_cd");
 
             while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -135,7 +142,9 @@ public sealed class KeyedSqlServerPacsLandDetailSource : IPacsLandDetailSource
                     LandSegMarketVal:   ReadDecimalOrNull(rdr, oMarketVal),
                     LandSegAgValue:     ReadDecimalOrNull(rdr, oAgValue),
                     LandSegAssessedVal: ReadDecimalOrNull(rdr, oAssessedVal),
-                    LandSegEffAge:      ReadInt16OrNull(rdr, oEffAge));
+                    LandSegEffAge:      ReadInt16OrNull(rdr, oEffAge),
+                    AgApply:            TrimOrNull(rdr, oAgApply),
+                    AgUseCd:            TrimOrNull(rdr, oAgUseCd));
             }
         }
     }

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
@@ -150,6 +150,58 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                     g => g.Key,
                     g => g.OrderByDescending(p => p.LandedAt).First());
 
+            // SYNC-DOCTRINE-4-IMPL-V3: build a (prop_id, prop_val_yr)
+            // → ag-program signal index from legacy_pacs_raw.land_detail.
+            // Aggregate semantics:
+            //   AgApply = 'T'  if ANY land segment has ag_apply='T'
+            //                  (under PACS char coding 'Y'/'T' both
+            //                   indicate participation; we accept either)
+            //   AgApply = 'F'  if NO segment has ag_apply='T' AND
+            //                  at least one has ag_apply='F' / 'N'
+            //   AgApply = NULL otherwise (no land_detail rows landed)
+            //
+            //   AgUseCd       = first non-null ag_use_cd from a segment
+            //                   that has ag_apply='T' (most-relevant);
+            //                   else first non-null overall; else NULL.
+            //
+            // The classifier only checks AgApply='T' for AG_CURRENT_USE
+            // today, so the OR-aggregate is safe: any single ag-segment
+            // routes the parcel to AG_CURRENT_USE regardless of how
+            // many residential segments it also has.
+            var imprvKeys = imprvRows
+                .Select(i => (i.PropId, i.PropValYr))
+                .Distinct()
+                .ToList();
+            var landDetailRows = await _db.LegacyPacsRawLandDetails
+                .Where(l => imprvPropIds.Contains(l.PropId))
+                .Select(l => new { l.PropId, l.PropValYr, l.AgApply, l.AgUseCd, l.LandedAt })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var agSignalByKey = new Dictionary<(int PropId, short PropValYr),
+                (string? AgApply, string? AgUseCd)>();
+            foreach (var grp in landDetailRows.GroupBy(l => (l.PropId, l.PropValYr)))
+            {
+                var rows = grp.OrderByDescending(l => l.LandedAt).ToList();
+                var anyT = rows.Any(r =>
+                    !string.IsNullOrEmpty(r.AgApply) &&
+                    (r.AgApply.Equals("T", StringComparison.OrdinalIgnoreCase) ||
+                     r.AgApply.Equals("Y", StringComparison.OrdinalIgnoreCase)));
+                var anyF = rows.Any(r =>
+                    !string.IsNullOrEmpty(r.AgApply) &&
+                    (r.AgApply.Equals("F", StringComparison.OrdinalIgnoreCase) ||
+                     r.AgApply.Equals("N", StringComparison.OrdinalIgnoreCase)));
+                var agApply = anyT ? "T" : (anyF ? "F" : (string?)null);
+                var agUseCd = rows
+                    .Where(r =>
+                        !string.IsNullOrEmpty(r.AgApply) &&
+                        (r.AgApply.Equals("T", StringComparison.OrdinalIgnoreCase) ||
+                         r.AgApply.Equals("Y", StringComparison.OrdinalIgnoreCase)) &&
+                        !string.IsNullOrEmpty(r.AgUseCd))
+                    .Select(r => r.AgUseCd)
+                    .FirstOrDefault()
+                    ?? rows.Select(r => r.AgUseCd).FirstOrDefault(c => !string.IsNullOrEmpty(c));
+                agSignalByKey[grp.Key] = (agApply, agUseCd);
+            }
+
             var considered = imprvRows.Count;
             var promoted = 0;
             var rejectedNoSupp = 0;
@@ -182,7 +234,7 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
 
                 // SYNC-DOCTRINE-4: classify universe.
                 var universe = await ClassifyUniverseAsync(
-                    imprv, latestPropertyByPropId, cancellationToken).ConfigureAwait(false);
+                    imprv, latestPropertyByPropId, agSignalByKey, cancellationToken).ConfigureAwait(false);
                 if (!universeCounts.TryAdd(universe.UniverseCode, 1))
                     universeCounts[universe.UniverseCode]++;
 
@@ -390,6 +442,7 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
     private async Task<UniverseClassification> ClassifyUniverseAsync(
         LegacyPacsRawImprv imprv,
         IReadOnlyDictionary<int, LegacyPacsRawProperty> propertyIndex,
+        IReadOnlyDictionary<(int PropId, short PropValYr), (string? AgApply, string? AgUseCd)> agSignalIndex,
         CancellationToken cancellationToken)
     {
         if (!propertyIndex.TryGetValue(imprv.PropId, out var property))
@@ -405,13 +458,20 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
         var hasLegacyMarker = property.PropCreateDt.HasValue
                               && property.PropCreateDt.Value < LegacyMarkerCutoff;
 
+        // SYNC-DOCTRINE-4-IMPL-V3: pass real ag-program signals from
+        // legacy_pacs_raw.land_detail when available. NULL (no land_detail
+        // rows landed for this prop_id+yr) is still possible and is
+        // accepted by the V2 classifier — modern rules with wildcard
+        // ag_apply guards will still match.
+        agSignalIndex.TryGetValue((imprv.PropId, imprv.PropValYr), out var agSignal);
+
         var input = new UniverseClassifierInput(
             County: DefaultCountyTag,
             PropValYr: imprv.PropValYr,
             PropTypeCd: property.PropTypeCd,
             PropertyUseCd: null,   // future: join dbo.property_val per (prop_id, prop_val_yr, sup_num)
-            AgApply: null,         // future: join dbo.land_detail per prop_id
-            AgUseCd: null,
+            AgApply: agSignal.AgApply,
+            AgUseCd: agSignal.AgUseCd,
             HasLegacyMarker: hasLegacyMarker);
 
         return await _universeClassifier.ClassifyAsync(input, cancellationToken)


### PR DESCRIPTION
## Why

V2 made REAL_RESIDENTIAL fire as the catch-all by relaxing the `ag_apply='F'` guard, but the AG_CURRENT_USE rule (precedence 1) still couldn't fire because `ag_apply` wasn't being read from PACS at all — `LegacyPacsRawLandDetail` had no column for it, so the truth promoter passed `null` into the classifier. V3 lands the missing data and wires the truth-promoter join.

## Schema

EF migration `20260506162612_SyncDoctrine4V3LandDetailAgApply`:
- `legacy_pacs_raw.land_detail.AgApply` — `varchar(4)`, nullable. PACS Y/T/F/N character-coded boolean.
- `legacy_pacs_raw.land_detail.AgUseCd` — `varchar(16)`, nullable. AG/OSP/CNV closed vocabulary.
- Index `ix_legacy_pacs_raw_land_detail_prop_year_agapply` on `(PropId, PropValYr, AgApply)` — hot read path for the promoter join.

## Source query

`KeyedSqlServerPacsLandDetailSource.SourceQueryText` projects `ag_apply, ag_use_cd` from `dbo.land_detail` verbatim.

## Landing service

`PacsLandDetailLandingService` writes the new fields and includes them in the row hash.

## Promoter join

`PacsImprvCurrentTruthPromoter` loads land_detail rows for the drained prop_ids, aggregates per `(PropId, PropValYr)`:
- `AgApply = 'T'` if ANY segment has `T`/`Y`
- `AgApply = 'F'` if no `T`/`Y` AND at least one `F`/`N`
- `AgApply = NULL` otherwise
- `AgUseCd` = first non-null from a `T`/`Y` segment, else first non-null overall.

The aggregated signals replace the always-NULL placeholders V2 fed the classifier. AG_CURRENT_USE rule now fires from real PACS data.

## Live verification (Harris PACS, post-V3)

**Land drain** TopN=200:
| AgApply | AgUseCd | count |
|---|---|---|
| T | AG | 64 |
| F | (null) | 175 |
| (null) | (null) | 0 (every landed row has the column) |

**Improvement drain** TopN=200 after land:
- promoted: 241
- universe-distribution gate: `AG_CURRENT_USE=28 REAL_RESIDENTIAL=213` (PASS)
- canonical: 28 AG_CURRENT_USE + 213 REAL_RESIDENTIAL

The 28 AG_CURRENT_USE rows are PACS parcels whose land_detail carries `ag_apply='T'` on at least one segment. The 213 REAL_RESIDENTIAL rows are the remainder — correct given the residential-skewed TopN=200 sample (chg_of_owner_id seed pulls recent owner-anchored sales).

## Doctrine evolution — same TopN=200 sample

| | V1 | V2 | V3 |
|---|---|---|---|
| Truth distribution | CONVERSION_LEGACY=241 | REAL_RESIDENTIAL=241 | REAL_RESIDENTIAL=213 + AG_CURRENT_USE=28 |
| Cause | sentinel marker over-fire | escape-hatch + relaxed guards | real ag_apply landed + joined |

## Tests

Solution: 0 errors / 0 warnings. Imprv-promoter regression: 31/31 passing.

## Out of scope

- `LegacyPacsRawPropertyVal` entity for `property_use_cd` — would let REAL_COMMERCIAL EXCLUDE rule discriminate against residential use codes.
- Backfill of pre-V3 land_detail rows carrying `NULL AgApply` (next land drain refreshes them naturally).
- Backfill of pre-V3 truth rows carrying NULL `UniverseCode` or stale CONVERSION_LEGACY classification.

## Reference commits

- V1 on main: `f5110f778` (PR #790)
- V2 on main: `0d6e19f4e` (PR #791)
- V3 commit: `24489ee9b` (this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended land detail records to capture agriculture program application status and use codes, improving property classification accuracy and assessment workflows.

* **Database Improvements**
  * Database schema updated with new fields and performance optimization indexes to efficiently support agriculture program data management and queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->