### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V7 — read-only quarantine profiler exposes the 9,504-row imprv_attr cohort

### DIFF
--- a/backend/TerraFusion.API.Tests/Doctrine/ImprvAttrQuarantineProfilerTests.cs
+++ b/backend/TerraFusion.API.Tests/Doctrine/ImprvAttrQuarantineProfilerTests.cs
@@ -1,0 +1,184 @@
+// SYNC-DOCTRINE-4-IMPL-V7 — quarantine profiler tests.
+//
+// Validates that the profiler:
+//   - aggregates by (UniverseCode, ImprvAttrId, IAttrValCd),
+//   - filters to UNKNOWN_ATTRIBUTE quarantine reason,
+//   - applies optional universe filter,
+//   - respects MaxCells cap,
+//   - returns per-universe rollup ordered by count.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.LegacyTfUnproven;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.API.Tests.Doctrine;
+
+public class ImprvAttrQuarantineProfilerTests
+{
+    private static (ImprvAttrQuarantineProfiler svc, IServiceProvider sp) Build()
+    {
+        var dbName = $"QuarProfiler_{Guid.NewGuid():N}";
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbName}.db",
+            }).Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(dbName));
+        var sp = services.BuildServiceProvider();
+
+        var dbForSvc = sp.CreateScope().ServiceProvider
+            .GetRequiredService<TerraFusionDbContext>();
+        var svc = new ImprvAttrQuarantineProfiler(
+            dbForSvc, NullLogger<ImprvAttrQuarantineProfiler>.Instance);
+        return (svc, sp);
+    }
+
+    private static async Task SeedQuarantineRowAsync(
+        IServiceProvider sp,
+        string? universeCode, long iAttrValId, string iAttrValCd,
+        string quarantineReason = "UNKNOWN_ATTRIBUTE")
+    {
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
+        {
+            PropValYr = 2026, SupNum = 0, PropId = 100, ImprvId = 1,
+            ImprvDetId = 10, IAttrValId = iAttrValId,
+            IAttrValCd = iAttrValCd,
+            UniverseCode = universeCode,
+            QuarantineReason = quarantineReason,
+            LandingLoadBatchId = Guid.NewGuid(),
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Profile_aggregates_by_universe_attr_id_and_val_cd()
+    {
+        var (svc, sp) = Build();
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR1");
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR1");
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR2");
+        await SeedQuarantineRowAsync(sp, "AG_CURRENT_USE", 200, "AG1");
+
+        var result = await svc.ProfileAsync(new ImprvAttrQuarantineProfileRequest());
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(4, result.TotalQuarantineRows);
+        Assert.Equal(4, result.RowsScopedByFilter);
+        Assert.Equal(2, result.DistinctUniverses);
+        Assert.Equal(3, result.DistinctCodes);
+        Assert.Equal(3, result.Cells.Count);
+
+        // Ordered by descending count → (RES, 100, GR1) with count=2 first.
+        Assert.Equal("REAL_RESIDENTIAL", result.Cells[0].UniverseCode);
+        Assert.Equal("100", result.Cells[0].ImprvAttrId);
+        Assert.Equal("GR1", result.Cells[0].IAttrValCd);
+        Assert.Equal(2, result.Cells[0].Count);
+    }
+
+    [Fact]
+    public async Task Reason_summary_lists_both_layers_independent_of_filter()
+    {
+        var (svc, sp) = Build();
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR1",
+            quarantineReason: "UNKNOWN_ATTRIBUTE");
+        await SeedQuarantineRowAsync(sp, null, 200, "X",
+            quarantineReason: "UNKNOWN_I_ATTR_VAL_CD");
+
+        // No filter → both layers present in cohort + reason summary.
+        var noFilter = await svc.ProfileAsync(new ImprvAttrQuarantineProfileRequest());
+        Assert.Equal(2, noFilter.TotalQuarantineRows);
+        Assert.Equal(2, noFilter.RowsScopedByFilter);
+        Assert.Equal(2, noFilter.ReasonSummary.Count);
+
+        // ReasonFilter scopes histogram but ReasonSummary still shows full cohort.
+        var canonicalOnly = await svc.ProfileAsync(
+            new ImprvAttrQuarantineProfileRequest(ReasonFilter: "UNKNOWN_ATTRIBUTE"));
+        Assert.Equal(2, canonicalOnly.TotalQuarantineRows);  // full cohort unchanged
+        Assert.Equal(1, canonicalOnly.RowsScopedByFilter);
+        Assert.Equal(2, canonicalOnly.ReasonSummary.Count);  // both layers in summary
+    }
+
+    [Fact]
+    public async Task Universe_filter_scopes_results()
+    {
+        var (svc, sp) = Build();
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR1");
+        await SeedQuarantineRowAsync(sp, "AG_CURRENT_USE", 200, "AG1");
+
+        var result = await svc.ProfileAsync(
+            new ImprvAttrQuarantineProfileRequest(UniverseFilter: "REAL_RESIDENTIAL", ReasonFilter: "UNKNOWN_ATTRIBUTE"));
+
+        Assert.Equal(2, result.TotalQuarantineRows);  // total cohort unchanged
+        Assert.Equal(1, result.RowsScopedByFilter);
+        Assert.Single(result.Cells);
+        Assert.Equal("REAL_RESIDENTIAL", result.Cells[0].UniverseCode);
+    }
+
+    [Fact]
+    public async Task MaxCells_caps_histogram_size()
+    {
+        var (svc, sp) = Build();
+        for (var i = 0; i < 5; i++)
+            await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100 + i, $"GR{i}");
+
+        var result = await svc.ProfileAsync(
+            new ImprvAttrQuarantineProfileRequest(MaxCells: 3));
+
+        Assert.Equal(5, result.RowsScopedByFilter);
+        Assert.Equal(3, result.Cells.Count);
+    }
+
+    [Fact]
+    public async Task NULL_universe_rows_are_grouped_distinctly()
+    {
+        var (svc, sp) = Build();
+        await SeedQuarantineRowAsync(sp, null, 100, "GR1");
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "GR1");
+
+        var result = await svc.ProfileAsync(new ImprvAttrQuarantineProfileRequest());
+
+        Assert.Equal(2, result.Cells.Count);
+        Assert.Equal(2, result.DistinctUniverses);  // null counts as a distinct value
+        Assert.Contains(result.Cells, c => c.UniverseCode == null);
+    }
+
+    [Fact]
+    public async Task Universe_summary_orders_by_descending_count()
+    {
+        var (svc, sp) = Build();
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 100, "A");
+        await SeedQuarantineRowAsync(sp, "REAL_RESIDENTIAL", 200, "B");
+        await SeedQuarantineRowAsync(sp, "AG_CURRENT_USE", 300, "C");
+
+        var result = await svc.ProfileAsync(new ImprvAttrQuarantineProfileRequest());
+
+        Assert.Equal(2, result.UniverseSummary.Count);
+        Assert.Equal("REAL_RESIDENTIAL", result.UniverseSummary[0].UniverseCode);
+        Assert.Equal(2, result.UniverseSummary[0].Count);
+        Assert.Equal("AG_CURRENT_USE", result.UniverseSummary[1].UniverseCode);
+        Assert.Equal(1, result.UniverseSummary[1].Count);
+    }
+
+    [Fact]
+    public async Task Empty_quarantine_yields_zeroes()
+    {
+        var (svc, sp) = Build();
+        var result = await svc.ProfileAsync(new ImprvAttrQuarantineProfileRequest());
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(0, result.TotalQuarantineRows);
+        Assert.Empty(result.Cells);
+        Assert.Empty(result.UniverseSummary);
+    }
+}

--- a/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
@@ -339,4 +339,26 @@ public class DoctrinePolicyController : ControllerBase
     public sealed record CanonicalBackfillRequestDto(
         bool? DryRun,
         int? MaxRows);
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4-IMPL-V7: read-only profile of the canonical-
+    /// layer imprv_attr quarantine cohort. Returns a
+    /// (UniverseCode, ImprvAttrId, IAttrValCd) histogram so the
+    /// operator can decide which codes are real (add to
+    /// attribute_definition) vs noise. Does NOT auto-seed any
+    /// dictionary — pure evidence production.
+    /// </summary>
+    [HttpGet("quarantine/imprv-attr/profile")]
+    public async Task<IActionResult> ProfileImprvAttrQuarantine(
+        [FromServices] IImprvAttrQuarantineProfiler profiler,
+        [FromQuery(Name = "universe")] string? universeFilter = null,
+        [FromQuery(Name = "reason")] string? reasonFilter = null,
+        [FromQuery(Name = "max_cells")] int? maxCells = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await profiler.ProfileAsync(
+            new ImprvAttrQuarantineProfileRequest(universeFilter, reasonFilter, maxCells),
+            cancellationToken);
+        return Ok(result);
+    }
 }

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1821,6 +1821,14 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.Doctrine.IPacsImprvUniverseBackfillService,
     TerraFusion.Data.Services.Doctrine.PacsImprvUniverseBackfillService>();
 
+// SYNC-DOCTRINE-4-IMPL-V7: read-only profiler for the canonical-layer
+// imprv_attr quarantine cohort. Returns a (UniverseCode, ImprvAttrId,
+// IAttrValCd) histogram so the operator can decide which codes are
+// real (add to attribute_definition) vs noise.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Doctrine.IImprvAttrQuarantineProfiler,
+    TerraFusion.Data.Services.Doctrine.ImprvAttrQuarantineProfiler>();
+
 // Slice D1: ArcGIS REST FeatureService raw landing. Wraps the
 // existing G1-C IArcGisFeatureServiceClient and writes verbatim
 // to legacy_arcgis_raw.parcel_geom with full provenance. Four

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IImprvAttrQuarantineProfiler.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IImprvAttrQuarantineProfiler.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V7: read-only profiler for the
+/// canonical-layer imprv_attr quarantine cohort.
+///
+/// <para>The 1,584+ rows in
+/// <c>legacy_tf_unproven.unresolved_imprv_attr</c> with
+/// <c>QuarantineReason = UNKNOWN_ATTRIBUTE</c> were quarantined
+/// because their PACS i_attr_val_id had no matching
+/// <c>canonical_tf.attribute_definition</c> entry. Post-V4, each
+/// quarantine row also carries the parent improvement's
+/// <c>UniverseCode</c> + <c>QuarantineReasonDetail</c>.</para>
+///
+/// <para>This profiler aggregates that cohort into a histogram
+/// keyed by <c>(UniverseCode, ImprvAttrId, IAttrValCd)</c> with
+/// counts and sample row ids. Operator inspects and decides which
+/// codes are real (add to <c>attribute_definition</c>) vs noise
+/// (leave quarantined). V7 produces evidence — it doesn't auto-
+/// seed any dictionary.</para>
+/// </summary>
+public interface IImprvAttrQuarantineProfiler
+{
+    Task<ImprvAttrQuarantineProfileResult> ProfileAsync(
+        ImprvAttrQuarantineProfileRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V7: profile request.</summary>
+/// <param name="UniverseFilter">
+/// Optional universe code to scope the profile (e.g.
+/// <c>"REAL_RESIDENTIAL"</c>). NULL = all universes including
+/// rows with NULL universe.
+/// </param>
+/// <param name="ReasonFilter">
+/// Optional <c>QuarantineReason</c> to scope the profile. Two
+/// recognized reasons:
+/// <list type="bullet">
+///   <item><c>"UNKNOWN_I_ATTR_VAL_CD"</c> — landing-layer reason
+///   from <c>PacsImprvAttrLandingService</c>. Most rows in
+///   production carry this reason; landed before canonical
+///   projection so they have NULL UniverseCode.</item>
+///   <item><c>"UNKNOWN_ATTRIBUTE"</c> — canonical-layer reason
+///   from <c>PacsImprvCanonicalProjector</c>. Rows that made it
+///   past landing but failed canonical AttributeDefinition lookup;
+///   carry universe context.</item>
+/// </list>
+/// NULL = profile both layers.
+/// </param>
+/// <param name="MaxCells">Hard cap on histogram cells returned.</param>
+public sealed record ImprvAttrQuarantineProfileRequest(
+    string? UniverseFilter = null,
+    string? ReasonFilter = null,
+    int? MaxCells = null);
+
+/// <summary>SYNC-DOCTRINE-4-IMPL-V7: profile result.</summary>
+public sealed record ImprvAttrQuarantineProfileResult
+{
+    public required string Status { get; init; }
+    public required int TotalQuarantineRows { get; init; }
+    public required int RowsScopedByFilter { get; init; }
+    public required int DistinctUniverses { get; init; }
+    public required int DistinctCodes { get; init; }
+
+    /// <summary>
+    /// Rollup by <c>QuarantineReason</c> across the FULL cohort
+    /// (independent of <see cref="ImprvAttrQuarantineProfileRequest.ReasonFilter"/>).
+    /// </summary>
+    public required IReadOnlyList<ReasonRollup> ReasonSummary { get; init; }
+
+    /// <summary>
+    /// Histogram cells, ordered by descending count.
+    /// </summary>
+    public required IReadOnlyList<ImprvAttrQuarantineProfileCell> Cells { get; init; }
+
+    /// <summary>
+    /// Universe → row count rollup, ordered by descending count.
+    /// </summary>
+    public required IReadOnlyList<UniverseRollup> UniverseSummary { get; init; }
+
+    public string? ErrorSummary { get; init; }
+}
+
+/// <summary>One histogram cell.</summary>
+/// <param name="UniverseCode">
+/// Parent improvement's UniverseCode at quarantine time. May be NULL
+/// for rows quarantined before SYNC-DOCTRINE-4-IMPL-V4.
+/// </param>
+/// <param name="ImprvAttrId">PACS imprv_attr_id (the i_attr_val_id integer, stringified).</param>
+/// <param name="IAttrValCd">PACS i_attr_val_cd (the value-code string).</param>
+/// <param name="Count">Number of quarantine rows matching this triple.</param>
+/// <param name="SampleUnprovenRowId">One example UnprovenRowId for operator drill-down.</param>
+public sealed record ImprvAttrQuarantineProfileCell(
+    string? UniverseCode,
+    string ImprvAttrId,
+    string IAttrValCd,
+    int Count,
+    System.Guid SampleUnprovenRowId);
+
+/// <summary>Per-universe rollup.</summary>
+public sealed record UniverseRollup(
+    string? UniverseCode,
+    int Count);
+
+/// <summary>Per-reason rollup.</summary>
+public sealed record ReasonRollup(
+    string QuarantineReason,
+    int Count);

--- a/backend/src/TerraFusion.Data/Services/Doctrine/ImprvAttrQuarantineProfiler.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/ImprvAttrQuarantineProfiler.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.SyncBridge;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V7: default
+/// <see cref="IImprvAttrQuarantineProfiler"/>.
+///
+/// <para>Read-only. Loads the canonical-layer imprv_attr
+/// quarantine cohort, builds a histogram keyed by
+/// <c>(UniverseCode, ImprvAttrId, IAttrValCd)</c>, and returns it
+/// alongside per-universe rollups.</para>
+///
+/// <para>Filters to <c>QuarantineReason = UNKNOWN_ATTRIBUTE</c>
+/// (the canonical-layer attribute quarantine reason — distinct
+/// from the landing-layer <c>UNKNOWN_I_ATTR_VAL_CD</c>).</para>
+/// </summary>
+public sealed class ImprvAttrQuarantineProfiler : IImprvAttrQuarantineProfiler
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<ImprvAttrQuarantineProfiler> _logger;
+
+    public ImprvAttrQuarantineProfiler(
+        TerraFusionDbContext db,
+        ILogger<ImprvAttrQuarantineProfiler> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<ImprvAttrQuarantineProfileResult> ProfileAsync(
+        ImprvAttrQuarantineProfileRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            // Full quarantine cohort (both landing- and canonical-layer reasons).
+            // Operator filters via ReasonFilter parameter if needed.
+            var allRows = await _db.LegacyTfUnprovenImprvAttrs
+                .Select(q => new
+                {
+                    q.UnprovenRowId,
+                    q.UniverseCode,
+                    q.IAttrValId,
+                    q.IAttrValCd,
+                    q.QuarantineReason,
+                })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var totalRows = allRows.Count;
+
+            // Reason rollup across the full cohort (independent of any filter).
+            var reasonSummary = allRows
+                .GroupBy(r => r.QuarantineReason ?? string.Empty)
+                .Select(g => new ReasonRollup(g.Key, g.Count()))
+                .OrderByDescending(r => r.Count)
+                .ToList();
+
+            // Apply reason filter, then universe filter.
+            var scoped = allRows
+                .Where(r => string.IsNullOrEmpty(request.ReasonFilter)
+                            || string.Equals(r.QuarantineReason, request.ReasonFilter, StringComparison.Ordinal))
+                .Where(r => string.IsNullOrEmpty(request.UniverseFilter)
+                            || string.Equals(r.UniverseCode, request.UniverseFilter, StringComparison.Ordinal))
+                .ToList();
+
+            // Histogram: (UniverseCode, ImprvAttrId, IAttrValCd) → count + sample id
+            var cells = scoped
+                .GroupBy(r => (r.UniverseCode, ImprvAttrId: r.IAttrValId.ToString(CultureInfo.InvariantCulture), r.IAttrValCd))
+                .Select(g => new ImprvAttrQuarantineProfileCell(
+                    UniverseCode: g.Key.UniverseCode,
+                    ImprvAttrId: g.Key.ImprvAttrId,
+                    IAttrValCd: g.Key.IAttrValCd,
+                    Count: g.Count(),
+                    SampleUnprovenRowId: g.First().UnprovenRowId))
+                .OrderByDescending(c => c.Count)
+                .ThenBy(c => c.UniverseCode ?? string.Empty, StringComparer.Ordinal)
+                .ThenBy(c => c.ImprvAttrId, StringComparer.Ordinal)
+                .ThenBy(c => c.IAttrValCd, StringComparer.Ordinal)
+                .ToList();
+
+            if (request.MaxCells.HasValue)
+                cells = cells.Take(request.MaxCells.Value).ToList();
+
+            // Per-universe rollup.
+            var universeSummary = scoped
+                .GroupBy(r => r.UniverseCode)
+                .Select(g => new UniverseRollup(g.Key, g.Count()))
+                .OrderByDescending(u => u.Count)
+                .ToList();
+
+            var distinctUniverses = scoped.Select(r => r.UniverseCode).Distinct().Count();
+            var distinctCodes = scoped.Select(r => r.IAttrValCd).Distinct().Count();
+
+            _logger.LogInformation(
+                "[Profile:imprv-attr-quarantine] total={Total} scoped={Scoped} cells={Cells} universes={Universes} codes={Codes}",
+                totalRows, scoped.Count, cells.Count, distinctUniverses, distinctCodes);
+
+            return new ImprvAttrQuarantineProfileResult
+            {
+                Status = "COMPLETED",
+                TotalQuarantineRows = totalRows,
+                RowsScopedByFilter = scoped.Count,
+                DistinctUniverses = distinctUniverses,
+                DistinctCodes = distinctCodes,
+                Cells = cells,
+                UniverseSummary = universeSummary,
+                ReasonSummary = reasonSummary,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "[Profile:imprv-attr-quarantine] FAILED");
+            return new ImprvAttrQuarantineProfileResult
+            {
+                Status = "FAILED",
+                TotalQuarantineRows = 0,
+                RowsScopedByFilter = 0,
+                DistinctUniverses = 0,
+                DistinctCodes = 0,
+                Cells = Array.Empty<ImprvAttrQuarantineProfileCell>(),
+                UniverseSummary = Array.Empty<UniverseRollup>(),
+                ReasonSummary = Array.Empty<ReasonRollup>(),
+                ErrorSummary = $"{ex.GetType().Name}: {ex.Message}",
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Why

V4 left `tf_doctrine_attribute_dictionary` empty by design ("waits on a profiling drain that captures per-universe distributions"). V7 ships that profiling drain — a read-only endpoint that aggregates the quarantine cohort by `(UniverseCode, ImprvAttrId, IAttrValCd)` so the operator can decide which codes are real (add to `attribute_definition`) vs noise.

**V7 is evidence-producing only — it does NOT auto-seed any dictionary.**

## New surface

- `IImprvAttrQuarantineProfiler` + `ImprvAttrQuarantineProfiler`
- `GET /api/sync/doctrine/policy/quarantine/imprv-attr/profile` with optional `universe`, `reason`, `max_cells` query params
- DI registration

## Profile result includes

- `totalQuarantineRows` / `rowsScopedByFilter` / `distinctUniverses` / `distinctCodes`
- **`reasonSummary`** — histogram by `QuarantineReason` across the FULL cohort (independent of any filter), since the operator should see both layers (landing `UNKNOWN_I_ATTR_VAL_CD` + canonical `UNKNOWN_ATTRIBUTE`) for triage
- `universeSummary` — rollup by `UniverseCode` within the filtered scope
- `cells` — top-N `(UniverseCode, ImprvAttrId, IAttrValCd)` histogram cells with counts and sample `UnprovenRowId` for drill-down

## Tests

7 unit tests (aggregation, reason filter, universe filter, MaxCells cap, NULL universe handling, descending order, empty cohort). All passing.

## Live evidence (Benton WA, 2026-05-06, 9,504-row cohort)

`reasonSummary`:
| Reason | Count |
|---|---|
| `UNKNOWN_I_ATTR_VAL_CD` (landing-layer) | 9,504 |

(Canonical-layer `UNKNOWN_ATTRIBUTE` cohort is currently empty — all quarantine happens at landing time before canonical projection assigns universes.)

**Top 10 cells** (UniverseCode is NULL because all rows are landing-layer, before canonical projection sets universe):

| imprvAttrId | iAttrValCd | count |
|---|---|---|
| 6 | Comp Shingle | 1,434 |
| 2 | Crawl/Concrete Perimeter Piers | 996 |
| 47 | Count | 882 |
| 15 | Count | 876 |
| 45 | Count | 876 |
| 3 | Hardboard | 810 |
| 10 | FIREPLACE | 492 |
| 9 | Central heat/cooling | 444 |
| 2 | Slab | 432 |
| 9 | Heat pump | 342 |

44 distinct codes total. These are real residential PACS attribute values (roofing, foundation, siding, HVAC, fireplace) that the global `canonical_tf.attribute_definition` table doesn't yet recognize.

Solution: 0 errors / 0 warnings.

## Out of scope (deferred)

- Operator-driven seeding of `attribute_definition` / per-universe dictionary (V8 if desired).
- Re-projection / quarantine release after dictionary seed (V9 if desired).

## Reference commits

- V6 on main: `02be63b63` (PR #796)
- V5 on main: `66317a2ec` (PR #794)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a quarantine profiling endpoint (`GET api/sync/doctrine/policy/quarantine/imprv-attr/profile`) enabling analysis of improved attribute quarantine data with optional filtering by universe and quarantine reason, configurable histogram cell limits, and comprehensive per-universe and per-reason rollup summaries.

* **Tests**
  * Added comprehensive test coverage validating quarantine profiling functionality including aggregation, filtering, ordering, and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->