### PR TITLE
feat(sync): SYNC-WORKBENCH-G — atomic decision-commit endpoint

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/WorkbenchGController.cs
+++ b/backend/src/TerraFusion.API/Controllers/WorkbenchGController.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.Workbench;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: atomic decision-commit panel.
+///
+/// <para>Mirrors the Phase 4 / V7 doctrine-policy controller pattern:
+/// no <c>[Authorize]</c>, no per-row CountyId filter (single-county-
+/// per-deployment doctrine). The commit endpoint runs inside one
+/// DbContext transaction; reads are <c>AsNoTracking</c>.</para>
+///
+/// <para>Endpoints:</para>
+/// <list type="bullet">
+///   <item><c>POST /api/sync/workbench/g/commit</c> — atomic,
+///   idempotent commit of pending Routed/Dismissed triage decisions
+///   plus a doctrine-gate snapshot.</item>
+///   <item><c>GET /api/sync/workbench/g/commits</c> — paged list
+///   of recent commits (newest first).</item>
+///   <item><c>GET /api/sync/workbench/g/commits/{commitId}</c> —
+///   single commit + linked decisions.</item>
+/// </list>
+/// </summary>
+[ApiController]
+[Route("api/sync/workbench/g")]
+public sealed class WorkbenchGController : ControllerBase
+{
+    private readonly IWorkbenchCommitService _service;
+    private readonly ILogger<WorkbenchGController> _logger;
+
+    public WorkbenchGController(
+        IWorkbenchCommitService service,
+        ILogger<WorkbenchGController> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// <c>POST /api/sync/workbench/g/commit</c>
+    /// </summary>
+    [HttpPost("commit")]
+    public async Task<IActionResult> Commit(
+        [FromBody] CommitRequest body,
+        CancellationToken cancellationToken = default)
+    {
+        if (body is null)
+            return BadRequest(new { error = "request body is required" });
+
+        var result = await _service.CommitAsync(body, cancellationToken);
+        return MapCommit(result);
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/workbench/g/commits</c>
+    /// </summary>
+    [HttpGet("commits")]
+    public async Task<IActionResult> ListCommits(
+        [FromQuery] int limit = 50,
+        [FromQuery] int offset = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _service.ListCommitsAsync(limit, offset, cancellationToken);
+        return MapList(result);
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/workbench/g/commits/{commitId}</c>
+    /// </summary>
+    [HttpGet("commits/{commitId:guid}")]
+    public async Task<IActionResult> GetCommit(
+        [FromRoute] Guid commitId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _service.GetCommitAsync(commitId, cancellationToken);
+        return MapDetail(result);
+    }
+
+    // ── Outcome → HTTP mapping ───────────────────────────────────────
+
+    private IActionResult MapCommit(CommitResult r) => r.Outcome switch
+    {
+        CommitOutcome.Ok => Ok(r.Payload),
+        CommitOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        CommitOutcome.NotFound => NotFound(new { error = r.ErrorMessage }),
+        CommitOutcome.Conflict => Conflict(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+
+    private IActionResult MapList(CommitListResult r) => r.Outcome switch
+    {
+        CommitOutcome.Ok => Ok(new
+        {
+            count = r.Items.Count,
+            limit = r.Limit,
+            offset = r.Offset,
+            items = r.Items,
+        }),
+        CommitOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+
+    private IActionResult MapDetail(CommitDetailResult r) => r.Outcome switch
+    {
+        CommitOutcome.Ok => Ok(r.Payload),
+        CommitOutcome.InvalidInput => BadRequest(new { error = r.ErrorMessage }),
+        CommitOutcome.NotFound => NotFound(new { error = r.ErrorMessage }),
+        _ => StatusCode(500, new { error = r.ErrorMessage }),
+    };
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1912,6 +1912,14 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.Workbench.IQuarantineTriageService,
     TerraFusion.Data.Services.Workbench.QuarantineTriageService>();
 
+// SYNC-WORKBENCH-G: atomic decision-commit. One transaction wraps
+// idempotency probe → pending-decision load → gate snapshot reads
+// → link inserts → commit row. Decision-log + gate-snapshot only;
+// does NOT mutate truth_pacs.* or canonical_tf.*.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Workbench.IWorkbenchCommitService,
+    TerraFusion.Data.Services.Workbench.WorkbenchCommitService>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.Core/Entities/Workbench/WorkbenchCommit.cs
+++ b/backend/src/TerraFusion.Core/Entities/Workbench/WorkbenchCommit.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace TerraFusion.Core.Entities.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: atomic decision-commit record. One row per
+/// operator-issued commit. Captures (a) the commit's idempotency
+/// key, operator, note; (b) counts of routed and dismissed decisions
+/// linked to the commit; (c) snapshot JSON of the universe and
+/// ratio gate distributions at decision time.
+///
+/// <para><b>Doctrine note</b>: this is a <i>decision log + gate
+/// snapshot</i> — NOT a truth-table mutator. Slice G never writes
+/// into <c>truth_pacs.*</c> or <c>canonical_tf.*</c>. The actual
+/// truth/canonical materialization happens via the existing
+/// <c>attr-drain-1</c> chain when the dictionary picks up the
+/// routed codes. Phase 6 (evidence packet) downloads from this
+/// record.</para>
+///
+/// <para>Audit fields (<see cref="CreatedAt"/>, <see cref="UpdatedAt"/>,
+/// <see cref="CreatedBy"/>, <see cref="UpdatedBy"/>) are
+/// auto-populated by <c>AuditableEntityInterceptor</c>.</para>
+/// </summary>
+public sealed class WorkbenchCommit
+{
+    /// <summary>Commit identity.</summary>
+    public Guid CommitId { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Operator-supplied idempotency key. Unique. Re-submission of
+    /// the same key returns the existing commit row instead of
+    /// creating a new one.
+    /// </summary>
+    public string IdempotencyKey { get; set; } = string.Empty;
+
+    /// <summary>Operator id supplied by the caller.</summary>
+    public string OperatorId { get; set; } = string.Empty;
+
+    /// <summary>Free-form operator note (optional).</summary>
+    public string? CommitNote { get; set; }
+
+    /// <summary>Count of <c>"Routed"</c> triage rows linked to this commit.</summary>
+    public int RoutedDecisionsApplied { get; set; }
+
+    /// <summary>Count of <c>"Dismissed"</c> triage rows linked to this commit.</summary>
+    public int DismissedDecisionsApplied { get; set; }
+
+    /// <summary>
+    /// JSON snapshot of <c>truth_pacs.imprv_current</c> universe
+    /// distribution at commit time. Schema:
+    /// <c>{"REAL_RESIDENTIAL": n, "REAL_COMMERCIAL": n, "MOBILE_HOME": n,
+    /// "AG_CURRENT_USE": n, "PERSONAL_PROPERTY": n,
+    /// "CONVERSION_LEGACY": n, "UNKNOWN": n}</c>. Missing keys are
+    /// zero-filled.
+    /// </summary>
+    public string UniverseDistributionJson { get; set; } = "{}";
+
+    /// <summary>
+    /// JSON snapshot of <c>canonical_tf.tf_sale</c> ratio
+    /// distribution at commit time. Four-cell matrix:
+    /// <c>{"DorQ_CountyQ": n, "DorQ_CountyN": n, "DorN_CountyQ": n,
+    /// "DorN_CountyN": n}</c>. Missing keys are zero-filled.
+    /// </summary>
+    public string RatioDistributionJson { get; set; } = "{}";
+
+    /// <summary>Wall-clock UTC at which the commit was finalized.</summary>
+    public DateTime CommittedAt { get; set; } = DateTime.UtcNow;
+
+    // ── Audit (auto-populated by AuditableEntityInterceptor) ────────
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/Workbench/WorkbenchCommitDecisionLink.cs
+++ b/backend/src/TerraFusion.Core/Entities/Workbench/WorkbenchCommitDecisionLink.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace TerraFusion.Core.Entities.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: link row binding one operator triage decision
+/// (<see cref="TerraFusion.Core.Entities.LegacyTfUnproven.UnprovenImprvAttrTriage"/>)
+/// to one <see cref="WorkbenchCommit"/>. The presence of this link
+/// row — not any mutation of the triage row — is the marker that a
+/// decision has been committed.
+///
+/// <para>Many-to-one with <see cref="WorkbenchCommit"/> by
+/// <see cref="CommitId"/>. One-to-one with the source triage row
+/// by <see cref="TriageId"/> (unique index — a triage decision
+/// cannot be committed twice).</para>
+///
+/// <para><b>Decision branch invariants</b>:
+/// <list type="bullet">
+///   <item><see cref="DecisionType"/> = <c>"Route"</c> ⇒
+///   <see cref="RoutedToUniverse"/> required;
+///   <see cref="DismissalReason"/> NULL.</item>
+///   <item><see cref="DecisionType"/> = <c>"Dismiss"</c> ⇒
+///   <see cref="DismissalReason"/> required;
+///   <see cref="RoutedToUniverse"/> +
+///   <see cref="RoutedToIAttrValCd"/> NULL.</item>
+/// </list>
+/// Enforced at the service layer; not as a CHECK constraint.</para>
+/// </summary>
+public sealed class WorkbenchCommitDecisionLink
+{
+    /// <summary>Link identity.</summary>
+    public Guid LinkId { get; set; } = Guid.NewGuid();
+
+    /// <summary>FK to <see cref="WorkbenchCommit.CommitId"/>.</summary>
+    public Guid CommitId { get; set; }
+
+    /// <summary>
+    /// FK to <c>UnprovenImprvAttrTriage.TriageId</c>. Unique — a
+    /// triage row may be linked to at most one commit.
+    /// </summary>
+    public Guid TriageId { get; set; }
+
+    /// <summary>
+    /// FK back to <c>LegacyTfUnprovenImprvAttr.UnprovenRowId</c>
+    /// (the underlying quarantine row). Captured here so downstream
+    /// consumers (Phase 6 evidence packet) need not re-join through
+    /// the triage table.
+    /// </summary>
+    public Guid UnprovenRowId { get; set; }
+
+    /// <summary>One of <c>"Route"</c> or <c>"Dismiss"</c>.</summary>
+    public string DecisionType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Universe routed to. Mirrors
+    /// <c>UnprovenImprvAttrTriage.RoutedToUniverse</c> at commit
+    /// time. NULL when <see cref="DecisionType"/> is
+    /// <c>"Dismiss"</c>.
+    /// </summary>
+    public string? RoutedToUniverse { get; set; }
+
+    /// <summary>
+    /// Specific dictionary code (within the routed universe)
+    /// suggested by the operator. NULL when the operator routed
+    /// to a universe without selecting a code, OR when
+    /// <see cref="DecisionType"/> is <c>"Dismiss"</c>.
+    /// </summary>
+    public string? RoutedToIAttrValCd { get; set; }
+
+    /// <summary>
+    /// Dismissal reason mirrored from
+    /// <c>UnprovenImprvAttrTriage.DismissalReason</c>. NULL when
+    /// <see cref="DecisionType"/> is <c>"Route"</c>.
+    /// </summary>
+    public string? DismissalReason { get; set; }
+
+    /// <summary>UTC at which the link row was inserted (= commit time).</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/TerraFusion.Core/Sync/Workbench/IWorkbenchCommitService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Workbench/IWorkbenchCommitService.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: atomic decision-commit service.
+///
+/// <para>Provides three operator surfaces:</para>
+/// <list type="number">
+///   <item><see cref="CommitAsync"/> — atomic, idempotent commit of
+///   all pending Routed/Dismissed triage decisions plus a snapshot
+///   of doctrine gate distributions.</item>
+///   <item><see cref="ListCommitsAsync"/> — paged list of recent
+///   commits (newest first).</item>
+///   <item><see cref="GetCommitAsync"/> — single commit + linked
+///   decisions.</item>
+/// </list>
+///
+/// <para><b>Boundary invariant</b>: this service does NOT mutate
+/// triage rows, does NOT mutate quarantine rows, and does NOT write
+/// into <c>truth_pacs.*</c> or <c>canonical_tf.*</c>. The link-row
+/// presence is the marker that a triage decision has been
+/// committed. Truth/canonical materialization is handled separately
+/// by the existing attr-drain chain.</para>
+/// </summary>
+public interface IWorkbenchCommitService
+{
+    Task<CommitResult> CommitAsync(
+        CommitRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<CommitListResult> ListCommitsAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default);
+
+    Task<CommitDetailResult> GetCommitAsync(
+        Guid commitId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Discriminator over commit-service outcomes mapped 1:1 to HTTP status by the controller.</summary>
+public enum CommitOutcome
+{
+    Ok,
+    InvalidInput,
+    NotFound,
+    Conflict,
+}
+
+// ── Commit ───────────────────────────────────────────────────────────
+
+/// <summary>Body of <c>POST /api/sync/workbench/g/commit</c>.</summary>
+public sealed record CommitRequest(
+    string IdempotencyKey,
+    string OperatorId,
+    string? CommitNote);
+
+public sealed record CommitResult(
+    CommitOutcome Outcome,
+    string? ErrorMessage,
+    CommitResponse? Payload);
+
+/// <summary>
+/// Commit response. <see cref="Status"/> is <c>"Created"</c> for a
+/// fresh commit and <c>"Idempotent"</c> when the idempotency key
+/// matched an existing commit row.
+/// </summary>
+public sealed record CommitResponse(
+    Guid CommitId,
+    string Status,
+    int RoutedDecisionsApplied,
+    int DismissedDecisionsApplied,
+    DateTime CommittedAt,
+    string UniverseDistributionJson,
+    string RatioDistributionJson);
+
+/// <summary>Closed vocabulary for <see cref="CommitResponse.Status"/>.</summary>
+public static class CommitStatuses
+{
+    public const string Created = "Created";
+    public const string Idempotent = "Idempotent";
+}
+
+// ── List ─────────────────────────────────────────────────────────────
+
+public sealed record CommitListResult(
+    CommitOutcome Outcome,
+    string? ErrorMessage,
+    IReadOnlyList<CommitSummaryResponse> Items,
+    int Limit,
+    int Offset);
+
+public sealed record CommitSummaryResponse(
+    Guid CommitId,
+    DateTime CommittedAt,
+    string OperatorId,
+    string IdempotencyKey,
+    int RoutedDecisionsApplied,
+    int DismissedDecisionsApplied,
+    string? CommitNote);
+
+// ── Detail ───────────────────────────────────────────────────────────
+
+public sealed record CommitDetailResult(
+    CommitOutcome Outcome,
+    string? ErrorMessage,
+    CommitDetailResponse? Payload);
+
+public sealed record CommitDetailResponse(
+    Guid CommitId,
+    DateTime CommittedAt,
+    string OperatorId,
+    string IdempotencyKey,
+    int RoutedDecisionsApplied,
+    int DismissedDecisionsApplied,
+    string? CommitNote,
+    string UniverseDistributionJson,
+    string RatioDistributionJson,
+    IReadOnlyList<DecisionLinkResponse> Decisions);
+
+public sealed record DecisionLinkResponse(
+    Guid LinkId,
+    Guid TriageId,
+    Guid UnprovenRowId,
+    string DecisionType,
+    string? RoutedToUniverse,
+    string? RoutedToIAttrValCd,
+    string? DismissalReason);
+
+/// <summary>Closed vocabulary for <see cref="DecisionLinkResponse.DecisionType"/> / link row column.</summary>
+public static class DecisionTypes
+{
+    public const string Route = "Route";
+    public const string Dismiss = "Dismiss";
+}
+
+// ── Distribution-snapshot keys (kept here so tests can reference them) ──
+
+/// <summary>
+/// Closed vocabulary for the four cells of the ratio-distribution
+/// JSON snapshot. Names are <c>Dor{Q|N}_County{Q|N}</c> where
+/// <c>Q</c> = qualified, <c>N</c> = not qualified.
+/// </summary>
+public static class RatioDistributionCells
+{
+    public const string DorQ_CountyQ = "DorQ_CountyQ";
+    public const string DorQ_CountyN = "DorQ_CountyN";
+    public const string DorN_CountyQ = "DorN_CountyQ";
+    public const string DorN_CountyN = "DorN_CountyN";
+
+    public static IReadOnlyList<string> All { get; } = new[]
+    {
+        DorQ_CountyQ,
+        DorQ_CountyN,
+        DorN_CountyQ,
+        DorN_CountyN,
+    };
+}

--- a/backend/src/TerraFusion.Data/Configurations/Workbench/WorkbenchCommitConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/Workbench/WorkbenchCommitConfiguration.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.Workbench;
+
+namespace TerraFusion.Data.Configurations.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: EF configuration for
+/// <see cref="WorkbenchCommit"/>. Schema <c>tf_workbench</c>; table
+/// <c>workbench_commit</c>. Unique on
+/// <see cref="WorkbenchCommit.IdempotencyKey"/>; descending index
+/// on <see cref="WorkbenchCommit.CommittedAt"/> for the list-paging
+/// surface.
+/// </summary>
+public sealed class WorkbenchCommitConfiguration
+    : IEntityTypeConfiguration<WorkbenchCommit>
+{
+    public void Configure(EntityTypeBuilder<WorkbenchCommit> builder)
+    {
+        builder.ToTable("workbench_commit", schema: "tf_workbench");
+
+        builder.HasKey(x => x.CommitId);
+        builder.Property(x => x.CommitId).IsRequired();
+
+        builder.Property(x => x.IdempotencyKey)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(x => x.OperatorId)
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.Property(x => x.CommitNote).HasMaxLength(2000);
+
+        builder.Property(x => x.RoutedDecisionsApplied).IsRequired();
+        builder.Property(x => x.DismissedDecisionsApplied).IsRequired();
+
+        // JSON snapshots stored as text (provider-portable). PostgreSQL
+        // can be migrated to jsonb later with a column-type-only change.
+        builder.Property(x => x.UniverseDistributionJson)
+            .IsRequired();
+        builder.Property(x => x.RatioDistributionJson)
+            .IsRequired();
+
+        builder.Property(x => x.CommittedAt).IsRequired();
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(255);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(255);
+
+        builder.HasIndex(x => x.IdempotencyKey)
+            .IsUnique()
+            .HasDatabaseName("ux_workbench_commit_idempotency_key");
+
+        // Descending index on CommittedAt — the list endpoint orders
+        // newest first.
+        builder.HasIndex(x => x.CommittedAt)
+            .IsDescending(true)
+            .HasDatabaseName("ix_workbench_commit_committed_at_desc");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/Workbench/WorkbenchCommitDecisionLinkConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/Workbench/WorkbenchCommitDecisionLinkConfiguration.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.Workbench;
+
+namespace TerraFusion.Data.Configurations.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G: EF configuration for
+/// <see cref="WorkbenchCommitDecisionLink"/>. Schema
+/// <c>tf_workbench</c>; table <c>workbench_commit_decision_link</c>.
+/// Unique on <see cref="WorkbenchCommitDecisionLink.TriageId"/> (a
+/// triage row may be linked to at most one commit); non-unique on
+/// <see cref="WorkbenchCommitDecisionLink.CommitId"/> for fast
+/// detail-endpoint loads.
+/// </summary>
+public sealed class WorkbenchCommitDecisionLinkConfiguration
+    : IEntityTypeConfiguration<WorkbenchCommitDecisionLink>
+{
+    public void Configure(EntityTypeBuilder<WorkbenchCommitDecisionLink> builder)
+    {
+        builder.ToTable("workbench_commit_decision_link", schema: "tf_workbench");
+
+        builder.HasKey(x => x.LinkId);
+        builder.Property(x => x.LinkId).IsRequired();
+
+        builder.Property(x => x.CommitId).IsRequired();
+        builder.Property(x => x.TriageId).IsRequired();
+        builder.Property(x => x.UnprovenRowId).IsRequired();
+
+        builder.Property(x => x.DecisionType)
+            .HasMaxLength(20)
+            .IsRequired();
+
+        builder.Property(x => x.RoutedToUniverse).HasMaxLength(50);
+        builder.Property(x => x.RoutedToIAttrValCd).HasMaxLength(32);
+        builder.Property(x => x.DismissalReason).HasMaxLength(50);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasIndex(x => x.CommitId)
+            .HasDatabaseName("ix_workbench_commit_decision_link_commit");
+
+        builder.HasIndex(x => x.TriageId)
+            .IsUnique()
+            .HasDatabaseName("ux_workbench_commit_decision_link_triage");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260508093708_SyncWorkbenchGCommitTables.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508093708_SyncWorkbenchGCommitTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508093708_SyncWorkbenchGCommitTables")]
+    partial class SyncWorkbenchGCommitTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260508093708_SyncWorkbenchGCommitTables.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508093708_SyncWorkbenchGCommitTables.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncWorkbenchGCommitTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "tf_workbench");
+
+            migrationBuilder.CreateTable(
+                name: "workbench_commit",
+                schema: "tf_workbench",
+                columns: table => new
+                {
+                    CommitId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IdempotencyKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    OperatorId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    CommitNote = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    RoutedDecisionsApplied = table.Column<int>(type: "integer", nullable: false),
+                    DismissedDecisionsApplied = table.Column<int>(type: "integer", nullable: false),
+                    UniverseDistributionJson = table.Column<string>(type: "text", nullable: false),
+                    RatioDistributionJson = table.Column<string>(type: "text", nullable: false),
+                    CommittedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workbench_commit", x => x.CommitId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "workbench_commit_decision_link",
+                schema: "tf_workbench",
+                columns: table => new
+                {
+                    LinkId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommitId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TriageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UnprovenRowId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DecisionType = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    RoutedToUniverse = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    RoutedToIAttrValCd = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    DismissalReason = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workbench_commit_decision_link", x => x.LinkId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_workbench_commit_committed_at_desc",
+                schema: "tf_workbench",
+                table: "workbench_commit",
+                column: "CommittedAt",
+                descending: new bool[0]);
+
+            migrationBuilder.CreateIndex(
+                name: "ux_workbench_commit_idempotency_key",
+                schema: "tf_workbench",
+                table: "workbench_commit",
+                column: "IdempotencyKey",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_workbench_commit_decision_link_commit",
+                schema: "tf_workbench",
+                table: "workbench_commit_decision_link",
+                column: "CommitId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_workbench_commit_decision_link_triage",
+                schema: "tf_workbench",
+                table: "workbench_commit_decision_link",
+                column: "TriageId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workbench_commit",
+                schema: "tf_workbench");
+
+            migrationBuilder.DropTable(
+                name: "workbench_commit_decision_link",
+                schema: "tf_workbench");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/WorkbenchCommitService.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/WorkbenchCommitService.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.Workbench;
+
+namespace TerraFusion.Data.Services.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G implementation of <see cref="IWorkbenchCommitService"/>.
+///
+/// <para>One <c>BeginTransactionAsync</c> wraps the entire commit
+/// path: idempotency probe → pending-decision load → gate snapshot
+/// reads → decision-link inserts → commit-row insert → commit. The
+/// service NEVER mutates the upstream triage row or the doctrine-
+/// immutable quarantine row. The link-row presence is the marker.</para>
+///
+/// <para>Gate-distribution snapshots are produced by aggregate
+/// queries against <c>truth_pacs.imprv_current</c> (universe
+/// distribution, 7 cells) and <c>canonical_tf.tf_sale</c> (4-cell
+/// DOR/county ratio matrix). Both surfaces are zero-filled so the
+/// JSON shape is stable regardless of source-side cardinality.</para>
+/// </summary>
+public sealed class WorkbenchCommitService : IWorkbenchCommitService
+{
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 200;
+
+    private static readonly string[] AllUniverseCells = new[]
+    {
+        UniverseCodes.RealResidential,
+        UniverseCodes.RealCommercial,
+        UniverseCodes.MobileHome,
+        UniverseCodes.AgCurrentUse,
+        UniverseCodes.PersonalProperty,
+        UniverseCodes.ConversionLegacy,
+        UniverseCodes.Unknown,
+    };
+
+    private readonly TerraFusionDbContext _db;
+
+    public WorkbenchCommitService(TerraFusionDbContext db)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        _db = db;
+    }
+
+    public async Task<CommitResult> CommitAsync(
+        CommitRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.IdempotencyKey))
+            return new CommitResult(
+                CommitOutcome.InvalidInput,
+                "IdempotencyKey is required.",
+                null);
+
+        if (string.IsNullOrWhiteSpace(request.OperatorId))
+            return new CommitResult(
+                CommitOutcome.InvalidInput,
+                "OperatorId is required.",
+                null);
+
+        // ── Idempotency probe (no transaction needed for the read).
+        var existing = await _db.WorkbenchCommits
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                c => c.IdempotencyKey == request.IdempotencyKey,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            return new CommitResult(
+                CommitOutcome.Ok,
+                null,
+                new CommitResponse(
+                    existing.CommitId,
+                    CommitStatuses.Idempotent,
+                    existing.RoutedDecisionsApplied,
+                    existing.DismissedDecisionsApplied,
+                    existing.CommittedAt,
+                    existing.UniverseDistributionJson,
+                    existing.RatioDistributionJson));
+        }
+
+        // The in-memory provider does not support relational
+        // transactions; guard so unit tests still exercise the
+        // happy-path logic.
+        var supportsTransactions = _db.Database.IsRelational();
+        await using var tx = supportsTransactions
+            ? await _db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+
+        // ── Load pending decisions: triage rows whose Status is
+        // Routed or Dismissed AND no prior link row exists for that
+        // TriageId. We anti-join against the link table (LEFT JOIN +
+        // null-check) for portability across providers.
+        var linkedTriageIds = _db.WorkbenchCommitDecisionLinks
+            .AsNoTracking()
+            .Select(l => l.TriageId);
+
+        var pending = await _db.UnprovenImprvAttrTriages
+            .AsNoTracking()
+            .Where(t =>
+                (t.Status == TriageStatuses.Routed ||
+                 t.Status == TriageStatuses.Dismissed) &&
+                !linkedTriageIds.Contains(t.TriageId))
+            .OrderBy(t => t.TriageId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (pending.Count == 0)
+        {
+            return new CommitResult(
+                CommitOutcome.Conflict,
+                "No pending decisions to commit.",
+                null);
+        }
+
+        // ── Snapshot doctrine gates. Both are read-only queries.
+        var universeJson = await BuildUniverseDistributionJsonAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var ratioJson = await BuildRatioDistributionJsonAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // ── Build the commit row + link rows.
+        var commitId = Guid.NewGuid();
+        var nowUtc = DateTime.UtcNow;
+
+        var routedCount = 0;
+        var dismissedCount = 0;
+        var links = new List<WorkbenchCommitDecisionLink>(pending.Count);
+
+        foreach (var t in pending)
+        {
+            string decisionType;
+            if (t.Status == TriageStatuses.Routed)
+            {
+                decisionType = DecisionTypes.Route;
+                routedCount++;
+            }
+            else
+            {
+                decisionType = DecisionTypes.Dismiss;
+                dismissedCount++;
+            }
+
+            links.Add(new WorkbenchCommitDecisionLink
+            {
+                LinkId = Guid.NewGuid(),
+                CommitId = commitId,
+                TriageId = t.TriageId,
+                UnprovenRowId = t.UnprovenRowId,
+                DecisionType = decisionType,
+                RoutedToUniverse = decisionType == DecisionTypes.Route
+                    ? t.RoutedToUniverse
+                    : null,
+                RoutedToIAttrValCd = decisionType == DecisionTypes.Route
+                    ? t.RoutedToIAttrValCd
+                    : null,
+                DismissalReason = decisionType == DecisionTypes.Dismiss
+                    ? t.DismissalReason
+                    : null,
+                CreatedAt = nowUtc,
+            });
+        }
+
+        var commit = new WorkbenchCommit
+        {
+            CommitId = commitId,
+            IdempotencyKey = request.IdempotencyKey,
+            OperatorId = request.OperatorId,
+            CommitNote = request.CommitNote,
+            RoutedDecisionsApplied = routedCount,
+            DismissedDecisionsApplied = dismissedCount,
+            UniverseDistributionJson = universeJson,
+            RatioDistributionJson = ratioJson,
+            CommittedAt = nowUtc,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc,
+        };
+
+        _db.WorkbenchCommits.Add(commit);
+        _db.WorkbenchCommitDecisionLinks.AddRange(links);
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        if (tx is not null)
+            await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+        return new CommitResult(
+            CommitOutcome.Ok,
+            null,
+            new CommitResponse(
+                commit.CommitId,
+                CommitStatuses.Created,
+                commit.RoutedDecisionsApplied,
+                commit.DismissedDecisionsApplied,
+                commit.CommittedAt,
+                commit.UniverseDistributionJson,
+                commit.RatioDistributionJson));
+    }
+
+    public async Task<CommitListResult> ListCommitsAsync(
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        var clampedLimit = limit <= 0
+            ? DefaultLimit
+            : (limit > MaxLimit ? MaxLimit : limit);
+        var clampedOffset = offset < 0 ? 0 : offset;
+
+        var rows = await _db.WorkbenchCommits
+            .AsNoTracking()
+            .OrderByDescending(c => c.CommittedAt)
+            .ThenByDescending(c => c.CommitId)
+            .Skip(clampedOffset)
+            .Take(clampedLimit)
+            .Select(c => new CommitSummaryResponse(
+                c.CommitId,
+                c.CommittedAt,
+                c.OperatorId,
+                c.IdempotencyKey,
+                c.RoutedDecisionsApplied,
+                c.DismissedDecisionsApplied,
+                c.CommitNote))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CommitListResult(
+            CommitOutcome.Ok,
+            null,
+            rows,
+            clampedLimit,
+            clampedOffset);
+    }
+
+    public async Task<CommitDetailResult> GetCommitAsync(
+        Guid commitId,
+        CancellationToken cancellationToken = default)
+    {
+        if (commitId == Guid.Empty)
+            return new CommitDetailResult(
+                CommitOutcome.InvalidInput,
+                "commitId is required.",
+                null);
+
+        var commit = await _db.WorkbenchCommits
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CommitId == commitId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (commit is null)
+            return new CommitDetailResult(
+                CommitOutcome.NotFound,
+                $"Commit '{commitId}' not found.",
+                null);
+
+        // Decision-link order: ascending TriageId. Stable, deterministic,
+        // does not depend on storage-engine row order.
+        var decisions = await _db.WorkbenchCommitDecisionLinks
+            .AsNoTracking()
+            .Where(l => l.CommitId == commitId)
+            .OrderBy(l => l.TriageId)
+            .Select(l => new DecisionLinkResponse(
+                l.LinkId,
+                l.TriageId,
+                l.UnprovenRowId,
+                l.DecisionType,
+                l.RoutedToUniverse,
+                l.RoutedToIAttrValCd,
+                l.DismissalReason))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CommitDetailResult(
+            CommitOutcome.Ok,
+            null,
+            new CommitDetailResponse(
+                commit.CommitId,
+                commit.CommittedAt,
+                commit.OperatorId,
+                commit.IdempotencyKey,
+                commit.RoutedDecisionsApplied,
+                commit.DismissedDecisionsApplied,
+                commit.CommitNote,
+                commit.UniverseDistributionJson,
+                commit.RatioDistributionJson,
+                decisions));
+    }
+
+    // ── Gate-distribution snapshot helpers ─────────────────────────
+
+    private async Task<string> BuildUniverseDistributionJsonAsync(
+        CancellationToken cancellationToken)
+    {
+        // GROUP BY UniverseCode on truth_pacs.imprv_current. Rows
+        // with NULL universe are bucketed as UNKNOWN. The result is
+        // zero-filled across all 7 universe cells for stable JSON
+        // shape.
+        var rawCounts = await _db.TruthPacsImprvCurrents
+            .AsNoTracking()
+            .GroupBy(r => r.UniverseCode ?? UniverseCodes.Unknown)
+            .Select(g => new { Universe = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var byUniverse = rawCounts
+            .ToDictionary(r => r.Universe, r => r.Count, StringComparer.Ordinal);
+
+        // Bucket any unrecognized universe code into UNKNOWN. Keeps
+        // the cell set closed even if a stray code lands.
+        var distribution = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var cell in AllUniverseCells)
+            distribution[cell] = 0;
+
+        foreach (var kv in byUniverse)
+        {
+            if (distribution.ContainsKey(kv.Key))
+                distribution[kv.Key] += kv.Value;
+            else
+                distribution[UniverseCodes.Unknown] += kv.Value;
+        }
+
+        return SerializeDistribution(distribution, AllUniverseCells);
+    }
+
+    private async Task<string> BuildRatioDistributionJsonAsync(
+        CancellationToken cancellationToken)
+    {
+        // GROUP BY (DorRatioQualified, CountyRatioQualified) on
+        // canonical_tf.tf_sale. Four-cell matrix. Zero-filled.
+        var rawCells = await _db.TfSales
+            .AsNoTracking()
+            .GroupBy(s => new
+            {
+                DorQ = s.DorRatioQualified,
+                CountyQ = s.CountyRatioQualified,
+            })
+            .Select(g => new
+            {
+                g.Key.DorQ,
+                g.Key.CountyQ,
+                Count = g.Count(),
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var distribution = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            [RatioDistributionCells.DorQ_CountyQ] = 0,
+            [RatioDistributionCells.DorQ_CountyN] = 0,
+            [RatioDistributionCells.DorN_CountyQ] = 0,
+            [RatioDistributionCells.DorN_CountyN] = 0,
+        };
+
+        foreach (var cell in rawCells)
+        {
+            var key = (cell.DorQ, cell.CountyQ) switch
+            {
+                (true, true) => RatioDistributionCells.DorQ_CountyQ,
+                (true, false) => RatioDistributionCells.DorQ_CountyN,
+                (false, true) => RatioDistributionCells.DorN_CountyQ,
+                (false, false) => RatioDistributionCells.DorN_CountyN,
+            };
+            distribution[key] += cell.Count;
+        }
+
+        return SerializeDistribution(distribution, RatioDistributionCells.All);
+    }
+
+    private static string SerializeDistribution(
+        IReadOnlyDictionary<string, int> distribution,
+        IReadOnlyList<string> orderedKeys)
+    {
+        // Hand-roll the JSON to keep key order stable + matchable
+        // across providers. The closed-vocabulary keys are simple
+        // ASCII identifiers so explicit quoting is safe and avoids
+        // a System.Text.Json round-trip.
+        var sb = new StringBuilder();
+        sb.Append('{');
+        for (var i = 0; i < orderedKeys.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            var key = orderedKeys[i];
+            sb.Append('"').Append(key).Append('"').Append(':');
+            sb.Append(distribution[key]);
+        }
+        sb.Append('}');
+        return sb.ToString();
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -246,6 +246,16 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.LegacyTfUnproven.UnprovenImprvAttrTriage>
     UnprovenImprvAttrTriages { get; set; } = null!;
 
+  // SYNC-WORKBENCH-G: atomic decision-commit ledger. One row per
+  // operator-issued commit (workbench_commit) plus a link table
+  // (workbench_commit_decision_link) binding each Routed/Dismissed
+  // triage row to its committing snapshot. Decision-log + gate-
+  // snapshot only; DOES NOT mutate truth_pacs.* or canonical_tf.*.
+  public DbSet<TerraFusion.Core.Entities.Workbench.WorkbenchCommit>
+    WorkbenchCommits { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.Workbench.WorkbenchCommitDecisionLink>
+    WorkbenchCommitDecisionLinks { get; set; } = null!;
+
   // Slice L1: land_detail landing — per-segment land breakdown
   // (homesite, ag, pasture, timber, etc). 4-key composite. Required
   // by the truth_pacs.land_current promoter (future).
@@ -1058,6 +1068,13 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
     // SYNC-WORKBENCH-F: triage sibling table.
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.LegacyTfUnproven.UnprovenImprvAttrTriageConfiguration());
+
+    // SYNC-WORKBENCH-G: atomic decision-commit ledger (commit row +
+    // per-decision link rows). Schema tf_workbench.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.Workbench.WorkbenchCommitConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.Workbench.WorkbenchCommitDecisionLinkConfiguration());
 
     // Slice L1: land_detail landing — per-segment land breakdown.
     modelBuilder.ApplyConfiguration(

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Workbench/WorkbenchCommitServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Workbench/WorkbenchCommitServiceTests.cs
@@ -1,0 +1,506 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.LegacyTfUnproven;
+using TerraFusion.Core.Entities.TruthPacs;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Core.Sync.Workbench;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Workbench;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Workbench;
+
+/// <summary>
+/// SYNC-WORKBENCH-G unit tests for <see cref="WorkbenchCommitService"/>.
+///
+/// <para>Mirrors the F2 / WORKBENCH-F in-memory DbContext fixture
+/// pattern. The in-memory provider does not support relational
+/// transactions, so the service guards <c>BeginTransactionAsync</c>
+/// with an <c>IsRelational()</c> check; happy-path semantics still
+/// surface in tests.</para>
+/// </summary>
+public sealed class WorkbenchCommitServiceTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public WorkbenchCommitServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"workbench-g-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private WorkbenchCommitService Build() => new(_db);
+
+    // ── Seeders ──────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedRoutedTriageAsync(
+        string targetUniverse = UniverseCodes.RealResidential,
+        string? targetCode = "ABC")
+    {
+        var unprovenId = Guid.NewGuid();
+        var triageId = Guid.NewGuid();
+        var nowUtc = DateTime.UtcNow;
+
+        _db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
+        {
+            UnprovenRowId = unprovenId,
+            PropValYr = 2025,
+            SupNum = 0,
+            PropId = 12345,
+            ImprvId = 100,
+            ImprvDetId = 200,
+            IAttrValId = 300,
+            IAttrValCd = "ZZZ",
+            QuarantineReason = "UNKNOWN_I_ATTR_VAL_CD",
+            UniverseCode = UniverseCodes.RealResidential,
+            LandingLoadBatchId = Guid.NewGuid(),
+            CreatedAt = nowUtc,
+        });
+
+        _db.UnprovenImprvAttrTriages.Add(new UnprovenImprvAttrTriage
+        {
+            TriageId = triageId,
+            UnprovenRowId = unprovenId,
+            Status = TriageStatuses.Routed,
+            RoutedToUniverse = targetUniverse,
+            RoutedToIAttrValCd = targetCode,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc,
+        });
+
+        await _db.SaveChangesAsync();
+        return triageId;
+    }
+
+    private async Task<Guid> SeedDismissedTriageAsync(
+        string reason = TriageDismissalReasons.IntentionalNoise)
+    {
+        var unprovenId = Guid.NewGuid();
+        var triageId = Guid.NewGuid();
+        var nowUtc = DateTime.UtcNow;
+
+        _db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
+        {
+            UnprovenRowId = unprovenId,
+            PropValYr = 2025,
+            SupNum = 0,
+            PropId = 67890,
+            ImprvId = 101,
+            ImprvDetId = 201,
+            IAttrValId = 301,
+            IAttrValCd = "WWW",
+            QuarantineReason = "UNKNOWN_I_ATTR_VAL_CD",
+            UniverseCode = UniverseCodes.RealResidential,
+            LandingLoadBatchId = Guid.NewGuid(),
+            CreatedAt = nowUtc,
+        });
+
+        _db.UnprovenImprvAttrTriages.Add(new UnprovenImprvAttrTriage
+        {
+            TriageId = triageId,
+            UnprovenRowId = unprovenId,
+            Status = TriageStatuses.Dismissed,
+            DismissalReason = reason,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc,
+        });
+
+        await _db.SaveChangesAsync();
+        return triageId;
+    }
+
+    private async Task SeedOpenTriageAsync()
+    {
+        var unprovenId = Guid.NewGuid();
+        var triageId = Guid.NewGuid();
+        var nowUtc = DateTime.UtcNow;
+
+        _db.LegacyTfUnprovenImprvAttrs.Add(new LegacyTfUnprovenImprvAttr
+        {
+            UnprovenRowId = unprovenId,
+            PropValYr = 2025,
+            SupNum = 0,
+            PropId = 9999,
+            ImprvId = 102,
+            ImprvDetId = 202,
+            IAttrValId = 302,
+            IAttrValCd = "OPN",
+            QuarantineReason = "UNKNOWN_I_ATTR_VAL_CD",
+            UniverseCode = UniverseCodes.RealResidential,
+            LandingLoadBatchId = Guid.NewGuid(),
+            CreatedAt = nowUtc,
+        });
+
+        _db.UnprovenImprvAttrTriages.Add(new UnprovenImprvAttrTriage
+        {
+            TriageId = triageId,
+            UnprovenRowId = unprovenId,
+            Status = TriageStatuses.Open,
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc,
+        });
+
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task SeedTruthPacsImprvAsync(string universeCode)
+    {
+        var nowUtc = DateTime.UtcNow;
+        _db.TruthPacsImprvCurrents.Add(new TruthPacsImprvCurrent
+        {
+            TruthImprvId = Guid.NewGuid(),
+            PropValYr = 2025,
+            SupNum = 0,
+            PropId = (int)Random.Shared.NextInt64(1, int.MaxValue),
+            ImprvId = Random.Shared.NextInt64(1, long.MaxValue),
+            UniverseCode = universeCode,
+            SourceImprvLandedRowId = Guid.NewGuid(),
+            SourceSuppAssocLandedRowId = Guid.NewGuid(),
+            ImprvLoadBatchId = Guid.NewGuid(),
+            SuppAssocLoadBatchId = Guid.NewGuid(),
+            PromotionLoadBatchId = Guid.NewGuid(),
+            PromotedAt = nowUtc,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task SeedTfSaleAsync(bool dorQ, bool countyQ)
+    {
+        var nowUtc = DateTime.UtcNow;
+        _db.TfSales.Add(new TfSale
+        {
+            TfSaleId = Guid.NewGuid(),
+            CountyId = Guid.NewGuid(),
+            TfParcelId = Guid.NewGuid(),
+            ChgOfOwnerId = Random.Shared.NextInt64(1, long.MaxValue),
+            DorRatioQualified = dorQ,
+            CountyRatioQualified = countyQ,
+            PromotionLoadBatchId = Guid.NewGuid(),
+            CreatedAt = nowUtc,
+            UpdatedAt = nowUtc,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private static CommitRequest MakeRequest(string? key = null) =>
+        new(
+            IdempotencyKey: key ?? $"key-{Guid.NewGuid():N}",
+            OperatorId: "tester@benton",
+            CommitNote: "test commit");
+
+    // ─────────────────────────────────────────────────────────────────
+    // Commit
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Commit_HappyPath_3Routed_2Dismissed_LinksAllFive()
+    {
+        for (var i = 0; i < 3; i++) await SeedRoutedTriageAsync();
+        for (var i = 0; i < 2; i++) await SeedDismissedTriageAsync();
+
+        var result = await Build().CommitAsync(MakeRequest());
+
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+        result.Payload!.Status.Should().Be(CommitStatuses.Created);
+        result.Payload.RoutedDecisionsApplied.Should().Be(3);
+        result.Payload.DismissedDecisionsApplied.Should().Be(2);
+
+        var links = await _db.WorkbenchCommitDecisionLinks
+            .AsNoTracking()
+            .Where(l => l.CommitId == result.Payload.CommitId)
+            .ToListAsync();
+        links.Should().HaveCount(5);
+        links.Count(l => l.DecisionType == DecisionTypes.Route).Should().Be(3);
+        links.Count(l => l.DecisionType == DecisionTypes.Dismiss).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Commit_SameIdempotencyKey_ReturnsExistingCommitWithIdempotentStatus()
+    {
+        await SeedRoutedTriageAsync();
+        var key = $"idem-{Guid.NewGuid():N}";
+
+        var first = await Build().CommitAsync(MakeRequest(key));
+        first.Outcome.Should().Be(CommitOutcome.Ok);
+        first.Payload!.Status.Should().Be(CommitStatuses.Created);
+        var firstCommitId = first.Payload.CommitId;
+
+        var second = await Build().CommitAsync(MakeRequest(key));
+        second.Outcome.Should().Be(CommitOutcome.Ok);
+        second.Payload!.Status.Should().Be(CommitStatuses.Idempotent);
+        second.Payload.CommitId.Should().Be(firstCommitId);
+
+        // Only one commit row + one link row.
+        (await _db.WorkbenchCommits.CountAsync()).Should().Be(1);
+        (await _db.WorkbenchCommitDecisionLinks.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Commit_NoPendingDecisions_Returns409Conflict()
+    {
+        var result = await Build().CommitAsync(MakeRequest());
+
+        result.Outcome.Should().Be(CommitOutcome.Conflict);
+        result.Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Commit_OnlyOpenTriageRowsPresent_Returns409Conflict()
+    {
+        await SeedOpenTriageAsync();
+        await SeedOpenTriageAsync();
+
+        var result = await Build().CommitAsync(MakeRequest());
+
+        result.Outcome.Should().Be(CommitOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task Commit_MixedOpenRoutedDismissed_OnlyRoutedAndDismissedAreCommitted_OpenUntouched()
+    {
+        await SeedOpenTriageAsync();
+        await SeedRoutedTriageAsync();
+        await SeedDismissedTriageAsync();
+
+        var result = await Build().CommitAsync(MakeRequest());
+
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+        result.Payload!.RoutedDecisionsApplied.Should().Be(1);
+        result.Payload.DismissedDecisionsApplied.Should().Be(1);
+
+        // Open row remains in Open status, untouched.
+        var stillOpen = await _db.UnprovenImprvAttrTriages
+            .AsNoTracking()
+            .CountAsync(t => t.Status == TriageStatuses.Open);
+        stillOpen.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Commit_AlreadyLinkedTriageRow_NotReprocessedOnSecondCommit()
+    {
+        await SeedRoutedTriageAsync();
+        var first = await Build().CommitAsync(MakeRequest());
+        first.Outcome.Should().Be(CommitOutcome.Ok);
+
+        // Second commit attempt with no NEW pending rows → 409.
+        var second = await Build().CommitAsync(MakeRequest());
+        second.Outcome.Should().Be(CommitOutcome.Conflict);
+
+        (await _db.WorkbenchCommits.CountAsync()).Should().Be(1);
+        (await _db.WorkbenchCommitDecisionLinks.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Commit_UniverseSnapshot_HasAllSevenUniversesWithZeroFill()
+    {
+        await SeedRoutedTriageAsync();
+        // Only seed two universes — the other five should appear as 0.
+        await SeedTruthPacsImprvAsync(UniverseCodes.RealResidential);
+        await SeedTruthPacsImprvAsync(UniverseCodes.RealResidential);
+        await SeedTruthPacsImprvAsync(UniverseCodes.AgCurrentUse);
+
+        var result = await Build().CommitAsync(MakeRequest());
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+
+        var json = result.Payload!.UniverseDistributionJson;
+
+        json.Should().Contain($"\"{UniverseCodes.RealResidential}\":2");
+        json.Should().Contain($"\"{UniverseCodes.AgCurrentUse}\":1");
+        json.Should().Contain($"\"{UniverseCodes.RealCommercial}\":0");
+        json.Should().Contain($"\"{UniverseCodes.MobileHome}\":0");
+        json.Should().Contain($"\"{UniverseCodes.PersonalProperty}\":0");
+        json.Should().Contain($"\"{UniverseCodes.ConversionLegacy}\":0");
+        json.Should().Contain($"\"{UniverseCodes.Unknown}\":0");
+    }
+
+    [Fact]
+    public async Task Commit_RatioSnapshot_HasFourCellsWithZeroFill()
+    {
+        await SeedRoutedTriageAsync();
+        // Seed only DorQ_CountyQ — the other three cells should be 0.
+        await SeedTfSaleAsync(dorQ: true, countyQ: true);
+        await SeedTfSaleAsync(dorQ: true, countyQ: true);
+
+        var result = await Build().CommitAsync(MakeRequest());
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+
+        var json = result.Payload!.RatioDistributionJson;
+        json.Should().Contain($"\"{RatioDistributionCells.DorQ_CountyQ}\":2");
+        json.Should().Contain($"\"{RatioDistributionCells.DorQ_CountyN}\":0");
+        json.Should().Contain($"\"{RatioDistributionCells.DorN_CountyQ}\":0");
+        json.Should().Contain($"\"{RatioDistributionCells.DorN_CountyN}\":0");
+    }
+
+    [Fact]
+    public async Task Commit_EmptyTruthPacsImprvCurrent_ProducesAllZeroUniverseSnapshot()
+    {
+        await SeedRoutedTriageAsync();
+
+        var result = await Build().CommitAsync(MakeRequest());
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+
+        var json = result.Payload!.UniverseDistributionJson;
+        json.Should().Contain($"\"{UniverseCodes.Unknown}\":0");
+        json.Should().Contain($"\"{UniverseCodes.RealResidential}\":0");
+        json.Should().Contain($"\"{UniverseCodes.AgCurrentUse}\":0");
+    }
+
+    [Fact]
+    public async Task Commit_EmptyTfSale_ProducesAllZeroRatioSnapshot()
+    {
+        await SeedRoutedTriageAsync();
+
+        var result = await Build().CommitAsync(MakeRequest());
+        result.Outcome.Should().Be(CommitOutcome.Ok);
+
+        var json = result.Payload!.RatioDistributionJson;
+        json.Should().Contain($"\"{RatioDistributionCells.DorQ_CountyQ}\":0");
+        json.Should().Contain($"\"{RatioDistributionCells.DorQ_CountyN}\":0");
+        json.Should().Contain($"\"{RatioDistributionCells.DorN_CountyQ}\":0");
+        json.Should().Contain($"\"{RatioDistributionCells.DorN_CountyN}\":0");
+    }
+
+    [Fact]
+    public async Task Commit_MissingIdempotencyKey_ReturnsBadRequest()
+    {
+        var result = await Build().CommitAsync(
+            new CommitRequest(IdempotencyKey: "  ", OperatorId: "op", CommitNote: null));
+        result.Outcome.Should().Be(CommitOutcome.InvalidInput);
+    }
+
+    [Fact]
+    public async Task Commit_MissingOperatorId_ReturnsBadRequest()
+    {
+        var result = await Build().CommitAsync(
+            new CommitRequest(IdempotencyKey: "k", OperatorId: "", CommitNote: null));
+        result.Outcome.Should().Be(CommitOutcome.InvalidInput);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // List
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_DefaultPaging_ReturnsNewestFirst()
+    {
+        await SeedRoutedTriageAsync();
+        var first = await Build().CommitAsync(MakeRequest());
+        await Task.Delay(15);
+        await SeedRoutedTriageAsync();
+        var second = await Build().CommitAsync(MakeRequest());
+
+        var listResult = await Build().ListCommitsAsync(50, 0);
+        listResult.Outcome.Should().Be(CommitOutcome.Ok);
+        listResult.Items.Should().HaveCount(2);
+        listResult.Items[0].CommitId.Should().Be(second.Payload!.CommitId);
+        listResult.Items[1].CommitId.Should().Be(first.Payload!.CommitId);
+    }
+
+    [Fact]
+    public async Task List_LimitOver200_IsClampedTo200()
+    {
+        var listResult = await Build().ListCommitsAsync(500, 0);
+        listResult.Limit.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task List_OffsetPaging_SkipsLeadingEntries()
+    {
+        await SeedRoutedTriageAsync();
+        await Build().CommitAsync(MakeRequest());
+        await Task.Delay(15);
+        await SeedRoutedTriageAsync();
+        var second = await Build().CommitAsync(MakeRequest());
+
+        var listResult = await Build().ListCommitsAsync(50, 1);
+        // After skipping the newest, the older one shows up.
+        listResult.Items.Should().HaveCount(1);
+        listResult.Items[0].CommitId.Should().NotBe(second.Payload!.CommitId);
+    }
+
+    [Fact]
+    public async Task List_EmptyDb_ReturnsEmptyArray()
+    {
+        var listResult = await Build().ListCommitsAsync(50, 0);
+        listResult.Outcome.Should().Be(CommitOutcome.Ok);
+        listResult.Items.Should().BeEmpty();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Detail
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Detail_HappyPath_ReturnsCommitWithLinkedDecisions()
+    {
+        await SeedRoutedTriageAsync();
+        await SeedDismissedTriageAsync();
+        var commit = await Build().CommitAsync(MakeRequest());
+
+        var detail = await Build().GetCommitAsync(commit.Payload!.CommitId);
+        detail.Outcome.Should().Be(CommitOutcome.Ok);
+        detail.Payload!.CommitId.Should().Be(commit.Payload.CommitId);
+        detail.Payload.Decisions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Detail_UnknownId_Returns404()
+    {
+        var detail = await Build().GetCommitAsync(Guid.NewGuid());
+        detail.Outcome.Should().Be(CommitOutcome.NotFound);
+        detail.Payload.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Detail_DecisionsOrderedByTriageId()
+    {
+        await SeedRoutedTriageAsync();
+        await SeedRoutedTriageAsync();
+        await SeedDismissedTriageAsync();
+        var commit = await Build().CommitAsync(MakeRequest());
+
+        var detail = await Build().GetCommitAsync(commit.Payload!.CommitId);
+        var ids = detail.Payload!.Decisions.Select(d => d.TriageId).ToList();
+        ids.Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task Detail_RouteAndDismissDecisions_BothSurfaceWithCorrectBranchFields()
+    {
+        await SeedRoutedTriageAsync(targetUniverse: UniverseCodes.AgCurrentUse, targetCode: "CODE1");
+        await SeedDismissedTriageAsync(reason: TriageDismissalReasons.ConversionArtifact);
+        var commit = await Build().CommitAsync(MakeRequest());
+
+        var detail = await Build().GetCommitAsync(commit.Payload!.CommitId);
+        detail.Outcome.Should().Be(CommitOutcome.Ok);
+
+        var routeRow = detail.Payload!.Decisions
+            .Single(d => d.DecisionType == DecisionTypes.Route);
+        routeRow.RoutedToUniverse.Should().Be(UniverseCodes.AgCurrentUse);
+        routeRow.RoutedToIAttrValCd.Should().Be("CODE1");
+        routeRow.DismissalReason.Should().BeNull();
+
+        var dismissRow = detail.Payload.Decisions
+            .Single(d => d.DecisionType == DecisionTypes.Dismiss);
+        dismissRow.DismissalReason.Should().Be(TriageDismissalReasons.ConversionArtifact);
+        dismissRow.RoutedToUniverse.Should().BeNull();
+        dismissRow.RoutedToIAttrValCd.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Workbench commit ledger: an atomic, idempotent record of "operator committed these triage decisions on this date, here are the doctrine gate distributions at decision time." Phase 6 (evidence packet) downloads from this record.

**Doctrine boundary**: this is a **decision log + gate snapshot** writer. NOT a truth-table mutator. The service NEVER writes into `truth_pacs.*` or `canonical_tf.*`. Truth/canonical materialization remains the job of the existing `attr-drain-1` chain when the dictionary picks up routed codes.

## Schema

One migration `20260508093708_SyncWorkbenchGCommitTables`, schema `tf_workbench`:
- `workbench_commit` — commit row + 7-cell universe + 4-cell ratio JSON snapshots; unique on `IdempotencyKey`; descending index on `CommittedAt`
- `workbench_commit_decision_link` — per-decision link; unique on `TriageId`; non-unique on `CommitId`

## Endpoints

Under `[Route("api/sync/workbench/g")]`:
- `POST /commit` — atomic commit, one `BeginTransactionAsync`
- `GET /commits` — paged list newest first (limit clamped to 200)
- `GET /commits/{commitId}` — commit + linked decisions ordered by `TriageId`

## Constraints honored

- One transaction wraps the commit path (guarded by `IsRelational()` so in-memory tests still exercise happy paths)
- DOES NOT mutate `UnprovenImprvAttrTriage` or `LegacyTfUnprovenImprvAttr` — link-row presence is the marker
- Idempotent: same `IdempotencyKey` returns `Status="Idempotent"`
- Empty pending set → 409 (NOT silent success)
- No `[Authorize]` (mirrors Phase 4 `WorkbenchFController` pattern)
- Universe + ratio snapshots zero-filled across all cells

## Test plan

- [x] 20 new tests in `WorkbenchCommitServiceTests.cs` (Commit happy/idempotent/conflict, list paging, detail surface, gate-snapshot zero-fill)
- [x] Full unit suite: 3195/3195 passing
- [x] Build clean: `dotnet build backend/TerraFusion.sln` 0 warnings, 0 errors
- [x] Migration generates clean (verified via `dotnet ef migrations script`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit endpoint to atomically persist pending workbench triage decisions with idempotency support.
  * Added list endpoint for paginated retrieval of recent commits (newest-first ordering, configurable limit/offset).
  * Added detail endpoint to view commit information including linked decisions and distribution snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->