### PR TITLE
feat(sync): SYNC-G3 — eraFilter query param on canonical read endpoints

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/ParcelOwnerController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ParcelOwnerController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using TerraFusion.API.Helpers;
 using TerraFusion.Core.Sync.PacsOwnerCanonical;
 
 namespace TerraFusion.API.Controllers;
@@ -11,18 +12,24 @@ namespace TerraFusion.API.Controllers;
 /// <summary>
 /// Slice B5: read-only endpoint for canonical parcel ownership.
 ///
-/// <para><c>GET /api/parcels/{tfParcelId}/owner-current?taxYear=...</c></para>
+/// <para><c>GET /api/parcels/{tfParcelId}/owner-current?taxYear=...&amp;era=...</c></para>
 ///
 /// <para>Contract:
 /// <list type="bullet">
 ///   <item>401 if unauthenticated (handled by <c>[Authorize]</c>).</item>
-///   <item>400 on missing / empty <c>tfParcelId</c> or non-positive <c>taxYear</c>.</item>
+///   <item>400 on missing / empty <c>tfParcelId</c>, non-positive
+///   <c>taxYear</c>, or unrecognized <c>era</c> token.</item>
 ///   <item>403 when the caller has no <c>countyId</c> claim (cannot enforce isolation).</item>
 ///   <item>404 when no parcel matches OR the parcel exists but has no link rows for the year.</item>
 ///   <item>404 (NOT 403) on cross-county access — existence must not leak.</item>
 ///   <item>200 with <see cref="TerraFusion.Core.DTOs.CanonicalTf.ParcelOwnerCurrentResponse"/> when found.</item>
 /// </list>
 /// </para>
+///
+/// <para>Slice G3 (v1.12): the optional <c>era</c> query parameter
+/// constrains the joined <c>tf_owner</c> rows to a single conversion
+/// era. Null defaults to <c>POST_CONVERSION</c>; <c>era=ALL</c>
+/// bypasses the filter for audit sweeps.</para>
 ///
 /// <para>The payload's <c>DisplayName</c> already reflects the
 /// canonical PII redaction (confidential rows show
@@ -50,6 +57,7 @@ public sealed class ParcelOwnerController : ControllerBase
     public async Task<IActionResult> GetOwnerCurrent(
         Guid tfParcelId,
         [FromQuery] short taxYear,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (tfParcelId == Guid.Empty)
@@ -69,6 +77,14 @@ public sealed class ParcelOwnerController : ControllerBase
             });
         }
 
+        // G3 (v1.12): normalize era query param. Null → POST_CONVERSION;
+        // unknown tokens → 400 with the valid-values list.
+        if (!EraQueryHelper.TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+        {
+            _logger.LogWarning("[ParcelOwner] invalid era token: {Era}", era);
+            return eraFail!;
+        }
+
         var principalCountyId = ResolveCountyClaim();
         if (principalCountyId is null)
         {
@@ -78,15 +94,15 @@ public sealed class ParcelOwnerController : ControllerBase
         }
 
         var lookup = await _reader
-            .GetOwnersAsync(tfParcelId, taxYear, ct)
+            .GetOwnersAsync(tfParcelId, taxYear, resolvedEra, ct)
             .ConfigureAwait(false);
 
         switch (lookup.Kind)
         {
             case ParcelOwnerLookupKind.NotFound:
                 _logger.LogInformation(
-                    "[ParcelOwner] tfParcelId={ParcelId} taxYear={TaxYear} not found.",
-                    tfParcelId, taxYear);
+                    "[ParcelOwner] tfParcelId={ParcelId} taxYear={TaxYear} era={Era} not found.",
+                    tfParcelId, taxYear, resolvedEra);
                 return NotFound();
 
             case ParcelOwnerLookupKind.NoOwners:
@@ -98,8 +114,8 @@ public sealed class ParcelOwnerController : ControllerBase
                     return NotFound();
                 }
                 _logger.LogInformation(
-                    "[ParcelOwner] tfParcelId={ParcelId} taxYear={TaxYear} has no canonical owners.",
-                    tfParcelId, taxYear);
+                    "[ParcelOwner] tfParcelId={ParcelId} taxYear={TaxYear} era={Era} has no canonical owners.",
+                    tfParcelId, taxYear, resolvedEra);
                 return NotFound();
 
             case ParcelOwnerLookupKind.Found:

--- a/backend/src/TerraFusion.API/Controllers/ParcelWsdorController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ParcelWsdorController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using TerraFusion.API.Helpers;
 using TerraFusion.Core.Sync.PacsWsdorCanonical;
 
 namespace TerraFusion.API.Controllers;
@@ -12,18 +13,24 @@ namespace TerraFusion.API.Controllers;
 /// Slice B5': read-only endpoint for canonical WSDOR-grade
 /// per-owner assessments.
 ///
-/// <para><c>GET /api/parcels/{tfParcelId}/wsdor-roll?taxYear=...</c></para>
+/// <para><c>GET /api/parcels/{tfParcelId}/wsdor-roll?taxYear=...&amp;era=...</c></para>
 ///
 /// <para>Contract:
 /// <list type="bullet">
 ///   <item>401 if unauthenticated (handled by <c>[Authorize]</c>).</item>
-///   <item>400 on missing / empty <c>tfParcelId</c> or non-positive <c>taxYear</c>.</item>
+///   <item>400 on missing / empty <c>tfParcelId</c>, non-positive
+///   <c>taxYear</c>, or unrecognized <c>era</c> token.</item>
 ///   <item>403 when the caller has no <c>countyId</c> claim.</item>
 ///   <item>404 when no parcel matches OR the parcel exists but has no WSDOR rows for the year.</item>
 ///   <item>404 (NOT 403) on cross-county access — existence must not leak.</item>
 ///   <item>200 with <see cref="TerraFusion.Core.DTOs.CanonicalTf.ParcelWsdorRollResponse"/> when found.</item>
 /// </list>
 /// </para>
+///
+/// <para>Slice G3 (v1.12): the optional <c>era</c> query parameter
+/// constrains the projected <c>tf_assessment_wsdor</c> rows to a
+/// single conversion era. Null defaults to <c>POST_CONVERSION</c>;
+/// <c>era=ALL</c> bypasses the filter for audit sweeps.</para>
 ///
 /// <para>Each entry's <c>OwnerDisplayName</c> reflects the canonical
 /// PII redaction policy already applied at B3; the reader does NOT
@@ -50,6 +57,7 @@ public sealed class ParcelWsdorController : ControllerBase
     public async Task<IActionResult> GetWsdorRoll(
         Guid tfParcelId,
         [FromQuery] short taxYear,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (tfParcelId == Guid.Empty)
@@ -69,6 +77,14 @@ public sealed class ParcelWsdorController : ControllerBase
             });
         }
 
+        // G3 (v1.12): normalize era query param. Null → POST_CONVERSION;
+        // unknown tokens → 400 with the valid-values list.
+        if (!EraQueryHelper.TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+        {
+            _logger.LogWarning("[ParcelWsdor] invalid era token: {Era}", era);
+            return eraFail!;
+        }
+
         var principalCountyId = ResolveCountyClaim();
         if (principalCountyId is null)
         {
@@ -78,15 +94,15 @@ public sealed class ParcelWsdorController : ControllerBase
         }
 
         var lookup = await _reader
-            .GetWsdorRollAsync(tfParcelId, taxYear, ct)
+            .GetWsdorRollAsync(tfParcelId, taxYear, resolvedEra, ct)
             .ConfigureAwait(false);
 
         switch (lookup.Kind)
         {
             case ParcelWsdorLookupKind.NotFound:
                 _logger.LogInformation(
-                    "[ParcelWsdor] tfParcelId={ParcelId} taxYear={TaxYear} not found.",
-                    tfParcelId, taxYear);
+                    "[ParcelWsdor] tfParcelId={ParcelId} taxYear={TaxYear} era={Era} not found.",
+                    tfParcelId, taxYear, resolvedEra);
                 return NotFound();
 
             case ParcelWsdorLookupKind.NoEntries:
@@ -98,8 +114,8 @@ public sealed class ParcelWsdorController : ControllerBase
                     return NotFound();
                 }
                 _logger.LogInformation(
-                    "[ParcelWsdor] tfParcelId={ParcelId} taxYear={TaxYear} has no WSDOR entries.",
-                    tfParcelId, taxYear);
+                    "[ParcelWsdor] tfParcelId={ParcelId} taxYear={TaxYear} era={Era} has no WSDOR entries.",
+                    tfParcelId, taxYear, resolvedEra);
                 return NotFound();
 
             case ParcelWsdorLookupKind.Found:

--- a/backend/src/TerraFusion.API/Controllers/SalesRatioStudyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SalesRatioStudyController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using TerraFusion.API.Helpers;
 using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.SalesRatioStudy;
 
@@ -53,19 +54,6 @@ public sealed class SalesRatioStudyController : ControllerBase
         _reader = reader;
         _logger = logger;
     }
-
-    /// <summary>
-    /// G3 (v1.12): valid era tokens accepted on the <c>era</c> query
-    /// parameter. Doctrine-frozen set; unrecognized values are 400.
-    /// </summary>
-    private static readonly IReadOnlySet<string> ValidEraValues =
-        new HashSet<string>
-        {
-            ConversionEras.PostConversion,
-            ConversionEras.PreConversion2017,
-            ConversionEras.Unknown,
-            ISalesRatioStudyReader.EraAll,
-        };
 
     /// <summary>
     /// Q1: count of valid sales for the county.
@@ -154,38 +142,20 @@ public sealed class SalesRatioStudyController : ControllerBase
 
     /// <summary>
     /// G3 (v1.12): normalizes the <c>era</c> query parameter.
-    /// Null/whitespace resolves to <see cref="ConversionEras.PostConversion"/>
-    /// (the documented default). Unrecognized values produce 400 with
-    /// the valid value list. Returns the resolved string for echo.
+    /// Delegates to <see cref="EraQueryHelper"/> so the doctrine
+    /// vocabulary stays single-sourced across all G3 read endpoints.
     /// </summary>
     private bool TryNormalizeEra(
         string? era,
         out string resolvedEra,
         out IActionResult? failureResult)
     {
-        if (string.IsNullOrWhiteSpace(era))
-        {
-            resolvedEra = ConversionEras.PostConversion;
-            failureResult = null;
-            return true;
-        }
-
-        var trimmed = era.Trim();
-        if (!ValidEraValues.Contains(trimmed))
+        if (!EraQueryHelper.TryNormalizeEra(era, out resolvedEra, out failureResult))
         {
             _logger.LogWarning(
-                "[SalesRatioStudy] invalid era token: {Era}", trimmed);
-            resolvedEra = string.Empty;
-            failureResult = BadRequest(new
-            {
-                error = "invalid era",
-                validValues = ValidEraValues,
-            });
+                "[SalesRatioStudy] invalid era token: {Era}", era);
             return false;
         }
-
-        resolvedEra = trimmed;
-        failureResult = null;
         return true;
     }
 

--- a/backend/src/TerraFusion.API/Controllers/TfSalesController.cs
+++ b/backend/src/TerraFusion.API/Controllers/TfSalesController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using TerraFusion.API.Helpers;
 using TerraFusion.Core.Sync.PacsSaleCanonical;
 
 namespace TerraFusion.API.Controllers;
@@ -12,21 +13,24 @@ namespace TerraFusion.API.Controllers;
 /// Slice S4: read-only paginated endpoint for the canonical sales
 /// corpus.
 ///
-/// <para><c>GET /api/sales?countyId={id}&amp;page&amp;pageSize</c></para>
+/// <para><c>GET /api/sales?countyId={id}&amp;page&amp;pageSize&amp;era</c></para>
 ///
 /// <para>Contract:
 /// <list type="bullet">
 ///   <item>401 if unauthenticated (handled by <c>[Authorize]</c>).</item>
-///   <item>400 on missing <c>countyId</c>, or pagination violations.</item>
+///   <item>400 on missing <c>countyId</c>, pagination violations, or
+///   invalid <c>era</c> token.</item>
 ///   <item>403 when the caller's <c>countyId</c> claim doesn't match.</item>
 ///   <item>200 with <see cref="TerraFusion.Core.DTOs.CanonicalTf.PagedTfSaleResponse"/>
 ///   on success — empty envelope when no rows qualify.</item>
 /// </list>
 /// </para>
 ///
-/// <para>Defaults: <c>page=1</c>, <c>pageSize=100</c>. Maximum
-/// <c>pageSize=500</c> (server refuses, never silently truncates,
-/// per the C39-A pagination contract).</para>
+/// <para>Defaults: <c>page=1</c>, <c>pageSize=100</c>, <c>era=POST_CONVERSION</c>.
+/// Maximum <c>pageSize=500</c> (server refuses, never silently truncates,
+/// per the C39-A pagination contract). The <c>era</c> default is the
+/// doctrine-frozen v1.10 §3 value; <c>era=ALL</c> bypasses the filter
+/// for audit / migration sweeps.</para>
 ///
 /// <para>Read-only: no DbContext writes, no audit-table mutations.
 /// Deterministic ordering by <c>(SlDt DESC, ChgOfOwnerId DESC)</c>
@@ -57,6 +61,7 @@ public sealed class TfSalesController : ControllerBase
         [FromQuery] Guid countyId,
         [FromQuery] int? page,
         [FromQuery] int? pageSize,
+        [FromQuery] string? era = null,
         CancellationToken ct = default)
     {
         if (countyId == Guid.Empty)
@@ -97,6 +102,14 @@ public sealed class TfSalesController : ControllerBase
             });
         }
 
+        // G3 (v1.12): normalize era query param. Null → POST_CONVERSION;
+        // unknown tokens → 400 with the valid-values list.
+        if (!EraQueryHelper.TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+        {
+            _logger.LogWarning("[TfSales] invalid era token: {Era}", era);
+            return eraFail!;
+        }
+
         var principalCountyId = ResolveCountyClaim();
         if (principalCountyId is null || principalCountyId.Value != countyId)
         {
@@ -110,12 +123,12 @@ public sealed class TfSalesController : ControllerBase
         var effectivePageSize = pageSize ?? DefaultPageSize;
 
         var result = await _reader
-            .ReadAsync(countyId, effectivePage, effectivePageSize, ct)
+            .ReadAsync(countyId, effectivePage, effectivePageSize, resolvedEra, ct)
             .ConfigureAwait(false);
 
         _logger.LogInformation(
-            "[TfSales] county={CountyId} page={Page} pageSize={PageSize} rows={Rows} total={Total}",
-            countyId, effectivePage, effectivePageSize,
+            "[TfSales] county={CountyId} page={Page} pageSize={PageSize} era={Era} rows={Rows} total={Total}",
+            countyId, effectivePage, effectivePageSize, resolvedEra,
             result.Items.Count, result.TotalCount);
 
         return Ok(result);

--- a/backend/src/TerraFusion.API/Helpers/EraQueryHelper.cs
+++ b/backend/src/TerraFusion.API/Helpers/EraQueryHelper.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.SalesRatioStudy;
+
+namespace TerraFusion.API.Helpers;
+
+/// <summary>
+/// Slice G3 (v1.12): shared helper for normalizing the
+/// <c>era</c> query-string parameter on canonical-tf read
+/// endpoints.
+///
+/// <para>Per Block-G G3 spec: every canonical read endpoint that
+/// queries an entity carrying a <c>ConversionEra</c> column accepts
+/// an <c>era</c> query parameter. Null/whitespace defaults to
+/// <see cref="ConversionEras.PostConversion"/> (the documented
+/// default per v1.10 Section 3). Unrecognized tokens produce a 400 with
+/// the valid-values list. The special <see cref="ISalesRatioStudyReader.EraAll"/>
+/// token bypasses the era filter entirely.</para>
+///
+/// <para>This helper is shared across
+/// <c>SalesRatioStudyController</c>, <c>TfSalesController</c>,
+/// <c>ParcelOwnerController</c>, and <c>ParcelWsdorController</c> --
+/// the spec asked for extraction once 3+ controllers shared the
+/// same validation. The era predicate itself stays in each reader
+/// because each entity's <c>ConversionEra</c> column lives in a
+/// different EF entity type (no shared base type to predicate on).</para>
+/// </summary>
+public static class EraQueryHelper
+{
+    /// <summary>
+    /// Doctrine-frozen set of valid era query tokens.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ValidEraValues =
+        new HashSet<string>
+        {
+            ConversionEras.PostConversion,
+            ConversionEras.PreConversion2017,
+            ConversionEras.Unknown,
+            ISalesRatioStudyReader.EraAll,
+        };
+
+    /// <summary>
+    /// Normalizes the <paramref name="era"/> query parameter.
+    /// Null/whitespace -> POST_CONVERSION. Unknown token -> 400 with
+    /// the valid-values list. Recognized tokens (trimmed) -> echoed back.
+    /// </summary>
+    public static bool TryNormalizeEra(
+        string? era,
+        out string resolvedEra,
+        out IActionResult? failureResult)
+    {
+        if (string.IsNullOrWhiteSpace(era))
+        {
+            resolvedEra = ConversionEras.PostConversion;
+            failureResult = null;
+            return true;
+        }
+
+        var trimmed = era.Trim();
+        if (!ValidEraValues.Contains(trimmed))
+        {
+            resolvedEra = string.Empty;
+            failureResult = new BadRequestObjectResult(new
+            {
+                error = "invalid era",
+                validValues = ValidEraValues,
+            });
+            return false;
+        }
+
+        resolvedEra = trimmed;
+        failureResult = null;
+        return true;
+    }
+}

--- a/backend/src/TerraFusion.Core/Sync/PacsOwnerCanonical/ITfParcelOwnerReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsOwnerCanonical/ITfParcelOwnerReader.cs
@@ -10,7 +10,7 @@ namespace TerraFusion.Core.Sync.PacsOwnerCanonical;
 /// joined to <c>canonical_tf.tf_owner</c> for the parcel-owner HTTP
 /// endpoint.
 ///
-/// <para>Returns a three-state lookup (mirrors G1-E-2's pattern):
+/// <para>Returns a three-state lookup:
 /// <c>NotFound</c> when no parcel matches; <c>NoOwners</c> when the
 /// parcel exists but has no link rows for the requested tax year;
 /// <c>Found</c> with the projection otherwise. The controller maps
@@ -21,16 +21,25 @@ namespace TerraFusion.Core.Sync.PacsOwnerCanonical;
 /// </summary>
 public interface ITfParcelOwnerReader
 {
+    /// <summary>
+    /// Slice G3 (v1.12): the <paramref name="era"/> filter constrains
+    /// the joined <c>tf_owner</c> rows to a single conversion era.
+    /// Null resolves to <c>POST_CONVERSION</c>. The special
+    /// <c>ISalesRatioStudyReader.EraAll</c> token bypasses the era
+    /// filter entirely. Unknown values throw
+    /// <see cref="System.ArgumentException"/>.
+    /// </summary>
     Task<ParcelOwnerLookup> GetOwnersAsync(
         Guid tfParcelId,
         short taxYear,
+        string? era = null,
         CancellationToken cancellationToken = default);
 }
 
 /// <summary>
 /// Three-state result. The controller distinguishes "no parcel" from
 /// "no link rows" for accurate logging without changing the HTTP
-/// contract (both → 404).
+/// contract (both -> 404).
 /// </summary>
 public sealed record ParcelOwnerLookup
 {

--- a/backend/src/TerraFusion.Core/Sync/PacsSaleCanonical/ITfSaleReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsSaleCanonical/ITfSaleReader.cs
@@ -11,6 +11,10 @@ namespace TerraFusion.Core.Sync.PacsSaleCanonical;
 /// (the controller has already verified the principal's claim).
 /// Deterministic ordering by <c>(SlDt DESC, ChgOfOwnerId DESC)</c>
 /// so paging is stable across requests.
+///
+/// <para>Slice G3 (v1.12): the read accepts an <c>era</c> filter so
+/// callers can constrain results to a single conversion era. Null
+/// resolves to <c>POST_CONVERSION</c> per the v1.10 default.</para>
 /// </summary>
 public interface ITfSaleReader
 {
@@ -19,9 +23,19 @@ public interface ITfSaleReader
     /// <paramref name="countyId"/>, plus the total count for the
     /// envelope's pagination metadata.
     /// </summary>
+    /// <param name="era">
+    /// Slice G3 (v1.12): conversion-era filter per Block-C contract
+    /// v1.12. Null resolves to <c>POST_CONVERSION</c>. Recognized
+    /// values: <c>POST_CONVERSION</c>, <c>PRE_CONVERSION_2017</c>,
+    /// <c>UNKNOWN</c>, and the special
+    /// <c>TerraFusion.Core.Sync.SalesRatioStudy.ISalesRatioStudyReader.EraAll</c>
+    /// (bypasses the era filter). Unknown values throw
+    /// <see cref="System.ArgumentException"/>.
+    /// </param>
     Task<PagedTfSaleResponse> ReadAsync(
         Guid countyId,
         int page,
         int pageSize,
+        string? era = null,
         CancellationToken cancellationToken = default);
 }

--- a/backend/src/TerraFusion.Core/Sync/PacsWsdorCanonical/ITfParcelWsdorReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/PacsWsdorCanonical/ITfParcelWsdorReader.cs
@@ -10,20 +10,25 @@ namespace TerraFusion.Core.Sync.PacsWsdorCanonical;
 /// <c>canonical_tf.tf_assessment_wsdor</c> joined to
 /// <c>canonical_tf.tf_owner</c> for the parcel-WSDOR HTTP endpoint.
 ///
-/// <para>Returns a three-state lookup (mirrors B5's pattern):
-/// <c>NotFound</c> when no parcel matches; <c>NoEntries</c> when
-/// the parcel exists but has no WSDOR rows for the requested year;
-/// <c>Found</c> with the projection otherwise. The controller maps
-/// both <c>NotFound</c> and <c>NoEntries</c> to 404 in v1.</para>
+/// <para>Returns a three-state lookup. The controller maps both
+/// <c>NotFound</c> and <c>NoEntries</c> to 404 in v1.</para>
 ///
-/// <para>Read-only by contract: <c>AsNoTracking</c>; no
-/// <c>SaveChangesAsync</c>; no audit-table writes.</para>
+/// <para>Read-only by contract.</para>
 /// </summary>
 public interface ITfParcelWsdorReader
 {
+    /// <summary>
+    /// Slice G3 (v1.12): the <paramref name="era"/> filter constrains
+    /// the projected <c>tf_assessment_wsdor</c> rows to a single
+    /// conversion era. Null resolves to <c>POST_CONVERSION</c>. The
+    /// special <c>ISalesRatioStudyReader.EraAll</c> token bypasses the
+    /// era filter entirely. Unknown values throw
+    /// <see cref="System.ArgumentException"/>.
+    /// </summary>
     Task<ParcelWsdorLookup> GetWsdorRollAsync(
         Guid tfParcelId,
         short taxYear,
+        string? era = null,
         CancellationToken cancellationToken = default);
 }
 

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/TfParcelOwnerReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/TfParcelOwnerReader.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsOwnerCanonical;
+using TerraFusion.Core.Sync.SalesRatioStudy;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
 
@@ -19,6 +23,14 @@ namespace TerraFusion.Data.Services.CanonicalTf;
 ///
 /// <para>Ordering: primary owners first (<c>IsPrimary DESC</c>),
 /// then by descending <c>PctOwnership</c>. Stable across requests.</para>
+///
+/// <para>Slice G3 (v1.12): supports the <c>era</c> conversion-era
+/// filter on the joined <c>tf_owner</c> row. <c>tf_owner</c> has no
+/// year column for fallback (per the entity contract), so pre-G2
+/// rows whose <c>ConversionEra</c> is NULL are NOT folded into
+/// POST/PRE — they only surface under the <c>ALL</c> escape hatch.
+/// This is intentional: re-promotion is the prescribed remediation
+/// per v1.11 §0.5 once G2 is deployed.</para>
 /// </summary>
 public sealed class TfParcelOwnerReader : ITfParcelOwnerReader
 {
@@ -29,6 +41,7 @@ public sealed class TfParcelOwnerReader : ITfParcelOwnerReader
     public async Task<ParcelOwnerLookup> GetOwnersAsync(
         Guid tfParcelId,
         short taxYear,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
         var parcel = await _db.TfParcels
@@ -42,10 +55,12 @@ public sealed class TfParcelOwnerReader : ITfParcelOwnerReader
             return ParcelOwnerLookup.NotFound();
         }
 
+        var ownerEraPredicate = ResolveOwnerEraPredicate(era);
+
         var entries = await (
             from link in _db.TfParcelOwnerLinks.AsNoTracking()
             where link.TfParcelId == tfParcelId && link.OwnerTaxYr == taxYear
-            join owner in _db.TfOwners.AsNoTracking()
+            join owner in _db.TfOwners.AsNoTracking().Where(ownerEraPredicate)
                 on link.TfOwnerId equals owner.TfOwnerId
             orderby link.IsPrimary descending,
                     link.PctOwnership descending,
@@ -75,5 +90,39 @@ public sealed class TfParcelOwnerReader : ITfParcelOwnerReader
                 TaxYear = taxYear,
                 Owners = entries,
             });
+    }
+
+    /// <summary>
+    /// Slice G3 (v1.12): translates an era filter token into a
+    /// <c>tf_owner</c> predicate. <c>tf_owner</c> has no year column
+    /// so there's no year-fallback for NULL <c>ConversionEra</c> —
+    /// callers needing pre-G2 rows must pass <c>ALL</c>.
+    /// </summary>
+    private static Expression<Func<TfOwner, bool>> ResolveOwnerEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == ISalesRatioStudyReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return o => o.ConversionEra == ConversionEras.PostConversion;
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return o => o.ConversionEra == ConversionEras.PreConversion2017;
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            return o => o.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {ISalesRatioStudyReader.EraAll}.",
+            nameof(era));
     }
 }

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/TfParcelWsdorReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/TfParcelWsdorReader.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsWsdorCanonical;
+using TerraFusion.Core.Sync.SalesRatioStudy;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
 
@@ -20,6 +24,12 @@ namespace TerraFusion.Data.Services.CanonicalTf;
 /// <para>Ordering: by descending <c>AssessedVal</c> (largest stake
 /// first), then by <c>OwnerDisplayName</c> ascending for stable tie-
 /// break. NULL <c>AssessedVal</c> sorts last.</para>
+///
+/// <para>Slice G3 (v1.12): supports the <c>era</c> conversion-era
+/// filter on <c>tf_assessment_wsdor</c>. The entity has an
+/// <c>AssessmentYear</c> column, so pre-G2 NULL rows fall back to a
+/// year-derived era using <c>AssessmentYear</c> vs the cutover year
+/// (mirrors the TfSale fallback shape).</para>
 /// </summary>
 public sealed class TfParcelWsdorReader : ITfParcelWsdorReader
 {
@@ -30,6 +40,7 @@ public sealed class TfParcelWsdorReader : ITfParcelWsdorReader
     public async Task<ParcelWsdorLookup> GetWsdorRollAsync(
         Guid tfParcelId,
         short taxYear,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
         var parcel = await _db.TfParcels
@@ -43,8 +54,10 @@ public sealed class TfParcelWsdorReader : ITfParcelWsdorReader
             return ParcelWsdorLookup.NotFound();
         }
 
+        var assessmentEraPredicate = ResolveWsdorEraPredicate(era);
+
         var entries = await (
-            from a in _db.TfAssessmentWsdors.AsNoTracking()
+            from a in _db.TfAssessmentWsdors.AsNoTracking().Where(assessmentEraPredicate)
             where a.TfParcelId == tfParcelId && a.AssessmentYear == taxYear
             join o in _db.TfOwners.AsNoTracking() on a.TfOwnerId equals o.TfOwnerId
             orderby (a.AssessedVal == null ? 1 : 0),
@@ -98,5 +111,42 @@ public sealed class TfParcelWsdorReader : ITfParcelWsdorReader
                 AssessedValTotal = assessedTotal,
                 MarketValTotal = marketTotal,
             });
+    }
+
+    /// <summary>
+    /// Slice G3 (v1.12): translates an era filter token into a
+    /// <c>tf_assessment_wsdor</c> predicate. NULL <c>ConversionEra</c>
+    /// rows fall back to a year-derived era using
+    /// <see cref="TfAssessmentWsdor.AssessmentYear"/> vs
+    /// <see cref="ConversionEras.CutoverYear"/>.
+    /// </summary>
+    private static Expression<Func<TfAssessmentWsdor, bool>> ResolveWsdorEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == ISalesRatioStudyReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return a => a.ConversionEra == ConversionEras.PostConversion
+                || (a.ConversionEra == null && a.AssessmentYear >= ConversionEras.CutoverYear);
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return a => a.ConversionEra == ConversionEras.PreConversion2017
+                || (a.ConversionEra == null && a.AssessmentYear < ConversionEras.CutoverYear);
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            return a => a.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {ISalesRatioStudyReader.EraAll}.",
+            nameof(era));
     }
 }

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/TfSaleReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/TfSaleReader.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
 using TerraFusion.Core.Sync.PacsSaleCanonical;
+using TerraFusion.Core.Sync.SalesRatioStudy;
 
 namespace TerraFusion.Data.Services.CanonicalTf;
 
@@ -19,9 +23,17 @@ namespace TerraFusion.Data.Services.CanonicalTf;
 /// <c>countyId</c> claim before invoking this. The
 /// <paramref name="countyId"/> filter applied here is the
 /// belt-and-suspenders enforcement at the read path.</para>
+///
+/// <para>Slice G3 (v1.12): supports the <c>era</c> conversion-era
+/// filter via the same predicate shape as
+/// <c>SalesRatioStudyReader</c> — pre-G2 NULL rows fall back to a
+/// year-derived era using <c>SlDt</c> vs the cutover date.</para>
 /// </summary>
 public sealed class TfSaleReader : ITfSaleReader
 {
+    private static readonly DateTime EraCutoverDate =
+        new(ConversionEras.CutoverYear, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     private readonly TerraFusionDbContext _db;
 
     public TfSaleReader(TerraFusionDbContext db) => _db = db;
@@ -30,11 +42,14 @@ public sealed class TfSaleReader : ITfSaleReader
         Guid countyId,
         int page,
         int pageSize,
+        string? era = null,
         CancellationToken cancellationToken = default)
     {
+        var eraPredicate = ResolveEraPredicate(era);
         var baseQuery = _db.TfSales
             .AsNoTracking()
-            .Where(s => s.CountyId == countyId);
+            .Where(s => s.CountyId == countyId)
+            .Where(eraPredicate);
 
         var totalCount = await baseQuery
             .CountAsync(cancellationToken)
@@ -73,5 +88,42 @@ public sealed class TfSaleReader : ITfSaleReader
             HasNextPage = page < totalPages,
             HasPreviousPage = page > 1 && totalCount > 0,
         };
+    }
+
+    /// <summary>
+    /// Slice G3 (v1.12): mirrors
+    /// <c>SalesRatioStudyReader.ResolveEraPredicate</c>. Null →
+    /// POST_CONVERSION; ALL bypasses the filter; recognized eras
+    /// match column equality with year fallback for POST/PRE when
+    /// <c>ConversionEra</c> is NULL (pre-G2 rows).
+    /// </summary>
+    private static Expression<Func<TfSale, bool>> ResolveEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == ISalesRatioStudyReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return s => s.ConversionEra == ConversionEras.PostConversion
+                || (s.ConversionEra == null && s.SlDt != null && s.SlDt >= EraCutoverDate);
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return s => s.ConversionEra == ConversionEras.PreConversion2017
+                || (s.ConversionEra == null && s.SlDt != null && s.SlDt < EraCutoverDate);
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            return s => s.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {ISalesRatioStudyReader.EraAll}.",
+            nameof(era));
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/G3EraFilterControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/G3EraFilterControllerTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.SalesRatioStudy;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Slice G3 (v1.12) acceptance tests for the <c>era</c> query
+/// parameter on the canonical read endpoints other than
+/// <c>SalesRatioStudyController</c> (which has its own dedicated
+/// tests in <see cref="SalesRatioStudyControllerTests"/>).
+///
+/// <para>For each modified endpoint
+/// (<see cref="TfSalesController"/>, <see cref="ParcelOwnerController"/>,
+/// <see cref="ParcelWsdorController"/>) we assert:
+/// <list type="bullet">
+///   <item>(a) default <c>null</c> filters to <c>POST_CONVERSION</c>;</item>
+///   <item>(b) <c>era=ALL</c> returns rows from all eras;</item>
+///   <item>(c) invalid era token returns 400.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class G3EraFilterControllerTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("19190019-1919-1919-1919-191919191919");
+
+    private readonly TerraFusionDbContext _db;
+
+    public G3EraFilterControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"g3-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private static ClaimsPrincipal PrincipalForCounty(Guid countyId)
+    {
+        var identity = new ClaimsIdentity(authenticationType: "Test");
+        identity.AddClaim(new Claim("countyId", countyId.ToString()));
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static ControllerContext ContextFor(ClaimsPrincipal principal) =>
+        new()
+        {
+            HttpContext = new DefaultHttpContext { User = principal },
+        };
+
+    // ========================================================
+    // TfSalesController
+    // ========================================================
+
+    private TfSalesController BuildSalesController()
+    {
+        var reader = new TfSaleReader(_db);
+        var ctrl = new TfSalesController(reader, NullLogger<TfSalesController>.Instance);
+        ctrl.ControllerContext = ContextFor(PrincipalForCounty(CountyA));
+        return ctrl;
+    }
+
+    private async Task SeedSaleAsync(long chgOfOwnerId, DateTime saleDt, string? era)
+    {
+        _db.TfSales.Add(new TfSale
+        {
+            CountyId = CountyA,
+            TfParcelId = Guid.NewGuid(),
+            ChgOfOwnerId = chgOfOwnerId,
+            SlDt = saleDt,
+            SlPrice = 350_000m,
+            AdjSlPrice = 350_000m,
+            SaleQualified = true,
+            PromotionLoadBatchId = Guid.NewGuid(),
+            ConversionEra = era,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task TfSales_DefaultEra_FiltersToPostConversion()
+    {
+        await SeedSaleAsync(1,
+            new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.PostConversion);
+        await SeedSaleAsync(2,
+            new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.PreConversion2017);
+        await SeedSaleAsync(3,
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.Unknown);
+
+        var ctrl = BuildSalesController();
+        var result = await ctrl.GetSales(CountyA, page: null, pageSize: null);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = ok.Value.Should().BeOfType<PagedTfSaleResponse>().Subject;
+        envelope.TotalCount.Should().Be(1, "default era=POST_CONVERSION excludes PRE / UNKNOWN rows");
+        envelope.Items.Should().ContainSingle(i => i.ChgOfOwnerId == 1L);
+    }
+
+    [Fact]
+    public async Task TfSales_EraAll_ReturnsAllEras()
+    {
+        await SeedSaleAsync(1,
+            new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.PostConversion);
+        await SeedSaleAsync(2,
+            new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.PreConversion2017);
+        await SeedSaleAsync(3,
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            era: ConversionEras.Unknown);
+
+        var ctrl = BuildSalesController();
+        var result = await ctrl.GetSales(
+            CountyA, page: null, pageSize: null, era: ISalesRatioStudyReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = ok.Value.Should().BeOfType<PagedTfSaleResponse>().Subject;
+        envelope.TotalCount.Should().Be(3, "era=ALL bypasses the conversion-era filter");
+    }
+
+    [Theory]
+    [InlineData("BOGUS_ERA")]
+    [InlineData("post_conversion")]
+    [InlineData("anythingelse")]
+    public async Task TfSales_InvalidEra_Returns400(string badEra)
+    {
+        var ctrl = BuildSalesController();
+        var result = await ctrl.GetSales(CountyA, page: null, pageSize: null, era: badEra);
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // ========================================================
+    // ParcelOwnerController
+    // ========================================================
+
+    private ParcelOwnerController BuildOwnerController()
+    {
+        var reader = new TfParcelOwnerReader(_db);
+        var ctrl = new ParcelOwnerController(
+            reader, NullLogger<ParcelOwnerController>.Instance);
+        ctrl.ControllerContext = ContextFor(PrincipalForCounty(CountyA));
+        return ctrl;
+    }
+
+    private async Task<TfParcel> SeedOwnerParcelAsync()
+    {
+        var p = new TfParcel
+        {
+            CountyId = CountyA,
+            ParcelNumber = $"P-{Guid.NewGuid():N}",
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(p);
+        await _db.SaveChangesAsync();
+        return p;
+    }
+
+    private async Task<TfOwner> SeedOwnerWithEraAsync(long acctId, string displayName, string? era)
+    {
+        var o = new TfOwner
+        {
+            CountyId = CountyA,
+            AcctId = acctId,
+            DisplayName = displayName,
+            ConfidentialFlag = false,
+            WebSuppression = false,
+            PromotionLoadBatchId = Guid.NewGuid(),
+            ConversionEra = era,
+        };
+        _db.TfOwners.Add(o);
+        await _db.SaveChangesAsync();
+        return o;
+    }
+
+    private async Task SeedLinkAsync(Guid parcelId, Guid ownerId, short year)
+    {
+        _db.TfParcelOwnerLinks.Add(new TfParcelOwnerLink
+        {
+            TfParcelId = parcelId,
+            TfOwnerId = ownerId,
+            OwnerTaxYr = year,
+            PctOwnership = 1.0m,
+            IsPrimary = true,
+            SourceTruthOwnerCurrentId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task ParcelOwner_DefaultEra_FiltersToPostConversion()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+        var post = await SeedOwnerWithEraAsync(1L, "Smith, John", ConversionEras.PostConversion);
+        var pre = await SeedOwnerWithEraAsync(2L, "Doe, Jane", ConversionEras.PreConversion2017);
+        await SeedLinkAsync(parcel.TfParcelId, post.TfOwnerId, 2026);
+        await SeedLinkAsync(parcel.TfParcelId, pre.TfOwnerId, 2026);
+
+        var ctrl = BuildOwnerController();
+        var result = await ctrl.GetOwnerCurrent(parcel.TfParcelId, taxYear: 2026);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<ParcelOwnerCurrentResponse>().Subject;
+        body.Owners.Should().ContainSingle()
+            .Which.DisplayName.Should().Be("Smith, John",
+                "default era=POST_CONVERSION excludes the PRE owner");
+    }
+
+    [Fact]
+    public async Task ParcelOwner_EraAll_ReturnsAllEras()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+        var post = await SeedOwnerWithEraAsync(1L, "Smith, John", ConversionEras.PostConversion);
+        var pre = await SeedOwnerWithEraAsync(2L, "Doe, Jane", ConversionEras.PreConversion2017);
+        await SeedLinkAsync(parcel.TfParcelId, post.TfOwnerId, 2026);
+        await SeedLinkAsync(parcel.TfParcelId, pre.TfOwnerId, 2026);
+
+        var ctrl = BuildOwnerController();
+        var result = await ctrl.GetOwnerCurrent(
+            parcel.TfParcelId, taxYear: 2026, era: ISalesRatioStudyReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<ParcelOwnerCurrentResponse>().Subject;
+        body.Owners.Should().HaveCount(2, "era=ALL bypasses the conversion-era filter");
+    }
+
+    [Fact]
+    public async Task ParcelOwner_InvalidEra_Returns400()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+
+        var ctrl = BuildOwnerController();
+        var result = await ctrl.GetOwnerCurrent(
+            parcel.TfParcelId, taxYear: 2026, era: "BOGUS_ERA");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // ========================================================
+    // ParcelWsdorController
+    // ========================================================
+
+    private ParcelWsdorController BuildWsdorController()
+    {
+        var reader = new TfParcelWsdorReader(_db);
+        var ctrl = new ParcelWsdorController(
+            reader, NullLogger<ParcelWsdorController>.Instance);
+        ctrl.ControllerContext = ContextFor(PrincipalForCounty(CountyA));
+        return ctrl;
+    }
+
+    private async Task SeedWsdorAssessmentAsync(
+        Guid parcelId, Guid ownerId, short year, string? era)
+    {
+        _db.TfAssessmentWsdors.Add(new TfAssessmentWsdor
+        {
+            CountyId = CountyA,
+            TfParcelId = parcelId,
+            TfOwnerId = ownerId,
+            AssessmentYear = year,
+            SupNum = 0,
+            AssessedVal = 250_000m,
+            MarketVal = 300_000m,
+            AppraisedVal = 250_000m,
+            TaxableClassified = 250_000m,
+            BoeStatus = "F",
+            PromotionLoadBatchId = Guid.NewGuid(),
+            ConversionEra = era,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task ParcelWsdor_DefaultEra_FiltersToPostConversion()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+        var owner = await SeedOwnerWithEraAsync(1L, "Smith, John", ConversionEras.PostConversion);
+        await SeedWsdorAssessmentAsync(parcel.TfParcelId, owner.TfOwnerId,
+            year: 2026, era: ConversionEras.PostConversion);
+        await SeedWsdorAssessmentAsync(parcel.TfParcelId, owner.TfOwnerId,
+            year: 2026, era: ConversionEras.PreConversion2017);
+
+        var ctrl = BuildWsdorController();
+        var result = await ctrl.GetWsdorRoll(parcel.TfParcelId, taxYear: 2026);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<ParcelWsdorRollResponse>().Subject;
+        body.Entries.Should().HaveCount(1, "default era=POST_CONVERSION excludes PRE rows");
+    }
+
+    [Fact]
+    public async Task ParcelWsdor_EraAll_ReturnsAllEras()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+        var owner = await SeedOwnerWithEraAsync(1L, "Smith, John", ConversionEras.PostConversion);
+        await SeedWsdorAssessmentAsync(parcel.TfParcelId, owner.TfOwnerId,
+            year: 2026, era: ConversionEras.PostConversion);
+        await SeedWsdorAssessmentAsync(parcel.TfParcelId, owner.TfOwnerId,
+            year: 2026, era: ConversionEras.PreConversion2017);
+        await SeedWsdorAssessmentAsync(parcel.TfParcelId, owner.TfOwnerId,
+            year: 2026, era: ConversionEras.Unknown);
+
+        var ctrl = BuildWsdorController();
+        var result = await ctrl.GetWsdorRoll(
+            parcel.TfParcelId, taxYear: 2026, era: ISalesRatioStudyReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<ParcelWsdorRollResponse>().Subject;
+        body.Entries.Should().HaveCount(3, "era=ALL bypasses the conversion-era filter");
+    }
+
+    [Fact]
+    public async Task ParcelWsdor_InvalidEra_Returns400()
+    {
+        var parcel = await SeedOwnerParcelAsync();
+
+        var ctrl = BuildWsdorController();
+        var result = await ctrl.GetWsdorRoll(
+            parcel.TfParcelId, taxYear: 2026, era: "BOGUS_ERA");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ParcelOwnerControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ParcelOwnerControllerTests.cs
@@ -86,7 +86,8 @@ public sealed class ParcelOwnerControllerTests : IDisposable
 
     private async Task<TfOwner> SeedOwnerAsync(
         Guid countyId, long acctId, string displayName,
-        bool confidential = false, bool webSupp = false)
+        bool confidential = false, bool webSupp = false,
+        string? era = null)
     {
         var o = new TfOwner
         {
@@ -96,6 +97,9 @@ public sealed class ParcelOwnerControllerTests : IDisposable
             ConfidentialFlag = confidential,
             WebSuppression = webSupp,
             PromotionLoadBatchId = Guid.NewGuid(),
+            // G3 (v1.12): default seed era to POST_CONVERSION so the new
+            // default era filter on the read endpoint surfaces these rows.
+            ConversionEra = era ?? TerraFusion.Core.Entities.TruthPacs.ConversionEras.PostConversion,
         };
         _db.TfOwners.Add(o);
         await _db.SaveChangesAsync();

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ParcelWsdorControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ParcelWsdorControllerTests.cs
@@ -106,7 +106,8 @@ public sealed class ParcelWsdorControllerTests : IDisposable
         decimal? assessed = 250_000m,
         decimal? market = 300_000m,
         string? boe = "F",
-        decimal? snrFrz = null)
+        decimal? snrFrz = null,
+        string? era = null)
     {
         _db.TfAssessmentWsdors.Add(new TfAssessmentWsdor
         {
@@ -122,6 +123,9 @@ public sealed class ParcelWsdorControllerTests : IDisposable
             BoeStatus = boe,
             SnrFrzImprvHs = snrFrz,
             PromotionLoadBatchId = Guid.NewGuid(),
+            // G3 (v1.12): default seed era to POST_CONVERSION so the new
+            // default era filter on the read endpoint surfaces these rows.
+            ConversionEra = era ?? TerraFusion.Core.Entities.TruthPacs.ConversionEras.PostConversion,
         });
         await _db.SaveChangesAsync();
     }


### PR DESCRIPTION
## Summary

Block G3 spec: every read endpoint accepts an `era` query param, default `PostConversion`. Audit found only `SalesRatioStudyController` had it; this slice extends the contract to `TfSalesController`, `ParcelOwnerController`, and `ParcelWsdorController`.

- New shared helper `EraQueryHelper.TryNormalizeEra` (used by 4 controllers, extracted per the 3+ rule).
- `ITfSaleReader`, `ITfParcelOwnerReader`, `ITfParcelWsdorReader` gain optional `era` parameter (default `null` → `POST_CONVERSION`).
- Reader implementations translate the era token to an EF predicate per entity. `TfSale` and `TfAssessmentWsdor` have year fallback (`SlDt` / `AssessmentYear` vs cutover); `TfOwner` has no year column so NULL `ConversionEra` rows surface only under `era=ALL`.
- `SalesRatioStudyController` switched to the shared helper (DRY); behavior unchanged.

## Endpoints modified

- `GET /api/sales` — `TfSalesController.GetSales`
- `GET /api/parcels/{tfParcelId}/owner-current` — `ParcelOwnerController.GetOwnerCurrent`
- `GET /api/parcels/{tfParcelId}/wsdor-roll` — `ParcelWsdorController.GetWsdorRoll`

`ParcelGeometryController` is intentionally NOT modified per the spec note: `TfParcel` / `TfParcelGeom` carry no `ConversionEra` column.

## Tests

- New `G3EraFilterControllerTests` (11 tests). For each modified endpoint: (a) default `null` filters to `PostConversion`, (b) `era=ALL` returns rows from all eras, (c) invalid era returns 400.
- Existing seed helpers in `ParcelOwnerControllerTests` + `ParcelWsdorControllerTests` now default `ConversionEra` to `POST_CONVERSION` so the existing test suite still surfaces seeded rows under the new default era filter.

## Test plan

- [x] Backend solution build clean: 0 errors, 0 warnings.
- [x] `TerraFusion.Unit.Tests` full suite: 3039/3039 passing.
- [x] `CanonicalTf` test subset (170 tests) green.
- [x] New `G3EraFilterControllerTests` (11 tests) green.
- [ ] CI gates green (Cloud Coach review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional era parameter to data retrieval endpoints (Sales, Parcel Owner, Assessment WSDOR) for filtering results by conversion period
  * Default behavior filters to post-conversion data when era is not specified
  * Use `era=ALL` parameter to retrieve data across all conversion periods
  * Invalid era values return HTTP 400 error with validation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->