### PR TITLE
feat(sync): SYNC-E1+G2 — six canonical dict_* tables + TfParcel.ConversionEra

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictExemptionType.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictExemptionType.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS exemption-type code domain
+/// (<c>exmpt_type_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// closes the fifth of six dictionaries listed in the design.
+/// Mirrors <see cref="DictNeighborhood"/> exactly.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="ExemptionTypeCd"/>
+/// is unique within <see cref="CountyId"/>.</para>
+/// </summary>
+public sealed class DictExemptionType
+{
+    public Guid DictExemptionTypeId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS <c>exmpt_type_cd</c> verbatim. Up to 10 chars.
+    /// </summary>
+    public string ExemptionTypeCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the exemption type. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Soft-retire flag.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance ──────────────────────────────────────────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictImprvState.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictImprvState.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS improvement-state code domain
+/// (<c>imprv_state_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// closes the fourth of six dictionaries listed in the design.
+/// Mirrors <see cref="DictNeighborhood"/> exactly.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="ImprvStateCd"/>
+/// is unique within <see cref="CountyId"/>.</para>
+/// </summary>
+public sealed class DictImprvState
+{
+    public Guid DictImprvStateId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS <c>imprv_state_cd</c> verbatim. Up to 10 chars.
+    /// </summary>
+    public string ImprvStateCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the improvement-state code. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Soft-retire flag.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance ──────────────────────────────────────────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictImprvType.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictImprvType.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS improvement-type code domain
+/// (<c>imprv_type_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// closes the third of six dictionaries listed in the design.
+/// Real Benton codes the operator already references include
+/// <c>CovPatio</c>, <c>ATTGAR</c>, <c>MA</c>, <c>BSMT</c>,
+/// <c>POLEBLDG</c>, <c>DETGAR</c>, <c>POOL</c>. Schema is locked
+/// here; operator-driven seeding is a separate slice.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="ImprvTypeCd"/> is
+/// unique within <see cref="CountyId"/>.</para>
+/// </summary>
+public sealed class DictImprvType
+{
+    public Guid DictImprvTypeId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS <c>imprv_type_cd</c> verbatim. Up to 10 chars; the
+    /// canonical <c>tf_improvement.ImprvTypeCd</c> column caps at
+    /// 8 but Benton's PACS dictionary domain spans up to 10.
+    /// </summary>
+    public string ImprvTypeCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the improvement type. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Soft-retire flag.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance ──────────────────────────────────────────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictLandState.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictLandState.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS land-state code domain
+/// (<c>land_state_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// closes the second of six dictionaries listed in the design.
+/// This row mirrors <see cref="DictNeighborhood"/> exactly for the
+/// <c>land_state_cd</c> code domain.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="LandStateCd"/> is
+/// unique within <see cref="CountyId"/>; the same code may carry
+/// different meanings across counties.</para>
+///
+/// <para>Provenance: every row carries <see cref="LoadBatchId"/>
+/// + <see cref="SourceQueryHash"/>.</para>
+///
+/// <para>Lifecycle: rows are never hard-deleted. Setting
+/// <see cref="IsActive"/> = false soft-retires a code.</para>
+/// </summary>
+public sealed class DictLandState
+{
+    public Guid DictLandStateId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS <c>land_state_cd</c> verbatim. Up to 10 chars to
+    /// accommodate the longest county-defined codes.
+    /// </summary>
+    public string LandStateCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the land-state code. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Soft-retire flag.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance ──────────────────────────────────────────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictLandUse.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictLandUse.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS land-use code domain
+/// (<c>land_use_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// "E1 canonical_tf.dict_* for: land use code, land state code,
+/// neighborhood (hood_cd), improvement type, improvement state,
+/// exemption type, situs/legal codes." This row mirrors
+/// <see cref="DictNeighborhood"/> exactly for the
+/// <c>land_use_cd</c> code domain.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="LandUseCd"/> is
+/// unique within <see cref="CountyId"/>, but the same code string
+/// may carry different meanings across counties. Cross-county
+/// joins on <see cref="LandUseCd"/> alone are a doctrine
+/// violation; always pair with <see cref="CountyId"/>.</para>
+///
+/// <para>Provenance: every row carries <see cref="LoadBatchId"/>
+/// + <see cref="SourceQueryHash"/>, the same provenance shape used
+/// by every other PACS-fed entity in the doctrine.</para>
+///
+/// <para>Lifecycle: rows are never hard-deleted. Setting
+/// <see cref="IsActive"/> = false soft-retires a code so that
+/// historical references still resolve while new ingestion stops
+/// surfacing the code in active panels.</para>
+///
+/// <para>What this slice does NOT do: no projector currently
+/// consumes this dictionary. E1 is a schema lock, not a runtime
+/// gate. Operator-driven seeding is a separate slice.</para>
+/// </summary>
+public sealed class DictLandUse
+{
+    public Guid DictLandUseId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS <c>land_use_cd</c> verbatim. Up to 10 chars to
+    /// accommodate the longest county-defined codes.
+    /// </summary>
+    public string LandUseCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the land-use code. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Soft-retire flag. False = retired but historically valid;
+    /// True = currently in use. Rows are never hard-deleted.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance (every PACS-fed row carries this) ─────────────
+    /// <summary>The dictionary-loader LoadBatch that produced this row.</summary>
+    public Guid LoadBatchId { get; set; }
+
+    /// <summary>
+    /// Stable hash of the SELECT statement that pulled this row
+    /// from the source PACS dictionary table.
+    /// </summary>
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictSitusLegal.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/DictSitusLegal.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace TerraFusion.Core.Entities.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): TerraFusion-native canonical
+/// dictionary for the PACS situs/legal code domain
+/// (<c>situs_legal_cd</c>).
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// closes the sixth (and final) dictionary listed in the design.
+/// Mirrors <see cref="DictNeighborhood"/> exactly. The
+/// "situs/legal" code domain unifies the PACS situs and legal
+/// description code lookups under a single canonical handle.</para>
+///
+/// <para>Sovereign-county isolation: <see cref="SitusLegalCd"/>
+/// is unique within <see cref="CountyId"/>.</para>
+/// </summary>
+public sealed class DictSitusLegal
+{
+    public Guid DictSitusLegalId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation. Required.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>
+    /// PACS situs/legal code verbatim. Up to 10 chars to match
+    /// the longest county-defined codes seen in this domain.
+    /// </summary>
+    public string SitusLegalCd { get; set; } = string.Empty;
+
+    /// <summary>Free-text description of the situs/legal code. Optional.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Soft-retire flag.</summary>
+    public bool IsActive { get; set; } = true;
+
+    // ── Provenance ──────────────────────────────────────────────
+    public Guid LoadBatchId { get; set; }
+    public string SourceQueryHash { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfParcel.cs
+++ b/backend/src/TerraFusion.Core/Entities/CanonicalTf/TfParcel.cs
@@ -41,6 +41,18 @@ public sealed class TfParcel
     public Guid? CurrentOwnerId { get; set; }
     public Guid? CurrentAssessmentId { get; set; }
 
+    /// <summary>
+    /// Slice G2 (Phase 2 closure): conversion-era marker derived
+    /// via
+    /// <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.MajorityOfTruth"/>
+    /// over the contributing truth row(s). Closes the parity gap
+    /// where every other canonical_tf entity (TfImprovement,
+    /// TfSale, TfLand, TfOwner, TfAssessmentWsdor,
+    /// TfImprovementFeature) already carries this column. Nullable
+    /// for back-compat with rows projected before this slice.
+    /// </summary>
+    public string? ConversionEra { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictExemptionTypeConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictExemptionTypeConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictExemptionType"/>. Schema <c>canonical_tf</c>;
+/// table <c>dict_exemption_type</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, ExemptionTypeCd)</c> is the natural
+/// unique key.</para>
+/// </summary>
+public sealed class DictExemptionTypeConfiguration
+    : IEntityTypeConfiguration<DictExemptionType>
+{
+    public void Configure(EntityTypeBuilder<DictExemptionType> builder)
+    {
+        builder.ToTable("dict_exemption_type", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictExemptionTypeId);
+        builder.Property(x => x.DictExemptionTypeId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.ExemptionTypeCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.CountyId, x.ExemptionTypeCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_exemption_type_county_code");
+
+        builder.HasIndex(x => new { x.CountyId, x.ExemptionTypeCd, x.IsActive })
+            .HasDatabaseName("ix_dict_exemption_type_county_code_active");
+
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_exemption_type_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictImprvStateConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictImprvStateConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictImprvState"/>. Schema <c>canonical_tf</c>;
+/// table <c>dict_imprv_state</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, ImprvStateCd)</c> is the natural unique
+/// key.</para>
+/// </summary>
+public sealed class DictImprvStateConfiguration
+    : IEntityTypeConfiguration<DictImprvState>
+{
+    public void Configure(EntityTypeBuilder<DictImprvState> builder)
+    {
+        builder.ToTable("dict_imprv_state", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictImprvStateId);
+        builder.Property(x => x.DictImprvStateId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.ImprvStateCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.CountyId, x.ImprvStateCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_imprv_state_county_code");
+
+        builder.HasIndex(x => new { x.CountyId, x.ImprvStateCd, x.IsActive })
+            .HasDatabaseName("ix_dict_imprv_state_county_code_active");
+
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_imprv_state_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictImprvTypeConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictImprvTypeConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictImprvType"/>. Schema <c>canonical_tf</c>;
+/// table <c>dict_imprv_type</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, ImprvTypeCd)</c> is the natural unique
+/// key.</para>
+/// </summary>
+public sealed class DictImprvTypeConfiguration
+    : IEntityTypeConfiguration<DictImprvType>
+{
+    public void Configure(EntityTypeBuilder<DictImprvType> builder)
+    {
+        builder.ToTable("dict_imprv_type", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictImprvTypeId);
+        builder.Property(x => x.DictImprvTypeId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.ImprvTypeCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.CountyId, x.ImprvTypeCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_imprv_type_county_code");
+
+        builder.HasIndex(x => new { x.CountyId, x.ImprvTypeCd, x.IsActive })
+            .HasDatabaseName("ix_dict_imprv_type_county_code_active");
+
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_imprv_type_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictLandStateConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictLandStateConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictLandState"/>. Schema <c>canonical_tf</c>;
+/// table <c>dict_land_state</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, LandStateCd)</c> is the natural unique
+/// key.</para>
+/// </summary>
+public sealed class DictLandStateConfiguration
+    : IEntityTypeConfiguration<DictLandState>
+{
+    public void Configure(EntityTypeBuilder<DictLandState> builder)
+    {
+        builder.ToTable("dict_land_state", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictLandStateId);
+        builder.Property(x => x.DictLandStateId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.LandStateCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.CountyId, x.LandStateCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_land_state_county_code");
+
+        builder.HasIndex(x => new { x.CountyId, x.LandStateCd, x.IsActive })
+            .HasDatabaseName("ix_dict_land_state_county_code_active");
+
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_land_state_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictLandUseConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictLandUseConfiguration.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictLandUse"/>. Schema <c>canonical_tf</c>; table
+/// <c>dict_land_use</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, LandUseCd)</c> is the natural unique
+/// key (sovereign-county isolation + closed-vocab uniqueness).
+/// Every row carries <c>LoadBatchId</c> + <c>SourceQueryHash</c>
+/// provenance.</para>
+/// </summary>
+public sealed class DictLandUseConfiguration
+    : IEntityTypeConfiguration<DictLandUse>
+{
+    public void Configure(EntityTypeBuilder<DictLandUse> builder)
+    {
+        builder.ToTable("dict_land_use", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictLandUseId);
+        builder.Property(x => x.DictLandUseId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.LandUseCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        // Provenance.
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        // Sovereign-county isolated uniqueness on the natural key.
+        builder.HasIndex(x => new { x.CountyId, x.LandUseCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_land_use_county_code");
+
+        // Lookup index for "active codes for county X".
+        builder.HasIndex(x => new { x.CountyId, x.LandUseCd, x.IsActive })
+            .HasDatabaseName("ix_dict_land_use_county_code_active");
+
+        // Provenance lookups.
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_land_use_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictSitusLegalConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/DictSitusLegalConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Data.Configurations.CanonicalTf;
+
+/// <summary>
+/// Slice E1 (Phase 2 closure): EF configuration for
+/// <see cref="DictSitusLegal"/>. Schema <c>canonical_tf</c>;
+/// table <c>dict_situs_legal</c>.
+///
+/// <para>Mirrors <see cref="DictNeighborhoodConfiguration"/>
+/// exactly. <c>(CountyId, SitusLegalCd)</c> is the natural
+/// unique key.</para>
+/// </summary>
+public sealed class DictSitusLegalConfiguration
+    : IEntityTypeConfiguration<DictSitusLegal>
+{
+    public void Configure(EntityTypeBuilder<DictSitusLegal> builder)
+    {
+        builder.ToTable("dict_situs_legal", schema: "canonical_tf");
+
+        builder.HasKey(x => x.DictSitusLegalId);
+        builder.Property(x => x.DictSitusLegalId).IsRequired();
+        builder.Property(x => x.CountyId).IsRequired();
+
+        builder.Property(x => x.SitusLegalCd)
+            .IsRequired()
+            .HasMaxLength(10);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+
+        builder.Property(x => x.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(x => x.LoadBatchId).IsRequired();
+        builder.Property(x => x.SourceQueryHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+
+        builder.HasIndex(x => new { x.CountyId, x.SitusLegalCd })
+            .IsUnique()
+            .HasDatabaseName("ux_dict_situs_legal_county_code");
+
+        builder.HasIndex(x => new { x.CountyId, x.SitusLegalCd, x.IsActive })
+            .HasDatabaseName("ix_dict_situs_legal_county_code_active");
+
+        builder.HasIndex(x => x.LoadBatchId)
+            .HasDatabaseName("ix_dict_situs_legal_load_batch");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfParcelConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/CanonicalTf/TfParcelConfiguration.cs
@@ -32,5 +32,12 @@ public sealed class TfParcelConfiguration : IEntityTypeConfiguration<TfParcel>
 
         builder.HasIndex(x => new { x.CountyId, x.ParcelNumber });
         builder.HasIndex(x => new { x.CountyId, x.ParcelStatus });
+
+        // G2 (Phase 2 closure): conversion-era marker. Mirrors the
+        // shape of the same column on TfImprovement/TfSale/TfLand/
+        // TfOwner/TfAssessmentWsdor/TfImprovementFeature.
+        builder.Property(x => x.ConversionEra).HasMaxLength(20);
+        builder.HasIndex(x => x.ConversionEra)
+            .HasDatabaseName("ix_tf_parcel_conversion_era");
     }
 }

--- a/backend/src/TerraFusion.Data/Migrations/20260508015117_SyncE1G2DictsAndTfParcelConversionEra.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508015117_SyncE1G2DictsAndTfParcelConversionEra.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508015117_SyncE1G2DictsAndTfParcelConversionEra")]
+    partial class SyncE1G2DictsAndTfParcelConversionEra
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260508015117_SyncE1G2DictsAndTfParcelConversionEra.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508015117_SyncE1G2DictsAndTfParcelConversionEra.cs
@@ -1,0 +1,301 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncE1G2DictsAndTfParcelConversionEra : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_parcel",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "dict_exemption_type",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictExemptionTypeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ExemptionTypeCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_exemption_type", x => x.DictExemptionTypeId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dict_imprv_state",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictImprvStateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ImprvStateCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_imprv_state", x => x.DictImprvStateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dict_imprv_type",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictImprvTypeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ImprvTypeCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_imprv_type", x => x.DictImprvTypeId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dict_land_state",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictLandStateId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LandStateCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_land_state", x => x.DictLandStateId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dict_land_use",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictLandUseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LandUseCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_land_use", x => x.DictLandUseId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dict_situs_legal",
+                schema: "canonical_tf",
+                columns: table => new
+                {
+                    DictSitusLegalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SitusLegalCd = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    LoadBatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SourceQueryHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_dict_situs_legal", x => x.DictSitusLegalId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_parcel_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_parcel",
+                column: "ConversionEra");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_exemption_type_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_exemption_type",
+                columns: new[] { "CountyId", "ExemptionTypeCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_exemption_type_load_batch",
+                schema: "canonical_tf",
+                table: "dict_exemption_type",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_exemption_type_county_code",
+                schema: "canonical_tf",
+                table: "dict_exemption_type",
+                columns: new[] { "CountyId", "ExemptionTypeCd" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_imprv_state_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_imprv_state",
+                columns: new[] { "CountyId", "ImprvStateCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_imprv_state_load_batch",
+                schema: "canonical_tf",
+                table: "dict_imprv_state",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_imprv_state_county_code",
+                schema: "canonical_tf",
+                table: "dict_imprv_state",
+                columns: new[] { "CountyId", "ImprvStateCd" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_imprv_type_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_imprv_type",
+                columns: new[] { "CountyId", "ImprvTypeCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_imprv_type_load_batch",
+                schema: "canonical_tf",
+                table: "dict_imprv_type",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_imprv_type_county_code",
+                schema: "canonical_tf",
+                table: "dict_imprv_type",
+                columns: new[] { "CountyId", "ImprvTypeCd" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_land_state_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_land_state",
+                columns: new[] { "CountyId", "LandStateCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_land_state_load_batch",
+                schema: "canonical_tf",
+                table: "dict_land_state",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_land_state_county_code",
+                schema: "canonical_tf",
+                table: "dict_land_state",
+                columns: new[] { "CountyId", "LandStateCd" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_land_use_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_land_use",
+                columns: new[] { "CountyId", "LandUseCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_land_use_load_batch",
+                schema: "canonical_tf",
+                table: "dict_land_use",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_land_use_county_code",
+                schema: "canonical_tf",
+                table: "dict_land_use",
+                columns: new[] { "CountyId", "LandUseCd" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_situs_legal_county_code_active",
+                schema: "canonical_tf",
+                table: "dict_situs_legal",
+                columns: new[] { "CountyId", "SitusLegalCd", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dict_situs_legal_load_batch",
+                schema: "canonical_tf",
+                table: "dict_situs_legal",
+                column: "LoadBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_dict_situs_legal_county_code",
+                schema: "canonical_tf",
+                table: "dict_situs_legal",
+                columns: new[] { "CountyId", "SitusLegalCd" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dict_exemption_type",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropTable(
+                name: "dict_imprv_state",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropTable(
+                name: "dict_imprv_type",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropTable(
+                name: "dict_land_state",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropTable(
+                name: "dict_land_use",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropTable(
+                name: "dict_situs_legal",
+                schema: "canonical_tf");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tf_parcel_conversion_era",
+                schema: "canonical_tf",
+                table: "tf_parcel");
+
+            migrationBuilder.DropColumn(
+                name: "ConversionEra",
+                schema: "canonical_tf",
+                table: "tf_parcel");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -333,6 +333,25 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictNeighborhood>
     DictNeighborhoods { get; set; } = null!;
 
+  // Slice E1 (Phase 2 closure): the remaining six canonical
+  // dictionary tables called out in
+  // docs/pacs/blocks-d-through-h-design.md §E. All six mirror
+  // dict_neighborhood exactly. No projector consumes any of them
+  // yet; this is schema lock, not a runtime gate. Operator-driven
+  // seeding is a separate slice.
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictLandUse>
+    DictLandUses { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictLandState>
+    DictLandStates { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictImprvType>
+    DictImprvTypes { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictImprvState>
+    DictImprvStates { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictExemptionType>
+    DictExemptionTypes { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.CanonicalTf.DictSitusLegal>
+    DictSitusLegals { get; set; } = null!;
+
   // Slice E2: canonical_tf.attribute_definition — i_attr_id
   // mapping spine. Per Block-C contract v1.2
   // (docs/pacs/block-c-contract-v1.2.md). E3 wires
@@ -1103,6 +1122,21 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // dictionary table. Per docs/pacs/block-c-contract-v1.1.md.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.CanonicalTf.DictNeighborhoodConfiguration());
+
+    // Slice E1 (Phase 2 closure): the remaining six dict_*
+    // tables. Per docs/pacs/blocks-d-through-h-design.md §E.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictLandUseConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictLandStateConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictImprvTypeConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictImprvStateConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictExemptionTypeConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.CanonicalTf.DictSitusLegalConfiguration());
 
     // Slice E2: canonical_tf.attribute_definition — i_attr_id
     // mapping spine. Per docs/pacs/block-c-contract-v1.2.md.

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/DictPhase2ClosureTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/DictPhase2ClosureTests.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Data;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Phase 2 closure — round-trip + sovereign-isolation acceptance
+/// tests for the remaining six canonical dictionary tables called
+/// out in <c>docs/pacs/blocks-d-through-h-design.md</c> §E:
+/// <list type="bullet">
+///   <item><see cref="DictLandUse"/></item>
+///   <item><see cref="DictLandState"/></item>
+///   <item><see cref="DictImprvType"/></item>
+///   <item><see cref="DictImprvState"/></item>
+///   <item><see cref="DictExemptionType"/></item>
+///   <item><see cref="DictSitusLegal"/></item>
+/// </list>
+///
+/// <para>Plus a TfParcel.ConversionEra round-trip test that closes
+/// the parity gap with the other five canonical_tf entities.</para>
+///
+/// <para>Note on uniqueness: the (CountyId, &lt;Code&gt;) unique
+/// indexes are locked at the EF model level and at the relational
+/// provider level via the SyncE1G2DictsAndTfParcelConversionEra
+/// migration. The InMemory provider used here does NOT enforce
+/// indexes, so we assert via shape on the EF model and via
+/// round-trip cross-county insert behavior, never via SaveChanges
+/// throw. Mirrors <see cref="DictNeighborhoodTests"/>.</para>
+/// </summary>
+public sealed class DictPhase2ClosureTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public DictPhase2ClosureTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"e1p2-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ──────────────────────────────────────────────────────────
+    // dict_land_use
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictLandUse_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        var loadBatchId = Guid.NewGuid();
+        _db.DictLandUses.Add(new DictLandUse
+        {
+            CountyId = countyId,
+            LandUseCd = "RES",
+            Description = "Residential",
+            LoadBatchId = loadBatchId,
+            SourceQueryHash = "qh-lu-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictLandUses.SingleAsync();
+        loaded.DictLandUseId.Should().NotBe(Guid.Empty);
+        loaded.CountyId.Should().Be(countyId);
+        loaded.LandUseCd.Should().Be("RES");
+        loaded.Description.Should().Be("Residential");
+        loaded.IsActive.Should().BeTrue("default IsActive is true");
+        loaded.LoadBatchId.Should().Be(loadBatchId);
+        loaded.SourceQueryHash.Should().Be("qh-lu-1");
+    }
+
+    [Fact]
+    public async Task DictLandUse_SameCode_AcrossDifferentCounties_IsAllowed()
+    {
+        var bentonId = Guid.NewGuid();
+        var franklinId = Guid.NewGuid();
+        _db.DictLandUses.AddRange(
+            new DictLandUse { CountyId = bentonId, LandUseCd = "AG",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" },
+            new DictLandUse { CountyId = franklinId, LandUseCd = "AG",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" });
+        await _db.SaveChangesAsync();
+
+        var both = await _db.DictLandUses.Where(d => d.LandUseCd == "AG").ToListAsync();
+        both.Should().HaveCount(2);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // dict_land_state
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictLandState_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictLandStates.Add(new DictLandState
+        {
+            CountyId = countyId,
+            LandStateCd = "WA",
+            Description = "Washington",
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "qh-ls-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictLandStates.SingleAsync();
+        loaded.LandStateCd.Should().Be("WA");
+        loaded.Description.Should().Be("Washington");
+        loaded.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DictLandState_SoftRetire_KeepsRowQueryable()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictLandStates.AddRange(
+            new DictLandState { CountyId = countyId, LandStateCd = "ACT",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" },
+            new DictLandState { CountyId = countyId, LandStateCd = "RET",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" });
+        await _db.SaveChangesAsync();
+
+        var retired = await _db.DictLandStates.SingleAsync(d => d.LandStateCd == "RET");
+        retired.IsActive = false;
+        await _db.SaveChangesAsync();
+
+        (await _db.DictLandStates.CountAsync(d => d.CountyId == countyId))
+            .Should().Be(2, "soft-retire never hard-deletes");
+        (await _db.DictLandStates.CountAsync(d => d.CountyId == countyId && d.IsActive))
+            .Should().Be(1);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // dict_imprv_type
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictImprvType_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictImprvTypes.Add(new DictImprvType
+        {
+            CountyId = countyId,
+            ImprvTypeCd = "ATTGAR",
+            Description = "Attached garage",
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "qh-it-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictImprvTypes.SingleAsync();
+        loaded.ImprvTypeCd.Should().Be("ATTGAR");
+        loaded.Description.Should().Be("Attached garage");
+    }
+
+    [Fact]
+    public async Task DictImprvType_SameCode_AcrossDifferentCounties_IsAllowed()
+    {
+        var c1 = Guid.NewGuid();
+        var c2 = Guid.NewGuid();
+        _db.DictImprvTypes.AddRange(
+            new DictImprvType { CountyId = c1, ImprvTypeCd = "MA",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" },
+            new DictImprvType { CountyId = c2, ImprvTypeCd = "MA",
+                LoadBatchId = Guid.NewGuid(), SourceQueryHash = "qh" });
+        await _db.SaveChangesAsync();
+        (await _db.DictImprvTypes.CountAsync()).Should().Be(2);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // dict_imprv_state
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictImprvState_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictImprvStates.Add(new DictImprvState
+        {
+            CountyId = countyId,
+            ImprvStateCd = "WA",
+            Description = "Washington",
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "qh-is-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictImprvStates.SingleAsync();
+        loaded.ImprvStateCd.Should().Be("WA");
+        loaded.IsActive.Should().BeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // dict_exemption_type
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictExemptionType_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictExemptionTypes.Add(new DictExemptionType
+        {
+            CountyId = countyId,
+            ExemptionTypeCd = "SR",
+            Description = "Senior exemption",
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "qh-ex-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictExemptionTypes.SingleAsync();
+        loaded.ExemptionTypeCd.Should().Be("SR");
+        loaded.Description.Should().Be("Senior exemption");
+    }
+
+    [Fact]
+    public async Task DictExemptionType_Provenance_RoundTrips()
+    {
+        var countyId = Guid.NewGuid();
+        var batch1 = Guid.NewGuid();
+        var batch2 = Guid.NewGuid();
+        _db.DictExemptionTypes.AddRange(
+            new DictExemptionType { CountyId = countyId, ExemptionTypeCd = "X1",
+                LoadBatchId = batch1, SourceQueryHash = "h1" },
+            new DictExemptionType { CountyId = countyId, ExemptionTypeCd = "X2",
+                LoadBatchId = batch2, SourceQueryHash = "h2" });
+        await _db.SaveChangesAsync();
+
+        var b1Rows = await _db.DictExemptionTypes
+            .Where(d => d.LoadBatchId == batch1).ToListAsync();
+        b1Rows.Should().HaveCount(1);
+        b1Rows[0].SourceQueryHash.Should().Be("h1");
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // dict_situs_legal
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DictSitusLegal_RoundTrip_Persists()
+    {
+        var countyId = Guid.NewGuid();
+        _db.DictSitusLegals.Add(new DictSitusLegal
+        {
+            CountyId = countyId,
+            SitusLegalCd = "PRIM",
+            Description = "Primary situs",
+            LoadBatchId = Guid.NewGuid(),
+            SourceQueryHash = "qh-sl-1",
+        });
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.DictSitusLegals.SingleAsync();
+        loaded.SitusLegalCd.Should().Be("PRIM");
+        loaded.IsActive.Should().BeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // EF model shape: every Dict* exposes a unique (CountyId, code)
+    // index per the sovereign-county isolation invariant
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DictLandUse_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictLandUse>("CountyId", "LandUseCd");
+
+    [Fact]
+    public void DictLandState_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictLandState>("CountyId", "LandStateCd");
+
+    [Fact]
+    public void DictImprvType_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictImprvType>("CountyId", "ImprvTypeCd");
+
+    [Fact]
+    public void DictImprvState_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictImprvState>("CountyId", "ImprvStateCd");
+
+    [Fact]
+    public void DictExemptionType_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictExemptionType>("CountyId", "ExemptionTypeCd");
+
+    [Fact]
+    public void DictSitusLegal_HasUniqueCountyCodeIndex()
+        => AssertHasUniqueCountyCodeIndex<DictSitusLegal>("CountyId", "SitusLegalCd");
+
+    private void AssertHasUniqueCountyCodeIndex<T>(string countyProp, string codeProp)
+        where T : class
+    {
+        var et = _db.Model.FindEntityType(typeof(T));
+        et.Should().NotBeNull($"{typeof(T).Name} must be mapped");
+        var indexes = et!.GetIndexes().ToList();
+        indexes.Should().Contain(idx =>
+            idx.IsUnique
+            && idx.Properties.Count == 2
+            && idx.Properties[0].Name == countyProp
+            && idx.Properties[1].Name == codeProp,
+            $"{typeof(T).Name} must have a unique ({countyProp}, {codeProp}) index per sovereign-county isolation");
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // TfParcel.ConversionEra (G2 closure)
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TfParcel_ConversionEra_RoundTrips()
+    {
+        var parcel = new TfParcel
+        {
+            CountyId = Guid.NewGuid(),
+            ParcelNumber = "1-2345-6789",
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+            ConversionEra = "POST_CONVERSION",
+        };
+        _db.TfParcels.Add(parcel);
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.TfParcels.SingleAsync();
+        loaded.ConversionEra.Should().Be("POST_CONVERSION",
+            "G2 parity: TfParcel.ConversionEra must persist alongside the other canonical_tf entities");
+    }
+
+    [Fact]
+    public async Task TfParcel_ConversionEra_NullablePersists()
+    {
+        // Back-compat: rows projected before this slice carry NULL.
+        var parcel = new TfParcel
+        {
+            CountyId = Guid.NewGuid(),
+            ParcelNumber = "1-2345-6789",
+            ParcelStatus = "ACTIVE",
+            ConversionEra = null,
+        };
+        _db.TfParcels.Add(parcel);
+        await _db.SaveChangesAsync();
+
+        var loaded = await _db.TfParcels.SingleAsync();
+        loaded.ConversionEra.Should().BeNull();
+    }
+
+    [Fact]
+    public void TfParcel_ConversionEra_IsNullable_AndMaxLength20()
+    {
+        var et = _db.Model.FindEntityType(typeof(TfParcel));
+        et.Should().NotBeNull();
+        var era = et!.FindProperty(nameof(TfParcel.ConversionEra));
+        era.Should().NotBeNull("G2 parity: TfParcel must carry ConversionEra");
+        era!.IsNullable.Should().BeTrue(
+            "G2 parity: ConversionEra is nullable for back-compat");
+        era.GetMaxLength().Should().Be(20,
+            "G2 parity: ConversionEra max length matches the other canonical_tf entities");
+        era.ClrType.Should().Be(typeof(string));
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Doctrine/BlockCContractV1Tests.cs
@@ -1263,6 +1263,12 @@ public sealed class BlockCContractV1Tests : IDisposable
             // Block-C contract v1.11 — ConversionEra column + index
             // on six canonical_tf lanes (G2).
             "AddConversionEraToCanonicalTf",
+            // Phase 2 closure — six remaining canonical dict_*
+            // tables (E1) + TfParcel.ConversionEra column (G2 gap
+            // closure). Per docs/pacs/blocks-d-through-h-design.md §E
+            // and the cross-canonical-entity ConversionEra parity
+            // requirement.
+            "SyncE1G2DictsAndTfParcelConversionEra",
         };
 
         foreach (var fragment in requiredFragments)


### PR DESCRIPTION
## Summary

Phase 2 closure for two doctrine gaps in **one** EF migration.

**E1 closure** — six remaining canonical dictionary tables called out in `docs/pacs/blocks-d-through-h-design.md` §E. `dict_neighborhood` was already shipped (Block-C contract v1.1). This slice closes the rest:

- `canonical_tf.dict_land_use` (`land_use_cd`)
- `canonical_tf.dict_land_state` (`land_state_cd`)
- `canonical_tf.dict_imprv_type` (`imprv_type_cd`)
- `canonical_tf.dict_imprv_state` (`imprv_state_cd`)
- `canonical_tf.dict_exemption_type` (`exmpt_type_cd`)
- `canonical_tf.dict_situs_legal` (situs/legal codes)

Each entity mirrors `DictNeighborhood` exactly: `(CountyId, <code>)` unique index for sovereign-county isolation, `IsActive` soft-retire, `LoadBatchId` + `SourceQueryHash` provenance, audit timestamps. Operator-driven seeding is a separate slice; this is schema lock, not a runtime gate.

**G2 closure** — `TfParcel.ConversionEra` column. Closes the parity gap where `TfImprovement`, `TfSale`, `TfLand`, `TfOwner`, `TfAssessmentWsdor`, and `TfImprovementFeature` already carried this column but `TfParcel` did not. Nullable for back-compat; same shape as the other six entities (`string?`, `MaxLength=20`).

**One** EF migration: `20260508015117_SyncE1G2DictsAndTfParcelConversionEra` — six `CreateTable` + 18 `CreateIndex` + one `AddColumn` + one `CreateIndex` on `tf_parcel`. Reverse drops symmetric.

## Test plan

- [x] Build green: `dotnet build backend/TerraFusion.sln` → 0 errors / 0 warnings
- [x] Unit.Tests: `3047/3047` passing (added 19 new tests; baseline was 3028)
- [x] Migration list assertion in `BlockCContractV1Tests` updated to include the new migration filename
- [x] Round-trip persistence test per dict entity (insert → query → assert)
- [x] Cross-county uniqueness behavior (same code in two different counties)
- [x] Soft-retire keeps row queryable but filtered from active lookups
- [x] Provenance round-trips (LoadBatchId + SourceQueryHash)
- [x] EF model shape gate per dict: `(CountyId, code)` unique index asserted via reflection
- [x] `TfParcel.ConversionEra` round-trip (POST_CONVERSION + null) + EF model shape (nullable, MaxLength=20)

## Out of scope

- Operator-driven dictionary seeding (separate slice)
- Projector wiring to consume the new dictionaries (E2-style FK landings)
- Backfill of `TfParcel.ConversionEra` for rows projected pre-slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new dictionary references for standardized data classification: exemption types, improvement states and types, land states and uses, and situs/legal designations.
  * Extended parcel records to track conversion era information for Phase 2 data closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->