### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V5 — universe backfill brings 1,906 stale truth rows to current classification

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/PacsImprvUniverseBackfillServiceTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PacsImprvUniverseBackfillServiceTests.cs
@@ -1,0 +1,305 @@
+// SYNC-DOCTRINE-4-IMPL-V5 — backfill service contract tests.
+//
+// Validates that the backfill correctly:
+//   - skips rows that already match the latest classification,
+//   - reclassifies rows whose UniverseCode is NULL,
+//   - reclassifies rows whose UniverseRuleId references an inactive rule,
+//   - reports could-not-classify when property row is missing,
+//   - dry-run computes the same transitions but doesn't UPDATE,
+//   - produces a per-transition audit map.
+//
+// Uses the production seeder + classifier; mocks only the data
+// surface (truth + property + property_val + land_detail rows).
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class PacsImprvUniverseBackfillServiceTests
+{
+    private const string County = "benton-wa";
+
+    private static (PacsImprvUniverseBackfillService svc, IServiceProvider sp) Build()
+    {
+        var dbName = $"BackfillTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        // Seed V2 universe rules so the classifier has rules to walk.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var seeder = new DoctrinePropertyUniverseSeeder(
+                db, NullLogger<DoctrinePropertyUniverseSeeder>.Instance);
+            seeder.SeedAsync().GetAwaiter().GetResult();
+        }
+
+        var classifier = new PropertyUniverseClassifier(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PropertyUniverseClassifier>.Instance);
+
+        var dbForSvc = sp.CreateScope().ServiceProvider
+            .GetRequiredService<TerraFusionDbContext>();
+        var svc = new PacsImprvUniverseBackfillService(
+            dbForSvc, classifier,
+            NullLogger<PacsImprvUniverseBackfillService>.Instance);
+        return (svc, sp);
+    }
+
+    private static async Task SeedTruthRowAsync(
+        IServiceProvider sp,
+        int propId, short propValYr, short supNum, long imprvId,
+        string? universeCode = null, Guid? universeRuleId = null,
+        string? propTypeCd = "R", string? propertyUseCd = null,
+        string? agApply = null, DateTime? propCreateDt = null)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        // truth row
+        db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
+        {
+            PropValYr = propValYr,
+            SupNum = supNum,
+            PropId = propId,
+            ImprvId = imprvId,
+            UniverseCode = universeCode,
+            UniverseRuleId = universeRuleId,
+            UniverseConfidence = universeCode == null ? null : "MED",
+            UniverseReason = universeCode == null ? null : "seeded test",
+            ImprvLoadBatchId = Guid.NewGuid(),
+            SuppAssocLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+            PromotedAt = DateTime.UtcNow,
+            SourceImprvLandedRowId = Guid.NewGuid(),
+            SourceSuppAssocLandedRowId = Guid.NewGuid(),
+        });
+
+        // property row (the classifier needs this to fire)
+        db.LegacyPacsRawProperties.Add(new LegacyPacsRawProperty
+        {
+            PropId = propId,
+            PropTypeCd = propTypeCd,
+            PropCreateDt = propCreateDt,
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "test",
+            SourceRowHash = "test",
+        });
+
+        // property_val row (optional)
+        if (propertyUseCd != null)
+        {
+            db.LegacyPacsRawPropertyVals.Add(new LegacyPacsRawPropertyVal
+            {
+                PropId = propId,
+                PropValYr = propValYr,
+                SupNum = supNum,
+                PropertyUseCd = propertyUseCd,
+                LoadBatchId = Guid.NewGuid(),
+                SourceQueryHash = "test",
+                SourceRowHash = "test",
+            });
+        }
+
+        // land_detail row (optional, for ag_apply)
+        if (agApply != null)
+        {
+            db.LegacyPacsRawLandDetails.Add(new LegacyPacsRawLandDetail
+            {
+                PropId = propId,
+                PropValYr = propValYr,
+                SupNum = supNum,
+                LandSegId = 1,
+                AgApply = agApply,
+                AgUseCd = agApply == "T" ? "AG" : null,
+                LoadBatchId = Guid.NewGuid(),
+                SourceQueryHash = "test",
+                SourceRowHash = "test",
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Null_universe_row_is_classified_REAL_RESIDENTIAL_for_R_typed_property()
+    {
+        var (svc, sp) = Build();
+        await SeedTruthRowAsync(sp, propId: 100, propValYr: 2026, supNum: 0, imprvId: 1,
+            universeCode: null, propTypeCd: "R");
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: false));
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1, result.RowsScanned);
+        Assert.Equal(1, result.RowsUpdated);
+        Assert.Equal(0, result.RowsUnchanged);
+
+        // Verify the truth row UniverseCode is now set.
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var row = await db.TruthPacsImprvCurrents.SingleAsync();
+        Assert.Equal(UniverseCodes.RealResidential, row.UniverseCode);
+    }
+
+    [Fact]
+    public async Task Row_with_inactive_V1_rule_id_is_reclassified_under_V2_rules()
+    {
+        var (svc, sp) = Build();
+        // Simulate a V1 cohort row: UniverseCode='CONVERSION_LEGACY',
+        // UniverseRuleId = a V1 GUID that the V2 seeder marked inactive.
+        var v1ConvLegacyRuleId = Guid.Parse("d0c7d0c7-0040-4001-be07-be0053005010");
+
+        // Inject the inactive V1 rule into the table so the backfill
+        // sees it. (V2 seeder normally does this on first boot.)
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.TfDoctrinePropertyUniverses.Add(new TfDoctrinePropertyUniverse
+            {
+                RuleId = v1ConvLegacyRuleId,
+                County = County,
+                EffectiveStartYear = 1990,
+                Precedence = 1,
+                UniverseCode = UniverseCodes.ConversionLegacy,
+                ActiveFlag = false,
+                Reason = "V1 inactive",
+                EvidenceSource = "V1",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await SeedTruthRowAsync(sp, propId: 200, propValYr: 2026, supNum: 0, imprvId: 1,
+            universeCode: UniverseCodes.ConversionLegacy,
+            universeRuleId: v1ConvLegacyRuleId,
+            propTypeCd: "R", propCreateDt: new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: false));
+
+        Assert.Equal(1, result.RowsScanned);
+        Assert.Equal(1, result.RowsUpdated);
+
+        using var scope2 = sp.CreateScope();
+        var db2 = scope2.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var row = await db2.TruthPacsImprvCurrents.SingleAsync();
+        // Under V2 rules, prop_type_cd='R' with no ag_apply='T'
+        // routes to REAL_RESIDENTIAL — the legacy marker is observed
+        // but precedence-7 CONVERSION_LEGACY only fires when no
+        // modern rule matches.
+        Assert.Equal(UniverseCodes.RealResidential, row.UniverseCode);
+        Assert.NotEqual(v1ConvLegacyRuleId, row.UniverseRuleId);
+    }
+
+    [Fact]
+    public async Task Row_with_active_universe_is_unchanged()
+    {
+        var (svc, sp) = Build();
+
+        // Seed a row already classified REAL_RESIDENTIAL with the
+        // active V2 GUID.
+        var v2ResidRuleId = Guid.Parse("d0c7d0c7-0040-4002-be07-be0053005060");
+        await SeedTruthRowAsync(sp, propId: 300, propValYr: 2026, supNum: 0, imprvId: 1,
+            universeCode: UniverseCodes.RealResidential,
+            universeRuleId: v2ResidRuleId,
+            propTypeCd: "R");
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: false));
+
+        // Active rule → no scan candidate at all.
+        Assert.Equal(0, result.RowsScanned);
+        Assert.Equal(0, result.RowsUpdated);
+    }
+
+    [Fact]
+    public async Task DryRun_counts_transitions_but_does_not_update()
+    {
+        var (svc, sp) = Build();
+        await SeedTruthRowAsync(sp, propId: 400, propValYr: 2026, supNum: 0, imprvId: 1,
+            universeCode: null, propTypeCd: "R");
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: true));
+
+        Assert.Equal(1, result.RowsScanned);
+        Assert.Equal(1, result.RowsUpdated);  // dry-run reports would-be-updates
+        Assert.True(result.DryRun);
+        Assert.Contains("(null) → REAL_RESIDENTIAL", result.Transitions.Keys);
+
+        // Truth row remains NULL.
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var row = await db.TruthPacsImprvCurrents.SingleAsync();
+        Assert.Null(row.UniverseCode);
+    }
+
+    [Fact]
+    public async Task Row_without_property_record_is_marked_could_not_classify()
+    {
+        var (svc, sp) = Build();
+        // Seed a truth row but NO property row.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
+            {
+                PropValYr = 2026,
+                SupNum = 0,
+                PropId = 999,
+                ImprvId = 1,
+                UniverseCode = null,
+                ImprvLoadBatchId = Guid.NewGuid(),
+                SuppAssocLoadBatchId = Guid.NewGuid(),
+                PromotionLoadBatchId = Guid.NewGuid(),
+                PromotedAt = DateTime.UtcNow,
+                SourceImprvLandedRowId = Guid.NewGuid(),
+                SourceSuppAssocLandedRowId = Guid.NewGuid(),
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: false));
+
+        Assert.Equal(1, result.RowsScanned);
+        Assert.Equal(0, result.RowsUpdated);
+        Assert.Equal(1, result.RowsCouldNotClassify);
+    }
+
+    [Fact]
+    public async Task Row_with_ag_apply_T_reclassifies_to_AG_CURRENT_USE()
+    {
+        var (svc, sp) = Build();
+        await SeedTruthRowAsync(sp, propId: 500, propValYr: 2026, supNum: 0, imprvId: 1,
+            universeCode: null, propTypeCd: "R", agApply: "T");
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(County, DryRun: false));
+
+        Assert.Equal(1, result.RowsUpdated);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var row = await db.TruthPacsImprvCurrents.SingleAsync();
+        Assert.Equal(UniverseCodes.AgCurrentUse, row.UniverseCode);
+    }
+}

--- a/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
@@ -284,4 +284,34 @@ public class DoctrinePolicyController : ControllerBase
             note = "Caches invalidated; classifier reads next call rebuild from DB.",
         });
     }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4-IMPL-V5: backfill universe classification onto
+    /// existing <c>truth_pacs.imprv_current</c> rows that were
+    /// promoted before the current rule set fired correctly. Use
+    /// dryRun=true first to inspect transition counts before
+    /// committing.
+    /// </summary>
+    [HttpPost("universe/backfill")]
+    public async Task<IActionResult> BackfillUniverse(
+        [FromServices] IPacsImprvUniverseBackfillService svc,
+        [FromBody] BackfillRequestDto? body,
+        CancellationToken cancellationToken = default)
+    {
+        var county = string.IsNullOrWhiteSpace(body?.County) ? "benton-wa" : body!.County!;
+        var dryRun = body?.DryRun ?? false;
+        var maxRows = body?.MaxRows;
+        var onlyNullUniverse = body?.OnlyNullUniverse ?? false;
+
+        var result = await svc.BackfillAsync(
+            new ImprvUniverseBackfillRequest(county, dryRun, maxRows, onlyNullUniverse),
+            cancellationToken);
+        return Ok(result);
+    }
+
+    public sealed record BackfillRequestDto(
+        string? County,
+        bool? DryRun,
+        int? MaxRows,
+        bool? OnlyNullUniverse);
 }

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1814,6 +1814,13 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.PacsPropertyVal.IPacsPropertyValLandingService,
     TerraFusion.Data.Services.LegacyPacsRaw.PacsPropertyValLandingService>();
 
+// SYNC-DOCTRINE-4-IMPL-V5: imprv universe backfill service — re-runs
+// the V4 classifier on existing truth_pacs.imprv_current rows so
+// pre-D4 rows + V1/V2 cohort stale labels can be brought forward.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Doctrine.IPacsImprvUniverseBackfillService,
+    TerraFusion.Data.Services.Doctrine.PacsImprvUniverseBackfillService>();
+
 // Slice D1: ArcGIS REST FeatureService raw landing. Wraps the
 // existing G1-C IArcGisFeatureServiceClient and writes verbatim
 // to legacy_arcgis_raw.parcel_geom with full provenance. Four

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IPacsImprvUniverseBackfillService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IPacsImprvUniverseBackfillService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V5: backfill universe classification onto
+/// existing <c>truth_pacs.imprv_current</c> rows that were promoted
+/// before the current rule set fired correctly.
+///
+/// <para>Use cases:</para>
+/// <list type="bullet">
+///   <item>Pre-D4 rows promoted before SYNC-DOCTRINE-4-IMPL —
+///   <c>UniverseCode IS NULL</c>.</item>
+///   <item>V1 cohort rows that classified <c>CONVERSION_LEGACY</c>
+///   under the over-firing precedence-1 rule that V2 deactivated.</item>
+///   <item>V2 cohort rows classified <c>REAL_RESIDENTIAL</c> when
+///   the underlying parcel actually had ag_apply='T' (V3 fix) or
+///   non-residential property_use_cd (V4 fix).</item>
+/// </list>
+///
+/// <para>Re-runs the V4 classifier in place against the same data
+/// sources the truth promoter uses (property, property_val,
+/// land_detail). Updates <c>truth_pacs.imprv_current.UniverseCode</c>
+/// + sibling fields directly. Idempotent — re-running on rows that
+/// already match the latest classification is a no-op.</para>
+///
+/// <para>Out of scope for V5: forwarding the new universe values to
+/// <c>canonical_tf.tf_improvement</c>. The canonical projector
+/// rebuilds canonical from truth on next imprv drain; until then
+/// canonical reflects last-projection state. A future slice may
+/// add joint truth+canonical backfill.</para>
+/// </summary>
+public interface IPacsImprvUniverseBackfillService
+{
+    Task<ImprvUniverseBackfillResult> BackfillAsync(
+        ImprvUniverseBackfillRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V5: backfill input.</summary>
+/// <param name="County">Lowercase-hyphenated county slug.</param>
+/// <param name="DryRun">
+/// True = scan + classify but never UPDATE. Returns the
+/// transition map so the operator can audit before committing.
+/// </param>
+/// <param name="MaxRows">
+/// Hard cap on truth rows scanned in a single invocation. NULL =
+/// no cap. Use to bound long-running backfills.
+/// </param>
+/// <param name="OnlyNullUniverse">
+/// True = scan only rows where <c>UniverseCode IS NULL</c>; ignore
+/// rows already classified (skips V1/V2 cohorts that have stale
+/// labels). False (default) = scan rows whose universe is null OR
+/// whose UniverseRuleId references a now-inactive doctrine rule.
+/// </param>
+public sealed record ImprvUniverseBackfillRequest(
+    string County,
+    bool DryRun,
+    int? MaxRows = null,
+    bool OnlyNullUniverse = false);
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V5: backfill outcome.</summary>
+public sealed record ImprvUniverseBackfillResult
+{
+    public required string Status { get; init; }
+    public required bool DryRun { get; init; }
+    public required int RowsScanned { get; init; }
+    public required int RowsUnchanged { get; init; }
+    public required int RowsUpdated { get; init; }
+    public required int RowsCouldNotClassify { get; init; }
+
+    /// <summary>
+    /// Map "OldUniverse → NewUniverse" → count of transitions. Use
+    /// to audit shift in classification. NULL old / new are
+    /// rendered as "(null)".
+    /// </summary>
+    public required IReadOnlyDictionary<string, int> Transitions { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/PacsImprvUniverseBackfillService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/PacsImprvUniverseBackfillService.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.LegacyPacsRaw;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V5: default
+/// <see cref="IPacsImprvUniverseBackfillService"/> implementation.
+///
+/// <para>Process per call:</para>
+/// <list type="number">
+///   <item>Snapshot the active rule-id set so we can detect rows
+///   carrying stale (inactive) UniverseRuleId values.</item>
+///   <item>Page through <c>truth_pacs.imprv_current</c> rows that
+///   match the request scope.</item>
+///   <item>For each page: load property + property_val + land_detail
+///   for the page's prop_ids, run the classifier, compute the new
+///   universe value, compare to the old one, UPDATE if changed.</item>
+///   <item>Aggregate transitions for audit; return.</item>
+/// </list>
+///
+/// <para>Service is registered Scoped because it uses
+/// <see cref="TerraFusionDbContext"/>. The classifier dependency
+/// is Singleton.</para>
+/// </summary>
+public sealed class PacsImprvUniverseBackfillService : IPacsImprvUniverseBackfillService
+{
+    private const int PageSize = 500;
+    private const string DefaultCountyTag = "benton-wa";
+    private static readonly DateTime LegacyMarkerCutoff =
+        new(2017, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly TerraFusionDbContext _db;
+    private readonly IPropertyUniverseClassifier _classifier;
+    private readonly ILogger<PacsImprvUniverseBackfillService> _logger;
+
+    public PacsImprvUniverseBackfillService(
+        TerraFusionDbContext db,
+        IPropertyUniverseClassifier classifier,
+        ILogger<PacsImprvUniverseBackfillService> logger)
+    {
+        _db = db;
+        _classifier = classifier;
+        _logger = logger;
+    }
+
+    public async Task<ImprvUniverseBackfillResult> BackfillAsync(
+        ImprvUniverseBackfillRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            // Snapshot the active rule ids so we can detect "stale"
+            // (rows whose UniverseRuleId is no longer active) — the
+            // V2-deactivated V1 GUIDs are the canonical example.
+            var activeRuleIds = await _db.TfDoctrinePropertyUniverses
+                .Where(r => r.County == request.County && r.ActiveFlag)
+                .Select(r => r.RuleId)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var activeSet = new HashSet<Guid>(activeRuleIds);
+
+            // Build the candidate query.
+            var query = _db.TruthPacsImprvCurrents.AsQueryable();
+            if (request.OnlyNullUniverse)
+            {
+                query = query.Where(t => t.UniverseCode == null);
+            }
+            // We can't easily express "ruleId not in active set" in
+            // SQL because the active set lives in memory. Solution:
+            // pull rows with NULL UniverseCode OR with a non-null
+            // UniverseRuleId; filter the active-rule case in code.
+            else
+            {
+                query = query.Where(t =>
+                    t.UniverseCode == null
+                    || t.UniverseRuleId == null
+                    || (t.UniverseRuleId != null && true));  // expanded below
+            }
+
+            query = query.OrderBy(t => t.PromotedAt);
+            if (request.MaxRows.HasValue) query = query.Take(request.MaxRows.Value);
+
+            var allCandidates = await query.ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // Filter in memory: keep rows whose universe is null OR
+            // whose UniverseRuleId is non-null but not in the active set.
+            // (When OnlyNullUniverse=true the EF clause already filtered.)
+            var candidates = request.OnlyNullUniverse
+                ? allCandidates
+                : allCandidates.Where(t =>
+                    t.UniverseCode == null
+                    || (t.UniverseRuleId.HasValue && !activeSet.Contains(t.UniverseRuleId.Value))
+                  ).ToList();
+
+            var rowsScanned = candidates.Count;
+            var rowsUnchanged = 0;
+            var rowsUpdated = 0;
+            var rowsCouldNotClassify = 0;
+            var transitions = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            // Page through candidates so the property / property_val /
+            // land_detail lookups stay bounded in memory.
+            for (var offset = 0; offset < candidates.Count; offset += PageSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var page = candidates.Skip(offset).Take(PageSize).ToList();
+                var pagePropIds = page.Select(t => t.PropId).Distinct().ToList();
+
+                // Load classifier inputs for the page.
+                var properties = await _db.LegacyPacsRawProperties
+                    .Where(p => pagePropIds.Contains(p.PropId))
+                    .Select(p => new { p.PropId, p.PropTypeCd, p.PropCreateDt, p.LandedAt })
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+                var latestPropertyByPropId = properties
+                    .GroupBy(p => p.PropId)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.OrderByDescending(p => p.LandedAt).First());
+
+                var propertyVals = await _db.LegacyPacsRawPropertyVals
+                    .Where(pv => pagePropIds.Contains(pv.PropId))
+                    .Select(pv => new { pv.PropId, pv.PropValYr, pv.SupNum,
+                                        pv.PropertyUseCd, pv.LandedAt })
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+                var propertyUseCdByKey = propertyVals
+                    .GroupBy(pv => (pv.PropId, pv.PropValYr, pv.SupNum))
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.OrderByDescending(pv => pv.LandedAt).First().PropertyUseCd);
+
+                var landDetails = await _db.LegacyPacsRawLandDetails
+                    .Where(l => pagePropIds.Contains(l.PropId))
+                    .Select(l => new { l.PropId, l.PropValYr, l.AgApply, l.AgUseCd, l.LandedAt })
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+                var agSignalByKey = new Dictionary<(int PropId, short PropValYr),
+                    (string? AgApply, string? AgUseCd)>();
+                foreach (var grp in landDetails.GroupBy(l => (l.PropId, l.PropValYr)))
+                {
+                    var rows = grp.OrderByDescending(l => l.LandedAt).ToList();
+                    var anyT = rows.Any(r =>
+                        !string.IsNullOrEmpty(r.AgApply) &&
+                        (r.AgApply.Equals("T", StringComparison.OrdinalIgnoreCase) ||
+                         r.AgApply.Equals("Y", StringComparison.OrdinalIgnoreCase)));
+                    var anyF = rows.Any(r =>
+                        !string.IsNullOrEmpty(r.AgApply) &&
+                        (r.AgApply.Equals("F", StringComparison.OrdinalIgnoreCase) ||
+                         r.AgApply.Equals("N", StringComparison.OrdinalIgnoreCase)));
+                    var agApply = anyT ? "T" : (anyF ? "F" : (string?)null);
+                    var agUseCd = rows
+                        .Where(r =>
+                            !string.IsNullOrEmpty(r.AgApply) &&
+                            (r.AgApply.Equals("T", StringComparison.OrdinalIgnoreCase) ||
+                             r.AgApply.Equals("Y", StringComparison.OrdinalIgnoreCase)) &&
+                            !string.IsNullOrEmpty(r.AgUseCd))
+                        .Select(r => r.AgUseCd)
+                        .FirstOrDefault()
+                        ?? rows.Select(r => r.AgUseCd).FirstOrDefault(c => !string.IsNullOrEmpty(c));
+                    agSignalByKey[grp.Key] = (agApply, agUseCd);
+                }
+
+                // Per-row classification.
+                foreach (var truth in page)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (!latestPropertyByPropId.TryGetValue(truth.PropId, out var property))
+                    {
+                        rowsCouldNotClassify++;
+                        Bump(transitions, $"{truth.UniverseCode ?? "(null)"} → could-not-classify");
+                        continue;
+                    }
+
+                    var hasLegacyMarker = property.PropCreateDt.HasValue
+                        && property.PropCreateDt.Value < LegacyMarkerCutoff;
+                    propertyUseCdByKey.TryGetValue(
+                        (truth.PropId, truth.PropValYr, truth.SupNum), out var propertyUseCd);
+                    agSignalByKey.TryGetValue((truth.PropId, truth.PropValYr), out var agSignal);
+
+                    var input = new UniverseClassifierInput(
+                        County: request.County,
+                        PropValYr: truth.PropValYr,
+                        PropTypeCd: property.PropTypeCd,
+                        PropertyUseCd: propertyUseCd,
+                        AgApply: agSignal.AgApply,
+                        AgUseCd: agSignal.AgUseCd,
+                        HasLegacyMarker: hasLegacyMarker);
+
+                    var classification = await _classifier.ClassifyAsync(input, cancellationToken)
+                        .ConfigureAwait(false);
+
+                    var oldUniverse = truth.UniverseCode ?? "(null)";
+                    var newUniverse = classification.UniverseCode;
+
+                    if (string.Equals(oldUniverse, newUniverse, StringComparison.Ordinal)
+                        && truth.UniverseRuleId == classification.RuleId)
+                    {
+                        rowsUnchanged++;
+                        Bump(transitions, $"{oldUniverse} → unchanged");
+                        continue;
+                    }
+
+                    Bump(transitions, $"{oldUniverse} → {newUniverse}");
+
+                    if (!request.DryRun)
+                    {
+                        truth.UniverseCode = classification.UniverseCode;
+                        truth.UniverseRuleId = classification.RuleId;
+                        truth.UniverseConfidence = classification.Confidence;
+                        truth.UniverseReason = classification.Reason;
+                        rowsUpdated++;
+                    }
+                    else
+                    {
+                        // Dry-run: count what would have updated.
+                        rowsUpdated++;
+                    }
+                }
+
+                if (!request.DryRun)
+                    await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation(
+                "[Backfill:imprv-universe] county={County} dryRun={DryRun} scanned={Scanned} updated={Updated} unchanged={Unchanged} couldNotClassify={CouldNot}",
+                request.County, request.DryRun, rowsScanned, rowsUpdated, rowsUnchanged, rowsCouldNotClassify);
+
+            return new ImprvUniverseBackfillResult
+            {
+                Status = "COMPLETED",
+                DryRun = request.DryRun,
+                RowsScanned = rowsScanned,
+                RowsUnchanged = rowsUnchanged,
+                RowsUpdated = rowsUpdated,
+                RowsCouldNotClassify = rowsCouldNotClassify,
+                Transitions = transitions,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "[Backfill:imprv-universe] FAILED for county {County}", request.County);
+            return new ImprvUniverseBackfillResult
+            {
+                Status = "FAILED",
+                DryRun = request.DryRun,
+                RowsScanned = 0,
+                RowsUnchanged = 0,
+                RowsUpdated = 0,
+                RowsCouldNotClassify = 0,
+                Transitions = new Dictionary<string, int>(),
+                ErrorSummary = $"{ex.GetType().Name}: {ex.Message}",
+            };
+        }
+    }
+
+    private static void Bump(Dictionary<string, int> map, string key) =>
+        map[key] = map.TryGetValue(key, out var c) ? c + 1 : 1;
+}


### PR DESCRIPTION
## Why

V1 → V4 evolved the doctrine through four slices, each fixing a real classifier signal. But existing truth rows promoted **before** each slice retain their OLD classification — V1 cohort labeled `CONVERSION_LEGACY`, V2 cohort labeled `REAL_RESIDENTIAL`, pre-D4 rows labeled NULL. The promoter is per-batch idempotent so subsequent drains don't reclassify them. V5 closes that gap.

## New surface

- `IPacsImprvUniverseBackfillService` + `PacsImprvUniverseBackfillService`
- `POST /api/sync/doctrine/policy/universe/backfill` endpoint with body `{ county, dryRun, maxRows?, onlyNullUniverse? }`
- DI registration

## Backfill semantics

Scans `truth_pacs.imprv_current` rows where:
- `UniverseCode IS NULL`, OR
- `UniverseRuleId` references an inactive doctrine rule (V1 GUIDs deactivated by V2 seeder).

Per row, runs the V4 classifier with the same data sources the promoter uses (property + property_val + land_detail). UPDATEs the truth row in place.

**Idempotent** — re-running on already-current rows is a no-op (active-rule filter excludes them from the scan).

Optional **dry-run** mode produces the full transition map without committing — useful for operator audit before the UPDATE.

## Out of scope (deferred)

- Forwarding new universe values to `canonical_tf.tf_improvement`. The canonical projector rebuilds canonical from truth on next imprv drain; until then canonical reflects last-projection state. A future slice may add joint truth+canonical backfill.

## Tests

6 unit tests covering:
- null-universe reclassification
- inactive-rule detection
- dry-run no-op
- could-not-classify (missing property row)
- `ag_apply='T'` routing to AG_CURRENT_USE
- active-rule skip

All passing. Solution: 0 errors / 0 warnings.

## Live verification (Benton WA, 2026-05-06)

**Pre-backfill truth state:**

| UniverseCode | count |
|---|---|
| NULL (pre-D4) | 1,665 |
| CONVERSION_LEGACY (V1 cohort) | 241 |
| REAL_RESIDENTIAL (V2/V3/V4 cohorts) | 904 |
| AG_CURRENT_USE | 56 |
| REAL_COMMERCIAL | 4 |

**Backfill result** (`dryRun: false`):

```
rowsScanned          = 1906   (NULL + CONVERSION_LEGACY only;
                                V2/V3/V4 cohorts skipped)
rowsUpdated          = 1906
rowsCouldNotClassify =    0
```

Transition map:

| from → to | count |
|---|---|
| (null) → REAL_RESIDENTIAL | 1,525 |
| (null) → AG_CURRENT_USE | 120 |
| (null) → REAL_COMMERCIAL | 20 |
| CONVERSION_LEGACY → REAL_RESIDENTIAL | 209 |
| CONVERSION_LEGACY → AG_CURRENT_USE | 28 |
| CONVERSION_LEGACY → REAL_COMMERCIAL | 4 |

**Post-backfill truth state:**

| UniverseCode | count |
|---|---|
| REAL_RESIDENTIAL | 2,638 |
| AG_CURRENT_USE | 204 |
| REAL_COMMERCIAL | 28 |
| NULL | **0** |
| CONVERSION_LEGACY | **0** |

Re-run **idempotency check**: scanned=0, updated=0. Every truth row now carries an active V2 universe rule.

## Reference commits

- V1 on main: `f5110f778` (PR #790)
- V2 on main: `0d6e19f4e` (PR #791)
- V3 on main: `762a5a6be` (PR #792)
- V4 on main: `cb8036fbc` (PR #793)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new backfill API endpoint to reclassify property universe codes
  * Supports dry-run mode, county filtering, row limits, and selective processing of null values
  * Returns detailed audit information including transition counts and classification results

* **Tests**
  * Introduced comprehensive test coverage for backfill scenarios including reclassification, dry-run behavior, and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->