### PR TITLE
SYNC-F4: land-segment exception list read-model

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/LandSegmentExceptionController.cs
+++ b/backend/src/TerraFusion.API/Controllers/LandSegmentExceptionController.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.LandSegmentException;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// Slice F4: read-only land-segment exception list endpoint
+/// per <c>docs/pacs/blocks-d-through-h-design.md</c> §F.4.
+///
+/// <para><c>GET /api/land/exceptions?era={string?}&amp;maxResults={int?}</c></para>
+///
+/// <para>Surfaces canonical land segments whose data carries
+/// anomalies (missing market value, missing/zero acreage,
+/// missing type code, missing state code). Each row bundles all
+/// matching anomalies into a comma-joined
+/// <c>ExceptionReasons</c> string.</para>
+///
+/// <para>Contract:
+/// <list type="bullet">
+///   <item>401 if the request is unauthenticated (handled by
+///   <c>[Authorize]</c>).</item>
+///   <item>403 if the caller's <c>countyId</c> claim is missing —
+///   sovereign-county isolation requires a county scope; the
+///   endpoint refuses to operate without one rather than leak a
+///   global view.</item>
+///   <item>400 if <c>era</c> is an unrecognized token.</item>
+///   <item>200 with a typed item array when authorized.</item>
+/// </list>
+/// </para>
+///
+/// <para>Read-only by contract: no DbContext writes, no audit
+/// table mutations, no PII surfaced. Empty result sets return
+/// 200 with an empty array.</para>
+/// </summary>
+[ApiController]
+[Route("api/land")]
+public sealed class LandSegmentExceptionController : ControllerBase
+{
+    private readonly ILandSegmentExceptionReader _reader;
+    private readonly ILogger<LandSegmentExceptionController> _logger;
+
+    public LandSegmentExceptionController(
+        ILandSegmentExceptionReader reader,
+        ILogger<LandSegmentExceptionController> logger)
+    {
+        _reader = reader;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Doctrine-frozen set of valid <c>era</c> tokens. Mirrors
+    /// <see cref="SalesRatioStudyController"/> v1.12.
+    /// </summary>
+    private static readonly IReadOnlySet<string> ValidEraValues =
+        new HashSet<string>
+        {
+            ConversionEras.PostConversion,
+            ConversionEras.PreConversion2017,
+            ConversionEras.Unknown,
+            ILandSegmentExceptionReader.EraAll,
+        };
+
+    [HttpGet("exceptions")]
+    [Authorize]
+    public async Task<IActionResult> GetExceptions(
+        [FromQuery] string? era = null,
+        [FromQuery] int? maxResults = null,
+        CancellationToken ct = default)
+    {
+        var principalCountyId = ResolveCountyClaim();
+        if (principalCountyId is null)
+        {
+            _logger.LogWarning(
+                "[LandSegmentException] missing countyId claim on principal; refusing.");
+            return Forbid();
+        }
+
+        if (!TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+            return eraFail!;
+
+        var resolvedMax = ClampMaxResults(maxResults);
+        var items = await _reader
+            .GetExceptionsAsync(principalCountyId.Value, resolvedEra, resolvedMax, ct)
+            .ConfigureAwait(false);
+
+        return Ok(new
+        {
+            countyId = principalCountyId.Value,
+            era = resolvedEra,
+            maxResults = resolvedMax,
+            count = items.Count,
+            items,
+        });
+    }
+
+    /// <summary>
+    /// Clamps caller-supplied <c>maxResults</c> to the
+    /// reader's <c>[1, AbsoluteMaxResults]</c> range. Null
+    /// resolves to the reader's default.
+    /// </summary>
+    private static int ClampMaxResults(int? maxResults)
+    {
+        if (maxResults is null)
+        {
+            return ILandSegmentExceptionReader.DefaultMaxResults;
+        }
+        var v = maxResults.Value;
+        if (v <= 0) return ILandSegmentExceptionReader.DefaultMaxResults;
+        if (v > ILandSegmentExceptionReader.AbsoluteMaxResults)
+        {
+            return ILandSegmentExceptionReader.AbsoluteMaxResults;
+        }
+        return v;
+    }
+
+    /// <summary>
+    /// Mirrors
+    /// <see cref="SalesRatioStudyController"/>'s era normalizer —
+    /// null/whitespace resolves to
+    /// <see cref="ConversionEras.PostConversion"/>; unknown
+    /// values produce 400 with the valid-values list.
+    /// </summary>
+    private bool TryNormalizeEra(
+        string? era,
+        out string resolvedEra,
+        out IActionResult? failureResult)
+    {
+        if (string.IsNullOrWhiteSpace(era))
+        {
+            resolvedEra = ConversionEras.PostConversion;
+            failureResult = null;
+            return true;
+        }
+
+        var trimmed = era.Trim();
+        if (!ValidEraValues.Contains(trimmed))
+        {
+            _logger.LogWarning(
+                "[LandSegmentException] invalid era token: {Era}", trimmed);
+            resolvedEra = string.Empty;
+            failureResult = BadRequest(new
+            {
+                error = "invalid era",
+                validValues = ValidEraValues,
+            });
+            return false;
+        }
+
+        resolvedEra = trimmed;
+        failureResult = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Mirrors <c>SalesRatioStudyController.ResolveCountyClaim</c>.
+    /// Narrow trust surface: Guid claim only, no county-name
+    /// fallback.
+    /// </summary>
+    private Guid? ResolveCountyClaim()
+    {
+        var raw = User.FindFirst("countyId")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return Guid.TryParse(raw, out var parsed) ? parsed : null;
+    }
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1877,6 +1877,15 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.SalesRatioStudy.ISalesRatioStudyReader,
     TerraFusion.Data.Services.CanonicalTf.SalesRatioStudyReader>();
 
+// Slice F4: land-segment exception list read-model. Surfaces
+// canonical_tf.tf_land rows whose data carries doctrine-frozen
+// anomalies (missing market val, missing/zero acreage, missing
+// type/state codes). Per docs/pacs/blocks-d-through-h-design.md
+// §F.4. Read-only by contract (AsNoTracking); no writes.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.LandSegmentException.ILandSegmentExceptionReader,
+    TerraFusion.Data.Services.CanonicalTf.LandSegmentExceptionReader>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.Core/Sync/LandSegmentException/ILandSegmentExceptionReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/LandSegmentException/ILandSegmentExceptionReader.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.LandSegmentException;
+
+/// <summary>
+/// Slice F4: read-only canonical exception list over
+/// <c>canonical_tf.tf_land</c>. Per
+/// <c>docs/pacs/blocks-d-through-h-design.md</c> §F.4:
+/// surfaces land segments whose canonical row carries
+/// data anomalies that block downstream ratio / valuation
+/// work, so an operator can triage them without running
+/// raw SQL.
+///
+/// <para>v1 anomaly taxonomy (closed; doctrine-frozen):
+/// <list type="bullet">
+///   <item><see cref="ReasonMissingMarketVal"/> —
+///   <c>LandSegMarketVal IS NULL</c>.</item>
+///   <item><see cref="ReasonMissingArea"/> —
+///   <c>SizeAcres IS NULL</c> OR <c>SizeAcres = 0</c>.</item>
+///   <item><see cref="ReasonMissingTypeCd"/> —
+///   <c>LandSegTypeCd IS NULL</c> or empty.</item>
+///   <item><see cref="ReasonMissingStateCd"/> —
+///   <c>LandSegStateCd IS NULL</c> or empty.</item>
+/// </list>
+/// </para>
+///
+/// <para>Read-only by contract: no DbContext writes, no audit
+/// table mutations. <c>countyId</c> isolation enforced by the
+/// caller (the controller resolves the principal's claim and
+/// passes it here verbatim).</para>
+/// </summary>
+public interface ILandSegmentExceptionReader
+{
+    /// <summary>Reason token: market value is null.</summary>
+    public const string ReasonMissingMarketVal = "MissingMarketVal";
+
+    /// <summary>Reason token: acreage is null or zero.</summary>
+    public const string ReasonMissingArea = "MissingArea";
+
+    /// <summary>Reason token: land segment type code is null/empty.</summary>
+    public const string ReasonMissingTypeCd = "MissingTypeCd";
+
+    /// <summary>Reason token: land segment state code is null/empty.</summary>
+    public const string ReasonMissingStateCd = "MissingStateCd";
+
+    /// <summary>
+    /// Slice G3 (v1.12) parity: special <c>era</c> token that
+    /// bypasses the conversion-era filter entirely. Returns rows
+    /// regardless of their <c>ConversionEra</c> column (including
+    /// <c>NULL</c>). Used for audit / migration sweeps; not the
+    /// default.
+    /// </summary>
+    public const string EraAll = "ALL";
+
+    /// <summary>
+    /// Default upper bound on the result set. The endpoint is
+    /// designed for an operator triage panel, not bulk export;
+    /// keep a hard ceiling to avoid pulling the entire table.
+    /// </summary>
+    public const int DefaultMaxResults = 200;
+
+    /// <summary>
+    /// Hard ceiling for <c>maxResults</c>. Anything above this
+    /// gets clamped down by the controller; the reader does not
+    /// enforce the clamp — it trusts its caller.
+    /// </summary>
+    public const int AbsoluteMaxResults = 1000;
+
+    /// <summary>
+    /// Returns up to <paramref name="maxResults"/> land-segment
+    /// exception items for the given county, filtered by
+    /// conversion era. Each item bundles all anomalies for a
+    /// single segment into one row with a comma-joined
+    /// <c>ExceptionReasons</c> string.
+    /// </summary>
+    /// <param name="countyId">Sovereign-county scope.</param>
+    /// <param name="era">
+    /// Conversion-era filter per Block-C contract v1.12 §2.
+    /// Null resolves to <see cref="Entities.TruthPacs.ConversionEras.PostConversion"/>.
+    /// Recognized values: <c>POST_CONVERSION</c>,
+    /// <c>PRE_CONVERSION_2017</c>, <c>UNKNOWN</c>,
+    /// <see cref="EraAll"/>. Unrecognized values throw
+    /// <see cref="ArgumentException"/>.
+    /// </param>
+    /// <param name="maxResults">
+    /// Upper bound on returned items. Defaults to
+    /// <see cref="DefaultMaxResults"/>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<LandSegmentExceptionItem>> GetExceptionsAsync(
+        Guid countyId,
+        string? era = null,
+        int? maxResults = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Slice F4: a single exception row. Bundles every anomaly
+/// for one canonical land segment into a comma-joined
+/// <see cref="ExceptionReasons"/> string so an operator panel
+/// can render it as one row instead of one-per-reason.
+/// </summary>
+public sealed record LandSegmentExceptionItem
+{
+    public required Guid TfLandId { get; init; }
+    public required Guid TfParcelId { get; init; }
+    public string? LandSegTypeCd { get; init; }
+    public string? LandSegStateCd { get; init; }
+    public decimal? AreaAcres { get; init; }
+    public decimal? LandSegMarketVal { get; init; }
+
+    /// <summary>
+    /// Comma-joined list of reason tokens (see
+    /// <c>ILandSegmentExceptionReader.Reason*</c> constants).
+    /// Order is stable: MarketVal, Area, TypeCd, StateCd, so the
+    /// string is comparable across runs.
+    /// </summary>
+    public required string ExceptionReasons { get; init; }
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/LandSegmentExceptionReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/LandSegmentExceptionReader.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.LandSegmentException;
+
+namespace TerraFusion.Data.Services.CanonicalTf;
+
+/// <summary>
+/// Slice F4: EF-backed read-model surface for land-segment
+/// exceptions over <c>canonical_tf.tf_land</c>. Per
+/// <c>docs/pacs/blocks-d-through-h-design.md</c> §F.4.
+///
+/// <para>Read-only by contract: <c>AsNoTracking</c> on every
+/// query, no <c>SaveChangesAsync</c>. The era filter mirrors
+/// <c>SalesRatioStudyReader</c> (v1.12 §2 doctrine) including
+/// the year-fallback for pre-G2 rows whose
+/// <see cref="TfLand.ConversionEra"/> column is still <c>NULL</c>.</para>
+///
+/// <para>The reader enforces the doctrine-frozen anomaly
+/// taxonomy: any row whose <c>LandSegMarketVal</c> is
+/// <c>NULL</c>, whose <c>SizeAcres</c> is <c>NULL</c> or
+/// <c>0</c>, whose <c>LandSegTypeCd</c> is null/empty, or
+/// whose <c>LandSegStateCd</c> is null/empty matches at least
+/// one reason and is returned. Rows with no anomalies are
+/// excluded.</para>
+/// </summary>
+public sealed class LandSegmentExceptionReader : ILandSegmentExceptionReader
+{
+    private readonly TerraFusionDbContext _db;
+
+    public LandSegmentExceptionReader(TerraFusionDbContext db) => _db = db;
+
+    public async Task<IReadOnlyList<LandSegmentExceptionItem>> GetExceptionsAsync(
+        Guid countyId,
+        string? era = null,
+        int? maxResults = null,
+        CancellationToken cancellationToken = default)
+    {
+        var eraPredicate = ResolveEraPredicate(era);
+        var limit = maxResults ?? ILandSegmentExceptionReader.DefaultMaxResults;
+        if (limit <= 0)
+        {
+            return Array.Empty<LandSegmentExceptionItem>();
+        }
+        if (limit > ILandSegmentExceptionReader.AbsoluteMaxResults)
+        {
+            limit = ILandSegmentExceptionReader.AbsoluteMaxResults;
+        }
+
+        // Anomaly predicate: the row matches if ANY of the four
+        // reasons fires. EF translates each branch to SQL.
+        // Order of branches mirrors the doctrine-frozen reason
+        // string ordering (MarketVal, Area, TypeCd, StateCd).
+        var rows = await _db.TfLands
+            .AsNoTracking()
+            .Where(l => l.CountyId == countyId)
+            .Where(eraPredicate)
+            .Where(l =>
+                l.LandSegMarketVal == null
+                || l.SizeAcres == null
+                || l.SizeAcres == 0m
+                || l.LandSegTypeCd == null
+                || l.LandSegTypeCd == string.Empty
+                || l.LandSegStateCd == null
+                || l.LandSegStateCd == string.Empty)
+            // Stable ordering for paging — TfLandId is a Guid, not
+            // monotonic, but a deterministic order keeps the panel
+            // from reshuffling between calls.
+            .OrderBy(l => l.TfLandId)
+            .Take(limit)
+            .Select(l => new
+            {
+                l.TfLandId,
+                l.TfParcelId,
+                l.LandSegTypeCd,
+                l.LandSegStateCd,
+                l.SizeAcres,
+                l.LandSegMarketVal,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = new List<LandSegmentExceptionItem>(rows.Count);
+        foreach (var r in rows)
+        {
+            var reasons = BuildReasonString(
+                marketValMissing: r.LandSegMarketVal == null,
+                areaMissing: r.SizeAcres == null || r.SizeAcres == 0m,
+                typeMissing: string.IsNullOrEmpty(r.LandSegTypeCd),
+                stateMissing: string.IsNullOrEmpty(r.LandSegStateCd));
+            // Defensive: the SQL filter guarantees at least one
+            // reason fired, but if a future schema change drops a
+            // branch this skip prevents an empty-string row.
+            if (reasons.Length == 0) continue;
+
+            items.Add(new LandSegmentExceptionItem
+            {
+                TfLandId = r.TfLandId,
+                TfParcelId = r.TfParcelId,
+                LandSegTypeCd = r.LandSegTypeCd,
+                LandSegStateCd = r.LandSegStateCd,
+                AreaAcres = r.SizeAcres,
+                LandSegMarketVal = r.LandSegMarketVal,
+                ExceptionReasons = reasons,
+            });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Builds the comma-joined reason string in the doctrine-
+    /// frozen order: MarketVal, Area, TypeCd, StateCd. Empty
+    /// string when no reason fires (defensive — caller skips).
+    /// </summary>
+    private static string BuildReasonString(
+        bool marketValMissing,
+        bool areaMissing,
+        bool typeMissing,
+        bool stateMissing)
+    {
+        var sb = new StringBuilder();
+        if (marketValMissing)
+        {
+            sb.Append(ILandSegmentExceptionReader.ReasonMissingMarketVal);
+        }
+        if (areaMissing)
+        {
+            if (sb.Length > 0) sb.Append(',');
+            sb.Append(ILandSegmentExceptionReader.ReasonMissingArea);
+        }
+        if (typeMissing)
+        {
+            if (sb.Length > 0) sb.Append(',');
+            sb.Append(ILandSegmentExceptionReader.ReasonMissingTypeCd);
+        }
+        if (stateMissing)
+        {
+            if (sb.Length > 0) sb.Append(',');
+            sb.Append(ILandSegmentExceptionReader.ReasonMissingStateCd);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Slice G3 (v1.12) parity: translates an era filter token
+    /// into a <see cref="TfLand"/> predicate. Mirrors
+    /// <c>SalesRatioStudyReader.ResolveEraPredicate</c>.
+    ///
+    /// <para>Year-fallback for pre-G2 rows: <see cref="TfLand"/>
+    /// does not carry a sale date — the canonical row is
+    /// projected from <c>truth_pacs.land_current</c> which keys
+    /// on <c>(prop_val_yr, sup_num, prop_id, land_seg_id)</c>.
+    /// Pre-G2 rows have <c>ConversionEra == NULL</c>; they have
+    /// no per-row date column on <see cref="TfLand"/> itself, so
+    /// the fallback for POST/PRE matches only the explicit
+    /// column value. UNKNOWN is the canonical-disagreement
+    /// signal and never falls back.</para>
+    /// </summary>
+    private static Expression<Func<TfLand, bool>> ResolveEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == ILandSegmentExceptionReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return l => l.ConversionEra == ConversionEras.PostConversion;
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return l => l.ConversionEra == ConversionEras.PreConversion2017;
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            return l => l.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {ILandSegmentExceptionReader.EraAll}.",
+            nameof(era));
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionControllerTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.LandSegmentException;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Slice F4 acceptance tests for
+/// <see cref="LandSegmentExceptionController"/>. Auth + reader-
+/// delegation coverage; the anomaly taxonomy and era predicate
+/// are fully covered by
+/// <see cref="LandSegmentExceptionReaderTests"/>.
+///
+/// <para>Contract focus:
+/// <list type="bullet">
+///   <item>200 happy path with default era resolves to POST_CONVERSION.</item>
+///   <item>200 with explicit recognized era is echoed back in the body.</item>
+///   <item>400 with invalid era token (and the valid-values list).</item>
+///   <item>403 enforced when caller lacks the county claim.</item>
+///   <item>maxResults clamping behavior.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class LandSegmentExceptionControllerTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("19190019-1919-1919-1919-191919191919");
+    private static readonly Guid CountyB =
+        Guid.Parse("48484848-4848-4848-4848-484848484848");
+
+    private readonly TerraFusionDbContext _db;
+
+    public LandSegmentExceptionControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"f4-ctrl-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private LandSegmentExceptionController BuildController(Guid? principalCountyClaim)
+    {
+        var reader = new LandSegmentExceptionReader(_db);
+        var ctrl = new LandSegmentExceptionController(
+            reader, NullLogger<LandSegmentExceptionController>.Instance);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: principalCountyClaim is null ? null : "Test");
+        if (principalCountyClaim is not null)
+        {
+            identity.AddClaim(new Claim("countyId", principalCountyClaim.Value.ToString()));
+        }
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+            },
+        };
+        return ctrl;
+    }
+
+    private async Task SeedAnomalousLandAsync(
+        Guid countyId,
+        string? era = ConversionEras.PostConversion)
+    {
+        _db.TfLands.Add(new TfLand
+        {
+            CountyId = countyId,
+            TfParcelId = Guid.NewGuid(),
+            // null market val → MissingMarketVal anomaly fires
+            LandSegMarketVal = null,
+            SizeAcres = 5m,
+            LandSegTypeCd = "RES",
+            LandSegStateCd = "WA",
+            ConversionEra = era,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private static T ExtractProperty<T>(object? body, string name)
+    {
+        body.Should().NotBeNull();
+        var prop = body!.GetType().GetProperty(
+            name, BindingFlags.Public | BindingFlags.Instance);
+        prop.Should().NotBeNull($"response body should expose '{name}'");
+        var value = prop!.GetValue(body);
+        value.Should().BeOfType<T>();
+        return (T)value!;
+    }
+
+    [Fact]
+    public async Task GetExceptions_OmittedEra_DefaultsToPostConversion()
+    {
+        await SeedAnomalousLandAsync(CountyA, ConversionEras.PostConversion);
+        await SeedAnomalousLandAsync(CountyA, ConversionEras.PreConversion2017);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+        ExtractProperty<int>(ok.Value, "count")
+            .Should().Be(1, "default era=POST excludes the PRE row");
+    }
+
+    [Fact]
+    public async Task GetExceptions_ExplicitEraAll_BypassesFilter()
+    {
+        await SeedAnomalousLandAsync(CountyA, ConversionEras.PostConversion);
+        await SeedAnomalousLandAsync(CountyA, ConversionEras.PreConversion2017);
+        await SeedAnomalousLandAsync(CountyA, ConversionEras.Unknown);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions(era: ILandSegmentExceptionReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ILandSegmentExceptionReader.EraAll);
+        ExtractProperty<int>(ok.Value, "count").Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData("BOGUS_ERA")]
+    [InlineData("post_conversion")]
+    public async Task GetExceptions_InvalidEra_Returns400(string badEra)
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions(era: badEra);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetExceptions_NoCountyClaim_Returns403()
+    {
+        var ctrl = BuildController(principalCountyClaim: null);
+        var result = await ctrl.GetExceptions();
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetExceptions_CrossCounty_NotLeaked()
+    {
+        // Caller is CountyA; only CountyB has anomalies.
+        // The endpoint resolves countyId from the claim, so the
+        // caller can never see CountyB's rows.
+        await SeedAnomalousLandAsync(CountyB);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<int>(ok.Value, "count")
+            .Should().Be(0, "claim-scoped query never crosses counties");
+        ExtractProperty<Guid>(ok.Value, "countyId")
+            .Should().Be(CountyA);
+    }
+
+    [Fact]
+    public async Task GetExceptions_DefaultMaxResults_EchoedInResponse()
+    {
+        await SeedAnomalousLandAsync(CountyA);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<int>(ok.Value, "maxResults")
+            .Should().Be(ILandSegmentExceptionReader.DefaultMaxResults);
+    }
+
+    [Fact]
+    public async Task GetExceptions_MaxResultsAboveCeiling_ClampedTo1000()
+    {
+        await SeedAnomalousLandAsync(CountyA);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions(maxResults: 99_999);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<int>(ok.Value, "maxResults")
+            .Should().Be(ILandSegmentExceptionReader.AbsoluteMaxResults);
+    }
+
+    [Fact]
+    public async Task GetExceptions_NegativeMaxResults_ResolvedToDefault()
+    {
+        await SeedAnomalousLandAsync(CountyA);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions(maxResults: -1);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<int>(ok.Value, "maxResults")
+            .Should().Be(ILandSegmentExceptionReader.DefaultMaxResults);
+    }
+
+    [Fact]
+    public async Task EraTrimWhitespace_AcceptedAsEquivalent()
+    {
+        await SeedAnomalousLandAsync(CountyA);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetExceptions(era: "  POST_CONVERSION  ");
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionReaderTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionReaderTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.LandSegmentException;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Slice F4 acceptance tests for
+/// <see cref="LandSegmentExceptionReader"/>. Per
+/// <c>docs/pacs/blocks-d-through-h-design.md</c> §F.4.
+///
+/// <para>Proves the reader's anomaly taxonomy is correctly
+/// applied: each of the four reasons (MissingMarketVal,
+/// MissingArea, MissingTypeCd, MissingStateCd) fires
+/// independently, multi-anomaly rows produce comma-joined
+/// reason strings, clean rows are excluded, county isolation
+/// is honored, and the era filter produces the same shape as
+/// <see cref="SalesRatioStudyReader"/> v1.12.</para>
+/// </summary>
+public sealed class LandSegmentExceptionReaderTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public LandSegmentExceptionReaderTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"f4-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private LandSegmentExceptionReader Build() => new(_db);
+
+    private async Task<TfLand> SeedLandAsync(
+        Guid countyId,
+        decimal? marketVal,
+        decimal? sizeAcres,
+        string? typeCd,
+        string? stateCd,
+        string? era = ConversionEras.PostConversion,
+        Guid? tfParcelId = null,
+        Guid? tfLandId = null)
+    {
+        var land = new TfLand
+        {
+            TfLandId = tfLandId ?? Guid.NewGuid(),
+            CountyId = countyId,
+            TfParcelId = tfParcelId ?? Guid.NewGuid(),
+            LandSegTypeCd = typeCd,
+            LandSegStateCd = stateCd,
+            SizeAcres = sizeAcres,
+            LandSegMarketVal = marketVal,
+            ConversionEra = era,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        };
+        _db.TfLands.Add(land);
+        await _db.SaveChangesAsync();
+        return land;
+    }
+
+    [Fact]
+    public async Task NullMarketVal_FlaggedMissingMarketVal()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingMarketVal);
+        items[0].LandSegMarketVal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task NullAcres_FlaggedMissingArea()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: null, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingArea);
+    }
+
+    [Fact]
+    public async Task ZeroAcres_FlaggedMissingArea()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 0m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingArea);
+        items[0].AreaAcres.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task NullTypeCd_FlaggedMissingTypeCd()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 5m, typeCd: null, stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingTypeCd);
+    }
+
+    [Fact]
+    public async Task EmptyTypeCd_FlaggedMissingTypeCd()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 5m, typeCd: string.Empty, stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingTypeCd);
+    }
+
+    [Fact]
+    public async Task NullStateCd_FlaggedMissingStateCd()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 5m, typeCd: "RES", stateCd: null);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingStateCd);
+    }
+
+    [Fact]
+    public async Task EmptyStateCd_FlaggedMissingStateCd()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 5m, typeCd: "RES", stateCd: string.Empty);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be(ILandSegmentExceptionReader.ReasonMissingStateCd);
+    }
+
+    [Fact]
+    public async Task MultipleAnomalies_JoinedInDoctrineOrder()
+    {
+        var county = Guid.NewGuid();
+        // All four anomalies fire on this row.
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 0m, typeCd: null, stateCd: null);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be("MissingMarketVal,MissingArea,MissingTypeCd,MissingStateCd",
+                "doctrine order is MarketVal, Area, TypeCd, StateCd");
+    }
+
+    [Fact]
+    public async Task PartialAnomalies_OnlyFiringReasonsListed()
+    {
+        var county = Guid.NewGuid();
+        // MarketVal + StateCd missing; Area + TypeCd present.
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: null);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].ExceptionReasons.Should()
+            .Be("MissingMarketVal,MissingStateCd");
+    }
+
+    [Fact]
+    public async Task CleanRow_Excluded()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: 100_000m, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().BeEmpty(
+            "rows with no anomalies must be filtered out");
+    }
+
+    [Fact]
+    public async Task CountyIsolation_OtherCountiesExcluded()
+    {
+        var benton = Guid.NewGuid();
+        var franklin = Guid.NewGuid();
+        await SeedLandAsync(benton,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+        await SeedLandAsync(franklin,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(benton);
+
+        items.Should().HaveCount(1, "only the requested county's rows return");
+    }
+
+    [Fact]
+    public async Task EraFilter_DefaultPostConversion()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PostConversion);
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PreConversion2017);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1,
+            "default era=POST_CONVERSION excludes the PRE row");
+    }
+
+    [Fact]
+    public async Task EraFilter_AllBypasses()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PostConversion);
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PreConversion2017);
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.Unknown);
+
+        var items = await Build()
+            .GetExceptionsAsync(county, era: ILandSegmentExceptionReader.EraAll);
+
+        items.Should().HaveCount(3,
+            "ALL bypasses the era filter regardless of column value");
+    }
+
+    [Fact]
+    public async Task EraFilter_PreConversionExplicit()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PostConversion);
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA",
+            era: ConversionEras.PreConversion2017);
+
+        var items = await Build()
+            .GetExceptionsAsync(county, era: ConversionEras.PreConversion2017);
+
+        items.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task EraFilter_InvalidThrows()
+    {
+        var county = Guid.NewGuid();
+
+        var act = () => Build().GetExceptionsAsync(county, era: "BOGUS");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task MaxResults_RespectsLimit()
+    {
+        var county = Guid.NewGuid();
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedLandAsync(county,
+                marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+        }
+
+        var items = await Build().GetExceptionsAsync(county, maxResults: 3);
+
+        items.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task MaxResults_ClampedToAbsoluteCeiling()
+    {
+        var county = Guid.NewGuid();
+        // Reader clamps caller-supplied maxResults > AbsoluteMaxResults.
+        // We don't seed 1001 rows; we seed 2 and assert the call doesn't
+        // error and returns what's there.
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county, maxResults: 5000);
+
+        items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task MaxResults_ZeroOrNegativeReturnsEmpty()
+    {
+        var county = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 5m, typeCd: "RES", stateCd: "WA");
+
+        var items = await Build().GetExceptionsAsync(county, maxResults: 0);
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItemPayload_PropagatesAllExpectedColumns()
+    {
+        var county = Guid.NewGuid();
+        var tfLandId = Guid.NewGuid();
+        var tfParcelId = Guid.NewGuid();
+        await SeedLandAsync(county,
+            marketVal: null, sizeAcres: 1.25m, typeCd: "AG", stateCd: "WA",
+            tfLandId: tfLandId, tfParcelId: tfParcelId);
+
+        var items = await Build().GetExceptionsAsync(county);
+
+        items.Should().HaveCount(1);
+        items[0].TfLandId.Should().Be(tfLandId);
+        items[0].TfParcelId.Should().Be(tfParcelId);
+        items[0].LandSegTypeCd.Should().Be("AG");
+        items[0].LandSegStateCd.Should().Be("WA");
+        items[0].AreaAcres.Should().Be(1.25m);
+        items[0].LandSegMarketVal.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Implements Block F4 per `docs/pacs/blocks-d-through-h-design.md` §F.4: a read-only canonical surface for land segments with data anomalies, so an operator can triage exception cases without raw SQL against `canonical_tf.tf_land`.

- **Anomaly taxonomy (closed/doctrine-frozen):** `MissingMarketVal`, `MissingArea` (NULL or 0 acres), `MissingTypeCd` (null/empty), `MissingStateCd` (null/empty)
- **Multi-anomaly rows** are bundled into a single item with a comma-joined `ExceptionReasons` string in stable doctrine order (MarketVal, Area, TypeCd, StateCd)
- **Era filter** mirrors `SalesRatioStudyController` v1.12 (G3) — default `POST_CONVERSION`, `ALL` bypasses, invalid token → 400
- **County isolation:** endpoint resolves `countyId` from the principal's `countyId` claim (no path segment); missing claim → 403, never leaks cross-county
- **Read-only** by contract (`AsNoTracking`); zero DbContext writes

## Endpoint

`GET /api/land/exceptions?era={string?}&maxResults={int?}`

- `era` defaults to `POST_CONVERSION`; `maxResults` defaults to 200, clamped to absolute max 1000

## Files

- `backend/src/TerraFusion.Core/Sync/LandSegmentException/ILandSegmentExceptionReader.cs` — interface + `LandSegmentExceptionItem` DTO + reason-token constants
- `backend/src/TerraFusion.Data/Services/CanonicalTf/LandSegmentExceptionReader.cs` — EF implementation with era predicate
- `backend/src/TerraFusion.API/Controllers/LandSegmentExceptionController.cs` — controller (auth, era normalization, maxResults clamp)
- `backend/src/TerraFusion.API/Program.cs` — DI registration
- `backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionReaderTests.cs` — 19 reader tests
- `backend/tests/TerraFusion.Unit.Tests/CanonicalTf/LandSegmentExceptionControllerTests.cs` — 10 controller tests

## Test plan

- [x] Build: 0 warnings, 0 errors (Debug + Release)
- [x] Unit.Tests: 3057/3057 passing (3028 baseline + 29 new F4 tests)
- [x] Reader covers all four anomaly types (incl. NULL vs zero acres, NULL vs empty string for codes)
- [x] Reader covers multi-anomaly comma-joined ordering
- [x] Reader excludes clean rows
- [x] Reader honors county isolation
- [x] Reader era filter: default POST, explicit PRE, ALL bypass, invalid throws
- [x] Reader maxResults: clamping above 1000, negative → default, zero → empty
- [x] Controller: 200 happy path, 400 invalid era, 403 missing county claim, cross-county never leaks
- [x] Controller: era trimming, maxResults clamping echoed in response

## Naming note

Task spec used `AreaAcres` for the size column; the canonical entity ships as `TfLand.SizeAcres`. The DTO surfaces it as `AreaAcres` for the operator-facing wire contract while the EF query reads `SizeAcres` verbatim — caller-friendly name without renaming the entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint `/api/land/exceptions` to retrieve land segment exception data.
  * Supports optional filtering by era and configurable result limits.
  * Includes authorization checks to ensure secure county-scoped access.
  * Returns detailed exception information including affected land parcels and specific anomaly types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->