### PR TITLE
feat(sync): SYNC-F3 — improvement field-check queue read-model

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/ImprovementFieldCheckQueueController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ImprovementFieldCheckQueueController.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.ImprovementFieldCheck;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// Block F3: read-only endpoint for the improvement field-check
+/// triage queue. Surfaces canonical improvements that need a
+/// physical re-verification visit — most usefully the rows where
+/// SYNC-DOCTRINE-4 has classified the universe but per-component
+/// features are still blank or not yet linked to a canonical
+/// dictionary attribute.
+///
+/// <para><c>GET /api/improvements/field-check-queue</c></para>
+///
+/// <para>Contract:
+/// <list type="bullet">
+///   <item>401 if the request is unauthenticated (handled by
+///   <c>[Authorize]</c>).</item>
+///   <item>403 if the caller's <c>countyId</c> claim is missing
+///   (cannot enforce sovereign-county isolation).</item>
+///   <item>400 if <c>era</c> is non-empty and not in the doctrine
+///   set (POST_CONVERSION / PRE_CONVERSION_2017 / UNKNOWN / ALL).</item>
+///   <item>400 if <c>universe</c> is non-empty and not in
+///   <see cref="UniverseCodes.AllIncludingUnknown"/>.</item>
+///   <item>200 with a typed list body when authorized.</item>
+/// </list>
+/// </para>
+///
+/// <para>Read-only by contract: no DbContext writes, no audit-table
+/// mutations, no PII surfaced. Empty queue returns 200 with an
+/// empty <c>items</c> list (operator gets a clean "nothing to do
+/// right now" view, not a 404).</para>
+/// </summary>
+[ApiController]
+[Route("api/improvements")]
+public sealed class ImprovementFieldCheckQueueController : ControllerBase
+{
+    /// <summary>
+    /// G3 doctrine-frozen valid era tokens. Mirrors the same set
+    /// declared on <c>SalesRatioStudyController</c>; the doctrine
+    /// extraction to a shared helper hasn't landed on this branch
+    /// yet, so F3 re-declares the set in the same shape.
+    /// </summary>
+    private static readonly IReadOnlySet<string> ValidEraValues =
+        new HashSet<string>
+        {
+            ConversionEras.PostConversion,
+            ConversionEras.PreConversion2017,
+            ConversionEras.Unknown,
+            IImprovementFieldCheckReader.EraAll,
+        };
+
+    private readonly IImprovementFieldCheckReader _reader;
+    private readonly ILogger<ImprovementFieldCheckQueueController> _logger;
+
+    public ImprovementFieldCheckQueueController(
+        IImprovementFieldCheckReader reader,
+        ILogger<ImprovementFieldCheckQueueController> logger)
+    {
+        _reader = reader;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// F3: read the field-check queue for the caller's county.
+    /// </summary>
+    [HttpGet("field-check-queue")]
+    [Authorize]
+    public async Task<IActionResult> GetFieldCheckQueue(
+        [FromQuery] string? universe = null,
+        [FromQuery] string? era = null,
+        [FromQuery] bool missingFeaturesOnly = false,
+        [FromQuery] short? minYearBuilt = null,
+        [FromQuery] short? maxYearBuilt = null,
+        [FromQuery] int? maxResults = null,
+        CancellationToken ct = default)
+    {
+        var principalCountyId = ResolveCountyClaim();
+        if (principalCountyId is null)
+        {
+            _logger.LogWarning(
+                "[ImprovementFieldCheckQueue] missing countyId claim on principal; refusing.");
+            return Forbid();
+        }
+
+        var resolvedUniverse = string.IsNullOrWhiteSpace(universe) ? null : universe.Trim();
+        if (resolvedUniverse is not null && !UniverseCodes.IsKnown(resolvedUniverse))
+        {
+            _logger.LogWarning(
+                "[ImprovementFieldCheckQueue] invalid universe token: {Universe}",
+                universe);
+            return BadRequest(new
+            {
+                error = "invalid universe",
+                validValues = UniverseCodes.AllIncludingUnknown,
+            });
+        }
+
+        if (!TryNormalizeEra(era, out var resolvedEra, out var eraFail))
+            return eraFail!;
+
+        var items = await _reader
+            .GetFieldCheckQueueAsync(
+                principalCountyId.Value,
+                resolvedUniverse,
+                resolvedEra,
+                missingFeaturesOnly,
+                minYearBuilt,
+                maxYearBuilt,
+                maxResults,
+                ct)
+            .ConfigureAwait(false);
+
+        return Ok(new
+        {
+            countyId = principalCountyId.Value,
+            universe = resolvedUniverse,
+            era = resolvedEra,
+            missingFeaturesOnly,
+            minYearBuilt,
+            maxYearBuilt,
+            maxResults = items.Count,
+            items,
+        });
+    }
+
+    /// <summary>
+    /// G3 (v1.12): normalizes the <c>era</c> query parameter.
+    /// Null/whitespace resolves to <see cref="ConversionEras.PostConversion"/>
+    /// (the documented default). Unrecognized values produce 400 with
+    /// the valid value list. Returns the resolved string for echo.
+    /// </summary>
+    private bool TryNormalizeEra(
+        string? era,
+        out string resolvedEra,
+        out IActionResult? failureResult)
+    {
+        if (string.IsNullOrWhiteSpace(era))
+        {
+            resolvedEra = ConversionEras.PostConversion;
+            failureResult = null;
+            return true;
+        }
+
+        var trimmed = era.Trim();
+        if (!ValidEraValues.Contains(trimmed))
+        {
+            _logger.LogWarning(
+                "[ImprovementFieldCheckQueue] invalid era token: {Era}", trimmed);
+            resolvedEra = string.Empty;
+            failureResult = BadRequest(new
+            {
+                error = "invalid era",
+                validValues = ValidEraValues,
+            });
+            return false;
+        }
+
+        resolvedEra = trimmed;
+        failureResult = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Mirrors <c>SalesRatioStudyController.ResolveCountyClaim</c> —
+    /// Guid claim only, no county-name fallback.
+    /// </summary>
+    private Guid? ResolveCountyClaim()
+    {
+        var raw = User.FindFirst("countyId")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        return Guid.TryParse(raw, out var parsed) ? parsed : null;
+    }
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1877,6 +1877,14 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.SalesRatioStudy.ISalesRatioStudyReader,
     TerraFusion.Data.Services.CanonicalTf.SalesRatioStudyReader>();
 
+// Block F3: improvement field-check queue read-model. Surfaces
+// canonical_tf.tf_improvement rows that need a physical re-look —
+// principally those with no AttributeId-resolved features. Per
+// docs/pacs/blocks-d-through-h-design.md §"F3". Read-only.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.ImprovementFieldCheck.IImprovementFieldCheckReader,
+    TerraFusion.Data.Services.CanonicalTf.ImprovementFieldCheckReader>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.Core/Sync/ImprovementFieldCheck/IImprovementFieldCheckReader.cs
+++ b/backend/src/TerraFusion.Core/Sync/ImprovementFieldCheck/IImprovementFieldCheckReader.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.ImprovementFieldCheck;
+
+/// <summary>
+/// Block F3: read-only canonical-equivalent of the operator's
+/// "improvements that need a physical re-verification visit"
+/// triage queue.
+///
+/// <para>Per <c>docs/pacs/blocks-d-through-h-design.md</c> §"F3":
+/// surfaces improvements from <c>canonical_tf.tf_improvement</c> that
+/// the assessor's office needs to look at — most usefully the rows
+/// where SYNC-DOCTRINE-4 has classified the universe but the per-
+/// component features (<c>tf_improvement_feature</c>) are still
+/// blank or do not yet carry an <c>AttributeId</c> linkage. Those
+/// are the rows where the data quality gap is between the cabinet
+/// and the field.</para>
+///
+/// <para>v1 simplifications:
+/// <list type="bullet">
+///   <item>County-scoped (single county per call) — sovereign
+///   isolation enforced at controller via <c>countyId</c> claim,
+///   belt-and-suspenders enforced again here.</item>
+///   <item>Aggregate-only output: returns
+///   <see cref="ImprovementFieldCheckItem"/> rows that already
+///   carry the parcel + universe + feature counts the queue panel
+///   needs. Per-feature drill-down stays on the existing
+///   improvement/feature controllers.</item>
+///   <item>Era filter mirrors G3 doctrine — defaults to
+///   <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.PostConversion"/>;
+///   <see cref="EraAll"/> bypasses; pre-G2 NULL-era rows fall back
+///   to no-era-classification (NULL-only included under
+///   <see cref="EraAll"/>).</item>
+///   <item>Universe filter accepts any value in
+///   <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes.AllIncludingUnknown"/>;
+///   null skips the filter.</item>
+///   <item><c>missingFeaturesOnly = true</c> excludes any improvement
+///   that has at least one <c>tf_improvement_feature</c> row with a
+///   non-null <c>AttributeId</c> — the dictionary-resolved features.
+///   Improvements with only un-resolved feature rows still surface as
+///   "missing" because the field hasn't told us what those features
+///   actually are.</item>
+/// </list>
+/// </para>
+///
+/// <para>Read-only by contract: no DbContext writes, no audit-table
+/// mutations, no PII surfaced. Empty datasets return an empty list
+/// (operator gets a clean "queue is empty" view, not a 404).</para>
+/// </summary>
+public interface IImprovementFieldCheckReader
+{
+    /// <summary>
+    /// Default page size when the caller omits <c>maxResults</c>. The
+    /// queue panel renders one row at a time so this is sized to fit
+    /// "what an appraiser will pull up to triage in a session" rather
+    /// than "everything that's broken".
+    /// </summary>
+    public const int DefaultMaxResults = 200;
+
+    /// <summary>
+    /// Hard ceiling on <c>maxResults</c>. Anything above this is
+    /// clamped down to <see cref="MaxAllowedResults"/>; the read
+    /// surface refuses to materialize an arbitrarily large list.
+    /// </summary>
+    public const int MaxAllowedResults = 1000;
+
+    /// <summary>
+    /// G3-style sentinel that bypasses the era filter entirely.
+    /// Mirrors <c>ISalesRatioStudyReader.EraAll</c> so callers can
+    /// audit cross-era field-check backlogs.
+    /// </summary>
+    public const string EraAll = "ALL";
+
+    /// <summary>
+    /// F3: read the field-check queue for a county.
+    /// </summary>
+    /// <param name="countyId">Sovereign-county scope.</param>
+    /// <param name="universeCode">
+    /// Optional universe filter. When non-null, must be a value in
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes.AllIncludingUnknown"/>;
+    /// invalid values throw <see cref="ArgumentException"/>.
+    /// Controller validates first and returns 400 before invoking
+    /// the reader, but the reader keeps a defensive throw to honor
+    /// the contract on direct callers.
+    /// </param>
+    /// <param name="era">
+    /// Conversion-era filter per Block-C contract v1.12 §2. Null
+    /// resolves to <see cref="TerraFusion.Core.Entities.TruthPacs.ConversionEras.PostConversion"/>.
+    /// Recognized values: <c>POST_CONVERSION</c>, <c>PRE_CONVERSION_2017</c>,
+    /// <c>UNKNOWN</c>, <see cref="EraAll"/>. Unknown values throw
+    /// <see cref="ArgumentException"/>.
+    /// </param>
+    /// <param name="missingFeaturesOnly">
+    /// When true, return only improvements with NO
+    /// <c>tf_improvement_feature</c> row whose <c>AttributeId</c> is
+    /// non-null — the true-gap rows the assessor needs eyes on.
+    /// </param>
+    /// <param name="minYearBuilt">
+    /// Optional lower bound on <c>YearBuilt</c> (inclusive).
+    /// </param>
+    /// <param name="maxYearBuilt">
+    /// Optional upper bound on <c>YearBuilt</c> (inclusive).
+    /// </param>
+    /// <param name="maxResults">
+    /// Page size; defaults to <see cref="DefaultMaxResults"/>; clamped
+    /// to <see cref="MaxAllowedResults"/>; values &lt; 1 are rounded
+    /// up to 1.
+    /// </param>
+    Task<IReadOnlyList<ImprovementFieldCheckItem>> GetFieldCheckQueueAsync(
+        Guid countyId,
+        string? universeCode = null,
+        string? era = null,
+        bool missingFeaturesOnly = false,
+        short? minYearBuilt = null,
+        short? maxYearBuilt = null,
+        int? maxResults = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Block F3: a single row in the field-check queue. Carries the
+/// minimum the operator panel needs to render and rank — universe
+/// classification, parcel linkage, age, and the feature-coverage
+/// counters that explain WHY the row is in the queue.
+/// </summary>
+public sealed record ImprovementFieldCheckItem
+{
+    /// <summary>Canonical improvement identity (TF-native).</summary>
+    public required Guid TfImprovementId { get; init; }
+
+    /// <summary>Canonical parcel FK.</summary>
+    public required Guid TfParcelId { get; init; }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-4 universe classification, forwarded from
+    /// truth. Null only on improvements promoted before D4-IMPL.
+    /// </summary>
+    public required string? UniverseCode { get; init; }
+
+    /// <summary>PACS improvement type code (R, MH, C, etc).</summary>
+    public required string? ImprvTypeCd { get; init; }
+
+    /// <summary>Free-form description from PACS.</summary>
+    public required string? ImprvDesc { get; init; }
+
+    /// <summary>Construction year-built (chronological).</summary>
+    public required short? YearBuilt { get; init; }
+
+    /// <summary>
+    /// PACS effective year-built — adjusted for major renovations.
+    /// Often the more useful number for triage.
+    /// </summary>
+    public required short? EffectiveYearBuilt { get; init; }
+
+    /// <summary>
+    /// Total <c>tf_improvement_feature</c> rows attached to this
+    /// improvement (any AttributeId state).
+    /// </summary>
+    public required int FeatureCount { get; init; }
+
+    /// <summary>
+    /// <c>tf_improvement_feature</c> rows with a non-null
+    /// <c>AttributeId</c>. Below <see cref="FeatureCount"/> means
+    /// some features have not yet been linked to the canonical
+    /// dictionary.
+    /// </summary>
+    public required int AttributedFeatureCount { get; init; }
+
+    /// <summary>
+    /// Short human-readable hint of why the row is in the queue.
+    /// One of: <c>NO_FEATURES</c> (zero feature rows),
+    /// <c>NO_ATTRIBUTED_FEATURES</c> (rows exist but none resolve to
+    /// AttributeId), <c>PARTIAL_ATTRIBUTION</c> (some rows resolved,
+    /// some not), <c>FULLY_ATTRIBUTED</c> (every row resolved — only
+    /// surfaced when <c>missingFeaturesOnly = false</c>).
+    /// </summary>
+    public required string ReviewReason { get; init; }
+}

--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/ImprovementFieldCheckReader.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/ImprovementFieldCheckReader.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.ImprovementFieldCheck;
+
+namespace TerraFusion.Data.Services.CanonicalTf;
+
+/// <summary>
+/// Block F3: EF-backed read-model for the improvement field-check
+/// queue. Joins <c>canonical_tf.tf_improvement</c> with the per-
+/// component <c>tf_improvement_feature</c> rows to surface the
+/// "needs an in-the-field re-look" backlog.
+///
+/// <para>Read-only by contract: <c>AsNoTracking</c> on every
+/// query, no <c>SaveChangesAsync</c>. The reader DOES enforce
+/// county isolation as belt-and-suspenders behind the controller's
+/// claim check.</para>
+/// </summary>
+public sealed class ImprovementFieldCheckReader : IImprovementFieldCheckReader
+{
+    private readonly TerraFusionDbContext _db;
+
+    public ImprovementFieldCheckReader(TerraFusionDbContext db) => _db = db;
+
+    public async Task<IReadOnlyList<ImprovementFieldCheckItem>> GetFieldCheckQueueAsync(
+        Guid countyId,
+        string? universeCode = null,
+        string? era = null,
+        bool missingFeaturesOnly = false,
+        short? minYearBuilt = null,
+        short? maxYearBuilt = null,
+        int? maxResults = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (universeCode is not null && !UniverseCodes.IsKnown(universeCode))
+        {
+            throw new ArgumentException(
+                $"Unrecognized universeCode '{universeCode}'. Valid values: " +
+                string.Join(", ", UniverseCodes.AllIncludingUnknown) + ".",
+                nameof(universeCode));
+        }
+
+        var resolvedTake = ResolveMaxResults(maxResults);
+        var eraPredicate = ResolveEraPredicate(era);
+
+        var query = _db.TfImprovements
+            .AsNoTracking()
+            .Where(i => i.CountyId == countyId)
+            .Where(eraPredicate);
+
+        if (universeCode is not null)
+        {
+            query = query.Where(i => i.UniverseCode == universeCode);
+        }
+
+        if (minYearBuilt is not null)
+        {
+            query = query.Where(i => i.YearBuilt != null && i.YearBuilt >= minYearBuilt);
+        }
+        if (maxYearBuilt is not null)
+        {
+            query = query.Where(i => i.YearBuilt != null && i.YearBuilt <= maxYearBuilt);
+        }
+
+        // Project (improvement, total feature count, attributed
+        // count) in one shot. Group on FK so we don't materialize
+        // every feature row. EF in-memory provider handles this
+        // pattern; Postgres will translate via a correlated subquery.
+        var projected = query
+            .Select(i => new
+            {
+                i.TfImprovementId,
+                i.TfParcelId,
+                i.UniverseCode,
+                i.ImprvTypeCd,
+                i.ImprvDesc,
+                i.YearBuilt,
+                i.EffectiveYearBuilt,
+                FeatureCount = _db.TfImprovementFeatures
+                    .Count(f => f.TfImprovementId == i.TfImprovementId),
+                AttributedFeatureCount = _db.TfImprovementFeatures
+                    .Count(f => f.TfImprovementId == i.TfImprovementId
+                                && f.AttributeId != null),
+            });
+
+        if (missingFeaturesOnly)
+        {
+            // True-gap rows: NO feature row carries a resolved
+            // AttributeId. Includes "zero feature rows at all" and
+            // "feature rows exist but none resolve" — both are
+            // visits-the-field-needs-to-make.
+            projected = projected.Where(x => x.AttributedFeatureCount == 0);
+        }
+
+        var rows = await projected
+            // Stable triage ordering: oldest YearBuilt first (the
+            // re-look backlog skews toward older stock), then
+            // deterministic ID for ties.
+            .OrderBy(x => x.YearBuilt ?? short.MaxValue)
+            .ThenBy(x => x.TfImprovementId)
+            .Take(resolvedTake)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows
+            .Select(x => new ImprovementFieldCheckItem
+            {
+                TfImprovementId = x.TfImprovementId,
+                TfParcelId = x.TfParcelId,
+                UniverseCode = x.UniverseCode,
+                ImprvTypeCd = x.ImprvTypeCd,
+                ImprvDesc = x.ImprvDesc,
+                YearBuilt = x.YearBuilt,
+                EffectiveYearBuilt = x.EffectiveYearBuilt,
+                FeatureCount = x.FeatureCount,
+                AttributedFeatureCount = x.AttributedFeatureCount,
+                ReviewReason = ResolveReviewReason(
+                    x.FeatureCount,
+                    x.AttributedFeatureCount),
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Clamps <paramref name="maxResults"/> to
+    /// [1, <see cref="IImprovementFieldCheckReader.MaxAllowedResults"/>],
+    /// defaulting null to
+    /// <see cref="IImprovementFieldCheckReader.DefaultMaxResults"/>.
+    /// </summary>
+    private static int ResolveMaxResults(int? maxResults)
+    {
+        if (maxResults is null)
+            return IImprovementFieldCheckReader.DefaultMaxResults;
+        if (maxResults < 1) return 1;
+        if (maxResults > IImprovementFieldCheckReader.MaxAllowedResults)
+            return IImprovementFieldCheckReader.MaxAllowedResults;
+        return maxResults.Value;
+    }
+
+    /// <summary>
+    /// Block-C contract v1.12 §2 era predicate adapted to
+    /// <c>tf_improvement</c>. Improvements have no date column to
+    /// fall back on (YearBuilt is construction year, NOT capture
+    /// year), so pre-G2 NULL-era rows fall through only under the
+    /// <c>ALL</c> sentinel. POST/PRE/UNKNOWN match the column value
+    /// strictly.
+    /// </summary>
+    private static Expression<Func<TfImprovement, bool>> ResolveEraPredicate(string? era)
+    {
+        var resolved = era ?? ConversionEras.PostConversion;
+
+        if (resolved == IImprovementFieldCheckReader.EraAll)
+        {
+            return _ => true;
+        }
+        if (resolved == ConversionEras.PostConversion)
+        {
+            return i => i.ConversionEra == ConversionEras.PostConversion;
+        }
+        if (resolved == ConversionEras.PreConversion2017)
+        {
+            return i => i.ConversionEra == ConversionEras.PreConversion2017;
+        }
+        if (resolved == ConversionEras.Unknown)
+        {
+            return i => i.ConversionEra == ConversionEras.Unknown;
+        }
+
+        throw new ArgumentException(
+            $"Unrecognized era '{era}'. Valid values: " +
+            $"{ConversionEras.PostConversion}, {ConversionEras.PreConversion2017}, " +
+            $"{ConversionEras.Unknown}, {IImprovementFieldCheckReader.EraAll}.",
+            nameof(era));
+    }
+
+    /// <summary>
+    /// Maps the (total, attributed) feature counts to the contract's
+    /// closed vocabulary of review reasons. Pure function so
+    /// controllers and tests can re-invoke if needed.
+    /// </summary>
+    private static string ResolveReviewReason(int total, int attributed)
+    {
+        if (total == 0) return "NO_FEATURES";
+        if (attributed == 0) return "NO_ATTRIBUTED_FEATURES";
+        if (attributed < total) return "PARTIAL_ATTRIBUTION";
+        return "FULLY_ATTRIBUTED";
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ImprovementFieldCheckQueueControllerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ImprovementFieldCheckQueueControllerTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.ImprovementFieldCheck;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Block F3 acceptance tests for
+/// <see cref="ImprovementFieldCheckQueueController"/>. Auth +
+/// boundary-validation coverage; the filter behavior itself is fully
+/// covered by <see cref="ImprovementFieldCheckReaderTests"/>.
+/// </summary>
+public sealed class ImprovementFieldCheckQueueControllerTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid CountyB =
+        Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly TerraFusionDbContext _db;
+
+    public ImprovementFieldCheckQueueControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"f3-ctrl-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ImprovementFieldCheckQueueController BuildController(Guid? principalCountyClaim)
+    {
+        var reader = new ImprovementFieldCheckReader(_db);
+        var ctrl = new ImprovementFieldCheckQueueController(
+            reader,
+            NullLogger<ImprovementFieldCheckQueueController>.Instance);
+
+        var identity = new ClaimsIdentity(
+            authenticationType: principalCountyClaim is null ? null : "Test");
+        if (principalCountyClaim is not null)
+        {
+            identity.AddClaim(new Claim("countyId", principalCountyClaim.Value.ToString()));
+        }
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity),
+            },
+        };
+        return ctrl;
+    }
+
+    private async Task<Guid> SeedImprovementAsync(
+        Guid countyId,
+        string? universe,
+        string? era,
+        short? yearBuilt = 1995)
+    {
+        var id = Guid.NewGuid();
+        _db.TfImprovements.Add(new TfImprovement
+        {
+            TfImprovementId = id,
+            CountyId = countyId,
+            TfParcelId = Guid.NewGuid(),
+            ImprvTypeCd = "R",
+            ImprvDesc = "Stick-built",
+            YearBuilt = yearBuilt,
+            EffectiveYearBuilt = yearBuilt,
+            UniverseCode = universe,
+            ConversionEra = era,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// The controller wraps each response in an anonymous-type
+    /// projection (countyId, era, items, ...). Reflection-extract
+    /// keeps tests independent of those types.
+    /// </summary>
+    private static T ExtractProperty<T>(object? body, string name)
+    {
+        body.Should().NotBeNull();
+        var prop = body!.GetType().GetProperty(
+            name, BindingFlags.Public | BindingFlags.Instance);
+        prop.Should().NotBeNull($"response body should expose '{name}'");
+        var value = prop!.GetValue(body);
+        if (value is null)
+        {
+            // Allow nullable extracted types
+            default(T).Should().BeAssignableTo<T?>();
+            return default!;
+        }
+        value.Should().BeAssignableTo<T>();
+        return (T)value!;
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_NoCountyClaim_Returns403()
+    {
+        var ctrl = BuildController(principalCountyClaim: null);
+        var result = await ctrl.GetFieldCheckQueue();
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_InvalidUniverse_Returns400()
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue(universe: "BOGUS_UNIVERSE");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_InvalidEra_Returns400()
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue(era: "BOGUS_ERA");
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_DefaultEra_ResolvesPostConversion()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PreConversion2017);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(ConversionEras.PostConversion);
+        var items = ExtractProperty<IReadOnlyList<ImprovementFieldCheckItem>>(
+            ok.Value, "items");
+        items.Should().HaveCount(1, "default POST excludes pre-conversion row");
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_UniverseFilter_NarrowsResults()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealCommercial, ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue(
+            universe: UniverseCodes.RealCommercial);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = ExtractProperty<IReadOnlyList<ImprovementFieldCheckItem>>(
+            ok.Value, "items");
+        items.Should().HaveCount(1);
+        items[0].UniverseCode.Should().Be(UniverseCodes.RealCommercial);
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_EraAll_BypassesFilter()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PreConversion2017);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue(
+            era: IImprovementFieldCheckReader.EraAll);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<string>(ok.Value, "era")
+            .Should().Be(IImprovementFieldCheckReader.EraAll);
+        var items = ExtractProperty<IReadOnlyList<ImprovementFieldCheckItem>>(
+            ok.Value, "items");
+        items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_CountyIsolation_OtherCountyInvisible()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyB, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = ExtractProperty<IReadOnlyList<ImprovementFieldCheckItem>>(
+            ok.Value, "items");
+        items.Should().HaveCount(1, "County B's improvement is not visible to County A");
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_EmptyResults_ReturnsOkWithEmptyList()
+    {
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = ExtractProperty<IReadOnlyList<ImprovementFieldCheckItem>>(
+            ok.Value, "items");
+        items.Should().BeEmpty("empty queue surfaces 200 not 404");
+    }
+
+    [Fact]
+    public async Task GetFieldCheckQueue_EchoesCountyClaimNotPathSegment()
+    {
+        // F3 is claim-driven (no countyId path segment) so the
+        // sovereign-county scope is the principal's claim alone.
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+
+        var ctrl = BuildController(CountyA);
+        var result = await ctrl.GetFieldCheckQueue();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ExtractProperty<Guid>(ok.Value, "countyId").Should().Be(CountyA);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ImprovementFieldCheckReaderTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/CanonicalTf/ImprovementFieldCheckReaderTests.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.ImprovementFieldCheck;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.CanonicalTf;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.CanonicalTf;
+
+/// <summary>
+/// Block F3 acceptance tests for
+/// <see cref="ImprovementFieldCheckReader"/>. Proves the reader's
+/// universe / era / missingFeaturesOnly / yearBuilt-range filters
+/// behave per the F3 contract over
+/// <c>canonical_tf.tf_improvement</c> + <c>tf_improvement_feature</c>.
+/// </summary>
+public sealed class ImprovementFieldCheckReaderTests : IDisposable
+{
+    private static readonly Guid CountyA =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid CountyB =
+        Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private static readonly Guid AttributeIdSeed =
+        Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    private readonly TerraFusionDbContext _db;
+
+    public ImprovementFieldCheckReaderTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"f3-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private ImprovementFieldCheckReader Build() => new(_db);
+
+    private async Task<Guid> SeedImprovementAsync(
+        Guid countyId,
+        string? universe,
+        string? era,
+        short? yearBuilt = 1995,
+        string? imprvTypeCd = "R",
+        string? imprvDesc = "Stick-built")
+    {
+        var id = Guid.NewGuid();
+        _db.TfImprovements.Add(new TfImprovement
+        {
+            TfImprovementId = id,
+            CountyId = countyId,
+            TfParcelId = Guid.NewGuid(),
+            ImprvTypeCd = imprvTypeCd,
+            ImprvDesc = imprvDesc,
+            YearBuilt = yearBuilt,
+            EffectiveYearBuilt = yearBuilt,
+            UniverseCode = universe,
+            ConversionEra = era,
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task SeedFeatureAsync(
+        Guid tfImprovementId,
+        Guid? attributeId)
+    {
+        _db.TfImprovementFeatures.Add(new TfImprovementFeature
+        {
+            TfImprovementId = tfImprovementId,
+            FeatureCode = "BSMT",
+            AttributeId = attributeId,
+            SourceImprvDetailLandedRowId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task UniverseFilter_ScopesResults()
+    {
+        var residential = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        var commercial = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealCommercial, ConversionEras.PostConversion);
+
+        var result = await Build().GetFieldCheckQueueAsync(
+            CountyA, universeCode: UniverseCodes.RealResidential);
+
+        result.Should().HaveCount(1);
+        result[0].TfImprovementId.Should().Be(residential);
+        result[0].UniverseCode.Should().Be(UniverseCodes.RealResidential);
+    }
+
+    [Fact]
+    public async Task UniverseFilter_NullReturnsAllUniverses()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.MobileHome, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.PersonalProperty, ConversionEras.PostConversion);
+
+        var result = await Build().GetFieldCheckQueueAsync(CountyA);
+
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task UniverseFilter_InvalidValue_Throws()
+    {
+        var act = async () => await Build().GetFieldCheckQueueAsync(
+            CountyA, universeCode: "BOGUS_UNIVERSE");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task MissingFeaturesOnly_ExcludesImprovementsWithAnyAttributedFeature()
+    {
+        var noFeatures = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1980);
+
+        var unattributed = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1985);
+        await SeedFeatureAsync(unattributed, attributeId: null);
+        await SeedFeatureAsync(unattributed, attributeId: null);
+
+        var partiallyAttributed = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1990);
+        await SeedFeatureAsync(partiallyAttributed, attributeId: AttributeIdSeed);
+        await SeedFeatureAsync(partiallyAttributed, attributeId: null);
+
+        var fullyAttributed = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 2000);
+        await SeedFeatureAsync(fullyAttributed, attributeId: AttributeIdSeed);
+
+        var result = await Build().GetFieldCheckQueueAsync(
+            CountyA, missingFeaturesOnly: true);
+
+        var ids = result.Select(r => r.TfImprovementId).ToHashSet();
+        ids.Should().Contain(noFeatures);
+        ids.Should().Contain(unattributed);
+        ids.Should().NotContain(partiallyAttributed,
+            "any attributed feature disqualifies the improvement from missing-only");
+        ids.Should().NotContain(fullyAttributed);
+    }
+
+    [Fact]
+    public async Task ReviewReason_ReflectsAttributionState()
+    {
+        var noFeatures = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1980);
+
+        var unattributed = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1985);
+        await SeedFeatureAsync(unattributed, attributeId: null);
+
+        var partial = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1990);
+        await SeedFeatureAsync(partial, attributeId: AttributeIdSeed);
+        await SeedFeatureAsync(partial, attributeId: null);
+
+        var full = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 2000);
+        await SeedFeatureAsync(full, attributeId: AttributeIdSeed);
+
+        var result = await Build().GetFieldCheckQueueAsync(CountyA);
+        var byId = result.ToDictionary(r => r.TfImprovementId, r => r);
+
+        byId[noFeatures].ReviewReason.Should().Be("NO_FEATURES");
+        byId[unattributed].ReviewReason.Should().Be("NO_ATTRIBUTED_FEATURES");
+        byId[partial].ReviewReason.Should().Be("PARTIAL_ATTRIBUTION");
+        byId[full].ReviewReason.Should().Be("FULLY_ATTRIBUTED");
+    }
+
+    [Fact]
+    public async Task EraFilter_DefaultsToPostConversion()
+    {
+        var post = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        var pre = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PreConversion2017);
+        var unknownEra = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.Unknown);
+
+        var result = await Build().GetFieldCheckQueueAsync(CountyA);
+
+        var ids = result.Select(r => r.TfImprovementId).ToHashSet();
+        ids.Should().Contain(post);
+        ids.Should().NotContain(pre);
+        ids.Should().NotContain(unknownEra);
+    }
+
+    [Fact]
+    public async Task EraFilter_AllBypassesFilter_IncludesNullEra()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PreConversion2017);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, era: null);
+
+        var result = await Build().GetFieldCheckQueueAsync(
+            CountyA, era: IImprovementFieldCheckReader.EraAll);
+
+        result.Should().HaveCount(3, "ALL bypasses including NULL-era rows");
+    }
+
+    [Fact]
+    public async Task EraFilter_InvalidValue_Throws()
+    {
+        var act = async () => await Build().GetFieldCheckQueueAsync(
+            CountyA, era: "BOGUS_ERA");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task CountyIsolation_EnforcedByReader()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyB, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+
+        var resultA = await Build().GetFieldCheckQueueAsync(CountyA);
+        var resultB = await Build().GetFieldCheckQueueAsync(CountyB);
+
+        resultA.Should().HaveCount(1);
+        resultB.Should().HaveCount(1);
+        resultA[0].TfImprovementId.Should().NotBe(resultB[0].TfImprovementId);
+    }
+
+    [Fact]
+    public async Task YearBuiltRange_FiltersAndIncludesEndpoints()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1950);
+        var inRangeLow = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1980);
+        var inRangeHigh = await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 2010);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 2025);
+
+        var result = await Build().GetFieldCheckQueueAsync(
+            CountyA, minYearBuilt: 1980, maxYearBuilt: 2010);
+
+        var ids = result.Select(r => r.TfImprovementId).ToHashSet();
+        ids.Should().HaveCount(2);
+        ids.Should().Contain(inRangeLow);
+        ids.Should().Contain(inRangeHigh);
+    }
+
+    [Fact]
+    public async Task MaxResults_ClampedToHardCeiling()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            await SeedImprovementAsync(
+                CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+                yearBuilt: (short)(1900 + i));
+        }
+
+        var huge = await Build().GetFieldCheckQueueAsync(
+            CountyA, maxResults: 50_000);
+        huge.Should().HaveCount(10, "ceiling clamps but the underlying set is small");
+
+        var tiny = await Build().GetFieldCheckQueueAsync(
+            CountyA, maxResults: 3);
+        tiny.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Ordering_OldestYearBuiltFirst()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 2000);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1950);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion,
+            yearBuilt: 1980);
+
+        var result = await Build().GetFieldCheckQueueAsync(CountyA);
+
+        result.Select(r => r.YearBuilt).Should().ContainInOrder(
+            (short)1950, (short)1980, (short)2000);
+    }
+
+    [Fact]
+    public async Task UnknownUniverse_AcceptedAsValidFilter()
+    {
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.Unknown, ConversionEras.PostConversion);
+        await SeedImprovementAsync(
+            CountyA, UniverseCodes.RealResidential, ConversionEras.PostConversion);
+
+        var result = await Build().GetFieldCheckQueueAsync(
+            CountyA, universeCode: UniverseCodes.Unknown);
+
+        result.Should().HaveCount(1);
+        result[0].UniverseCode.Should().Be(UniverseCodes.Unknown);
+    }
+}


### PR DESCRIPTION
## Summary

Block F3 per `docs/pacs/blocks-d-through-h-design.md` §"F3" — read-only triage queue surfacing canonical improvements that need a physical re-verification visit. The defining filter is `missingFeaturesOnly`, which excludes any improvement carrying at least one V8 dictionary-resolved feature row (`tf_improvement_feature.AttributeId` non-null).

- `GET /api/improvements/field-check-queue` (claim-driven sovereign-county scope)
- Filters: `universe`, `era` (defaults POST_CONVERSION; ALL bypasses), `missingFeaturesOnly`, `minYearBuilt`/`maxYearBuilt`, `maxResults` (default 200, hard cap 1000)
- Returns `ImprovementFieldCheckItem` rows with `FeatureCount`, `AttributedFeatureCount`, and a closed-vocabulary `ReviewReason` (`NO_FEATURES` / `NO_ATTRIBUTED_FEATURES` / `PARTIAL_ATTRIBUTION` / `FULLY_ATTRIBUTED`)

## Files

- `backend/src/TerraFusion.Core/Sync/ImprovementFieldCheck/IImprovementFieldCheckReader.cs` (interface + DTO)
- `backend/src/TerraFusion.Data/Services/CanonicalTf/ImprovementFieldCheckReader.cs` (EF AsNoTracking impl, county-scoped, era predicate adapted to `tf_improvement` no-date semantics)
- `backend/src/TerraFusion.API/Controllers/ImprovementFieldCheckQueueController.cs`
- DI in `backend/src/TerraFusion.API/Program.cs`
- 22 new unit tests in `backend/tests/TerraFusion.Unit.Tests/CanonicalTf/`

## Contract

| Status | Trigger |
|---|---|
| 401 | Unauthenticated (default `[Authorize]`) |
| 403 | Missing `countyId` claim |
| 400 | `universe` not in `UniverseCodes.AllIncludingUnknown` |
| 400 | `era` not in {POST_CONVERSION, PRE_CONVERSION_2017, UNKNOWN, ALL} |
| 200 | Authorized; empty queue returns 200 with `items: []` |

## Test plan

- [x] Unit reader tests: 12 (universe filter, missingFeaturesOnly, ReviewReason, era default + ALL bypass, county isolation, yearBuilt range, maxResults clamp, ordering, UNKNOWN universe accepted, invalid universe/era throws)
- [x] Unit controller tests: 10 (403 missing claim, 400 invalid universe, 400 invalid era, default era resolves POST, universe filter narrows, ALL bypasses, county isolation, empty queue 200 not 404, response echoes claim)
- [x] Build clean (0 warnings, 0 errors)
- [x] Full unit suite: 3050/3050 passing locally

## Deviations

- The task spec referenced `EraQueryHelper.TryNormalizeEra`. That helper is not yet on `main` (it lives on the in-flight `feat/sync-g3-erafilter-readendpoints` branch). F3 inlines the same `TryNormalizeEra` shape on the controller — identical surface contract; helper extraction can roll forward when G3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only API endpoint returning an improvement field-check triage queue scoped to the caller’s county; supports universe, era, year-range, missing-features filter, clamps max results, and echoes resolved parameters with result count, items and review reasons.
* **Tests**
  * Added comprehensive tests covering auth, input validation, filtering, ordering, county isolation, era defaults, max-results behavior, and review-reason outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->