### PR TITLE
feat(sync-ux): UX-1A — quarantine triage UI

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -76,6 +76,14 @@ const SyncDoctrineConsole = lazy(
   () => import('./pages/workbench/sync-doctrine/SyncDoctrineConsole'),
 );
 
+// SYNC-UX-1A: Sync Quarantine Triage — read-write operator surface
+// for the imprv-attr quarantine cohort. Lives at /workbench/sync/*
+// (new namespace, sibling to sync-doctrine). Wraps the
+// SYNC-WORKBENCH-F triage controller (route + dismiss decisions).
+const SyncQuarantinePage = lazy(
+  () => import('./pages/workbench/sync-quarantine/SyncQuarantinePage'),
+);
+
 const Monitoring = lazy(() => import('./pages/Monitoring'));
 const TerraFusionMarketplace = lazy(
   () => import('./components/marketplace/TerraFusionMarketplace')
@@ -219,6 +227,12 @@ const Router: React.FC = () => {
                   <Route
                     path='workbench/sync-doctrine'
                     element={<SyncDoctrineConsole />}
+                  />
+
+                  {/* SYNC-UX-1A: Sync Quarantine Triage (read-write) */}
+                  <Route
+                    path='workbench/sync/quarantine'
+                    element={<SyncQuarantinePage />}
                   />
 
                   <Route path='monitoring' element={<Monitoring />} />

--- a/frontend/apps/os-shell/src/api/syncQuarantine.ts
+++ b/frontend/apps/os-shell/src/api/syncQuarantine.ts
@@ -1,0 +1,332 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * SYNC-UX-1A: SYNC QUARANTINE TRIAGE API CLIENT
+ *
+ * Wraps the SYNC-WORKBENCH-F triage surface:
+ *   GET  /api/sync/workbench/f/quarantine/imprv-attr
+ *   POST /api/sync/workbench/f/quarantine/imprv-attr/{id}/route
+ *   POST /api/sync/workbench/f/quarantine/imprv-attr/{id}/dismiss
+ *
+ * Pattern mirrors src/api/syncDoctrine.ts (compact fetch-based;
+ * no axios). DTOs are camelCase to match ASP.NET default System.Text.Json
+ * naming policy on the controller's record returns.
+ *
+ * The triage page is the operator-facing surface for the
+ * imprv_attr quarantine cohort surfaced by SYNC-DOCTRINE-4-IMPL-V8.
+ * Decisions are doctrine-immutable on the source quarantine row and
+ * are recorded on a sibling triage table; this client never mutates
+ * the quarantine entity itself.
+ *
+ * No secrets. No PII beyond the canonical (PropId, ImprvId, ImprvDetId,
+ * IAttrValCd) tuple already exposed by the doctrine console.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import { getViteEnv } from '@/env/getViteEnv';
+
+const API_BASE_URL = getViteEnv().VITE_API_URL || '';
+
+// ───────────────────────────────────────────────────────────────
+// Closed vocabularies — mirror server-side const lists exactly.
+// Adding a value here without server agreement will surface as a
+// 400 InvalidInput from the controller's MapList/MapRoute paths.
+// ───────────────────────────────────────────────────────────────
+
+export const QuarantineReasons = [
+  'UNKNOWN_UNIVERSE',
+  'UNKNOWN_FOR_UNIVERSE_DICTIONARY',
+  'UNIVERSE_NOT_EVALUATED',
+  'DICTIONARY_NOT_LOADED_FOR_UNIVERSE',
+  'LEGACY_CLASSIFICATION_UNCERTAIN',
+] as const;
+export type QuarantineReason = (typeof QuarantineReasons)[number];
+
+export const UniverseCodes = [
+  'REAL_RESIDENTIAL',
+  'REAL_COMMERCIAL',
+  'MOBILE_HOME',
+  'AG_CURRENT_USE',
+  'PERSONAL_PROPERTY',
+  'CONVERSION_LEGACY',
+  'UNKNOWN',
+] as const;
+export type UniverseCode = (typeof UniverseCodes)[number];
+
+export const DismissalReasons = [
+  'IntentionalNoise',
+  'LegitimateMissing',
+  'ConversionArtifact',
+] as const;
+export type DismissalReason = (typeof DismissalReasons)[number];
+
+export const TriageStatuses = ['Open', 'Routed', 'Dismissed'] as const;
+export type TriageStatus = (typeof TriageStatuses)[number];
+
+// ───────────────────────────────────────────────────────────────
+// DTOs — camelCase to match ASP.NET record serialization.
+// ───────────────────────────────────────────────────────────────
+
+export interface QuarantineRowResponse {
+  unprovenRowId: string;
+  propId: number;
+  propValYr: number;
+  supNum: number;
+  imprvId: number;
+  imprvDetId: number;
+  iAttrValId: number;
+  iAttrValCd: string;
+  attrValueText: string | null;
+  attrValueNumeric: number | null;
+  quarantineReason: string;
+  quarantineReasonDetail: string | null;
+  universeCode: string | null;
+  createdAt: string;
+  triageStatus: string;
+  suggestedReroute: string | null;
+}
+
+export interface QuarantineListResponse {
+  count: number;
+  limit: number;
+  offset: number;
+  items: QuarantineRowResponse[];
+}
+
+export interface RouteDecisionPayload {
+  triageId: string;
+  unprovenRowId: string;
+  status: string;
+  routedToUniverse: string;
+  routedToIAttrValCd: string | null;
+  updatedAt: string;
+}
+
+export interface DismissDecisionPayload {
+  triageId: string;
+  unprovenRowId: string;
+  status: string;
+  dismissalReason: string;
+  updatedAt: string;
+}
+
+export interface RouteRequestBody {
+  TargetUniverse: string;
+  TargetIAttrValCd?: string | null;
+  OperatorNote?: string | null;
+}
+
+export interface DismissRequestBody {
+  DismissalReason: string;
+  OperatorNote?: string | null;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Error envelope — surfaces the shape the controller returns on
+// non-2xx so the UI can format conflict / not-found / validation
+// messages without re-parsing fetch errors.
+// ───────────────────────────────────────────────────────────────
+
+export class QuarantineApiError extends Error {
+  status: number;
+  body: { error?: string } | null;
+  constructor(status: number, message: string, body: { error?: string } | null) {
+    super(message);
+    this.name = 'QuarantineApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function readErrorBody(res: Response): Promise<{ error?: string } | null> {
+  try {
+    const text = await res.text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text) as { error?: string };
+    } catch {
+      return { error: text };
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ───────────────────────────────────────────────────────────────
+// Filter / pagination input
+// ───────────────────────────────────────────────────────────────
+
+export interface QuarantineListParams {
+  reason?: QuarantineReason | '';
+  universe?: UniverseCode | '';
+  propId?: number | null;
+  limit?: number;
+  offset?: number;
+  /**
+   * Client-only filter: status is not a server-side filter today.
+   * Status filtering is applied in the page hook over fetched rows.
+   */
+  status?: TriageStatus | 'All';
+}
+
+// ───────────────────────────────────────────────────────────────
+// Fetch functions
+// ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetch one page of imprv-attr quarantine rows. Reason / universe /
+ * propId are optional server-side filters; limit/offset are required
+ * for paging. The server caps limit; passing larger values is safe
+ * but the response will reflect the server-side cap.
+ */
+export async function listQuarantineImprvAttr(
+  params: QuarantineListParams,
+  signal?: AbortSignal,
+): Promise<QuarantineListResponse> {
+  const qs = new URLSearchParams();
+  if (params.reason) qs.set('reason', params.reason);
+  if (params.universe) qs.set('universe', params.universe);
+  if (params.propId !== undefined && params.propId !== null && !Number.isNaN(params.propId)) {
+    qs.set('propId', String(params.propId));
+  }
+  qs.set('limit', String(params.limit ?? 100));
+  qs.set('offset', String(params.offset ?? 0));
+
+  const url = `${API_BASE_URL}/sync/workbench/f/quarantine/imprv-attr?${qs.toString()}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    const body = await readErrorBody(res);
+    throw new QuarantineApiError(
+      res.status,
+      `listQuarantineImprvAttr failed: HTTP ${res.status} ${res.statusText}`,
+      body,
+    );
+  }
+  return (await res.json()) as QuarantineListResponse;
+}
+
+/**
+ * Record a route decision against a single quarantined row. The
+ * server is idempotent on identical re-routes (200 with the
+ * existing decision); cross-target re-routes return 409 Conflict.
+ */
+export async function routeQuarantineImprvAttr(
+  unprovenRowId: string,
+  body: RouteRequestBody,
+  signal?: AbortSignal,
+): Promise<RouteDecisionPayload> {
+  const url = `${API_BASE_URL}/sync/workbench/f/quarantine/imprv-attr/${encodeURIComponent(unprovenRowId)}/route`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    const errBody = await readErrorBody(res);
+    throw new QuarantineApiError(
+      res.status,
+      `routeQuarantineImprvAttr failed: HTTP ${res.status} ${res.statusText}`,
+      errBody,
+    );
+  }
+  return (await res.json()) as RouteDecisionPayload;
+}
+
+/**
+ * Record a dismiss decision. Idempotent on identical reason; cross-
+ * branch (Routed → Dismissed) and divergent reasons surface as 409.
+ */
+export async function dismissQuarantineImprvAttr(
+  unprovenRowId: string,
+  body: DismissRequestBody,
+  signal?: AbortSignal,
+): Promise<DismissDecisionPayload> {
+  const url = `${API_BASE_URL}/sync/workbench/f/quarantine/imprv-attr/${encodeURIComponent(unprovenRowId)}/dismiss`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.ok) {
+    const errBody = await readErrorBody(res);
+    throw new QuarantineApiError(
+      res.status,
+      `dismissQuarantineImprvAttr failed: HTTP ${res.status} ${res.statusText}`,
+      errBody,
+    );
+  }
+  return (await res.json()) as DismissDecisionPayload;
+}
+
+// ───────────────────────────────────────────────────────────────
+// Bulk helpers — fan out N parallel mutations with a configurable
+// concurrency cap. Each item resolves to an outcome record so the
+// UI can render per-row status without short-circuiting on the
+// first failure.
+// ───────────────────────────────────────────────────────────────
+
+export type BulkOutcome<TPayload> =
+  | { unprovenRowId: string; status: 'ok'; payload: TPayload }
+  | { unprovenRowId: string; status: 'error'; error: QuarantineApiError | Error };
+
+const DEFAULT_PARALLELISM = 8;
+
+async function runWithConcurrency<TPayload>(
+  ids: readonly string[],
+  worker: (id: string) => Promise<TPayload>,
+  parallelism: number,
+): Promise<BulkOutcome<TPayload>[]> {
+  const results: BulkOutcome<TPayload>[] = new Array(ids.length);
+  let cursor = 0;
+
+  async function pull(): Promise<void> {
+    while (cursor < ids.length) {
+      const i = cursor++;
+      const id = ids[i]!;
+      try {
+        const payload = await worker(id);
+        results[i] = { unprovenRowId: id, status: 'ok', payload };
+      } catch (e) {
+        const error =
+          e instanceof QuarantineApiError
+            ? e
+            : e instanceof Error
+              ? e
+              : new Error(String(e));
+        results[i] = { unprovenRowId: id, status: 'error', error };
+      }
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, parallelism), ids.length || 1) },
+    () => pull(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export async function bulkRouteQuarantineImprvAttr(
+  ids: readonly string[],
+  body: RouteRequestBody,
+  parallelism: number = DEFAULT_PARALLELISM,
+): Promise<BulkOutcome<RouteDecisionPayload>[]> {
+  return runWithConcurrency(
+    ids,
+    (id) => routeQuarantineImprvAttr(id, body),
+    parallelism,
+  );
+}
+
+export async function bulkDismissQuarantineImprvAttr(
+  ids: readonly string[],
+  body: DismissRequestBody,
+  parallelism: number = DEFAULT_PARALLELISM,
+): Promise<BulkOutcome<DismissDecisionPayload>[]> {
+  return runWithConcurrency(
+    ids,
+    (id) => dismissQuarantineImprvAttr(id, body),
+    parallelism,
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineDismissModal.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineDismissModal.tsx
@@ -1,0 +1,289 @@
+/**
+ * SYNC-UX-1A: dismiss-decision modal (single + bulk).
+ *
+ * Form: DismissalReason (3 closed values), Operator Note. Submission
+ * pattern mirrors QuarantineRouteModal — N parallel POSTs with a
+ * concurrency cap, per-row outcome rendering, modal stays open on
+ * partial failure so the operator can see exactly which rows
+ * conflicted.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  DismissalReasons,
+  QuarantineApiError,
+  type DismissRequestBody,
+  type DismissalReason,
+} from '@/api/syncQuarantine';
+import { useDismissQuarantineMutation } from './useQuarantineMutations';
+
+interface QuarantineDismissModalProps {
+  open: boolean;
+  rowIds: readonly string[];
+  contextLabel?: string;
+  onClose: () => void;
+  onSubmitted: () => void;
+}
+
+export default function QuarantineDismissModal({
+  open,
+  rowIds,
+  contextLabel,
+  onClose,
+  onSubmitted,
+}: QuarantineDismissModalProps): React.ReactElement | null {
+  const mutation = useDismissQuarantineMutation();
+  const [reason, setReason] = useState<DismissalReason | ''>('');
+  const [note, setNote] = useState<string>('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setReason('');
+      setNote('');
+      setValidationError(null);
+      mutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!reason) {
+      setValidationError('Dismissal reason is required.');
+      return;
+    }
+    setValidationError(null);
+    const body: DismissRequestBody = {
+      DismissalReason: reason,
+      OperatorNote: note.trim() === '' ? null : note.trim(),
+    };
+    try {
+      const results = await mutation.submit(rowIds, body);
+      const allOk = results.every((r) => r.status === 'ok');
+      if (allOk) {
+        onSubmitted();
+        onClose();
+      }
+    } catch {
+      // captured in mutation state
+    }
+  };
+
+  const errorRows = mutation.results.filter((r) => r.status === 'error');
+
+  return (
+    <div
+      role='dialog'
+      aria-modal='true'
+      aria-label='Dismiss quarantine rows'
+      data-testid='dismiss-modal'
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 50,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !mutation.isRunning) onClose();
+      }}
+    >
+      <form
+        onSubmit={onSubmit}
+        className='tf-panel p-4'
+        style={{
+          width: 'min(560px, 92vw)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          background: 'var(--tf-bg, #0f172a)',
+          border: '1px solid var(--tf-border)',
+          borderRadius: 6,
+        }}
+      >
+        <header style={{ marginBottom: 12 }}>
+          <h2 className='tf-text font-semibold' style={{ fontSize: '1.05rem', margin: 0 }}>
+            Dismiss {rowIds.length === 1 ? '1 quarantine row' : `${rowIds.length} quarantine rows`}
+          </h2>
+          {contextLabel && (
+            <p className='tf-text-secondary' style={{ fontSize: '0.8rem', marginTop: 4 }}>
+              {contextLabel}
+            </p>
+          )}
+        </header>
+
+        <label className='tf-text-secondary' style={{ display: 'block', fontSize: '0.85rem', marginBottom: 8 }}>
+          Dismissal reason <span className='tf-status-error' style={{ padding: '0 4px' }}>required</span>
+          <select
+            aria-label='Dismissal reason'
+            data-testid='dismiss-reason'
+            value={reason}
+            onChange={(e) => setReason(e.target.value as DismissalReason | '')}
+            disabled={mutation.isRunning}
+            className='tf-text'
+            style={{
+              display: 'block',
+              width: '100%',
+              marginTop: 2,
+              padding: '6px 8px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.9rem',
+            }}
+          >
+            <option value=''>Select a reason…</option>
+            {DismissalReasons.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className='tf-text-secondary' style={{ display: 'block', fontSize: '0.85rem', marginBottom: 8 }}>
+          Operator note <span style={{ opacity: 0.7 }}>(optional, audit-visible)</span>
+          <textarea
+            aria-label='Operator note'
+            data-testid='dismiss-operator-note'
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            disabled={mutation.isRunning}
+            rows={3}
+            className='tf-text'
+            style={{
+              display: 'block',
+              width: '100%',
+              marginTop: 2,
+              padding: '6px 8px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.9rem',
+              fontFamily: 'inherit',
+              resize: 'vertical',
+            }}
+          />
+        </label>
+
+        {validationError && (
+          <p
+            className='tf-status-error'
+            data-testid='dismiss-validation-error'
+            style={{ padding: '6px 8px', borderRadius: 3, fontSize: '0.85rem' }}
+          >
+            {validationError}
+          </p>
+        )}
+
+        {mutation.isRunning && (
+          <div
+            data-testid='dismiss-progress'
+            className='tf-text-secondary'
+            style={{ fontSize: '0.85rem', marginTop: 8 }}
+          >
+            Submitting… {mutation.completed}/{mutation.total}
+            <div
+              aria-hidden
+              style={{
+                marginTop: 4,
+                height: 4,
+                width: '100%',
+                background: 'var(--tf-border)',
+                borderRadius: 2,
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  height: '100%',
+                  width: `${mutation.total > 0 ? Math.round((mutation.completed / mutation.total) * 100) : 0}%`,
+                  background: 'var(--tf-transcend-cyan, #00ffee)',
+                  transition: 'width 100ms linear',
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {errorRows.length > 0 && (
+          <div
+            data-testid='dismiss-error-summary'
+            className='tf-status-error'
+            style={{ padding: '6px 8px', borderRadius: 3, fontSize: '0.8rem', marginTop: 8 }}
+          >
+            <strong>{errorRows.length}</strong> of {mutation.results.length} rows failed.
+            <ul style={{ marginTop: 4, paddingLeft: 16 }}>
+              {errorRows.slice(0, 5).map((r) => (
+                <li key={r.unprovenRowId} style={{ wordBreak: 'break-all' }}>
+                  <code>{r.unprovenRowId.slice(0, 8)}…</code>{': '}
+                  {describeError(r.status === 'error' ? r.error : null)}
+                </li>
+              ))}
+              {errorRows.length > 5 && <li>… and {errorRows.length - 5} more</li>}
+            </ul>
+          </div>
+        )}
+
+        <footer
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+            marginTop: 12,
+            paddingTop: 12,
+            borderTop: '1px solid var(--tf-border)',
+          }}
+        >
+          <button
+            type='button'
+            aria-label='Cancel dismiss'
+            data-testid='dismiss-cancel-button'
+            onClick={onClose}
+            disabled={mutation.isRunning}
+            className='tf-status-info'
+            style={{ padding: '6px 12px', borderRadius: 3, fontSize: '0.85rem', cursor: 'pointer' }}
+          >
+            Cancel
+          </button>
+          <button
+            type='submit'
+            aria-label='Submit dismiss decision'
+            data-testid='dismiss-submit-button'
+            disabled={mutation.isRunning}
+            className='tf-status-warning'
+            style={{
+              padding: '6px 12px',
+              borderRadius: 3,
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              cursor: mutation.isRunning ? 'not-allowed' : 'pointer',
+              opacity: mutation.isRunning ? 0.7 : 1,
+            }}
+          >
+            {mutation.isRunning ? 'Dismissing…' : 'Dismiss'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}
+
+function describeError(error: Error | QuarantineApiError | null): string {
+  if (!error) return 'unknown error';
+  if (error instanceof QuarantineApiError) {
+    if (error.status === 404) return 'row not found (refresh and retry)';
+    if (error.status === 409)
+      return error.body?.error
+        ? `conflict: ${error.body.error}`
+        : 'conflict: existing decision differs';
+    if (error.status === 400)
+      return error.body?.error ? `invalid: ${error.body.error}` : 'invalid input';
+    return error.body?.error ? `${error.status}: ${error.body.error}` : `HTTP ${error.status}`;
+  }
+  return error.message;
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineFilterBar.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineFilterBar.tsx
@@ -1,0 +1,208 @@
+/**
+ * SYNC-UX-1A: sticky filter bar for the quarantine triage page.
+ *
+ * Four controls:
+ *   - Reason (5 closed values + All)
+ *   - Universe (7 universes + All)
+ *   - PropId (numeric input, clearable)
+ *   - Status (Open / Routed / Dismissed / All — client-only filter)
+ *
+ * Styling matches the doctrine console's ConfigBar: tf-* classes,
+ * borders via --tf-border, no shadcn for now (the existing console
+ * uses raw inputs and labels; matching that for visual consistency).
+ */
+
+import React from 'react';
+import {
+  DismissalReasons as _DismissalReasons,
+  QuarantineReasons,
+  TriageStatuses,
+  UniverseCodes,
+  type QuarantineReason,
+  type TriageStatus,
+  type UniverseCode,
+} from '@/api/syncQuarantine';
+
+void _DismissalReasons; // re-export anchor for any future expansion
+
+export interface QuarantineFilterValue {
+  reason: QuarantineReason | '';
+  universe: UniverseCode | '';
+  propId: number | null;
+  status: TriageStatus | 'All';
+}
+
+interface QuarantineFilterBarProps {
+  value: QuarantineFilterValue;
+  onChange: (next: QuarantineFilterValue) => void;
+  disabled?: boolean;
+}
+
+export default function QuarantineFilterBar({
+  value,
+  onChange,
+  disabled,
+}: QuarantineFilterBarProps): React.ReactElement {
+  return (
+    <div
+      data-testid='quarantine-filter-bar'
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 12,
+        padding: '8px 0',
+        borderTop: '1px solid var(--tf-border)',
+        borderBottom: '1px solid var(--tf-border)',
+        background: 'var(--tf-bg, transparent)',
+      }}
+    >
+      <label style={{ fontSize: '0.8rem' }} className='tf-text-secondary'>
+        Reason
+        <select
+          aria-label='Filter by quarantine reason'
+          data-testid='filter-reason'
+          value={value.reason}
+          onChange={(e) =>
+            onChange({ ...value, reason: e.target.value as QuarantineReason | '' })
+          }
+          disabled={disabled}
+          className='tf-text'
+          style={{
+            display: 'block',
+            width: '100%',
+            marginTop: 2,
+            padding: '4px 6px',
+            background: 'transparent',
+            border: '1px solid var(--tf-border)',
+            borderRadius: 3,
+            fontSize: '0.85rem',
+          }}
+        >
+          <option value=''>All reasons</option>
+          {QuarantineReasons.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label style={{ fontSize: '0.8rem' }} className='tf-text-secondary'>
+        Universe
+        <select
+          aria-label='Filter by universe'
+          data-testid='filter-universe'
+          value={value.universe}
+          onChange={(e) =>
+            onChange({ ...value, universe: e.target.value as UniverseCode | '' })
+          }
+          disabled={disabled}
+          className='tf-text'
+          style={{
+            display: 'block',
+            width: '100%',
+            marginTop: 2,
+            padding: '4px 6px',
+            background: 'transparent',
+            border: '1px solid var(--tf-border)',
+            borderRadius: 3,
+            fontSize: '0.85rem',
+          }}
+        >
+          <option value=''>All universes</option>
+          {UniverseCodes.map((u) => (
+            <option key={u} value={u}>
+              {u}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label style={{ fontSize: '0.8rem' }} className='tf-text-secondary'>
+        PropId
+        <span style={{ display: 'flex', gap: 4, marginTop: 2 }}>
+          <input
+            type='number'
+            aria-label='Filter by property id'
+            data-testid='filter-propid'
+            value={value.propId ?? ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === '') {
+                onChange({ ...value, propId: null });
+              } else {
+                const n = Number(v);
+                onChange({ ...value, propId: Number.isNaN(n) ? null : n });
+              }
+            }}
+            disabled={disabled}
+            min={0}
+            placeholder='any'
+            className='tf-text'
+            style={{
+              flex: 1,
+              padding: '4px 6px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.85rem',
+            }}
+          />
+          {value.propId !== null && (
+            <button
+              type='button'
+              aria-label='Clear property id filter'
+              data-testid='filter-propid-clear'
+              onClick={() => onChange({ ...value, propId: null })}
+              disabled={disabled}
+              className='tf-status-info'
+              style={{
+                padding: '0 8px',
+                borderRadius: 3,
+                fontSize: '0.8rem',
+                cursor: 'pointer',
+              }}
+            >
+              X
+            </button>
+          )}
+        </span>
+      </label>
+
+      <label style={{ fontSize: '0.8rem' }} className='tf-text-secondary'>
+        Triage status
+        <select
+          aria-label='Filter by triage status'
+          data-testid='filter-status'
+          value={value.status}
+          onChange={(e) =>
+            onChange({ ...value, status: e.target.value as TriageStatus | 'All' })
+          }
+          disabled={disabled}
+          className='tf-text'
+          style={{
+            display: 'block',
+            width: '100%',
+            marginTop: 2,
+            padding: '4px 6px',
+            background: 'transparent',
+            border: '1px solid var(--tf-border)',
+            borderRadius: 3,
+            fontSize: '0.85rem',
+          }}
+        >
+          <option value='Open'>Open</option>
+          {TriageStatuses.filter((s) => s !== 'Open').map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+          <option value='All'>All</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineRouteModal.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineRouteModal.tsx
@@ -1,0 +1,320 @@
+/**
+ * SYNC-UX-1A: route-decision modal (single + bulk).
+ *
+ * Form: Target Universe (closed dropdown), Target IAttrValCd (text),
+ * Operator Note (textarea). Submits one or N parallel route POSTs
+ * via useRouteQuarantineMutation. Stays open on conflict so the
+ * operator can read the per-row error and amend the target without
+ * losing form state.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  QuarantineApiError,
+  UniverseCodes,
+  type RouteRequestBody,
+  type UniverseCode,
+} from '@/api/syncQuarantine';
+import { useRouteQuarantineMutation } from './useQuarantineMutations';
+
+interface QuarantineRouteModalProps {
+  open: boolean;
+  rowIds: readonly string[];
+  /** Optional summary line for the bulk header (e.g. "PropId 12345" for single). */
+  contextLabel?: string;
+  onClose: () => void;
+  /** Called after a successful, all-rows-accepted submission. */
+  onSubmitted: () => void;
+}
+
+export default function QuarantineRouteModal({
+  open,
+  rowIds,
+  contextLabel,
+  onClose,
+  onSubmitted,
+}: QuarantineRouteModalProps): React.ReactElement | null {
+  const mutation = useRouteQuarantineMutation();
+  const [targetUniverse, setTargetUniverse] = useState<UniverseCode | ''>('');
+  const [targetCode, setTargetCode] = useState<string>('');
+  const [note, setNote] = useState<string>('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Reset form whenever the modal opens.
+  useEffect(() => {
+    if (open) {
+      setTargetUniverse('');
+      setTargetCode('');
+      setNote('');
+      setValidationError(null);
+      mutation.reset();
+    }
+    // mutation.reset is stable; intentional
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!targetUniverse) {
+      setValidationError('Target universe is required.');
+      return;
+    }
+    setValidationError(null);
+    const body: RouteRequestBody = {
+      TargetUniverse: targetUniverse,
+      TargetIAttrValCd: targetCode.trim() === '' ? null : targetCode.trim(),
+      OperatorNote: note.trim() === '' ? null : note.trim(),
+    };
+    try {
+      const results = await mutation.submit(rowIds, body);
+      const allOk = results.every((r) => r.status === 'ok');
+      if (allOk) {
+        onSubmitted();
+        onClose();
+      }
+      // else: keep modal open so operator can review per-row errors
+    } catch {
+      // mutation already captured the top-level error in state
+    }
+  };
+
+  const errorRows = mutation.results.filter((r) => r.status === 'error');
+
+  return (
+    <div
+      role='dialog'
+      aria-modal='true'
+      aria-label='Route quarantine rows'
+      data-testid='route-modal'
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 50,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !mutation.isRunning) onClose();
+      }}
+    >
+      <form
+        onSubmit={onSubmit}
+        className='tf-panel p-4'
+        style={{
+          width: 'min(560px, 92vw)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          background: 'var(--tf-bg, #0f172a)',
+          border: '1px solid var(--tf-border)',
+          borderRadius: 6,
+        }}
+      >
+        <header style={{ marginBottom: 12 }}>
+          <h2 className='tf-text font-semibold' style={{ fontSize: '1.05rem', margin: 0 }}>
+            Route {rowIds.length === 1 ? '1 quarantine row' : `${rowIds.length} quarantine rows`}
+          </h2>
+          {contextLabel && (
+            <p className='tf-text-secondary' style={{ fontSize: '0.8rem', marginTop: 4 }}>
+              {contextLabel}
+            </p>
+          )}
+        </header>
+
+        <label className='tf-text-secondary' style={{ display: 'block', fontSize: '0.85rem', marginBottom: 8 }}>
+          Target universe <span className='tf-status-error' style={{ padding: '0 4px' }}>required</span>
+          <select
+            aria-label='Target universe'
+            data-testid='route-target-universe'
+            value={targetUniverse}
+            onChange={(e) => setTargetUniverse(e.target.value as UniverseCode | '')}
+            disabled={mutation.isRunning}
+            className='tf-text'
+            style={{
+              display: 'block',
+              width: '100%',
+              marginTop: 2,
+              padding: '6px 8px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.9rem',
+            }}
+          >
+            <option value=''>Select a universe…</option>
+            {UniverseCodes.map((u) => (
+              <option key={u} value={u}>
+                {u}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className='tf-text-secondary' style={{ display: 'block', fontSize: '0.85rem', marginBottom: 8 }}>
+          Target IAttrValCd <span style={{ opacity: 0.7 }}>(optional)</span>
+          <input
+            type='text'
+            aria-label='Target IAttrValCd'
+            data-testid='route-target-code'
+            value={targetCode}
+            onChange={(e) => setTargetCode(e.target.value)}
+            disabled={mutation.isRunning}
+            className='tf-text'
+            style={{
+              display: 'block',
+              width: '100%',
+              marginTop: 2,
+              padding: '6px 8px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.9rem',
+            }}
+          />
+        </label>
+
+        <label className='tf-text-secondary' style={{ display: 'block', fontSize: '0.85rem', marginBottom: 8 }}>
+          Operator note <span style={{ opacity: 0.7 }}>(optional, audit-visible)</span>
+          <textarea
+            aria-label='Operator note'
+            data-testid='route-operator-note'
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            disabled={mutation.isRunning}
+            rows={3}
+            className='tf-text'
+            style={{
+              display: 'block',
+              width: '100%',
+              marginTop: 2,
+              padding: '6px 8px',
+              background: 'transparent',
+              border: '1px solid var(--tf-border)',
+              borderRadius: 3,
+              fontSize: '0.9rem',
+              fontFamily: 'inherit',
+              resize: 'vertical',
+            }}
+          />
+        </label>
+
+        {validationError && (
+          <p
+            className='tf-status-error'
+            data-testid='route-validation-error'
+            style={{ padding: '6px 8px', borderRadius: 3, fontSize: '0.85rem' }}
+          >
+            {validationError}
+          </p>
+        )}
+
+        {mutation.isRunning && (
+          <div
+            data-testid='route-progress'
+            className='tf-text-secondary'
+            style={{ fontSize: '0.85rem', marginTop: 8 }}
+          >
+            Submitting… {mutation.completed}/{mutation.total}
+            <div
+              aria-hidden
+              style={{
+                marginTop: 4,
+                height: 4,
+                width: '100%',
+                background: 'var(--tf-border)',
+                borderRadius: 2,
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  height: '100%',
+                  width: `${mutation.total > 0 ? Math.round((mutation.completed / mutation.total) * 100) : 0}%`,
+                  background: 'var(--tf-transcend-cyan, #00ffee)',
+                  transition: 'width 100ms linear',
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {errorRows.length > 0 && (
+          <div
+            data-testid='route-error-summary'
+            className='tf-status-error'
+            style={{ padding: '6px 8px', borderRadius: 3, fontSize: '0.8rem', marginTop: 8 }}
+          >
+            <strong>{errorRows.length}</strong> of {mutation.results.length} rows failed.
+            <ul style={{ marginTop: 4, paddingLeft: 16 }}>
+              {errorRows.slice(0, 5).map((r) => (
+                <li key={r.unprovenRowId} style={{ wordBreak: 'break-all' }}>
+                  <code>{r.unprovenRowId.slice(0, 8)}…</code>{': '}
+                  {describeError(r.status === 'error' ? r.error : null)}
+                </li>
+              ))}
+              {errorRows.length > 5 && <li>… and {errorRows.length - 5} more</li>}
+            </ul>
+          </div>
+        )}
+
+        <footer
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 8,
+            marginTop: 12,
+            paddingTop: 12,
+            borderTop: '1px solid var(--tf-border)',
+          }}
+        >
+          <button
+            type='button'
+            aria-label='Cancel route'
+            data-testid='route-cancel-button'
+            onClick={onClose}
+            disabled={mutation.isRunning}
+            className='tf-status-info'
+            style={{ padding: '6px 12px', borderRadius: 3, fontSize: '0.85rem', cursor: 'pointer' }}
+          >
+            Cancel
+          </button>
+          <button
+            type='submit'
+            aria-label='Submit route decision'
+            data-testid='route-submit-button'
+            disabled={mutation.isRunning}
+            className='tf-status-success'
+            style={{
+              padding: '6px 12px',
+              borderRadius: 3,
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              cursor: mutation.isRunning ? 'not-allowed' : 'pointer',
+              opacity: mutation.isRunning ? 0.7 : 1,
+            }}
+          >
+            {mutation.isRunning ? 'Routing…' : 'Route'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}
+
+function describeError(error: Error | QuarantineApiError | null): string {
+  if (!error) return 'unknown error';
+  if (error instanceof QuarantineApiError) {
+    if (error.status === 404) return 'row not found (refresh and retry)';
+    if (error.status === 409)
+      return error.body?.error
+        ? `conflict: ${error.body.error}`
+        : 'conflict: existing decision differs (dismiss first then re-route)';
+    if (error.status === 400)
+      return error.body?.error ? `invalid: ${error.body.error}` : 'invalid input';
+    return error.body?.error ? `${error.status}: ${error.body.error}` : `HTTP ${error.status}`;
+  }
+  return error.message;
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineTable.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/QuarantineTable.tsx
@@ -1,0 +1,336 @@
+/**
+ * SYNC-UX-1A: paged table of imprv-attr quarantine rows.
+ *
+ * - 9 columns: PropId, ImprvId/ImprvDetId, IAttrValCd, AttrValueText,
+ *   UniverseCode, ReasonDetail, TriageStatus (badge), SuggestedReroute,
+ *   CreatedAt
+ * - Per-row Route + Dismiss actions
+ * - Multi-select via checkboxes (header check toggles all on page)
+ * - Pagination: prev/next + "page X of Y" + page-size selector
+ *
+ * Visual language matches the doctrine console's tables: tabular-nums
+ * for counts, monospace code in IAttrValCd / SuggestedReroute, status
+ * badges via tf-status-* tokens.
+ */
+
+import React from 'react';
+import type { QuarantineRowResponse } from '@/api/syncQuarantine';
+
+export const PAGE_SIZE_OPTIONS = [25, 50, 100, 200, 500] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+interface QuarantineTableProps {
+  rows: QuarantineRowResponse[];
+  selectedIds: ReadonlySet<string>;
+  onToggleRow: (unprovenRowId: string) => void;
+  onToggleAll: (checked: boolean) => void;
+  onRouteRow: (row: QuarantineRowResponse) => void;
+  onDismissRow: (row: QuarantineRowResponse) => void;
+  // Pagination
+  page: number; // 1-based
+  pageSize: PageSize;
+  hasNextPage: boolean;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+  onPageSizeChange: (n: PageSize) => void;
+  // Loading state for refresh / pagination
+  isFetching: boolean;
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case 'Routed':
+      return 'tf-status-success';
+    case 'Dismissed':
+      return 'tf-status-warning';
+    case 'Open':
+    default:
+      return 'tf-status-info';
+  }
+}
+
+export default function QuarantineTable({
+  rows,
+  selectedIds,
+  onToggleRow,
+  onToggleAll,
+  onRouteRow,
+  onDismissRow,
+  page,
+  pageSize,
+  hasNextPage,
+  onPrevPage,
+  onNextPage,
+  onPageSizeChange,
+  isFetching,
+}: QuarantineTableProps): React.ReactElement {
+  const allOnPageSelected =
+    rows.length > 0 && rows.every((r) => selectedIds.has(r.unprovenRowId));
+  const someOnPageSelected = !allOnPageSelected && rows.some((r) => selectedIds.has(r.unprovenRowId));
+
+  return (
+    <section
+      className='tf-panel p-4 mt-4'
+      aria-label='Quarantine rows'
+      data-testid='quarantine-table-panel'
+    >
+      <div
+        style={{
+          overflowX: 'auto',
+          maxWidth: '100%',
+        }}
+      >
+        <table
+          style={{ width: '100%', fontSize: '0.8rem', borderCollapse: 'collapse' }}
+          data-testid='quarantine-table'
+        >
+          <thead>
+            <tr className='tf-text-secondary'>
+              <th style={{ padding: '4px 8px', textAlign: 'left', width: 28 }}>
+                <input
+                  type='checkbox'
+                  aria-label='Select all rows on this page'
+                  data-testid='select-all-checkbox'
+                  checked={allOnPageSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someOnPageSelected;
+                  }}
+                  onChange={(e) => onToggleAll(e.target.checked)}
+                />
+              </th>
+              <th style={{ textAlign: 'right', padding: '4px 8px' }}>PropId</th>
+              <th style={{ textAlign: 'right', padding: '4px 8px' }}>Imprv / Det</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>IAttrValCd</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>AttrValueText</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Universe</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Reason</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Triage</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Suggested</th>
+              <th style={{ textAlign: 'right', padding: '4px 8px' }}>Created</th>
+              <th style={{ textAlign: 'right', padding: '4px 8px' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={11}
+                  className='tf-text-secondary'
+                  style={{ padding: '12px 8px', textAlign: 'center' }}
+                  data-testid='quarantine-empty'
+                >
+                  {isFetching ? 'Loading…' : 'No quarantine rows match the current filters.'}
+                </td>
+              </tr>
+            )}
+            {rows.map((row) => {
+              const checked = selectedIds.has(row.unprovenRowId);
+              return (
+                <tr
+                  key={row.unprovenRowId}
+                  data-testid='quarantine-row'
+                  data-row-id={row.unprovenRowId}
+                  data-status={row.triageStatus}
+                  style={{ borderTop: '1px solid var(--tf-border)' }}
+                >
+                  <td style={{ padding: '4px 8px' }}>
+                    <input
+                      type='checkbox'
+                      aria-label={`Select quarantine row ${row.unprovenRowId}`}
+                      data-testid='row-checkbox'
+                      checked={checked}
+                      onChange={() => onToggleRow(row.unprovenRowId)}
+                    />
+                  </td>
+                  <td
+                    className='tf-text'
+                    style={{
+                      padding: '4px 8px',
+                      textAlign: 'right',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {row.propId.toLocaleString()}
+                  </td>
+                  <td
+                    className='tf-text-secondary'
+                    style={{
+                      padding: '4px 8px',
+                      textAlign: 'right',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {row.imprvId.toLocaleString()} / {row.imprvDetId.toLocaleString()}
+                  </td>
+                  <td className='tf-text' style={{ padding: '4px 8px' }}>
+                    <code>{row.iAttrValCd}</code>
+                  </td>
+                  <td
+                    className='tf-text-secondary'
+                    style={{
+                      padding: '4px 8px',
+                      maxWidth: 240,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                    title={row.attrValueText ?? ''}
+                  >
+                    {row.attrValueText ?? '—'}
+                  </td>
+                  <td className='tf-text' style={{ padding: '4px 8px' }}>
+                    <code>{row.universeCode ?? 'UNKNOWN'}</code>
+                  </td>
+                  <td
+                    className='tf-text-secondary'
+                    style={{
+                      padding: '4px 8px',
+                      maxWidth: 200,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                    title={row.quarantineReasonDetail ?? row.quarantineReason}
+                  >
+                    <code>{row.quarantineReason}</code>
+                  </td>
+                  <td style={{ padding: '4px 8px' }}>
+                    <span
+                      className={statusClass(row.triageStatus)}
+                      data-testid='triage-badge'
+                      style={{ padding: '2px 6px', borderRadius: 3 }}
+                    >
+                      {row.triageStatus}
+                    </span>
+                  </td>
+                  <td className='tf-text-secondary' style={{ padding: '4px 8px' }}>
+                    {row.suggestedReroute ? <code>{row.suggestedReroute}</code> : '—'}
+                  </td>
+                  <td
+                    className='tf-text-secondary'
+                    style={{ padding: '4px 8px', textAlign: 'right' }}
+                  >
+                    {new Date(row.createdAt).toLocaleString()}
+                  </td>
+                  <td style={{ padding: '4px 8px', textAlign: 'right' }}>
+                    <button
+                      type='button'
+                      aria-label={`Route quarantine row ${row.unprovenRowId}`}
+                      data-testid='row-route-button'
+                      onClick={() => onRouteRow(row)}
+                      className='tf-status-success'
+                      style={{
+                        padding: '2px 8px',
+                        borderRadius: 3,
+                        fontSize: '0.75rem',
+                        marginRight: 4,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Route
+                    </button>
+                    <button
+                      type='button'
+                      aria-label={`Dismiss quarantine row ${row.unprovenRowId}`}
+                      data-testid='row-dismiss-button'
+                      onClick={() => onDismissRow(row)}
+                      className='tf-status-warning'
+                      style={{
+                        padding: '2px 8px',
+                        borderRadius: 3,
+                        fontSize: '0.75rem',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Dismiss
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginTop: 8,
+          paddingTop: 8,
+          borderTop: '1px solid var(--tf-border)',
+          fontSize: '0.8rem',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <div className='tf-text-secondary' data-testid='page-indicator'>
+          page {page}
+          {hasNextPage ? '' : ' (last)'}
+          {' · '}
+          {rows.length} {rows.length === 1 ? 'row' : 'rows'} on page
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <label className='tf-text-secondary' style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+            show
+            <select
+              aria-label='Rows per page'
+              data-testid='page-size-select'
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value) as PageSize)}
+              className='tf-text'
+              style={{
+                background: 'transparent',
+                border: '1px solid var(--tf-border)',
+                borderRadius: 3,
+                padding: '2px 4px',
+                fontSize: '0.8rem',
+              }}
+            >
+              {PAGE_SIZE_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type='button'
+            aria-label='Previous page'
+            data-testid='prev-page-button'
+            onClick={onPrevPage}
+            disabled={page <= 1 || isFetching}
+            className='tf-status-info'
+            style={{
+              padding: '4px 10px',
+              borderRadius: 3,
+              fontSize: '0.8rem',
+              opacity: page <= 1 || isFetching ? 0.5 : 1,
+              cursor: page <= 1 || isFetching ? 'not-allowed' : 'pointer',
+            }}
+          >
+            ← Prev
+          </button>
+          <button
+            type='button'
+            aria-label='Next page'
+            data-testid='next-page-button'
+            onClick={onNextPage}
+            disabled={!hasNextPage || isFetching}
+            className='tf-status-info'
+            style={{
+              padding: '4px 10px',
+              borderRadius: 3,
+              fontSize: '0.8rem',
+              opacity: !hasNextPage || isFetching ? 0.5 : 1,
+              cursor: !hasNextPage || isFetching ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Next →
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/SyncQuarantinePage.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/SyncQuarantinePage.tsx
@@ -227,7 +227,7 @@ export default function SyncQuarantinePage(): React.ReactElement {
         </span>
       </div>
 
-      <QuarantineFilterBar value={filter} onChange={onFilterChange} disabled={query.isFetching} />
+      <QuarantineFilterBar value={filter} onChange={onFilterChange} />
 
       {selectedIds.size > 0 && (
         <div
@@ -326,23 +326,22 @@ export default function SyncQuarantinePage(): React.ReactElement {
         </p>
       )}
 
-      {(query.data || !query.isLoading) && (
-        <QuarantineTable
-          rows={visibleRows}
-          selectedIds={selectedIds}
-          onToggleRow={onToggleRow}
-          onToggleAll={onToggleAll}
-          onRouteRow={onRouteRow}
-          onDismissRow={onDismissRow}
-          page={page}
-          pageSize={pageSize}
-          hasNextPage={hasNextPage}
-          onPrevPage={() => setPage((p) => Math.max(1, p - 1))}
-          onNextPage={() => setPage((p) => p + 1)}
-          onPageSizeChange={onPageSizeChange}
-          isFetching={query.isFetching}
-        />
-      )}
+      {/* table renders unconditionally so pagination + empty states stay visible during loading + refetch */}
+      <QuarantineTable
+        rows={visibleRows}
+        selectedIds={selectedIds}
+        onToggleRow={onToggleRow}
+        onToggleAll={onToggleAll}
+        onRouteRow={onRouteRow}
+        onDismissRow={onDismissRow}
+        page={page}
+        pageSize={pageSize}
+        hasNextPage={hasNextPage}
+        onPrevPage={() => setPage((p) => Math.max(1, p - 1))}
+        onNextPage={() => setPage((p) => p + 1)}
+        onPageSizeChange={onPageSizeChange}
+        isFetching={query.isFetching}
+      />
 
       <QuarantineRouteModal
         open={routeTargetIds !== null}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/SyncQuarantinePage.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/SyncQuarantinePage.tsx
@@ -1,0 +1,422 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * SYNC-UX-1A: SYNC QUARANTINE TRIAGE PAGE
+ *
+ * Operator triage surface for the imprv_attr quarantine cohort.
+ * Sibling to /workbench/sync-doctrine (read-only status board);
+ * this surface is read-write and lives at /workbench/sync/quarantine.
+ *
+ * Renders:
+ *   - Header + count badge (rows visible vs total page)
+ *   - Sticky filter bar (reason, universe, propId, status)
+ *   - Paged quarantine table with Route / Dismiss per-row + bulk
+ *   - Route + Dismiss modals (single + bulk)
+ *   - Manual refresh button (TanStack Query staleTime=30s,
+ *     refetchOnWindowFocus=true)
+ *
+ * Spec discipline (matches SyncDoctrineConsole):
+ *   - tf-* utility classes only
+ *   - tf-status-success / -warning / -error / -info for verdicts
+ *   - one screen, one filter bar, modals only on operator-initiated
+ *     decisions
+ *   - tabular-nums for counts
+ *
+ * Decisions are doctrine-immutable on the source quarantine row;
+ * the page only writes the sibling triage table via the
+ * SYNC-WORKBENCH-F controller.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  QuarantineApiError,
+  type QuarantineRowResponse,
+  type TriageStatus,
+} from '@/api/syncQuarantine';
+import QuarantineFilterBar, { type QuarantineFilterValue } from './QuarantineFilterBar';
+import QuarantineTable, { type PageSize } from './QuarantineTable';
+import QuarantineRouteModal from './QuarantineRouteModal';
+import QuarantineDismissModal from './QuarantineDismissModal';
+import { useQuarantineList } from './useQuarantineList';
+
+type ToastKind = 'info' | 'success' | 'warning' | 'error';
+interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+const DEFAULT_FILTER: QuarantineFilterValue = {
+  reason: '',
+  universe: '',
+  propId: null,
+  status: 'Open',
+};
+
+export default function SyncQuarantinePage(): React.ReactElement {
+  const [filter, setFilter] = useState<QuarantineFilterValue>(DEFAULT_FILTER);
+  const [pageSize, setPageSize] = useState<PageSize>(100);
+  const [page, setPage] = useState<number>(1); // 1-based
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const [routeTargetIds, setRouteTargetIds] = useState<readonly string[] | null>(null);
+  const [routeContextLabel, setRouteContextLabel] = useState<string | undefined>(undefined);
+  const [dismissTargetIds, setDismissTargetIds] = useState<readonly string[] | null>(null);
+  const [dismissContextLabel, setDismissContextLabel] = useState<string | undefined>(undefined);
+
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const offset = (page - 1) * pageSize;
+  const query = useQuarantineList({
+    reason: filter.reason,
+    universe: filter.universe,
+    propId: filter.propId,
+    limit: pageSize,
+    offset,
+  });
+
+  // Reset pagination + selection when filters or page-size change.
+  // We deliberately leave selection intact across server refetches so
+  // the operator can refresh the list without losing their queue.
+  const onFilterChange = useCallback((next: QuarantineFilterValue) => {
+    setFilter(next);
+    setPage(1);
+  }, []);
+
+  const onPageSizeChange = useCallback((next: PageSize) => {
+    setPageSize(next);
+    setPage(1);
+  }, []);
+
+  // Apply the client-side status filter over the fetched page. This
+  // is intentional: server today filters only by reason/universe/propId.
+  const visibleRows: QuarantineRowResponse[] = useMemo(() => {
+    const items = query.data?.items ?? [];
+    if (filter.status === 'All') return items;
+    return items.filter((r) => normalizeStatus(r.triageStatus) === filter.status);
+  }, [query.data, filter.status]);
+
+  const hasNextPage = (query.data?.items.length ?? 0) >= pageSize;
+
+  const onToggleRow = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const onToggleAll = useCallback(
+    (checked: boolean) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (checked) {
+          for (const r of visibleRows) next.add(r.unprovenRowId);
+        } else {
+          for (const r of visibleRows) next.delete(r.unprovenRowId);
+        }
+        return next;
+      });
+    },
+    [visibleRows],
+  );
+
+  const pushToast = useCallback((kind: ToastKind, message: string) => {
+    const id = Date.now() + Math.random();
+    setToasts((t) => [...t, { id, kind, message }]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((x) => x.id !== id));
+    }, 6000);
+  }, []);
+
+  const handleQueryError = useCallback(() => {
+    if (!query.error) return;
+    const e = query.error as Error | QuarantineApiError;
+    if (e instanceof QuarantineApiError && e.status === 404) {
+      pushToast('warning', 'Row not found, refreshing list…');
+      void query.refetch();
+    } else {
+      pushToast('error', `Failed to load quarantine list: ${e.message}`);
+    }
+  }, [query, pushToast]);
+
+  React.useEffect(() => {
+    if (query.isError) handleQueryError();
+    // intentional: only run when the error toggles
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.isError]);
+
+  const onRouteRow = useCallback((row: QuarantineRowResponse) => {
+    setRouteTargetIds([row.unprovenRowId]);
+    setRouteContextLabel(`PropId ${row.propId} · imprv ${row.imprvId}/${row.imprvDetId} · ${row.iAttrValCd}`);
+  }, []);
+
+  const onDismissRow = useCallback((row: QuarantineRowResponse) => {
+    setDismissTargetIds([row.unprovenRowId]);
+    setDismissContextLabel(`PropId ${row.propId} · imprv ${row.imprvId}/${row.imprvDetId} · ${row.iAttrValCd}`);
+  }, []);
+
+  const onBulkRoute = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    setRouteTargetIds([...selectedIds]);
+    setRouteContextLabel(`${selectedIds.size} selected rows`);
+  }, [selectedIds]);
+
+  const onBulkDismiss = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    setDismissTargetIds([...selectedIds]);
+    setDismissContextLabel(`${selectedIds.size} selected rows`);
+  }, [selectedIds]);
+
+  const onModalSubmitted = useCallback(() => {
+    setSelectedIds(new Set());
+    pushToast('success', 'Decision recorded.');
+  }, [pushToast]);
+
+  const totalOnPage = query.data?.items.length ?? 0;
+
+  return (
+    <main
+      className='p-6'
+      aria-label='Sync Quarantine Triage'
+      data-testid='sync-quarantine-page'
+      data-state={query.isFetching ? 'refreshing' : query.isError ? 'error' : 'loaded'}
+    >
+      <header className='mb-4'>
+        <h1 className='tf-text font-semibold' style={{ fontSize: '1.4rem' }}>
+          TerraFusion · Workbench · Improvement-Attr Quarantine
+        </h1>
+        <p className='tf-text-secondary' style={{ fontSize: '0.9rem' }}>
+          Triage imprv_attr quarantine cohort: route to a target universe / dictionary
+          code, or dismiss as noise / legitimate-missing / conversion artifact. Decisions
+          are recorded on the sibling triage table; the doctrine quarantine row is never
+          mutated.{' '}
+          <span className='tf-text' data-testid='count-badge'>
+            {visibleRows.length}
+          </span>{' '}
+          shown
+          {filter.status !== 'All' ? ` (status=${filter.status})` : ''} · {totalOnPage} fetched on page
+        </p>
+      </header>
+
+      <div className='flex items-center gap-4 my-4' style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <button
+          type='button'
+          aria-label='Refresh quarantine list'
+          data-testid='refresh-button'
+          className='tf-status-info'
+          style={{
+            padding: '6px 12px',
+            borderRadius: 3,
+            fontWeight: 600,
+            fontSize: '0.85rem',
+            opacity: query.isFetching ? 0.6 : 1,
+            cursor: query.isFetching ? 'not-allowed' : 'pointer',
+          }}
+          disabled={query.isFetching}
+          onClick={() => void query.refetch()}
+        >
+          {query.isFetching ? 'Refreshing…' : 'Refresh'}
+        </button>
+        <span className='tf-text-secondary' style={{ fontSize: '0.85rem' }}>
+          {query.dataUpdatedAt
+            ? `last refresh: ${new Date(query.dataUpdatedAt).toLocaleTimeString()}`
+            : 'no fetch yet'}
+          {' · staleTime 30s · refetch on window focus'}
+        </span>
+      </div>
+
+      <QuarantineFilterBar value={filter} onChange={onFilterChange} disabled={query.isFetching} />
+
+      {selectedIds.size > 0 && (
+        <div
+          data-testid='bulk-actions-bar'
+          className='tf-panel p-2 mt-4'
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+            padding: '8px 12px',
+            border: '1px solid var(--tf-border)',
+            borderRadius: 3,
+          }}
+        >
+          <span className='tf-text-secondary' style={{ fontSize: '0.85rem' }}>
+            <strong className='tf-text'>{selectedIds.size}</strong> rows selected
+            <button
+              type='button'
+              aria-label='Clear selection'
+              data-testid='bulk-clear-selection'
+              onClick={() => setSelectedIds(new Set())}
+              className='tf-text-secondary'
+              style={{
+                marginLeft: 8,
+                padding: '2px 6px',
+                background: 'transparent',
+                border: '1px solid var(--tf-border)',
+                borderRadius: 3,
+                fontSize: '0.75rem',
+                cursor: 'pointer',
+              }}
+            >
+              clear
+            </button>
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              type='button'
+              aria-label='Bulk route selected rows'
+              data-testid='bulk-route-button'
+              onClick={onBulkRoute}
+              className='tf-status-success'
+              style={{
+                padding: '4px 10px',
+                borderRadius: 3,
+                fontSize: '0.8rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Bulk Route
+            </button>
+            <button
+              type='button'
+              aria-label='Bulk dismiss selected rows'
+              data-testid='bulk-dismiss-button'
+              onClick={onBulkDismiss}
+              className='tf-status-warning'
+              style={{
+                padding: '4px 10px',
+                borderRadius: 3,
+                fontSize: '0.8rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Bulk Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {query.isLoading && !query.data && (
+        <p className='tf-text-secondary' data-testid='quarantine-loading' style={{ marginTop: 12 }}>
+          Loading quarantine rows…
+        </p>
+      )}
+
+      {query.isError && (
+        <p
+          className='tf-status-error p-3 rounded'
+          data-testid='quarantine-error'
+          style={{ marginTop: 12, padding: 12, borderRadius: 3 }}
+        >
+          Failed to load quarantine list.{' '}
+          <button
+            type='button'
+            data-testid='quarantine-error-retry'
+            onClick={() => void query.refetch()}
+            className='tf-status-info'
+            style={{ padding: '2px 8px', borderRadius: 3, marginLeft: 8, cursor: 'pointer' }}
+          >
+            Retry
+          </button>
+        </p>
+      )}
+
+      {(query.data || !query.isLoading) && (
+        <QuarantineTable
+          rows={visibleRows}
+          selectedIds={selectedIds}
+          onToggleRow={onToggleRow}
+          onToggleAll={onToggleAll}
+          onRouteRow={onRouteRow}
+          onDismissRow={onDismissRow}
+          page={page}
+          pageSize={pageSize}
+          hasNextPage={hasNextPage}
+          onPrevPage={() => setPage((p) => Math.max(1, p - 1))}
+          onNextPage={() => setPage((p) => p + 1)}
+          onPageSizeChange={onPageSizeChange}
+          isFetching={query.isFetching}
+        />
+      )}
+
+      <QuarantineRouteModal
+        open={routeTargetIds !== null}
+        rowIds={routeTargetIds ?? []}
+        contextLabel={routeContextLabel}
+        onClose={() => {
+          setRouteTargetIds(null);
+          setRouteContextLabel(undefined);
+        }}
+        onSubmitted={onModalSubmitted}
+      />
+
+      <QuarantineDismissModal
+        open={dismissTargetIds !== null}
+        rowIds={dismissTargetIds ?? []}
+        contextLabel={dismissContextLabel}
+        onClose={() => {
+          setDismissTargetIds(null);
+          setDismissContextLabel(undefined);
+        }}
+        onSubmitted={onModalSubmitted}
+      />
+
+      {toasts.length > 0 && (
+        <div
+          data-testid='toast-container'
+          aria-live='polite'
+          style={{
+            position: 'fixed',
+            right: 16,
+            bottom: 16,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 6,
+            zIndex: 60,
+            maxWidth: 380,
+          }}
+        >
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              data-testid={`toast-${t.kind}`}
+              className={`tf-status-${toastClassSuffix(t.kind)}`}
+              style={{
+                padding: '8px 12px',
+                borderRadius: 3,
+                fontSize: '0.85rem',
+                boxShadow: '0 2px 8px rgba(0,0,0,0.4)',
+              }}
+            >
+              {t.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function normalizeStatus(raw: string): TriageStatus {
+  if (raw === 'Routed' || raw === 'Dismissed' || raw === 'Open') return raw;
+  return 'Open';
+}
+
+function toastClassSuffix(kind: ToastKind): string {
+  switch (kind) {
+    case 'success':
+      return 'success';
+    case 'warning':
+      return 'warning';
+    case 'error':
+      return 'error';
+    case 'info':
+    default:
+      return 'info';
+  }
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/QuarantineRouteModal.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/QuarantineRouteModal.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * SYNC-UX-1A: QuarantineRouteModal unit tests.
+ *
+ * Locks down: hidden when closed, shown when open, calls onClose
+ * for cancel, validates required universe, triggers the bulk route
+ * API call on submit with the right payload, surfaces 409 conflicts
+ * without closing.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+
+import QuarantineRouteModal from '../QuarantineRouteModal';
+import { QuarantineApiError } from '@/api/syncQuarantine';
+
+vi.mock('@/api/syncQuarantine', async () => {
+  const actual = await vi.importActual<typeof import('@/api/syncQuarantine')>(
+    '@/api/syncQuarantine',
+  );
+  return {
+    ...actual,
+    bulkRouteQuarantineImprvAttr: vi.fn(),
+  };
+});
+
+import { bulkRouteQuarantineImprvAttr } from '@/api/syncQuarantine';
+
+const ROW_ID_1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ROW_ID_2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function renderModal(props: Partial<React.ComponentProps<typeof QuarantineRouteModal>>) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const onClose = vi.fn();
+  const onSubmitted = vi.fn();
+  render(
+    <QueryClientProvider client={qc}>
+      <QuarantineRouteModal
+        open
+        rowIds={[ROW_ID_1]}
+        onClose={onClose}
+        onSubmitted={onSubmitted}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+  return { onClose, onSubmitted, qc };
+}
+
+beforeEach(() => {
+  vi.mocked(bulkRouteQuarantineImprvAttr).mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('QuarantineRouteModal', () => {
+  it('renders when open=true', () => {
+    renderModal({});
+    expect(screen.getByTestId('route-modal')).toBeInTheDocument();
+  });
+
+  it('returns null when open=false', () => {
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <QuarantineRouteModal
+          open={false}
+          rowIds={[]}
+          onClose={vi.fn()}
+          onSubmitted={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByTestId('route-modal')).not.toBeInTheDocument();
+  });
+
+  it('cancel button calls onClose', async () => {
+    const { onClose } = renderModal({});
+    await userEvent.click(screen.getByTestId('route-cancel-button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('validates that target universe is required', async () => {
+    renderModal({});
+    await userEvent.click(screen.getByTestId('route-submit-button'));
+    expect(await screen.findByTestId('route-validation-error')).toBeInTheDocument();
+    expect(vi.mocked(bulkRouteQuarantineImprvAttr)).not.toHaveBeenCalled();
+  });
+
+  it('submits the bulk route call with the form payload and closes on success', async () => {
+    vi.mocked(bulkRouteQuarantineImprvAttr).mockResolvedValueOnce([
+      {
+        unprovenRowId: ROW_ID_1,
+        status: 'ok',
+        payload: {
+          triageId: 't',
+          unprovenRowId: ROW_ID_1,
+          status: 'Routed',
+          routedToUniverse: 'REAL_COMMERCIAL',
+          routedToIAttrValCd: null,
+          updatedAt: 'now',
+        },
+      },
+    ]);
+    const { onClose, onSubmitted } = renderModal({});
+
+    const modal = screen.getByTestId('route-modal');
+    await userEvent.selectOptions(
+      within(modal).getByTestId('route-target-universe'),
+      'REAL_COMMERCIAL',
+    );
+    await userEvent.type(within(modal).getByTestId('route-target-code'), 'CMRC-METAL');
+    await userEvent.type(within(modal).getByTestId('route-operator-note'), 'audit note');
+    await userEvent.click(within(modal).getByTestId('route-submit-button'));
+
+    await waitFor(() => expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalledWith(
+      [ROW_ID_1],
+      {
+        TargetUniverse: 'REAL_COMMERCIAL',
+        TargetIAttrValCd: 'CMRC-METAL',
+        OperatorNote: 'audit note',
+      },
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onSubmitted).toHaveBeenCalled();
+  });
+
+  it('keeps modal open and shows error summary on 409', async () => {
+    vi.mocked(bulkRouteQuarantineImprvAttr).mockResolvedValueOnce([
+      {
+        unprovenRowId: ROW_ID_1,
+        status: 'error',
+        error: new QuarantineApiError(409, 'Conflict', { error: 'differs' }),
+      },
+    ]);
+    const { onClose, onSubmitted } = renderModal({});
+
+    const modal = screen.getByTestId('route-modal');
+    await userEvent.selectOptions(
+      within(modal).getByTestId('route-target-universe'),
+      'REAL_RESIDENTIAL',
+    );
+    await userEvent.click(within(modal).getByTestId('route-submit-button'));
+
+    await waitFor(() => expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalled());
+    expect(await within(modal).findByTestId('route-error-summary')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('supports bulk submission with multiple ids', async () => {
+    vi.mocked(bulkRouteQuarantineImprvAttr).mockResolvedValueOnce([
+      {
+        unprovenRowId: ROW_ID_1,
+        status: 'ok',
+        payload: {
+          triageId: 't1',
+          unprovenRowId: ROW_ID_1,
+          status: 'Routed',
+          routedToUniverse: 'REAL_RESIDENTIAL',
+          routedToIAttrValCd: null,
+          updatedAt: 'now',
+        },
+      },
+      {
+        unprovenRowId: ROW_ID_2,
+        status: 'ok',
+        payload: {
+          triageId: 't2',
+          unprovenRowId: ROW_ID_2,
+          status: 'Routed',
+          routedToUniverse: 'REAL_RESIDENTIAL',
+          routedToIAttrValCd: null,
+          updatedAt: 'now',
+        },
+      },
+    ]);
+    renderModal({ rowIds: [ROW_ID_1, ROW_ID_2] });
+
+    expect(screen.getByText(/Route 2 quarantine rows/i)).toBeInTheDocument();
+    await userEvent.selectOptions(
+      screen.getByTestId('route-target-universe'),
+      'REAL_RESIDENTIAL',
+    );
+    await userEvent.click(screen.getByTestId('route-submit-button'));
+
+    await waitFor(() =>
+      expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalledWith(
+        [ROW_ID_1, ROW_ID_2],
+        expect.objectContaining({ TargetUniverse: 'REAL_RESIDENTIAL' }),
+      ),
+    );
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/QuarantineTable.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/QuarantineTable.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * SYNC-UX-1A: QuarantineTable unit tests.
+ *
+ * Renders the table in isolation (no QueryClient / Router), with
+ * controlled props, to lock down: the empty state, the row layout,
+ * the multi-select header behavior, and pagination button gating.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import QuarantineTable, { type PageSize } from '../QuarantineTable';
+import type { QuarantineRowResponse } from '@/api/syncQuarantine';
+
+const ROW_1 = '11111111-1111-1111-1111-111111111111';
+const ROW_2 = '22222222-2222-2222-2222-222222222222';
+
+function makeRow(overrides: Partial<QuarantineRowResponse> = {}): QuarantineRowResponse {
+  return {
+    unprovenRowId: ROW_1,
+    propId: 12345,
+    propValYr: 2026,
+    supNum: 0,
+    imprvId: 999_111,
+    imprvDetId: 999_222,
+    iAttrValId: 31,
+    iAttrValCd: 'WD-FRAME',
+    attrValueText: 'Wood Frame',
+    attrValueNumeric: null,
+    quarantineReason: 'UNKNOWN_FOR_UNIVERSE_DICTIONARY',
+    quarantineReasonDetail: 'No dictionary entry for REAL_RESIDENTIAL',
+    universeCode: 'REAL_RESIDENTIAL',
+    createdAt: '2026-05-07T12:00:00Z',
+    triageStatus: 'Open',
+    suggestedReroute: 'WOOD_FRAME',
+    ...overrides,
+  };
+}
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof QuarantineTable>> = {}) {
+  return {
+    rows: [],
+    selectedIds: new Set<string>(),
+    onToggleRow: vi.fn(),
+    onToggleAll: vi.fn(),
+    onRouteRow: vi.fn(),
+    onDismissRow: vi.fn(),
+    page: 1,
+    pageSize: 100 as PageSize,
+    hasNextPage: false,
+    onPrevPage: vi.fn(),
+    onNextPage: vi.fn(),
+    onPageSizeChange: vi.fn(),
+    isFetching: false,
+    ...overrides,
+  };
+}
+
+describe('QuarantineTable', () => {
+  it('renders the empty state when no rows', () => {
+    render(<QuarantineTable {...makeProps({ rows: [] })} />);
+    expect(screen.getByTestId('quarantine-empty')).toBeInTheDocument();
+  });
+
+  it('disables prev on the first page and next when hasNextPage=false', () => {
+    render(<QuarantineTable {...makeProps({ page: 1, hasNextPage: false })} />);
+    expect(screen.getByTestId('prev-page-button')).toBeDisabled();
+    expect(screen.getByTestId('next-page-button')).toBeDisabled();
+  });
+
+  it('enables next when hasNextPage=true', () => {
+    render(<QuarantineTable {...makeProps({ rows: [makeRow()], hasNextPage: true })} />);
+    expect(screen.getByTestId('next-page-button')).toBeEnabled();
+  });
+
+  it('toggle-all checkbox calls onToggleAll(true)', async () => {
+    const onToggleAll = vi.fn();
+    render(
+      <QuarantineTable
+        {...makeProps({
+          rows: [makeRow(), makeRow({ unprovenRowId: ROW_2, propId: 200 })],
+          onToggleAll,
+        })}
+      />,
+    );
+    await userEvent.click(screen.getByTestId('select-all-checkbox'));
+    expect(onToggleAll).toHaveBeenCalledWith(true);
+  });
+
+  it('per-row Route + Dismiss buttons fire callbacks with the row payload', async () => {
+    const onRouteRow = vi.fn();
+    const onDismissRow = vi.fn();
+    const row = makeRow();
+    render(
+      <QuarantineTable
+        {...makeProps({ rows: [row], onRouteRow, onDismissRow })}
+      />,
+    );
+    const rowEl = screen.getByTestId('quarantine-row');
+    await userEvent.click(within(rowEl).getByTestId('row-route-button'));
+    expect(onRouteRow).toHaveBeenCalledWith(row);
+    await userEvent.click(within(rowEl).getByTestId('row-dismiss-button'));
+    expect(onDismissRow).toHaveBeenCalledWith(row);
+  });
+
+  it('renders triage badges with the right tf-status-* class per status', () => {
+    render(
+      <QuarantineTable
+        {...makeProps({
+          rows: [
+            makeRow({ unprovenRowId: ROW_1, triageStatus: 'Open' }),
+            makeRow({ unprovenRowId: ROW_2, triageStatus: 'Routed', propId: 2 }),
+            makeRow({
+              unprovenRowId: '33333333-3333-3333-3333-333333333333',
+              triageStatus: 'Dismissed',
+              propId: 3,
+            }),
+          ],
+        })}
+      />,
+    );
+    const badges = screen.getAllByTestId('triage-badge');
+    expect(badges[0]).toHaveClass('tf-status-info');
+    expect(badges[1]).toHaveClass('tf-status-success');
+    expect(badges[2]).toHaveClass('tf-status-warning');
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/SyncQuarantinePage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/SyncQuarantinePage.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * SYNC-UX-1A: SyncQuarantinePage acceptance tests.
+ *
+ * Mirrors the sync-readiness console test pattern: vi.mock the API
+ * client, render the page in a MemoryRouter + QueryClientProvider,
+ * exercise the operator surface end-to-end via @testing-library.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import SyncQuarantinePage from '../SyncQuarantinePage';
+import {
+  QuarantineApiError,
+  type QuarantineListResponse,
+  type QuarantineRowResponse,
+} from '@/api/syncQuarantine';
+
+// ───────────────────────────────────────────────────────────────
+// Mock the API client. We do NOT mock useQuarantineList directly —
+// we want the real TanStack Query layer in tests.
+// ───────────────────────────────────────────────────────────────
+
+vi.mock('@/api/syncQuarantine', async () => {
+  const actual = await vi.importActual<typeof import('@/api/syncQuarantine')>(
+    '@/api/syncQuarantine',
+  );
+  return {
+    ...actual,
+    listQuarantineImprvAttr: vi.fn(),
+    routeQuarantineImprvAttr: vi.fn(),
+    dismissQuarantineImprvAttr: vi.fn(),
+    bulkRouteQuarantineImprvAttr: vi.fn(),
+    bulkDismissQuarantineImprvAttr: vi.fn(),
+  };
+});
+
+import {
+  bulkDismissQuarantineImprvAttr,
+  bulkRouteQuarantineImprvAttr,
+  listQuarantineImprvAttr,
+} from '@/api/syncQuarantine';
+
+const ROW_ID_1 = '11111111-1111-1111-1111-111111111111';
+const ROW_ID_2 = '22222222-2222-2222-2222-222222222222';
+const ROW_ID_3 = '33333333-3333-3333-3333-333333333333';
+
+function makeRow(overrides: Partial<QuarantineRowResponse> = {}): QuarantineRowResponse {
+  return {
+    unprovenRowId: ROW_ID_1,
+    propId: 12345,
+    propValYr: 2026,
+    supNum: 0,
+    imprvId: 999_111,
+    imprvDetId: 999_222,
+    iAttrValId: 31,
+    iAttrValCd: 'WD-FRAME',
+    attrValueText: 'Wood Frame',
+    attrValueNumeric: null,
+    quarantineReason: 'UNKNOWN_FOR_UNIVERSE_DICTIONARY',
+    quarantineReasonDetail: 'No dictionary entry for REAL_RESIDENTIAL',
+    universeCode: 'REAL_RESIDENTIAL',
+    createdAt: '2026-05-07T12:00:00Z',
+    triageStatus: 'Open',
+    suggestedReroute: null,
+    ...overrides,
+  };
+}
+
+function makeList(rows: QuarantineRowResponse[], limit = 100, offset = 0): QuarantineListResponse {
+  return { count: rows.length, limit, offset, items: rows };
+}
+
+function renderPage(): { qc: QueryClient } {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
+    },
+  });
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/workbench/sync/quarantine']}>
+        <SyncQuarantinePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { qc };
+}
+
+beforeEach(() => {
+  vi.mocked(listQuarantineImprvAttr).mockReset();
+  vi.mocked(bulkRouteQuarantineImprvAttr).mockReset();
+  vi.mocked(bulkDismissQuarantineImprvAttr).mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SyncQuarantinePage', () => {
+  it('renders an empty state when no rows match', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValueOnce(makeList([]));
+    renderPage();
+
+    expect(await screen.findByTestId('sync-quarantine-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('quarantine-empty')).toBeInTheDocument();
+    expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100, offset: 0 }),
+      expect.anything(),
+    );
+  });
+
+  it('renders a paged list with status badges', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValueOnce(
+      makeList([
+        makeRow({ unprovenRowId: ROW_ID_1, triageStatus: 'Open', propId: 100 }),
+        makeRow({ unprovenRowId: ROW_ID_2, triageStatus: 'Open', propId: 200 }),
+        makeRow({ unprovenRowId: ROW_ID_3, triageStatus: 'Open', propId: 300 }),
+      ]),
+    );
+    renderPage();
+
+    const rows = await screen.findAllByTestId('quarantine-row');
+    expect(rows).toHaveLength(3);
+    const badges = await screen.findAllByTestId('triage-badge');
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveClass('tf-status-info'); // Open
+  });
+
+  it('refetches when filter changes', async () => {
+    vi.mocked(listQuarantineImprvAttr)
+      .mockResolvedValueOnce(makeList([makeRow({ propId: 100 })]))
+      .mockResolvedValueOnce(makeList([makeRow({ propId: 200, unprovenRowId: ROW_ID_2 })]));
+
+    renderPage();
+    await screen.findByTestId('quarantine-row');
+    expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledTimes(1);
+
+    await userEvent.selectOptions(screen.getByTestId('filter-reason'), 'UNKNOWN_UNIVERSE');
+
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'UNKNOWN_UNIVERSE' }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('shows bulk-actions bar when rows are selected', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValueOnce(
+      makeList([
+        makeRow({ unprovenRowId: ROW_ID_1 }),
+        makeRow({ unprovenRowId: ROW_ID_2, propId: 200 }),
+      ]),
+    );
+    renderPage();
+
+    const rowCheckboxes = await screen.findAllByTestId('row-checkbox');
+    expect(rowCheckboxes).toHaveLength(2);
+
+    expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument();
+    await userEvent.click(rowCheckboxes[0]!);
+    expect(await screen.findByTestId('bulk-actions-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('bulk-route-button')).toBeInTheDocument();
+    expect(screen.getByTestId('bulk-dismiss-button')).toBeInTheDocument();
+  });
+
+  it('manual refresh fires a refetch', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    renderPage();
+
+    await screen.findByTestId('quarantine-row');
+    expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByTestId('refresh-button'));
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('opens route modal when row Route button is clicked, validates required universe', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValueOnce(makeList([makeRow()]));
+    renderPage();
+
+    const routeBtns = await screen.findAllByTestId('row-route-button');
+    await userEvent.click(routeBtns[0]!);
+
+    const modal = await screen.findByTestId('route-modal');
+    expect(modal).toBeInTheDocument();
+
+    // Submit without selecting a universe → validation error.
+    await userEvent.click(within(modal).getByTestId('route-submit-button'));
+    expect(await within(modal).findByTestId('route-validation-error')).toBeInTheDocument();
+    expect(vi.mocked(bulkRouteQuarantineImprvAttr)).not.toHaveBeenCalled();
+  });
+
+  it('submits a route decision, closes modal, and refetches the list', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    vi.mocked(bulkRouteQuarantineImprvAttr).mockResolvedValueOnce([
+      {
+        unprovenRowId: ROW_ID_1,
+        status: 'ok',
+        payload: {
+          triageId: 'tid-1',
+          unprovenRowId: ROW_ID_1,
+          status: 'Routed',
+          routedToUniverse: 'REAL_RESIDENTIAL',
+          routedToIAttrValCd: 'WD-FRAME',
+          updatedAt: '2026-05-07T13:00:00Z',
+        },
+      },
+    ]);
+
+    renderPage();
+    const routeBtns = await screen.findAllByTestId('row-route-button');
+    await userEvent.click(routeBtns[0]!);
+
+    const modal = await screen.findByTestId('route-modal');
+    await userEvent.selectOptions(
+      within(modal).getByTestId('route-target-universe'),
+      'REAL_RESIDENTIAL',
+    );
+    await userEvent.click(within(modal).getByTestId('route-submit-button'));
+
+    await waitFor(() => expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalledWith(
+      [ROW_ID_1],
+      expect.objectContaining({ TargetUniverse: 'REAL_RESIDENTIAL' }),
+    );
+    await waitFor(() => expect(screen.queryByTestId('route-modal')).not.toBeInTheDocument());
+    expect(await screen.findByTestId('toast-success')).toBeInTheDocument();
+  });
+
+  it('keeps modal open and shows error summary on 409 conflict', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    const conflict = new QuarantineApiError(409, 'Conflict', {
+      error: 'Decision already exists with different target',
+    });
+    vi.mocked(bulkRouteQuarantineImprvAttr).mockResolvedValueOnce([
+      { unprovenRowId: ROW_ID_1, status: 'error', error: conflict },
+    ]);
+
+    renderPage();
+    await userEvent.click((await screen.findAllByTestId('row-route-button'))[0]!);
+    const modal = await screen.findByTestId('route-modal');
+    await userEvent.selectOptions(
+      within(modal).getByTestId('route-target-universe'),
+      'REAL_RESIDENTIAL',
+    );
+    await userEvent.click(within(modal).getByTestId('route-submit-button'));
+
+    await waitFor(() => expect(vi.mocked(bulkRouteQuarantineImprvAttr)).toHaveBeenCalled());
+    // Modal stays open with the per-row error visible.
+    expect(await within(modal).findByTestId('route-error-summary')).toBeInTheDocument();
+    expect(within(modal).getByTestId('route-error-summary').textContent).toMatch(/conflict/i);
+    expect(screen.getByTestId('route-modal')).toBeInTheDocument();
+  });
+
+  it('dismiss modal validates a required reason', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValueOnce(makeList([makeRow()]));
+    renderPage();
+
+    const dismissBtns = await screen.findAllByTestId('row-dismiss-button');
+    await userEvent.click(dismissBtns[0]!);
+
+    const modal = await screen.findByTestId('dismiss-modal');
+    await userEvent.click(within(modal).getByTestId('dismiss-submit-button'));
+    expect(await within(modal).findByTestId('dismiss-validation-error')).toBeInTheDocument();
+    expect(vi.mocked(bulkDismissQuarantineImprvAttr)).not.toHaveBeenCalled();
+  });
+
+  it('submits a dismiss decision and closes the modal', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    vi.mocked(bulkDismissQuarantineImprvAttr).mockResolvedValueOnce([
+      {
+        unprovenRowId: ROW_ID_1,
+        status: 'ok',
+        payload: {
+          triageId: 'tid-1',
+          unprovenRowId: ROW_ID_1,
+          status: 'Dismissed',
+          dismissalReason: 'IntentionalNoise',
+          updatedAt: '2026-05-07T13:00:00Z',
+        },
+      },
+    ]);
+
+    renderPage();
+    await userEvent.click((await screen.findAllByTestId('row-dismiss-button'))[0]!);
+    const modal = await screen.findByTestId('dismiss-modal');
+    await userEvent.selectOptions(
+      within(modal).getByTestId('dismiss-reason'),
+      'IntentionalNoise',
+    );
+    await userEvent.click(within(modal).getByTestId('dismiss-submit-button'));
+
+    await waitFor(() => expect(vi.mocked(bulkDismissQuarantineImprvAttr)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(bulkDismissQuarantineImprvAttr)).toHaveBeenCalledWith(
+      [ROW_ID_1],
+      expect.objectContaining({ DismissalReason: 'IntentionalNoise' }),
+    );
+    await waitFor(() => expect(screen.queryByTestId('dismiss-modal')).not.toBeInTheDocument());
+  });
+
+  it('paginates next/prev', async () => {
+    // Page 1 returns full pageSize -> hasNextPage true.
+    vi.mocked(listQuarantineImprvAttr).mockImplementation(async (params) => {
+      const offset = params.offset ?? 0;
+      if (offset === 0) {
+        return makeList(
+          Array.from({ length: 100 }, (_, i) =>
+            makeRow({ unprovenRowId: `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`, propId: 1000 + i }),
+          ),
+          100,
+          0,
+        );
+      }
+      return makeList(
+        [makeRow({ unprovenRowId: ROW_ID_3, propId: 9001 })],
+        100,
+        100,
+      );
+    });
+
+    renderPage();
+    await screen.findAllByTestId('quarantine-row');
+
+    const nextBtn = screen.getByTestId('next-page-button');
+    expect(nextBtn).toBeEnabled();
+    await userEvent.click(nextBtn);
+
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+        expect.objectContaining({ offset: 100 }),
+        expect.anything(),
+      ),
+    );
+
+    expect(screen.getByTestId('page-indicator').textContent).toMatch(/page 2/);
+  });
+
+  it('changes page size via the selector and resets to page 1', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    renderPage();
+    await screen.findByTestId('quarantine-row');
+
+    const sel = screen.getByTestId('page-size-select');
+    await userEvent.selectOptions(sel, '50');
+
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, offset: 0 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('shows error state with retry on network failure', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockRejectedValueOnce(new Error('boom'));
+    renderPage();
+
+    expect(await screen.findByTestId('quarantine-error')).toBeInTheDocument();
+    expect(screen.getByTestId('quarantine-error-retry')).toBeEnabled();
+  });
+
+  it('clears propId via the X button', async () => {
+    vi.mocked(listQuarantineImprvAttr).mockResolvedValue(makeList([makeRow()]));
+    renderPage();
+    await screen.findByTestId('quarantine-row');
+
+    const propIdInput = screen.getByTestId('filter-propid');
+    await userEvent.type(propIdInput, '12345');
+
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+        expect.objectContaining({ propId: 12345 }),
+        expect.anything(),
+      ),
+    );
+
+    const clearBtn = await screen.findByTestId('filter-propid-clear');
+    await userEvent.click(clearBtn);
+
+    await waitFor(() =>
+      expect(vi.mocked(listQuarantineImprvAttr)).toHaveBeenCalledWith(
+        expect.objectContaining({ propId: null }),
+        expect.anything(),
+      ),
+    );
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineList.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineList.ts
@@ -1,0 +1,51 @@
+/**
+ * SYNC-UX-1A: TanStack Query hook for the imprv-attr quarantine page.
+ *
+ * Mirrors useDoctrineState's polling shape. The list endpoint reads
+ * doctrine quarantine rows joined with the optional triage decision
+ * table; both are TerraFusion DB reads, so 30s staleTime + window-
+ * focus refetch matches the operator's "have I missed anything?"
+ * mental model without hammering the server.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  listQuarantineImprvAttr,
+  type QuarantineListParams,
+  type QuarantineListResponse,
+} from '@/api/syncQuarantine';
+
+export const QUARANTINE_LIST_STALE_MS = 30_000;
+
+export function useQuarantineList(
+  params: QuarantineListParams,
+): UseQueryResult<QuarantineListResponse, Error> {
+  // Only the server-side filters belong in the queryKey. The
+  // client-only `status` filter is applied over the fetched rows
+  // by the page; including it here would cause a needless refetch.
+  const serverKey = {
+    reason: params.reason ?? '',
+    universe: params.universe ?? '',
+    propId: params.propId ?? null,
+    limit: params.limit ?? 100,
+    offset: params.offset ?? 0,
+  };
+
+  return useQuery<QuarantineListResponse, Error>({
+    queryKey: ['sync-quarantine-imprv-attr', serverKey],
+    queryFn: ({ signal }) =>
+      listQuarantineImprvAttr(
+        {
+          reason: params.reason,
+          universe: params.universe,
+          propId: params.propId,
+          limit: serverKey.limit,
+          offset: serverKey.offset,
+        },
+        signal,
+      ),
+    staleTime: QUARANTINE_LIST_STALE_MS,
+    refetchOnWindowFocus: true,
+    retry: 1,
+  });
+}

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineList.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineList.ts
@@ -46,6 +46,9 @@ export function useQuarantineList(
       ),
     staleTime: QUARANTINE_LIST_STALE_MS,
     refetchOnWindowFocus: true,
-    retry: 1,
+    // Surface fetch failures to the operator immediately. The page renders an
+    // error panel with a retry button; silently retrying once would mask
+    // network failures and skip the UI's intentional retry surface.
+    retry: false,
   });
 }

--- a/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineMutations.ts
+++ b/frontend/apps/os-shell/src/pages/workbench/sync-quarantine/useQuarantineMutations.ts
@@ -1,0 +1,122 @@
+/**
+ * SYNC-UX-1A: route + dismiss mutation hooks.
+ *
+ * Wraps the bulk fan-out helpers from @/api/syncQuarantine so the
+ * page can submit a single decision or N decisions through the
+ * same surface. Each individual call surfaces its own outcome
+ * record (ok/error) so the modal can render per-row status without
+ * short-circuiting on the first failure.
+ */
+
+import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  bulkDismissQuarantineImprvAttr,
+  bulkRouteQuarantineImprvAttr,
+  type BulkOutcome,
+  type DismissDecisionPayload,
+  type DismissRequestBody,
+  type RouteDecisionPayload,
+  type RouteRequestBody,
+} from '@/api/syncQuarantine';
+
+export interface BulkMutationState<TPayload> {
+  isRunning: boolean;
+  completed: number;
+  total: number;
+  results: BulkOutcome<TPayload>[];
+  error: Error | null;
+}
+
+const idle = <T>(): BulkMutationState<T> => ({
+  isRunning: false,
+  completed: 0,
+  total: 0,
+  results: [],
+  error: null,
+});
+
+export function useRouteQuarantineMutation() {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<BulkMutationState<RouteDecisionPayload>>(idle());
+
+  const submit = useCallback(
+    async (
+      ids: readonly string[],
+      body: RouteRequestBody,
+    ): Promise<BulkOutcome<RouteDecisionPayload>[]> => {
+      setState({ isRunning: true, completed: 0, total: ids.length, results: [], error: null });
+      try {
+        // The bulk helper resolves all outcomes — even partial errors
+        // come back as `{ status: 'error' }` records, not throws.
+        const results = await bulkRouteQuarantineImprvAttr(ids, body);
+        setState({
+          isRunning: false,
+          completed: results.length,
+          total: ids.length,
+          results,
+          error: null,
+        });
+        // Invalidate the list query — visible row triageStatus changes.
+        await queryClient.invalidateQueries({ queryKey: ['sync-quarantine-imprv-attr'] });
+        return results;
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e));
+        setState({
+          isRunning: false,
+          completed: 0,
+          total: ids.length,
+          results: [],
+          error,
+        });
+        throw error;
+      }
+    },
+    [queryClient],
+  );
+
+  const reset = useCallback(() => setState(idle()), []);
+
+  return { ...state, submit, reset };
+}
+
+export function useDismissQuarantineMutation() {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<BulkMutationState<DismissDecisionPayload>>(idle());
+
+  const submit = useCallback(
+    async (
+      ids: readonly string[],
+      body: DismissRequestBody,
+    ): Promise<BulkOutcome<DismissDecisionPayload>[]> => {
+      setState({ isRunning: true, completed: 0, total: ids.length, results: [], error: null });
+      try {
+        const results = await bulkDismissQuarantineImprvAttr(ids, body);
+        setState({
+          isRunning: false,
+          completed: results.length,
+          total: ids.length,
+          results,
+          error: null,
+        });
+        await queryClient.invalidateQueries({ queryKey: ['sync-quarantine-imprv-attr'] });
+        return results;
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e));
+        setState({
+          isRunning: false,
+          completed: 0,
+          total: ids.length,
+          results: [],
+          error,
+        });
+        throw error;
+      }
+    },
+    [queryClient],
+  );
+
+  const reset = useCallback(() => setState(idle()), []);
+
+  return { ...state, submit, reset };
+}


### PR DESCRIPTION
## Summary

- New operator-facing read-write surface at `/workbench/sync/quarantine` for triaging the imprv_attr quarantine cohort surfaced by SYNC-DOCTRINE-4-IMPL-V8. Sibling to the existing read-only `SyncDoctrineConsole`.
- Wraps the SYNC-WORKBENCH-F triage controller (`GET .../quarantine/imprv-attr`, `POST .../route`, `POST .../dismiss`) with TanStack Query (30s staleTime, refetch on window focus) and a fan-out bulk helper capped at 8 parallel mutations.
- Decisions are doctrine-immutable on the source quarantine row; the page only writes the sibling triage table.

## Files

- `api/syncQuarantine.ts` — fetch client, closed vocabularies (5 reasons / 7 universes / 3 dismiss reasons), `QuarantineApiError` envelope, bulk fan-out helpers
- `pages/workbench/sync-quarantine/`
  - `SyncQuarantinePage.tsx` — main page (header + count badge, refresh, filter bar, bulk-actions bar, paged table, two modals, toast container)
  - `QuarantineFilterBar.tsx` — sticky filter bar (reason / universe / propId / triage status)
  - `QuarantineTable.tsx` — paged table, multi-select, status badges, prev/next + page-size selector (25/50/100/200/500)
  - `QuarantineRouteModal.tsx` — route modal with progress bar + per-row error summary; stays open on partial failure
  - `QuarantineDismissModal.tsx` — dismiss modal (mirrors route modal)
  - `useQuarantineList.ts` — TanStack Query hook (server-key only; client-only status filter applied in page)
  - `useQuarantineMutations.ts` — bulk route + dismiss mutation hooks; invalidate list on success
  - `__tests__/` — 26 Vitest+RTL tests across the page, table, and route modal
- `Router.tsx` — lazy-loaded route under `/workbench/sync/quarantine`

## Discipline

- `tf-*` utility classes only; no new design tokens, no inline color hardcoding (matches `SyncDoctrineConsole`)
- `aria-label` + `data-testid` on every interactive element
- Lazy-loaded route, no backend changes
- 404 → toast + refetch · 409 → keep modal open with per-row error · 400 → form validation message · network error → retry button

## Test plan

- [ ] CI runs the 26 new tests under `apps/os-shell/src/pages/workbench/sync-quarantine/__tests__/`
- [ ] Type-check stays clean (verified locally: 0 errors)
- [ ] Lint stays clean on the new files (verified locally: 0 errors)
- [ ] Manual smoke against a backend with `WorkbenchFController` mounted: filter changes refetch, refresh fires fetch, single-row Route works, single-row Dismiss works, bulk Route on N selected rows works, 409 conflict surfaces in the modal without closing
- [ ] Verify `/workbench/sync/quarantine` is reachable from the app shell (lazy load resolves; no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazy-loaded quarantine triage workbench page with filters, paged selectable table, per-row and bulk Route/Dismiss modals (validation, progress, per-row error summaries), and registered route for access.
  * New client-side API and bulk mutation helpers plus a data-list hook with configurable stale-time and manual refresh.

* **Tests**
  * Added unit and acceptance tests covering page flows, table behaviors, modals, bulk actions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->