### PR TITLE
feat(sync): SYNC-D4-NEIGHBORS — neighbor-lookup endpoint via centroid-haversine

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/ParcelGeometryController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ParcelGeometryController.cs
@@ -109,6 +109,127 @@ public sealed class ParcelGeometryController : ControllerBase
         }
     }
 
+    // ────────────────────────────────────────────────────────────
+    // Slice D4-Neighbors:
+    //   GET /api/parcels/{tfParcelId}/neighbors
+    //   ?radiusFeet=<float, default 500.0, max 50000>
+    //   &maxResults=<int,   default 50,     max 500>
+    //
+    // Contract:
+    //   - 401 if unauthenticated (handled by [Authorize])
+    //   - 403 if no countyId claim is present
+    //   - 400 on Guid.Empty or invalid radiusFeet/maxResults
+    //   - 404 if anchor parcel not found OR has no active geometry
+    //   - 404 (NOT 403) on cross-county anchor — existence MUST NOT
+    //     leak across county boundaries
+    //   - 200 with ParcelNeighborResponse otherwise (Neighbors may
+    //     be empty when radiusFeet=0 or no candidate qualifies)
+    //
+    // Implementation: in-memory haversine over centroids stored on
+    // tf_parcel_geom rows in the SAME CountyId as the anchor. PostGIS
+    // not required.
+    // ────────────────────────────────────────────────────────────
+    private const double DefaultRadiusFeet = 500.0;
+    private const double MaxRadiusFeet = 50_000.0;
+    private const int DefaultMaxResults = 50;
+    private const int MaxMaxResults = 500;
+
+    [HttpGet("{tfParcelId:guid}/neighbors")]
+    [Authorize]
+    public async Task<IActionResult> GetNeighbors(
+        Guid tfParcelId,
+        [FromQuery] double? radiusFeet = null,
+        [FromQuery] int? maxResults = null,
+        CancellationToken ct = default)
+    {
+        if (tfParcelId == Guid.Empty)
+        {
+            return BadRequest(new
+            {
+                error = "tfParcelId must be a non-empty Guid.",
+            });
+        }
+
+        // Validate query params before consulting principal/db so
+        // misuse never leaks county-existence timing.
+        var effectiveRadius = radiusFeet ?? DefaultRadiusFeet;
+        if (double.IsNaN(effectiveRadius) || double.IsInfinity(effectiveRadius) || effectiveRadius < 0d)
+        {
+            return BadRequest(new
+            {
+                error = "radiusFeet must be a finite, non-negative number.",
+            });
+        }
+        if (effectiveRadius > MaxRadiusFeet)
+        {
+            effectiveRadius = MaxRadiusFeet;
+        }
+
+        var effectiveMax = maxResults ?? DefaultMaxResults;
+        if (effectiveMax < 0)
+        {
+            return BadRequest(new
+            {
+                error = "maxResults must be a non-negative integer.",
+            });
+        }
+        if (effectiveMax > MaxMaxResults)
+        {
+            effectiveMax = MaxMaxResults;
+        }
+
+        var principalCountyId = ResolveCountyClaim();
+        if (principalCountyId is null)
+        {
+            _logger.LogWarning(
+                "[ParcelGeometry/Neighbors] missing countyId claim on principal; refusing.");
+            return Forbid();
+        }
+
+        var lookup = await _reader
+            .GetNeighborsAsync(tfParcelId, effectiveRadius, effectiveMax, ct)
+            .ConfigureAwait(false);
+
+        switch (lookup.Kind)
+        {
+            case ParcelGeometryLookupKind.NotFound:
+                _logger.LogInformation(
+                    "[ParcelGeometry/Neighbors] anchor tfParcelId={ParcelId} not found.",
+                    tfParcelId);
+                return NotFound();
+
+            case ParcelGeometryLookupKind.NoGeometry:
+                // County isolation FIRST — same doctrine as the
+                // /geometry endpoint: do not distinguish "exists in
+                // another county" from "missing".
+                if (lookup.CountyId != principalCountyId.Value)
+                {
+                    _logger.LogWarning(
+                        "[ParcelGeometry/Neighbors] cross-county refused: principal={Principal} parcel={ParcelId} parcelCounty={County}",
+                        principalCountyId, tfParcelId, lookup.CountyId);
+                    return NotFound();
+                }
+                _logger.LogInformation(
+                    "[ParcelGeometry/Neighbors] anchor tfParcelId={ParcelId} has no active geometry.",
+                    tfParcelId);
+                return NotFound();
+
+            case ParcelGeometryLookupKind.Found:
+                if (lookup.CountyId != principalCountyId.Value)
+                {
+                    _logger.LogWarning(
+                        "[ParcelGeometry/Neighbors] cross-county refused: principal={Principal} parcel={ParcelId} parcelCounty={County}",
+                        principalCountyId, tfParcelId, lookup.CountyId);
+                    return NotFound();
+                }
+                return Ok(lookup.Payload);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unrecognized lookup kind: {lookup.Kind}");
+        }
+    }
+
     /// <summary>
     /// Mirrors <c>SyncController.ResolveCountyClaim</c> — same
     /// contract, narrow trust surface (Guid claim only, no

--- a/backend/src/TerraFusion.Core/DTOs/GisTf/ParcelNeighborResponse.cs
+++ b/backend/src/TerraFusion.Core/DTOs/GisTf/ParcelNeighborResponse.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.DTOs.GisTf;
+
+/// <summary>
+/// Slice D4-Neighbors: response payload for
+/// <c>GET /api/parcels/{tfParcelId}/neighbors</c>.
+///
+/// <para>Doctrine: PII-free. Returns a list of canonical-parcel ids
+/// whose stored centroids fall within the requested radius of the
+/// anchor parcel's centroid, ordered by ascending great-circle
+/// distance and capped by <c>maxResults</c>. Distance is computed
+/// in-memory using the haversine formula on stored
+/// <see cref="ParcelNeighbor.CentroidLat"/> /
+/// <see cref="ParcelNeighbor.CentroidLon"/> values — PostGIS is NOT
+/// required.</para>
+///
+/// <para>The anchor parcel itself is never included in the result
+/// list.</para>
+/// </summary>
+public sealed record ParcelNeighborResponse
+{
+    public required Guid AnchorTfParcelId { get; init; }
+    public required Guid CountyId { get; init; }
+
+    /// <summary>Anchor centroid latitude (WGS84) — echoed for client convenience.</summary>
+    public required double AnchorCentroidLat { get; init; }
+
+    /// <summary>Anchor centroid longitude (WGS84) — echoed for client convenience.</summary>
+    public required double AnchorCentroidLon { get; init; }
+
+    /// <summary>Effective radius in feet used for the lookup (post clamp).</summary>
+    public required double RadiusFeet { get; init; }
+
+    /// <summary>Effective max-results cap used for the lookup (post clamp).</summary>
+    public required int MaxResults { get; init; }
+
+    /// <summary>
+    /// Neighbors ordered by ascending <see cref="ParcelNeighbor.DistanceFeet"/>.
+    /// Empty list when no parcel falls within the radius.
+    /// </summary>
+    public required IReadOnlyList<ParcelNeighbor> Neighbors { get; init; }
+}
+
+/// <summary>
+/// One neighbor entry in <see cref="ParcelNeighborResponse"/>. PII-free
+/// by construction; no owner, address, or value fields are surfaced.
+/// </summary>
+public sealed record ParcelNeighbor
+{
+    public required Guid TfParcelId { get; init; }
+    public required string GeomWkt { get; init; }
+    public required double CentroidLat { get; init; }
+    public required double CentroidLon { get; init; }
+
+    /// <summary>Great-circle distance from the anchor centroid, in feet.</summary>
+    public required double DistanceFeet { get; init; }
+}

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/IParcelGeometryReader.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/IParcelGeometryReader.cs
@@ -23,6 +23,28 @@ public interface IParcelGeometryReader
     Task<ParcelGeometryLookup> GetGeometryAsync(
         Guid tfParcelId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Slice D4-Neighbors: returns parcels in the same county as the
+    /// anchor whose stored centroids fall within
+    /// <paramref name="radiusFeet"/> of the anchor's centroid, ordered
+    /// by ascending great-circle distance and capped at
+    /// <paramref name="maxResults"/>.
+    ///
+    /// <para>Mirrors the three-state lookup of
+    /// <see cref="GetGeometryAsync"/>: <c>NotFound</c> when the anchor
+    /// parcel is absent, <c>NoGeometry</c> when it exists with no
+    /// active <c>tf_parcel_geom</c>, <c>Found</c> with the neighbor
+    /// list (possibly empty) otherwise. The implementation MUST
+    /// enforce sovereign-county isolation — a parcel in
+    /// <c>CountyB</c> can NEVER appear when the anchor is in
+    /// <c>CountyA</c>.</para>
+    /// </summary>
+    Task<ParcelNeighborLookup> GetNeighborsAsync(
+        Guid tfParcelId,
+        double radiusFeet,
+        int maxResults,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -63,4 +85,35 @@ public enum ParcelGeometryLookupKind
     NotFound = 0,
     NoGeometry = 1,
     Found = 2,
+}
+
+/// <summary>
+/// Slice D4-Neighbors: three-state result for the neighbor-lookup
+/// path. Mirrors <see cref="ParcelGeometryLookup"/>'s shape so the
+/// controller can reuse the same NotFound/NoGeometry/Found mapping
+/// (and the same cross-county "look like a 404" doctrine).
+/// </summary>
+public sealed record ParcelNeighborLookup
+{
+    public required ParcelGeometryLookupKind Kind { get; init; }
+
+    /// <summary>Anchor's CountyId — set when <see cref="Kind"/> is <c>NoGeometry</c> or <c>Found</c>.</summary>
+    public Guid? CountyId { get; init; }
+
+    /// <summary>Set only when <see cref="Kind"/> is <c>Found</c>.</summary>
+    public ParcelNeighborResponse? Payload { get; init; }
+
+    public static ParcelNeighborLookup NotFound() =>
+        new() { Kind = ParcelGeometryLookupKind.NotFound };
+
+    public static ParcelNeighborLookup NoGeometry(Guid countyId) =>
+        new() { Kind = ParcelGeometryLookupKind.NoGeometry, CountyId = countyId };
+
+    public static ParcelNeighborLookup Found(Guid countyId, ParcelNeighborResponse payload) =>
+        new()
+        {
+            Kind = ParcelGeometryLookupKind.Found,
+            CountyId = countyId,
+            Payload = payload,
+        };
 }

--- a/backend/src/TerraFusion.Data/Services/GisTf/ParcelGeometryReader.cs
+++ b/backend/src/TerraFusion.Data/Services/GisTf/ParcelGeometryReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,4 +60,145 @@ public sealed class ParcelGeometryReader : IParcelGeometryReader
         };
         return ParcelGeometryLookup.Found(parcel.CountyId, payload);
     }
+
+    /// <summary>
+    /// Slice D4-Neighbors: in-memory haversine over the anchor's
+    /// county-scoped active <c>tf_parcel_geom</c> rows. Sovereign-
+    /// county isolation is enforced at the EF query level — every
+    /// candidate row is filtered by <c>g.CountyId == anchor.CountyId</c>
+    /// before it leaves the database. PostGIS is intentionally NOT
+    /// used: per Block-D doctrine, centroid-haversine is sufficient
+    /// for v1 and keeps the read path portable across SQLite (dev)
+    /// and Postgres (prod).
+    /// </summary>
+    public async Task<ParcelNeighborLookup> GetNeighborsAsync(
+        Guid tfParcelId,
+        double radiusFeet,
+        int maxResults,
+        CancellationToken cancellationToken = default)
+    {
+        var anchorParcel = await _db.TfParcels
+            .AsNoTracking()
+            .Where(p => p.TfParcelId == tfParcelId)
+            .Select(p => new { p.TfParcelId, p.CountyId })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (anchorParcel is null)
+        {
+            return ParcelNeighborLookup.NotFound();
+        }
+
+        var anchorGeom = await _db.TfParcelGeoms
+            .AsNoTracking()
+            .Where(g => g.TfParcelId == tfParcelId && g.IsActive)
+            .OrderByDescending(g => g.LastSyncedAt)
+            .Select(g => new { g.CentroidLat, g.CentroidLon })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (anchorGeom is null)
+        {
+            return ParcelNeighborLookup.NoGeometry(anchorParcel.CountyId);
+        }
+
+        // Defensive clamp to the public contract; the controller is
+        // responsible for surface-level validation but the reader
+        // re-applies the floor to keep the SQL plan honest.
+        if (radiusFeet < 0d) radiusFeet = 0d;
+        if (maxResults < 0) maxResults = 0;
+
+        // Pull every active candidate in the same county, excluding
+        // the anchor parcel itself. CountyId scoping is the sole
+        // sovereign-isolation gate; nothing downstream of this filter
+        // can reintroduce a cross-county row.
+        var candidates = await _db.TfParcelGeoms
+            .AsNoTracking()
+            .Where(g => g.IsActive
+                        && g.CountyId == anchorParcel.CountyId
+                        && g.TfParcelId != null
+                        && g.TfParcelId != tfParcelId)
+            .Select(g => new
+            {
+                g.TfParcelId,
+                g.GeomWkt,
+                g.CentroidLat,
+                g.CentroidLon,
+                g.LastSyncedAt,
+            })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        // De-dupe by TfParcelId — pick the most-recently-synced row
+        // per parcel so callers don't see ghost duplicates from
+        // historical re-syncs.
+        var latestPerParcel = candidates
+            .GroupBy(c => c.TfParcelId!.Value)
+            .Select(grp => grp.OrderByDescending(g => g.LastSyncedAt).First());
+
+        var anchorLat = anchorGeom.CentroidLat;
+        var anchorLon = anchorGeom.CentroidLon;
+
+        var neighbors = new List<ParcelNeighbor>();
+        foreach (var c in latestPerParcel)
+        {
+            var distFt = HaversineFeet(
+                anchorLat, anchorLon, c.CentroidLat, c.CentroidLon);
+            if (distFt <= radiusFeet)
+            {
+                neighbors.Add(new ParcelNeighbor
+                {
+                    TfParcelId = c.TfParcelId!.Value,
+                    GeomWkt = c.GeomWkt,
+                    CentroidLat = c.CentroidLat,
+                    CentroidLon = c.CentroidLon,
+                    DistanceFeet = distFt,
+                });
+            }
+        }
+
+        var ordered = neighbors
+            .OrderBy(n => n.DistanceFeet)
+            .ThenBy(n => n.TfParcelId) // deterministic tie-break
+            .Take(maxResults)
+            .ToList();
+
+        var payload = new ParcelNeighborResponse
+        {
+            AnchorTfParcelId = tfParcelId,
+            CountyId = anchorParcel.CountyId,
+            AnchorCentroidLat = anchorLat,
+            AnchorCentroidLon = anchorLon,
+            RadiusFeet = radiusFeet,
+            MaxResults = maxResults,
+            Neighbors = ordered,
+        };
+        return ParcelNeighborLookup.Found(anchorParcel.CountyId, payload);
+    }
+
+    /// <summary>
+    /// Great-circle distance between two WGS84 lat/lon pairs, in feet.
+    /// Uses the haversine formula with mean Earth radius
+    /// 6,371,000 m × 3.28084 ft/m. Accuracy is sufficient for
+    /// county-scope neighbor lookups (sub-50 km radii).
+    /// </summary>
+    private static double HaversineFeet(
+        double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg)
+    {
+        const double EarthRadiusMeters = 6_371_000d;
+        const double MetersToFeet = 3.28084d;
+
+        var lat1 = DegToRad(lat1Deg);
+        var lat2 = DegToRad(lat2Deg);
+        var dLat = DegToRad(lat2Deg - lat1Deg);
+        var dLon = DegToRad(lon2Deg - lon1Deg);
+
+        var sinDLat = Math.Sin(dLat / 2d);
+        var sinDLon = Math.Sin(dLon / 2d);
+
+        var a = (sinDLat * sinDLat) +
+                (Math.Cos(lat1) * Math.Cos(lat2) * sinDLon * sinDLon);
+        var c = 2d * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1d - a));
+
+        return EarthRadiusMeters * c * MetersToFeet;
+    }
+
+    private static double DegToRad(double deg) => deg * (Math.PI / 180d);
 }

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ParcelGeometryNeighborControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ParcelGeometryNeighborControllerTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.DTOs.GisTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.GisTf;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.GisTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.GisTf.ArcGisRest;
+
+/// <summary>
+/// Slice D4-Neighbors controller tests for
+/// <c>GET /api/parcels/{tfParcelId}/neighbors</c>. Mirrors the
+/// pattern from <see cref="ParcelGeometryControllerTests"/>: real
+/// EF InMemory context, claims principal injection, no network.
+///
+/// <para>Asserts:
+/// <list type="bullet">
+///   <item>404 when the anchor parcel is missing.</item>
+///   <item>404 when the anchor exists but has no active geometry.</item>
+///   <item>200 with empty neighbor list when <c>radiusFeet=0</c>.</item>
+///   <item>Neighbors are ordered by ascending distance and
+///        <c>maxResults</c> caps the result count.</item>
+///   <item>Sovereign-county isolation: a parcel in another county
+///        is NEVER surfaced — even when its centroid is meters
+///        away from the anchor's centroid.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class ParcelGeometryNeighborControllerTests : IDisposable
+{
+    private static readonly Guid CountyA = Guid.Parse("3d4d4d4d-4d4d-4d4d-4d4d-4d4d4d4d4d4d");
+    private static readonly Guid CountyB = Guid.Parse("4e5e5e5e-5e5e-5e5e-5e5e-5e5e5e5e5e5e");
+
+    private readonly TerraFusionDbContext _db;
+
+    public ParcelGeometryNeighborControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"d4-neighbors-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ParcelGeometryController BuildController(Guid? principalCountyClaim)
+    {
+        var reader = new ParcelGeometryReader(_db);
+        var ctrl = new ParcelGeometryController(
+            reader, NullLogger<ParcelGeometryController>.Instance);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: principalCountyClaim is null ? null : "Test");
+        if (principalCountyClaim is not null)
+        {
+            identity.AddClaim(new Claim("countyId", principalCountyClaim.Value.ToString()));
+        }
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+            },
+        };
+        return ctrl;
+    }
+
+    private async Task<TfParcel> SeedParcelAsync(Guid countyId, string apn)
+    {
+        var p = new TfParcel
+        {
+            CountyId = countyId,
+            ParcelNumber = apn,
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(p);
+        await _db.SaveChangesAsync();
+        return p;
+    }
+
+    private async Task<TfParcelGeom> SeedGeomAsync(
+        Guid parcelId,
+        Guid countyId,
+        double centroidLat,
+        double centroidLon,
+        bool isActive = true,
+        long objectId = 1)
+    {
+        var g = new TfParcelGeom
+        {
+            TfParcelId = parcelId,
+            CountyId = countyId,
+            ArcGisObjectId = objectId,
+            ArcGisApn = "ABC",
+            GeomWkt = $"POLYGON(({centroidLon} {centroidLat}, {centroidLon + 0.0001} {centroidLat}, {centroidLon + 0.0001} {centroidLat + 0.0001}, {centroidLon} {centroidLat + 0.0001}, {centroidLon} {centroidLat}))",
+            CentroidLat = centroidLat,
+            CentroidLon = centroidLon,
+            AreaSqFt = 5000.0,
+            SourceServiceUrl = "https://example.org/FeatureServer/0",
+            LastSyncedAt = DateTime.UtcNow,
+            IsActive = isActive,
+        };
+        _db.TfParcelGeoms.Add(g);
+        await _db.SaveChangesAsync();
+        return g;
+    }
+
+    [Fact]
+    public async Task Returns_404_WhenAnchorParcelMissing()
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetNeighbors(Guid.NewGuid());
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Returns_404_WhenAnchorHasNoActiveGeometry()
+    {
+        var anchor = await SeedParcelAsync(CountyA, "ANCHOR");
+        // No active geom row seeded for anchor.
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetNeighbors(anchor.TfParcelId);
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task RadiusZero_ReturnsEmptyNeighborList()
+    {
+        var anchor = await SeedParcelAsync(CountyA, "ANCHOR");
+        await SeedGeomAsync(anchor.TfParcelId, CountyA, 46.25, -119.25);
+
+        // A second parcel sitting essentially on the same coordinate
+        // — only radius=0 should reject it (haversine of identical
+        // points is 0, but DistanceFeet must be <= radiusFeet, and
+        // the other parcel's distance is non-zero).
+        var other = await SeedParcelAsync(CountyA, "OTHER");
+        await SeedGeomAsync(
+            other.TfParcelId, CountyA, 46.2501, -119.2501, objectId: 2);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetNeighbors(anchor.TfParcelId, radiusFeet: 0d);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<ParcelNeighborResponse>().Subject;
+        dto.AnchorTfParcelId.Should().Be(anchor.TfParcelId);
+        dto.CountyId.Should().Be(CountyA);
+        dto.RadiusFeet.Should().Be(0d);
+        dto.Neighbors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Neighbors_AreOrderedByAscendingDistance()
+    {
+        // Anchor near (46.25, -119.25). Seed three neighbors at
+        // increasing distances and one outside the radius.
+        var anchor = await SeedParcelAsync(CountyA, "ANCHOR");
+        await SeedGeomAsync(anchor.TfParcelId, CountyA, 46.25, -119.25);
+
+        // Roughly: 0.0001 deg lat ≈ 36.5 ft; we exaggerate to keep
+        // the math obvious for readers.
+        var near = await SeedParcelAsync(CountyA, "NEAR");
+        await SeedGeomAsync(near.TfParcelId, CountyA, 46.2501, -119.25, objectId: 10);
+
+        var middle = await SeedParcelAsync(CountyA, "MID");
+        await SeedGeomAsync(middle.TfParcelId, CountyA, 46.2510, -119.25, objectId: 11);
+
+        var far = await SeedParcelAsync(CountyA, "FAR");
+        await SeedGeomAsync(far.TfParcelId, CountyA, 46.2530, -119.25, objectId: 12);
+
+        // Outside the requested radius (~10 km north).
+        var beyond = await SeedParcelAsync(CountyA, "BEYOND");
+        await SeedGeomAsync(beyond.TfParcelId, CountyA, 46.35, -119.25, objectId: 13);
+
+        var ctrl = BuildController(CountyA);
+        // 5000 ft radius — ~1.5 km — covers near/middle/far, excludes beyond.
+        var result = await ctrl.GetNeighbors(
+            anchor.TfParcelId, radiusFeet: 5000d, maxResults: 50);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<ParcelNeighborResponse>().Subject;
+
+        dto.Neighbors.Should().HaveCount(3, "beyond is past the radius");
+        dto.Neighbors[0].TfParcelId.Should().Be(near.TfParcelId);
+        dto.Neighbors[1].TfParcelId.Should().Be(middle.TfParcelId);
+        dto.Neighbors[2].TfParcelId.Should().Be(far.TfParcelId);
+
+        // Distances must be strictly non-decreasing.
+        var distances = dto.Neighbors.Select(n => n.DistanceFeet).ToList();
+        distances.Should().BeInAscendingOrder();
+        distances.Should().AllSatisfy(d => d.Should().BeGreaterThanOrEqualTo(0d));
+    }
+
+    [Fact]
+    public async Task MaxResults_CapsResultCount()
+    {
+        var anchor = await SeedParcelAsync(CountyA, "ANCHOR");
+        await SeedGeomAsync(anchor.TfParcelId, CountyA, 46.25, -119.25);
+
+        // Seed 5 candidates within a generous radius, all in CountyA.
+        for (var i = 0; i < 5; i++)
+        {
+            var p = await SeedParcelAsync(CountyA, $"P{i}");
+            await SeedGeomAsync(
+                p.TfParcelId, CountyA,
+                46.25 + ((i + 1) * 0.0001),
+                -119.25,
+                objectId: 100 + i);
+        }
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetNeighbors(
+            anchor.TfParcelId, radiusFeet: 50_000d, maxResults: 2);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<ParcelNeighborResponse>().Subject;
+        dto.MaxResults.Should().Be(2);
+        dto.Neighbors.Should().HaveCount(2, "maxResults caps the response");
+        // The two closest are the first two seeded.
+        dto.Neighbors.Select(n => n.DistanceFeet)
+            .Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task CrossCountyParcels_AreNeverReturned_EvenWhenSpatiallyClose()
+    {
+        // Anchor in CountyA at (46.25, -119.25).
+        var anchor = await SeedParcelAsync(CountyA, "ANCHOR");
+        await SeedGeomAsync(anchor.TfParcelId, CountyA, 46.25, -119.25);
+
+        // CountyA neighbor — should appear.
+        var sameCounty = await SeedParcelAsync(CountyA, "SAME");
+        await SeedGeomAsync(
+            sameCounty.TfParcelId, CountyA, 46.2502, -119.25, objectId: 200);
+
+        // CountyB intruder sitting at the SAME coordinate as the
+        // anchor — distance is zero, but sovereign-county isolation
+        // must drop it. This is the critical test: the spatial
+        // engine must never override the county boundary.
+        var crossCounty = await SeedParcelAsync(CountyB, "INTRUDER");
+        await SeedGeomAsync(
+            crossCounty.TfParcelId, CountyB, 46.25, -119.25, objectId: 201);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetNeighbors(
+            anchor.TfParcelId, radiusFeet: 5000d, maxResults: 50);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var dto = ok.Value.Should().BeOfType<ParcelNeighborResponse>().Subject;
+        dto.CountyId.Should().Be(CountyA);
+        dto.Neighbors.Should().HaveCount(1, "CountyB parcels are sovereign-isolated");
+        dto.Neighbors.Single().TfParcelId.Should().Be(sameCounty.TfParcelId);
+        dto.Neighbors.Should()
+            .NotContain(n => n.TfParcelId == crossCounty.TfParcelId,
+                "cross-county parcels are NEVER surfaced regardless of distance");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the missing third leg of D4 (parcel geom read-models). The `/geometry` endpoint and bbox query already existed; this PR adds the neighbor-lookup contract:

- **New endpoint:** `GET /api/parcels/{tfParcelId:guid}/neighbors`
- **Query params:**
  - `radiusFeet` — optional, default `500.0`, hard-capped at `50_000`
  - `maxResults` — optional, default `50`, hard-capped at `500`
- **Response:** `ParcelNeighborResponse` with the anchor's centroid echoed back, the effective (post-clamp) `radiusFeet` / `maxResults`, and a list of `ParcelNeighbor` rows ordered by ascending great-circle distance.

## Why

Block-D doctrine wanted a centroid-based neighbor lookup *without* taking a PostGIS dependency in v1. Same parcel page that renders `/geometry` can now ask "what's around me?" without round-tripping per parcel, and the read path stays portable across SQLite (dev) and Postgres (prod).

## How

- **Pure haversine on stored centroids.** No PostGIS, no migration, no schema change. Uses existing `tf_parcel_geom.CentroidLat` / `CentroidLon` columns the sync engine already pre-computes.
- **Sovereign-county isolation enforced at the EF query** — the `Where(g => g.CountyId == anchor.CountyId)` clause is the only spatial gate that runs before any distance math. Cross-county candidates never leave the database.
- **Three-state `ParcelNeighborLookup`** mirrors the existing `ParcelGeometryLookup` shape so `ParcelGeometryController.GetNeighbors` reuses the same `NotFound`/`NoGeometry`/`Found` mapping AND the cross-county "look like a 404" doctrine.
- **De-dupe by `TfParcelId`** picking the most-recently-synced row, deterministic tie-break by `TfParcelId` for stable ordering.

## Contract

| Condition | Status |
|---|---|
| Unauthenticated | 401 (via `[Authorize]`) |
| No `countyId` claim | 403 |
| `Guid.Empty`, NaN/Infinity radius, negative max | 400 |
| Anchor parcel missing | 404 |
| Anchor exists but has no active geometry | 404 |
| Anchor exists in another county | 404 (NOT 403 — existence MUST NOT leak) |
| Otherwise | 200 with `ParcelNeighborResponse` (Neighbors may be empty) |

## Tests (all in `TerraFusion.Unit.Tests`)

1. `Returns_404_WhenAnchorParcelMissing`
2. `Returns_404_WhenAnchorHasNoActiveGeometry`
3. `RadiusZero_ReturnsEmptyNeighborList`
4. `Neighbors_AreOrderedByAscendingDistance`
5. `MaxResults_CapsResultCount`
6. `CrossCountyParcels_AreNeverReturned_EvenWhenSpatiallyClose` — seeds a CountyB parcel at the **same coordinate as the anchor**; asserts it never appears.

## Test plan

- [x] `dotnet build backend/TerraFusion.sln` — 0 errors, 0 warnings
- [x] 6 new tests pass (`ParcelGeometryNeighborControllerTests`)
- [x] 16/16 pass when extended to `ParcelGeometryController` + `D4ReadModel` + new neighbor tests (no regression in existing D4 surface)
- [ ] Live-replay against Benton ArcGIS data (post-merge, ops-side)

## Out of scope

- No EF migration; reuses existing `TfParcelGeom` columns.
- No PostGIS adapter — Block-D Phase 2 concern.
- No `MaxRadiusFeet` / `MaxMaxResults` config knob — hardcoded constants for v1; promote if a county needs different limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added endpoint to retrieve neighboring parcels within a specified search radius
  * Supports customizable radius and maximum results limit
  * Results ordered by ascending distance from anchor parcel
  * Returns parcel identifiers, coordinates, geometry, and computed distance
  * Respects county boundaries when retrieving neighbors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->