### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V4 — land property_val for property_use_cd, REAL_COMMERCIAL fires from real PACS

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -24,6 +24,7 @@ using TerraFusion.Core.Sync.ArcGisTruthPromotion;
 using TerraFusion.Core.Sync.PacsLandCanonical;
 using TerraFusion.Core.Sync.PacsLandDetail;
 using TerraFusion.Core.Sync.PacsLandTruth;
+using TerraFusion.Core.Sync.PacsPropertyVal;
 using TerraFusion.Core.Sync.PacsWashPropOwnerVal;
 using TerraFusion.Core.Sync.PacsWashPropOwnerValTruth;
 using TerraFusion.Core.Sync.PacsWsdorCanonical;
@@ -344,6 +345,8 @@ public class DoctrineDrainController : ControllerBase
         [FromServices] IPacsImprvAttrLandingService imprvAttrSvc,
         [FromServices] IPacsImprvCurrentTruthPromoter imprvTruthPromoter,
         [FromServices] IPacsImprvCanonicalProjector imprvCanonicalProjector,
+        [FromServices] IPacsLandDetailLandingService landDetailSvc,
+        [FromServices] IPacsPropertyValLandingService propertyValSvc,
         [FromServices] IConfiguration config,
         [FromBody] DoctrineDrainRequest? request,
         CancellationToken cancellationToken = default)
@@ -414,6 +417,38 @@ public class DoctrineDrainController : ControllerBase
             if (!IsCompleted(suppS1.Status))
                 return await FailLaneAsync(LaneName, "Supp-S1", suppS1.ErrorSummary,
                     batchIds, startedAt, quarantineBefore, cancellationToken);
+
+            // SYNC-DOCTRINE-4-IMPL-V4: PropertyVal S1 (universe classifier
+            // reads property_use_cd from these rows). Non-blocking on
+            // failure — the truth promoter falls through to NULL
+            // property_use_cd which the V2 classifier handles by
+            // routing prop_type_cd='R' rows to REAL_RESIDENTIAL.
+            var propertyValSrc = new KeyedSqlServerPacsPropertyValSource(pacsCs!, imprvKeys);
+            var propertyValS1 = await propertyValSvc.LandPropertyValsAsync(
+                propertyValSrc, operatorName, cancellationToken);
+            batchIds.Add(propertyValS1.LoadBatchId);
+            if (!IsCompleted(propertyValS1.Status))
+            {
+                _logger.LogWarning(
+                    "[Drain:improvement] PropertyVal-S1 failed (non-blocking): {Err}. " +
+                    "Promoter will pass NULL property_use_cd to classifier.",
+                    propertyValS1.ErrorSummary);
+            }
+
+            // SYNC-DOCTRINE-4-IMPL-V4: LandDetail S1 (universe classifier
+            // reads ag_apply / ag_use_cd from these rows). Same
+            // non-blocking semantics as PropertyVal-S1.
+            var landDetailSrc = new KeyedSqlServerPacsLandDetailSource(pacsCs!, imprvKeys);
+            var landDetailS1 = await landDetailSvc.LandLandDetailsAsync(
+                landDetailSrc, operatorName, cancellationToken);
+            batchIds.Add(landDetailS1.LoadBatchId);
+            if (!IsCompleted(landDetailS1.Status))
+            {
+                _logger.LogWarning(
+                    "[Drain:improvement] LandDetail-S1 failed (non-blocking): {Err}. " +
+                    "Promoter will pass NULL ag_apply to classifier.",
+                    landDetailS1.ErrorSummary);
+            }
 
             // Imprv S1.
             var imprvSrc = new KeyedSqlServerPacsImprvSource(pacsCs!, imprvKeys);

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1808,6 +1808,12 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.PacsLandDetail.IPacsLandDetailLandingService,
     TerraFusion.Data.Services.LegacyPacsRaw.PacsLandDetailLandingService>();
 
+// SYNC-DOCTRINE-4-IMPL-V4: PACS property_val raw landing — provides
+// property_use_cd for the universe classifier.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.PacsPropertyVal.IPacsPropertyValLandingService,
+    TerraFusion.Data.Services.LegacyPacsRaw.PacsPropertyValLandingService>();
+
 // Slice D1: ArcGIS REST FeatureService raw landing. Wraps the
 // existing G1-C IArcGisFeatureServiceClient and writes verbatim
 // to legacy_arcgis_raw.parcel_geom with full provenance. Four

--- a/backend/src/TerraFusion.Core/Entities/LegacyPacsRaw/LegacyPacsRawPropertyVal.cs
+++ b/backend/src/TerraFusion.Core/Entities/LegacyPacsRaw/LegacyPacsRawPropertyVal.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace TerraFusion.Core.Entities.LegacyPacsRaw;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: raw PACS <c>property_val</c> landing zone.
+///
+/// <para>The PACS doctrine: <c>property_val</c> is the per-year,
+/// per-supplement valuation row — keyed by
+/// <c>(prop_val_yr, sup_num, prop_id)</c>. One physical parcel
+/// (<c>dbo.property</c>) maps to many <c>property_val</c> rows
+/// (one per (year, supplement) revision). The supp-aware filter
+/// lives on <c>prop_supp_assoc</c>; this layer preserves verbatim.</para>
+///
+/// <para>SYNC-DOCTRINE-4 reads <see cref="PropertyUseCd"/> for the
+/// universe classifier — it lets <c>REAL_COMMERCIAL</c>'s EXCLUDE
+/// rule discriminate between residential and commercial code sets
+/// among <c>prop_type_cd='R'</c> parcels. Earlier slices (V1/V2/V3)
+/// passed NULL for property_use_cd because the column wasn't being
+/// landed; V4 closes that gap.</para>
+///
+/// <para>Lifecycle: <see cref="PropInactiveDt"/> lives here (not on
+/// <c>dbo.property</c>) — operator-supplied PACS doctrine confirms
+/// active-vs-retired parcel state is determined per-supp-year on
+/// this row. Future slices may consume it for parcel-spine retire
+/// logic.</para>
+///
+/// <para>Provenance is non-negotiable: <see cref="LoadBatchId"/> +
+/// <see cref="SourceQueryHash"/> on every landed row.</para>
+/// </summary>
+public sealed class LegacyPacsRawPropertyVal
+{
+    /// <summary>Synthetic landing-row id.</summary>
+    public Guid LandedRowId { get; set; } = Guid.NewGuid();
+
+    // ── PACS source identity (the 3-key composite) ────────────────
+    public short PropValYr { get; set; }
+    public short SupNum { get; set; }
+    public int PropId { get; set; }
+
+    // ── Type / classification ────────────────────────────────────
+    /// <summary>
+    /// PACS <c>property_val.property_use_cd</c>. Closed vocabulary;
+    /// Benton uses 11/12/13/14/18 for residential variants and
+    /// distinct codes for commercial / industrial / agricultural.
+    /// Used by SYNC-DOCTRINE-4 REAL_COMMERCIAL EXCLUDE rule.
+    /// </summary>
+    public string? PropertyUseCd { get; set; }
+
+    // ── Lifecycle ────────────────────────────────────────────────
+    /// <summary>
+    /// PACS <c>property_val.prop_inactive_dt</c>. NULL when the
+    /// parcel is active for this (year, supplement). Reserved for
+    /// future slices that filter inactive parcels.
+    /// </summary>
+    public DateTime? PropInactiveDt { get; set; }
+
+    // ── Provenance (the doctrine's non-negotiable surface) ────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+    public string SourceRowHash { get; set; } = string.Empty;
+    public DateTime LandedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/IPacsPropertyValLandingService.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/IPacsPropertyValLandingService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.PacsPropertyVal;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: PACS property_val raw landing orchestrator.
+///
+/// <para>Doctrine: this service does NOT promote into
+/// <c>truth_pacs.*</c> or <c>canonical_tf.*</c>. It records two
+/// promotion gates:</para>
+/// <list type="bullet">
+///   <item><c>property-val-distribution</c> — informational; rows
+///   per (year, sup_num).</item>
+///   <item><c>property-val-key-uniqueness</c> — FAIL when any 3-key
+///   tuple appears more than once.</item>
+/// </list>
+/// </summary>
+public interface IPacsPropertyValLandingService
+{
+    Task<PacsPropertyValLandingResult> LandPropertyValsAsync(
+        IPacsPropertyValSource source,
+        string operatorName,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V4: outcome of one landing run.</summary>
+public sealed record PacsPropertyValLandingResult
+{
+    public required Guid LoadBatchId { get; init; }
+
+    /// <summary>'COMPLETED' | 'FAILED'.</summary>
+    public required string Status { get; init; }
+
+    public required int RowsLanded { get; init; }
+
+    /// <summary>3-key duplicates. Doctrine: must be 0 for the gate to PASS.</summary>
+    public required int DuplicateKeyViolations { get; init; }
+
+    public required int RowsWithPropertyUseCd { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}

--- a/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/IPacsPropertyValSource.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/IPacsPropertyValSource.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace TerraFusion.Core.Sync.PacsPropertyVal;
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V4: PACS <c>property_val</c> source contract.</summary>
+public interface IPacsPropertyValSource
+{
+    string SourceSystem { get; }
+    string SourceFileOrDatabase { get; }
+    string SourceQueryText { get; }
+
+    IAsyncEnumerable<PacsSourcePropertyVal> StreamPropertyValsAsync(
+        CancellationToken cancellationToken);
+}

--- a/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/PacsSourcePropertyVal.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsPropertyVal/PacsSourcePropertyVal.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TerraFusion.Core.Sync.PacsPropertyVal;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: source-shaped PACS <c>property_val</c> row.
+/// </summary>
+public sealed record PacsSourcePropertyVal(
+    short PropValYr,
+    short SupNum,
+    int PropId,
+    string? PropertyUseCd,
+    DateTime? PropInactiveDt);

--- a/backend/src/TerraFusion.Data/Configurations/LegacyPacsRaw/LegacyPacsRawPropertyValConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/LegacyPacsRaw/LegacyPacsRawPropertyValConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
+
+namespace TerraFusion.Data.Configurations.LegacyPacsRaw;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: EF configuration for
+/// <see cref="LegacyPacsRawPropertyVal"/>. Schema
+/// <c>legacy_pacs_raw</c>; table <c>property_val</c>.
+/// </summary>
+public sealed class LegacyPacsRawPropertyValConfiguration
+    : IEntityTypeConfiguration<LegacyPacsRawPropertyVal>
+{
+    public void Configure(EntityTypeBuilder<LegacyPacsRawPropertyVal> builder)
+    {
+        builder.ToTable("property_val", schema: "legacy_pacs_raw");
+
+        builder.HasKey(x => x.LandedRowId);
+        builder.Property(x => x.LandedRowId).IsRequired();
+
+        builder.Property(x => x.PropValYr).IsRequired();
+        builder.Property(x => x.SupNum).IsRequired();
+        builder.Property(x => x.PropId).IsRequired();
+
+        // Benton dominant property_use_cd values are 2-3 chars; width 16 is generous.
+        builder.Property(x => x.PropertyUseCd).HasMaxLength(16);
+
+        builder.Property(x => x.PropInactiveDt);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash).HasMaxLength(64).IsRequired();
+        builder.Property(x => x.SourceRowHash).HasMaxLength(64).IsRequired();
+        builder.Property(x => x.LandedAt).IsRequired();
+
+        // Read by the 3-key composite — for joining back to imprv during promotion.
+        builder.HasIndex(x => new { x.PropId, x.PropValYr, x.SupNum })
+            .HasDatabaseName("ix_legacy_pacs_raw_property_val_3key");
+
+        // Use-cd scans (commercial-vs-residential split).
+        builder.HasIndex(x => x.PropertyUseCd)
+            .HasDatabaseName("ix_legacy_pacs_raw_property_val_use_cd");
+
+        // Re-runs / rollback.
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_legacy_pacs_raw_property_val_loadbatch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260506182219_SyncDoctrine4V4PropertyValLanding.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506182219_SyncDoctrine4V4PropertyValLanding.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506182219_SyncDoctrine4V4PropertyValLanding")]
+    partial class SyncDoctrine4V4PropertyValLanding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260506182219_SyncDoctrine4V4PropertyValLanding.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260506182219_SyncDoctrine4V4PropertyValLanding.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncDoctrine4V4PropertyValLanding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "property_val",
+                schema: "legacy_pacs_raw",
+                columns: table => new
+                {
+                    LandedRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PropValYr = table.Column<short>(type: "smallint", nullable: false),
+                    SupNum = table.Column<short>(type: "smallint", nullable: false),
+                    PropId = table.Column<int>(type: "integer", nullable: false),
+                    PropertyUseCd = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: true),
+                    PropInactiveDt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    SourceRowHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    LandedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_property_val", x => x.LandedRowId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_pacs_raw_property_val_3key",
+                schema: "legacy_pacs_raw",
+                table: "property_val",
+                columns: new[] { "PropId", "PropValYr", "SupNum" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_pacs_raw_property_val_loadbatch",
+                schema: "legacy_pacs_raw",
+                table: "property_val",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_legacy_pacs_raw_property_val_use_cd",
+                schema: "legacy_pacs_raw",
+                table: "property_val",
+                column: "PropertyUseCd");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "property_val",
+                schema: "legacy_pacs_raw");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsPropertyValLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyPacsRaw/PacsPropertyValLandingService.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Sync.PacsPropertyVal;
+
+namespace TerraFusion.Data.Services.LegacyPacsRaw;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: drains an
+/// <see cref="IPacsPropertyValSource"/> into
+/// <c>legacy_pacs_raw.property_val</c> with full provenance and
+/// records four landing gates (distribution, key-uniqueness,
+/// provenance-coverage, use-cd-coverage).
+/// </summary>
+public sealed class PacsPropertyValLandingService : IPacsPropertyValLandingService
+{
+    private const int BatchSize = 1000;
+
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<PacsPropertyValLandingService> _logger;
+
+    public PacsPropertyValLandingService(
+        TerraFusionDbContext db,
+        ILogger<PacsPropertyValLandingService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<PacsPropertyValLandingResult> LandPropertyValsAsync(
+        IPacsPropertyValSource source,
+        string operatorName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var queryHash = ComputeStableHash(source.SourceQueryText);
+        var batch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.PacsOltp,
+            SourceSystem = source.SourceSystem,
+            SourceFileOrDatabase = source.SourceFileOrDatabase,
+            SourceQueryHash = queryHash,
+            Operator = operatorName,
+            Status = "IN_PROGRESS",
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.SyncBridgeLoadBatches.Add(batch);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var rowsLanded = 0;
+        var rowsWithUseCd = 0;
+        var pending = 0;
+        var keyCounts = new Dictionary<(short, short, int), int>();
+
+        try
+        {
+            using (var _bulkScope = BulkInsertScope.Begin(_db))
+            {
+                await foreach (var src in source
+                    .StreamPropertyValsAsync(cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    _db.LegacyPacsRawPropertyVals.Add(new LegacyPacsRawPropertyVal
+                    {
+                        PropValYr = src.PropValYr,
+                        SupNum = src.SupNum,
+                        PropId = src.PropId,
+                        PropertyUseCd = src.PropertyUseCd,
+                        PropInactiveDt = src.PropInactiveDt,
+                        LoadBatchId = batch.LoadBatchId,
+                        SourceQueryHash = queryHash,
+                        SourceRowHash = ComputeRowHash(src),
+                        LandedAt = DateTime.UtcNow,
+                    });
+
+                    var key = (src.PropValYr, src.SupNum, src.PropId);
+                    keyCounts[key] = keyCounts.TryGetValue(key, out var c) ? c + 1 : 1;
+                    if (!string.IsNullOrEmpty(src.PropertyUseCd)) rowsWithUseCd++;
+
+                    rowsLanded++;
+                    pending++;
+                    if (pending >= BatchSize)
+                    {
+                        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                        pending = 0;
+                    }
+                }
+
+                if (pending > 0)
+                    await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var duplicateKeyViolations = keyCounts.Values.Count(c => c > 1);
+
+            await WriteGatesAsync(
+                batch, rowsLanded, duplicateKeyViolations, rowsWithUseCd,
+                cancellationToken).ConfigureAwait(false);
+
+            batch.Status = "COMPLETED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.RowsExtracted = rowsLanded;
+            batch.RowsPromoted = rowsLanded;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "PACS property_val landing COMPLETED. batch={BatchId} rows={Rows} duplicates={Dups} useCd={UseCd}",
+                batch.LoadBatchId, rowsLanded, duplicateKeyViolations, rowsWithUseCd);
+
+            return new PacsPropertyValLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "COMPLETED",
+                RowsLanded = rowsLanded,
+                DuplicateKeyViolations = duplicateKeyViolations,
+                RowsWithPropertyUseCd = rowsWithUseCd,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var summary = $"{ex.GetType().Name}: {ex.Message}";
+            batch.Status = "FAILED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.ErrorSummary = summary;
+            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _logger.LogError(ex,
+                "PACS property_val landing FAILED. batch={BatchId} summary={Summary}",
+                batch.LoadBatchId, summary);
+
+            return new PacsPropertyValLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "FAILED",
+                RowsLanded = 0,
+                DuplicateKeyViolations = 0,
+                RowsWithPropertyUseCd = 0,
+                ErrorSummary = summary,
+            };
+        }
+    }
+
+    private async Task WriteGatesAsync(
+        LoadBatch batch,
+        int rowsLanded,
+        int duplicateKeyViolations,
+        int rowsWithUseCd,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+
+        // 1) property-val-distribution — informational PASS.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "property-val-distribution",
+            GateStage = "SOURCE_TO_RAW",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = rowsLanded.ToString(CultureInfo.InvariantCulture),
+            Detail = $"rows={rowsLanded} withUseCd={rowsWithUseCd}",
+            ExecutedAt = now,
+        });
+
+        // 2) property-val-key-uniqueness — doctrine invariant.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "property-val-key-uniqueness",
+            GateStage = "SOURCE_TO_RAW",
+            Status = duplicateKeyViolations == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = duplicateKeyViolations.ToString(CultureInfo.InvariantCulture),
+            Detail = duplicateKeyViolations == 0
+                ? "every (year, sup, prop_id) is unique"
+                : $"{duplicateKeyViolations} 3-key tuples appeared more than once",
+            ExecutedAt = now,
+        });
+
+        // 3) provenance-coverage — assert from DB.
+        var unprovenanced = await _db.LegacyPacsRawPropertyVals
+            .Where(r => r.LoadBatchId == batch.LoadBatchId
+                        && (r.LoadBatchId == Guid.Empty
+                            || string.IsNullOrEmpty(r.SourceQueryHash)))
+            .CountAsync(cancellationToken).ConfigureAwait(false);
+
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "provenance-coverage",
+            GateStage = "SOURCE_TO_RAW",
+            Status = unprovenanced == 0 ? "PASS" : "FAIL",
+            Expected = "0",
+            Actual = unprovenanced.ToString(CultureInfo.InvariantCulture),
+            Detail = unprovenanced == 0
+                ? $"all {rowsLanded} landed rows have load_batch_id and source_query_hash"
+                : $"{unprovenanced} rows lack provenance",
+            ExecutedAt = now,
+        });
+
+        // 4) property-val-use-cd-coverage — informational; share of
+        //    rows that landed a non-null property_use_cd. Useful to
+        //    audit PACS data quality independently of doctrine
+        //    classification.
+        _db.SyncBridgePromotionGateResults.Add(new PromotionGateResult
+        {
+            LoadBatchId = batch.LoadBatchId,
+            GateName = "property-val-use-cd-coverage",
+            GateStage = "SOURCE_TO_RAW",
+            Status = "PASS",
+            Expected = "informational",
+            Actual = rowsWithUseCd.ToString(CultureInfo.InvariantCulture),
+            Detail = rowsLanded == 0
+                ? "no rows landed"
+                : $"{rowsWithUseCd}/{rowsLanded} rows have property_use_cd",
+            ExecutedAt = now,
+        });
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static string ComputeStableHash(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input ?? string.Empty));
+        return Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+    }
+
+    internal static string ComputeRowHash(PacsSourcePropertyVal src)
+    {
+        var seed = string.Join("|",
+            src.PropValYr.ToString(CultureInfo.InvariantCulture),
+            src.SupNum.ToString(CultureInfo.InvariantCulture),
+            src.PropId.ToString(CultureInfo.InvariantCulture),
+            src.PropertyUseCd ?? "",
+            src.PropInactiveDt?.ToString("o", CultureInfo.InvariantCulture) ?? "");
+        return ComputeStableHash(seed);
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/PacsSources/KeyedSqlServerPacsPropertyValSource.cs
+++ b/backend/src/TerraFusion.Data/Services/PacsSources/KeyedSqlServerPacsPropertyValSource.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using Microsoft.Data.SqlClient;
+using TerraFusion.Core.Sync.PacsPropertyVal;
+
+namespace TerraFusion.Data.Services.PacsSources;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V4: keyed property_val source. Drains
+/// <c>pacs_oltp.dbo.property_val</c> for ONLY the
+/// (prop_id, prop_val_yr) tuples explicitly requested. Filters to
+/// <c>sup_num = 0</c>.
+///
+/// <para>One physical parcel maps to multiple property_val rows
+/// (one per year-supplement pair). The improvement drain anchors
+/// on a working year + sup=0; this source matches that scope.</para>
+/// </summary>
+public sealed class KeyedSqlServerPacsPropertyValSource : IPacsPropertyValSource
+{
+    private const int KeyChunkSize = 1000;
+
+    private readonly string _connectionString;
+    private readonly IReadOnlyCollection<(int PropId, short PropValYr)> _keys;
+
+    public KeyedSqlServerPacsPropertyValSource(
+        string connectionString,
+        IReadOnlyCollection<(int PropId, short PropValYr)> keys)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+            throw new ArgumentException("PACS connection string is required.", nameof(connectionString));
+        _connectionString = connectionString;
+        _keys = keys ?? throw new ArgumentNullException(nameof(keys));
+    }
+
+    public string SourceSystem => "JCHARRISPACS";
+    public string SourceFileOrDatabase => "pacs_oltp";
+
+    public string SourceQueryText =>
+        $"SELECT CAST(prop_val_yr AS smallint) AS prop_val_yr, " +
+        $"CAST(sup_num AS smallint) AS sup_num, " +
+        $"prop_id, property_use_cd, prop_inactive_dt " +
+        $"FROM dbo.property_val " +
+        $"WHERE sup_num = 0 AND (prop_id, prop_val_yr) IN ({_keys.Count} keyed pairs)";
+
+    public async IAsyncEnumerable<PacsSourcePropertyVal> StreamPropertyValsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        if (_keys.Count == 0) yield break;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var chunk in Chunk(_keys, KeyChunkSize))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var sb = new StringBuilder();
+            sb.AppendLine("SELECT CAST(prop_val_yr AS smallint) AS prop_val_yr,");
+            sb.AppendLine("       CAST(sup_num AS smallint) AS sup_num,");
+            sb.AppendLine("       prop_id, property_use_cd, prop_inactive_dt");
+            sb.AppendLine("FROM dbo.property_val");
+            sb.AppendLine("WHERE sup_num = 0 AND (");
+
+            await using var cmd = new SqlCommand { Connection = conn, CommandTimeout = 600 };
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                if (i > 0) sb.Append("   OR ");
+                sb.AppendLine($"(prop_id = @p{i} AND prop_val_yr = @y{i})");
+                cmd.Parameters.AddWithValue($"@p{i}", chunk[i].PropId);
+                cmd.Parameters.AddWithValue($"@y{i}", (int)chunk[i].PropValYr);
+            }
+            sb.AppendLine(")");
+            cmd.CommandText = sb.ToString();
+
+            await using var rdr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var oPropValYr  = rdr.GetOrdinal("prop_val_yr");
+            var oSupNum     = rdr.GetOrdinal("sup_num");
+            var oPropId     = rdr.GetOrdinal("prop_id");
+            var oUseCd      = rdr.GetOrdinal("property_use_cd");
+            var oInactiveDt = rdr.GetOrdinal("prop_inactive_dt");
+
+            while (await rdr.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // PACS returns prop_inactive_dt with Kind=Unspecified.
+                // Npgsql requires UTC for `timestamp with time zone`
+                // columns. Treat the PACS timestamp as already UTC
+                // (it is — PACS stores in server-local but the column
+                // semantics are calendar-date-style anyway).
+                DateTime? inactiveDt = rdr.IsDBNull(oInactiveDt)
+                    ? null
+                    : DateTime.SpecifyKind(rdr.GetDateTime(oInactiveDt), DateTimeKind.Utc);
+
+                yield return new PacsSourcePropertyVal(
+                    PropValYr:      rdr.GetInt16(oPropValYr),
+                    SupNum:         rdr.GetInt16(oSupNum),
+                    PropId:         rdr.GetInt32(oPropId),
+                    PropertyUseCd:  TrimOrNull(rdr, oUseCd),
+                    PropInactiveDt: inactiveDt);
+            }
+        }
+    }
+
+    private static string? TrimOrNull(SqlDataReader rdr, int ordinal)
+    {
+        if (rdr.IsDBNull(ordinal)) return null;
+        var raw = rdr.GetString(ordinal).Trim();
+        return string.IsNullOrEmpty(raw) ? null : raw;
+    }
+
+    private static IEnumerable<List<T>> Chunk<T>(IEnumerable<T> source, int size)
+    {
+        var bucket = new List<T>(size);
+        foreach (var item in source)
+        {
+            bucket.Add(item);
+            if (bucket.Count == size) { yield return bucket; bucket = new List<T>(size); }
+        }
+        if (bucket.Count > 0) yield return bucket;
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
+++ b/backend/src/TerraFusion.Data/Services/TruthPacs/PacsImprvCurrentTruthPromoter.cs
@@ -172,6 +172,22 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
                 .Select(i => (i.PropId, i.PropValYr))
                 .Distinct()
                 .ToList();
+
+            // SYNC-DOCTRINE-4-IMPL-V4: build a (prop_id, prop_val_yr,
+            // sup_num) → property_use_cd index from
+            // legacy_pacs_raw.property_val. Latest LandedAt wins. The
+            // classifier reads property_use_cd to discriminate
+            // residential vs commercial among prop_type_cd='R' rows.
+            var propertyValRows = await _db.LegacyPacsRawPropertyVals
+                .Where(pv => imprvPropIds.Contains(pv.PropId))
+                .Select(pv => new { pv.PropId, pv.PropValYr, pv.SupNum, pv.PropertyUseCd, pv.LandedAt })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var propertyUseCdByKey = propertyValRows
+                .GroupBy(pv => (pv.PropId, pv.PropValYr, pv.SupNum))
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(pv => pv.LandedAt).First().PropertyUseCd);
+
             var landDetailRows = await _db.LegacyPacsRawLandDetails
                 .Where(l => imprvPropIds.Contains(l.PropId))
                 .Select(l => new { l.PropId, l.PropValYr, l.AgApply, l.AgUseCd, l.LandedAt })
@@ -234,7 +250,8 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
 
                 // SYNC-DOCTRINE-4: classify universe.
                 var universe = await ClassifyUniverseAsync(
-                    imprv, latestPropertyByPropId, agSignalByKey, cancellationToken).ConfigureAwait(false);
+                    imprv, latestPropertyByPropId, propertyUseCdByKey, agSignalByKey,
+                    cancellationToken).ConfigureAwait(false);
                 if (!universeCounts.TryAdd(universe.UniverseCode, 1))
                     universeCounts[universe.UniverseCode]++;
 
@@ -442,6 +459,7 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
     private async Task<UniverseClassification> ClassifyUniverseAsync(
         LegacyPacsRawImprv imprv,
         IReadOnlyDictionary<int, LegacyPacsRawProperty> propertyIndex,
+        IReadOnlyDictionary<(int PropId, short PropValYr, short SupNum), string?> propertyUseCdIndex,
         IReadOnlyDictionary<(int PropId, short PropValYr), (string? AgApply, string? AgUseCd)> agSignalIndex,
         CancellationToken cancellationToken)
     {
@@ -465,11 +483,20 @@ public sealed class PacsImprvCurrentTruthPromoter : IPacsImprvCurrentTruthPromot
         // ag_apply guards will still match.
         agSignalIndex.TryGetValue((imprv.PropId, imprv.PropValYr), out var agSignal);
 
+        // SYNC-DOCTRINE-4-IMPL-V4: pass real property_use_cd from
+        // legacy_pacs_raw.property_val when available. Looked up by
+        // the imprv row's full (PropId, PropValYr, SupNum) key. NULL
+        // is still possible and the V2 classifier semantics handle
+        // it correctly (EXCLUDE rule short-circuits to false on NULL,
+        // falls through to RESIDENTIAL).
+        propertyUseCdIndex.TryGetValue(
+            (imprv.PropId, imprv.PropValYr, imprv.SupNum), out var propertyUseCd);
+
         var input = new UniverseClassifierInput(
             County: DefaultCountyTag,
             PropValYr: imprv.PropValYr,
             PropTypeCd: property.PropTypeCd,
-            PropertyUseCd: null,   // future: join dbo.property_val per (prop_id, prop_val_yr, sup_num)
+            PropertyUseCd: propertyUseCd,
             AgApply: agSignal.AgApply,
             AgUseCd: agSignal.AgUseCd,
             HasLegacyMarker: hasLegacyMarker);

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -195,6 +195,12 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.LegacyPacsRaw.LegacyPacsRawProperty>
     LegacyPacsRawProperties { get; set; } = null!;
 
+  // SYNC-DOCTRINE-4-IMPL-V4: legacy_pacs_raw.property_val. Per-year
+  // per-supplement valuation rows; carries property_use_cd that
+  // SYNC-DOCTRINE-4 REAL_COMMERCIAL EXCLUDE rule reads.
+  public DbSet<TerraFusion.Core.Entities.LegacyPacsRaw.LegacyPacsRawPropertyVal>
+    LegacyPacsRawPropertyVals { get; set; } = null!;
+
   // Slice B1-A: account landing — the global party/entity identity
   // record with the rich PII surface. Block B's first stop.
   public DbSet<TerraFusion.Core.Entities.LegacyPacsRaw.LegacyPacsRawAccount>
@@ -992,6 +998,11 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // identity table for the doctrine parcel pipeline.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.LegacyPacsRaw.LegacyPacsRawPropertyConfiguration());
+
+    // SYNC-DOCTRINE-4-IMPL-V4: per-year property_val landing. Provides
+    // property_use_cd to the universe classifier.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.LegacyPacsRaw.LegacyPacsRawPropertyValConfiguration());
 
     // Slice B1-A: account landing — Block B's PII-rich identity table.
     modelBuilder.ApplyConfiguration(


### PR DESCRIPTION
## Why

V3 wired `ag_apply` so AG_CURRENT_USE could fire. V4 lands the last remaining classifier signal — `property_use_cd` from PACS `dbo.property_val` — so REAL_COMMERCIAL's EXCLUDE rule can discriminate residential vs commercial codes among `prop_type_cd='R'` parcels. The classifier now consumes all the modern signals locked in the original V1 design.

## Schema

EF migration `20260506182219_SyncDoctrine4V4PropertyValLanding`:
- `legacy_pacs_raw.property_val` table — 3-key (PropValYr/SupNum/PropId) + `PropertyUseCd` (varchar(16)) + `PropInactiveDt` (timestamp tz) + provenance + 3 indexes (3-key, PropertyUseCd, LoadBatchId).

## New surface

- `LegacyPacsRawPropertyVal` entity + EF config + DbSet
- `PacsSourcePropertyVal` DTO
- `IPacsPropertyValSource` + `KeyedSqlServerPacsPropertyValSource` (chunked at 1000 keys per round-trip)
- `IPacsPropertyValLandingService` + `PacsPropertyValLandingService` (4 gates: distribution, key-uniqueness, provenance-coverage, use-cd-coverage)
- DI registration in `Program.cs`

## UTC fix

PACS returns `prop_inactive_dt` with `Kind=Unspecified`. Npgsql refuses to coerce `Unspecified` into `timestamp with time zone`. Reader forces `DateTimeKind.Utc` on read — calendar-date semantic preserved since PACS stores these as date-style timestamps anyway. Surfaced and fixed during the first V4 drain attempt.

## Promoter join

`PacsImprvCurrentTruthPromoter` loads `property_val` rows for the drained `prop_ids` and builds a `(PropId, PropValYr, SupNum) → PropertyUseCd` map. The full 3-key match is used (each imprv row's `SupNum` is matched explicitly). Latest `LandedAt` wins on duplicates. Replaces V3's always-NULL `property_use_cd` in the classifier input.

## Improvement drain chain update

`DoctrineDrainController.DrainImprovement` now lands `PropertyVal-S1` AND `LandDetail-S1` in the chain after `Supp-S1` and before `Imprv-S1`. Both are non-blocking on failure — promoter falls through to NULL signals which the V2 classifier handles by routing `prop_type_cd='R'` rows to REAL_RESIDENTIAL. **One drain produces fully-classified truth rows in a single API call** (no more "drain land first, then improvement" two-step that V3 required).

## Live verification (Harris PACS, post-V4)

`property_val` landing TopN=200:
- 200 rows landed, 200 with `property_use_cd`, 4 with `prop_inactive_dt`
- histogram: code 11=139, code 83=31, code 81=10, code 18=5, code 59=4, code 12=2, code 91=2, code 68=2, plus singletons

Improvement drain truth distribution:
- `AG_CURRENT_USE` = 28
- **`REAL_COMMERCIAL` = 4 (NEW — V4)**
- `REAL_RESIDENTIAL` = 209

Universe-distribution gate: PASS.

## Doctrine evolution V1 → V4 on the same TopN=200 sample

| | V1 | V2 | V3 | V4 |
|---|---|---|---|---|
| CONVERSION_LEGACY | 241 | 0 | 0 | 0 |
| REAL_RESIDENTIAL | 0 | 241 | 213 | 209 |
| AG_CURRENT_USE | 0 | 0 | 28 | 28 |
| REAL_COMMERCIAL | 0 | 0 | 0 | **4** |
| Cause | sentinel over-fire | escape-hatch + relaxed guards | real ag_apply | real property_use_cd |

CONVERSION_LEGACY=0 from V4. All four modern universes fire correctly from real Harris PACS data.

## Tests

Solution: 0 errors / 0 warnings. Imprv promoter regression: 60/60 passing.

## Out of scope

- `PacsPropertyValTruthPromoter` / canonical projector (this slice only lands raw; doctrine consumers join from raw directly).
- `prop_inactive_dt`-driven retire logic in parcel spine (column landed but unused this slice).
- Tighten REAL_COMMERCIAL `property_use_cd` CSV from `EXCLUDE-{11,12,13,14,18}` to `INCLUDE-{actual commercial codes}` once the operator profiles the full distribution (codes 81, 83 likely commercial; needs operator confirmation).
- Backfill of pre-V4 truth rows currently carrying NULL UniverseCode or stale CONVERSION_LEGACY / RESIDENTIAL classification.

## Reference commits

- V1 on main: `f5110f778` (PR #790)
- V2 on main: `0d6e19f4e` (PR #791)
- V3 on main: `762a5a6be` (PR #792)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended property value landing support to the PACS data pipeline, enabling the system to capture and process property use codes and inactive date information.
  * Integrated property value data into the promotion workflow, improving data enrichment for existing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->