### PR TITLE
feat(sync): SYNC-WORKBENCH-F — improvement-attr quarantine triage

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/WorkbenchFController.cs
+++ b/backend/src/TerraFusion.API/Controllers/WorkbenchFController.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.Workbench;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// SYNC-WORKBENCH-F: improvement-attribute quarantine triage panel.
+///
+/// <para>Mirrors the V7 doctrine-policy controller pattern: no
+/// <c>[Authorize]</c>, no per-row CountyId filter (single-county-
+/// per-deployment doctrine). The quarantine entity is doctrine-
+/// immutable; this controller only writes the sibling triage table.</para>
+///
+/// <para>Endpoints:</para>
+/// <list type="bullet">
+///   <item><c>GET /api/sync/workbench/f/quarantine/imprv-attr</c> —
+///   paged list with optional reason / universe / propId filters.</item>
+///   <item><c>POST /api/sync/workbench/f/quarantine/imprv-attr/{id}/route</c> —
+///   record a routing decision.</item>
+///   <item><c>POST /api/sync/workbench/f/quarantine/imprv-attr/{id}/dismiss</c> —
+///   record a dismissal decision.</item>
+/// </list>
+/// </summary>
+[ApiController]
+[Route("api/sync/workbench/f")]
+public sealed class WorkbenchFController : ControllerBase
+{
+    private readonly IQuarantineTriageService _service;
+    private readonly ILogger<WorkbenchFController> _logger;
+
+    public WorkbenchFController(
+        IQuarantineTriageService service,
+        ILogger<WorkbenchFController> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/workbench/f/quarantine/imprv-attr</c>
+    /// </summary>
+    [HttpGet("quarantine/imprv-attr")]
+    public async Task<IActionResult> ListQuarantine(
+        [FromQuery] string? reason = null,
+        [FromQuery] string? universe = null,
+        [FromQuery] int? propId = null,
+        [FromQuery] int limit = 100,
+        [FromQuery] int offset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _service.ListAsync(
+            new QuarantineListRequest(reason, universe, propId, limit, offset),
+            cancellationToken);
+
+        return MapList(result);
+    }
+
+    /// <summary>
+    /// <c>POST /api/sync/workbench/f/quarantine/imprv-attr/{unprovenRowId}/route</c>
+    /// </summary>
+    [HttpPost("quarantine/imprv-attr/{unprovenRowId:guid}/route")]
+    public async Task<IActionResult> Route(
+        [FromRoute] Guid unprovenRowId,
+        [FromBody] RouteRequest body,
+        CancellationToken cancellationToken = default)
+    {
+        if (body is null)
+            return BadRequest(new { error = "request body is required" });
+
+        var result = await _service.RouteAsync(unprovenRowId, body, cancellationToken);
+        return MapRoute(result);
+    }
+
+    /// <summary>
+    /// <c>POST /api/sync/workbench/f/quarantine/imprv-attr/{unprovenRowId}/dismiss</c>
+    /// </summary>
+    [HttpPost("quarantine/imprv-attr/{unprovenRowId:guid}/dismiss")]
+    public async Task<IActionResult> Dismiss(
+        [FromRoute] Guid unprovenRowId,
+        [FromBody] DismissRequest body,
+        CancellationToken cancellationToken = default)
+    {
+        if (body is null)
+            return BadRequest(new { error = "request body is required" });
+
+        var result = await _service.DismissAsync(unprovenRowId, body, cancellationToken);
+        return MapDismiss(result);
+    }
+
+    // ── Outcome → HTTP mapping ───────────────────────────────────────
+
+    private IActionResult MapList(QuarantineListResult r) => r.Outcome switch
+    {
+        TriageOutcome.Ok => Ok(new
+        {
+            count = r.Items.Count,
+            limit = r.Limit,
+            offset = r.Offset,
+            items = r.Items,
+        }),
+        TriageOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+
+    private IActionResult MapRoute(RouteDecisionResult r) => r.Outcome switch
+    {
+        TriageOutcome.Ok => Ok(r.Payload),
+        TriageOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        TriageOutcome.NotFound => NotFound(new { error = r.ErrorMessage }),
+        TriageOutcome.Conflict => Conflict(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+
+    private IActionResult MapDismiss(DismissDecisionResult r) => r.Outcome switch
+    {
+        TriageOutcome.Ok => Ok(r.Payload),
+        TriageOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        TriageOutcome.NotFound => NotFound(new { error = r.ErrorMessage }),
+        TriageOutcome.Conflict => Conflict(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1903,6 +1903,15 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.LandSegmentException.ILandSegmentExceptionReader,
     TerraFusion.Data.Services.CanonicalTf.LandSegmentExceptionReader>();
 
+// SYNC-WORKBENCH-F: improvement-attr quarantine triage. Reads
+// legacy_tf_unproven.unresolved_imprv_attr (doctrine-immutable)
+// LEFT-JOIN unproven_imprv_attr_triage; writes only the triage
+// sibling. Mirrors V7 controller pattern (no [Authorize], no
+// CountyId column).
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Workbench.IQuarantineTriageService,
+    TerraFusion.Data.Services.Workbench.QuarantineTriageService>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.Core/Entities/LegacyTfUnproven/UnprovenImprvAttrTriage.cs
+++ b/backend/src/TerraFusion.Core/Entities/LegacyTfUnproven/UnprovenImprvAttrTriage.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace TerraFusion.Core.Entities.LegacyTfUnproven;
+
+/// <summary>
+/// SYNC-WORKBENCH-F: operator-decision sibling table for
+/// <see cref="LegacyTfUnprovenImprvAttr"/>. Records the operator's
+/// triage outcome — either <b>route</b> the quarantined attribute
+/// to a target universe / dictionary code, or <b>dismiss</b> it as
+/// noise / legitimately-missing / conversion artifact.
+///
+/// <para><b>Why a sibling table:</b> the doctrine-immutable
+/// quarantine entity (<see cref="LegacyTfUnprovenImprvAttr"/>) is
+/// frozen by C1-C contract. Operator decisions live here so the
+/// raw quarantine row remains a faithful record of the landing-time
+/// failure while triage state evolves over time.</para>
+///
+/// <para>One-to-one with <see cref="LegacyTfUnprovenImprvAttr"/> by
+/// <see cref="UnprovenRowId"/> (unique index). Audit fields
+/// (<see cref="CreatedAt"/>, <see cref="UpdatedAt"/>,
+/// <see cref="CreatedBy"/>, <see cref="UpdatedBy"/>) are
+/// auto-populated by <c>AuditableEntityInterceptor</c> — do NOT set
+/// manually.</para>
+/// </summary>
+public sealed class UnprovenImprvAttrTriage
+{
+    /// <summary>Triage record identity.</summary>
+    public Guid TriageId { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// FK to <see cref="LegacyTfUnprovenImprvAttr.UnprovenRowId"/>.
+    /// Unique — at most one triage decision per quarantine row.
+    /// </summary>
+    public Guid UnprovenRowId { get; set; }
+
+    /// <summary>
+    /// Triage status. One of <c>"Open"</c> (default — no decision),
+    /// <c>"Routed"</c>, or <c>"Dismissed"</c>. The reader returns
+    /// <c>"Open"</c> for any quarantine row without a triage record.
+    /// </summary>
+    public string Status { get; set; } = "Open";
+
+    // ── Routed branch ───────────────────────────────────────────────
+    /// <summary>
+    /// Target universe for routed rows. One of
+    /// <see cref="TerraFusion.Core.Sync.Doctrine.UniverseCodes"/>.
+    /// NULL when <see cref="Status"/> is not <c>"Routed"</c>.
+    /// </summary>
+    public string? RoutedToUniverse { get; set; }
+
+    /// <summary>
+    /// Optional target IAttrValCd code within the routed universe's
+    /// dictionary. NULL when the operator routes to a universe but
+    /// declines to suggest a specific code.
+    /// </summary>
+    public string? RoutedToIAttrValCd { get; set; }
+
+    // ── Dismissed branch ────────────────────────────────────────────
+    /// <summary>
+    /// Reason for dismissal. One of
+    /// <c>"IntentionalNoise"</c>, <c>"LegitimateMissing"</c>,
+    /// <c>"ConversionArtifact"</c>. NULL unless
+    /// <see cref="Status"/> is <c>"Dismissed"</c>.
+    /// </summary>
+    public string? DismissalReason { get; set; }
+
+    /// <summary>Free-form operator note (optional).</summary>
+    public string? OperatorNote { get; set; }
+
+    // ── Audit (auto-populated by AuditableEntityInterceptor) ────────
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Sync/Workbench/IQuarantineTriageService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Workbench/IQuarantineTriageService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-F: improvement-attribute quarantine triage service.
+///
+/// <para>Provides three operator surfaces:</para>
+/// <list type="number">
+///   <item><see cref="ListAsync"/> — paged list of quarantined
+///   imprv_attr rows joined with their (optional) triage decisions.</item>
+///   <item><see cref="RouteAsync"/> — record an operator's decision
+///   to route a quarantined row to a target universe / dictionary code.</item>
+///   <item><see cref="DismissAsync"/> — record an operator's decision
+///   to dismiss a quarantined row as noise / legitimately-missing /
+///   conversion artifact.</item>
+/// </list>
+///
+/// <para>Idempotency: a same-target re-route or same-reason
+/// re-dismiss is a no-op (returns <see cref="TriageOutcome.Ok"/>
+/// with the existing decision). Cross-branch transitions
+/// (Routed→Dismissed or Dismissed→Routed) and same-branch divergent
+/// targets surface as <see cref="TriageOutcome.Conflict"/>.</para>
+/// </summary>
+public interface IQuarantineTriageService
+{
+    Task<QuarantineListResult> ListAsync(
+        QuarantineListRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<RouteDecisionResult> RouteAsync(
+        Guid unprovenRowId,
+        RouteRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<DismissDecisionResult> DismissAsync(
+        Guid unprovenRowId,
+        DismissRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Discriminator over service-layer outcomes mapped 1:1 to HTTP status by the controller.</summary>
+public enum TriageOutcome
+{
+    Ok,
+    InvalidInput,
+    NotFound,
+    Conflict,
+}
+
+// ── List ─────────────────────────────────────────────────────────────
+
+public sealed record QuarantineListRequest(
+    string? Reason,
+    string? Universe,
+    int? PropId,
+    int Limit,
+    int Offset);
+
+public sealed record QuarantineListResult(
+    TriageOutcome Outcome,
+    string? ErrorMessage,
+    IReadOnlyList<QuarantineRow> Items,
+    int Limit,
+    int Offset);
+
+/// <summary>
+/// Quarantine row joined with optional triage row. <c>TriageStatus</c>
+/// is <c>"Open"</c> for any quarantine row without a triage decision.
+/// </summary>
+public sealed record QuarantineRow(
+    Guid UnprovenRowId,
+    int PropId,
+    short PropValYr,
+    short SupNum,
+    long ImprvId,
+    long ImprvDetId,
+    long IAttrValId,
+    string IAttrValCd,
+    string? AttrValueText,
+    decimal? AttrValueNumeric,
+    string QuarantineReason,
+    string? QuarantineReasonDetail,
+    string? UniverseCode,
+    DateTime CreatedAt,
+    string TriageStatus,
+    string? SuggestedReroute);
+
+// ── Route ────────────────────────────────────────────────────────────
+
+public sealed record RouteRequest(
+    string TargetUniverse,
+    string? TargetIAttrValCd,
+    string? OperatorNote);
+
+public sealed record RouteDecisionResult(
+    TriageOutcome Outcome,
+    string? ErrorMessage,
+    RouteDecisionPayload? Payload);
+
+public sealed record RouteDecisionPayload(
+    Guid TriageId,
+    Guid UnprovenRowId,
+    string Status,
+    string RoutedToUniverse,
+    string? RoutedToIAttrValCd,
+    DateTime UpdatedAt);
+
+// ── Dismiss ──────────────────────────────────────────────────────────
+
+public sealed record DismissRequest(
+    string DismissalReason,
+    string? OperatorNote);
+
+public sealed record DismissDecisionResult(
+    TriageOutcome Outcome,
+    string? ErrorMessage,
+    DismissDecisionPayload? Payload);
+
+public sealed record DismissDecisionPayload(
+    Guid TriageId,
+    Guid UnprovenRowId,
+    string Status,
+    string DismissalReason,
+    DateTime UpdatedAt);
+
+/// <summary>Closed vocabulary for the triage Status column.</summary>
+public static class TriageStatuses
+{
+    public const string Open = "Open";
+    public const string Routed = "Routed";
+    public const string Dismissed = "Dismissed";
+}
+
+/// <summary>Closed vocabulary for <see cref="DismissRequest.DismissalReason"/>.</summary>
+public static class TriageDismissalReasons
+{
+    public const string IntentionalNoise = "IntentionalNoise";
+    public const string LegitimateMissing = "LegitimateMissing";
+    public const string ConversionArtifact = "ConversionArtifact";
+
+    public static IReadOnlySet<string> All { get; } = new HashSet<string>
+    {
+        IntentionalNoise,
+        LegitimateMissing,
+        ConversionArtifact,
+    };
+
+    public static bool IsKnown(string? value) =>
+        !string.IsNullOrEmpty(value) && All.Contains(value);
+}

--- a/backend/src/TerraFusion.Data/Configurations/LegacyTfUnproven/UnprovenImprvAttrTriageConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/LegacyTfUnproven/UnprovenImprvAttrTriageConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.LegacyTfUnproven;
+
+namespace TerraFusion.Data.Configurations.LegacyTfUnproven;
+
+/// <summary>
+/// SYNC-WORKBENCH-F: EF configuration for
+/// <see cref="UnprovenImprvAttrTriage"/>. Schema
+/// <c>legacy_tf_unproven</c>; table <c>unproven_imprv_attr_triage</c>.
+/// Unique on <see cref="UnprovenImprvAttrTriage.UnprovenRowId"/>;
+/// non-unique on <see cref="UnprovenImprvAttrTriage.Status"/>.
+/// </summary>
+public sealed class UnprovenImprvAttrTriageConfiguration
+    : IEntityTypeConfiguration<UnprovenImprvAttrTriage>
+{
+    public void Configure(EntityTypeBuilder<UnprovenImprvAttrTriage> builder)
+    {
+        builder.ToTable("unproven_imprv_attr_triage", schema: "legacy_tf_unproven");
+
+        builder.HasKey(x => x.TriageId);
+        builder.Property(x => x.TriageId).IsRequired();
+
+        builder.Property(x => x.UnprovenRowId).IsRequired();
+
+        builder.Property(x => x.Status).HasMaxLength(20).IsRequired();
+
+        builder.Property(x => x.RoutedToUniverse).HasMaxLength(50);
+        builder.Property(x => x.RoutedToIAttrValCd).HasMaxLength(32);
+
+        builder.Property(x => x.DismissalReason).HasMaxLength(50);
+        builder.Property(x => x.OperatorNote).HasMaxLength(1000);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(255);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(255);
+
+        // One triage decision per quarantine row.
+        builder.HasIndex(x => x.UnprovenRowId)
+            .IsUnique()
+            .HasDatabaseName("ux_unproven_imprv_attr_triage_unproven_row");
+
+        // Status is the primary filter from the workbench list view.
+        builder.HasIndex(x => x.Status)
+            .HasDatabaseName("ix_unproven_imprv_attr_triage_status");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260508083117_SyncWorkbenchFTriageTable.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508083117_SyncWorkbenchFTriageTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508083117_SyncWorkbenchFTriageTable")]
+    partial class SyncWorkbenchFTriageTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260508083117_SyncWorkbenchFTriageTable.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508083117_SyncWorkbenchFTriageTable.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncWorkbenchFTriageTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "unproven_imprv_attr_triage",
+                schema: "legacy_tf_unproven",
+                columns: table => new
+                {
+                    TriageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnprovenRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    RoutedToUniverse = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    RoutedToIAttrValCd = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    DismissalReason = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    OperatorNote = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_unproven_imprv_attr_triage", x => x.TriageId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unproven_imprv_attr_triage_status",
+                schema: "legacy_tf_unproven",
+                table: "unproven_imprv_attr_triage",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_unproven_imprv_attr_triage_unproven_row",
+                schema: "legacy_tf_unproven",
+                table: "unproven_imprv_attr_triage",
+                column: "UnprovenRowId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "unproven_imprv_attr_triage",
+                schema: "legacy_tf_unproven");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/QuarantineTriageService.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/QuarantineTriageService.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.LegacyTfUnproven;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.Workbench;
+
+namespace TerraFusion.Data.Services.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-F implementation of <see cref="IQuarantineTriageService"/>.
+///
+/// <para>Reads from <c>legacy_tf_unproven.unresolved_imprv_attr</c>
+/// (doctrine-immutable) LEFT-JOIN <c>legacy_tf_unproven.unproven_imprv_attr_triage</c>
+/// (operator decisions). Writes only to the triage sibling table.</para>
+///
+/// <para>SuggestedReroute v1: surfaces the row's own
+/// <see cref="LegacyTfUnprovenImprvAttr.UniverseCode"/>. Cheap and
+/// already populated by the V4 promoter at quarantine time. Richer
+/// reroute calculation is deferred per spec.</para>
+/// </summary>
+public sealed class QuarantineTriageService : IQuarantineTriageService
+{
+    private const int DefaultLimit = 100;
+    private const int MaxLimit = 500;
+
+    private readonly TerraFusionDbContext _db;
+
+    public QuarantineTriageService(TerraFusionDbContext db)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        _db = db;
+    }
+
+    public async Task<QuarantineListResult> ListAsync(
+        QuarantineListRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var limit = request.Limit <= 0
+            ? DefaultLimit
+            : (request.Limit > MaxLimit ? MaxLimit : request.Limit);
+        var offset = request.Offset < 0 ? 0 : request.Offset;
+
+        var query = _db.LegacyTfUnprovenImprvAttrs.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(request.Reason))
+            query = query.Where(q => q.QuarantineReason == request.Reason);
+
+        if (!string.IsNullOrWhiteSpace(request.Universe))
+            query = query.Where(q => q.UniverseCode == request.Universe);
+
+        if (request.PropId.HasValue)
+            query = query.Where(q => q.PropId == request.PropId.Value);
+
+        // LEFT JOIN to triage table by UnprovenRowId.
+        var joined =
+            from q in query
+            join t in _db.UnprovenImprvAttrTriages.AsNoTracking()
+                on q.UnprovenRowId equals t.UnprovenRowId into triageGroup
+            from t in triageGroup.DefaultIfEmpty()
+            orderby q.CreatedAt descending
+            select new
+            {
+                Q = q,
+                TriageStatus = t == null ? TriageStatuses.Open : t.Status,
+            };
+
+        var rows = await joined
+            .Skip(offset)
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows
+            .Select(r => new QuarantineRow(
+                UnprovenRowId: r.Q.UnprovenRowId,
+                PropId: r.Q.PropId,
+                PropValYr: r.Q.PropValYr,
+                SupNum: r.Q.SupNum,
+                ImprvId: r.Q.ImprvId,
+                ImprvDetId: r.Q.ImprvDetId,
+                IAttrValId: r.Q.IAttrValId,
+                IAttrValCd: r.Q.IAttrValCd,
+                AttrValueText: r.Q.AttrValueText,
+                AttrValueNumeric: r.Q.AttrValueNumeric,
+                QuarantineReason: r.Q.QuarantineReason,
+                QuarantineReasonDetail: r.Q.QuarantineReasonDetail,
+                UniverseCode: r.Q.UniverseCode,
+                CreatedAt: r.Q.CreatedAt,
+                TriageStatus: r.TriageStatus,
+                SuggestedReroute: r.Q.UniverseCode))
+            .ToList();
+
+        return new QuarantineListResult(
+            Outcome: TriageOutcome.Ok,
+            ErrorMessage: null,
+            Items: items,
+            Limit: limit,
+            Offset: offset);
+    }
+
+    public async Task<RouteDecisionResult> RouteAsync(
+        Guid unprovenRowId,
+        RouteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (unprovenRowId == Guid.Empty)
+            return new RouteDecisionResult(
+                TriageOutcome.InvalidInput,
+                "unprovenRowId is required.",
+                null);
+
+        if (string.IsNullOrWhiteSpace(request.TargetUniverse) ||
+            !UniverseCodes.IsKnown(request.TargetUniverse))
+        {
+            return new RouteDecisionResult(
+                TriageOutcome.InvalidInput,
+                $"Unknown TargetUniverse: '{request.TargetUniverse}'.",
+                null);
+        }
+
+        var quarantine = await _db.LegacyTfUnprovenImprvAttrs
+            .AsNoTracking()
+            .FirstOrDefaultAsync(q => q.UnprovenRowId == unprovenRowId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (quarantine is null)
+            return new RouteDecisionResult(
+                TriageOutcome.NotFound,
+                $"Quarantine row '{unprovenRowId}' not found.",
+                null);
+
+        var existing = await _db.UnprovenImprvAttrTriages
+            .FirstOrDefaultAsync(t => t.UnprovenRowId == unprovenRowId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var nowUtc = DateTime.UtcNow;
+
+        if (existing is not null)
+        {
+            if (existing.Status == TriageStatuses.Dismissed)
+                return new RouteDecisionResult(
+                    TriageOutcome.Conflict,
+                    "Quarantine row is already dismissed; dismiss before routing.",
+                    null);
+
+            if (existing.Status == TriageStatuses.Routed)
+            {
+                // Idempotent re-route to same target.
+                if (existing.RoutedToUniverse == request.TargetUniverse &&
+                    existing.RoutedToIAttrValCd == request.TargetIAttrValCd)
+                {
+                    return new RouteDecisionResult(
+                        TriageOutcome.Ok,
+                        null,
+                        new RouteDecisionPayload(
+                            existing.TriageId,
+                            existing.UnprovenRowId,
+                            existing.Status,
+                            existing.RoutedToUniverse!,
+                            existing.RoutedToIAttrValCd,
+                            existing.UpdatedAt));
+                }
+
+                return new RouteDecisionResult(
+                    TriageOutcome.Conflict,
+                    "Already routed to a different target; dismiss before re-routing.",
+                    null);
+            }
+
+            // Defensive: existing.Status not Open/Routed/Dismissed.
+            existing.Status = TriageStatuses.Routed;
+            existing.RoutedToUniverse = request.TargetUniverse;
+            existing.RoutedToIAttrValCd = request.TargetIAttrValCd;
+            existing.DismissalReason = null;
+            existing.OperatorNote = request.OperatorNote;
+            existing.UpdatedAt = nowUtc;
+        }
+        else
+        {
+            var newRow = new UnprovenImprvAttrTriage
+            {
+                TriageId = Guid.NewGuid(),
+                UnprovenRowId = unprovenRowId,
+                Status = TriageStatuses.Routed,
+                RoutedToUniverse = request.TargetUniverse,
+                RoutedToIAttrValCd = request.TargetIAttrValCd,
+                OperatorNote = request.OperatorNote,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc,
+            };
+            _db.UnprovenImprvAttrTriages.Add(newRow);
+            existing = newRow;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RouteDecisionResult(
+            TriageOutcome.Ok,
+            null,
+            new RouteDecisionPayload(
+                existing.TriageId,
+                existing.UnprovenRowId,
+                existing.Status,
+                existing.RoutedToUniverse!,
+                existing.RoutedToIAttrValCd,
+                existing.UpdatedAt));
+    }
+
+    public async Task<DismissDecisionResult> DismissAsync(
+        Guid unprovenRowId,
+        DismissRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (unprovenRowId == Guid.Empty)
+            return new DismissDecisionResult(
+                TriageOutcome.InvalidInput,
+                "unprovenRowId is required.",
+                null);
+
+        if (!TriageDismissalReasons.IsKnown(request.DismissalReason))
+        {
+            return new DismissDecisionResult(
+                TriageOutcome.InvalidInput,
+                $"Unknown DismissalReason: '{request.DismissalReason}'.",
+                null);
+        }
+
+        var quarantine = await _db.LegacyTfUnprovenImprvAttrs
+            .AsNoTracking()
+            .FirstOrDefaultAsync(q => q.UnprovenRowId == unprovenRowId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (quarantine is null)
+            return new DismissDecisionResult(
+                TriageOutcome.NotFound,
+                $"Quarantine row '{unprovenRowId}' not found.",
+                null);
+
+        var existing = await _db.UnprovenImprvAttrTriages
+            .FirstOrDefaultAsync(t => t.UnprovenRowId == unprovenRowId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var nowUtc = DateTime.UtcNow;
+
+        if (existing is not null)
+        {
+            if (existing.Status == TriageStatuses.Routed)
+                return new DismissDecisionResult(
+                    TriageOutcome.Conflict,
+                    "Quarantine row is already routed; clear routing before dismissing.",
+                    null);
+
+            if (existing.Status == TriageStatuses.Dismissed)
+            {
+                if (existing.DismissalReason == request.DismissalReason)
+                {
+                    return new DismissDecisionResult(
+                        TriageOutcome.Ok,
+                        null,
+                        new DismissDecisionPayload(
+                            existing.TriageId,
+                            existing.UnprovenRowId,
+                            existing.Status,
+                            existing.DismissalReason!,
+                            existing.UpdatedAt));
+                }
+
+                return new DismissDecisionResult(
+                    TriageOutcome.Conflict,
+                    "Already dismissed with a different reason.",
+                    null);
+            }
+
+            existing.Status = TriageStatuses.Dismissed;
+            existing.DismissalReason = request.DismissalReason;
+            existing.RoutedToUniverse = null;
+            existing.RoutedToIAttrValCd = null;
+            existing.OperatorNote = request.OperatorNote;
+            existing.UpdatedAt = nowUtc;
+        }
+        else
+        {
+            var newRow = new UnprovenImprvAttrTriage
+            {
+                TriageId = Guid.NewGuid(),
+                UnprovenRowId = unprovenRowId,
+                Status = TriageStatuses.Dismissed,
+                DismissalReason = request.DismissalReason,
+                OperatorNote = request.OperatorNote,
+                CreatedAt = nowUtc,
+                UpdatedAt = nowUtc,
+            };
+            _db.UnprovenImprvAttrTriages.Add(newRow);
+            existing = newRow;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new DismissDecisionResult(
+            TriageOutcome.Ok,
+            null,
+            new DismissDecisionPayload(
+                existing.TriageId,
+                existing.UnprovenRowId,
+                existing.Status,
+                existing.DismissalReason!,
+                existing.UpdatedAt));
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -239,6 +239,13 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.LegacyTfUnproven.LegacyTfUnprovenImprvAttr>
     LegacyTfUnprovenImprvAttrs { get; set; } = null!;
 
+  // SYNC-WORKBENCH-F: operator-decision sibling for
+  // legacy_tf_unproven.unresolved_imprv_attr. One row per triage
+  // decision (route or dismiss); doctrine-immutable quarantine row
+  // remains untouched.
+  public DbSet<TerraFusion.Core.Entities.LegacyTfUnproven.UnprovenImprvAttrTriage>
+    UnprovenImprvAttrTriages { get; set; } = null!;
+
   // Slice L1: land_detail landing — per-segment land breakdown
   // (homesite, ag, pasture, timber, etc). 4-key composite. Required
   // by the truth_pacs.land_current promoter (future).
@@ -1048,6 +1055,9 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
       new TerraFusion.Data.Configurations.LegacyPacsRaw.LegacyPacsRawImprvAttrConfiguration());
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.LegacyTfUnproven.LegacyTfUnprovenImprvAttrConfiguration());
+    // SYNC-WORKBENCH-F: triage sibling table.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.LegacyTfUnproven.UnprovenImprvAttrTriageConfiguration());
 
     // Slice L1: land_detail landing — per-segment land breakdown.
     modelBuilder.ApplyConfiguration(

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Workbench/QuarantineTriageServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Workbench/QuarantineTriageServiceTests.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.LegacyTfUnproven;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.Workbench;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Workbench;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-F unit tests for <see cref="QuarantineTriageService"/>.
+///
+/// <para>Uses an in-memory <see cref="TerraFusionDbContext"/> per
+/// test (mirrors the F2 <c>SalesReviewReaderTests</c> fixture
+/// pattern). The triage table's unique index on
+/// <c>UnprovenRowId</c> is honored by the in-memory provider so
+/// idempotency / conflict semantics surface in tests as they would
+/// in production.</para>
+/// </summary>
+public sealed class QuarantineTriageServiceTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public QuarantineTriageServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"workbench-f-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private QuarantineTriageService Build() => new(_db);
+
+    private async Task<Guid> SeedQuarantineAsync(
+        string reason = "UNKNOWN_I_ATTR_VAL_CD",
+        string? universe = UniverseCodes.RealResidential,
+        int propId = 12345,
+        string code = "ZZZ",
+        DateTime? createdAt = null)
+    {
+        var id = Guid.NewGuid();
+        _db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
+        {
+            UnprovenRowId = id,
+            PropValYr = 2025,
+            SupNum = 0,
+            PropId = propId,
+            ImprvId = 100,
+            ImprvDetId = 200,
+            IAttrValId = 300,
+            IAttrValCd = code,
+            QuarantineReason = reason,
+            UniverseCode = universe,
+            LandingLoadBatchId = Guid.NewGuid(),
+            CreatedAt = createdAt ?? DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+        return id;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // List
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_ReturnsUntriagedRowsAsOpen()
+    {
+        var id = await SeedQuarantineAsync();
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 100, 0));
+
+        result.Outcome.Should().Be(TriageOutcome.Ok);
+        result.Items.Should().ContainSingle();
+        var row = result.Items.Single();
+        row.UnprovenRowId.Should().Be(id);
+        row.TriageStatus.Should().Be(TriageStatuses.Open);
+    }
+
+    [Fact]
+    public async Task List_FiltersByReason()
+    {
+        await SeedQuarantineAsync(reason: "UNKNOWN_I_ATTR_VAL_CD");
+        await SeedQuarantineAsync(reason: "OTHER_REASON");
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest("UNKNOWN_I_ATTR_VAL_CD", null, null, 100, 0));
+
+        result.Items.Should().ContainSingle()
+            .Which.QuarantineReason.Should().Be("UNKNOWN_I_ATTR_VAL_CD");
+    }
+
+    [Fact]
+    public async Task List_FiltersByUniverse()
+    {
+        await SeedQuarantineAsync(universe: UniverseCodes.RealResidential);
+        await SeedQuarantineAsync(universe: UniverseCodes.AgCurrentUse);
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, UniverseCodes.AgCurrentUse, null, 100, 0));
+
+        result.Items.Should().ContainSingle()
+            .Which.UniverseCode.Should().Be(UniverseCodes.AgCurrentUse);
+    }
+
+    [Fact]
+    public async Task List_FiltersByPropId()
+    {
+        await SeedQuarantineAsync(propId: 1001);
+        await SeedQuarantineAsync(propId: 2002);
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, null, 2002, 100, 0));
+
+        result.Items.Should().ContainSingle()
+            .Which.PropId.Should().Be(2002);
+    }
+
+    [Fact]
+    public async Task List_RespectsPaging()
+    {
+        for (int i = 0; i < 5; i++)
+            await SeedQuarantineAsync(propId: 9000 + i,
+                createdAt: DateTime.UtcNow.AddSeconds(-i));
+
+        var page1 = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 2, 0));
+        var page2 = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 2, 2));
+
+        page1.Items.Count.Should().Be(2);
+        page2.Items.Count.Should().Be(2);
+        page1.Items[0].PropId.Should().NotBe(page2.Items[0].PropId);
+    }
+
+    [Fact]
+    public async Task List_ReportsRoutedStatusForRoutedRows()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, "ROOF_TYPE", "noted"));
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 100, 0));
+
+        result.Items.Single().TriageStatus.Should().Be(TriageStatuses.Routed);
+    }
+
+    [Fact]
+    public async Task List_ReportsDismissedStatusForDismissedRows()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.IntentionalNoise, null));
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 100, 0));
+
+        result.Items.Single().TriageStatus.Should().Be(TriageStatuses.Dismissed);
+    }
+
+    [Fact]
+    public async Task List_SuggestedReroute_EchoesUniverseCode()
+    {
+        await SeedQuarantineAsync(universe: UniverseCodes.MobileHome);
+
+        var result = await Build().ListAsync(
+            new QuarantineListRequest(null, null, null, 100, 0));
+
+        result.Items.Single().SuggestedReroute.Should().Be(UniverseCodes.MobileHome);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Route
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Route_HappyPath_CreatesRoutedRow()
+    {
+        var id = await SeedQuarantineAsync();
+        var result = await Build().RouteAsync(id,
+            new RouteRequest(UniverseCodes.RealCommercial, "WALL_TYPE", "ok"));
+
+        result.Outcome.Should().Be(TriageOutcome.Ok);
+        result.Payload.Should().NotBeNull();
+        result.Payload!.Status.Should().Be(TriageStatuses.Routed);
+        result.Payload.RoutedToUniverse.Should().Be(UniverseCodes.RealCommercial);
+        result.Payload.RoutedToIAttrValCd.Should().Be("WALL_TYPE");
+    }
+
+    [Fact]
+    public async Task Route_UnknownUniverse_ReturnsInvalidInput()
+    {
+        var id = await SeedQuarantineAsync();
+        var result = await Build().RouteAsync(id,
+            new RouteRequest("NOT_A_UNIVERSE", null, null));
+
+        result.Outcome.Should().Be(TriageOutcome.InvalidInput);
+        result.Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Route_UnknownId_ReturnsNotFound()
+    {
+        var result = await Build().RouteAsync(Guid.NewGuid(),
+            new RouteRequest(UniverseCodes.RealResidential, null, null));
+
+        result.Outcome.Should().Be(TriageOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task Route_SameTargetIdempotent_ReturnsOk()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, "X", "first"));
+
+        var result = await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, "X", "second"));
+
+        result.Outcome.Should().Be(TriageOutcome.Ok);
+        result.Payload!.RoutedToUniverse.Should().Be(UniverseCodes.RealResidential);
+    }
+
+    [Fact]
+    public async Task Route_DifferentTarget_ReturnsConflict()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, "X", null));
+
+        var result = await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealCommercial, "Y", null));
+
+        result.Outcome.Should().Be(TriageOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task Route_AfterDismissal_ReturnsConflict()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.IntentionalNoise, null));
+
+        var result = await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, null, null));
+
+        result.Outcome.Should().Be(TriageOutcome.Conflict);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Dismiss
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_HappyPath_CreatesDismissedRow()
+    {
+        var id = await SeedQuarantineAsync();
+        var result = await Build().DismissAsync(id,
+            new DismissRequest(TriageDismissalReasons.LegitimateMissing, "expected"));
+
+        result.Outcome.Should().Be(TriageOutcome.Ok);
+        result.Payload!.Status.Should().Be(TriageStatuses.Dismissed);
+        result.Payload.DismissalReason.Should().Be(TriageDismissalReasons.LegitimateMissing);
+    }
+
+    [Fact]
+    public async Task Dismiss_InvalidReason_ReturnsInvalidInput()
+    {
+        var id = await SeedQuarantineAsync();
+        var result = await Build().DismissAsync(id,
+            new DismissRequest("NotAReason", null));
+
+        result.Outcome.Should().Be(TriageOutcome.InvalidInput);
+    }
+
+    [Fact]
+    public async Task Dismiss_UnknownId_ReturnsNotFound()
+    {
+        var result = await Build().DismissAsync(Guid.NewGuid(),
+            new DismissRequest(TriageDismissalReasons.IntentionalNoise, null));
+
+        result.Outcome.Should().Be(TriageOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task Dismiss_SameReasonIdempotent_ReturnsOk()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.ConversionArtifact, "first"));
+
+        var result = await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.ConversionArtifact, "second"));
+
+        result.Outcome.Should().Be(TriageOutcome.Ok);
+        result.Payload!.DismissalReason.Should().Be(TriageDismissalReasons.ConversionArtifact);
+    }
+
+    [Fact]
+    public async Task Dismiss_DifferentReason_ReturnsConflict()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.IntentionalNoise, null));
+
+        var result = await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.LegitimateMissing, null));
+
+        result.Outcome.Should().Be(TriageOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task Dismiss_AfterRouting_ReturnsConflict()
+    {
+        var id = await SeedQuarantineAsync();
+        await Build().RouteAsync(id, new RouteRequest(
+            UniverseCodes.RealResidential, null, null));
+
+        var result = await Build().DismissAsync(id, new DismissRequest(
+            TriageDismissalReasons.IntentionalNoise, null));
+
+        result.Outcome.Should().Be(TriageOutcome.Conflict);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a sibling triage table (`legacy_tf_unproven.unproven_imprv_attr_triage`) alongside the doctrine-immutable `LegacyTfUnprovenImprvAttr` quarantine entity, plus three operator endpoints under `/api/sync/workbench/f/quarantine/imprv-attr` for **list**, **route**, and **dismiss** decisions.
- Quarantine entity is untouched (C1-C contract is doctrine-immutable). Operator decisions live in the new sibling so the original quarantine row stays a faithful record of the landing-time failure while triage state evolves.
- Mirrors the V7 doctrine-policy controller pattern: no `[Authorize]`, no per-row `CountyId` filter (single-county-per-deployment doctrine).

## What's in the slice
- **Entity**: `UnprovenImprvAttrTriage` — TriageId PK, unique `UnprovenRowId`, `Status` (Open/Routed/Dismissed), branch fields for routed (`RoutedToUniverse`/`RoutedToIAttrValCd`) and dismissed (`DismissalReason`), `OperatorNote`, audit fields.
- **Migration**: `SyncWorkbenchFTriageTable` — single migration; creates `legacy_tf_unproven.unproven_imprv_attr_triage` with unique index on `UnprovenRowId` + non-unique index on `Status`.
- **Service contract** `IQuarantineTriageService`:
  - `ListAsync` — paged list with `reason` / `universe` / `propId` filters, LEFT-JOIN to triage; untriaged rows surface as `TriageStatus="Open"`. `SuggestedReroute` v1 echoes the row's existing `UniverseCode` (cheap surface, deferred richer calc per spec).
  - `RouteAsync` — idempotent same-target re-route (200); cross-branch or divergent-target → 409 Conflict; unknown `UniverseCode` → 400; unknown id → 404.
  - `DismissAsync` — same idempotency contract for same-reason; closed vocabulary `{IntentionalNoise, LegitimateMissing, ConversionArtifact}`.
- **Service impl** `QuarantineTriageService` registered Scoped adjacent to F2/F3/F4 readers in `Program.cs`.
- **Controller** `WorkbenchFController` — `[Route("api/sync/workbench/f")]`, no auth attribute, maps `TriageOutcome` → HTTP status.

## Verified
- `dotnet build backend/TerraFusion.sln` — 0 warn, 0 err
- `dotnet test --filter Workbench` — **20/20 pass**
- `dotnet test` full unit suite — **3175/3175 pass**

## Test plan
- [x] List returns untriaged rows as `Open`
- [x] List filters by reason / universe / propId
- [x] List paging respected
- [x] List surfaces `Routed` / `Dismissed` after a triage decision
- [x] Route happy path / 400 invalid universe / 404 unknown id
- [x] Route idempotent same-target / 409 different target / 409 after dismiss
- [x] Dismiss happy path / 400 invalid reason / 404 unknown id
- [x] Dismiss idempotent same-reason / 409 different reason / 409 after route

## Notes
- `SuggestedReroute` v1 surfaces the quarantine row's own `UniverseCode` rather than re-running the universe classifier; richer reroute calculation is intentionally deferred (Phase 4.5 if needed).
- The DbContext docstring describes `AuditableEntityInterceptor` as auto-populating audit fields, but inspection of `TerraFusionDbContext.SaveChangesAsync` shows that hook only writes `AuditLogs` rows — `CreatedAt`/`UpdatedAt` on entities are still set by services. This slice follows the established convention used by `SyncCountyActiveWorkbookService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched quarantine item triage management with capabilities to list, route, and dismiss items
  * Added filtering options by reason, universe, and property ID with pagination support
  * Includes triage status tracking and reroute recommendations

* **Tests**
  * Added comprehensive test coverage for the new triage functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->