### PR TITLE
feat(sync): SYNC-COMPLETE-2 — durable full-corpus runner + reconciliation

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/FullCorpusController.cs
+++ b/backend/src/TerraFusion.API/Controllers/FullCorpusController.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.API.Controllers;
+
+/// <summary>
+/// SYNC-COMPLETE-2: durable full-corpus sync runner endpoints.
+///
+/// <para>Mirrors the workbench controller pattern: no
+/// <c>[Authorize]</c>, single-county-per-deployment doctrine, all
+/// state mutations go through the orchestrator service (status
+/// transitions are the orchestrator's responsibility, not the
+/// controller's).</para>
+///
+/// <para>Endpoints:</para>
+/// <list type="bullet">
+///   <item><c>POST /start</c> — enqueue a new full-corpus run.
+///   Returns 202 with run id; the hosted worker picks it up.</item>
+///   <item><c>POST /{runId}/resume</c> — flip a Failed | Interrupted
+///   run to Queued so the worker resumes from
+///   <c>NextLaneOnResume</c>.</item>
+///   <item><c>GET /{runId}</c> — run + 6 lane results.</item>
+///   <item><c>GET /{runId}/reconciliation</c> — run + 6 reconciliation
+///   rows (empty array if not yet computed).</item>
+///   <item><c>GET /{runId}/evidence.zip</c> — corpus-scope evidence
+///   ZIP (HMAC-signed manifest + run.csv + lane-results.csv +
+///   reconciliation.csv + gate-summaries.json).</item>
+/// </list>
+/// </summary>
+[ApiController]
+[Route("api/sync/corpus")]
+[AllowAnonymous]
+public sealed class FullCorpusController : ControllerBase
+{
+    private const string ZipMediaType = "application/zip";
+
+    private readonly IFullCorpusOrchestrator _orchestrator;
+    private readonly ICorpusEvidencePacketService _evidence;
+    private readonly ILogger<FullCorpusController> _logger;
+
+    public FullCorpusController(
+        IFullCorpusOrchestrator orchestrator,
+        ICorpusEvidencePacketService evidence,
+        ILogger<FullCorpusController> logger)
+    {
+        _orchestrator = orchestrator;
+        _evidence = evidence;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// <c>POST /api/sync/corpus/start</c>
+    ///
+    /// <para>Enqueue a new full-corpus run. Returns 202 with the
+    /// new run id; the hosted worker picks it up within the next
+    /// poll interval (5 seconds).</para>
+    /// </summary>
+    [HttpPost("start")]
+    public async Task<IActionResult> Start(
+        [FromBody] StartCorpusRequest? request,
+        CancellationToken cancellationToken = default)
+    {
+        var operatorName = string.IsNullOrWhiteSpace(request?.OperatorName)
+            ? "full-corpus-runner"
+            : request!.OperatorName!.Trim();
+        var workingYear = (short)(request?.WorkingYear ?? 2026);
+
+        var result = await _orchestrator.StartAsync(operatorName, workingYear, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "[Corpus] Started run id={RunId} operator={Op} year={Year}",
+            result.RunId, operatorName, workingYear);
+
+        return Accepted(new
+        {
+            runId = result.RunId,
+            status = result.Status,
+        });
+    }
+
+    /// <summary>
+    /// <c>POST /api/sync/corpus/{runId}/resume</c>
+    ///
+    /// <para>Returns 202 on success; 404 when the run does not exist;
+    /// 409 when the run is not in a resumable state.</para>
+    /// </summary>
+    [HttpPost("{runId:guid}/resume")]
+    public async Task<IActionResult> Resume(
+        [FromRoute] Guid runId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _orchestrator.ResumeAsync(runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            CorpusOutcome.Ok => Accepted(new { runId = result.RunId, status = result.Status }),
+            CorpusOutcome.NotFound => NotFound(new { error = result.ErrorMessage }),
+            CorpusOutcome.Conflict => Conflict(new
+            {
+                error = result.ErrorMessage,
+                status = result.Status,
+            }),
+            _ => StatusCode(500, new { error = result.ErrorMessage }),
+        };
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/corpus/{runId}</c>
+    /// </summary>
+    [HttpGet("{runId:guid}")]
+    public async Task<IActionResult> GetStatus(
+        [FromRoute] Guid runId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _orchestrator.GetStatusAsync(runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            CorpusOutcome.Ok => Ok(new
+            {
+                run = result.Run,
+                lanes = result.Lanes,
+            }),
+            CorpusOutcome.NotFound => NotFound(new { error = result.ErrorMessage }),
+            _ => StatusCode(500, new { error = result.ErrorMessage }),
+        };
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/corpus/{runId}/reconciliation</c>
+    /// </summary>
+    [HttpGet("{runId:guid}/reconciliation")]
+    public async Task<IActionResult> GetReconciliation(
+        [FromRoute] Guid runId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _orchestrator.GetReconciliationAsync(runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            CorpusOutcome.Ok => Ok(new
+            {
+                run = result.Run,
+                reconciliations = result.Reconciliations,
+            }),
+            CorpusOutcome.NotFound => NotFound(new { error = result.ErrorMessage }),
+            _ => StatusCode(500, new { error = result.ErrorMessage }),
+        };
+    }
+
+    /// <summary>
+    /// <c>GET /api/sync/corpus/{runId}/evidence.zip</c>
+    /// </summary>
+    [HttpGet("{runId:guid}/evidence.zip")]
+    public async Task<IActionResult> GetEvidence(
+        [FromRoute] Guid runId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _evidence.BuildAsync(runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            CorpusEvidencePacketOutcome.Ok =>
+                File(result.ZipContent!, ZipMediaType, result.FileName),
+            CorpusEvidencePacketOutcome.NotFound =>
+                NotFound(new { error = result.ErrorMessage }),
+            CorpusEvidencePacketOutcome.ConfigurationError =>
+                StatusCode(500, new { error = result.ErrorMessage }),
+            _ => StatusCode(500, new { error = result.ErrorMessage }),
+        };
+    }
+
+    public sealed record StartCorpusRequest(string? OperatorName, int? WorkingYear);
+}

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1928,6 +1928,31 @@ builder.Services.AddScoped<
     TerraFusion.Core.Sync.Workbench.IEvidencePacketService,
     TerraFusion.Data.Services.Workbench.EvidencePacketService>();
 
+// SYNC-COMPLETE-2: durable full-corpus runner. Orchestrator owns
+// the FullCorpusRun state machine (Queued → Running → Completed |
+// Failed | Interrupted | Resumed); HTTP-loopback lane runner calls
+// the existing /api/sync/doctrine/drain/{lane} endpoints; PACS
+// baseline reconciler queries source counts vs. canonical for the
+// post-drain reconciliation pass; corpus evidence packet service
+// builds an HMAC-signed ZIP at run scope; hosted background worker
+// polls for queued runs every 5 seconds and stays alive across the
+// host's lifetime.
+builder.Services.AddHttpClient();
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Corpus.IFullCorpusOrchestrator,
+    TerraFusion.Data.Services.Workbench.Corpus.FullCorpusOrchestrator>();
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Corpus.ICorpusLaneRunner,
+    TerraFusion.Data.Services.Workbench.Corpus.HttpCorpusLaneRunner>();
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Corpus.IPacsBaselineReconciler,
+    TerraFusion.Data.Services.Workbench.Corpus.PacsBaselineReconciler>();
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Corpus.ICorpusEvidencePacketService,
+    TerraFusion.Data.Services.Workbench.Corpus.CorpusEvidencePacketService>();
+builder.Services.AddHostedService<
+    TerraFusion.Data.Services.Workbench.Corpus.FullCorpusOrchestratorHostedService>();
+
 // Slice B2-A: truth_pacs.owner_current promoter — supp-aware
 // owner snapshot with account-link enforcement and HARD pct-
 // completeness gate. Five T-* gates. Idempotent by OwnerLoadBatchId.

--- a/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusLaneResult.cs
+++ b/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusLaneResult.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace TerraFusion.Core.Entities.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: per-lane result row inside a
+/// <see cref="FullCorpusRun"/>.
+///
+/// <para>Six rows per run, one per lane (parcel, owner-wsdor,
+/// improvement, land, sales, geometry). Pre-created in
+/// <c>"Pending"</c> state at <see cref="FullCorpusRun"/> insertion;
+/// transitioned to <c>"Running"</c> as the worker enters the lane
+/// and to <c>"Completed"</c> | <c>"Failed"</c> | <c>"Skipped"</c>
+/// when the lane returns. Carries the lane's batch ids and
+/// counts/gate JSON exactly as the existing
+/// <c>DoctrineDrainController</c> endpoints emit them.</para>
+///
+/// <para>Unique on <c>(RunId, Lane)</c> so each lane has at most
+/// one result row per run. Audit fields auto-populated.</para>
+/// </summary>
+public sealed class FullCorpusLaneResult
+{
+    public Guid LaneResultId { get; set; } = Guid.NewGuid();
+
+    /// <summary>FK to <see cref="FullCorpusRun.RunId"/>.</summary>
+    public Guid RunId { get; set; }
+
+    /// <summary>parcel | owner-wsdor | improvement | land | sales | geometry.</summary>
+    public string Lane { get; set; } = string.Empty;
+
+    /// <summary>Pending | Running | Completed | Failed | Skipped.</summary>
+    public string Status { get; set; } = "Pending";
+
+    public DateTime? StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>JSON array of Guid batch ids produced by the lane.</summary>
+    public string? BatchIdsJson { get; set; }
+
+    /// <summary>JSON object of count metrics (rowsLanded, rowsPromotedToTruth, etc).</summary>
+    public string? CountsJson { get; set; }
+
+    /// <summary>JSON of per-gate pass/fail aggregation for the lane's batches.</summary>
+    public string? GateSummaryJson { get; set; }
+
+    /// <summary>JSON quarantine before/after/delta object.</summary>
+    public string? QuarantineDeltaJson { get; set; }
+
+    /// <summary>Lane error summary on <c>Status="Failed"</c>.</summary>
+    public string? ErrorMessage { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusReconciliation.cs
+++ b/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusReconciliation.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace TerraFusion.Core.Entities.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: per-lane reconciliation row recording the
+/// PACS-side baseline count vs. the TerraFusion canonical count
+/// after a full-corpus run completes.
+///
+/// <para>Six rows per run, one per lane (or fewer when an upstream
+/// lane fails before reconciliation runs). Per-lane policy lives in
+/// <c>CorpusReconciliationPolicy</c>; tolerance is decimal pct.</para>
+///
+/// <para>Statuses: <c>Match</c> (delta == 0), <c>AcceptableDelta</c>
+/// (|deltaPct| ≤ TolerancePct), <c>Investigate</c> (over tolerance,
+/// or PACS/external feature service unreachable). PACS unreachability
+/// is diagnostic — never fatal.</para>
+///
+/// <para>Audit fields auto-populated.</para>
+/// </summary>
+public sealed class FullCorpusReconciliation
+{
+    public Guid ReconciliationId { get; set; } = Guid.NewGuid();
+
+    /// <summary>FK to <see cref="FullCorpusRun.RunId"/>.</summary>
+    public Guid RunId { get; set; }
+
+    /// <summary>parcel | owner-wsdor | improvement | land | sales | geometry.</summary>
+    public string Lane { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-lane reconciliation policy basis. One of
+    /// <c>RAW_SOURCE</c>, <c>DOCTRINE_FILTERED</c>,
+    /// <c>DEDUPED_CANONICAL</c>, <c>EXTERNAL_FEATURE_COUNT</c>.
+    /// </summary>
+    public string ExpectedBasis { get; set; } = string.Empty;
+
+    public long PacsSourceCount { get; set; }
+    public long TfCanonicalCount { get; set; }
+
+    /// <summary>Signed: <c>TfCanonicalCount - PacsSourceCount</c>.</summary>
+    public long Delta { get; set; }
+
+    /// <summary><c>|Delta| / max(PacsSourceCount, 1) * 100</c>.</summary>
+    public decimal DeltaPct { get; set; }
+
+    /// <summary>Per-lane policy tolerance (pct).</summary>
+    public decimal TolerancePct { get; set; }
+
+    /// <summary>Match | AcceptableDelta | Investigate.</summary>
+    public string ReconciliationStatus { get; set; } = string.Empty;
+
+    /// <summary>Optional notes (e.g. "PACS unreachable", aggregation explanation).</summary>
+    public string? Notes { get; set; }
+
+    public DateTime ComputedAt { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusRun.cs
+++ b/backend/src/TerraFusion.Core/Entities/Workbench/FullCorpusRun.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace TerraFusion.Core.Entities.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: durable full-corpus sync run.
+///
+/// <para>One row per operator-issued <c>POST /api/sync/corpus/start</c>
+/// call. Tracks the run's lifecycle through the six lanes (parcel,
+/// owner-wsdor, improvement, land, sales, geometry) and the post-
+/// drain reconciliation pass. The hosted background worker
+/// (<c>FullCorpusOrchestratorHostedService</c>) polls
+/// <see cref="Status"/>=<c>"Queued"</c> rows, advances them through
+/// the lanes, and on completion populates
+/// <c>FullCorpusReconciliation</c> rows.</para>
+///
+/// <para>A 6+ hour full-county drain exceeds curl's 6h timeout and any
+/// reasonable HTTP timeout. This entity provides the durable state
+/// the worker needs to <i>resume</i> after backend restarts: the
+/// startup sweep marks any <c>"Running"</c> row as <c>"Interrupted"</c>
+/// and waits for an explicit operator <c>POST resume</c>.</para>
+///
+/// <para>Audit fields auto-populated by <c>AuditableEntityInterceptor</c>.</para>
+/// </summary>
+public sealed class FullCorpusRun
+{
+    /// <summary>Run identity.</summary>
+    public Guid RunId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Operator identifier supplied at start time.</summary>
+    public string OperatorName { get; set; } = string.Empty;
+
+    /// <summary>PACS <c>prop_val_yr</c> filter for year-grain lanes.</summary>
+    public short WorkingYear { get; set; }
+
+    /// <summary>Queued | Running | Completed | Failed | Interrupted | Resumed.</summary>
+    public string Status { get; set; } = "Queued";
+
+    /// <summary>
+    /// Which lane is currently being processed (for in-flight runs).
+    /// One of: parcel, owner-wsdor, improvement, land, sales,
+    /// geometry, or null.
+    /// </summary>
+    public string? CurrentLane { get; set; }
+
+    /// <summary>
+    /// The next lane the orchestrator will process when resumed.
+    /// NULL when the run finished or never started.
+    /// </summary>
+    public string? NextLaneOnResume { get; set; }
+
+    public DateTime StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+
+    /// <summary>Error summary if <see cref="Status"/> is <c>"Failed"</c>.</summary>
+    public string? ErrorMessage { get; set; }
+
+    // ── Audit (auto-populated by AuditableEntityInterceptor) ────────
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Sync/Corpus/CorpusReconciliationPolicy.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/CorpusReconciliationPolicy.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerraFusion.Core.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: per-lane reconciliation policy registry.
+///
+/// <para>Each lane has a policy expressed as
+/// <c>(ExpectedBasis, TolerancePct)</c>:</para>
+/// <list type="bullet">
+///   <item><c>RAW_SOURCE</c> — match the raw PACS row count exactly
+///   (parcel: real-property filter; land: per-segment).</item>
+///   <item><c>DOCTRINE_FILTERED</c> — match PACS rows after doctrine
+///   filter (sales, improvement, wsdor).</item>
+///   <item><c>DEDUPED_CANONICAL</c> — canonical de-duped against
+///   PACS source (owner).</item>
+///   <item><c>EXTERNAL_FEATURE_COUNT</c> — match an external feature
+///   service (geometry → ArcGIS).</item>
+/// </list>
+///
+/// <para>Tolerances LOCKED per the SYNC-COMPLETE-2 spec.</para>
+/// </summary>
+public static class CorpusReconciliationPolicy
+{
+    public const string ExpectedBasisRawSource = "RAW_SOURCE";
+    public const string ExpectedBasisDoctrineFiltered = "DOCTRINE_FILTERED";
+    public const string ExpectedBasisDedupedCanonical = "DEDUPED_CANONICAL";
+    public const string ExpectedBasisExternalFeatureCount = "EXTERNAL_FEATURE_COUNT";
+
+    public const string ReconciliationStatusMatch = "Match";
+    public const string ReconciliationStatusAcceptableDelta = "AcceptableDelta";
+    public const string ReconciliationStatusInvestigate = "Investigate";
+
+    public const string LaneParcel = "parcel";
+    public const string LaneOwnerWsdor = "owner-wsdor";
+    public const string LaneImprovement = "improvement";
+    public const string LaneLand = "land";
+    public const string LaneSales = "sales";
+    public const string LaneGeometry = "geometry";
+
+    /// <summary>Canonical lane order for the orchestrator.</summary>
+    public static readonly IReadOnlyList<string> LaneOrder = new[]
+    {
+        LaneParcel,
+        LaneOwnerWsdor,
+        LaneImprovement,
+        LaneLand,
+        LaneSales,
+        LaneGeometry,
+    };
+
+    public static IReadOnlyDictionary<string, LanePolicy> Policies { get; } =
+        new Dictionary<string, LanePolicy>(StringComparer.OrdinalIgnoreCase)
+        {
+            [LaneParcel] = new(ExpectedBasisRawSource, 0.00m),
+            [LaneOwnerWsdor] = new(ExpectedBasisDedupedCanonical, 2.00m),
+            [LaneImprovement] = new(ExpectedBasisDoctrineFiltered, 1.00m),
+            [LaneLand] = new(ExpectedBasisRawSource, 0.10m),
+            [LaneSales] = new(ExpectedBasisDoctrineFiltered, 0.50m),
+            [LaneGeometry] = new(ExpectedBasisExternalFeatureCount, 0.00m),
+        };
+
+    /// <summary>
+    /// Classify a reconciliation result based on
+    /// <see cref="LanePolicy.TolerancePct"/>:
+    /// <list type="bullet">
+    ///   <item>Delta == 0 → Match</item>
+    ///   <item>0 &lt; |DeltaPct| &lt;= TolerancePct → AcceptableDelta</item>
+    ///   <item>|DeltaPct| &gt; TolerancePct → Investigate</item>
+    /// </list>
+    /// </summary>
+    public static string Classify(long delta, decimal deltaPct, decimal tolerancePct)
+    {
+        if (delta == 0)
+            return ReconciliationStatusMatch;
+        var abs = deltaPct < 0 ? -deltaPct : deltaPct;
+        return abs <= tolerancePct
+            ? ReconciliationStatusAcceptableDelta
+            : ReconciliationStatusInvestigate;
+    }
+
+    /// <summary>Compute deltaPct, clamping the denominator at 1 to avoid divide-by-zero.</summary>
+    public static decimal ComputeDeltaPct(long pacsSourceCount, long delta)
+    {
+        var denom = pacsSourceCount <= 0 ? 1L : pacsSourceCount;
+        var abs = delta < 0 ? -delta : delta;
+        return (decimal)abs / denom * 100m;
+    }
+
+    public sealed record LanePolicy(string ExpectedBasis, decimal TolerancePct);
+}

--- a/backend/src/TerraFusion.Core/Sync/Corpus/ICorpusEvidencePacketService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/ICorpusEvidencePacketService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: builds an evidence ZIP for a completed corpus
+/// run. Mirrors the SYNC-WORKBENCH-H pattern (HMAC-signed manifest +
+/// CSV payloads + deterministic ZIP encoding) but at corpus scope:
+/// the run row, six lane results, six reconciliation rows, and a
+/// consolidated gate summary.
+///
+/// <para>Reads only — no mutations. Uses the same
+/// <c>Workbench:Evidence:HmacKey</c> config the H slice uses.</para>
+/// </summary>
+public interface ICorpusEvidencePacketService
+{
+    Task<CorpusEvidencePacketResult> BuildAsync(
+        Guid runId,
+        CancellationToken cancellationToken);
+}
+
+public enum CorpusEvidencePacketOutcome
+{
+    Ok,
+    NotFound,
+    ConfigurationError,
+}
+
+public sealed record CorpusEvidencePacketResult(
+    CorpusEvidencePacketOutcome Outcome,
+    string? ErrorMessage,
+    string? FileName,
+    byte[]? ZipContent,
+    string? SignatureHex);

--- a/backend/src/TerraFusion.Core/Sync/Corpus/ICorpusLaneRunner.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/ICorpusLaneRunner.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: lane-runner abstraction the hosted worker uses
+/// to invoke each of the six lane drains.
+///
+/// <para>Implementations may either (a) call into the same DI'd
+/// services that <c>DoctrineDrainController</c> uses (preferred,
+/// chosen here — direct DI, no localhost roundtrip, easier to test
+/// + cleaner error capture) or (b) make an HTTP call against the
+/// existing <c>POST /api/sync/doctrine/drain/{lane}</c> endpoint.
+/// The worker doesn't care which.</para>
+///
+/// <para>The result shape mirrors the existing controller's
+/// successful-lane response so reconciliation + evidence packets
+/// can persist it verbatim.</para>
+/// </summary>
+public interface ICorpusLaneRunner
+{
+    Task<CorpusLaneRunResult> RunLaneAsync(
+        string lane,
+        string operatorName,
+        short workingYear,
+        bool fullCorpus,
+        int? topN,
+        CancellationToken cancellationToken);
+}
+
+public enum CorpusLaneRunOutcome
+{
+    Completed,
+    Failed,
+    UnknownLane,
+}
+
+public sealed record CorpusLaneRunResult(
+    CorpusLaneRunOutcome Outcome,
+    IReadOnlyList<Guid> BatchIds,
+    string? CountsJson,
+    string? GateSummaryJson,
+    string? QuarantineDeltaJson,
+    string? ErrorMessage);

--- a/backend/src/TerraFusion.Core/Sync/Corpus/IFullCorpusOrchestrator.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/IFullCorpusOrchestrator.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: orchestrator for durable full-corpus drains.
+///
+/// <para><see cref="StartAsync"/> creates the run + 6 lane-result
+/// rows in <c>"Pending"</c> state and returns immediately; the
+/// hosted background worker picks up the queued run.</para>
+///
+/// <para><see cref="ResumeAsync"/> flips a Failed | Interrupted run
+/// back to Queued (worker resumes from <c>NextLaneOnResume</c>).
+/// Other states return a non-OK outcome.</para>
+///
+/// <para>Status / reconciliation reads are read-only.</para>
+/// </summary>
+public interface IFullCorpusOrchestrator
+{
+    Task<StartCorpusResult> StartAsync(
+        string operatorName,
+        short workingYear,
+        CancellationToken cancellationToken);
+
+    Task<ResumeCorpusResult> ResumeAsync(
+        Guid runId,
+        CancellationToken cancellationToken);
+
+    Task<CorpusStatusResult> GetStatusAsync(
+        Guid runId,
+        CancellationToken cancellationToken);
+
+    Task<CorpusReconciliationViewResult> GetReconciliationAsync(
+        Guid runId,
+        CancellationToken cancellationToken);
+}
+
+public enum CorpusOutcome
+{
+    Ok,
+    NotFound,
+    Conflict,
+}
+
+public sealed record StartCorpusResult(
+    CorpusOutcome Outcome,
+    Guid RunId,
+    string Status,
+    string? ErrorMessage);
+
+public sealed record ResumeCorpusResult(
+    CorpusOutcome Outcome,
+    Guid RunId,
+    string Status,
+    string? ErrorMessage);
+
+public sealed record CorpusStatusResult(
+    CorpusOutcome Outcome,
+    string? ErrorMessage,
+    CorpusRunSnapshot? Run,
+    IReadOnlyList<CorpusLaneSnapshot>? Lanes);
+
+public sealed record CorpusReconciliationViewResult(
+    CorpusOutcome Outcome,
+    string? ErrorMessage,
+    CorpusRunSnapshot? Run,
+    IReadOnlyList<CorpusReconciliationSnapshot>? Reconciliations);
+
+public sealed record CorpusRunSnapshot(
+    Guid RunId,
+    string OperatorName,
+    short WorkingYear,
+    string Status,
+    string? CurrentLane,
+    string? NextLaneOnResume,
+    DateTime StartedAt,
+    DateTime? FinishedAt,
+    string? ErrorMessage);
+
+public sealed record CorpusLaneSnapshot(
+    Guid LaneResultId,
+    Guid RunId,
+    string Lane,
+    string Status,
+    DateTime? StartedAt,
+    DateTime? FinishedAt,
+    string? BatchIdsJson,
+    string? CountsJson,
+    string? GateSummaryJson,
+    string? QuarantineDeltaJson,
+    string? ErrorMessage);
+
+public sealed record CorpusReconciliationSnapshot(
+    Guid ReconciliationId,
+    Guid RunId,
+    string Lane,
+    string ExpectedBasis,
+    long PacsSourceCount,
+    long TfCanonicalCount,
+    long Delta,
+    decimal DeltaPct,
+    decimal TolerancePct,
+    string ReconciliationStatus,
+    string? Notes,
+    DateTime ComputedAt);

--- a/backend/src/TerraFusion.Core/Sync/Corpus/IPacsBaselineReconciler.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/IPacsBaselineReconciler.cs
@@ -1,0 +1,40 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: queries the PACS baseline row count for a given
+/// lane so the orchestrator can compute delta vs. canonical.
+///
+/// <para>Implementations query <c>ConnectionStrings:PacsConnection</c>
+/// (or for the geometry lane, the ArcGIS feature service). When the
+/// underlying query is unreachable or misconfigured, the result
+/// returns <see cref="PacsBaselineOutcome.Unreachable"/> with
+/// <see cref="PacsBaselineResult.Notes"/> populated; the orchestrator
+/// records that as <c>Investigate</c> instead of throwing.</para>
+/// </summary>
+public interface IPacsBaselineReconciler
+{
+    Task<PacsBaselineResult> QueryAsync(
+        string lane,
+        short workingYear,
+        CancellationToken cancellationToken);
+
+    Task<long> CountTfCanonicalAsync(
+        string lane,
+        short workingYear,
+        CancellationToken cancellationToken);
+}
+
+public enum PacsBaselineOutcome
+{
+    Ok,
+    Unreachable,
+    UnknownLane,
+}
+
+public sealed record PacsBaselineResult(
+    PacsBaselineOutcome Outcome,
+    long Count,
+    string? Notes);

--- a/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusLaneResultConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusLaneResultConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.Workbench;
+
+namespace TerraFusion.Data.Configurations.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: EF configuration for
+/// <see cref="FullCorpusLaneResult"/>. Schema <c>tf_workbench</c>;
+/// table <c>full_corpus_lane_result</c>. Unique on
+/// <c>(RunId, Lane)</c> — exactly one row per (run, lane) pair.
+/// </summary>
+public sealed class FullCorpusLaneResultConfiguration
+    : IEntityTypeConfiguration<FullCorpusLaneResult>
+{
+    public void Configure(EntityTypeBuilder<FullCorpusLaneResult> builder)
+    {
+        builder.ToTable("full_corpus_lane_result", schema: "tf_workbench");
+
+        builder.HasKey(x => x.LaneResultId);
+        builder.Property(x => x.LaneResultId).IsRequired();
+
+        builder.Property(x => x.RunId).IsRequired();
+        builder.Property(x => x.Lane).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.Status).HasMaxLength(32).IsRequired();
+
+        builder.Property(x => x.BatchIdsJson);
+        builder.Property(x => x.CountsJson);
+        builder.Property(x => x.GateSummaryJson);
+        builder.Property(x => x.QuarantineDeltaJson);
+        builder.Property(x => x.ErrorMessage).HasMaxLength(4000);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(255);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(255);
+
+        builder.HasIndex(x => new { x.RunId, x.Lane })
+            .IsUnique()
+            .HasDatabaseName("ux_full_corpus_lane_result_run_lane");
+
+        builder.HasIndex(x => x.RunId)
+            .HasDatabaseName("ix_full_corpus_lane_result_run_id");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusReconciliationConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusReconciliationConfiguration.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.Workbench;
+
+namespace TerraFusion.Data.Configurations.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: EF configuration for
+/// <see cref="FullCorpusReconciliation"/>. Schema
+/// <c>tf_workbench</c>; table <c>full_corpus_reconciliation</c>.
+/// Unique on <c>(RunId, Lane)</c>.
+/// </summary>
+public sealed class FullCorpusReconciliationConfiguration
+    : IEntityTypeConfiguration<FullCorpusReconciliation>
+{
+    public void Configure(EntityTypeBuilder<FullCorpusReconciliation> builder)
+    {
+        builder.ToTable("full_corpus_reconciliation", schema: "tf_workbench");
+
+        builder.HasKey(x => x.ReconciliationId);
+        builder.Property(x => x.ReconciliationId).IsRequired();
+
+        builder.Property(x => x.RunId).IsRequired();
+        builder.Property(x => x.Lane).HasMaxLength(32).IsRequired();
+        builder.Property(x => x.ExpectedBasis).HasMaxLength(32).IsRequired();
+
+        builder.Property(x => x.PacsSourceCount).IsRequired();
+        builder.Property(x => x.TfCanonicalCount).IsRequired();
+        builder.Property(x => x.Delta).IsRequired();
+        builder.Property(x => x.DeltaPct)
+            .HasPrecision(18, 6)
+            .IsRequired();
+        builder.Property(x => x.TolerancePct)
+            .HasPrecision(18, 6)
+            .IsRequired();
+
+        builder.Property(x => x.ReconciliationStatus)
+            .HasMaxLength(32)
+            .IsRequired();
+        builder.Property(x => x.Notes).HasMaxLength(4000);
+        builder.Property(x => x.ComputedAt).IsRequired();
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(255);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(255);
+
+        builder.HasIndex(x => new { x.RunId, x.Lane })
+            .IsUnique()
+            .HasDatabaseName("ux_full_corpus_reconciliation_run_lane");
+
+        builder.HasIndex(x => x.RunId)
+            .HasDatabaseName("ix_full_corpus_reconciliation_run_id");
+    }
+}

--- a/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusRunConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/Workbench/FullCorpusRunConfiguration.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.Workbench;
+
+namespace TerraFusion.Data.Configurations.Workbench;
+
+/// <summary>
+/// SYNC-COMPLETE-2: EF configuration for
+/// <see cref="FullCorpusRun"/>. Schema <c>tf_workbench</c>; table
+/// <c>full_corpus_run</c>. Descending index on
+/// <see cref="FullCorpusRun.StartedAt"/> for the list-newest-first
+/// query the operator uses to find recent runs.
+/// </summary>
+public sealed class FullCorpusRunConfiguration
+    : IEntityTypeConfiguration<FullCorpusRun>
+{
+    public void Configure(EntityTypeBuilder<FullCorpusRun> builder)
+    {
+        builder.ToTable("full_corpus_run", schema: "tf_workbench");
+
+        builder.HasKey(x => x.RunId);
+        builder.Property(x => x.RunId).IsRequired();
+
+        builder.Property(x => x.OperatorName)
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.Property(x => x.WorkingYear).IsRequired();
+
+        builder.Property(x => x.Status)
+            .HasMaxLength(32)
+            .IsRequired();
+
+        builder.Property(x => x.CurrentLane).HasMaxLength(32);
+        builder.Property(x => x.NextLaneOnResume).HasMaxLength(32);
+
+        builder.Property(x => x.StartedAt).IsRequired();
+        builder.Property(x => x.ErrorMessage).HasMaxLength(4000);
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(255);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(255);
+
+        builder.HasIndex(x => x.StartedAt)
+            .IsDescending(true)
+            .HasDatabaseName("ix_full_corpus_run_started_at_desc");
+
+        builder.HasIndex(x => x.Status)
+            .HasDatabaseName("ix_full_corpus_run_status");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260508161603_SyncComplete2FullCorpusRun.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508161603_SyncComplete2FullCorpusRun.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508161603_SyncComplete2FullCorpusRun")]
+    partial class SyncComplete2FullCorpusRun
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260508161603_SyncComplete2FullCorpusRun.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508161603_SyncComplete2FullCorpusRun.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncComplete2FullCorpusRun : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "full_corpus_lane_result",
+                schema: "tf_workbench",
+                columns: table => new
+                {
+                    LaneResultId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Lane = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    FinishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    BatchIdsJson = table.Column<string>(type: "text", nullable: true),
+                    CountsJson = table.Column<string>(type: "text", nullable: true),
+                    GateSummaryJson = table.Column<string>(type: "text", nullable: true),
+                    QuarantineDeltaJson = table.Column<string>(type: "text", nullable: true),
+                    ErrorMessage = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_full_corpus_lane_result", x => x.LaneResultId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "full_corpus_reconciliation",
+                schema: "tf_workbench",
+                columns: table => new
+                {
+                    ReconciliationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Lane = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ExpectedBasis = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    PacsSourceCount = table.Column<long>(type: "bigint", nullable: false),
+                    TfCanonicalCount = table.Column<long>(type: "bigint", nullable: false),
+                    Delta = table.Column<long>(type: "bigint", nullable: false),
+                    DeltaPct = table.Column<decimal>(type: "numeric(18,6)", precision: 18, scale: 6, nullable: false),
+                    TolerancePct = table.Column<decimal>(type: "numeric(18,6)", precision: 18, scale: 6, nullable: false),
+                    ReconciliationStatus = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Notes = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_full_corpus_reconciliation", x => x.ReconciliationId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "full_corpus_run",
+                schema: "tf_workbench",
+                columns: table => new
+                {
+                    RunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OperatorName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    WorkingYear = table.Column<short>(type: "smallint", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CurrentLane = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    NextLaneOnResume = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    FinishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ErrorMessage = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_full_corpus_run", x => x.RunId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_full_corpus_lane_result_run_id",
+                schema: "tf_workbench",
+                table: "full_corpus_lane_result",
+                column: "RunId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_full_corpus_lane_result_run_lane",
+                schema: "tf_workbench",
+                table: "full_corpus_lane_result",
+                columns: new[] { "RunId", "Lane" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_full_corpus_reconciliation_run_id",
+                schema: "tf_workbench",
+                table: "full_corpus_reconciliation",
+                column: "RunId");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_full_corpus_reconciliation_run_lane",
+                schema: "tf_workbench",
+                table: "full_corpus_reconciliation",
+                columns: new[] { "RunId", "Lane" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_full_corpus_run_started_at_desc",
+                schema: "tf_workbench",
+                table: "full_corpus_run",
+                column: "StartedAt",
+                descending: new bool[0]);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_full_corpus_run_status",
+                schema: "tf_workbench",
+                table: "full_corpus_run",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "full_corpus_lane_result",
+                schema: "tf_workbench");
+
+            migrationBuilder.DropTable(
+                name: "full_corpus_reconciliation",
+                schema: "tf_workbench");
+
+            migrationBuilder.DropTable(
+                name: "full_corpus_run",
+                schema: "tf_workbench");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/CorpusEvidencePacketService.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/CorpusEvidencePacketService.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.Data.Services.Workbench.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: corpus-scope evidence packet service. Mirrors
+/// the SYNC-WORKBENCH-H <c>EvidencePacketService</c> pattern at
+/// run-scope: <c>manifest.json</c> + <c>run.csv</c> +
+/// <c>lane-results.csv</c> + <c>reconciliation.csv</c> +
+/// <c>gate-summaries.json</c>.
+///
+/// <para>Uses the same <c>Workbench:Evidence:HmacKey</c> config so a
+/// single key rotation covers both H (commit) and SYNC-COMPLETE-2
+/// (corpus run) artefacts. The signature covers the manifest JSON
+/// with <c>signature.hex</c> blanked to <c>""</c>; verifiers re-zero
+/// before recomputing.</para>
+/// </summary>
+public sealed class CorpusEvidencePacketService : ICorpusEvidencePacketService
+{
+    public const string SchemaVersion = "1.0";
+    public const string GeneratorService = "TerraFusion.SyncComplete2";
+    public const string GeneratorVersion = "1.0.0";
+
+    private const string HmacKeyConfigPath = "Workbench:Evidence:HmacKey";
+    private const string KeyIdConfigPath = "Workbench:Evidence:KeyId";
+    private const int MinHmacKeyByteLength = 32;
+    private const string HmacAlgorithm = "HMAC-SHA256";
+    private const string DefaultKeyId = "default";
+
+    private const string EntryManifest = "manifest.json";
+    private const string EntryRunCsv = "run.csv";
+    private const string EntryLanesCsv = "lane-results.csv";
+    private const string EntryReconciliationCsv = "reconciliation.csv";
+    private const string EntryGatesJson = "gate-summaries.json";
+
+    private static readonly JsonSerializerOptions ManifestSerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private static readonly DateTime DeterministicZipTimestamp =
+        new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly TerraFusionDbContext _db;
+    private readonly IConfiguration _configuration;
+    private readonly Func<DateTime> _utcNow;
+
+    public CorpusEvidencePacketService(
+        TerraFusionDbContext db,
+        IConfiguration configuration)
+        : this(db, configuration, () => DateTime.UtcNow)
+    {
+    }
+
+    public CorpusEvidencePacketService(
+        TerraFusionDbContext db,
+        IConfiguration configuration,
+        Func<DateTime> utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(utcNow);
+        _db = db;
+        _configuration = configuration;
+        _utcNow = utcNow;
+    }
+
+    public async Task<CorpusEvidencePacketResult> BuildAsync(
+        Guid runId,
+        CancellationToken cancellationToken)
+    {
+        if (runId == Guid.Empty)
+            return Failure(CorpusEvidencePacketOutcome.NotFound, $"Run '{runId}' not found.");
+
+        var keyResult = TryReadHmacKey();
+        if (!keyResult.Ok)
+            return Failure(CorpusEvidencePacketOutcome.ConfigurationError, keyResult.Error!);
+
+        var run = await _db.FullCorpusRuns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RunId == runId, cancellationToken)
+            .ConfigureAwait(false);
+        if (run is null)
+            return Failure(CorpusEvidencePacketOutcome.NotFound, $"Run '{runId}' not found.");
+
+        var lanes = await _db.FullCorpusLaneResults
+            .AsNoTracking()
+            .Where(l => l.RunId == runId)
+            .OrderBy(l => l.Lane)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var reconciliations = await _db.FullCorpusReconciliations
+            .AsNoTracking()
+            .Where(r => r.RunId == runId)
+            .OrderBy(r => r.Lane)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var runCsv = BuildRunCsv(run);
+        var lanesCsv = BuildLanesCsv(lanes);
+        var reconCsv = BuildReconciliationCsv(reconciliations);
+        var gatesJson = BuildGateSummariesJson(lanes);
+
+        var entries = new[]
+        {
+            new EvidenceEntry(EntryRunCsv, runCsv),
+            new EvidenceEntry(EntryLanesCsv, lanesCsv),
+            new EvidenceEntry(EntryReconciliationCsv, reconCsv),
+            new EvidenceEntry(EntryGatesJson, gatesJson),
+        };
+
+        var manifestBytes = BuildSignedManifest(
+            run, lanes.Count, reconciliations.Count, entries,
+            keyResult.Key!, keyResult.KeyId!,
+            out var signatureHex);
+
+        using var zipStream = new MemoryStream();
+        using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteZipEntry(archive, EntryManifest, manifestBytes);
+            foreach (var entry in entries)
+                WriteZipEntry(archive, entry.Name, entry.Content);
+        }
+
+        return new CorpusEvidencePacketResult(
+            CorpusEvidencePacketOutcome.Ok,
+            null,
+            BuildFileName(run),
+            zipStream.ToArray(),
+            signatureHex);
+    }
+
+    // ── HMAC + manifest ─────────────────────────────────────────────
+
+    private (bool Ok, byte[]? Key, string? KeyId, string? Error) TryReadHmacKey()
+    {
+        var raw = _configuration[HmacKeyConfigPath];
+        if (string.IsNullOrEmpty(raw))
+            return (false, null, null, "workbench evidence HMAC key not configured");
+        var bytes = Encoding.UTF8.GetBytes(raw);
+        if (bytes.Length < MinHmacKeyByteLength)
+            return (false, null, null,
+                $"workbench evidence HMAC key must be at least {MinHmacKeyByteLength} bytes (got {bytes.Length})");
+        var keyId = _configuration[KeyIdConfigPath];
+        if (string.IsNullOrWhiteSpace(keyId)) keyId = DefaultKeyId;
+        return (true, bytes, keyId, null);
+    }
+
+    private byte[] BuildSignedManifest(
+        FullCorpusRun run,
+        int laneCount,
+        int reconciliationCount,
+        IReadOnlyList<EvidenceEntry> entries,
+        byte[] key,
+        string keyId,
+        out string signatureHex)
+    {
+        const string SignaturePlaceholder = "";
+
+        var placeholderManifest = BuildManifestObject(
+            run, laneCount, reconciliationCount, entries, keyId, SignaturePlaceholder);
+        var placeholderBytes = JsonSerializer.SerializeToUtf8Bytes(
+            placeholderManifest, ManifestSerializerOptions);
+
+        using var hmac = new HMACSHA256(key);
+        var sigBytes = hmac.ComputeHash(placeholderBytes);
+        signatureHex = Convert.ToHexString(sigBytes).ToLowerInvariant();
+
+        var signed = BuildManifestObject(
+            run, laneCount, reconciliationCount, entries, keyId, signatureHex);
+        return JsonSerializer.SerializeToUtf8Bytes(signed, ManifestSerializerOptions);
+    }
+
+    private ManifestRoot BuildManifestObject(
+        FullCorpusRun run,
+        int laneCount,
+        int reconciliationCount,
+        IReadOnlyList<EvidenceEntry> entries,
+        string keyId,
+        string signatureHex)
+    {
+        var entrySummaries = new List<ManifestEntrySummary>(entries.Count);
+        foreach (var e in entries)
+        {
+            entrySummaries.Add(new ManifestEntrySummary(
+                Name: e.Name,
+                Sha256: ComputeSha256Hex(e.Content),
+                ByteCount: e.Content.Length));
+        }
+
+        return new ManifestRoot(
+            SchemaVersion: SchemaVersion,
+            RunId: run.RunId,
+            OperatorName: run.OperatorName,
+            WorkingYear: run.WorkingYear,
+            Status: run.Status,
+            StartedAtUtc: FormatUtc(run.StartedAt),
+            FinishedAtUtc: run.FinishedAt.HasValue ? FormatUtc(run.FinishedAt.Value) : null,
+            LaneCount: laneCount,
+            ReconciliationCount: reconciliationCount,
+            Entries: entrySummaries,
+            Signature: new ManifestSignature(HmacAlgorithm, keyId, signatureHex),
+            Generator: new ManifestGenerator(
+                GeneratorService, GeneratorVersion, FormatUtc(_utcNow())));
+    }
+
+    // ── CSV / JSON builders ─────────────────────────────────────────
+
+    private static byte[] BuildRunCsv(FullCorpusRun run)
+    {
+        var sb = new StringBuilder();
+        sb.Append("RunId,OperatorName,WorkingYear,Status,CurrentLane,NextLaneOnResume," +
+                  "StartedAt,FinishedAt,ErrorMessage\n");
+        sb.Append(CsvEscape(run.RunId.ToString())).Append(',');
+        sb.Append(CsvEscape(run.OperatorName)).Append(',');
+        sb.Append(run.WorkingYear.ToString(CultureInfo.InvariantCulture)).Append(',');
+        sb.Append(CsvEscape(run.Status)).Append(',');
+        sb.Append(CsvEscape(run.CurrentLane ?? string.Empty)).Append(',');
+        sb.Append(CsvEscape(run.NextLaneOnResume ?? string.Empty)).Append(',');
+        sb.Append(CsvEscape(FormatUtc(run.StartedAt))).Append(',');
+        sb.Append(CsvEscape(run.FinishedAt.HasValue ? FormatUtc(run.FinishedAt.Value) : string.Empty)).Append(',');
+        sb.Append(CsvEscape(run.ErrorMessage ?? string.Empty));
+        sb.Append('\n');
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static byte[] BuildLanesCsv(IReadOnlyList<FullCorpusLaneResult> lanes)
+    {
+        var sb = new StringBuilder();
+        sb.Append("LaneResultId,RunId,Lane,Status,StartedAt,FinishedAt," +
+                  "BatchIdsJson,CountsJson,QuarantineDeltaJson,ErrorMessage\n");
+        foreach (var l in lanes)
+        {
+            sb.Append(CsvEscape(l.LaneResultId.ToString())).Append(',');
+            sb.Append(CsvEscape(l.RunId.ToString())).Append(',');
+            sb.Append(CsvEscape(l.Lane)).Append(',');
+            sb.Append(CsvEscape(l.Status)).Append(',');
+            sb.Append(CsvEscape(l.StartedAt.HasValue ? FormatUtc(l.StartedAt.Value) : string.Empty)).Append(',');
+            sb.Append(CsvEscape(l.FinishedAt.HasValue ? FormatUtc(l.FinishedAt.Value) : string.Empty)).Append(',');
+            sb.Append(CsvEscape(l.BatchIdsJson ?? string.Empty)).Append(',');
+            sb.Append(CsvEscape(l.CountsJson ?? string.Empty)).Append(',');
+            sb.Append(CsvEscape(l.QuarantineDeltaJson ?? string.Empty)).Append(',');
+            sb.Append(CsvEscape(l.ErrorMessage ?? string.Empty));
+            sb.Append('\n');
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static byte[] BuildReconciliationCsv(IReadOnlyList<FullCorpusReconciliation> rows)
+    {
+        var sb = new StringBuilder();
+        sb.Append("ReconciliationId,RunId,Lane,ExpectedBasis," +
+                  "PacsSourceCount,TfCanonicalCount,Delta,DeltaPct,TolerancePct," +
+                  "ReconciliationStatus,Notes,ComputedAt\n");
+        foreach (var r in rows)
+        {
+            sb.Append(CsvEscape(r.ReconciliationId.ToString())).Append(',');
+            sb.Append(CsvEscape(r.RunId.ToString())).Append(',');
+            sb.Append(CsvEscape(r.Lane)).Append(',');
+            sb.Append(CsvEscape(r.ExpectedBasis)).Append(',');
+            sb.Append(r.PacsSourceCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.TfCanonicalCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.Delta.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.DeltaPct.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.TolerancePct.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(CsvEscape(r.ReconciliationStatus)).Append(',');
+            sb.Append(CsvEscape(r.Notes ?? string.Empty)).Append(',');
+            sb.Append(CsvEscape(FormatUtc(r.ComputedAt)));
+            sb.Append('\n');
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static byte[] BuildGateSummariesJson(IReadOnlyList<FullCorpusLaneResult> lanes)
+    {
+        var consolidated = lanes.Select(l => new
+        {
+            lane = l.Lane,
+            status = l.Status,
+            gateSummary = SafeParseRaw(l.GateSummaryJson),
+        }).ToList();
+        return JsonSerializer.SerializeToUtf8Bytes(consolidated, ManifestSerializerOptions);
+    }
+
+    private static object? SafeParseRaw(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return JsonSerializer.Deserialize<JsonElement>(doc.RootElement.GetRawText());
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    // ── Encoding utilities ──────────────────────────────────────────
+
+    private static string CsvEscape(string field)
+    {
+        if (string.IsNullOrEmpty(field)) return string.Empty;
+        var needsQuoting = false;
+        for (var i = 0; i < field.Length; i++)
+        {
+            var c = field[i];
+            if (c == ',' || c == '"' || c == '\n' || c == '\r') { needsQuoting = true; break; }
+        }
+        if (!needsQuoting) return field;
+        var escaped = field.Replace("\"", "\"\"", StringComparison.Ordinal);
+        return $"\"{escaped}\"";
+    }
+
+    private static string FormatUtc(DateTime dt)
+    {
+        var utc = dt.Kind == DateTimeKind.Utc ? dt : DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+        return utc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    }
+
+    private static string ComputeSha256Hex(byte[] content)
+    {
+        var hash = SHA256.HashData(content);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string BuildFileName(FullCorpusRun run)
+    {
+        var stamp = (run.StartedAt.Kind == DateTimeKind.Utc
+                ? run.StartedAt
+                : DateTime.SpecifyKind(run.StartedAt, DateTimeKind.Utc))
+            .ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
+        return $"terrafusion-corpus-evidence-{run.RunId}-{stamp}.zip";
+    }
+
+    private static void WriteZipEntry(ZipArchive archive, string name, byte[] content)
+    {
+        var entry = archive.CreateEntry(name, CompressionLevel.NoCompression);
+        entry.LastWriteTime = DeterministicZipTimestamp;
+        using var stream = entry.Open();
+        stream.Write(content, 0, content.Length);
+    }
+
+    private static CorpusEvidencePacketResult Failure(CorpusEvidencePacketOutcome o, string err) =>
+        new(o, err, null, null, null);
+
+    private sealed record EvidenceEntry(string Name, byte[] Content);
+
+    // ── Manifest DTOs ───────────────────────────────────────────────
+
+    private sealed record ManifestRoot(
+        [property: System.Text.Json.Serialization.JsonPropertyName("schemaVersion")] string SchemaVersion,
+        [property: System.Text.Json.Serialization.JsonPropertyName("runId")] Guid RunId,
+        [property: System.Text.Json.Serialization.JsonPropertyName("operatorName")] string OperatorName,
+        [property: System.Text.Json.Serialization.JsonPropertyName("workingYear")] short WorkingYear,
+        [property: System.Text.Json.Serialization.JsonPropertyName("status")] string Status,
+        [property: System.Text.Json.Serialization.JsonPropertyName("startedAtUtc")] string StartedAtUtc,
+        [property: System.Text.Json.Serialization.JsonPropertyName("finishedAtUtc")] string? FinishedAtUtc,
+        [property: System.Text.Json.Serialization.JsonPropertyName("laneCount")] int LaneCount,
+        [property: System.Text.Json.Serialization.JsonPropertyName("reconciliationCount")] int ReconciliationCount,
+        [property: System.Text.Json.Serialization.JsonPropertyName("entries")] IReadOnlyList<ManifestEntrySummary> Entries,
+        [property: System.Text.Json.Serialization.JsonPropertyName("signature")] ManifestSignature Signature,
+        [property: System.Text.Json.Serialization.JsonPropertyName("generator")] ManifestGenerator Generator);
+
+    private sealed record ManifestEntrySummary(
+        [property: System.Text.Json.Serialization.JsonPropertyName("name")] string Name,
+        [property: System.Text.Json.Serialization.JsonPropertyName("sha256")] string Sha256,
+        [property: System.Text.Json.Serialization.JsonPropertyName("byteCount")] int ByteCount);
+
+    private sealed record ManifestSignature(
+        [property: System.Text.Json.Serialization.JsonPropertyName("algorithm")] string Algorithm,
+        [property: System.Text.Json.Serialization.JsonPropertyName("keyId")] string KeyId,
+        [property: System.Text.Json.Serialization.JsonPropertyName("hex")] string Hex);
+
+    private sealed record ManifestGenerator(
+        [property: System.Text.Json.Serialization.JsonPropertyName("service")] string Service,
+        [property: System.Text.Json.Serialization.JsonPropertyName("version")] string Version,
+        [property: System.Text.Json.Serialization.JsonPropertyName("generatedAtUtc")] string GeneratedAtUtc);
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestrator.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestrator.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.Data.Services.Workbench.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: orchestrator implementation. Owns the
+/// transition diagram for <see cref="FullCorpusRun"/>:
+///
+/// <pre>
+///   StartAsync   : (none)            → Queued
+///   worker pick  : Queued            → Running
+///   worker done  : Running           → Completed
+///   worker err   : Running           → Failed
+///   restart sweep: Running           → Interrupted
+///   ResumeAsync  : Failed|Interrupted→ Queued (Resumed bookkeeping)
+/// </pre>
+///
+/// <para>The orchestrator never calls into PACS directly; the hosted
+/// worker drives lane execution via <see cref="ICorpusLaneRunner"/>
+/// and reconciliation via <see cref="IPacsBaselineReconciler"/>. This
+/// service is the persistent state-machine.</para>
+/// </summary>
+public sealed class FullCorpusOrchestrator : IFullCorpusOrchestrator
+{
+    public const string StatusQueued = "Queued";
+    public const string StatusRunning = "Running";
+    public const string StatusCompleted = "Completed";
+    public const string StatusFailed = "Failed";
+    public const string StatusInterrupted = "Interrupted";
+    public const string StatusResumed = "Resumed";
+
+    public const string LaneStatusPending = "Pending";
+
+    private readonly TerraFusionDbContext _db;
+
+    public FullCorpusOrchestrator(TerraFusionDbContext db)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        _db = db;
+    }
+
+    public async Task<StartCorpusResult> StartAsync(
+        string operatorName,
+        short workingYear,
+        CancellationToken cancellationToken)
+    {
+        var trimmed = string.IsNullOrWhiteSpace(operatorName)
+            ? "full-corpus-runner"
+            : operatorName.Trim();
+
+        var nowUtc = DateTime.UtcNow;
+        var run = new FullCorpusRun
+        {
+            RunId = Guid.NewGuid(),
+            OperatorName = trimmed,
+            WorkingYear = workingYear,
+            Status = StatusQueued,
+            CurrentLane = null,
+            NextLaneOnResume = CorpusReconciliationPolicy.LaneOrder[0],
+            StartedAt = nowUtc,
+            FinishedAt = null,
+            ErrorMessage = null,
+        };
+        _db.FullCorpusRuns.Add(run);
+
+        foreach (var lane in CorpusReconciliationPolicy.LaneOrder)
+        {
+            _db.FullCorpusLaneResults.Add(new FullCorpusLaneResult
+            {
+                LaneResultId = Guid.NewGuid(),
+                RunId = run.RunId,
+                Lane = lane,
+                Status = LaneStatusPending,
+            });
+        }
+
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return new StartCorpusResult(CorpusOutcome.Ok, run.RunId, run.Status, null);
+    }
+
+    public async Task<ResumeCorpusResult> ResumeAsync(
+        Guid runId,
+        CancellationToken cancellationToken)
+    {
+        var run = await _db.FullCorpusRuns
+            .FirstOrDefaultAsync(r => r.RunId == runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (run is null)
+            return new ResumeCorpusResult(
+                CorpusOutcome.NotFound,
+                runId,
+                string.Empty,
+                $"Run '{runId}' not found.");
+
+        if (run.Status != StatusFailed && run.Status != StatusInterrupted)
+            return new ResumeCorpusResult(
+                CorpusOutcome.Conflict,
+                runId,
+                run.Status,
+                $"Run is in status '{run.Status}'; only Failed or Interrupted runs are resumable.");
+
+        run.Status = StatusQueued;
+        run.ErrorMessage = null;
+        // NextLaneOnResume left intact — worker resumes from there.
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new ResumeCorpusResult(CorpusOutcome.Ok, runId, run.Status, null);
+    }
+
+    public async Task<CorpusStatusResult> GetStatusAsync(
+        Guid runId,
+        CancellationToken cancellationToken)
+    {
+        var run = await _db.FullCorpusRuns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RunId == runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (run is null)
+            return new CorpusStatusResult(
+                CorpusOutcome.NotFound,
+                $"Run '{runId}' not found.",
+                null,
+                null);
+
+        var lanes = await _db.FullCorpusLaneResults
+            .AsNoTracking()
+            .Where(l => l.RunId == runId)
+            .OrderBy(l => l.Lane)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CorpusStatusResult(
+            CorpusOutcome.Ok,
+            null,
+            ToSnapshot(run),
+            lanes.Select(ToSnapshot).ToList());
+    }
+
+    public async Task<CorpusReconciliationViewResult> GetReconciliationAsync(
+        Guid runId,
+        CancellationToken cancellationToken)
+    {
+        var run = await _db.FullCorpusRuns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RunId == runId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (run is null)
+            return new CorpusReconciliationViewResult(
+                CorpusOutcome.NotFound,
+                $"Run '{runId}' not found.",
+                null,
+                null);
+
+        var rec = await _db.FullCorpusReconciliations
+            .AsNoTracking()
+            .Where(r => r.RunId == runId)
+            .OrderBy(r => r.Lane)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CorpusReconciliationViewResult(
+            CorpusOutcome.Ok,
+            null,
+            ToSnapshot(run),
+            rec.Select(ToSnapshot).ToList());
+    }
+
+    private static CorpusRunSnapshot ToSnapshot(FullCorpusRun r) => new(
+        r.RunId,
+        r.OperatorName,
+        r.WorkingYear,
+        r.Status,
+        r.CurrentLane,
+        r.NextLaneOnResume,
+        r.StartedAt,
+        r.FinishedAt,
+        r.ErrorMessage);
+
+    private static CorpusLaneSnapshot ToSnapshot(FullCorpusLaneResult l) => new(
+        l.LaneResultId,
+        l.RunId,
+        l.Lane,
+        l.Status,
+        l.StartedAt,
+        l.FinishedAt,
+        l.BatchIdsJson,
+        l.CountsJson,
+        l.GateSummaryJson,
+        l.QuarantineDeltaJson,
+        l.ErrorMessage);
+
+    private static CorpusReconciliationSnapshot ToSnapshot(FullCorpusReconciliation r) => new(
+        r.ReconciliationId,
+        r.RunId,
+        r.Lane,
+        r.ExpectedBasis,
+        r.PacsSourceCount,
+        r.TfCanonicalCount,
+        r.Delta,
+        r.DeltaPct,
+        r.TolerancePct,
+        r.ReconciliationStatus,
+        r.Notes,
+        r.ComputedAt);
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestratorHostedService.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestratorHostedService.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.Data.Services.Workbench.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: durable background worker that drives queued
+/// <see cref="FullCorpusRun"/> rows through the six-lane sequence
+/// and the post-drain reconciliation pass.
+///
+/// <para><b>Lifecycle:</b></para>
+/// <list type="number">
+///   <item>On <c>StartAsync</c>: run the <i>interrupted-run sweep</i>
+///   — any row stuck at <c>Status="Running"</c> from before the
+///   restart is flipped to <c>Interrupted</c> with an explanatory
+///   <c>ErrorMessage</c>. <b>Auto-resume is intentionally NOT done</b>:
+///   the operator must call <c>POST /api/sync/corpus/{id}/resume</c>
+///   explicitly so a flapping backend can't burn through compute.</item>
+///   <item>Spawn a long-running <c>Task.Run</c> background loop that
+///   polls every <see cref="PollInterval"/> for the oldest
+///   <c>Status="Queued"</c> run; when found, runs each remaining
+///   lane sequentially via <see cref="ICorpusLaneRunner"/>; advances
+///   <c>NextLaneOnResume</c> after each successful lane; on failure
+///   marks the run <c>Status="Failed"</c> and exits the lane loop.</item>
+///   <item>After all six lanes complete: invokes
+///   <see cref="IPacsBaselineReconciler"/> for each lane, persists
+///   <see cref="FullCorpusReconciliation"/> rows, then marks the
+///   run <c>Status="Completed"</c>.</item>
+///   <item>On <c>StopAsync</c>: cancels the loop. Any in-flight lane
+///   continues to its natural finish (we do not abort mid-lane to
+///   avoid leaving the doctrine layer in a torn-down state).</item>
+/// </list>
+///
+/// <para>The worker stays alive across the 5-second poll interval by
+/// keeping a single <c>Task.Run</c> task active for the host's
+/// lifetime; the task itself uses <c>Task.Delay(PollInterval, ct)</c>
+/// to wait between polls.</para>
+/// </summary>
+public sealed class FullCorpusOrchestratorHostedService : IHostedService, IDisposable
+{
+    /// <summary>How often the worker polls for queued runs.</summary>
+    public static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FullCorpusOrchestratorHostedService> _logger;
+
+    private readonly CancellationTokenSource _stoppingCts = new();
+    private Task? _workerLoop;
+
+    public FullCorpusOrchestratorHostedService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FullCorpusOrchestratorHostedService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Step 1: interrupted-run sweep. Synchronous on startup —
+        // must happen before the loop accepts the first poll.
+        try
+        {
+            await SweepInterruptedRunsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: we never want to crash backend startup over
+            // a stale sweep. Operator can investigate via the
+            // /status endpoint.
+            _logger.LogWarning(ex,
+                "FullCorpusOrchestratorHostedService: interrupted-run sweep failed; " +
+                "continuing to start poll loop.");
+        }
+
+        // Step 2: spin up the long-running poll loop on a thread-pool
+        // task. We do NOT await the task here — that would block
+        // backend startup forever.
+        _workerLoop = Task.Run(() => PollLoopAsync(_stoppingCts.Token));
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _stoppingCts.Cancel();
+        }
+        catch (ObjectDisposedException) { /* already stopped */ }
+
+        if (_workerLoop is not null)
+        {
+            try
+            {
+                await _workerLoop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* expected */ }
+        }
+    }
+
+    public void Dispose() => _stoppingCts.Dispose();
+
+    // ── Sweep ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Mark any <c>Status="Running"</c> rows as <c>Interrupted</c>.
+    /// The backend was restarted between when the worker flipped
+    /// the row to Running and when it finished.
+    /// </summary>
+    private async Task SweepInterruptedRunsAsync(CancellationToken ct)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+
+        var stale = await db.FullCorpusRuns
+            .Where(r => r.Status == FullCorpusOrchestrator.StatusRunning)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        if (stale.Count == 0) return;
+
+        foreach (var r in stale)
+        {
+            r.Status = FullCorpusOrchestrator.StatusInterrupted;
+            r.ErrorMessage = "backend restarted before run completed";
+        }
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        _logger.LogInformation(
+            "FullCorpusOrchestratorHostedService: swept {Count} stale Running rows → Interrupted.",
+            stale.Count);
+    }
+
+    // ── Poll loop ───────────────────────────────────────────────────
+
+    private async Task PollLoopAsync(CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "FullCorpusOrchestratorHostedService: poll loop online (interval={Interval}).",
+            PollInterval);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var didWork = await TryProcessNextQueuedRunAsync(ct).ConfigureAwait(false);
+                if (!didWork)
+                {
+                    await Task.Delay(PollInterval, ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "FullCorpusOrchestratorHostedService: poll loop iteration threw; " +
+                    "continuing after delay.");
+                try
+                {
+                    await Task.Delay(PollInterval, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        _logger.LogInformation("FullCorpusOrchestratorHostedService: poll loop offline.");
+    }
+
+    private async Task<bool> TryProcessNextQueuedRunAsync(CancellationToken ct)
+    {
+        Guid runId;
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var run = await db.FullCorpusRuns
+                .Where(r => r.Status == FullCorpusOrchestrator.StatusQueued)
+                .OrderBy(r => r.StartedAt)
+                .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+            if (run is null) return false;
+
+            run.Status = FullCorpusOrchestrator.StatusRunning;
+            run.CurrentLane = run.NextLaneOnResume;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            runId = run.RunId;
+        }
+
+        await ProcessRunAsync(runId, ct).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Process the run from <c>NextLaneOnResume</c> through the lane
+    /// sequence, then reconciliation. Mutates the run row + per-lane
+    /// rows + reconciliation rows via fresh scopes per stage.
+    /// </summary>
+    public async Task ProcessRunAsync(Guid runId, CancellationToken ct)
+    {
+        // Determine the starting lane from a fresh scope.
+        string? startLane;
+        string operatorName;
+        short workingYear;
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var run = await db.FullCorpusRuns
+                .FirstOrDefaultAsync(r => r.RunId == runId, ct).ConfigureAwait(false);
+            if (run is null) return;
+            startLane = run.NextLaneOnResume;
+            operatorName = run.OperatorName;
+            workingYear = run.WorkingYear;
+        }
+
+        var startIdx = startLane is null
+            ? CorpusReconciliationPolicy.LaneOrder.Count
+            : Math.Max(0, CorpusReconciliationPolicy.LaneOrder
+                .ToList()
+                .FindIndex(l => string.Equals(l, startLane, StringComparison.OrdinalIgnoreCase)));
+
+        for (var i = startIdx; i < CorpusReconciliationPolicy.LaneOrder.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var lane = CorpusReconciliationPolicy.LaneOrder[i];
+
+            var success = await ExecuteLaneAsync(runId, lane, operatorName, workingYear, ct)
+                .ConfigureAwait(false);
+            if (!success)
+                return;  // Run is now Failed; do not reconcile.
+
+            // Advance NextLaneOnResume to the lane after this one (or
+            // null when this was the final lane).
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var run = await db.FullCorpusRuns
+                .FirstOrDefaultAsync(r => r.RunId == runId, ct).ConfigureAwait(false);
+            if (run is null) return;
+            run.NextLaneOnResume = i + 1 < CorpusReconciliationPolicy.LaneOrder.Count
+                ? CorpusReconciliationPolicy.LaneOrder[i + 1]
+                : null;
+            run.CurrentLane = run.NextLaneOnResume;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        // All six lanes complete → reconciliation pass.
+        await RunReconciliationAsync(runId, workingYear, ct).ConfigureAwait(false);
+
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var run = await db.FullCorpusRuns
+                .FirstOrDefaultAsync(r => r.RunId == runId, ct).ConfigureAwait(false);
+            if (run is null) return;
+            run.Status = FullCorpusOrchestrator.StatusCompleted;
+            run.FinishedAt = DateTime.UtcNow;
+            run.CurrentLane = null;
+            run.NextLaneOnResume = null;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> ExecuteLaneAsync(
+        Guid runId, string lane, string operatorName, short workingYear, CancellationToken ct)
+    {
+        // Mark lane Running.
+        Guid laneResultId;
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var laneRow = await db.FullCorpusLaneResults
+                .FirstOrDefaultAsync(l => l.RunId == runId && l.Lane == lane, ct)
+                .ConfigureAwait(false);
+            if (laneRow is null) return false;
+            laneRow.Status = "Running";
+            laneRow.StartedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            laneResultId = laneRow.LaneResultId;
+        }
+
+        // Run the lane.
+        CorpusLaneRunResult laneResult;
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var runner = scope.ServiceProvider.GetRequiredService<ICorpusLaneRunner>();
+            laneResult = await runner.RunLaneAsync(
+                lane, operatorName, workingYear,
+                fullCorpus: true, topN: null, ct).ConfigureAwait(false);
+        }
+
+        // Persist lane result.
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var laneRow = await db.FullCorpusLaneResults
+                .FirstOrDefaultAsync(l => l.LaneResultId == laneResultId, ct)
+                .ConfigureAwait(false);
+            if (laneRow is null) return false;
+            laneRow.Status = laneResult.Outcome == CorpusLaneRunOutcome.Completed
+                ? "Completed"
+                : "Failed";
+            laneRow.FinishedAt = DateTime.UtcNow;
+            laneRow.BatchIdsJson = JsonSerializer.Serialize(laneResult.BatchIds);
+            laneRow.CountsJson = laneResult.CountsJson;
+            laneRow.GateSummaryJson = laneResult.GateSummaryJson;
+            laneRow.QuarantineDeltaJson = laneResult.QuarantineDeltaJson;
+            laneRow.ErrorMessage = laneResult.ErrorMessage;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        if (laneResult.Outcome == CorpusLaneRunOutcome.Completed)
+            return true;
+
+        // Lane failed: mark run Failed.
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            var run = await db.FullCorpusRuns
+                .FirstOrDefaultAsync(r => r.RunId == runId, ct).ConfigureAwait(false);
+            if (run is null) return false;
+            run.Status = FullCorpusOrchestrator.StatusFailed;
+            run.ErrorMessage = $"lane '{lane}' failed: {laneResult.ErrorMessage}";
+            run.FinishedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Runs the per-lane reconciliation pass in parallel-by-lane (one
+    /// scope per lane). Failures persist as <c>Investigate</c>; the
+    /// run is still marked <c>Completed</c> after this pass.
+    /// </summary>
+    public async Task RunReconciliationAsync(Guid runId, short workingYear, CancellationToken ct)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var rows = new List<FullCorpusReconciliation>();
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var reconciler = scope.ServiceProvider.GetRequiredService<IPacsBaselineReconciler>();
+
+        foreach (var lane in CorpusReconciliationPolicy.LaneOrder)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var policy = CorpusReconciliationPolicy.Policies[lane];
+
+            var pacsResult = await reconciler.QueryAsync(lane, workingYear, ct).ConfigureAwait(false);
+            var tfCount = await reconciler.CountTfCanonicalAsync(lane, workingYear, ct)
+                .ConfigureAwait(false);
+
+            string status;
+            string? notes = pacsResult.Notes;
+            long pacsCount = pacsResult.Count;
+            long delta = tfCount - pacsCount;
+            decimal deltaPct;
+
+            if (pacsResult.Outcome != PacsBaselineOutcome.Ok)
+            {
+                status = CorpusReconciliationPolicy.ReconciliationStatusInvestigate;
+                deltaPct = 0m;
+            }
+            else
+            {
+                deltaPct = CorpusReconciliationPolicy.ComputeDeltaPct(pacsCount, delta);
+                status = CorpusReconciliationPolicy.Classify(delta, deltaPct, policy.TolerancePct);
+            }
+
+            rows.Add(new FullCorpusReconciliation
+            {
+                ReconciliationId = Guid.NewGuid(),
+                RunId = runId,
+                Lane = lane,
+                ExpectedBasis = policy.ExpectedBasis,
+                PacsSourceCount = pacsCount,
+                TfCanonicalCount = tfCount,
+                Delta = delta,
+                DeltaPct = deltaPct,
+                TolerancePct = policy.TolerancePct,
+                ReconciliationStatus = status,
+                Notes = notes,
+                ComputedAt = nowUtc,
+            });
+        }
+
+        db.FullCorpusReconciliations.AddRange(rows);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/HttpCorpusLaneRunner.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/HttpCorpusLaneRunner.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.Data.Services.Workbench.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: HTTP-loopback implementation of
+/// <see cref="ICorpusLaneRunner"/>.
+///
+/// <para><b>Design choice — HTTP loopback over direct DI</b>: each
+/// lane endpoint in <c>DoctrineDrainController</c> injects 4-12
+/// scoped services and threads a county-resolution + Benton xref
+/// pre-call. Re-wiring all of those into a hosted-service-scope
+/// would couple the corpus runner to every lane's internal
+/// composition; an HTTP call against the local controller stays
+/// stable across lane refactors and exercises the same code path
+/// the operator uses today. The trade-off is one localhost roundtrip
+/// per lane (six total per run) which is dwarfed by the multi-hour
+/// lane drain itself.</para>
+///
+/// <para>Configuration:
+/// <c>FullCorpus:LoopbackBaseUrl</c> (default
+/// <c>http://localhost:5000</c>). Per-call timeout is unbounded
+/// (PerRequest&gt;6h drains intentional).</para>
+///
+/// <para>The endpoints are <c>[AllowAnonymous]</c> so no auth is
+/// required.</para>
+/// </summary>
+public sealed class HttpCorpusLaneRunner : ICorpusLaneRunner
+{
+    private const string DefaultBaseUrl = "http://localhost:5000";
+    private const string LoopbackBaseUrlConfigPath = "FullCorpus:LoopbackBaseUrl";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<HttpCorpusLaneRunner> _logger;
+
+    public HttpCorpusLaneRunner(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<HttpCorpusLaneRunner> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(logger);
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<CorpusLaneRunResult> RunLaneAsync(
+        string lane,
+        string operatorName,
+        short workingYear,
+        bool fullCorpus,
+        int? topN,
+        CancellationToken cancellationToken)
+    {
+        if (!CorpusReconciliationPolicy.LaneOrder.Contains(lane, StringComparer.OrdinalIgnoreCase))
+            return new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.UnknownLane,
+                Array.Empty<Guid>(),
+                null, null, null,
+                $"Unknown lane: '{lane}'.");
+
+        var baseUrl = (_configuration[LoopbackBaseUrlConfigPath] ?? DefaultBaseUrl).TrimEnd('/');
+        var url = $"{baseUrl}/api/sync/doctrine/drain/{lane}";
+
+        try
+        {
+            using var http = _httpClientFactory.CreateClient();
+            // Lane drains can take hours on a full corpus run.
+            http.Timeout = Timeout.InfiniteTimeSpan;
+
+            var body = new
+            {
+                operatorName,
+                workingYear = (int)workingYear,
+                fullCorpus,
+                topN,
+            };
+
+            _logger.LogInformation(
+                "[CorpusRunner] Invoking lane={Lane} operator={Op} year={Yr} fullCorpus={Full} topN={Top}",
+                lane, operatorName, workingYear, fullCorpus, topN);
+
+            var response = await http.PostAsJsonAsync(url, body, cancellationToken).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            return ParseLaneResponse(response.IsSuccessStatusCode, responseText);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[CorpusRunner] HTTP call to lane={Lane} threw.", lane);
+            return new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Failed,
+                Array.Empty<Guid>(),
+                null, null, null,
+                $"Lane HTTP call failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Parse the controller's response shape:
+    /// <c>{ lane, status, batchIds, counts, durationSec, gateSummary,
+    /// quarantineDelta, nextRecommendedLane, error?, failedStage? }</c>.
+    /// Returns the runner's normalized result with JSON sub-objects
+    /// preserved verbatim for the lane-result row.
+    /// </summary>
+    public static CorpusLaneRunResult ParseLaneResponse(bool isSuccess, string responseText)
+    {
+        if (string.IsNullOrWhiteSpace(responseText))
+            return new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Failed,
+                Array.Empty<Guid>(),
+                null, null, null,
+                "Empty response from lane endpoint.");
+
+        try
+        {
+            using var doc = JsonDocument.Parse(responseText);
+            var root = doc.RootElement;
+
+            var batchIds = ExtractBatchIds(root);
+            var counts = root.TryGetProperty("counts", out var cEl)
+                ? cEl.GetRawText()
+                : null;
+            var gates = root.TryGetProperty("gateSummary", out var gEl)
+                ? gEl.GetRawText()
+                : null;
+            var quarantineDelta = root.TryGetProperty("quarantineDelta", out var qEl)
+                ? qEl.GetRawText()
+                : null;
+
+            var status = root.TryGetProperty("status", out var sEl) && sEl.ValueKind == JsonValueKind.String
+                ? sEl.GetString()
+                : null;
+
+            if (isSuccess && string.Equals(status, "Succeeded", StringComparison.OrdinalIgnoreCase))
+                return new CorpusLaneRunResult(
+                    CorpusLaneRunOutcome.Completed,
+                    batchIds,
+                    counts, gates, quarantineDelta,
+                    null);
+
+            var failedStage = root.TryGetProperty("failedStage", out var fEl) && fEl.ValueKind == JsonValueKind.String
+                ? fEl.GetString()
+                : null;
+            var error = root.TryGetProperty("error", out var eEl) && eEl.ValueKind == JsonValueKind.String
+                ? eEl.GetString()
+                : null;
+            var compositeError = string.IsNullOrEmpty(failedStage)
+                ? error
+                : $"{failedStage}: {error}";
+
+            return new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Failed,
+                batchIds,
+                counts, gates, quarantineDelta,
+                compositeError ?? "Lane endpoint returned non-success status.");
+        }
+        catch (JsonException ex)
+        {
+            return new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Failed,
+                Array.Empty<Guid>(),
+                null, null, null,
+                $"Could not parse lane response JSON: {ex.Message}");
+        }
+    }
+
+    private static IReadOnlyList<Guid> ExtractBatchIds(JsonElement root)
+    {
+        if (!root.TryGetProperty("batchIds", out var bEl) ||
+            bEl.ValueKind != JsonValueKind.Array)
+            return Array.Empty<Guid>();
+
+        var list = new List<Guid>();
+        foreach (var entry in bEl.EnumerateArray())
+        {
+            if (entry.ValueKind == JsonValueKind.String &&
+                Guid.TryParse(entry.GetString(), out var g))
+                list.Add(g);
+        }
+        return list;
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/PacsBaselineReconciler.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/PacsBaselineReconciler.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Sync.Corpus;
+
+namespace TerraFusion.Data.Services.Workbench.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2: queries PACS / ArcGIS for the per-lane baseline
+/// row count and TerraFusion canonical for the matching count.
+///
+/// <para>The PACS-side queries mirror the same row population each
+/// lane drains:</para>
+/// <list type="bullet">
+///   <item><b>parcel</b>: distinct <c>prop_id</c> from
+///   <c>dbo.owner</c> with <c>sup_num=0 AND owner_tax_yr&gt;=2018</c>
+///   — the owner-anchored seed each parcel drain uses.</item>
+///   <item><b>owner-wsdor</b>: distinct <c>owner_id</c> from
+///   <c>dbo.owner</c> + WPOV count for the working year. We aggregate
+///   into one count: <c>distinct owner_id + wash_prop_owner_val(@yr)</c>
+///   to reconcile against canonical <c>tf_owner + tf_assessment_wsdor</c>.</item>
+///   <item><b>improvement</b>: <c>dbo.imprv</c> filtered by
+///   <c>prop_val_yr=@yr</c>.</item>
+///   <item><b>land</b>: <c>dbo.land_detail</c> filtered by
+///   <c>prop_val_yr=@yr</c>.</item>
+///   <item><b>sales</b>: <c>dbo.sale</c> doctrine-qualified count
+///   (<c>sl_county_ratio_cd IN ('100','0') OR sl_ratio_type_cd='00'</c>)
+///   per the SYNC-DOCTRINE-3 seal.</item>
+///   <item><b>geometry</b>: ArcGIS feature service
+///   <c>?where=1=1&amp;returnCountOnly=true</c> against
+///   <c>ArcGis:FeatureServiceUrl</c>.</item>
+/// </list>
+///
+/// <para>Failures are <i>diagnostic, not fatal</i>: PACS unreachable
+/// or ArcGIS misconfigured returns <c>Outcome=Unreachable</c> with
+/// <c>Notes</c>; the orchestrator records that as <c>Investigate</c>
+/// instead of throwing.</para>
+/// </summary>
+public sealed class PacsBaselineReconciler : IPacsBaselineReconciler
+{
+    private const int CommandTimeoutSec = 600;
+
+    private readonly TerraFusionDbContext _db;
+    private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory? _httpClientFactory;
+    private readonly ILogger<PacsBaselineReconciler> _logger;
+
+    public PacsBaselineReconciler(
+        TerraFusionDbContext db,
+        IConfiguration configuration,
+        ILogger<PacsBaselineReconciler> logger,
+        IHttpClientFactory? httpClientFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(logger);
+        _db = db;
+        _configuration = configuration;
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<PacsBaselineResult> QueryAsync(
+        string lane,
+        short workingYear,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(lane))
+            return new PacsBaselineResult(PacsBaselineOutcome.UnknownLane, 0,
+                "Lane name is required.");
+
+        // Geometry uses ArcGIS, not PACS.
+        if (string.Equals(lane, CorpusReconciliationPolicy.LaneGeometry, StringComparison.OrdinalIgnoreCase))
+            return await QueryArcGisCountAsync(cancellationToken).ConfigureAwait(false);
+
+        var pacsCs = _configuration.GetConnectionString("PacsConnection");
+        if (string.IsNullOrWhiteSpace(pacsCs))
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                "ConnectionStrings:PacsConnection is not configured.");
+
+        try
+        {
+            return lane switch
+            {
+                CorpusReconciliationPolicy.LaneParcel =>
+                    await QueryParcelAsync(pacsCs, cancellationToken).ConfigureAwait(false),
+                CorpusReconciliationPolicy.LaneOwnerWsdor =>
+                    await QueryOwnerWsdorAsync(pacsCs, workingYear, cancellationToken).ConfigureAwait(false),
+                CorpusReconciliationPolicy.LaneImprovement =>
+                    await QueryImprovementAsync(pacsCs, workingYear, cancellationToken).ConfigureAwait(false),
+                CorpusReconciliationPolicy.LaneLand =>
+                    await QueryLandAsync(pacsCs, workingYear, cancellationToken).ConfigureAwait(false),
+                CorpusReconciliationPolicy.LaneSales =>
+                    await QuerySalesAsync(pacsCs, cancellationToken).ConfigureAwait(false),
+                _ => new PacsBaselineResult(PacsBaselineOutcome.UnknownLane, 0,
+                    $"Unknown lane: '{lane}'."),
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PacsBaselineReconciler: lane={Lane} query failed; recording Unreachable.", lane);
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                $"PACS query failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    public async Task<long> CountTfCanonicalAsync(
+        string lane,
+        short workingYear,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(lane)) return 0L;
+
+        return lane switch
+        {
+            CorpusReconciliationPolicy.LaneParcel =>
+                await _db.TfParcels.CountAsync(cancellationToken).ConfigureAwait(false),
+
+            // owner+wsdor aggregation: tf_owner deduped count + tf_assessment_wsdor for year.
+            CorpusReconciliationPolicy.LaneOwnerWsdor =>
+                await _db.TfOwners.CountAsync(cancellationToken).ConfigureAwait(false)
+                + await _db.TfAssessmentWsdors
+                    .Where(w => w.AssessmentYear == workingYear)
+                    .CountAsync(cancellationToken).ConfigureAwait(false),
+
+            CorpusReconciliationPolicy.LaneImprovement =>
+                await _db.TfImprovements.CountAsync(cancellationToken).ConfigureAwait(false),
+
+            CorpusReconciliationPolicy.LaneLand =>
+                await _db.TfLands.CountAsync(cancellationToken).ConfigureAwait(false),
+
+            CorpusReconciliationPolicy.LaneSales =>
+                await _db.TfSales
+                    .Where(s => s.DorRatioQualified || s.CountyRatioQualified)
+                    .CountAsync(cancellationToken).ConfigureAwait(false),
+
+            CorpusReconciliationPolicy.LaneGeometry =>
+                await _db.TfParcelGeoms.CountAsync(cancellationToken).ConfigureAwait(false),
+
+            _ => 0L,
+        };
+    }
+
+    // ── PACS queries (per lane) ─────────────────────────────────────
+
+    /// <summary>
+    /// Parcel lane reconciles against the owner-anchored seed
+    /// population: distinct prop_id across <c>dbo.owner</c> at
+    /// <c>sup_num=0 AND owner_tax_yr&gt;=2018</c>. This matches the
+    /// row population the parcel drain actually lands.
+    /// </summary>
+    private async Task<PacsBaselineResult> QueryParcelAsync(string cs, CancellationToken ct)
+    {
+        const string sql =
+            "SELECT COUNT(DISTINCT prop_id) FROM dbo.owner " +
+            "WHERE sup_num = 0 AND owner_tax_yr >= 2018";
+        var count = await ExecuteScalarLongAsync(cs, sql, ct).ConfigureAwait(false);
+        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+    }
+
+    /// <summary>
+    /// Owner-WSDOR aggregation: distinct owner_id (deduped owner
+    /// canonical) plus wash_prop_owner_val rows for the working year
+    /// (WSDOR canonical population). One number compared to
+    /// <c>tf_owner.Count + tf_assessment_wsdor(@yr).Count</c>.
+    /// </summary>
+    private async Task<PacsBaselineResult> QueryOwnerWsdorAsync(string cs, short yr, CancellationToken ct)
+    {
+        var ownerSql =
+            "SELECT COUNT(DISTINCT owner_id) FROM dbo.owner " +
+            "WHERE sup_num = 0 AND owner_tax_yr >= 2018";
+        var ownerCount = await ExecuteScalarLongAsync(cs, ownerSql, ct).ConfigureAwait(false);
+
+        var wpovSql = "SELECT COUNT(*) FROM dbo.wash_prop_owner_val WHERE prop_val_yr = @yr";
+        var wpovCount = await ExecuteScalarLongAsync(
+            cs, wpovSql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
+
+        var total = ownerCount + wpovCount;
+        return new PacsBaselineResult(
+            PacsBaselineOutcome.Ok, total,
+            $"Aggregated: distinct owner_id ({ownerCount}) + wash_prop_owner_val(@yr={yr}) ({wpovCount}). " +
+            "Compared against tf_owner + tf_assessment_wsdor(@yr).");
+    }
+
+    private async Task<PacsBaselineResult> QueryImprovementAsync(string cs, short yr, CancellationToken ct)
+    {
+        const string sql = "SELECT COUNT(*) FROM dbo.imprv WHERE prop_val_yr = @yr";
+        var count = await ExecuteScalarLongAsync(cs, sql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
+        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+    }
+
+    private async Task<PacsBaselineResult> QueryLandAsync(string cs, short yr, CancellationToken ct)
+    {
+        const string sql = "SELECT COUNT(*) FROM dbo.land_detail WHERE prop_val_yr = @yr";
+        var count = await ExecuteScalarLongAsync(cs, sql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
+        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+    }
+
+    /// <summary>
+    /// Sales doctrine-qualified count per SYNC-DOCTRINE-3:
+    /// <c>sl_county_ratio_cd IN ('100','0') OR sl_ratio_type_cd='00'</c>.
+    /// </summary>
+    private async Task<PacsBaselineResult> QuerySalesAsync(string cs, CancellationToken ct)
+    {
+        const string sql =
+            "SELECT COUNT(*) FROM dbo.sale " +
+            "WHERE sl_county_ratio_cd IN ('100','0') OR sl_ratio_type_cd = '00'";
+        var count = await ExecuteScalarLongAsync(cs, sql, ct).ConfigureAwait(false);
+        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+    }
+
+    private async Task<PacsBaselineResult> QueryArcGisCountAsync(CancellationToken ct)
+    {
+        var url = _configuration["ArcGis:FeatureServiceUrl"];
+        if (string.IsNullOrWhiteSpace(url))
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                "ArcGis:FeatureServiceUrl is not configured; cannot reconcile geometry lane.");
+
+        if (_httpClientFactory is null)
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                "IHttpClientFactory is not registered; cannot reach ArcGIS feature service.");
+
+        try
+        {
+            var queryUrl = url.TrimEnd('/') + "/query?where=1%3D1&returnCountOnly=true&f=json";
+            using var http = _httpClientFactory.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(60);
+            var response = await http.GetAsync(queryUrl, ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("count", out var countEl) &&
+                countEl.TryGetInt64(out var cnt))
+            {
+                return new PacsBaselineResult(PacsBaselineOutcome.Ok, cnt, null);
+            }
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                "ArcGIS feature service response did not contain a numeric 'count' property.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PacsBaselineReconciler: ArcGIS feature service unreachable.");
+            return new PacsBaselineResult(PacsBaselineOutcome.Unreachable, 0,
+                $"ArcGIS feature service unreachable: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // ── Scalar helper ───────────────────────────────────────────────
+
+    private static async Task<long> ExecuteScalarLongAsync(
+        string cs,
+        string sql,
+        CancellationToken ct,
+        params (string Name, object Value)[] parameters)
+    {
+        await using var conn = new SqlConnection(cs);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        await using var cmd = new SqlCommand(sql, conn) { CommandTimeout = CommandTimeoutSec };
+        foreach (var (name, value) in parameters)
+            cmd.Parameters.AddWithValue(name, value);
+        var raw = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        return raw switch
+        {
+            null => 0L,
+            DBNull => 0L,
+            long l => l,
+            int i => i,
+            decimal d => (long)d,
+            _ => Convert.ToInt64(raw),
+        };
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -256,6 +256,17 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.Workbench.WorkbenchCommitDecisionLink>
     WorkbenchCommitDecisionLinks { get; set; } = null!;
 
+  // SYNC-COMPLETE-2: durable full-corpus sync runner. One row per
+  // operator-issued run + 6 pre-created lane-result rows + 6
+  // reconciliation rows after the run completes. Hosted background
+  // worker advances queued runs through the lane sequence.
+  public DbSet<TerraFusion.Core.Entities.Workbench.FullCorpusRun>
+    FullCorpusRuns { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.Workbench.FullCorpusLaneResult>
+    FullCorpusLaneResults { get; set; } = null!;
+  public DbSet<TerraFusion.Core.Entities.Workbench.FullCorpusReconciliation>
+    FullCorpusReconciliations { get; set; } = null!;
+
   // Slice L1: land_detail landing — per-segment land breakdown
   // (homesite, ag, pasture, timber, etc). 4-key composite. Required
   // by the truth_pacs.land_current promoter (future).
@@ -1075,6 +1086,15 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
       new TerraFusion.Data.Configurations.Workbench.WorkbenchCommitConfiguration());
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.Workbench.WorkbenchCommitDecisionLinkConfiguration());
+
+    // SYNC-COMPLETE-2: durable full-corpus runner (run + per-lane
+    // result + per-lane reconciliation). Schema tf_workbench.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.Workbench.FullCorpusRunConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.Workbench.FullCorpusLaneResultConfiguration());
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.Workbench.FullCorpusReconciliationConfiguration());
 
     // Slice L1: land_detail landing — per-segment land breakdown.
     modelBuilder.ApplyConfiguration(

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/CorpusReconciliationPolicyTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/CorpusReconciliationPolicyTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using TerraFusion.Core.Sync.Corpus;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2 unit tests for the locked policy table and the
+/// classification function.
+/// </summary>
+public sealed class CorpusReconciliationPolicyTests
+{
+    [Theory]
+    [InlineData("parcel", "RAW_SOURCE", 0.00)]
+    [InlineData("owner-wsdor", "DEDUPED_CANONICAL", 2.00)]
+    [InlineData("improvement", "DOCTRINE_FILTERED", 1.00)]
+    [InlineData("land", "RAW_SOURCE", 0.10)]
+    [InlineData("sales", "DOCTRINE_FILTERED", 0.50)]
+    [InlineData("geometry", "EXTERNAL_FEATURE_COUNT", 0.00)]
+    public void Policy_table_is_locked_per_spec(string lane, string basis, double tolerance)
+    {
+        var policy = CorpusReconciliationPolicy.Policies[lane];
+        policy.ExpectedBasis.Should().Be(basis);
+        policy.TolerancePct.Should().Be((decimal)tolerance);
+    }
+
+    [Fact]
+    public void Lane_order_is_canonical_six()
+    {
+        CorpusReconciliationPolicy.LaneOrder.Should().Equal(
+            "parcel", "owner-wsdor", "improvement", "land", "sales", "geometry");
+    }
+
+    [Fact]
+    public void Classify_returns_Match_when_delta_is_zero()
+    {
+        var result = CorpusReconciliationPolicy.Classify(0, 0m, 1.0m);
+        result.Should().Be(CorpusReconciliationPolicy.ReconciliationStatusMatch);
+    }
+
+    [Fact]
+    public void Classify_returns_AcceptableDelta_within_tolerance()
+    {
+        // |deltaPct| = 0.5 ≤ tolerance 1.0
+        var result = CorpusReconciliationPolicy.Classify(5, 0.5m, 1.0m);
+        result.Should().Be(CorpusReconciliationPolicy.ReconciliationStatusAcceptableDelta);
+    }
+
+    [Fact]
+    public void Classify_returns_Investigate_above_tolerance()
+    {
+        // |deltaPct| = 1.5 > tolerance 1.0
+        var result = CorpusReconciliationPolicy.Classify(15, 1.5m, 1.0m);
+        result.Should().Be(CorpusReconciliationPolicy.ReconciliationStatusInvestigate);
+    }
+
+    [Fact]
+    public void Classify_handles_negative_delta_pct()
+    {
+        // Tf < Pacs → negative delta. Absolute value still classifies cleanly.
+        var result = CorpusReconciliationPolicy.Classify(-5, -0.3m, 1.0m);
+        result.Should().Be(CorpusReconciliationPolicy.ReconciliationStatusAcceptableDelta);
+    }
+
+    [Fact]
+    public void ComputeDeltaPct_clamps_denominator_at_one_when_pacs_is_zero()
+    {
+        // Avoids divide-by-zero.
+        var result = CorpusReconciliationPolicy.ComputeDeltaPct(0, 5);
+        result.Should().Be(500m);
+    }
+
+    [Fact]
+    public void ComputeDeltaPct_handles_negative_delta_as_absolute()
+    {
+        var result = CorpusReconciliationPolicy.ComputeDeltaPct(100, -5);
+        result.Should().Be(5m);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorHostedServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorHostedServiceTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Corpus;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Workbench.Corpus;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2 unit tests for
+/// <see cref="FullCorpusOrchestratorHostedService"/>. We exercise
+/// the worker's <c>ProcessRunAsync</c> + <c>RunReconciliationAsync</c>
+/// + sweep methods directly via the same scope-factory the host
+/// uses, with fakes for <see cref="ICorpusLaneRunner"/> and
+/// <see cref="IPacsBaselineReconciler"/>.
+///
+/// <para>The worker uses fresh DbContext scopes per stage, so a
+/// scope-factory wrapping a single in-memory database is the
+/// cleanest fixture.</para>
+/// </summary>
+public sealed class FullCorpusOrchestratorHostedServiceTests : IDisposable
+{
+    private readonly string _dbName = $"corpus-host-{Guid.NewGuid():N}";
+    private readonly ServiceProvider _provider;
+
+    public FullCorpusOrchestratorHostedServiceTests()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TerraFusionDbContext>(opt => opt.UseInMemoryDatabase(_dbName));
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>()).Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<ICorpusLaneRunner>(new SuccessLaneRunner());
+        services.AddSingleton<IPacsBaselineReconciler>(new FakeReconciler());
+        _provider = services.BuildServiceProvider();
+        // Ensure schema created.
+        using var scope = _provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>().Database.EnsureCreated();
+    }
+
+    public void Dispose() => _provider.Dispose();
+
+    private FullCorpusOrchestratorHostedService BuildHost()
+    {
+        var scopeFactory = _provider.GetRequiredService<IServiceScopeFactory>();
+        return new FullCorpusOrchestratorHostedService(
+            scopeFactory,
+            NullLogger<FullCorpusOrchestratorHostedService>.Instance);
+    }
+
+    /// <summary>
+    /// Read snapshot. The scope is disposed when the test ends via
+    /// <see cref="Dispose"/> on the service provider; we don't need
+    /// to track it here for in-memory provider correctness.
+    /// </summary>
+    private TerraFusionDbContext GetReadDb()
+    {
+        var scope = _provider.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+    }
+
+    [Fact]
+    public async Task StartAsync_sweeps_stale_Running_runs_to_Interrupted()
+    {
+        // Seed a Running run from a "previous" backend lifetime.
+        using (var scope = _provider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            db.FullCorpusRuns.Add(new FullCorpusRun
+            {
+                RunId = Guid.NewGuid(),
+                OperatorName = "stale",
+                WorkingYear = 2026,
+                Status = FullCorpusOrchestrator.StatusRunning,
+                StartedAt = DateTime.UtcNow.AddHours(-3),
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var host = BuildHost();
+        await host.StartAsync(CancellationToken.None);
+        await host.StopAsync(CancellationToken.None);
+
+        var read = GetReadDb();
+        var swept = await read.FullCorpusRuns.SingleAsync();
+        swept.Status.Should().Be(FullCorpusOrchestrator.StatusInterrupted);
+        swept.ErrorMessage.Should().Contain("backend restarted");
+    }
+
+    [Fact]
+    public async Task ProcessRunAsync_advances_NextLaneOnResume_after_each_lane()
+    {
+        var runId = await SeedQueuedRunAsync();
+        var host = BuildHost();
+        await host.ProcessRunAsync(runId, CancellationToken.None);
+
+        var read = GetReadDb();
+        var run = await read.FullCorpusRuns.SingleAsync(r => r.RunId == runId);
+        run.Status.Should().Be(FullCorpusOrchestrator.StatusCompleted);
+        run.NextLaneOnResume.Should().BeNull();
+
+        var lanes = await read.FullCorpusLaneResults.Where(l => l.RunId == runId).ToListAsync();
+        lanes.Should().OnlyContain(l => l.Status == "Completed");
+    }
+
+    [Fact]
+    public async Task ProcessRunAsync_on_lane_failure_marks_run_Failed_and_preserves_NextLaneOnResume()
+    {
+        // Use a runner that fails on the third lane (improvement).
+        var failingRunner = new FailOnLaneRunner("improvement");
+        ReplaceRunner(failingRunner);
+        var runId = await SeedQueuedRunAsync();
+        var host = BuildHost();
+        await host.ProcessRunAsync(runId, CancellationToken.None);
+
+        var read = GetReadDb();
+        var run = await read.FullCorpusRuns.SingleAsync(r => r.RunId == runId);
+        run.Status.Should().Be(FullCorpusOrchestrator.StatusFailed);
+        run.ErrorMessage.Should().Contain("improvement");
+        // First two lanes advanced NextLaneOnResume to "improvement"; failure
+        // does not advance further. Worker resumes from improvement on retry.
+        run.NextLaneOnResume.Should().Be("improvement");
+    }
+
+    [Fact]
+    public async Task ProcessRunAsync_after_six_lanes_runs_reconciliation_pass()
+    {
+        var runId = await SeedQueuedRunAsync();
+        var host = BuildHost();
+        await host.ProcessRunAsync(runId, CancellationToken.None);
+
+        var read = GetReadDb();
+        var rec = await read.FullCorpusReconciliations.Where(r => r.RunId == runId).ToListAsync();
+        rec.Should().HaveCount(6);
+        rec.Select(r => r.Lane).Should().BeEquivalentTo(CorpusReconciliationPolicy.LaneOrder);
+    }
+
+    [Fact]
+    public async Task ProcessRunAsync_persists_lane_batch_ids_and_counts_json()
+    {
+        var runId = await SeedQueuedRunAsync();
+        var host = BuildHost();
+        await host.ProcessRunAsync(runId, CancellationToken.None);
+
+        var read = GetReadDb();
+        var lanes = await read.FullCorpusLaneResults.Where(l => l.RunId == runId).ToListAsync();
+        lanes.Should().OnlyContain(l => !string.IsNullOrEmpty(l.BatchIdsJson));
+        lanes.Should().OnlyContain(l => l.CountsJson != null);
+    }
+
+    [Fact]
+    public async Task RunReconciliationAsync_records_Investigate_when_reconciler_unreachable()
+    {
+        ReplaceReconciler(new UnreachableReconciler());
+        var runId = await SeedQueuedRunAsync();
+        var host = BuildHost();
+        await host.RunReconciliationAsync(runId, 2026, CancellationToken.None);
+
+        var read = GetReadDb();
+        var rec = await read.FullCorpusReconciliations.Where(r => r.RunId == runId).ToListAsync();
+        rec.Should().HaveCount(6);
+        rec.Should().OnlyContain(r =>
+            r.ReconciliationStatus == CorpusReconciliationPolicy.ReconciliationStatusInvestigate);
+        rec.Should().OnlyContain(r => !string.IsNullOrEmpty(r.Notes));
+    }
+
+    private async Task<Guid> SeedQueuedRunAsync()
+    {
+        using var scope = _provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+        var orchestrator = new FullCorpusOrchestrator(db);
+        var result = await orchestrator.StartAsync("test-op", 2026, CancellationToken.None);
+        // Flip to Running so worker treats it as a picked run.
+        var run = await db.FullCorpusRuns.SingleAsync(r => r.RunId == result.RunId);
+        run.Status = FullCorpusOrchestrator.StatusRunning;
+        run.CurrentLane = "parcel";
+        await db.SaveChangesAsync();
+        return result.RunId;
+    }
+
+    private void ReplaceRunner(ICorpusLaneRunner runner) =>
+        ((SuccessLaneRunner)_provider.GetRequiredService<ICorpusLaneRunner>())
+            .OverrideWith = runner;
+
+    private void ReplaceReconciler(IPacsBaselineReconciler reconciler) =>
+        ((FakeReconciler)_provider.GetRequiredService<IPacsBaselineReconciler>())
+            .OverrideWith = reconciler;
+
+    // ── Fakes ───────────────────────────────────────────────────────
+
+    private sealed class SuccessLaneRunner : ICorpusLaneRunner
+    {
+        public ICorpusLaneRunner? OverrideWith { get; set; }
+
+        public Task<CorpusLaneRunResult> RunLaneAsync(
+            string lane, string operatorName, short workingYear,
+            bool fullCorpus, int? topN, CancellationToken cancellationToken)
+        {
+            if (OverrideWith is not null)
+                return OverrideWith.RunLaneAsync(
+                    lane, operatorName, workingYear, fullCorpus, topN, cancellationToken);
+
+            return Task.FromResult(new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Completed,
+                new[] { Guid.NewGuid() },
+                "{\"rowsLanded\":42}",
+                "{\"totals\":[]}",
+                "{\"before\":0,\"after\":0,\"delta\":0}",
+                null));
+        }
+    }
+
+    private sealed class FailOnLaneRunner : ICorpusLaneRunner
+    {
+        private readonly string _failLane;
+        public FailOnLaneRunner(string failLane) { _failLane = failLane; }
+
+        public Task<CorpusLaneRunResult> RunLaneAsync(
+            string lane, string operatorName, short workingYear,
+            bool fullCorpus, int? topN, CancellationToken cancellationToken)
+        {
+            if (string.Equals(lane, _failLane, StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(new CorpusLaneRunResult(
+                    CorpusLaneRunOutcome.Failed,
+                    Array.Empty<Guid>(),
+                    null, null, null,
+                    "simulated failure"));
+
+            return Task.FromResult(new CorpusLaneRunResult(
+                CorpusLaneRunOutcome.Completed,
+                new[] { Guid.NewGuid() },
+                "{}", "{}", "{}",
+                null));
+        }
+    }
+
+    private sealed class FakeReconciler : IPacsBaselineReconciler
+    {
+        public IPacsBaselineReconciler? OverrideWith { get; set; }
+
+        public Task<PacsBaselineResult> QueryAsync(
+            string lane, short workingYear, CancellationToken ct)
+        {
+            if (OverrideWith is not null)
+                return OverrideWith.QueryAsync(lane, workingYear, ct);
+            return Task.FromResult(new PacsBaselineResult(
+                PacsBaselineOutcome.Ok, 100L, null));
+        }
+
+        public Task<long> CountTfCanonicalAsync(
+            string lane, short workingYear, CancellationToken ct)
+        {
+            if (OverrideWith is not null)
+                return OverrideWith.CountTfCanonicalAsync(lane, workingYear, ct);
+            return Task.FromResult(100L);
+        }
+    }
+
+    private sealed class UnreachableReconciler : IPacsBaselineReconciler
+    {
+        public Task<PacsBaselineResult> QueryAsync(
+            string lane, short workingYear, CancellationToken ct) =>
+            Task.FromResult(new PacsBaselineResult(
+                PacsBaselineOutcome.Unreachable, 0, "PACS unreachable in test fixture."));
+
+        public Task<long> CountTfCanonicalAsync(
+            string lane, short workingYear, CancellationToken ct) =>
+            Task.FromResult(0L);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.Core.Entities.Workbench;
+using TerraFusion.Core.Sync.Corpus;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Workbench.Corpus;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2 unit tests for
+/// <see cref="FullCorpusOrchestrator"/>. In-memory DbContext fixture
+/// mirrors the WORKBENCH-G test pattern.
+/// </summary>
+public sealed class FullCorpusOrchestratorTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public FullCorpusOrchestratorTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"corpus-orch-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "InMemory" })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private FullCorpusOrchestrator Build() => new(_db);
+
+    [Fact]
+    public async Task StartAsync_creates_run_with_status_Queued()
+    {
+        var svc = Build();
+        var result = await svc.StartAsync("op", 2026, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Ok);
+        var run = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == result.RunId);
+        run.Status.Should().Be(FullCorpusOrchestrator.StatusQueued);
+        run.OperatorName.Should().Be("op");
+        run.WorkingYear.Should().Be((short)2026);
+    }
+
+    [Fact]
+    public async Task StartAsync_creates_six_lane_result_rows_in_Pending()
+    {
+        var svc = Build();
+        var result = await svc.StartAsync("op", 2026, CancellationToken.None);
+
+        var lanes = await _db.FullCorpusLaneResults
+            .Where(l => l.RunId == result.RunId).ToListAsync();
+        lanes.Should().HaveCount(6);
+        lanes.Select(l => l.Lane).Should().BeEquivalentTo(
+            new[] { "parcel", "owner-wsdor", "improvement", "land", "sales", "geometry" });
+        lanes.Should().OnlyContain(l => l.Status == FullCorpusOrchestrator.LaneStatusPending);
+    }
+
+    [Fact]
+    public async Task StartAsync_sets_NextLaneOnResume_to_parcel()
+    {
+        var svc = Build();
+        var result = await svc.StartAsync("op", 2026, CancellationToken.None);
+
+        var run = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == result.RunId);
+        run.NextLaneOnResume.Should().Be("parcel");
+    }
+
+    [Fact]
+    public async Task StartAsync_normalizes_blank_operator_to_default_value()
+    {
+        var svc = Build();
+        var result = await svc.StartAsync("   ", 2026, CancellationToken.None);
+
+        var run = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == result.RunId);
+        run.OperatorName.Should().Be("full-corpus-runner");
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_Failed_run_flips_to_Queued()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusFailed);
+        var result = await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Ok);
+        var refreshed = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == run.RunId);
+        refreshed.Status.Should().Be(FullCorpusOrchestrator.StatusQueued);
+        refreshed.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_Interrupted_run_flips_to_Queued()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusInterrupted);
+        var result = await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Ok);
+        var refreshed = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == run.RunId);
+        refreshed.Status.Should().Be(FullCorpusOrchestrator.StatusQueued);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_Running_run_returns_Conflict()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusRunning);
+        var result = await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Conflict);
+        result.Status.Should().Be(FullCorpusOrchestrator.StatusRunning);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_Completed_run_returns_Conflict()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusCompleted);
+        var result = await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_Queued_run_returns_Conflict()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusQueued);
+        var result = await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Conflict);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_on_unknown_run_returns_NotFound()
+    {
+        var result = await Build().ResumeAsync(Guid.NewGuid(), CancellationToken.None);
+        result.Outcome.Should().Be(CorpusOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_preserves_NextLaneOnResume()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusFailed, nextLane: "improvement");
+        await Build().ResumeAsync(run.RunId, CancellationToken.None);
+
+        var refreshed = await _db.FullCorpusRuns.SingleAsync(r => r.RunId == run.RunId);
+        refreshed.NextLaneOnResume.Should().Be("improvement");
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_returns_run_and_six_lane_rows()
+    {
+        var svc = Build();
+        var startResult = await svc.StartAsync("op", 2026, CancellationToken.None);
+        var status = await svc.GetStatusAsync(startResult.RunId, CancellationToken.None);
+
+        status.Outcome.Should().Be(CorpusOutcome.Ok);
+        status.Run.Should().NotBeNull();
+        status.Lanes.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_on_unknown_run_returns_NotFound()
+    {
+        var status = await Build().GetStatusAsync(Guid.NewGuid(), CancellationToken.None);
+        status.Outcome.Should().Be(CorpusOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task GetReconciliationAsync_returns_empty_when_not_yet_run()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusRunning);
+        var result = await Build().GetReconciliationAsync(run.RunId, CancellationToken.None);
+
+        result.Outcome.Should().Be(CorpusOutcome.Ok);
+        result.Reconciliations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetReconciliationAsync_returns_six_rows_when_complete()
+    {
+        var run = await SeedRunAsync(FullCorpusOrchestrator.StatusCompleted);
+        foreach (var lane in CorpusReconciliationPolicy.LaneOrder)
+        {
+            _db.FullCorpusReconciliations.Add(new FullCorpusReconciliation
+            {
+                ReconciliationId = Guid.NewGuid(),
+                RunId = run.RunId,
+                Lane = lane,
+                ExpectedBasis = CorpusReconciliationPolicy.Policies[lane].ExpectedBasis,
+                ReconciliationStatus = CorpusReconciliationPolicy.ReconciliationStatusMatch,
+                ComputedAt = DateTime.UtcNow,
+            });
+        }
+        await _db.SaveChangesAsync();
+
+        var result = await Build().GetReconciliationAsync(run.RunId, CancellationToken.None);
+        result.Outcome.Should().Be(CorpusOutcome.Ok);
+        result.Reconciliations.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public async Task GetReconciliationAsync_on_unknown_run_returns_NotFound()
+    {
+        var result = await Build().GetReconciliationAsync(Guid.NewGuid(), CancellationToken.None);
+        result.Outcome.Should().Be(CorpusOutcome.NotFound);
+    }
+
+    private async Task<FullCorpusRun> SeedRunAsync(
+        string status,
+        string? nextLane = "parcel")
+    {
+        var run = new FullCorpusRun
+        {
+            RunId = Guid.NewGuid(),
+            OperatorName = "test-op",
+            WorkingYear = 2026,
+            Status = status,
+            NextLaneOnResume = nextLane,
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.FullCorpusRuns.Add(run);
+        await _db.SaveChangesAsync();
+        return run;
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/HttpCorpusLaneRunnerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/HttpCorpusLaneRunnerTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using TerraFusion.Core.Sync.Corpus;
+using TerraFusion.Data.Services.Workbench.Corpus;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2 unit tests for the response-parser inside
+/// <see cref="HttpCorpusLaneRunner"/>. We don't issue real HTTP
+/// calls — we exercise the JSON-shape parser against the documented
+/// success and failure response shapes from
+/// <c>DoctrineDrainController</c>.
+/// </summary>
+public sealed class HttpCorpusLaneRunnerTests
+{
+    [Fact]
+    public void ParseLaneResponse_extracts_batch_ids_counts_gates_quarantine_on_success()
+    {
+        var batchA = Guid.NewGuid();
+        var batchB = Guid.NewGuid();
+        var json = $@"{{
+            ""lane"":""parcel"",
+            ""status"":""Succeeded"",
+            ""batchIds"":[""{batchA}"",""{batchB}""],
+            ""counts"":{{""rowsLanded"":42}},
+            ""gateSummary"":{{""totals"":[]}},
+            ""quarantineDelta"":{{""before"":0,""after"":0,""delta"":0}}
+        }}";
+
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(true, json);
+        result.Outcome.Should().Be(CorpusLaneRunOutcome.Completed);
+        result.BatchIds.Should().Equal(batchA, batchB);
+        result.CountsJson.Should().Contain("rowsLanded");
+        result.GateSummaryJson.Should().Contain("totals");
+        result.QuarantineDeltaJson.Should().Contain("delta");
+    }
+
+    [Fact]
+    public void ParseLaneResponse_returns_Failed_with_composite_error_on_failure_response()
+    {
+        var json = @"{
+            ""lane"":""improvement"",
+            ""status"":""Failed"",
+            ""failedStage"":""Imprv-Truth"",
+            ""error"":""boom"",
+            ""batchIds"":[]
+        }";
+
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(false, json);
+        result.Outcome.Should().Be(CorpusLaneRunOutcome.Failed);
+        result.ErrorMessage.Should().Be("Imprv-Truth: boom");
+    }
+
+    [Fact]
+    public void ParseLaneResponse_returns_Failed_when_response_status_is_not_Succeeded()
+    {
+        // 200 OK from the controller but status field says Failed.
+        var json = @"{""lane"":""sales"",""status"":""Failed"",""batchIds"":[]}";
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(true, json);
+        result.Outcome.Should().Be(CorpusLaneRunOutcome.Failed);
+    }
+
+    [Fact]
+    public void ParseLaneResponse_handles_empty_response_text()
+    {
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(true, string.Empty);
+        result.Outcome.Should().Be(CorpusLaneRunOutcome.Failed);
+        result.ErrorMessage.Should().Contain("Empty response");
+    }
+
+    [Fact]
+    public void ParseLaneResponse_handles_invalid_json_gracefully()
+    {
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(true, "not-json");
+        result.Outcome.Should().Be(CorpusLaneRunOutcome.Failed);
+        result.ErrorMessage.Should().Contain("parse");
+    }
+
+    [Fact]
+    public void ParseLaneResponse_skips_invalid_batch_id_entries()
+    {
+        var goodId = Guid.NewGuid();
+        var json = $@"{{
+            ""lane"":""parcel"",
+            ""status"":""Succeeded"",
+            ""batchIds"":[""{goodId}"",""not-a-guid"",null,42]
+        }}";
+        var result = HttpCorpusLaneRunner.ParseLaneResponse(true, json);
+        result.BatchIds.Should().ContainSingle().Which.Should().Be(goodId);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/PacsBaselineReconcilerTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/PacsBaselineReconcilerTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.CanonicalTf;
+using TerraFusion.Core.Entities.GisTf;
+using TerraFusion.Core.Sync.Corpus;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Workbench.Corpus;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Corpus;
+
+/// <summary>
+/// SYNC-COMPLETE-2 unit tests for
+/// <see cref="PacsBaselineReconciler"/>. We exercise the
+/// canonical-count side (against the in-memory db) and the
+/// PACS-side unreachable path (no <c>PacsConnection</c> configured).
+///
+/// <para>The PACS query path isn't exercised in unit tests — it
+/// requires a real SQL Server connection and is proven against
+/// live PACS in the SYNC-COMPLETE-3 live-replay seal.</para>
+/// </summary>
+public sealed class PacsBaselineReconcilerTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly IConfiguration _emptyConfig;
+
+    public PacsBaselineReconcilerTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"corpus-recon-{Guid.NewGuid():N}")
+            .Options;
+        _emptyConfig = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        _db = new TerraFusionDbContext(options, _emptyConfig);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private PacsBaselineReconciler Build(IConfiguration? config = null) =>
+        new(_db, config ?? _emptyConfig,
+            NullLogger<PacsBaselineReconciler>.Instance);
+
+    [Fact]
+    public async Task QueryAsync_without_PacsConnection_returns_Unreachable()
+    {
+        var result = await Build().QueryAsync(
+            CorpusReconciliationPolicy.LaneParcel, 2026, CancellationToken.None);
+        result.Outcome.Should().Be(PacsBaselineOutcome.Unreachable);
+        result.Notes.Should().Contain("PacsConnection");
+    }
+
+    [Fact]
+    public async Task QueryAsync_with_blank_lane_name_returns_UnknownLane()
+    {
+        // Lane validation happens before the PacsConnection guard.
+        var result = await Build().QueryAsync(" ", 2026, CancellationToken.None);
+        result.Outcome.Should().Be(PacsBaselineOutcome.UnknownLane);
+    }
+
+    [Fact]
+    public async Task QueryAsync_geometry_without_ArcGis_url_returns_Unreachable()
+    {
+        var result = await Build().QueryAsync(
+            CorpusReconciliationPolicy.LaneGeometry, 2026, CancellationToken.None);
+        result.Outcome.Should().Be(PacsBaselineOutcome.Unreachable);
+        result.Notes.Should().Contain("ArcGis");
+    }
+
+    [Fact]
+    public async Task CountTfCanonicalAsync_parcel_returns_zero_when_empty()
+    {
+        var count = await Build().CountTfCanonicalAsync(
+            CorpusReconciliationPolicy.LaneParcel, 2026, CancellationToken.None);
+        count.Should().Be(0L);
+    }
+
+    [Fact]
+    public async Task CountTfCanonicalAsync_parcel_counts_seeded_rows()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            _db.TfParcels.Add(new TfParcel { TfParcelId = Guid.NewGuid(), CountyId = Guid.NewGuid() });
+        }
+        await _db.SaveChangesAsync();
+
+        var count = await Build().CountTfCanonicalAsync(
+            CorpusReconciliationPolicy.LaneParcel, 2026, CancellationToken.None);
+        count.Should().Be(3L);
+    }
+
+    [Fact]
+    public async Task CountTfCanonicalAsync_sales_only_counts_qualified_rows()
+    {
+        _db.TfSales.Add(new TfSale
+        {
+            TfSaleId = Guid.NewGuid(),
+            DorRatioQualified = true,
+            CountyRatioQualified = false,
+        });
+        _db.TfSales.Add(new TfSale
+        {
+            TfSaleId = Guid.NewGuid(),
+            DorRatioQualified = false,
+            CountyRatioQualified = true,
+        });
+        _db.TfSales.Add(new TfSale
+        {
+            TfSaleId = Guid.NewGuid(),
+            DorRatioQualified = false,
+            CountyRatioQualified = false,
+        });
+        await _db.SaveChangesAsync();
+
+        var count = await Build().CountTfCanonicalAsync(
+            CorpusReconciliationPolicy.LaneSales, 2026, CancellationToken.None);
+        count.Should().Be(2L);
+    }
+
+    [Fact]
+    public async Task CountTfCanonicalAsync_owner_wsdor_aggregates_owner_and_wsdor_rows()
+    {
+        _db.TfOwners.Add(new TfOwner { TfOwnerId = Guid.NewGuid() });
+        _db.TfOwners.Add(new TfOwner { TfOwnerId = Guid.NewGuid() });
+        _db.TfAssessmentWsdors.Add(new TfAssessmentWsdor
+        {
+            TfAssessmentWsdorId = Guid.NewGuid(),
+            AssessmentYear = 2026,
+        });
+        _db.TfAssessmentWsdors.Add(new TfAssessmentWsdor
+        {
+            TfAssessmentWsdorId = Guid.NewGuid(),
+            AssessmentYear = 2025,  // wrong year — excluded
+        });
+        await _db.SaveChangesAsync();
+
+        var count = await Build().CountTfCanonicalAsync(
+            CorpusReconciliationPolicy.LaneOwnerWsdor, 2026, CancellationToken.None);
+        count.Should().Be(3L);
+    }
+
+    [Fact]
+    public async Task CountTfCanonicalAsync_unknown_lane_returns_zero()
+    {
+        var count = await Build().CountTfCanonicalAsync(
+            "not-a-lane", 2026, CancellationToken.None);
+        count.Should().Be(0L);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds durable full-corpus sync runner (`FullCorpusRun` + `FullCorpusLaneResult` + `FullCorpusReconciliation`) so a 6+ hour full-county drain survives backend restarts and exposes reconciliation against PACS baselines.
- Hosted background worker polls every 5 seconds, sweeps stale Running rows to Interrupted on startup (no auto-resume — operator calls `POST resume`), runs the six lane sequence sequentially via HTTP loopback against the existing `/api/sync/doctrine/drain/{lane}` endpoints, then computes per-lane reconciliation.
- Five endpoints under `/api/sync/corpus`: start, resume, status, reconciliation, evidence.zip (HMAC-signed corpus-scope packet — manifest + run.csv + lane-results.csv + reconciliation.csv + gate-summaries.json).
- One migration: `SyncComplete2FullCorpusRun` adds three tables to `tf_workbench` (full_corpus_run, full_corpus_lane_result, full_corpus_reconciliation) with unique (RunId, Lane) constraints on the latter two.
- Per-lane reconciliation policy locked per spec: parcel/land RAW_SOURCE, owner-wsdor DEDUPED_CANONICAL (2.0%), improvement/sales DOCTRINE_FILTERED, geometry EXTERNAL_FEATURE_COUNT against ArcGIS feature service.

## Design notes
- **HTTP loopback over direct DI**: each lane endpoint injects 4-12 scoped services; threading those through the hosted worker would couple the corpus runner to every lane's internal composition. One localhost roundtrip per lane (six per run) is dwarfed by multi-hour drain time, and stays stable across lane refactors. Endpoints are `[AllowAnonymous]` so no auth headers needed.
- **PACS reconciler is diagnostic, not fatal**: PACS unreachable / ArcGIS misconfigured → `Outcome=Unreachable` with `Notes` populated; orchestrator records `Investigate` instead of throwing.
- **No auto-resume**: startup sweep flips `Running → Interrupted` with `ErrorMessage="backend restarted before run completed"`. Operator must explicitly call `POST resume`.
- **Worker stays alive**: single `Task.Run` task that uses `Task.Delay(PollInterval, ct)` between polls; cancellation token threads through `StopAsync` for graceful shutdown.

## Test plan
- [x] 49 SYNC-COMPLETE-2 tests (orchestrator state-machine, reconciliation policy classification, hosted worker lifecycle, HTTP response parser, canonical count queries) all pass
- [x] Full unit suite: 3268/3268 passing
- [x] `dotnet build TerraFusion.sln` clean — 0 warnings, 0 errors
- [x] Migration `SyncComplete2FullCorpusRun` generated — three tables, six indexes, all in `tf_workbench` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added full-corpus synchronization REST API endpoints at `/api/sync/corpus` for starting and managing corpus sync operations
- Ability to start new sync runs with configurable operator and working year parameters  
- Status tracking and retrieval endpoints for monitoring in-progress or completed runs
- Reconciliation query endpoint to retrieve per-lane reconciliation metrics and delta analysis
- Evidence packet download capability with deterministic, signed manifest files

**Tests**
- Added comprehensive unit test coverage for reconciliation workflows and lane execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->