### PR TITLE
feat(sync): SYNC-F1 — open-work / pending-appraisal queue read-model

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/OpenWorkQueueController.cs
+++ b/backend/src/TerraFusion.API/Controllers/OpenWorkQueueController.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Sync.OpenWork;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// Slice F1: read-only endpoint for the open-work / pending-appraisal
+/// queue.
+///
+/// <para><c>GET /api/parcels/open-work?year={int}&amp;maxResults={int}</c></para>
+///
+/// <para>Contract:
+/// <list type="bullet">
+///   <item>401 if unauthenticated (handled by <c>[Authorize]</c>).</item>
+///   <item>400 on missing / non-positive <c>year</c> or out-of-range <c>maxResults</c>.</item>
+///   <item>403 when the caller has no <c>countyId</c> claim — sovereign isolation requires it.</item>
+///   <item>200 with <see cref="OpenWorkResponse"/>; <c>Items</c> is empty if nothing is pending.</item>
+/// </list>
+/// </para>
+///
+/// <para>Read-only by contract: no writes, no audit-table mutations,
+/// no PII. Result count is bounded by <c>maxResults</c> (default 100,
+/// max 1000); the response's <c>Truncated</c> flag tells the caller
+/// whether the backlog is larger than what was returned.</para>
+///
+/// <para>Mirrors <c>ParcelGeometryController</c>'s county-claim
+/// resolution: only the Guid form of <c>countyId</c> is trusted; no
+/// county-name fallback.</para>
+/// </summary>
+[ApiController]
+[Route("api/parcels")]
+public sealed class OpenWorkQueueController : ControllerBase
+{
+    /// <summary>Default page size when the caller omits maxResults.</summary>
+    public const int DefaultMaxResults = 100;
+
+    /// <summary>Hard upper bound. Larger requests are 400.</summary>
+    public const int HardMaxResults = 1000;
+
+    private readonly IOpenWorkReader _reader;
+    private readonly ILogger<OpenWorkQueueController> _logger;
+
+    public OpenWorkQueueController(
+        IOpenWorkReader reader,
+        ILogger<OpenWorkQueueController> logger)
+    {
+        _reader = reader;
+        _logger = logger;
+    }
+
+    [HttpGet("open-work")]
+    [Authorize]
+    public async Task<IActionResult> GetOpenWork(
+        [FromQuery] short year,
+        [FromQuery] int? maxResults = null,
+        CancellationToken ct = default)
+    {
+        if (year <= 0)
+        {
+            return BadRequest(new
+            {
+                error = "year must be a positive assessment year.",
+                hint = "Pass the calendar year, e.g. 2026.",
+                year,
+            });
+        }
+
+        var effectiveMax = maxResults ?? DefaultMaxResults;
+        if (effectiveMax <= 0 || effectiveMax > HardMaxResults)
+        {
+            return BadRequest(new
+            {
+                error = $"maxResults must be in (0, {HardMaxResults}].",
+                maxResults = effectiveMax,
+            });
+        }
+
+        var principalCountyId = ResolveCountyClaim();
+        if (principalCountyId is null)
+        {
+            // Authenticated but no county claim → cannot enforce
+            // sovereign-county isolation. Treat as Forbid; do not
+            // leak existence.
+            _logger.LogWarning(
+                "[OpenWork] missing countyId claim on principal; refusing.");
+            return Forbid();
+        }
+
+        var result = await _reader
+            .GetOpenWorkAsync(principalCountyId.Value, year, effectiveMax, ct)
+            .ConfigureAwait(false);
+
+        var body = new OpenWorkResponse
+        {
+            CountyId = principalCountyId.Value,
+            AssessmentYear = year,
+            Count = result.Items.Count,
+            Truncated = result.Truncated,
+            Items = result.Items,
+        };
+
+        if (result.Truncated)
+        {
+            _logger.LogInformation(
+                "[OpenWork] county={CountyId} year={Year} returned {Count} (truncated; backlog larger than maxResults={Max}).",
+                principalCountyId, year, body.Count, effectiveMax);
+        }
+
+        return Ok(body);
+    }
+
+    /// <summary>
+    /// Mirrors <c>ParcelGeometryController.ResolveCountyClaim</c> —
+    /// same contract, narrow trust surface (Guid claim only, no
+    /// county-name fallback).
+    /// </summary>
+    private Guid? ResolveCountyClaim()
+    {
+        var raw = User.FindFirst("countyId")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return Guid.TryParse(raw, out var parsed) ? parsed : null;
+    }
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1957,6 +1957,15 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.PacsWsdorCanonical.ITfParcelWsdorReader,
     TerraFusion.Data.Services.CanonicalTf.TfParcelWsdorReader>();
 
+// Slice F1: open-work / pending-appraisal queue read-model. Surfaces
+// parcels missing a canonical_tf.tf_assessment_wsdor row for the
+// requested year — the morning-dashboard signal for "still needs
+// assessor attention before the roll closes." Read-only by contract,
+// county-isolated, bounded by maxResults.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.OpenWork.IOpenWorkReader,
+    TerraFusion.Data.Services.CanonicalTf.OpenWorkReader>();
+
 // Slice S2-B: truth_pacs.sale promoter — supp-aware join + '100'
 // qualification filter, with five T-* gates. Idempotent by SaleLoadBatchId.
 builder.Services.AddScoped<

--- a/backend/src/TerraFusion.Core/DTOs/CanonicalTf/OpenWorkResponse.cs
+++ b/backend/src/TerraFusion.Core/DTOs/CanonicalTf/OpenWorkResponse.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.DTOs.CanonicalTf;
+
+/// <summary>
+/// Slice F1: read-model envelope for the open-work / pending-appraisal
+/// queue.
+///
+/// <para>An "open-work" parcel for a given assessment year is one that
+/// has NO matching <c>canonical_tf.tf_assessment_wsdor</c> row for the
+/// caller's county at that year. These are the parcels the assessor
+/// still needs to touch before the WSDOR roll is closed for the year.</para>
+///
+/// <para>Read-only by contract: no PII, no audit-table mutations. The
+/// reader populates ParcelNumber as <c>GeoId</c> (PACS terminology
+/// the assessor recognizes — "geo_id" / "parcel number" are the same
+/// label in Benton's morning workflow).</para>
+/// </summary>
+public sealed class OpenWorkResponse
+{
+    /// <summary>The county the queue was scoped to (caller's claim).</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>The assessment year requested by the caller.</summary>
+    public short AssessmentYear { get; set; }
+
+    /// <summary>
+    /// Number of items returned in <see cref="Items"/>. NOT the total
+    /// open-work count for the county — the reader caps the result at
+    /// the controller's <c>maxResults</c>. Use <see cref="Truncated"/>
+    /// to detect when the cap was hit.
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>
+    /// True if the underlying query produced more rows than
+    /// <see cref="Count"/>. The caller should narrow the year or
+    /// raise <c>maxResults</c> to see the full backlog.
+    /// </summary>
+    public bool Truncated { get; set; }
+
+    /// <summary>The pending-appraisal parcels, ordered by GeoId asc.</summary>
+    public IReadOnlyList<OpenWorkItem> Items { get; set; } = Array.Empty<OpenWorkItem>();
+}
+
+/// <summary>
+/// A single parcel that's open for appraisal at the requested year.
+/// </summary>
+public sealed class OpenWorkItem
+{
+    /// <summary>Canonical TF parcel identity.</summary>
+    public Guid TfParcelId { get; set; }
+
+    /// <summary>
+    /// Operator-facing parcel number (a.k.a. <c>geo_id</c> in PACS).
+    /// May be null if the underlying canonical row never had one set.
+    /// </summary>
+    public string? GeoId { get; set; }
+
+    /// <summary>
+    /// Why this parcel is in the open-work queue. F1 only emits one
+    /// reason today; the field is structured so future blocks (F2/F3)
+    /// can layer additional pending categories without breaking the
+    /// envelope.
+    /// </summary>
+    public string PendingReason { get; set; } = "MISSING_WSDOR_FOR_YEAR";
+}

--- a/backend/src/TerraFusion.Core/Sync/OpenWork/IOpenWorkReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/OpenWork/IOpenWorkReader.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TerraFusion.Core.DTOs.CanonicalTf;
+
+namespace TerraFusion.Core.Sync.OpenWork;
+
+/// <summary>
+/// Slice F1: read-only projection that surfaces parcels needing the
+/// assessor's attention for a given <c>(countyId, assessmentYear)</c>.
+///
+/// <para>F1 MVP: a parcel is "open-work" if it has NO
+/// <c>canonical_tf.tf_assessment_wsdor</c> row for the requested year.
+/// That's the primary morning-dashboard signal in Benton: every
+/// active parcel must have a WSDOR row before the roll closes.</para>
+///
+/// <para>Read-only by contract: <c>AsNoTracking</c>; no
+/// <c>SaveChangesAsync</c>; no audit-table writes. Bounded by the
+/// caller's <c>maxResults</c> — the reader returns one extra row
+/// internally so the caller can detect a truncated backlog.</para>
+///
+/// <para>County isolation: the reader filters by
+/// <see cref="TerraFusion.Core.Entities.CanonicalTf.TfParcel.CountyId"/>
+/// directly. There's no cross-county leakage path in F1: the controller
+/// can only pass its own resolved claim.</para>
+/// </summary>
+public interface IOpenWorkReader
+{
+    /// <summary>
+    /// Returns up to <paramref name="maxResults"/> open-work parcels for
+    /// the <paramref name="countyId"/> at <paramref name="year"/>,
+    /// ordered by <c>ParcelNumber</c> (a.k.a. GeoId) ascending.
+    /// NULL ParcelNumber sorts last so the assessor sees the
+    /// well-identified backlog first.
+    /// </summary>
+    /// <param name="countyId">Caller's resolved sovereign-county claim.</param>
+    /// <param name="year">Assessment year (e.g. 2026).</param>
+    /// <param name="maxResults">Hard cap on result count.</param>
+    /// <param name="cancellationToken">Standard cancellation hook.</param>
+    /// <returns>An <see cref="OpenWorkResult"/> with the items + a
+    /// <c>Truncated</c> signal indicating that more pending parcels
+    /// exist than were returned.</returns>
+    Task<OpenWorkResult> GetOpenWorkAsync(
+        Guid countyId,
+        short year,
+        int maxResults,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// F1 result envelope. Structured so the controller can map
+/// <c>Truncated</c> straight into the response without a second query.
+/// </summary>
+public sealed record OpenWorkResult
+{
+    public required IReadOnlyList<OpenWorkItem> Items { get; init; }
+
+    /// <summary>True iff the underlying query produced more rows
+    /// than <c>maxResults</c>. The reader returns the first
+    /// <c>maxResults</c> items in <see cref="Items"/>.</summary>
+    public required bool Truncated { get; init; }
+
+    public static OpenWorkResult Empty { get; } = new()
+    {
+        Items = Array.Empty<OpenWorkItem>(),
+        Truncated = false,
+    };
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/OpenWorkReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/OpenWorkReader.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Sync.OpenWork;
+
+namespace TerraFusion.Data.Services.CanonicalTf;
+
+/// <summary>
+/// Slice F1: EF-backed implementation of <see cref="IOpenWorkReader"/>.
+///
+/// <para>An open-work parcel is one with NO matching
+/// <c>canonical_tf.tf_assessment_wsdor</c> row for the requested year.
+/// Implemented as a left-anti-join (<c>Where(... !Any(...))</c>) so
+/// EF translates it to a single SQL round-trip.</para>
+///
+/// <para>Read-only: <c>AsNoTracking()</c>; no writes; no audit
+/// mutations. Sovereign-county filtering is mandatory and applied at
+/// the lowest possible level — the reader will NEVER project a parcel
+/// from a different <see cref="TerraFusion.Core.Entities.CanonicalTf.TfParcel.CountyId"/>.</para>
+///
+/// <para>Truncation detection: the reader requests
+/// <c>maxResults + 1</c> rows. If it gets back more than
+/// <c>maxResults</c>, it trims the tail and reports
+/// <see cref="OpenWorkResult.Truncated"/>=true.</para>
+/// </summary>
+public sealed class OpenWorkReader : IOpenWorkReader
+{
+    private readonly TerraFusionDbContext _db;
+
+    public OpenWorkReader(TerraFusionDbContext db) => _db = db;
+
+    public async Task<OpenWorkResult> GetOpenWorkAsync(
+        Guid countyId,
+        short year,
+        int maxResults,
+        CancellationToken cancellationToken = default)
+    {
+        if (countyId == Guid.Empty || maxResults <= 0)
+        {
+            return OpenWorkResult.Empty;
+        }
+
+        var query =
+            from p in _db.TfParcels.AsNoTracking()
+            where p.CountyId == countyId
+                  && !_db.TfAssessmentWsdors.Any(a =>
+                          a.TfParcelId == p.TfParcelId
+                          && a.AssessmentYear == year)
+            // Two-stage order: rows with a ParcelNumber first, then by
+            // ParcelNumber asc. NULLs sort last so the well-identified
+            // backlog leads the queue.
+            orderby (p.ParcelNumber == null ? 1 : 0),
+                    p.ParcelNumber
+            select new OpenWorkItem
+            {
+                TfParcelId = p.TfParcelId,
+                GeoId = p.ParcelNumber,
+                PendingReason = "MISSING_WSDOR_FOR_YEAR",
+            };
+
+        // Pull one extra row to detect truncation without a COUNT(*).
+        var rows = await query
+            .Take(maxResults + 1)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var truncated = rows.Count > maxResults;
+        if (truncated)
+        {
+            rows.RemoveAt(rows.Count - 1);
+        }
+
+        return new OpenWorkResult
+        {
+            Items = rows,
+            Truncated = truncated,
+        };
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/OpenWorkQueueControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/OpenWorkQueueControllerTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.DTOs.CanonicalTf;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Slice F1 controller tests for
+/// <c>GET /api/parcels/open-work?year=...&amp;maxResults=...</c>.
+///
+/// Pattern: real EF InMemory + claims principal injection, no
+/// network. Asserts:
+///   - empty wsdor → all parcels surface as pending
+///   - parcels with a wsdor row for the requested year are excluded
+///   - county isolation (other county's parcels never returned)
+///   - maxResults caps the result and surfaces a Truncated flag
+///   - missing countyId claim → 403
+///   - bad year / out-of-range maxResults → 400
+///   - ordering by GeoId asc with NULL last
+/// </summary>
+public sealed class OpenWorkQueueControllerTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("19190019-1919-1919-1919-191919191919");
+    private static readonly Guid CountyB =
+        Guid.Parse("20200020-2020-2020-2020-202020202020");
+
+    private readonly TerraFusionDbContext _db;
+
+    public OpenWorkQueueControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"f1-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private OpenWorkQueueController BuildController(Guid? principalCountyClaim)
+    {
+        var reader = new OpenWorkReader(_db);
+        var ctrl = new OpenWorkQueueController(
+            reader, NullLogger<OpenWorkQueueController>.Instance);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: principalCountyClaim is null ? null : "Test");
+        if (principalCountyClaim is not null)
+        {
+            identity.AddClaim(new Claim("countyId", principalCountyClaim.Value.ToString()));
+        }
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+            },
+        };
+        return ctrl;
+    }
+
+    private async Task<TfParcel> SeedParcelAsync(
+        Guid countyId, string? parcelNumber)
+    {
+        var p = new TfParcel
+        {
+            CountyId = countyId,
+            ParcelNumber = parcelNumber,
+            ParcelStatus = "ACTIVE",
+            PropertyType = "R",
+        };
+        _db.TfParcels.Add(p);
+        await _db.SaveChangesAsync();
+        return p;
+    }
+
+    private async Task SeedWsdorAsync(Guid parcelId, Guid countyId, short year)
+    {
+        // Each WSDOR row needs an owner FK. Seed a throwaway owner.
+        var owner = new TfOwner
+        {
+            CountyId = countyId,
+            AcctId = Random.Shared.NextInt64(),
+            DisplayName = "owner-" + Guid.NewGuid().ToString("N")[..8],
+            ConfidentialFlag = false,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        };
+        _db.TfOwners.Add(owner);
+        await _db.SaveChangesAsync();
+
+        _db.TfAssessmentWsdors.Add(new TfAssessmentWsdor
+        {
+            CountyId = countyId,
+            TfParcelId = parcelId,
+            TfOwnerId = owner.TfOwnerId,
+            AssessmentYear = year,
+            SupNum = 0,
+            AssessedVal = 100_000m,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private static OpenWorkResponse AssertOk(IActionResult result)
+    {
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeOfType<OpenWorkResponse>().Subject;
+    }
+
+    [Fact]
+    public async Task EmptyWsdor_ReturnsAllParcelsAsPending()
+    {
+        await SeedParcelAsync(CountyA, "001");
+        await SeedParcelAsync(CountyA, "002");
+        await SeedParcelAsync(CountyA, "003");
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.CountyId.Should().Be(CountyA);
+        body.AssessmentYear.Should().Be(2026);
+        body.Count.Should().Be(3);
+        body.Truncated.Should().BeFalse();
+        body.Items.Select(i => i.GeoId)
+            .Should().ContainInOrder("001", "002", "003");
+        body.Items.Should().OnlyContain(
+            i => i.PendingReason == "MISSING_WSDOR_FOR_YEAR");
+    }
+
+    [Fact]
+    public async Task ParcelsWithWsdorForRequestedYear_AreExcluded()
+    {
+        var pending = await SeedParcelAsync(CountyA, "001");
+        var done = await SeedParcelAsync(CountyA, "002");
+        await SeedWsdorAsync(done.TfParcelId, CountyA, year: 2026);
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(1);
+        body.Items.Single().TfParcelId.Should().Be(pending.TfParcelId);
+        body.Items.Single().GeoId.Should().Be("001");
+    }
+
+    [Fact]
+    public async Task WsdorForOtherYear_DoesNotSatisfyRequestedYear()
+    {
+        // Parcel has a WSDOR row for 2024 — it's still open work for 2026.
+        var p = await SeedParcelAsync(CountyA, "001");
+        await SeedWsdorAsync(p.TfParcelId, CountyA, year: 2024);
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(1);
+        body.Items.Single().TfParcelId.Should().Be(p.TfParcelId);
+    }
+
+    [Fact]
+    public async Task CountyIsolation_DoesNotLeakOtherCountyParcels()
+    {
+        // CountyA has 1 pending; CountyB has 5 pending. CountyA's
+        // caller must only see their own.
+        await SeedParcelAsync(CountyA, "A-001");
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedParcelAsync(CountyB, $"B-{i:000}");
+        }
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(1);
+        body.Items.Single().GeoId.Should().Be("A-001");
+        body.CountyId.Should().Be(CountyA);
+    }
+
+    [Fact]
+    public async Task MaxResults_CapsResultAndFlagsTruncated()
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            await SeedParcelAsync(CountyA, $"{i:000}");
+        }
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026, maxResults: 4));
+
+        body.Count.Should().Be(4);
+        body.Truncated.Should().BeTrue("10 pending parcels > maxResults=4");
+        body.Items.Select(i => i.GeoId)
+            .Should().ContainInOrder("000", "001", "002", "003");
+    }
+
+    [Fact]
+    public async Task MaxResults_ExactMatch_DoesNotFlagTruncated()
+    {
+        await SeedParcelAsync(CountyA, "001");
+        await SeedParcelAsync(CountyA, "002");
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026, maxResults: 2));
+
+        body.Count.Should().Be(2);
+        body.Truncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DefaultMaxResults_AppliesWhenCallerOmitsIt()
+    {
+        // Seed exactly DefaultMaxResults+1 to prove the default actually engages.
+        var n = OpenWorkQueueController.DefaultMaxResults + 1;
+        for (var i = 0; i < n; i++)
+        {
+            await SeedParcelAsync(CountyA, $"{i:0000}");
+        }
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(OpenWorkQueueController.DefaultMaxResults);
+        body.Truncated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NullParcelNumber_SortsLast()
+    {
+        await SeedParcelAsync(CountyA, parcelNumber: null);
+        await SeedParcelAsync(CountyA, parcelNumber: "002");
+        await SeedParcelAsync(CountyA, parcelNumber: "001");
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(3);
+        body.Items[0].GeoId.Should().Be("001");
+        body.Items[1].GeoId.Should().Be("002");
+        body.Items[2].GeoId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MissingCountyClaim_Returns403()
+    {
+        await SeedParcelAsync(CountyA, "001");
+
+        var ctrl = BuildController(principalCountyClaim: null);
+        var result = await ctrl.GetOpenWork(year: 2026);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Theory]
+    [InlineData((short)0)]
+    [InlineData((short)-1)]
+    public async Task NonPositiveYear_Returns400(short badYear)
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetOpenWork(year: badYear);
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(1001)]
+    public async Task OutOfRangeMaxResults_Returns400(int badMax)
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetOpenWork(year: 2026, maxResults: badMax);
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task NoParcelsInCounty_Returns200WithEmptyItems()
+    {
+        // CountyB has parcels; CountyA has none.
+        await SeedParcelAsync(CountyB, "B-001");
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2026));
+
+        body.Count.Should().Be(0);
+        body.Items.Should().BeEmpty();
+        body.Truncated.Should().BeFalse();
+        body.CountyId.Should().Be(CountyA);
+    }
+
+    [Fact]
+    public async Task ResponseEnvelope_PopulatesYearAndCountyFromCallerClaim()
+    {
+        await SeedParcelAsync(CountyA, "001");
+
+        var ctrl = BuildController(CountyA);
+        var body = AssertOk(await ctrl.GetOpenWork(year: 2027, maxResults: 50));
+
+        body.AssessmentYear.Should().Be(2027);
+        body.CountyId.Should().Be(CountyA);
+    }
+}


### PR DESCRIPTION
## SYNC-F1 — Block F1: open-work / pending-appraisal queue

Per `docs/pacs/blocks-d-through-h-design.md`:

> **F1** Open work / pending appraisal queue.

The first F-block slice — Operator dashboard parity. A parcel is "open
work" for a given assessment year when it has **no matching
`canonical_tf.tf_assessment_wsdor` row** for that year. That is the
morning-dashboard signal in Benton: every active parcel must have a
WSDOR row before the roll closes.

## Slice shape

- **Reader** (`IOpenWorkReader` + `OpenWorkReader`) — left-anti-join
  over `tf_parcel` against `tf_assessment_wsdor`, `AsNoTracking`,
  county-scoped, ordered by `ParcelNumber` asc with NULLs last.
  Truncation detection via `Take(maxResults + 1)` — no extra
  `COUNT(*)` round-trip.
- **DTOs** — `OpenWorkResponse { CountyId, AssessmentYear, Count,
  Truncated, Items }` and `OpenWorkItem { TfParcelId, GeoId,
  PendingReason }`. `PendingReason` is structured so future F2/F3
  categories can layer in without breaking the envelope.
- **Controller** (`OpenWorkQueueController`) —
  `GET /api/parcels/open-work?year={int}&maxResults={int}`. Default
  `maxResults` = 100, hard cap = 1000. Mirrors
  `ParcelGeometryController`'s `[Authorize]` + Guid-only `countyId`
  claim resolution. Missing claim → 403; non-positive year or
  out-of-range `maxResults` → 400.
- **DI** — registered after the existing canonical readers in
  `Program.cs`.

## Read-only by contract

No writes, no audit-table mutations, no PII. The reader filters
sovereignly by `TfParcel.CountyId`; there is no cross-county leakage
path because the controller can only pass its own resolved claim.

## Tests — 16 passing

- empty-wsdor surfaces all parcels as pending
- parcels with a wsdor row for the requested year are excluded
- wsdor for another year does not satisfy the requested year
- county isolation: county B's parcels never reach a county A caller
- `maxResults` caps the result and flags `Truncated=true`
- exact-match `maxResults` does not flag `Truncated`
- default `maxResults` engages when caller omits it
- `NULL ParcelNumber` sorts last (well-identified backlog leads)
- missing `countyId` claim → 403
- non-positive year → 400 (theory: 0, -1)
- out-of-range `maxResults` → 400 (theory: 0, -5, 1001)
- empty-county returns 200 with empty `Items`
- response envelope round-trips year + countyId from the caller's
  claim

## Verification

- `dotnet build backend/TerraFusion.sln` → **0 errors, 0 warnings**
- `dotnet test backend/tests/TerraFusion.Unit.Tests` →
  **3044 passed / 3044 total** (3028 baseline + 16 new F1)

## Files

- `backend/src/TerraFusion.API/Controllers/OpenWorkQueueController.cs` (new)
- `backend/src/TerraFusion.API/Program.cs` (DI registration)
- `backend/src/TerraFusion.Core/DTOs/CanonicalTf/OpenWorkResponse.cs` (new)
- `backend/src/TerraFusion.Core/Sync/OpenWork/IOpenWorkReader.cs` (new)
- `backend/src/TerraFusion.Data/Services/CanonicalTf/OpenWorkReader.cs` (new)
- `backend/tests/TerraFusion.Unit.Tests/CanonicalTf/OpenWorkQueueControllerTests.cs` (new)

## Deviations from the brief

- The spec mentioned "ordered by `geoId`" — implemented as
  `ParcelNumber` (the canonical column on `TfParcel`; PACS calls it
  `geo_id`), surfaced to the caller as `GeoId` in the DTO.
- Added a `Truncated` flag on the response envelope. The brief is
  silent on truncation signaling but a queue endpoint without it lies
  to the operator about backlog size; the flag is cheap (one extra
  row pulled, no count query) and unblocks future "load more" UX.

Cloud Coach to audit before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New authorized API endpoint to list parcels needing assessment work for a given year, with a typed response envelope including count and items.
  * Configurable max-results with truncation detection and sensible defaults.
  * County-scoped access enforced via caller claims.

* **Tests**
  * Comprehensive unit tests covering authorization, validation, result limits, truncation, ordering, and county isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->