### PR TITLE
fix(ci): correct Dockerfile.api → Dockerfile.API case in main-push docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
       - name: Build Docker Images
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          docker build -f backend/Dockerfile.api -t terrafusion-api:${{ github.sha }} -t terrafusion-api:latest backend/
+          docker build -f backend/Dockerfile.API -t terrafusion-api:${{ github.sha }} -t terrafusion-api:latest backend/
           docker build -f frontend/Dockerfile -t terrafusion-frontend:${{ github.sha }} -t terrafusion-frontend:latest .
           docker build -f backend/Dockerfile.agents -t terrafusion-agents:${{ github.sha }} -t terrafusion-agents:latest backend/
           docker build -f backend/Dockerfile.spatial -t terrafusion-spatial:${{ github.sha }} -t terrafusion-spatial:latest backend/


### PR DESCRIPTION
## What

One-character fix in `.github/workflows/ci.yml`: the "Build Docker Images" step references `backend/Dockerfile.api` (lowercase) but the file on disk is `backend/Dockerfile.API` (uppercase).

Linux runners are case-sensitive, so this fails:

```
ERROR: failed to build: failed to solve: failed to read dockerfile:
       open Dockerfile.api: no such file or directory
```

## Why latent until now

The "Build Docker Images" step is gated to push-to-main only:

```yaml
if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
```

PR CI never ran it. Surfaced when SYNC-DOCTRINE-4-IMPL-V5 (`66317a2ec`) merged to main and triggered the workflow on V5's path-set.

## Verified safe

Other Dockerfile references in `ci.yml` already match the disk:
- `frontend/Dockerfile` (no extension; matches)
- `backend/Dockerfile.agents` (lowercase on disk; matches)
- `backend/Dockerfile.spatial` (lowercase on disk; matches)

Other workflows are independently correct:
- `slsa-provenance.yml` already uses `Dockerfile.API` (uppercase).
- `terrafusion-ci-cd-production.yml` references a different path (`infrastructure/docker/Dockerfile.api`) — out of scope.

## Test plan

- Merge to main; the post-merge "Build Docker Images" step finds `backend/Dockerfile.API` and proceeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed CI/CD pipeline configuration to properly reference the backend API Docker build, ensuring builds execute correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->