### PR TITLE
feat(sync-ux): UX-1B — workbench commits + evidence UI

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -76,6 +76,14 @@ const SyncDoctrineConsole = lazy(
   () => import('./pages/workbench/sync-doctrine/SyncDoctrineConsole'),
 );
 
+// SYNC-UX-1B: Sync Commits page — operator surface for the
+// SYNC-WORKBENCH-G/H spine. Lists recent decision-commits, drills
+// into a single commit's snapshot, and downloads the signed
+// evidence ZIP / inspects the manifest.
+const SyncCommitsPage = lazy(
+  () => import('./pages/workbench/sync-commits/SyncCommitsPage'),
+);
+
 const Monitoring = lazy(() => import('./pages/Monitoring'));
 const TerraFusionMarketplace = lazy(
   () => import('./components/marketplace/TerraFusionMarketplace')
@@ -219,6 +227,16 @@ const Router: React.FC = () => {
                   <Route
                     path='workbench/sync-doctrine'
                     element={<SyncDoctrineConsole />}
+                  />
+
+                  {/* SYNC-UX-1B: Workbench commits + evidence UI */}
+                  <Route
+                    path='workbench/sync/commits'
+                    element={<SyncCommitsPage />}
+                  />
+                  <Route
+                    path='workbench/sync/commits/:commitId'
+                    element={<SyncCommitsPage />}
                   />
 
                   <Route path='monitoring' element={<Monitoring />} />

--- a/frontend/apps/os-shell/src/api/syncCommits.ts
+++ b/frontend/apps/os-shell/src/api/syncCommits.ts
@@ -1,0 +1,297 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * SYNC-UX-1B: WORKBENCH COMMIT + EVIDENCE API CLIENT
+ *
+ * Wraps the SYNC-WORKBENCH-G (commit) and SYNC-WORKBENCH-H
+ * (evidence) backend surfaces. The /workbench/sync/commits
+ * page consumes these to render the decision-history panel and
+ * download evidence packets.
+ *
+ * Pattern mirrors src/api/syncDoctrine.ts (compact fetch-based;
+ * no axios, no secrets, DTOs carry counts + timestamps + IDs).
+ *
+ * No mutation of triage / quarantine / canonical rows occurs from
+ * this UI surface. All endpoints are operator-driven.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import { getViteEnv } from '@/env/getViteEnv';
+
+const API_BASE_URL = getViteEnv().VITE_API_URL || '';
+
+// ───────────────────────────────────────────────────────────────
+// Commit types — mirror IWorkbenchCommitService DTOs
+// ───────────────────────────────────────────────────────────────
+
+export interface CommitCreateRequest {
+  IdempotencyKey: string;
+  OperatorId: string;
+  CommitNote?: string | null;
+}
+
+export interface CommitCreateResponse {
+  commitId: string;
+  status: 'Created' | 'Idempotent' | string;
+  routedDecisionsApplied: number;
+  dismissedDecisionsApplied: number;
+  committedAt: string;
+  universeDistributionJson: string;
+  ratioDistributionJson: string;
+}
+
+export interface CommitSummaryResponse {
+  commitId: string;
+  committedAt: string;
+  operatorId: string;
+  idempotencyKey: string;
+  routedDecisionsApplied: number;
+  dismissedDecisionsApplied: number;
+  commitNote: string | null;
+}
+
+export interface CommitListResponse {
+  count: number;
+  limit: number;
+  offset: number;
+  items: CommitSummaryResponse[];
+}
+
+export interface DecisionLinkResponse {
+  linkId: string;
+  triageId: string;
+  unprovenRowId: string;
+  decisionType: 'Route' | 'Dismiss' | string;
+  routedToUniverse: string | null;
+  routedToIAttrValCd: string | null;
+  dismissalReason: string | null;
+}
+
+export interface CommitDetailResponse extends CommitSummaryResponse {
+  universeDistributionJson: string;
+  ratioDistributionJson: string;
+  decisions: DecisionLinkResponse[];
+}
+
+// ───────────────────────────────────────────────────────────────
+// Distribution snapshot shapes (parsed from JSON strings)
+// ───────────────────────────────────────────────────────────────
+
+export interface UniverseDistribution {
+  REAL_RESIDENTIAL: number;
+  REAL_COMMERCIAL: number;
+  MOBILE_HOME: number;
+  AG_CURRENT_USE: number;
+  PERSONAL_PROPERTY: number;
+  CONVERSION_LEGACY: number;
+  UNKNOWN: number;
+}
+
+export interface RatioDistribution {
+  DorQ_CountyQ: number;
+  DorQ_CountyN: number;
+  DorN_CountyQ: number;
+  DorN_CountyN: number;
+}
+
+export const UNIVERSE_KEYS: ReadonlyArray<keyof UniverseDistribution> = [
+  'REAL_RESIDENTIAL',
+  'REAL_COMMERCIAL',
+  'MOBILE_HOME',
+  'AG_CURRENT_USE',
+  'PERSONAL_PROPERTY',
+  'CONVERSION_LEGACY',
+  'UNKNOWN',
+];
+
+export const RATIO_KEYS: ReadonlyArray<keyof RatioDistribution> = [
+  'DorQ_CountyQ',
+  'DorQ_CountyN',
+  'DorN_CountyQ',
+  'DorN_CountyN',
+];
+
+/**
+ * Tolerant JSON parse for the universe-distribution snapshot. Returns null
+ * when the payload is unparseable so the UI can render a "could not parse"
+ * placeholder instead of crashing the panel.
+ */
+export function parseUniverseDistribution(json: string): UniverseDistribution | null {
+  if (!json) return null;
+  try {
+    const raw = JSON.parse(json) as Record<string, unknown>;
+    const out = {} as UniverseDistribution;
+    for (const k of UNIVERSE_KEYS) {
+      const v = raw?.[k];
+      out[k] = typeof v === 'number' && Number.isFinite(v) ? v : 0;
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/** Tolerant parse for the 4-cell ratio-distribution snapshot. */
+export function parseRatioDistribution(json: string): RatioDistribution | null {
+  if (!json) return null;
+  try {
+    const raw = JSON.parse(json) as Record<string, unknown>;
+    const out = {} as RatioDistribution;
+    for (const k of RATIO_KEYS) {
+      const v = raw?.[k];
+      out[k] = typeof v === 'number' && Number.isFinite(v) ? v : 0;
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+// ───────────────────────────────────────────────────────────────
+// Error types
+// ───────────────────────────────────────────────────────────────
+
+/**
+ * Thrown by createCommit when the backend returns a structured error
+ * (400/404/409/500). The UI maps `status` to operator-facing toasts:
+ *   409 → "no pending decisions"
+ *   400 → input-validation error
+ *   500 → generic failure
+ */
+export class CommitApiError extends Error {
+  public readonly status: number;
+  public readonly serverMessage: string | null;
+
+  constructor(status: number, serverMessage: string | null, message?: string) {
+    super(message ?? serverMessage ?? `HTTP ${status}`);
+    this.name = 'CommitApiError';
+    this.status = status;
+    this.serverMessage = serverMessage;
+  }
+}
+
+async function readErrorMessage(res: Response): Promise<string | null> {
+  try {
+    const text = await res.text();
+    if (!text) return null;
+    try {
+      const parsed = JSON.parse(text) as { error?: string };
+      return parsed?.error ?? text;
+    } catch {
+      return text;
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ───────────────────────────────────────────────────────────────
+// Fetch functions — Commit (G)
+// ───────────────────────────────────────────────────────────────
+
+/**
+ * <c>POST /api/sync/workbench/g/commit</c>
+ *
+ * 200 — Created or Idempotent commit returned.
+ * 400 — Invalid request body.
+ * 409 — Conflict (e.g., no pending decisions to commit).
+ * Throws CommitApiError on non-2xx so callers can branch on status.
+ */
+export async function createCommit(
+  request: CommitCreateRequest,
+  signal?: AbortSignal,
+): Promise<CommitCreateResponse> {
+  const url = `${API_BASE_URL}/api/sync/workbench/g/commit`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+    signal,
+  });
+  if (!res.ok) {
+    const msg = await readErrorMessage(res);
+    throw new CommitApiError(res.status, msg);
+  }
+  return (await res.json()) as CommitCreateResponse;
+}
+
+/**
+ * <c>GET /api/sync/workbench/g/commits?limit=&offset=</c>
+ */
+export async function listCommits(
+  limit = 50,
+  offset = 0,
+  signal?: AbortSignal,
+): Promise<CommitListResponse> {
+  const url = `${API_BASE_URL}/api/sync/workbench/g/commits?limit=${limit}&offset=${offset}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    throw new Error(`listCommits failed: HTTP ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as CommitListResponse;
+}
+
+/**
+ * <c>GET /api/sync/workbench/g/commits/{commitId}</c>
+ */
+export async function getCommit(
+  commitId: string,
+  signal?: AbortSignal,
+): Promise<CommitDetailResponse> {
+  const url = `${API_BASE_URL}/api/sync/workbench/g/commits/${encodeURIComponent(commitId)}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    throw new Error(`getCommit failed: HTTP ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as CommitDetailResponse;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Fetch functions — Evidence packet (H)
+// ───────────────────────────────────────────────────────────────
+
+/** Build the absolute href for the evidence ZIP download anchor. */
+export function evidenceZipHref(commitId: string): string {
+  return `${API_BASE_URL}/api/sync/workbench/h/evidence/${encodeURIComponent(commitId)}.zip`;
+}
+
+/** Fetch the manifest JSON for a commit (returns parsed object). */
+export async function getEvidenceManifest(
+  commitId: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const url = `${API_BASE_URL}/api/sync/workbench/h/evidence/${encodeURIComponent(
+    commitId,
+  )}/manifest`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    throw new Error(`getEvidenceManifest failed: HTTP ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as unknown;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate an RFC 4122 v4 idempotency key. Uses crypto.randomUUID when
+ * available and falls back to a Math.random shim for older runtimes /
+ * non-secure contexts (idempotency key is operator-supplied, not a
+ * security boundary).
+ */
+export function generateIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback v4 shim (RFC4122-ish; NOT cryptographically strong).
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/** First 8 chars of a UUID — the operator-friendly short ID. */
+export function shortId(id: string): string {
+  return id?.slice(0, 8) ?? '';
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitCreateModal.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitCreateModal.tsx
@@ -1,0 +1,243 @@
+/**
+ * SYNC-UX-1B: New-commit modal.
+ *
+ * Operator inputs:
+ *   - Operator Id (text, required)
+ *   - Idempotency Key (text, auto v4 UUID; editable)
+ *   - Commit Note (textarea, optional)
+ *
+ * Outcomes:
+ *   - 200 / Created   → onCreated(commitId)  + soft "created" toast
+ *   - 200 / Idempotent → onCreated(commitId) + soft "idempotent" toast
+ *   - 400              → inline error (input validation)
+ *   - 409              → inline soft-warning ("no pending decisions")
+ *   - 5xx              → inline generic error
+ *
+ * The component is uncontrolled w.r.t. mount state — the parent
+ * mounts/unmounts it. We do not build a backdrop; the parent panel
+ * styling supplies the surface.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  CommitApiError,
+  type CommitCreateResponse,
+  generateIdempotencyKey,
+} from '@/api/syncCommits';
+import { useCommitCreate } from './useCommitCreate';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the new commitId after a successful Create or Idempotent. */
+  onCreated: (response: CommitCreateResponse, isIdempotent: boolean) => void;
+}
+
+export default function CommitCreateModal({
+  open,
+  onClose,
+  onCreated,
+}: Props): React.ReactElement | null {
+  const [operatorId, setOperatorId] = useState('');
+  const [idempotencyKey, setIdempotencyKey] = useState(() => generateIdempotencyKey());
+  const [commitNote, setCommitNote] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const mutation = useCommitCreate();
+
+  // Reset form whenever the modal re-opens. We refresh the idempotency
+  // key too so accidental re-opens don't reuse the previous key.
+  useEffect(() => {
+    if (open) {
+      setOperatorId('');
+      setIdempotencyKey(generateIdempotencyKey());
+      setCommitNote('');
+      setValidationError(null);
+      mutation.reset();
+    }
+    // mutation.reset is stable for the lifetime of the mutation object
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setValidationError(null);
+
+    const trimmedOperator = operatorId.trim();
+    if (!trimmedOperator) {
+      setValidationError('Operator Id is required.');
+      return;
+    }
+    if (!idempotencyKey.trim()) {
+      setValidationError('Idempotency key is required.');
+      return;
+    }
+
+    try {
+      const result = await mutation.mutateAsync({
+        IdempotencyKey: idempotencyKey.trim(),
+        OperatorId: trimmedOperator,
+        CommitNote: commitNote.trim() ? commitNote.trim() : null,
+      });
+      onCreated(result.response, result.isIdempotent);
+      onClose();
+    } catch {
+      // Error is surfaced via mutation.error below; nothing to do here.
+    }
+  };
+
+  const apiError = mutation.error instanceof CommitApiError ? mutation.error : null;
+  const isConflict = apiError?.status === 409;
+
+  return (
+    <div
+      role='dialog'
+      aria-modal='true'
+      aria-label='New commit'
+      data-testid='commit-create-modal'
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.45)',
+        zIndex: 50,
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className='tf-panel p-5 rounded'
+        style={{ width: 'min(520px, 92vw)', display: 'flex', flexDirection: 'column', gap: 12 }}
+      >
+        <div className='flex items-center justify-between'>
+          <h2 className='tf-text font-semibold' style={{ fontSize: '1.1rem' }}>
+            New commit
+          </h2>
+          <button
+            type='button'
+            onClick={onClose}
+            className='tf-text-secondary'
+            aria-label='Close new-commit dialog'
+            data-testid='commit-create-close'
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.1rem' }}
+          >
+            ×
+          </button>
+        </div>
+
+        <p className='tf-text-secondary' style={{ fontSize: '0.8rem' }}>
+          Seals all pending Routed/Dismissed triage decisions plus a doctrine-gate
+          snapshot into one atomic commit.
+        </p>
+
+        <label className='tf-text' style={{ fontSize: '0.85rem' }}>
+          Operator Id
+          <span aria-hidden='true' style={{ color: 'var(--tf-status-error, #f00)' }}>
+            {' '}
+            *
+          </span>
+          <input
+            type='text'
+            value={operatorId}
+            onChange={(e) => setOperatorId(e.target.value)}
+            data-testid='commit-create-operator-id'
+            aria-required='true'
+            className='tf-panel p-2 rounded'
+            style={{ width: '100%', marginTop: 4, fontSize: '0.85rem' }}
+            autoComplete='off'
+          />
+        </label>
+
+        <label className='tf-text' style={{ fontSize: '0.85rem' }}>
+          Idempotency key
+          <input
+            type='text'
+            value={idempotencyKey}
+            onChange={(e) => setIdempotencyKey(e.target.value)}
+            data-testid='commit-create-idempotency-key'
+            className='tf-panel p-2 rounded'
+            style={{
+              width: '100%',
+              marginTop: 4,
+              fontSize: '0.8rem',
+              fontFamily: 'monospace',
+            }}
+            autoComplete='off'
+          />
+        </label>
+
+        <label className='tf-text' style={{ fontSize: '0.85rem' }}>
+          Commit note (optional)
+          <textarea
+            value={commitNote}
+            onChange={(e) => setCommitNote(e.target.value)}
+            data-testid='commit-create-note'
+            className='tf-panel p-2 rounded'
+            style={{
+              width: '100%',
+              marginTop: 4,
+              fontSize: '0.85rem',
+              minHeight: 72,
+              resize: 'vertical',
+            }}
+          />
+        </label>
+
+        {validationError && (
+          <p
+            className='tf-status-error p-2 rounded'
+            data-testid='commit-create-validation-error'
+            style={{ fontSize: '0.8rem' }}
+          >
+            {validationError}
+          </p>
+        )}
+
+        {isConflict && (
+          <p
+            className='tf-status-warning p-2 rounded'
+            data-testid='commit-create-conflict'
+            style={{ fontSize: '0.8rem' }}
+          >
+            No pending decisions to commit. Triage some quarantine rows first.
+          </p>
+        )}
+
+        {apiError && !isConflict && (
+          <p
+            className='tf-status-error p-2 rounded'
+            data-testid='commit-create-error'
+            style={{ fontSize: '0.8rem' }}
+          >
+            Commit failed (HTTP {apiError.status}):{' '}
+            {apiError.serverMessage ?? 'see backend logs.'}
+          </p>
+        )}
+
+        <div className='flex items-center justify-end gap-2 mt-2'>
+          <button
+            type='button'
+            onClick={onClose}
+            className='tf-panel px-3 py-1.5 rounded'
+            data-testid='commit-create-cancel'
+            style={{ fontSize: '0.85rem' }}
+          >
+            Cancel
+          </button>
+          <button
+            type='submit'
+            className='tf-status-info px-4 py-1.5 rounded font-medium'
+            disabled={mutation.isPending}
+            data-testid='commit-create-submit'
+            style={{ fontSize: '0.85rem' }}
+          >
+            {mutation.isPending ? 'Committing…' : 'Commit'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitDetail.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitDetail.tsx
@@ -1,0 +1,274 @@
+/**
+ * SYNC-UX-1B: Right-pane commit detail.
+ *
+ * Renders the selected commit's full payload — header (commit id +
+ * timestamp + operator + idempotency key + note), routed/dismissed
+ * counts, parsed universe + ratio distribution snapshots, decisions
+ * table, and the evidence-packet section (download + manifest viewer).
+ *
+ * Distribution-snapshot JSON parse failures are non-fatal — the
+ * panel renders a labeled placeholder so the operator can still
+ * download the evidence ZIP and inspect the manifest directly.
+ */
+
+import React, { useState } from 'react';
+import {
+  evidenceZipHref,
+  parseRatioDistribution,
+  parseUniverseDistribution,
+  type CommitDetailResponse,
+} from '@/api/syncCommits';
+import DecisionsTable from './DecisionsTable';
+import ManifestViewer from './ManifestViewer';
+import RatioDistributionMatrix from './RatioDistributionMatrix';
+import UniverseDistributionChart from './UniverseDistributionChart';
+
+interface Props {
+  commit: CommitDetailResponse | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export default function CommitDetail({
+  commit,
+  isLoading,
+  isError,
+}: Props): React.ReactElement {
+  if (isLoading) {
+    return (
+      <section
+        className='tf-panel p-4'
+        aria-label='Commit detail'
+        data-testid='commit-detail-loading'
+      >
+        <p className='tf-text-secondary' style={{ fontSize: '0.9rem' }}>
+          Loading commit detail…
+        </p>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className='tf-status-error p-4 rounded' data-testid='commit-detail-error'>
+        Failed to load commit detail.
+      </section>
+    );
+  }
+
+  if (!commit) {
+    return (
+      <section
+        className='tf-panel p-4'
+        aria-label='Commit detail empty'
+        data-testid='commit-detail-empty'
+      >
+        <p className='tf-text-secondary' style={{ fontSize: '0.9rem' }}>
+          Select a commit on the left to view its decisions and evidence packet.
+        </p>
+      </section>
+    );
+  }
+
+  const universe = parseUniverseDistribution(commit.universeDistributionJson);
+  const ratio = parseRatioDistribution(commit.ratioDistributionJson);
+
+  return (
+    <section
+      aria-label='Commit detail'
+      data-testid='commit-detail'
+      data-commit-id={commit.commitId}
+      style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+    >
+      <CommitHeader commit={commit} />
+
+      <CountsRow commit={commit} />
+
+      {universe ? (
+        <UniverseDistributionChart distribution={universe} />
+      ) : (
+        <UnparseablePlaceholder kind='universe' />
+      )}
+
+      {ratio ? (
+        <RatioDistributionMatrix distribution={ratio} />
+      ) : (
+        <UnparseablePlaceholder kind='ratio' />
+      )}
+
+      <DecisionsTable decisions={commit.decisions} />
+
+      <EvidencePacketSection commitId={commit.commitId} committedAt={commit.committedAt} />
+    </section>
+  );
+}
+
+function CommitHeader({ commit }: { commit: CommitDetailResponse }): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(commit.commitId);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      // best-effort
+    }
+  };
+
+  return (
+    <header className='tf-panel p-4' data-testid='commit-detail-header'>
+      <div className='flex items-center gap-2 mb-2'>
+        <code
+          className='tf-text font-semibold'
+          style={{ fontSize: '0.95rem', wordBreak: 'break-all' }}
+          data-testid='commit-id-full'
+        >
+          {commit.commitId}
+        </code>
+        <button
+          type='button'
+          className='tf-status-info px-2 py-0.5 rounded'
+          onClick={onCopy}
+          aria-label='Copy commit id'
+          data-testid='commit-id-copy'
+          style={{ fontSize: '0.75rem' }}
+        >
+          {copied ? 'Copied' : 'Copy id'}
+        </button>
+      </div>
+      <dl
+        className='tf-text-secondary'
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          gap: '4px 12px',
+          fontSize: '0.8rem',
+          margin: 0,
+        }}
+      >
+        <dt>Committed at</dt>
+        <dd className='tf-text' data-testid='commit-committed-at'>
+          {new Date(commit.committedAt).toLocaleString()}
+        </dd>
+        <dt>Operator</dt>
+        <dd className='tf-text' data-testid='commit-operator'>
+          {commit.operatorId}
+        </dd>
+        <dt>Idempotency key</dt>
+        <dd
+          className='tf-text'
+          style={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+          data-testid='commit-idempotency-key'
+        >
+          {commit.idempotencyKey}
+        </dd>
+        {commit.commitNote && (
+          <>
+            <dt>Note</dt>
+            <dd className='tf-text' data-testid='commit-note'>
+              {commit.commitNote}
+            </dd>
+          </>
+        )}
+      </dl>
+    </header>
+  );
+}
+
+function CountsRow({ commit }: { commit: CommitDetailResponse }): React.ReactElement {
+  return (
+    <div
+      style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12 }}
+      data-testid='commit-counts'
+    >
+      <div className='tf-status-info p-3 rounded'>
+        <div className='tf-text-secondary' style={{ fontSize: '0.7rem' }}>
+          Routed decisions applied
+        </div>
+        <div
+          className='tf-text font-semibold'
+          style={{ fontSize: '1.2rem', fontVariantNumeric: 'tabular-nums' }}
+          data-testid='commit-routed-count'
+        >
+          {commit.routedDecisionsApplied.toLocaleString()}
+        </div>
+      </div>
+      <div className='tf-status-warning p-3 rounded'>
+        <div className='tf-text-secondary' style={{ fontSize: '0.7rem' }}>
+          Dismissed decisions applied
+        </div>
+        <div
+          className='tf-text font-semibold'
+          style={{ fontSize: '1.2rem', fontVariantNumeric: 'tabular-nums' }}
+          data-testid='commit-dismissed-count'
+        >
+          {commit.dismissedDecisionsApplied.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UnparseablePlaceholder({
+  kind,
+}: {
+  kind: 'universe' | 'ratio';
+}): React.ReactElement {
+  return (
+    <section
+      className='tf-status-warning p-3 rounded'
+      data-testid={`unparseable-${kind}`}
+      aria-label={`${kind} distribution unparseable`}
+    >
+      Could not parse {kind} distribution snapshot — see manifest for raw bytes.
+    </section>
+  );
+}
+
+function EvidencePacketSection({
+  commitId,
+  committedAt,
+}: {
+  commitId: string;
+  committedAt: string;
+}): React.ReactElement {
+  const href = evidenceZipHref(commitId);
+  // The backend sets Content-Disposition; we hint the filename via the
+  // download attribute so saves outside Chrome / before redirects also
+  // get a sensible default name.
+  const safeStamp = committedAt.replace(/[:.]/g, '-');
+  const downloadName = `terrafusion-evidence-${commitId}-${safeStamp}.zip`;
+
+  return (
+    <section
+      className='tf-panel p-4'
+      aria-label='Evidence packet'
+      data-testid='evidence-section'
+    >
+      <h3 className='tf-text font-medium mb-2' style={{ fontSize: '0.95rem' }}>
+        Evidence packet
+      </h3>
+      <p className='tf-text-secondary' style={{ fontSize: '0.8rem', marginBottom: 8 }}>
+        Signed ZIP plus inspectable JSON manifest. Counts in this commit are
+        sealed at commit time; subsequent doctrine drains do not retroactively
+        change the snapshot.
+      </p>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+        <a
+          className='tf-status-info px-3 py-1.5 rounded font-medium'
+          href={href}
+          download={downloadName}
+          data-testid='evidence-download-link'
+          style={{ fontSize: '0.85rem', textDecoration: 'none' }}
+          aria-label='Download evidence ZIP'
+        >
+          Download evidence ZIP
+        </a>
+        <ManifestViewer commitId={commitId} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitsList.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/CommitsList.tsx
@@ -1,0 +1,188 @@
+/**
+ * SYNC-UX-1B: Left-rail paged commit list.
+ *
+ * Each row shows the short commit id, committed-at (relative time +
+ * absolute on tooltip), operator id, and routed/dismissed counts.
+ * Click a row to select it — selection drives the right detail panel
+ * via the parent page's state and the URL :commitId param.
+ */
+
+import React from 'react';
+import { type CommitSummaryResponse, shortId } from '@/api/syncCommits';
+
+interface Props {
+  items: CommitSummaryResponse[];
+  selectedCommitId: string | null;
+  onSelect: (commitId: string) => void;
+  isLoading: boolean;
+  isError: boolean;
+  totalCount: number;
+  offset: number;
+  pageSize: number;
+  onPageChange: (offset: number) => void;
+}
+
+function relativeTime(iso: string): string {
+  try {
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return iso;
+    const delta = Math.round((Date.now() - t) / 1000);
+    if (delta < 60) return `${delta}s ago`;
+    if (delta < 3600) return `${Math.round(delta / 60)}m ago`;
+    if (delta < 86400) return `${Math.round(delta / 3600)}h ago`;
+    return `${Math.round(delta / 86400)}d ago`;
+  } catch {
+    return iso;
+  }
+}
+
+export default function CommitsList({
+  items,
+  selectedCommitId,
+  onSelect,
+  isLoading,
+  isError,
+  totalCount,
+  offset,
+  pageSize,
+  onPageChange,
+}: Props): React.ReactElement {
+  const showingFrom = items.length === 0 ? 0 : offset + 1;
+  const showingTo = offset + items.length;
+
+  return (
+    <section
+      className='tf-panel p-3'
+      aria-label='Recent commits'
+      data-testid='commits-list'
+      style={{ overflowY: 'auto' }}
+    >
+      <div className='flex items-center justify-between mb-2'>
+        <h3 className='tf-text font-medium' style={{ fontSize: '0.9rem' }}>
+          Commits
+        </h3>
+        <span className='tf-text-secondary' style={{ fontSize: '0.75rem' }}>
+          {totalCount > 0 ? `${showingFrom}–${showingTo}` : '—'}
+        </span>
+      </div>
+
+      {isLoading && (
+        <p
+          className='tf-text-secondary'
+          style={{ fontSize: '0.85rem' }}
+          data-testid='commits-list-loading'
+        >
+          Loading commits…
+        </p>
+      )}
+      {isError && (
+        <p
+          className='tf-status-error p-2 rounded'
+          style={{ fontSize: '0.85rem' }}
+          data-testid='commits-list-error'
+        >
+          Failed to load commits.
+        </p>
+      )}
+      {!isLoading && !isError && items.length === 0 && (
+        <p
+          className='tf-text-secondary'
+          style={{ fontSize: '0.85rem' }}
+          data-testid='commits-list-empty'
+        >
+          No commits yet. Click "New Commit" to seal pending decisions.
+        </p>
+      )}
+
+      <ul
+        style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 4 }}
+      >
+        {items.map((c) => {
+          const isSelected = c.commitId === selectedCommitId;
+          return (
+            <li key={c.commitId}>
+              <button
+                type='button'
+                onClick={() => onSelect(c.commitId)}
+                aria-current={isSelected ? 'true' : undefined}
+                aria-label={`Select commit ${shortId(c.commitId)}`}
+                data-testid={`commit-row-${c.commitId}`}
+                data-selected={isSelected ? 'true' : 'false'}
+                className={isSelected ? 'tf-status-info' : 'tf-panel'}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '8px 10px',
+                  borderRadius: 4,
+                  cursor: 'pointer',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                }}
+              >
+                <div
+                  className='tf-text'
+                  style={{
+                    fontSize: '0.85rem',
+                    fontFamily: 'monospace',
+                    fontWeight: 600,
+                  }}
+                >
+                  {shortId(c.commitId)}
+                </div>
+                <div
+                  className='tf-text-secondary'
+                  style={{ fontSize: '0.7rem' }}
+                  title={new Date(c.committedAt).toLocaleString()}
+                >
+                  {relativeTime(c.committedAt)} · {c.operatorId}
+                </div>
+                <div style={{ display: 'flex', gap: 4, marginTop: 2, fontSize: '0.7rem' }}>
+                  <span
+                    className='tf-status-info px-1.5 rounded'
+                    data-testid={`commit-routed-${c.commitId}`}
+                  >
+                    R {c.routedDecisionsApplied}
+                  </span>
+                  <span
+                    className='tf-status-warning px-1.5 rounded'
+                    data-testid={`commit-dismissed-${c.commitId}`}
+                  >
+                    D {c.dismissedDecisionsApplied}
+                  </span>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {(items.length > 0 || offset > 0) && (
+        <div
+          className='flex items-center justify-between mt-3'
+          style={{ fontSize: '0.75rem' }}
+          data-testid='commits-list-pager'
+        >
+          <button
+            type='button'
+            className='tf-status-info px-2 py-1 rounded'
+            disabled={offset === 0}
+            onClick={() => onPageChange(Math.max(0, offset - pageSize))}
+            aria-label='Previous page of commits'
+          >
+            ‹ Prev
+          </button>
+          <button
+            type='button'
+            className='tf-status-info px-2 py-1 rounded'
+            disabled={items.length < pageSize}
+            onClick={() => onPageChange(offset + pageSize)}
+            aria-label='Next page of commits'
+          >
+            Next ›
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/DecisionsTable.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/DecisionsTable.tsx
@@ -1,0 +1,156 @@
+/**
+ * SYNC-UX-1B: Paged table of commit-linked triage decisions.
+ *
+ * 50 rows/page client-side pagination — the backend already returns
+ * the full decision-link set inline on the commit-detail payload, so
+ * we slice in-memory rather than refetching.
+ *
+ * Columns: TriageId (short), DecisionType (badge), RoutedToUniverse,
+ * RoutedToIAttrValCd, DismissalReason. Empty fields render '—'.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { type DecisionLinkResponse, shortId } from '@/api/syncCommits';
+
+interface Props {
+  decisions: DecisionLinkResponse[];
+  pageSize?: number;
+}
+
+export const DECISIONS_PAGE_SIZE = 50;
+
+export default function DecisionsTable({
+  decisions,
+  pageSize = DECISIONS_PAGE_SIZE,
+}: Props): React.ReactElement {
+  const [page, setPage] = useState(0);
+  const total = decisions.length;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+
+  const slice = useMemo(() => {
+    const start = safePage * pageSize;
+    return decisions.slice(start, start + pageSize);
+  }, [decisions, safePage, pageSize]);
+
+  if (total === 0) {
+    return (
+      <section
+        className='tf-panel p-4'
+        aria-label='Decisions in commit'
+        data-testid='decisions-table'
+      >
+        <h3 className='tf-text font-medium mb-3' style={{ fontSize: '0.95rem' }}>
+          Decisions
+        </h3>
+        <p className='tf-text-secondary' style={{ fontSize: '0.85rem' }}>
+          No decision links recorded for this commit.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className='tf-panel p-4'
+      aria-label='Decisions in commit'
+      data-testid='decisions-table'
+    >
+      <div className='flex items-center justify-between mb-3'>
+        <h3 className='tf-text font-medium' style={{ fontSize: '0.95rem' }}>
+          Decisions ({total.toLocaleString()})
+        </h3>
+        {pageCount > 1 && (
+          <div
+            className='tf-text-secondary'
+            style={{ fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: 8 }}
+            data-testid='decisions-pager'
+          >
+            <button
+              type='button'
+              className='tf-status-info px-2 py-1 rounded'
+              disabled={safePage === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              aria-label='Previous page of decisions'
+            >
+              ‹ Prev
+            </button>
+            <span>
+              page {safePage + 1} / {pageCount}
+            </span>
+            <button
+              type='button'
+              className='tf-status-info px-2 py-1 rounded'
+              disabled={safePage >= pageCount - 1}
+              onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+              aria-label='Next page of decisions'
+            >
+              Next ›
+            </button>
+          </div>
+        )}
+      </div>
+
+      <table style={{ width: '100%', fontSize: '0.8rem', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr className='tf-text-secondary'>
+            <th style={{ textAlign: 'left', padding: '4px 8px' }}>Triage</th>
+            <th style={{ textAlign: 'left', padding: '4px 8px' }}>Type</th>
+            <th style={{ textAlign: 'left', padding: '4px 8px' }}>Routed Universe</th>
+            <th style={{ textAlign: 'left', padding: '4px 8px' }}>Routed Attr Code</th>
+            <th style={{ textAlign: 'left', padding: '4px 8px' }}>Dismissal Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {slice.map((d) => {
+            const badgeClass =
+              d.decisionType === 'Route'
+                ? 'tf-status-info'
+                : d.decisionType === 'Dismiss'
+                  ? 'tf-status-warning'
+                  : 'tf-text-secondary';
+            return (
+              <tr
+                key={d.linkId}
+                data-testid={`decision-row-${d.linkId}`}
+                data-decision-type={d.decisionType}
+              >
+                <td className='tf-text' style={{ padding: '4px 8px' }} title={d.triageId}>
+                  <code>{shortId(d.triageId)}</code>
+                </td>
+                <td style={{ padding: '4px 8px' }}>
+                  <span
+                    className={`${badgeClass} px-2 py-0.5 rounded`}
+                    style={{ fontSize: '0.7rem', fontWeight: 600 }}
+                    data-testid={`decision-badge-${d.linkId}`}
+                  >
+                    {d.decisionType}
+                  </span>
+                </td>
+                <td className='tf-text' style={{ padding: '4px 8px' }}>
+                  {d.routedToUniverse ? <code>{d.routedToUniverse}</code> : <span aria-label='empty'>—</span>}
+                </td>
+                <td className='tf-text' style={{ padding: '4px 8px' }}>
+                  {d.routedToIAttrValCd ? <code>{d.routedToIAttrValCd}</code> : <span aria-label='empty'>—</span>}
+                </td>
+                <td
+                  className='tf-text-secondary'
+                  style={{
+                    padding: '4px 8px',
+                    maxWidth: 320,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                  title={d.dismissalReason ?? ''}
+                >
+                  {d.dismissalReason ?? <span aria-label='empty'>—</span>}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/ManifestViewer.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/ManifestViewer.tsx
@@ -1,0 +1,142 @@
+/**
+ * SYNC-UX-1B: Inline manifest JSON viewer.
+ *
+ * The manifest is fetched from <c>GET /api/sync/workbench/h/evidence/
+ * {commitId}/manifest</c> on demand (toggle button). Pretty-prints
+ * the JSON and exposes a Copy button. The viewer never auto-fetches
+ * — operator clicks "View Manifest" to pull bytes.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { getEvidenceManifest } from '@/api/syncCommits';
+
+interface Props {
+  commitId: string;
+}
+
+export default function ManifestViewer({ commitId }: Props): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const [manifest, setManifest] = useState<unknown | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Reset cached manifest when the commit changes — different commit, different bytes.
+  useEffect(() => {
+    setOpen(false);
+    setManifest(null);
+    setError(null);
+    setCopied(false);
+  }, [commitId]);
+
+  const loadManifest = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const m = await getEvidenceManifest(commitId);
+      setManifest(m);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [commitId]);
+
+  const handleToggle = useCallback(async () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (manifest === null && !error) {
+      await loadManifest();
+    }
+  }, [open, manifest, error, loadManifest]);
+
+  const handleCopy = useCallback(async () => {
+    if (manifest === null) return;
+    const text = JSON.stringify(manifest, null, 2);
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      // Best-effort; no toast escalation needed.
+    }
+  }, [manifest]);
+
+  const pretty = manifest === null ? '' : JSON.stringify(manifest, null, 2);
+
+  return (
+    <div data-testid='manifest-viewer'>
+      <button
+        type='button'
+        className='tf-status-info px-3 py-1.5 rounded font-medium'
+        onClick={handleToggle}
+        aria-expanded={open}
+        aria-controls={`manifest-${commitId}`}
+        data-testid='manifest-toggle'
+        style={{ fontSize: '0.85rem' }}
+      >
+        {open ? 'Hide manifest' : 'View manifest'}
+      </button>
+
+      {open && (
+        <div
+          id={`manifest-${commitId}`}
+          className='tf-panel p-3 mt-2 rounded'
+          data-testid='manifest-body'
+          style={{ overflowX: 'auto' }}
+        >
+          {loading && (
+            <p className='tf-text-secondary' style={{ fontSize: '0.85rem' }}>
+              Loading manifest…
+            </p>
+          )}
+          {error && (
+            <p
+              className='tf-status-error p-2 rounded'
+              data-testid='manifest-error'
+              style={{ fontSize: '0.85rem' }}
+            >
+              Failed to load manifest: {error}
+            </p>
+          )}
+          {!loading && !error && manifest !== null && (
+            <>
+              <div
+                className='flex items-center justify-between mb-2'
+                style={{ fontSize: '0.8rem' }}
+              >
+                <span className='tf-text-secondary'>manifest.json</span>
+                <button
+                  type='button'
+                  className='tf-status-info px-2 py-1 rounded'
+                  onClick={handleCopy}
+                  data-testid='manifest-copy'
+                  aria-label='Copy manifest JSON to clipboard'
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+              <pre
+                className='tf-text'
+                data-testid='manifest-json'
+                style={{
+                  fontSize: '0.75rem',
+                  margin: 0,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {pretty}
+              </pre>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/RatioDistributionMatrix.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/RatioDistributionMatrix.tsx
@@ -1,0 +1,84 @@
+/**
+ * SYNC-UX-1B: Ratio distribution 2x2 matrix.
+ *
+ * Renders the four cells of the SYNC-DOCTRINE-1 sales-ratio policy
+ * crosstab snapshot:
+ *
+ *                       County qualified    County not-qualified
+ *   DOR qualified           DorQ_CountyQ           DorQ_CountyN
+ *   DOR not-qualified       DorN_CountyQ           DorN_CountyN
+ *
+ * The diagonal cells (DorQ_CountyQ, DorN_CountyN) are concordant.
+ * The off-diagonal cells expose disagreement between DOR and the
+ * county's internal ratio — these are operator-relevant.
+ */
+
+import React from 'react';
+import type { RatioDistribution } from '@/api/syncCommits';
+
+interface Props {
+  distribution: RatioDistribution;
+}
+
+interface CellSpec {
+  key: keyof RatioDistribution;
+  label: string;
+  concordant: boolean;
+}
+
+const CELLS: CellSpec[][] = [
+  [
+    { key: 'DorQ_CountyQ', label: 'DOR Q · County Q', concordant: true },
+    { key: 'DorQ_CountyN', label: 'DOR Q · County N', concordant: false },
+  ],
+  [
+    { key: 'DorN_CountyQ', label: 'DOR N · County Q', concordant: false },
+    { key: 'DorN_CountyN', label: 'DOR N · County N', concordant: true },
+  ],
+];
+
+export default function RatioDistributionMatrix({ distribution }: Props): React.ReactElement {
+  return (
+    <section
+      className='tf-panel p-4'
+      aria-label='Ratio distribution snapshot'
+      data-testid='ratio-distribution-matrix'
+    >
+      <h3 className='tf-text font-medium mb-3' style={{ fontSize: '0.95rem' }}>
+        Sales-ratio distribution (DOR × County qualification)
+      </h3>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 8,
+        }}
+      >
+        {CELLS.flat().map((cell) => {
+          const count = distribution[cell.key] ?? 0;
+          const cls = cell.concordant ? 'tf-status-success' : 'tf-status-warning';
+          return (
+            <div
+              key={cell.key}
+              data-testid={`ratio-cell-${cell.key}`}
+              data-cell={cell.key}
+              data-count={count}
+              className={`${cls} p-3 rounded`}
+              style={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+            >
+              <span className='tf-text-secondary' style={{ fontSize: '0.7rem' }}>
+                {cell.label}
+              </span>
+              <span
+                className='tf-text font-semibold'
+                style={{ fontSize: '1.2rem', fontVariantNumeric: 'tabular-nums' }}
+              >
+                {count.toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/SyncCommitsPage.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/SyncCommitsPage.tsx
@@ -1,0 +1,195 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * SYNC-UX-1B: WORKBENCH COMMITS — DECISION HISTORY
+ *
+ * Operator surface for the SYNC-WORKBENCH-G/H spine. Lists recent
+ * decision-commits, drills into a single commit's snapshot
+ * (universe + ratio + per-decision rows), and lets the operator
+ * download the signed evidence ZIP / inspect the manifest.
+ *
+ * Route: /workbench/sync/commits[/:commitId]
+ *
+ * Sibling to /workbench/sync-doctrine (read-only doctrine status)
+ * and /workbench/sync-readiness (PACS reachability probes).
+ *
+ * Spec discipline (per OPS-1 / DASHBOARD-1 design language):
+ *   - One screen, list + detail panels, single modal
+ *   - tf-* utility classes only — no new design tokens
+ *   - tf-status-{success,warning,error,info} for verdicts
+ *   - No polling — operator-driven; commit list invalidates after
+ *     a successful Create
+ *
+ * The page reads decision history; it does not mutate triage rows,
+ * does not mutate quarantine rows, and does not write into
+ * truth_pacs.* / canonical_tf.*. Truth/canonical materialization is
+ * handled separately by the existing attr-drain chain.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import CommitCreateModal from './CommitCreateModal';
+import CommitDetail from './CommitDetail';
+import CommitsList from './CommitsList';
+import { COMMITS_LIST_PAGE_SIZE, useCommitsList } from './useCommitsList';
+import { useCommitDetail } from './useCommitDetail';
+import type { CommitCreateResponse } from '@/api/syncCommits';
+
+interface ToastState {
+  kind: 'success' | 'info' | 'warning' | 'error';
+  message: string;
+  ttl: number;
+}
+
+export default function SyncCommitsPage(): React.ReactElement {
+  const params = useParams<{ commitId?: string }>();
+  const navigate = useNavigate();
+
+  const [offset, setOffset] = useState(0);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const list = useCommitsList(offset, COMMITS_LIST_PAGE_SIZE);
+
+  // Selection drives the right detail panel. Source of truth: URL param.
+  // We fall back to the first item in the list when no param is set so the
+  // page is never blank after a fresh page load.
+  const selectedCommitId = useMemo<string | null>(() => {
+    if (params.commitId) return params.commitId;
+    return null;
+  }, [params.commitId]);
+
+  const detail = useCommitDetail(selectedCommitId);
+
+  // Toast auto-dismiss
+  useEffect(() => {
+    if (!toast) return;
+    const handle = window.setTimeout(() => setToast(null), toast.ttl);
+    return () => window.clearTimeout(handle);
+  }, [toast]);
+
+  const handleSelect = useCallback(
+    (commitId: string) => {
+      navigate(`/workbench/sync/commits/${commitId}`);
+    },
+    [navigate],
+  );
+
+  const handleCreated = useCallback(
+    (response: CommitCreateResponse, isIdempotent: boolean) => {
+      const shortCommitId = response.commitId.slice(0, 8);
+      setToast({
+        kind: isIdempotent ? 'info' : 'success',
+        message: isIdempotent
+          ? `Existing commit returned (idempotent · ${shortCommitId})`
+          : `Commit ${shortCommitId} created`,
+        ttl: 4000,
+      });
+      navigate(`/workbench/sync/commits/${response.commitId}`);
+    },
+    [navigate],
+  );
+
+  const totalCount = list.data?.count ?? 0;
+  const items = list.data?.items ?? [];
+
+  return (
+    <main
+      className='p-6'
+      aria-label='Sync Workbench Commits'
+      data-testid='sync-commits-page'
+    >
+      <Header totalCount={totalCount} />
+
+      <div
+        className='flex items-center gap-3 mb-4'
+        data-testid='sync-commits-actionbar'
+      >
+        <button
+          type='button'
+          className='tf-status-success px-4 py-2 rounded font-medium'
+          onClick={() => setCreateOpen(true)}
+          data-testid='new-commit-button'
+          aria-label='Open new-commit dialog'
+        >
+          + New Commit
+        </button>
+        <button
+          type='button'
+          className='tf-status-info px-3 py-2 rounded'
+          onClick={() => list.refetch()}
+          disabled={list.isFetching}
+          data-testid='commits-refresh-button'
+          aria-label='Refresh commits list'
+          style={{ fontSize: '0.85rem' }}
+        >
+          {list.isFetching ? 'Refreshing…' : 'Refresh'}
+        </button>
+        <span className='tf-text-secondary' style={{ fontSize: '0.8rem' }}>
+          Read-only history of sealed decisions. No polling.
+        </span>
+      </div>
+
+      {toast && (
+        <div
+          className={`tf-status-${toast.kind} p-2 rounded mb-3`}
+          role='status'
+          aria-live='polite'
+          data-testid='sync-commits-toast'
+          data-toast-kind={toast.kind}
+        >
+          {toast.message}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(260px, 1fr) minmax(0, 2fr)',
+          gap: 16,
+        }}
+      >
+        <CommitsList
+          items={items}
+          selectedCommitId={selectedCommitId}
+          onSelect={handleSelect}
+          isLoading={list.isLoading && !list.data}
+          isError={list.isError}
+          totalCount={totalCount}
+          offset={offset}
+          pageSize={COMMITS_LIST_PAGE_SIZE}
+          onPageChange={setOffset}
+        />
+
+        <div data-testid='commit-detail-pane'>
+          <CommitDetail
+            commit={detail.data}
+            isLoading={detail.isLoading && Boolean(selectedCommitId)}
+            isError={detail.isError}
+          />
+        </div>
+      </div>
+
+      <CommitCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={handleCreated}
+      />
+    </main>
+  );
+}
+
+function Header({ totalCount }: { totalCount: number }): React.ReactElement {
+  return (
+    <header className='mb-4' data-testid='sync-commits-header'>
+      <h1 className='tf-text font-semibold' style={{ fontSize: '1.4rem' }}>
+        TerraFusion · Workbench · Sync Commits
+      </h1>
+      <p className='tf-text-secondary' style={{ fontSize: '0.9rem' }}>
+        Decision history — sealed Routed/Dismissed triage commits with
+        evidence packets. Total commits visible:{' '}
+        <strong className='tf-text'>{totalCount.toLocaleString()}</strong>
+      </p>
+    </header>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/UniverseDistributionChart.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/UniverseDistributionChart.tsx
@@ -1,0 +1,75 @@
+/**
+ * SYNC-UX-1B: Universe distribution display.
+ *
+ * Renders the 7-cell SYNC-DOCTRINE-4 universe taxonomy snapshot
+ * captured at commit time. We use a labeled CSS grid (not Recharts)
+ * because:
+ *   - the cohort is fixed at 7 categorical buckets
+ *   - the operator wants exact counts, not visual ratios
+ *   - keeps the page bundle thin (no Recharts pull-in for 7 cells)
+ *
+ * If the backend's universeDistributionJson can't be parsed, the
+ * page (caller) renders the unparseable placeholder; this component
+ * always receives a parsed snapshot.
+ */
+
+import React from 'react';
+import { UNIVERSE_KEYS, type UniverseDistribution } from '@/api/syncCommits';
+
+interface Props {
+  distribution: UniverseDistribution;
+}
+
+export default function UniverseDistributionChart({ distribution }: Props): React.ReactElement {
+  const total = UNIVERSE_KEYS.reduce((acc, k) => acc + (distribution[k] ?? 0), 0);
+
+  return (
+    <section
+      className='tf-panel p-4'
+      aria-label='Universe distribution snapshot'
+      data-testid='universe-distribution-chart'
+    >
+      <h3 className='tf-text font-medium mb-3' style={{ fontSize: '0.95rem' }}>
+        Universe distribution ({total.toLocaleString()} truth rows at commit time)
+      </h3>
+      <div
+        role='list'
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+          gap: 8,
+        }}
+      >
+        {UNIVERSE_KEYS.map((key) => {
+          const count = distribution[key] ?? 0;
+          return (
+            <div
+              key={key}
+              role='listitem'
+              data-testid={`universe-cell-${key}`}
+              data-universe={key}
+              data-count={count}
+              className='tf-status-info p-3 rounded'
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                opacity: count > 0 ? 1 : 0.55,
+              }}
+            >
+              <code className='tf-text-secondary' style={{ fontSize: '0.7rem' }}>
+                {key}
+              </code>
+              <span
+                className='tf-text font-semibold'
+                style={{ fontSize: '1.2rem', fontVariantNumeric: 'tabular-nums' }}
+              >
+                {count.toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/CommitCreateModal.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/CommitCreateModal.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * SYNC-UX-1B: CommitCreateModal interaction tests.
+ *
+ * Verifies:
+ *   - opens with auto-generated idempotency key
+ *   - submit blocked when Operator Id empty
+ *   - successful POST → onCreated called with isIdempotent=false
+ *   - 200 with status=Idempotent → onCreated(...,isIdempotent=true)
+ *   - 409 → soft conflict warning, onCreated NOT called
+ *
+ * The fetch is mocked via vi.stubGlobal — this avoids depending on
+ * msw or a global setup file. We render the modal inside a fresh
+ * QueryClientProvider so mutations are isolated per test.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CommitCreateModal from '../CommitCreateModal';
+import type { CommitCreateResponse } from '@/api/syncCommits';
+
+function renderModal(onCreated = vi.fn(), onClose = vi.fn(), open = true) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <CommitCreateModal open={open} onClose={onClose} onCreated={onCreated} />
+    </QueryClientProvider>,
+  );
+  return { ...utils, qc, onCreated, onClose };
+}
+
+function mockFetchOnce(status: number, body: unknown) {
+  const res = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'mock',
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    json: async () => body,
+  } as unknown as Response;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => res) as unknown as typeof fetch,
+  );
+}
+
+describe('CommitCreateModal', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('does not render when open=false', () => {
+    renderModal(undefined, undefined, false);
+    expect(screen.queryByTestId('commit-create-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders form fields and auto-fills the idempotency key', () => {
+    renderModal();
+    expect(screen.getByTestId('commit-create-modal')).toBeInTheDocument();
+    const idemInput = screen.getByTestId(
+      'commit-create-idempotency-key',
+    ) as HTMLInputElement;
+    expect(idemInput.value).toMatch(/^[0-9a-f]{8}-/);
+  });
+
+  it('shows validation error when Operator Id is blank', async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderModal();
+
+    await user.click(screen.getByTestId('commit-create-submit'));
+
+    expect(screen.getByTestId('commit-create-validation-error')).toHaveTextContent(
+      /Operator Id is required/i,
+    );
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it('submits successfully and calls onCreated for a Created commit', async () => {
+    const user = userEvent.setup();
+    const response: CommitCreateResponse = {
+      commitId: '11111111-2222-3333-4444-555555555555',
+      status: 'Created',
+      routedDecisionsApplied: 1,
+      dismissedDecisionsApplied: 0,
+      committedAt: '2026-05-08T10:00:00Z',
+      universeDistributionJson: '{}',
+      ratioDistributionJson: '{}',
+    };
+    mockFetchOnce(200, response);
+
+    const { onCreated, onClose } = renderModal();
+
+    await user.type(screen.getByTestId('commit-create-operator-id'), 'bsvalues');
+    await user.click(screen.getByTestId('commit-create-submit'));
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledTimes(1);
+    });
+
+    const [resp, isIdempotent] = onCreated.mock.calls[0];
+    expect(resp.commitId).toBe(response.commitId);
+    expect(isIdempotent).toBe(false);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('flags isIdempotent=true when backend returns status=Idempotent', async () => {
+    const user = userEvent.setup();
+    const response: CommitCreateResponse = {
+      commitId: '99999999-2222-3333-4444-555555555555',
+      status: 'Idempotent',
+      routedDecisionsApplied: 0,
+      dismissedDecisionsApplied: 0,
+      committedAt: '2026-05-08T10:00:00Z',
+      universeDistributionJson: '{}',
+      ratioDistributionJson: '{}',
+    };
+    mockFetchOnce(200, response);
+
+    const { onCreated } = renderModal();
+
+    await user.type(screen.getByTestId('commit-create-operator-id'), 'bsvalues');
+    await user.click(screen.getByTestId('commit-create-submit'));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    const [, isIdempotent] = onCreated.mock.calls[0];
+    expect(isIdempotent).toBe(true);
+  });
+
+  it('shows soft conflict warning on 409 and does not call onCreated', async () => {
+    const user = userEvent.setup();
+    mockFetchOnce(409, { error: 'no pending decisions' });
+
+    const { onCreated } = renderModal();
+
+    await user.type(screen.getByTestId('commit-create-operator-id'), 'bsvalues');
+    fireEvent.click(screen.getByTestId('commit-create-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('commit-create-conflict')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('commit-create-conflict')).toHaveTextContent(
+      /no pending decisions/i,
+    );
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/CommitDetail.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/CommitDetail.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * SYNC-UX-1B: CommitDetail unit tests.
+ *
+ * Verifies the right-pane detail panel:
+ *   - renders all the header / counts / decision rows / evidence section
+ *   - parses universe + ratio JSON snapshots and renders the matrix cells
+ *   - degrades gracefully on bad JSON (renders unparseable placeholders)
+ *   - decisions table renders Route / Dismiss badges and "—" for empties
+ *   - evidence link points at the H endpoint with the commitId
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CommitDetail from '../CommitDetail';
+import type { CommitDetailResponse } from '@/api/syncCommits';
+
+const baseCommit: CommitDetailResponse = {
+  commitId: '11111111-2222-3333-4444-555555555555',
+  committedAt: '2026-05-08T15:34:21.000Z',
+  operatorId: 'bsvalues',
+  idempotencyKey: 'idem-key-abc',
+  routedDecisionsApplied: 3,
+  dismissedDecisionsApplied: 2,
+  commitNote: 'first triage commit',
+  universeDistributionJson: JSON.stringify({
+    REAL_RESIDENTIAL: 100,
+    REAL_COMMERCIAL: 5,
+    MOBILE_HOME: 1,
+    AG_CURRENT_USE: 10,
+    PERSONAL_PROPERTY: 0,
+    CONVERSION_LEGACY: 0,
+    UNKNOWN: 2,
+  }),
+  ratioDistributionJson: JSON.stringify({
+    DorQ_CountyQ: 50,
+    DorQ_CountyN: 4,
+    DorN_CountyQ: 7,
+    DorN_CountyN: 39,
+  }),
+  decisions: [
+    {
+      linkId: 'aaaaaaaa-1111-1111-1111-111111111111',
+      triageId: 'bbbbbbbb-1111-1111-1111-111111111111',
+      unprovenRowId: 'cccccccc-1111-1111-1111-111111111111',
+      decisionType: 'Route',
+      routedToUniverse: 'REAL_RESIDENTIAL',
+      routedToIAttrValCd: 'COMP_SHINGLE',
+      dismissalReason: null,
+    },
+    {
+      linkId: 'aaaaaaaa-2222-2222-2222-222222222222',
+      triageId: 'bbbbbbbb-2222-2222-2222-222222222222',
+      unprovenRowId: 'cccccccc-2222-2222-2222-222222222222',
+      decisionType: 'Dismiss',
+      routedToUniverse: null,
+      routedToIAttrValCd: null,
+      dismissalReason: 'Bad source data',
+    },
+  ],
+};
+
+describe('CommitDetail', () => {
+  it('renders the empty placeholder when no commit is selected', () => {
+    render(<CommitDetail commit={undefined} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('commit-detail-empty')).toBeInTheDocument();
+  });
+
+  it('renders the loading placeholder when fetching', () => {
+    render(<CommitDetail commit={undefined} isLoading={true} isError={false} />);
+    expect(screen.getByTestId('commit-detail-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    render(<CommitDetail commit={undefined} isLoading={false} isError={true} />);
+    expect(screen.getByTestId('commit-detail-error')).toBeInTheDocument();
+  });
+
+  it('shows the full commit id, operator, idempotency key and note', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+
+    expect(screen.getByTestId('commit-id-full')).toHaveTextContent(baseCommit.commitId);
+    expect(screen.getByTestId('commit-operator')).toHaveTextContent('bsvalues');
+    expect(screen.getByTestId('commit-idempotency-key')).toHaveTextContent('idem-key-abc');
+    expect(screen.getByTestId('commit-note')).toHaveTextContent('first triage commit');
+  });
+
+  it('renders routed and dismissed counts', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('commit-routed-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('commit-dismissed-count')).toHaveTextContent('2');
+  });
+
+  it('parses universeDistributionJson and renders all 7 cells', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('universe-distribution-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('universe-cell-REAL_RESIDENTIAL').dataset.count).toBe('100');
+    expect(screen.getByTestId('universe-cell-MOBILE_HOME').dataset.count).toBe('1');
+    expect(screen.getByTestId('universe-cell-UNKNOWN').dataset.count).toBe('2');
+  });
+
+  it('parses ratioDistributionJson and renders 4 matrix cells', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('ratio-distribution-matrix')).toBeInTheDocument();
+    expect(screen.getByTestId('ratio-cell-DorQ_CountyQ').dataset.count).toBe('50');
+    expect(screen.getByTestId('ratio-cell-DorQ_CountyN').dataset.count).toBe('4');
+    expect(screen.getByTestId('ratio-cell-DorN_CountyQ').dataset.count).toBe('7');
+    expect(screen.getByTestId('ratio-cell-DorN_CountyN').dataset.count).toBe('39');
+  });
+
+  it('renders unparseable placeholder when universe JSON is invalid', () => {
+    const broken = { ...baseCommit, universeDistributionJson: '{not json' };
+    render(<CommitDetail commit={broken} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('unparseable-universe')).toBeInTheDocument();
+    expect(screen.queryByTestId('universe-distribution-chart')).not.toBeInTheDocument();
+  });
+
+  it('renders unparseable placeholder when ratio JSON is invalid', () => {
+    const broken = { ...baseCommit, ratioDistributionJson: 'garbage' };
+    render(<CommitDetail commit={broken} isLoading={false} isError={false} />);
+    expect(screen.getByTestId('unparseable-ratio')).toBeInTheDocument();
+    expect(screen.queryByTestId('ratio-distribution-matrix')).not.toBeInTheDocument();
+  });
+
+  it('renders Route and Dismiss decision rows with correct badges', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    const routeRow = screen.getByTestId(
+      `decision-row-${baseCommit.decisions[0].linkId}`,
+    );
+    const dismissRow = screen.getByTestId(
+      `decision-row-${baseCommit.decisions[1].linkId}`,
+    );
+    expect(routeRow.dataset.decisionType).toBe('Route');
+    expect(dismissRow.dataset.decisionType).toBe('Dismiss');
+
+    const routeBadge = screen.getByTestId(
+      `decision-badge-${baseCommit.decisions[0].linkId}`,
+    );
+    expect(routeBadge).toHaveTextContent('Route');
+
+    const dismissBadge = screen.getByTestId(
+      `decision-badge-${baseCommit.decisions[1].linkId}`,
+    );
+    expect(dismissBadge).toHaveTextContent('Dismiss');
+  });
+
+  it("renders '—' for empty decision fields", () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    // Dismiss row has null routedToUniverse / null routedToIAttrValCd
+    const dismissRow = screen.getByTestId(
+      `decision-row-${baseCommit.decisions[1].linkId}`,
+    );
+    const emDashes = dismissRow.querySelectorAll('[aria-label="empty"]');
+    expect(emDashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders evidence ZIP download link with commit id in href', () => {
+    render(<CommitDetail commit={baseCommit} isLoading={false} isError={false} />);
+    const link = screen.getByTestId('evidence-download-link') as HTMLAnchorElement;
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toContain(
+      `/api/sync/workbench/h/evidence/${baseCommit.commitId}.zip`,
+    );
+    expect(link.getAttribute('download')).toContain(baseCommit.commitId);
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/SyncCommitsPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/SyncCommitsPage.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * SYNC-UX-1B: SyncCommitsPage integration tests.
+ *
+ * Verifies the wired list+detail page:
+ *   - empty list state
+ *   - paged list renders rows + selecting a row drives the detail
+ *     panel via the URL :commitId param
+ *   - "New Commit" button opens the modal
+ *
+ * Fetches are routed through a stubbed global fetch dispatcher that
+ * branches on URL — keeps tests deterministic without msw.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SyncCommitsPage from '../SyncCommitsPage';
+import type {
+  CommitDetailResponse,
+  CommitListResponse,
+  CommitSummaryResponse,
+} from '@/api/syncCommits';
+
+interface FetchRouter {
+  list?: CommitListResponse;
+  detail?: CommitDetailResponse;
+  detailStatus?: number;
+}
+
+function installFetchRouter(router: FetchRouter): void {
+  const handler = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : (input as URL).toString();
+    if (url.includes('/api/sync/workbench/g/commits/')) {
+      const status = router.detailStatus ?? (router.detail ? 200 : 404);
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'mock',
+        text: async () => JSON.stringify(router.detail ?? { error: 'not found' }),
+        json: async () => router.detail ?? { error: 'not found' },
+      } as unknown as Response;
+    }
+    if (url.includes('/api/sync/workbench/g/commits')) {
+      const list: CommitListResponse =
+        router.list ?? { count: 0, limit: 50, offset: 0, items: [] };
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'mock',
+        text: async () => JSON.stringify(list),
+        json: async () => list,
+      } as unknown as Response;
+    }
+    return {
+      ok: false,
+      status: 404,
+      statusText: 'unhandled',
+      text: async () => '{}',
+      json: async () => ({}),
+    } as unknown as Response;
+  };
+  vi.stubGlobal('fetch', vi.fn(handler) as unknown as typeof fetch);
+}
+
+function renderPage(initialPath = '/workbench/sync/commits') {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path='/workbench/sync/commits' element={<SyncCommitsPage />} />
+          <Route
+            path='/workbench/sync/commits/:commitId'
+            element={<SyncCommitsPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const summary: CommitSummaryResponse = {
+  commitId: '11111111-aaaa-bbbb-cccc-dddddddddddd',
+  committedAt: '2026-05-08T16:00:00Z',
+  operatorId: 'bsvalues',
+  idempotencyKey: 'idem-1',
+  routedDecisionsApplied: 5,
+  dismissedDecisionsApplied: 2,
+  commitNote: 'first commit',
+};
+
+const detail: CommitDetailResponse = {
+  ...summary,
+  universeDistributionJson: JSON.stringify({
+    REAL_RESIDENTIAL: 50,
+    REAL_COMMERCIAL: 0,
+    MOBILE_HOME: 0,
+    AG_CURRENT_USE: 0,
+    PERSONAL_PROPERTY: 0,
+    CONVERSION_LEGACY: 0,
+    UNKNOWN: 0,
+  }),
+  ratioDistributionJson: JSON.stringify({
+    DorQ_CountyQ: 1,
+    DorQ_CountyN: 0,
+    DorN_CountyQ: 0,
+    DorN_CountyN: 0,
+  }),
+  decisions: [],
+};
+
+describe('SyncCommitsPage', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the empty state when no commits exist', async () => {
+    installFetchRouter({ list: { count: 0, limit: 50, offset: 0, items: [] } });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('commits-list-empty')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('commit-detail-empty')).toBeInTheDocument();
+  });
+
+  it('renders the action bar with the New Commit button', async () => {
+    installFetchRouter({ list: { count: 0, limit: 50, offset: 0, items: [] } });
+
+    renderPage();
+
+    expect(screen.getByTestId('new-commit-button')).toBeInTheDocument();
+    expect(screen.getByTestId('commits-refresh-button')).toBeInTheDocument();
+  });
+
+  it('renders commit rows and the row label for each summary item', async () => {
+    installFetchRouter({
+      list: { count: 1, limit: 50, offset: 0, items: [summary] },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`commit-row-${summary.commitId}`),
+      ).toBeInTheDocument();
+    });
+    const row = screen.getByTestId(`commit-row-${summary.commitId}`);
+    expect(within(row).getByTestId(`commit-routed-${summary.commitId}`)).toHaveTextContent(
+      'R 5',
+    );
+    expect(within(row).getByTestId(`commit-dismissed-${summary.commitId}`)).toHaveTextContent(
+      'D 2',
+    );
+  });
+
+  it('selects a commit on click and renders its detail', async () => {
+    installFetchRouter({
+      list: { count: 1, limit: 50, offset: 0, items: [summary] },
+      detail,
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`commit-row-${summary.commitId}`),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId(`commit-row-${summary.commitId}`));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('commit-detail')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('commit-id-full')).toHaveTextContent(summary.commitId);
+    expect(screen.getByTestId('commit-routed-count')).toHaveTextContent('5');
+  });
+
+  it('opens the New Commit modal when the button is clicked', async () => {
+    installFetchRouter({ list: { count: 0, limit: 50, offset: 0, items: [] } });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByTestId('new-commit-button'));
+    expect(screen.getByTestId('commit-create-modal')).toBeInTheDocument();
+  });
+
+  it('hydrates a commit selected via the URL :commitId param', async () => {
+    installFetchRouter({
+      list: { count: 1, limit: 50, offset: 0, items: [summary] },
+      detail,
+    });
+
+    renderPage(`/workbench/sync/commits/${summary.commitId}`);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('commit-detail')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('commit-id-full')).toHaveTextContent(summary.commitId);
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/UniverseDistributionChart.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/__tests__/UniverseDistributionChart.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * SYNC-UX-1B: UniverseDistributionChart unit tests.
+ *
+ * The chart is purely presentational — given a parsed
+ * UniverseDistribution, it must render exactly 7 cells with the
+ * correct labels and counts.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import UniverseDistributionChart from '../UniverseDistributionChart';
+import { UNIVERSE_KEYS, type UniverseDistribution } from '@/api/syncCommits';
+
+const sampleDistribution: UniverseDistribution = {
+  REAL_RESIDENTIAL: 209,
+  REAL_COMMERCIAL: 4,
+  MOBILE_HOME: 0,
+  AG_CURRENT_USE: 28,
+  PERSONAL_PROPERTY: 0,
+  CONVERSION_LEGACY: 0,
+  UNKNOWN: 0,
+};
+
+describe('UniverseDistributionChart', () => {
+  it('renders all 7 universe cells', () => {
+    render(<UniverseDistributionChart distribution={sampleDistribution} />);
+    for (const k of UNIVERSE_KEYS) {
+      expect(screen.getByTestId(`universe-cell-${k}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders each cell with the correct count', () => {
+    render(<UniverseDistributionChart distribution={sampleDistribution} />);
+    expect(screen.getByTestId('universe-cell-REAL_RESIDENTIAL').dataset.count).toBe('209');
+    expect(screen.getByTestId('universe-cell-AG_CURRENT_USE').dataset.count).toBe('28');
+    expect(screen.getByTestId('universe-cell-REAL_COMMERCIAL').dataset.count).toBe('4');
+    expect(screen.getByTestId('universe-cell-MOBILE_HOME').dataset.count).toBe('0');
+  });
+
+  it('renders the panel total in the header', () => {
+    render(<UniverseDistributionChart distribution={sampleDistribution} />);
+    // total = 209 + 4 + 0 + 28 + 0 + 0 + 0 = 241
+    expect(
+      screen.getByLabelText('Universe distribution snapshot'),
+    ).toHaveTextContent('241 truth rows');
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitCreate.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitCreate.ts
@@ -1,0 +1,38 @@
+/**
+ * SYNC-UX-1B: TanStack Query mutation for creating a commit.
+ *
+ * On success invalidates the commits-list query so the new commit
+ * appears at the top of the list immediately. On 409 (no pending
+ * decisions) the caller surfaces a soft toast — no list refresh.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createCommit,
+  type CommitCreateRequest,
+  type CommitCreateResponse,
+  CommitApiError,
+} from '@/api/syncCommits';
+
+export interface CommitCreateOutcome {
+  response: CommitCreateResponse;
+  isIdempotent: boolean;
+}
+
+export function useCommitCreate() {
+  const qc = useQueryClient();
+
+  return useMutation<CommitCreateOutcome, CommitApiError, CommitCreateRequest>({
+    mutationFn: async (req) => {
+      const response = await createCommit(req);
+      return {
+        response,
+        isIdempotent: response.status === 'Idempotent',
+      };
+    },
+    onSuccess: () => {
+      // Refresh paginated list — the new commit lives at the top.
+      qc.invalidateQueries({ queryKey: ['sync-workbench-commits'] });
+    },
+  });
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitDetail.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitDetail.ts
@@ -1,0 +1,21 @@
+/**
+ * SYNC-UX-1B: TanStack Query hook for a single commit's full detail.
+ *
+ * Disabled until a commit is selected. The detail payload includes
+ * the decision-link rows for the table; ~few-KB JSON typical so a
+ * single fetch is fine.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getCommit, type CommitDetailResponse } from '@/api/syncCommits';
+
+export function useCommitDetail(commitId: string | null) {
+  return useQuery<CommitDetailResponse>({
+    queryKey: ['sync-workbench-commit', commitId ?? 'none'],
+    queryFn: ({ signal }) => getCommit(commitId as string, signal),
+    enabled: Boolean(commitId),
+    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+    retry: 1,
+  });
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitsList.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-commits/useCommitsList.ts
@@ -1,0 +1,23 @@
+/**
+ * SYNC-UX-1B: TanStack Query hook for the paged commits list.
+ *
+ * The commit list is operator-controlled (paged manually) so we
+ * don't poll. refetchOnWindowFocus is left at the QueryClient
+ * default (off in os-shell) — the operator clicks "New Commit"
+ * to refresh when needed.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { listCommits, type CommitListResponse } from '@/api/syncCommits';
+
+export const COMMITS_LIST_PAGE_SIZE = 50;
+
+export function useCommitsList(offset = 0, limit = COMMITS_LIST_PAGE_SIZE) {
+  return useQuery<CommitListResponse>({
+    queryKey: ['sync-workbench-commits', limit, offset],
+    queryFn: ({ signal }) => listCommits(limit, offset, signal),
+    refetchOnWindowFocus: false,
+    staleTime: 10_000,
+    retry: 1,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `/workbench/sync/commits[/:commitId]` — operator surface for the SYNC-WORKBENCH-G/H spine: paged decision-commit list, drill-down to a single commit's snapshot (universe + ratio distributions, decision links), and the evidence-packet section (signed ZIP download + inline manifest viewer with copy).
- New API client `syncCommits.ts` wraps the four backend endpoints (`POST /commit`, `GET /commits`, `GET /commits/{id}`, `GET evidence/{id}.zip` + `/manifest`). Tolerant JSON parsers for the two distribution snapshots fail-safe to `null` so the UI renders an "unparseable" placeholder instead of crashing the panel.
- Three TanStack Query hooks (`useCommitsList`, `useCommitDetail`, `useCommitCreate`) — no polling; the list invalidates after a successful Create.

## What's NOT in this slice
- No backend changes.
- No new design tokens (tf-* utilities only).
- Recharts was already in `package.json` but the 7-cell universe panel uses a labeled CSS grid; pulling Recharts into the page bundle for 7 cells doesn't justify the cost.

## Test plan
- [x] `cd frontend && npm run type-check` — clean
- [x] `cd frontend && npm test -- --run apps/os-shell/src/pages/workbench/sync-commits` — 4 files / 27 tests pass (target was 14+)
- [x] `npx eslint apps/os-shell/src/pages/workbench/sync-commits apps/os-shell/src/api/syncCommits.ts` — 0 errors / 0 warnings on new files
- [ ] Manual: open `/workbench/sync/commits` against a backend with at least one committed decision and verify list → detail → ZIP/manifest flow
- [ ] Manual: with no pending decisions, open New Commit modal → confirm 409 surfaces as the soft "no pending decisions" warning rather than a hard error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Sync Commits workbench page enabling users to create, list, and inspect commits.
  * Added ability to create new commits with operator tracking and idempotency support.
  * Implemented commit list view with pagination and refresh functionality.
  * Added commit detail view displaying decisions, distribution snapshots, and evidence manifests.
  * Enabled evidence packet downloads in ZIP format with manifest viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->