### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V6 — canonical universe backfill propagates V5 truth changes to canonical_tf.tf_improvement

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/PacsImprvUniverseCanonicalBackfillTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/PacsImprvUniverseCanonicalBackfillTests.cs
@@ -1,0 +1,271 @@
+// SYNC-DOCTRINE-4-IMPL-V6 — canonical-side backfill tests.
+//
+// Validates that BackfillCanonicalAsync correctly:
+//   - matches canonical → truth via SourceXref 4-key,
+//   - skips canonical rows already matching their source truth,
+//   - updates canonical rows whose universe drifts from truth,
+//   - reports without-truth count when no matching truth exists,
+//   - dry-run no-op,
+//   - idempotency: re-running on already-matched rows is a no-op.
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class PacsImprvUniverseCanonicalBackfillTests
+{
+    private const string County = "benton-wa";
+
+    private static (PacsImprvUniverseBackfillService svc, IServiceProvider sp) Build()
+    {
+        var dbName = $"CanonicalBackfillTest_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        // Seed V2 universe rules.
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            new DoctrinePropertyUniverseSeeder(db,
+                NullLogger<DoctrinePropertyUniverseSeeder>.Instance)
+                .SeedAsync().GetAwaiter().GetResult();
+        }
+
+        var classifier = new PropertyUniverseClassifier(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<PropertyUniverseClassifier>.Instance);
+
+        var dbForSvc = sp.CreateScope().ServiceProvider
+            .GetRequiredService<TerraFusionDbContext>();
+        var svc = new PacsImprvUniverseBackfillService(
+            dbForSvc, classifier,
+            NullLogger<PacsImprvUniverseBackfillService>.Instance);
+        return (svc, sp);
+    }
+
+    private static async Task SeedCanonicalAndTruthAsync(
+        IServiceProvider sp,
+        Guid tfImprovementId,
+        int propId, short propValYr, short supNum, long imprvId,
+        string? canonicalUniverse,
+        string? truthUniverse,
+        Guid? truthRuleId = null)
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        // Canonical row.
+        db.TfImprovements.Add(new TfImprovement
+        {
+            TfImprovementId = tfImprovementId,
+            CountyId = Guid.NewGuid(),
+            TfParcelId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+            UniverseCode = canonicalUniverse,
+        });
+
+        // SourceXref linking canonical to PACS keys.
+        var keyJson = JsonSerializer.Serialize(new
+        {
+            prop_id = propId,
+            prop_val_yr = (int)propValYr,
+            sup_num = (int)supNum,
+            imprv_id = imprvId,
+        });
+        db.SyncBridgeSourceXrefs.Add(new SourceXref
+        {
+            TfEntityType = "improvement",
+            TfEntityId = tfImprovementId,
+            SourceSystem = "PACS_OLTP",
+            SourceTable = "imprv",
+            SourceKeyJson = keyJson,
+            SourceQueryHash = "test",
+            LoadBatchId = Guid.NewGuid(),
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+            IsActive = true,
+        });
+
+        // Truth row matching the 4-key.
+        db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
+        {
+            PropValYr = propValYr,
+            SupNum = supNum,
+            PropId = propId,
+            ImprvId = imprvId,
+            UniverseCode = truthUniverse,
+            UniverseRuleId = truthRuleId,
+            UniverseConfidence = truthUniverse == null ? null : "MED",
+            UniverseReason = truthUniverse == null ? null : "seeded",
+            ImprvLoadBatchId = Guid.NewGuid(),
+            SuppAssocLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+            PromotedAt = DateTime.UtcNow,
+            SourceImprvLandedRowId = Guid.NewGuid(),
+            SourceSuppAssocLandedRowId = Guid.NewGuid(),
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Canonical_with_NULL_universe_is_updated_when_truth_has_universe()
+    {
+        var (svc, sp) = Build();
+        var canonicalId = Guid.NewGuid();
+        await SeedCanonicalAndTruthAsync(sp, canonicalId, 100, 2026, 0, 1,
+            canonicalUniverse: null, truthUniverse: UniverseCodes.RealResidential);
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1, result.CanonicalRowsScanned);
+        Assert.Equal(1, result.CanonicalRowsUpdated);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var canonical = await db.TfImprovements.FindAsync(canonicalId);
+        Assert.Equal(UniverseCodes.RealResidential, canonical!.UniverseCode);
+    }
+
+    [Fact]
+    public async Task Canonical_already_matching_truth_is_unchanged()
+    {
+        var (svc, sp) = Build();
+        await SeedCanonicalAndTruthAsync(sp, Guid.NewGuid(), 200, 2026, 0, 1,
+            canonicalUniverse: UniverseCodes.RealResidential,
+            truthUniverse: UniverseCodes.RealResidential);
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+
+        Assert.Equal(1, result.CanonicalRowsScanned);
+        Assert.Equal(0, result.CanonicalRowsUpdated);
+        Assert.Equal(1, result.CanonicalRowsAlreadyMatched);
+    }
+
+    [Fact]
+    public async Task Canonical_drift_is_corrected()
+    {
+        var (svc, sp) = Build();
+        var canonicalId = Guid.NewGuid();
+        // Canonical says CONVERSION_LEGACY (V1 era), truth says RESIDENTIAL (post-V5 backfill).
+        await SeedCanonicalAndTruthAsync(sp, canonicalId, 300, 2026, 0, 1,
+            canonicalUniverse: UniverseCodes.ConversionLegacy,
+            truthUniverse: UniverseCodes.RealResidential);
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+
+        Assert.Equal(1, result.CanonicalRowsUpdated);
+        Assert.Contains("CONVERSION_LEGACY → REAL_RESIDENTIAL", result.Transitions.Keys);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var canonical = await db.TfImprovements.FindAsync(canonicalId);
+        Assert.Equal(UniverseCodes.RealResidential, canonical!.UniverseCode);
+    }
+
+    [Fact]
+    public async Task DryRun_records_transitions_but_does_not_update()
+    {
+        var (svc, sp) = Build();
+        var canonicalId = Guid.NewGuid();
+        await SeedCanonicalAndTruthAsync(sp, canonicalId, 400, 2026, 0, 1,
+            canonicalUniverse: null, truthUniverse: UniverseCodes.AgCurrentUse);
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: true));
+
+        Assert.True(result.DryRun);
+        Assert.Equal(1, result.CanonicalRowsUpdated);  // would-be
+        Assert.Contains("(null) → AG_CURRENT_USE", result.Transitions.Keys);
+
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var canonical = await db.TfImprovements.FindAsync(canonicalId);
+        Assert.Null(canonical!.UniverseCode);
+    }
+
+    [Fact]
+    public async Task Canonical_without_matching_truth_is_counted_as_orphan()
+    {
+        var (svc, sp) = Build();
+        // Seed canonical + xref BUT no truth row with matching 4-key.
+        var canonicalId = Guid.NewGuid();
+        using (var scope = sp.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.TfImprovements.Add(new TfImprovement
+            {
+                TfImprovementId = canonicalId,
+                CountyId = Guid.NewGuid(),
+                TfParcelId = Guid.NewGuid(),
+                PromotionLoadBatchId = Guid.NewGuid(),
+                UniverseCode = UniverseCodes.RealResidential,
+            });
+            db.SyncBridgeSourceXrefs.Add(new SourceXref
+            {
+                TfEntityType = "improvement",
+                TfEntityId = canonicalId,
+                SourceSystem = "PACS_OLTP",
+                SourceTable = "imprv",
+                SourceKeyJson = JsonSerializer.Serialize(new
+                {
+                    prop_id = 9999, prop_val_yr = 2026, sup_num = 0, imprv_id = 1,
+                }),
+                SourceQueryHash = "test",
+                LoadBatchId = Guid.NewGuid(),
+                FirstSeenAt = DateTime.UtcNow,
+                LastSeenAt = DateTime.UtcNow,
+                IsActive = true,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+
+        Assert.Equal(1, result.CanonicalRowsScanned);
+        Assert.Equal(0, result.CanonicalRowsUpdated);
+        Assert.Equal(1, result.CanonicalRowsWithoutTruth);
+    }
+
+    [Fact]
+    public async Task Idempotent_rerun_after_initial_backfill()
+    {
+        var (svc, sp) = Build();
+        await SeedCanonicalAndTruthAsync(sp, Guid.NewGuid(), 500, 2026, 0, 1,
+            canonicalUniverse: null, truthUniverse: UniverseCodes.RealResidential);
+
+        // First run: 1 update.
+        var first = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+        Assert.Equal(1, first.CanonicalRowsUpdated);
+
+        // Second run: 0 updates, 1 already-matched.
+        var second = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(DryRun: false));
+        Assert.Equal(0, second.CanonicalRowsUpdated);
+        Assert.Equal(1, second.CanonicalRowsAlreadyMatched);
+    }
+}

--- a/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
@@ -314,4 +314,29 @@ public class DoctrinePolicyController : ControllerBase
         bool? DryRun,
         int? MaxRows,
         bool? OnlyNullUniverse);
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4-IMPL-V6: forward backfilled universe values
+    /// from <c>truth_pacs.imprv_current</c> onto matching
+    /// <c>canonical_tf.tf_improvement</c> rows. Use after
+    /// <c>POST .../universe/backfill</c> brings truth current.
+    /// </summary>
+    [HttpPost("universe/backfill-canonical")]
+    public async Task<IActionResult> BackfillCanonicalUniverse(
+        [FromServices] IPacsImprvUniverseBackfillService svc,
+        [FromBody] CanonicalBackfillRequestDto? body,
+        CancellationToken cancellationToken = default)
+    {
+        var dryRun = body?.DryRun ?? false;
+        var maxRows = body?.MaxRows;
+
+        var result = await svc.BackfillCanonicalAsync(
+            new CanonicalUniverseBackfillRequest(dryRun, maxRows),
+            cancellationToken);
+        return Ok(result);
+    }
+
+    public sealed record CanonicalBackfillRequestDto(
+        bool? DryRun,
+        int? MaxRows);
 }

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IPacsImprvUniverseBackfillService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IPacsImprvUniverseBackfillService.cs
@@ -38,6 +38,37 @@ public interface IPacsImprvUniverseBackfillService
     Task<ImprvUniverseBackfillResult> BackfillAsync(
         ImprvUniverseBackfillRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4-IMPL-V6: forward backfilled universe values
+    /// from <c>truth_pacs.imprv_current</c> onto matching
+    /// <c>canonical_tf.tf_improvement</c> rows.
+    ///
+    /// <para>The canonical projector creates canonical rows from truth
+    /// rows at promotion time and bakes the truth row's UniverseCode
+    /// into them. After V5 backfilled truth in place, canonical rows
+    /// projected before V5 still carry the OLD universe (or NULL).
+    /// V6 reconciles them.</para>
+    ///
+    /// <para>Lookup: for each canonical row, find its matching truth
+    /// row via <c>sync_bridge.source_xref</c>:</para>
+    /// <list type="number">
+    ///   <item>SourceXref where TfEntityType='improvement' and
+    ///   TfEntityId = canonical.TfImprovementId.</item>
+    ///   <item>Parse SourceKeyJson for the 4-key (prop_id,
+    ///   prop_val_yr, sup_num, imprv_id).</item>
+    ///   <item>Find truth_pacs.imprv_current rows with that 4-key,
+    ///   pick the most recent by PromotedAt.</item>
+    ///   <item>If canonical.UniverseCode != truth.UniverseCode,
+    ///   UPDATE canonical to match.</item>
+    /// </list>
+    ///
+    /// <para>Idempotent — re-running on already-matched rows is a
+    /// no-op.</para>
+    /// </summary>
+    Task<CanonicalUniverseBackfillResult> BackfillCanonicalAsync(
+        CanonicalUniverseBackfillRequest request,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>SYNC-DOCTRINE-4-IMPL-V5: backfill input.</summary>
@@ -77,6 +108,27 @@ public sealed record ImprvUniverseBackfillResult
     /// to audit shift in classification. NULL old / new are
     /// rendered as "(null)".
     /// </summary>
+    public required IReadOnlyDictionary<string, int> Transitions { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V6: canonical-side backfill input.</summary>
+public sealed record CanonicalUniverseBackfillRequest(
+    bool DryRun,
+    int? MaxRows = null);
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V6: canonical-side backfill outcome.</summary>
+public sealed record CanonicalUniverseBackfillResult
+{
+    public required string Status { get; init; }
+    public required bool DryRun { get; init; }
+    public required int CanonicalRowsScanned { get; init; }
+    public required int CanonicalRowsUpdated { get; init; }
+    public required int CanonicalRowsAlreadyMatched { get; init; }
+    public required int CanonicalRowsWithoutTruth { get; init; }
+
+    /// <summary>"OldUniverse → NewUniverse" → count.</summary>
     public required IReadOnlyDictionary<string, int> Transitions { get; init; }
 
     public string? ErrorSummary { get; init; }

--- a/backend/src/TerraFusion.Data/Services/Doctrine/PacsImprvUniverseBackfillService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/PacsImprvUniverseBackfillService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -261,6 +262,189 @@ public sealed class PacsImprvUniverseBackfillService : IPacsImprvUniverseBackfil
                 ErrorSummary = $"{ex.GetType().Name}: {ex.Message}",
             };
         }
+    }
+
+    public async Task<CanonicalUniverseBackfillResult> BackfillCanonicalAsync(
+        CanonicalUniverseBackfillRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            // Load all canonical improvement rows. Bound by MaxRows.
+            var canonicalQuery = _db.TfImprovements.AsQueryable();
+            if (request.MaxRows.HasValue)
+                canonicalQuery = canonicalQuery.Take(request.MaxRows.Value);
+            var canonicals = await canonicalQuery.ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (canonicals.Count == 0)
+            {
+                return new CanonicalUniverseBackfillResult
+                {
+                    Status = "COMPLETED",
+                    DryRun = request.DryRun,
+                    CanonicalRowsScanned = 0,
+                    CanonicalRowsUpdated = 0,
+                    CanonicalRowsAlreadyMatched = 0,
+                    CanonicalRowsWithoutTruth = 0,
+                    Transitions = new Dictionary<string, int>(),
+                };
+            }
+
+            var canonicalIds = canonicals.Select(c => c.TfImprovementId).ToList();
+
+            // Pre-fetch SourceXrefs for all canonical rows in one query.
+            var xrefs = await _db.SyncBridgeSourceXrefs
+                .Where(x => x.TfEntityType == "improvement"
+                            && canonicalIds.Contains(x.TfEntityId))
+                .Select(x => new { x.TfEntityId, x.SourceKeyJson })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            // Parse SourceKeyJson into 4-keys, indexed by canonical id.
+            var keyByCanonical = new Dictionary<Guid, (int PropId, short PropValYr, short SupNum, long ImprvId)>();
+            foreach (var x in xrefs)
+            {
+                if (TryParseImprvKey(x.SourceKeyJson, out var key))
+                    keyByCanonical[x.TfEntityId] = key;
+            }
+
+            // Pre-fetch all truth rows for the relevant prop_ids in one query,
+            // then index by 4-key (latest PromotedAt wins on duplicates).
+            var imprvPropIds = keyByCanonical.Values.Select(k => k.PropId).Distinct().ToList();
+            var truthRows = await _db.TruthPacsImprvCurrents
+                .Where(t => imprvPropIds.Contains(t.PropId))
+                .Select(t => new
+                {
+                    t.PropId, t.PropValYr, t.SupNum, t.ImprvId,
+                    t.UniverseCode, t.UniverseRuleId,
+                    t.UniverseConfidence, t.UniverseReason,
+                    t.PromotedAt,
+                })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            var truthByKey = truthRows
+                .GroupBy(t => (t.PropId, t.PropValYr, t.SupNum, t.ImprvId))
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(t => t.PromotedAt).First());
+
+            var scanned = 0;
+            var updated = 0;
+            var alreadyMatched = 0;
+            var withoutTruth = 0;
+            var transitions = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            foreach (var canonical in canonicals)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                scanned++;
+
+                if (!keyByCanonical.TryGetValue(canonical.TfImprovementId, out var key))
+                {
+                    // No SourceXref for this canonical row — should not
+                    // happen per the canonical-imprv-source-xref-coverage
+                    // gate, but be defensive.
+                    withoutTruth++;
+                    continue;
+                }
+
+                if (!truthByKey.TryGetValue(key, out var truth))
+                {
+                    // SourceXref points to a truth row that no longer
+                    // exists (e.g. the prop_id was removed from PACS).
+                    // Treat as orphan; don't touch the canonical row.
+                    withoutTruth++;
+                    continue;
+                }
+
+                // Already matched?
+                if (string.Equals(canonical.UniverseCode, truth.UniverseCode, StringComparison.Ordinal)
+                    && canonical.UniverseRuleId == truth.UniverseRuleId)
+                {
+                    alreadyMatched++;
+                    continue;
+                }
+
+                var oldU = canonical.UniverseCode ?? "(null)";
+                var newU = truth.UniverseCode ?? "(null)";
+                Bump(transitions, $"{oldU} → {newU}");
+
+                if (!request.DryRun)
+                {
+                    canonical.UniverseCode = truth.UniverseCode;
+                    canonical.UniverseRuleId = truth.UniverseRuleId;
+                    canonical.UniverseConfidence = truth.UniverseConfidence;
+                    canonical.UniverseReason = truth.UniverseReason;
+                    canonical.UpdatedAt = DateTime.UtcNow;
+                }
+                updated++;
+            }
+
+            if (!request.DryRun)
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "[Backfill:imprv-universe-canonical] dryRun={DryRun} scanned={Scanned} updated={Updated} alreadyMatched={Matched} withoutTruth={NoTruth}",
+                request.DryRun, scanned, updated, alreadyMatched, withoutTruth);
+
+            return new CanonicalUniverseBackfillResult
+            {
+                Status = "COMPLETED",
+                DryRun = request.DryRun,
+                CanonicalRowsScanned = scanned,
+                CanonicalRowsUpdated = updated,
+                CanonicalRowsAlreadyMatched = alreadyMatched,
+                CanonicalRowsWithoutTruth = withoutTruth,
+                Transitions = transitions,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "[Backfill:imprv-universe-canonical] FAILED");
+            return new CanonicalUniverseBackfillResult
+            {
+                Status = "FAILED",
+                DryRun = request.DryRun,
+                CanonicalRowsScanned = 0,
+                CanonicalRowsUpdated = 0,
+                CanonicalRowsAlreadyMatched = 0,
+                CanonicalRowsWithoutTruth = 0,
+                Transitions = new Dictionary<string, int>(),
+                ErrorSummary = $"{ex.GetType().Name}: {ex.Message}",
+            };
+        }
+    }
+
+    /// <summary>
+    /// Parse the canonical projector's SourceKeyJson shape — emitted as
+    /// `{"prop_id":..., "prop_val_yr":..., "sup_num":..., "imprv_id":...}`
+    /// per <c>PacsImprvCanonicalProjector</c>.
+    /// </summary>
+    private static bool TryParseImprvKey(
+        string sourceKeyJson,
+        out (int PropId, short PropValYr, short SupNum, long ImprvId) key)
+    {
+        key = default;
+        if (string.IsNullOrEmpty(sourceKeyJson)) return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(sourceKeyJson);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("prop_id", out var pidEl)) return false;
+            if (!root.TryGetProperty("prop_val_yr", out var yrEl)) return false;
+            if (!root.TryGetProperty("sup_num", out var supEl)) return false;
+            if (!root.TryGetProperty("imprv_id", out var imprvEl)) return false;
+
+            key = (
+                pidEl.GetInt32(),
+                (short)yrEl.GetInt32(),
+                (short)supEl.GetInt32(),
+                imprvEl.GetInt64());
+            return true;
+        }
+        catch (JsonException) { return false; }
     }
 
     private static void Bump(Dictionary<string, int> map, string key) =>


### PR DESCRIPTION
## Why

V5 backfilled `truth_pacs.imprv_current` in place (1,906 stale rows updated to current V4 classification). But `canonical_tf.tf_improvement` rows projected before V5 still carried their OLD universe values — the canonical projector only refreshes canonical on per-truth-batch projection; existing canonical rows from prior drains stayed stale. V6 closes this final gap.

## New surface

- `BackfillCanonicalAsync` method on `IPacsImprvUniverseBackfillService`
- `POST /api/sync/doctrine/policy/universe/backfill-canonical` endpoint with body `{ dryRun, maxRows? }`

## Lookup logic

For each `canonical_tf.tf_improvement` row:

1. Resolve `sync_bridge.source_xref` WHERE `TfEntityType='improvement'` AND `TfEntityId = canonical.TfImprovementId`.
2. Parse `SourceKeyJson` for the 4-key (`prop_id, prop_val_yr, sup_num, imprv_id`) — same shape the canonical projector emits.
3. Find `truth_pacs.imprv_current` rows with that 4-key, pick the most recent by `PromotedAt` (handles multiple promotions of the same PACS keys).
4. If `canonical.UniverseCode != truth.UniverseCode` (or `RuleId` differs), UPDATE canonical to match.

**Idempotent** — re-running on already-matched rows is a no-op. Optional dry-run mode produces the full transition map without committing.

## Tests

6 unit tests covering:
- null → assigned update
- already-matched skip
- drift correction
- dry-run no-op
- orphan canonical (no matching truth)
- re-run idempotency

All passing. 12/12 V5+V6 backfill tests + 0 errors / 0 warnings.

## Live verification (Benton WA, 2026-05-06)

**Pre-canonical state:**

| UniverseCode | count |
|---|---|
| REAL_RESIDENTIAL | 209 |
| AG_CURRENT_USE | 28 |
| REAL_COMMERCIAL | 4 |
| NULL | 247 |

**Backfill result** (`dryRun: false`):

```
canonicalRowsScanned         = 488
canonicalRowsUpdated         = 247
canonicalRowsAlreadyMatched  = 241   (V4 cohort, active V2 rule)
canonicalRowsWithoutTruth    =   0
```

Single transition: `(null) → REAL_RESIDENTIAL: 247`

**Post-canonical state:**

| UniverseCode | count |
|---|---|
| REAL_RESIDENTIAL | 456 |
| AG_CURRENT_USE | 28 |
| REAL_COMMERCIAL | 4 |
| NULL | **0** |

Re-run idempotency: `scanned=488, updated=0, alreadyMatched=488`. Every canonical row now mirrors its source truth.

## Doctrine evolution closure

Truth (V5) AND canonical (V6) now reflect current V4 classification consistently. Future imprv drains will project new universe values from truth at promotion time; backfill is reserved for re-classifying historical rows after a doctrine evolution.

## Reference commits

- V5 on main: `66317a2ec` (PR #794)
- V4 on main: `cb8036fbc` (PR #793)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for backfilling canonical universe classification values with dry-run support.
  * Includes metrics tracking for scanned rows, updates, and transition reporting.

* **Tests**
  * Added comprehensive test suite covering multiple canonical backfill scenarios, including null-to-value updates, unchanged rows, drift correction, dry-run verification, and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->