### PR TITLE
feat(sync): SYNC-DOCTRINE-4-IMPL-V8 — auto-refresh imprv_attr dictionary from PACS at startup; releases the 9,504-row quarantine cohort

### DIFF
--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1829,6 +1829,15 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.Doctrine.IImprvAttrQuarantineProfiler,
     TerraFusion.Data.Services.Doctrine.ImprvAttrQuarantineProfiler>();
 
+// SYNC-DOCTRINE-4-IMPL-V8: hosted service that refreshes the
+// landing-layer imprv_attr dictionary from PACS at backend startup.
+// Without this, RefreshableImprvAttrDictionary boots empty and all
+// imprv_attr rows quarantine with UNKNOWN_I_ATTR_VAL_CD until an
+// operator manually runs /api/debug/attr-drain-1/run-drain. Idempotent
+// + non-fatal on failure.
+builder.Services.AddHostedService<
+    TerraFusion.Data.Services.PacsImprvAttr.ImprvAttrDictionaryRefreshHostedService>();
+
 // Slice D1: ArcGIS REST FeatureService raw landing. Wraps the
 // existing G1-C IArcGisFeatureServiceClient and writes verbatim
 // to legacy_arcgis_raw.parcel_geom with full provenance. Four

--- a/backend/src/TerraFusion.Data/Services/PacsImprvAttr/ImprvAttrDictionaryRefreshHostedService.cs
+++ b/backend/src/TerraFusion.Data/Services/PacsImprvAttr/ImprvAttrDictionaryRefreshHostedService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.PacsImprvAttr;
+using TerraFusion.Data.Services.PacsSources;
+
+namespace TerraFusion.Data.Services.PacsImprvAttr;
+
+/// <summary>
+/// SYNC-DOCTRINE-4-IMPL-V8: at backend startup, populate the
+/// landing-layer <see cref="RefreshableImprvAttrDictionary"/> from
+/// live PACS so subsequent imprv drains land cleanly without
+/// requiring a manual <c>POST /api/debug/attr-drain-1/run-drain</c>
+/// call.
+///
+/// <para>The loader (<see cref="SqlServerImprvAttrValDictionaryLoader"/>)
+/// first tries <c>dbo.imprv_attr_val</c> (the proper dictionary
+/// table); falls back to <c>SELECT DISTINCT i_attr_val_cd FROM
+/// dbo.imprv_attr</c> when the dictionary table is empty (Benton's
+/// case). Live data IS the dictionary per the Block-C contract:
+/// any value that exists in PACS imprv_attr is, by definition, a
+/// real PACS code that should be recognized.</para>
+///
+/// <para>Failure is non-fatal: if PACS is unreachable or the query
+/// fails, the host logs a warning and proceeds with an empty
+/// dictionary. The landing service will then quarantine all rows
+/// with <c>UNKNOWN_I_ATTR_VAL_CD</c> until the operator manually
+/// runs the existing attr-drain-1 endpoint.</para>
+/// </summary>
+public sealed class ImprvAttrDictionaryRefreshHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConfiguration _configuration;
+    private readonly RefreshableImprvAttrDictionary _dictionary;
+    private readonly ILogger<ImprvAttrDictionaryRefreshHostedService> _logger;
+
+    public ImprvAttrDictionaryRefreshHostedService(
+        IServiceScopeFactory scopeFactory,
+        IConfiguration configuration,
+        RefreshableImprvAttrDictionary dictionary,
+        ILogger<ImprvAttrDictionaryRefreshHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _configuration = configuration;
+        _dictionary = dictionary;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var pacsCs = _configuration.GetConnectionString("PacsConnection");
+            if (string.IsNullOrWhiteSpace(pacsCs))
+            {
+                _logger.LogInformation(
+                    "ImprvAttrDictionaryRefreshHostedService: ConnectionStrings:PacsConnection " +
+                    "not configured; skipping dictionary refresh. Landing service will quarantine " +
+                    "all imprv_attr rows until operator runs attr-drain-1 manually.");
+                return;
+            }
+
+            var loader = new SqlServerImprvAttrValDictionaryLoader(pacsCs);
+            var codes = await loader.LoadDistinctCodesAsync(cancellationToken).ConfigureAwait(false);
+
+            var before = _dictionary.Count;
+            _dictionary.Refresh(codes);
+            _logger.LogInformation(
+                "ImprvAttrDictionaryRefreshHostedService: refreshed landing dictionary; " +
+                "{Before} → {After} codes loaded from PACS.",
+                before, _dictionary.Count);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: PACS may be unreachable at startup (e.g.
+            // dev environment without VPN). Operator can run
+            // attr-drain-1 manually once PACS is reachable.
+            _logger.LogWarning(ex,
+                "ImprvAttrDictionaryRefreshHostedService: refresh failed; landing service " +
+                "will quarantine imprv_attr rows until operator runs attr-drain-1 manually.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Why

V7 surfaced 9,504 imprv_attr rows quarantined with `UNKNOWN_I_ATTR_VAL_CD` because `RefreshableImprvAttrDictionary` was empty — the existing `SqlServerImprvAttrValDictionaryLoader` was wired to a manual `/api/debug/attr-drain-1/run-drain` endpoint but never invoked at backend startup. V8 closes that gap.

**Two outcomes shipped together:**
1. **Code change** — new hosted service that auto-refreshes the dictionary on backend startup so future imprv drains land cleanly without operator intervention.
2. **Live release** — ran the existing `attr-drain-1/run-drain` endpoint to drain the historical 9,504-row quarantine cohort. The endpoint refreshes the dictionary, deletes stale quarantine, and re-drains affected (year, prop_id) tuples through the full chain (parcel → supp → imprv → detail → attr → truth → canonical).

## What V8 added

- `ImprvAttrDictionaryRefreshHostedService` (IHostedService).
  On `StartAsync`: loads `i_attr_val_cd` vocabulary from PACS via the existing `SqlServerImprvAttrValDictionaryLoader` (tries `dbo.imprv_attr_val` first, falls back to `SELECT DISTINCT i_attr_val_cd FROM dbo.imprv_attr` — Block-C contract: live data IS the dictionary). Calls `RefreshableImprvAttrDictionary.Refresh(codes)`. **Idempotent + non-fatal on PACS unreachability.**
- DI registration in `Program.cs`.

## Live verification (Benton WA, 2026-05-07)

**Pre-V8 quarantine state:**
- landing-layer (`UNKNOWN_I_ATTR_VAL_CD`) = 9,504
- canonical-layer (`UNKNOWN_ATTRIBUTE`) = 0

**`attr-drain-1/run-drain` (live, dryRun=false):**

| metric | value |
|---|---|
| `landingDictionaryBefore` | 0 |
| `landingDictionaryAfter` | **193** (loaded from PACS) |
| parcels processed | 151 |
| truth rows considered | 230 |
| improvements projected | 230 |
| features projected | 13,445 |
| attributes considered | 3,169 |
| **attributes resolved** | **3,169 (100 %)** |
| attributes quarantined | 0 |
| `featuresAttributedBefore` | 1,592 |
| `featuresAttributedAfter` | **3,176 (+1,584)** |

**Post-V8 quarantine state:**
- landing-layer = 0
- canonical-layer = 0
- Total = **0**

**Cold-start verification (hosted service):**

Backend stopped, restarted from clean state. Backend log:

```
ImprvAttrDictionaryRefreshHostedService: refreshed landing dictionary;
0 → 193 codes loaded from PACS.
```

Subsequent dry-run probe: dictionary at 193 codes, no manual refresh needed.

## What this fixes for assessor work

Real residential building features (Comp Shingle, Hardboard, FIREPLACE, Crawl/Concrete Perimeter Piers, Central heat/cooling, Heat pump, Slab, etc.) now flow into `canonical_tf.tf_improvement_feature` with proper `AttributeId` — exactly the data the cost-calibration workflow needs.

## Out of scope (deferred)

- Periodic re-refresh schedule (today: refresh-on-startup only). A future slice could add a scheduled refresh background loop if PACS dictionary content changes during backend lifetime.

## Reference commits

- V7 on main: `d64b37db6` (PR #797)
- V6 on main: `02be63b63` (PR #796)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The improvement attributes dictionary is now automatically populated from PACS on application startup when the PACS connection is configured. If the connection is missing or the refresh fails, the application continues to start normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->