### PR TITLE
feat(sync): SYNC-DOCTRINE-5 — sales qualification codes doctrine table + audit

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrinePolicyController.cs
@@ -361,4 +361,79 @@ public class DoctrinePolicyController : ControllerBase
             cancellationToken);
         return Ok(result);
     }
+
+    // ────────────────────────────────────────────────────────────────
+    // SYNC-DOCTRINE-5: sales qualification codes doctrine endpoints.
+    // ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// List sales-qualification doctrine rules. Optional filters by
+    /// surface and source field. Mirrors the ratio/universe endpoint
+    /// shapes.
+    /// </summary>
+    [HttpGet("sales-qualification")]
+    public async Task<IActionResult> ListSalesQualificationRules(
+        [FromQuery] string? surface,
+        [FromQuery(Name = "source_field")] string? sourceField,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _db.TfDoctrineSalesQualificationCodes.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(surface))
+            query = query.Where(r => r.SurfaceCode == surface);
+        if (!string.IsNullOrWhiteSpace(sourceField))
+            query = query.Where(r => r.SourceField == sourceField);
+
+        var rules = await query
+            .OrderBy(r => r.SurfaceCode)
+            .ThenBy(r => r.EffectiveStartYear)
+            .Select(r => new
+            {
+                r.RuleId,
+                r.SurfaceCode,
+                r.SourceField,
+                r.EffectiveStartYear,
+                r.EffectiveEndYear,
+                r.QualifiedCodesJson,
+                r.EvidenceSource,
+                r.Confidence,
+                r.ActiveFlag,
+            })
+            .ToListAsync(cancellationToken);
+
+        return Ok(new { count = rules.Count, rules });
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-5: audit report comparing the doctrine rows
+    /// against the PacsSaleTruthPromoter snapshot. Read-only.
+    /// </summary>
+    [HttpGet("sales-qualification/audit")]
+    public async Task<IActionResult> AuditSalesQualification(
+        [FromServices] IDoctrineSalesAuditService audit,
+        CancellationToken cancellationToken = default)
+    {
+        var report = await audit.AuditAsync(cancellationToken);
+        return Ok(report);
+    }
+
+    /// <summary>
+    /// SYNC-DOCTRINE-5: re-run the idempotent sales-qualification
+    /// seeder. Existing rows with matching deterministic RuleIds are
+    /// no-ops; new rows are inserted. Deactivated rules are NOT
+    /// reactivated (soft-disable is sticky).
+    /// </summary>
+    [HttpPost("sales-qualification/seed")]
+    public async Task<IActionResult> SeedSalesQualification(
+        [FromServices] SalesQualificationCodesSeeder seeder,
+        CancellationToken cancellationToken = default)
+    {
+        var added = await seeder.SeedAsync(cancellationToken);
+        return Ok(new
+        {
+            inserted = added,
+            note = added == 0
+                ? "All seed rules already present."
+                : $"Inserted {added} new rule(s).",
+        });
+    }
 }

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1801,6 +1801,17 @@ builder.Services.AddScoped<
 builder.Services.AddHostedService<
     TerraFusion.Data.Services.Doctrine.DoctrinePropertyUniverseSeederHostedService>();
 
+// SYNC-DOCTRINE-5: sales qualification codes doctrine table + audit.
+// Read-only audit service compares promoter snapshot against doctrine
+// rules; seeder + hosted-service mirror the D1/D4 patterns.
+builder.Services.AddScoped<
+    TerraFusion.Core.Sync.Doctrine.IDoctrineSalesAuditService,
+    TerraFusion.Data.Services.Doctrine.DoctrineSalesAuditService>();
+builder.Services.AddScoped<
+    TerraFusion.Data.Services.Doctrine.SalesQualificationCodesSeeder>();
+builder.Services.AddHostedService<
+    TerraFusion.Data.Services.Doctrine.SalesQualificationCodesSeederHostedService>();
+
 // Slice L1: PACS land_detail raw landing — Block C's land lane
 // per-segment table. Four gates: distribution, 4-key-uniqueness,
 // provenance-coverage, aggregate.

--- a/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrineSalesQualificationCode.cs
+++ b/backend/src/TerraFusion.Core/Entities/DoctrineTf/TfDoctrineSalesQualificationCode.cs
@@ -1,0 +1,119 @@
+using System;
+
+namespace TerraFusion.Core.Entities.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: year-aware, evidence-backed sales qualification
+/// codes table. Companion to <see cref="TfDoctrineRatioPolicy"/> —
+/// where the ratio policy table models named studies (DOR_RATIO,
+/// COUNTY_INTERNAL_RATIO, LEGACY_CODEBOOK_VALID) keyed by county +
+/// study + year window, this table indexes the same domain by
+/// <em>doctrine vocabulary surface</em> (DOR_RATIO | COUNTY_RATIO)
+/// and the underlying PACS column (<c>sl_county_ratio_cd</c> |
+/// <c>sl_ratio_type_cd</c>).
+///
+/// <para>The operator's prescription
+/// (reference_benton_sync_doctrine_corrections.md) calls for four
+/// doctrine-* tables:
+/// {sales, improvement, property_universe, ratio_policy}. The
+/// ratio_policy table (D1) and the property_universe + attribute
+/// dictionary tables (D4) are already shipped; this slice (D5) adds
+/// the missing <c>sales</c> doctrine table so audit tooling can
+/// answer "what qualified codes does Benton consider valid for which
+/// surface, in which year window?" without grepping promoter source.
+/// </para>
+///
+/// <para>Critical Benton-specific facts encoded by this table
+/// (per the operator's 2026-05-06 corrections):</para>
+/// <list type="bullet">
+///   <item><c>SurfaceCode = "DOR_RATIO"</c> /
+///   <c>SourceField = "sl_county_ratio_cd"</c> / years 2017+ /
+///   QualifiedCodes = ["100"] — post-2017 PACS DOR ratio convention.</item>
+///   <item><c>SurfaceCode = "DOR_RATIO"</c> /
+///   <c>SourceField = "sl_county_ratio_cd"</c> / years 1990-2016 /
+///   QualifiedCodes = ["0"] — pre-2017 legacy carryover ('0' meant
+///   "Valid Sale" in the legacy <c>county_ratio_code</c> codebook).</item>
+///   <item><c>SurfaceCode = "COUNTY_RATIO"</c> /
+///   <c>SourceField = "sl_ratio_type_cd"</c> / years 2018+ /
+///   QualifiedCodes = ["00"] — county started using its own ratio
+///   for internal studies ~2018.</item>
+/// </list>
+///
+/// <para>Lookup contract: callers filter
+/// <c>WHERE EffectiveStartYear &lt;= year AND
+/// (EffectiveEndYear IS NULL OR EffectiveEndYear &gt;= year)
+/// AND ActiveFlag = true</c>, optionally narrowed by SurfaceCode or
+/// SourceField. The most-specific (smallest year window) match wins.
+/// </para>
+///
+/// <para>Constitutional principle (operator, 2026-05-06):
+/// "Transport gates can be green. Doctrine gates are not green
+/// until policy is explicit, versioned, and evidence-backed."
+/// Every row carries <see cref="EvidenceSource"/> and
+/// <see cref="Confidence"/>; soft-disable via
+/// <see cref="ActiveFlag"/> rather than DELETE so the audit trail
+/// survives.</para>
+/// </summary>
+public sealed class TfDoctrineSalesQualificationCode
+{
+    /// <summary>Surrogate primary key.</summary>
+    public Guid RuleId { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Doctrine vocabulary surface this rule belongs to:
+    /// <c>"DOR_RATIO"</c> (Washington Department of Revenue ratio
+    /// study) | <c>"COUNTY_RATIO"</c> (Benton internal ratio study).
+    /// Closed vocab.
+    /// </summary>
+    public string SurfaceCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The PACS column this rule applies to:
+    /// <c>"sl_county_ratio_cd"</c> | <c>"sl_ratio_type_cd"</c>.
+    /// Free-text in v1; future v2 may move to closed vocab.
+    /// </summary>
+    public string SourceField { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Year boundary: rule applies to PACS sales with
+    /// <c>prop_val_yr &gt;= EffectiveStartYear</c>. Inclusive.
+    /// </summary>
+    public short EffectiveStartYear { get; set; }
+
+    /// <summary>
+    /// Year boundary: rule applies to <c>prop_val_yr &lt;=
+    /// EffectiveEndYear</c>. Inclusive end. NULL = open-ended
+    /// ("rule still in effect").
+    /// </summary>
+    public short? EffectiveEndYear { get; set; }
+
+    /// <summary>
+    /// JSON array of qualified codes for this
+    /// (Surface, SourceField, year-range) tuple. e.g. <c>["100"]</c>,
+    /// <c>["00"]</c>, <c>["0"]</c>. Empty array = "no codes qualify
+    /// under this surface in this year window".
+    /// </summary>
+    public string QualifiedCodesJson { get; set; } = "[]";
+
+    /// <summary>
+    /// Free-text evidence: WAC ref, DOR memo URL, operator-email
+    /// subject, codebook citation, etc. Required for HIGH confidence.
+    /// </summary>
+    public string EvidenceSource { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Closed vocabulary: <c>'HIGH'</c> | <c>'MEDIUM'</c> |
+    /// <c>'LOW'</c>. HIGH = formal WAC/DOR ref. MEDIUM = operator
+    /// confirmation. LOW = inferred.
+    /// </summary>
+    public string Confidence { get; set; } = "MEDIUM";
+
+    /// <summary>Soft-disable knob; lookups skip rules with <c>ActiveFlag = false</c>.</summary>
+    public bool ActiveFlag { get; set; } = true;
+
+    // ── Audit fields (auto-populated by AuditableEntityInterceptor) ────
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Sync/Doctrine/IDoctrineSalesAuditService.cs
+++ b/backend/src/TerraFusion.Core/Sync/Doctrine/IDoctrineSalesAuditService.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TerraFusion.Core.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: read-only audit of the sales qualification
+/// doctrine. Compares the rules in
+/// <c>doctrine_tf.tf_doctrine_sales_qualification_codes</c> against
+/// the hardcoded behavior of
+/// <see cref="TerraFusion.Data.Services.TruthPacs.PacsSaleTruthPromoter"/>
+/// (captured by a static snapshot — see
+/// <see cref="PacsSaleTruthPromoterSnapshot"/>) and emits an
+/// operator-readable report covering doctrine state, promoter
+/// alignment, and year-awareness presence.
+///
+/// <para>Surfaces three things:</para>
+/// <list type="bullet">
+///   <item><c>doctrineState</c> — totalRules, activeRules, full
+///   row dump.</item>
+///   <item><c>promoterAlignment</c> — does the promoter's hardcoded
+///   filter agree with what the doctrine says is qualified for that
+///   surface? Surfaces discrepancies as actionable findings.</item>
+///   <item><c>yearAwarenessCheck</c> — confirms the post-2017 DOR,
+///   pre-2017 DOR, and post-2018 COUNTY rules are all PRESENT (or
+///   reports MISSING).</item>
+/// </list>
+/// </summary>
+public interface IDoctrineSalesAuditService
+{
+    Task<DoctrineSalesAuditReport> AuditAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Year-aware lookup: return all ACTIVE doctrine rules whose
+    /// year window covers <paramref name="propValYr"/>.
+    /// Optionally narrow by surface (DOR_RATIO | COUNTY_RATIO).
+    /// Used by tests to verify pre-2017 vs post-2017 year boundaries
+    /// and by operators to spot-check applicability.
+    /// </summary>
+    Task<IReadOnlyList<DoctrineRuleView>> LookupRulesForYearAsync(
+        short propValYr,
+        string? surface = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Snapshot of <c>PacsSaleTruthPromoter</c>'s current hardcoded
+/// behavior, captured here so the audit can reason about it without
+/// grepping the promoter's source at runtime AND without modifying
+/// the promoter to expose a constant. Update this snapshot whenever
+/// the promoter's qualification surface changes.
+/// </summary>
+/// <remarks>
+/// As of SYNC-DOCTRINE-2 (B2): the promoter no longer has a single
+/// hardcoded code list — it consults <c>IRatioQualificationPolicy</c>
+/// for both DOR_RATIO and COUNTY_INTERNAL_RATIO and promotes the
+/// sale if either qualifies. The "promoter alignment" check
+/// therefore reduces to: does the promoter still consult both
+/// surfaces against the right columns (sl_ratio_type_cd for DOR,
+/// sl_county_ratio_cd for COUNTY)? This snapshot captures that
+/// answer for audit comparison.
+///
+/// <para>Pre-D2 the promoter hardcoded sl_county_ratio_cd='100';
+/// the audit uses that historical fact to recognize the snapshot's
+/// "DOR_RATIO via sl_county_ratio_cd → ['100']" surface, which
+/// remains the doctrine's post-2017 expectation today.</para>
+/// </remarks>
+public static class PacsSaleTruthPromoterSnapshot
+{
+    /// <summary>
+    /// The PACS column the promoter (historically + per the
+    /// post-2017 DOR convention) treats as the DOR_RATIO surface.
+    /// </summary>
+    public const string DorRatioColumn = "sl_county_ratio_cd";
+
+    /// <summary>
+    /// The hardcoded code-set the promoter (pre-D2 directly, post-D2
+    /// via IRatioQualificationPolicy + DoctrineRatioPolicySeeder)
+    /// treats as DOR_RATIO-qualified for that column.
+    /// </summary>
+    public static IReadOnlyList<string> DorRatioCodes { get; } = new[] { "100" };
+
+    /// <summary>
+    /// The PACS column the promoter consults for the COUNTY_RATIO
+    /// surface (post-D2: via IRatioQualificationPolicy.EvaluateAsync
+    /// against COUNTY_INTERNAL_RATIO).
+    /// </summary>
+    public const string CountyRatioColumn = "sl_ratio_type_cd";
+}
+
+/// <summary>
+/// SYNC-DOCTRINE-5: report shape returned by
+/// <see cref="IDoctrineSalesAuditService.AuditAsync"/>.
+/// </summary>
+public sealed record DoctrineSalesAuditReport(
+    DateTime AuditedAt,
+    DoctrineStateView DoctrineState,
+    PromoterAlignmentView PromoterAlignment,
+    YearAwarenessCheckView YearAwarenessCheck,
+    IReadOnlyList<string> OperatorActionableNotes);
+
+public sealed record DoctrineStateView(
+    bool TableExists,
+    int TotalRules,
+    int ActiveRules,
+    IReadOnlyList<DoctrineRuleView> Rules);
+
+public sealed record DoctrineRuleView(
+    Guid RuleId,
+    string SurfaceCode,
+    string SourceField,
+    short EffectiveStartYear,
+    short? EffectiveEndYear,
+    IReadOnlyList<string> QualifiedCodes,
+    string Confidence,
+    bool ActiveFlag);
+
+public sealed record PromoterAlignmentView(
+    string PacsSaleTruthPromoterColumn,
+    IReadOnlyList<string> PacsSaleTruthPromoterCodes,
+    bool AlignedWithDoctrine,
+    IReadOnlyList<string> Discrepancies);
+
+public sealed record YearAwarenessCheckView(
+    string Post2017DorRule,
+    string Pre2017DorRule,
+    string Post2018CountyRule);

--- a/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrineSalesQualificationCodeConfiguration.cs
+++ b/backend/src/TerraFusion.Data/Configurations/DoctrineTf/TfDoctrineSalesQualificationCodeConfiguration.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TerraFusion.Core.Entities.DoctrineTf;
+
+namespace TerraFusion.Data.Configurations.DoctrineTf;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: EF configuration for
+/// <see cref="TfDoctrineSalesQualificationCode"/>.
+/// Schema <c>doctrine_tf</c>; table
+/// <c>tf_doctrine_sales_qualification_codes</c>.
+/// </summary>
+public sealed class TfDoctrineSalesQualificationCodeConfiguration
+    : IEntityTypeConfiguration<TfDoctrineSalesQualificationCode>
+{
+    public void Configure(EntityTypeBuilder<TfDoctrineSalesQualificationCode> builder)
+    {
+        builder.ToTable("tf_doctrine_sales_qualification_codes", schema: "doctrine_tf");
+
+        builder.HasKey(x => x.RuleId);
+        builder.Property(x => x.RuleId).IsRequired();
+
+        // Closed vocab: "DOR_RATIO" | "COUNTY_RATIO".
+        builder.Property(x => x.SurfaceCode)
+            .IsRequired()
+            .HasMaxLength(32);
+
+        // Free-text v1 (e.g. "sl_county_ratio_cd", "sl_ratio_type_cd").
+        builder.Property(x => x.SourceField)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.EffectiveStartYear).IsRequired();
+        builder.Property(x => x.EffectiveEndYear);
+
+        // JSON array of qualified codes; default empty array.
+        builder.Property(x => x.QualifiedCodesJson)
+            .IsRequired()
+            .HasMaxLength(1024)
+            .HasDefaultValue("[]");
+
+        builder.Property(x => x.EvidenceSource)
+            .IsRequired()
+            .HasMaxLength(1024)
+            .HasDefaultValue(string.Empty);
+
+        builder.Property(x => x.Confidence)
+            .IsRequired()
+            .HasMaxLength(8)
+            .HasDefaultValue("MEDIUM");
+
+        builder.Property(x => x.ActiveFlag).IsRequired();
+
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UpdatedAt).IsRequired();
+        builder.Property(x => x.CreatedBy).HasMaxLength(128);
+        builder.Property(x => x.UpdatedBy).HasMaxLength(128);
+
+        // Primary lookup index: (SurfaceCode, EffectiveStartYear).
+        // Year-range queries narrow first by surface, then by year.
+        builder.HasIndex(x => new { x.SurfaceCode, x.EffectiveStartYear })
+            .HasDatabaseName("ix_tf_doctrine_sales_qualification_codes_surface_start");
+
+        // Secondary lookup by underlying PACS column.
+        builder.HasIndex(x => x.SourceField)
+            .HasDatabaseName("ix_tf_doctrine_sales_qualification_codes_source_field");
+
+        // Active-flag filter.
+        builder.HasIndex(x => x.ActiveFlag)
+            .HasDatabaseName("ix_tf_doctrine_sales_qualification_codes_active");
+    }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260508172855_SyncDoctrine5SalesQualificationCodes.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508172855_SyncDoctrine5SalesQualificationCodes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508172855_SyncDoctrine5SalesQualificationCodes")]
+    partial class SyncDoctrine5SalesQualificationCodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260508172855_SyncDoctrine5SalesQualificationCodes.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260508172855_SyncDoctrine5SalesQualificationCodes.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncDoctrine5SalesQualificationCodes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tf_doctrine_sales_qualification_codes",
+                schema: "doctrine_tf",
+                columns: table => new
+                {
+                    RuleId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SurfaceCode = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    SourceField = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    EffectiveStartYear = table.Column<short>(type: "smallint", nullable: false),
+                    EffectiveEndYear = table.Column<short>(type: "smallint", nullable: true),
+                    QualifiedCodesJson = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false, defaultValue: "[]"),
+                    EvidenceSource = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false, defaultValue: ""),
+                    Confidence = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false, defaultValue: "MEDIUM"),
+                    ActiveFlag = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tf_doctrine_sales_qualification_codes", x => x.RuleId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_sales_qualification_codes_active",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_sales_qualification_codes",
+                column: "ActiveFlag");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_sales_qualification_codes_source_field",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_sales_qualification_codes",
+                column: "SourceField");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tf_doctrine_sales_qualification_codes_surface_start",
+                schema: "doctrine_tf",
+                table: "tf_doctrine_sales_qualification_codes",
+                columns: new[] { "SurfaceCode", "EffectiveStartYear" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tf_doctrine_sales_qualification_codes",
+                schema: "doctrine_tf");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineSalesAuditService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/DoctrineSalesAuditService.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: default <see cref="IDoctrineSalesAuditService"/>
+/// implementation. Reads
+/// <c>doctrine_tf.tf_doctrine_sales_qualification_codes</c> and the
+/// <see cref="PacsSaleTruthPromoterSnapshot"/> static surface to
+/// produce an operator-readable audit report.
+///
+/// <para>Pure read-only — never mutates the doctrine table. Safe to
+/// invoke at any time without side effects.</para>
+/// </summary>
+public sealed class DoctrineSalesAuditService : IDoctrineSalesAuditService
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<DoctrineSalesAuditService> _logger;
+
+    public DoctrineSalesAuditService(
+        TerraFusionDbContext db,
+        ILogger<DoctrineSalesAuditService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<DoctrineSalesAuditReport> AuditAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var rules = await _db.TfDoctrineSalesQualificationCodes
+            .AsNoTracking()
+            .OrderBy(r => r.SurfaceCode)
+            .ThenBy(r => r.EffectiveStartYear)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var ruleViews = rules
+            .Select(r => new DoctrineRuleView(
+                r.RuleId,
+                r.SurfaceCode,
+                r.SourceField,
+                r.EffectiveStartYear,
+                r.EffectiveEndYear,
+                ParseQualifiedCodes(r.QualifiedCodesJson),
+                r.Confidence,
+                r.ActiveFlag))
+            .ToList();
+
+        var doctrineState = new DoctrineStateView(
+            TableExists: true,
+            TotalRules: rules.Count,
+            ActiveRules: rules.Count(r => r.ActiveFlag),
+            Rules: ruleViews);
+
+        var alignment = ComputePromoterAlignment(rules);
+        var yearCheck = ComputeYearAwareness(rules);
+        var notes = BuildOperatorNotes(alignment, yearCheck);
+
+        _logger.LogDebug(
+            "DoctrineSalesAuditService.AuditAsync: total={Total} active={Active} aligned={Aligned}",
+            rules.Count, doctrineState.ActiveRules, alignment.AlignedWithDoctrine);
+
+        return new DoctrineSalesAuditReport(
+            AuditedAt: DateTime.UtcNow,
+            DoctrineState: doctrineState,
+            PromoterAlignment: alignment,
+            YearAwarenessCheck: yearCheck,
+            OperatorActionableNotes: notes);
+    }
+
+    public async Task<IReadOnlyList<DoctrineRuleView>> LookupRulesForYearAsync(
+        short propValYr,
+        string? surface = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _db.TfDoctrineSalesQualificationCodes
+            .AsNoTracking()
+            .Where(r => r.ActiveFlag
+                     && r.EffectiveStartYear <= propValYr
+                     && (r.EffectiveEndYear == null || r.EffectiveEndYear >= propValYr));
+
+        if (!string.IsNullOrWhiteSpace(surface))
+            query = query.Where(r => r.SurfaceCode == surface);
+
+        var matches = await query
+            .OrderBy(r => r.SurfaceCode)
+            .ThenBy(r => r.EffectiveStartYear)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return matches
+            .Select(r => new DoctrineRuleView(
+                r.RuleId, r.SurfaceCode, r.SourceField,
+                r.EffectiveStartYear, r.EffectiveEndYear,
+                ParseQualifiedCodes(r.QualifiedCodesJson),
+                r.Confidence, r.ActiveFlag))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Compute the promoter-vs-doctrine alignment view.
+    ///
+    /// <para>Promoter snapshot (per
+    /// <see cref="PacsSaleTruthPromoterSnapshot"/>): treats column
+    /// <c>sl_county_ratio_cd</c> as the DOR_RATIO surface and
+    /// considers <c>['100']</c> qualified.</para>
+    ///
+    /// <para>Alignment rule: there must exist an ACTIVE doctrine rule
+    /// with <c>SurfaceCode='DOR_RATIO'</c> AND
+    /// <c>SourceField='sl_county_ratio_cd'</c> AND its qualified-code
+    /// set must equal the snapshot's code set. If no such rule
+    /// exists, OR if the doctrine's qualified codes diverge from the
+    /// snapshot, that is a discrepancy.</para>
+    /// </summary>
+    private static PromoterAlignmentView ComputePromoterAlignment(
+        IReadOnlyList<TfDoctrineSalesQualificationCode> rules)
+    {
+        var promoterCol = PacsSaleTruthPromoterSnapshot.DorRatioColumn;
+        var promoterCodes = PacsSaleTruthPromoterSnapshot.DorRatioCodes;
+        var discrepancies = new List<string>();
+
+        var activeDorRulesForCol = rules
+            .Where(r => r.ActiveFlag
+                     && r.SurfaceCode == "DOR_RATIO"
+                     && r.SourceField == promoterCol)
+            .ToList();
+
+        if (activeDorRulesForCol.Count == 0)
+        {
+            discrepancies.Add(
+                $"PacsSaleTruthPromoter snapshot uses column '{promoterCol}' as DOR_RATIO surface, " +
+                "but no active doctrine rule exists for (DOR_RATIO, " + promoterCol + "). " +
+                "Run the seeder to populate, or operator must add a rule.");
+
+            return new PromoterAlignmentView(
+                PacsSaleTruthPromoterColumn: promoterCol,
+                PacsSaleTruthPromoterCodes: promoterCodes,
+                AlignedWithDoctrine: false,
+                Discrepancies: discrepancies);
+        }
+
+        // Union of every active rule's qualified codes for this surface
+        // across all year windows. Promoter alignment passes iff the
+        // promoter's snapshot codes are a SUBSET of that union (i.e.
+        // the doctrine recognizes everything the promoter qualifies).
+        var doctrineCodes = activeDorRulesForCol
+            .SelectMany(r => ParseQualifiedCodes(r.QualifiedCodesJson))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = promoterCodes
+            .Where(c => !doctrineCodes.Contains(c))
+            .ToList();
+
+        var aligned = missing.Count == 0;
+        if (!aligned)
+        {
+            discrepancies.Add(
+                $"PacsSaleTruthPromoter qualifies codes [{string.Join(",", missing)}] " +
+                $"on column '{promoterCol}', but no active doctrine rule covers them. " +
+                "Either tighten the promoter or extend doctrine.");
+        }
+
+        return new PromoterAlignmentView(
+            PacsSaleTruthPromoterColumn: promoterCol,
+            PacsSaleTruthPromoterCodes: promoterCodes,
+            AlignedWithDoctrine: aligned,
+            Discrepancies: discrepancies);
+    }
+
+    /// <summary>
+    /// Determine PRESENT / MISSING for the three locked rules.
+    /// PRESENT requires an ACTIVE rule covering the year window.
+    /// </summary>
+    private static YearAwarenessCheckView ComputeYearAwareness(
+        IReadOnlyList<TfDoctrineSalesQualificationCode> rules)
+    {
+        bool HasActive(string surface, string col, short startYear, short? endYear)
+            => rules.Any(r => r.ActiveFlag
+                              && r.SurfaceCode == surface
+                              && r.SourceField == col
+                              && r.EffectiveStartYear == startYear
+                              && r.EffectiveEndYear == endYear);
+
+        var post2017Dor = HasActive("DOR_RATIO", "sl_county_ratio_cd", 2017, null);
+        var pre2017Dor  = HasActive("DOR_RATIO", "sl_county_ratio_cd", 1990, 2016);
+        var post2018Cnty = HasActive("COUNTY_RATIO", "sl_ratio_type_cd", 2018, null);
+
+        return new YearAwarenessCheckView(
+            Post2017DorRule: post2017Dor ? "PRESENT" : "MISSING",
+            Pre2017DorRule:  pre2017Dor  ? "PRESENT" : "MISSING",
+            Post2018CountyRule: post2018Cnty ? "PRESENT" : "MISSING");
+    }
+
+    private static List<string> BuildOperatorNotes(
+        PromoterAlignmentView alignment,
+        YearAwarenessCheckView yearCheck)
+    {
+        var notes = new List<string>();
+
+        // Always include the alignment-statement so the operator gets
+        // a single-line summary regardless of pass/fail.
+        var codes = string.Join(",", alignment.PacsSaleTruthPromoterCodes
+            .Select(c => $"'{c}'"));
+        notes.Add(
+            $"PacsSaleTruthPromoter currently uses [{codes}] for column " +
+            $"{alignment.PacsSaleTruthPromoterColumn}; this " +
+            (alignment.AlignedWithDoctrine
+                ? "aligns with DOR_RATIO post-2017 doctrine."
+                : "does NOT align with doctrine — see discrepancies."));
+
+        foreach (var d in alignment.Discrepancies)
+            notes.Add(d);
+
+        if (yearCheck.Post2017DorRule == "MISSING")
+            notes.Add("Year-awareness gap: post-2017 DOR_RATIO rule MISSING. Run seeder.");
+        if (yearCheck.Pre2017DorRule == "MISSING")
+            notes.Add("Year-awareness gap: pre-2017 DOR_RATIO rule MISSING. Run seeder.");
+        if (yearCheck.Post2018CountyRule == "MISSING")
+            notes.Add("Year-awareness gap: post-2018 COUNTY_RATIO rule MISSING. Run seeder.");
+
+        return notes;
+    }
+
+    /// <summary>
+    /// Parse a <c>QualifiedCodesJson</c> string into an immutable
+    /// list. Returns empty on parse failure (defensive — operator
+    /// could enter malformed JSON via raw SQL update).
+    /// </summary>
+    private static IReadOnlyList<string> ParseQualifiedCodes(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return Array.Empty<string>();
+
+        try
+        {
+            var arr = JsonSerializer.Deserialize<string[]>(json);
+            return arr ?? Array.Empty<string>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/SalesQualificationCodesSeeder.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/SalesQualificationCodesSeeder.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TerraFusion.Core.Entities.DoctrineTf;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: seed verified Benton sales qualification code
+/// rules into <c>doctrine_tf.tf_doctrine_sales_qualification_codes</c>.
+///
+/// <para>Idempotent: each rule has a deterministic seed RuleId so
+/// repeat invocations are no-ops. Rules with the same RuleId that
+/// were deactivated by an operator (<c>ActiveFlag = false</c>) are
+/// LEFT ALONE — the seeder only inserts missing rows; it never
+/// reactivates a deactivated rule.</para>
+///
+/// <para>Mirrors the <see cref="DoctrineRatioPolicySeeder"/> pattern:
+/// code-side seeder rather than EF HasData migration so the rules
+/// can carry operator-mutable approval timestamps and confidence
+/// markers, and so that the schema migration is purely structural.
+/// </para>
+///
+/// <para>Run by <see cref="SalesQualificationCodesSeederHostedService"/>
+/// at backend startup, OR invoked manually via
+/// <c>POST /api/sync/doctrine/policy/sales-qualification/seed</c>.</para>
+/// </summary>
+public sealed class SalesQualificationCodesSeeder
+{
+    private readonly TerraFusionDbContext _db;
+    private readonly ILogger<SalesQualificationCodesSeeder> _logger;
+
+    public SalesQualificationCodesSeeder(
+        TerraFusionDbContext db,
+        ILogger<SalesQualificationCodesSeeder> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<int> SeedAsync(CancellationToken cancellationToken = default)
+    {
+        var seedRules = BuildBentonSeed();
+
+        var existingIds = await _db.TfDoctrineSalesQualificationCodes
+            .Select(r => r.RuleId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var existingSet = new HashSet<Guid>(existingIds);
+
+        var added = 0;
+        foreach (var rule in seedRules)
+        {
+            if (existingSet.Contains(rule.RuleId))
+            {
+                // Existing row — leave alone. Even if it has
+                // ActiveFlag=false (operator-deactivated), do NOT
+                // reactivate. Per V2 doctrine convention: soft-disable
+                // is sticky.
+                continue;
+            }
+            _db.TfDoctrineSalesQualificationCodes.Add(rule);
+            added++;
+        }
+
+        if (added > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "SalesQualificationCodesSeeder: inserted {Added} new rule(s); existing {Existing}",
+                added, existingSet.Count);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "SalesQualificationCodesSeeder: no new rules to insert; {Existing} already present",
+                existingSet.Count);
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// The verified Benton seed. Three rules covering the post-2017
+    /// DOR convention, the pre-2017 legacy carryover, and the post-
+    /// 2018 county-internal-ratio convention.
+    /// </summary>
+    private static TfDoctrineSalesQualificationCode[] BuildBentonSeed()
+    {
+        // Deterministic GUIDs for idempotency. Naming convention:
+        // d0c75a1e (= "doctrine sale") prefix + seed-id + Benton-FIPS
+        // 53005 in trailing group.
+        var ruleDorPost2017 = Guid.Parse("d0c75a1e-0001-4d05-be07-be0053005001");
+        var ruleDorPre2017  = Guid.Parse("d0c75a1e-0002-4d05-be07-be0053005002");
+        var ruleCountyPost2018 = Guid.Parse("d0c75a1e-0003-4d05-be07-be0053005003");
+
+        return new[]
+        {
+            // DOR_RATIO post-2017: sl_county_ratio_cd = '100' = "Valid Sale"
+            new TfDoctrineSalesQualificationCode
+            {
+                RuleId = ruleDorPost2017,
+                SurfaceCode = "DOR_RATIO",
+                SourceField = "sl_county_ratio_cd",
+                EffectiveStartYear = 2017,
+                EffectiveEndYear = null,
+                QualifiedCodesJson = "[\"100\"]",
+                EvidenceSource =
+                    "PACS post-2017 DOR ratio convention; SYNC-COMPLETE-3 seal evidence",
+                Confidence = "HIGH",
+                ActiveFlag = true,
+            },
+
+            // DOR_RATIO pre-2017: sl_county_ratio_cd = '0' = "VALID SALE" (legacy codebook)
+            new TfDoctrineSalesQualificationCode
+            {
+                RuleId = ruleDorPre2017,
+                SurfaceCode = "DOR_RATIO",
+                SourceField = "sl_county_ratio_cd",
+                EffectiveStartYear = 1990,
+                EffectiveEndYear = 2016,
+                QualifiedCodesJson = "[\"0\"]",
+                EvidenceSource =
+                    "PACS pre-2017 DOR ratio convention; legacy column carryover",
+                Confidence = "HIGH",
+                ActiveFlag = true,
+            },
+
+            // COUNTY_RATIO post-2018: sl_ratio_type_cd = '00'
+            new TfDoctrineSalesQualificationCode
+            {
+                RuleId = ruleCountyPost2018,
+                SurfaceCode = "COUNTY_RATIO",
+                SourceField = "sl_ratio_type_cd",
+                EffectiveStartYear = 2018,
+                EffectiveEndYear = null,
+                QualifiedCodesJson = "[\"00\"]",
+                EvidenceSource =
+                    "County started using own ratio ~2018; reference_benton_sync_doctrine_corrections.md",
+                Confidence = "MEDIUM",
+                ActiveFlag = true,
+            },
+        };
+    }
+}

--- a/backend/src/TerraFusion.Data/Services/Doctrine/SalesQualificationCodesSeederHostedService.cs
+++ b/backend/src/TerraFusion.Data/Services/Doctrine/SalesQualificationCodesSeederHostedService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TerraFusion.Data.Services.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: hosted service that runs the
+/// <see cref="SalesQualificationCodesSeeder"/> once at backend startup
+/// so the doctrine table is populated before the first audit call.
+///
+/// <para>Idempotent — the seeder skips rules whose deterministic
+/// RuleIds already exist. Non-fatal: if seeding throws (migration
+/// pending, etc.), the host logs a warning and proceeds. Operators
+/// can re-seed manually via
+/// <c>POST /api/sync/doctrine/policy/sales-qualification/seed</c>.
+/// </para>
+/// </summary>
+public sealed class SalesQualificationCodesSeederHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SalesQualificationCodesSeederHostedService> _logger;
+
+    public SalesQualificationCodesSeederHostedService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SalesQualificationCodesSeederHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var seeder = scope.ServiceProvider
+                .GetRequiredService<SalesQualificationCodesSeeder>();
+            var inserted = await seeder.SeedAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "SalesQualificationCodesSeederHostedService: startup seed ran; {Inserted} new rule(s) inserted",
+                inserted);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "SalesQualificationCodesSeederHostedService: startup seed failed; " +
+                "operator may need to run POST /api/sync/doctrine/policy/sales-qualification/seed manually");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -409,6 +409,15 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TerraFusion.Core.Entities.DoctrineTf.TfDoctrineAttributeDictionary>
     TfDoctrineAttributeDictionaries { get; set; } = null!;
 
+  // SYNC-DOCTRINE-5: doctrine_tf.tf_doctrine_sales_qualification_codes.
+  // Year-aware, evidence-backed sales qualification codes indexed by
+  // doctrine vocabulary surface (DOR_RATIO | COUNTY_RATIO) and the
+  // underlying PACS column (sl_county_ratio_cd | sl_ratio_type_cd).
+  // Companion to tf_doctrine_ratio_policy; powers the audit endpoint
+  // that compares promoter behavior against doctrine.
+  public DbSet<TerraFusion.Core.Entities.DoctrineTf.TfDoctrineSalesQualificationCode>
+    TfDoctrineSalesQualificationCodes { get; set; } = null!;
+
   // Slice D1: legacy_arcgis_raw.parcel_geom — first stop in the
   // 5-schema doctrine for ArcGIS-sourced geometry. Per Block-D
   // execution plan (docs/pacs/block-d-execution-plan.md §3.1).
@@ -1202,6 +1211,11 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
       new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrinePropertyUniverseConfiguration());
     modelBuilder.ApplyConfiguration(
       new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrineAttributeDictionaryConfiguration());
+
+    // SYNC-DOCTRINE-5: doctrine_tf.tf_doctrine_sales_qualification_codes.
+    // Year-aware sales qualification codes by surface + source column.
+    modelBuilder.ApplyConfiguration(
+      new TerraFusion.Data.Configurations.DoctrineTf.TfDoctrineSalesQualificationCodeConfiguration());
 
     // Slice D1: legacy_arcgis_raw.parcel_geom — raw FeatureService
     // landing. Per docs/pacs/block-d-execution-plan.md §3.1.

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrinePolicySalesAuditEndpointTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrinePolicySalesAuditEndpointTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Controllers;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: thin endpoint contract test for the
+/// <c>GET /api/sync/doctrine/policy/sales-qualification/audit</c>
+/// endpoint. Exercises the controller method directly (rather than
+/// via WebApplicationFactory) since the controller logic is a thin
+/// pass-through and the underlying audit service is exhaustively
+/// covered by <see cref="DoctrineSalesAuditServiceTests"/>.
+/// </summary>
+public sealed class DoctrinePolicySalesAuditEndpointTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public DoctrinePolicySalesAuditEndpointTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"sync-d5-endpoint-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private DoctrinePolicyController BuildController()
+        => new(_db, NullLogger<DoctrinePolicyController>.Instance);
+
+    private IDoctrineSalesAuditService BuildAudit()
+        => new DoctrineSalesAuditService(_db, NullLogger<DoctrineSalesAuditService>.Instance);
+
+    [Fact]
+    public async Task AuditSalesQualification_returns_OK_with_report()
+    {
+        await new SalesQualificationCodesSeeder(
+            _db, NullLogger<SalesQualificationCodesSeeder>.Instance).SeedAsync();
+
+        var controller = BuildController();
+        var result = await controller.AuditSalesQualification(BuildAudit(), default);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var report = ok.Value.Should().BeOfType<DoctrineSalesAuditReport>().Subject;
+        report.DoctrineState.TotalRules.Should().Be(3);
+        report.PromoterAlignment.AlignedWithDoctrine.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AuditSalesQualification_on_empty_table_still_returns_OK()
+    {
+        var controller = BuildController();
+        var result = await controller.AuditSalesQualification(BuildAudit(), default);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var report = ok.Value.Should().BeOfType<DoctrineSalesAuditReport>().Subject;
+        report.DoctrineState.TotalRules.Should().Be(0);
+        report.YearAwarenessCheck.Post2017DorRule.Should().Be("MISSING");
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineSalesAuditServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineSalesAuditServiceTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: contract tests for
+/// <see cref="DoctrineSalesAuditService"/>. Validates the report
+/// shape, promoter alignment computation, year-awareness presence
+/// detection, and operator-actionable notes.
+/// </summary>
+public sealed class DoctrineSalesAuditServiceTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public DoctrineSalesAuditServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"sync-d5-audit-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private DoctrineSalesAuditService BuildAudit()
+        => new(_db, NullLogger<DoctrineSalesAuditService>.Instance);
+
+    private SalesQualificationCodesSeeder BuildSeeder()
+        => new(_db, NullLogger<SalesQualificationCodesSeeder>.Instance);
+
+    [Fact]
+    public async Task Empty_doctrine_table_reports_zero_rules_but_table_exists()
+    {
+        var audit = BuildAudit();
+
+        var report = await audit.AuditAsync();
+
+        report.DoctrineState.TableExists.Should().BeTrue();
+        report.DoctrineState.TotalRules.Should().Be(0);
+        report.DoctrineState.ActiveRules.Should().Be(0);
+        report.DoctrineState.Rules.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Seeded_state_returns_three_rules()
+    {
+        await BuildSeeder().SeedAsync();
+        var report = await BuildAudit().AuditAsync();
+
+        report.DoctrineState.TotalRules.Should().Be(3);
+        report.DoctrineState.ActiveRules.Should().Be(3);
+        report.DoctrineState.Rules.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task All_three_year_awareness_checks_PRESENT_after_seed()
+    {
+        await BuildSeeder().SeedAsync();
+        var report = await BuildAudit().AuditAsync();
+
+        report.YearAwarenessCheck.Post2017DorRule.Should().Be("PRESENT");
+        report.YearAwarenessCheck.Pre2017DorRule.Should().Be("PRESENT");
+        report.YearAwarenessCheck.Post2018CountyRule.Should().Be("PRESENT");
+    }
+
+    [Fact]
+    public async Task Pre2017_DOR_rule_MISSING_when_deactivated()
+    {
+        await BuildSeeder().SeedAsync();
+
+        var pre2017 = await _db.TfDoctrineSalesQualificationCodes
+            .FirstAsync(r => r.SurfaceCode == "DOR_RATIO"
+                          && r.EffectiveStartYear == 1990);
+        pre2017.ActiveFlag = false;
+        await _db.SaveChangesAsync();
+
+        var report = await BuildAudit().AuditAsync();
+
+        report.YearAwarenessCheck.Pre2017DorRule.Should().Be("MISSING");
+        report.YearAwarenessCheck.Post2017DorRule.Should().Be("PRESENT");
+        report.YearAwarenessCheck.Post2018CountyRule.Should().Be("PRESENT");
+    }
+
+    [Fact]
+    public async Task Promoter_alignment_aligned_against_default_seed()
+    {
+        await BuildSeeder().SeedAsync();
+        var report = await BuildAudit().AuditAsync();
+
+        report.PromoterAlignment.PacsSaleTruthPromoterColumn
+            .Should().Be("sl_county_ratio_cd");
+        report.PromoterAlignment.PacsSaleTruthPromoterCodes
+            .Should().Equal(new[] { "100" });
+        report.PromoterAlignment.AlignedWithDoctrine.Should().BeTrue();
+        report.PromoterAlignment.Discrepancies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Promoter_alignment_diverges_when_doctrine_lacks_100()
+    {
+        // Seed only a hypothetical doctrine where '100' is NOT in the
+        // qualified set (operator entered ['00'] for the DOR surface
+        // by mistake). The audit should flag the divergence.
+        _db.TfDoctrineSalesQualificationCodes.Add(new TfDoctrineSalesQualificationCode
+        {
+            RuleId = Guid.NewGuid(),
+            SurfaceCode = "DOR_RATIO",
+            SourceField = "sl_county_ratio_cd",
+            EffectiveStartYear = 2017,
+            EffectiveEndYear = null,
+            QualifiedCodesJson = "[\"00\"]", // deliberately NOT '100'
+            EvidenceSource = "test-mismatch",
+            Confidence = "LOW",
+            ActiveFlag = true,
+        });
+        await _db.SaveChangesAsync();
+
+        var report = await BuildAudit().AuditAsync();
+
+        report.PromoterAlignment.AlignedWithDoctrine.Should().BeFalse();
+        report.PromoterAlignment.Discrepancies.Should().NotBeEmpty();
+        report.PromoterAlignment.Discrepancies.Should().Contain(d =>
+            d.Contains("100", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Promoter_alignment_diverges_when_no_DOR_rule_for_column()
+    {
+        // Doctrine missing entirely for the promoter's column.
+        _db.TfDoctrineSalesQualificationCodes.Add(new TfDoctrineSalesQualificationCode
+        {
+            RuleId = Guid.NewGuid(),
+            SurfaceCode = "COUNTY_RATIO",
+            SourceField = "sl_ratio_type_cd",
+            EffectiveStartYear = 2018,
+            QualifiedCodesJson = "[\"00\"]",
+            EvidenceSource = "test",
+            Confidence = "MEDIUM",
+            ActiveFlag = true,
+        });
+        await _db.SaveChangesAsync();
+
+        var report = await BuildAudit().AuditAsync();
+
+        report.PromoterAlignment.AlignedWithDoctrine.Should().BeFalse();
+        report.PromoterAlignment.Discrepancies.Should().Contain(d =>
+            d.Contains("no active doctrine rule", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Operator_notes_contain_promoter_alignment_statement_when_aligned()
+    {
+        await BuildSeeder().SeedAsync();
+        var report = await BuildAudit().AuditAsync();
+
+        report.OperatorActionableNotes.Should().NotBeEmpty();
+        report.OperatorActionableNotes[0].Should().Contain("PacsSaleTruthPromoter");
+        report.OperatorActionableNotes[0].Should().Contain("'100'");
+        report.OperatorActionableNotes[0].Should().Contain("aligns with");
+    }
+
+    [Fact]
+    public async Task Operator_notes_contain_diverge_statement_when_not_aligned()
+    {
+        var report = await BuildAudit().AuditAsync();
+
+        report.OperatorActionableNotes.Should().NotBeEmpty();
+        report.OperatorActionableNotes[0].Should().Contain("does NOT align");
+    }
+
+    [Fact]
+    public async Task Audited_at_is_recent()
+    {
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        var report = await BuildAudit().AuditAsync();
+        var after = DateTime.UtcNow.AddSeconds(1);
+
+        report.AuditedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public async Task Inactive_rules_show_in_total_but_not_active_count()
+    {
+        await BuildSeeder().SeedAsync();
+        var any = await _db.TfDoctrineSalesQualificationCodes.FirstAsync();
+        any.ActiveFlag = false;
+        await _db.SaveChangesAsync();
+
+        var report = await BuildAudit().AuditAsync();
+        report.DoctrineState.TotalRules.Should().Be(3);
+        report.DoctrineState.ActiveRules.Should().Be(2);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/SalesQualificationCodesSeederTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/SalesQualificationCodesSeederTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Entities.DoctrineTf;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: contract tests for
+/// <see cref="SalesQualificationCodesSeeder"/>.
+/// </summary>
+public sealed class SalesQualificationCodesSeederTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public SalesQualificationCodesSeederTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"sync-d5-seed-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private SalesQualificationCodesSeeder Build()
+        => new(_db, NullLogger<SalesQualificationCodesSeeder>.Instance);
+
+    [Fact]
+    public async Task First_run_inserts_three_seed_rules()
+    {
+        var seeder = Build();
+
+        var added = await seeder.SeedAsync();
+
+        added.Should().Be(3);
+        var rules = await _db.TfDoctrineSalesQualificationCodes.ToListAsync();
+        rules.Should().HaveCount(3);
+        rules.Should().AllSatisfy(r => r.ActiveFlag.Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task Second_run_is_idempotent_no_duplicates()
+    {
+        var seeder = Build();
+
+        await seeder.SeedAsync();
+        var added2 = await seeder.SeedAsync();
+
+        added2.Should().Be(0);
+        var count = await _db.TfDoctrineSalesQualificationCodes.CountAsync();
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Seeder_does_not_reactivate_deactivated_rules()
+    {
+        var seeder = Build();
+        await seeder.SeedAsync();
+
+        // Operator deactivates the pre-2017 DOR rule.
+        var pre2017 = await _db.TfDoctrineSalesQualificationCodes
+            .FirstAsync(r => r.SurfaceCode == "DOR_RATIO"
+                          && r.EffectiveStartYear == 1990);
+        pre2017.ActiveFlag = false;
+        await _db.SaveChangesAsync();
+
+        // Re-run.
+        var added2 = await seeder.SeedAsync();
+
+        added2.Should().Be(0);
+        var refreshed = await _db.TfDoctrineSalesQualificationCodes
+            .FirstAsync(r => r.RuleId == pre2017.RuleId);
+        refreshed.ActiveFlag.Should().BeFalse(
+            "soft-disable is sticky; seeder must not reactivate operator-disabled rules");
+    }
+
+    [Fact]
+    public async Task Seeded_rules_each_carry_evidence_and_confidence()
+    {
+        var seeder = Build();
+        await seeder.SeedAsync();
+
+        var rules = await _db.TfDoctrineSalesQualificationCodes.ToListAsync();
+        rules.Should().AllSatisfy(r =>
+        {
+            r.EvidenceSource.Should().NotBeNullOrWhiteSpace();
+            r.Confidence.Should().BeOneOf("HIGH", "MEDIUM", "LOW");
+            r.SurfaceCode.Should().BeOneOf("DOR_RATIO", "COUNTY_RATIO");
+            r.QualifiedCodesJson.Should().StartWith("[").And.EndWith("]");
+        });
+    }
+
+    [Fact]
+    public async Task Adding_an_extra_rule_alongside_seed_is_preserved()
+    {
+        var seeder = Build();
+        await seeder.SeedAsync();
+
+        // Operator adds a hypothetical new rule.
+        _db.TfDoctrineSalesQualificationCodes.Add(new TfDoctrineSalesQualificationCode
+        {
+            RuleId = Guid.NewGuid(),
+            SurfaceCode = "DOR_RATIO",
+            SourceField = "sl_county_ratio_cd",
+            EffectiveStartYear = 2030,
+            EffectiveEndYear = null,
+            QualifiedCodesJson = "[\"100\",\"110\"]",
+            EvidenceSource = "operator-extension future",
+            Confidence = "LOW",
+            ActiveFlag = true,
+        });
+        await _db.SaveChangesAsync();
+
+        var added2 = await seeder.SeedAsync();
+
+        added2.Should().Be(0, "the three deterministic seed rules were already inserted");
+        var total = await _db.TfDoctrineSalesQualificationCodes.CountAsync();
+        total.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Deterministic_rule_ids_used_so_seed_is_reproducible()
+    {
+        var seeder = Build();
+        await seeder.SeedAsync();
+
+        var ids = await _db.TfDoctrineSalesQualificationCodes
+            .Select(r => r.RuleId)
+            .OrderBy(g => g)
+            .ToListAsync();
+
+        // Re-run on a fresh DB and confirm the same IDs.
+        var opts2 = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"sync-d5-seed-2-{Guid.NewGuid():N}")
+            .Options;
+        var cfg2 = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        using var db2 = new TerraFusionDbContext(opts2, cfg2);
+        db2.Database.EnsureCreated();
+
+        var seeder2 = new SalesQualificationCodesSeeder(
+            db2, NullLogger<SalesQualificationCodesSeeder>.Instance);
+        await seeder2.SeedAsync();
+        var ids2 = await db2.TfDoctrineSalesQualificationCodes
+            .Select(r => r.RuleId)
+            .OrderBy(g => g)
+            .ToListAsync();
+
+        ids2.Should().Equal(ids);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/SalesQualificationYearBoundaryTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/SalesQualificationYearBoundaryTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.Core.Sync.Doctrine;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.Doctrine;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Doctrine;
+
+/// <summary>
+/// SYNC-DOCTRINE-5: year-aware lookup contract tests for
+/// <see cref="DoctrineSalesAuditService.LookupRulesForYearAsync"/>.
+/// Validates that pre-2017 vs post-2017 boundaries are honored.
+/// </summary>
+public sealed class SalesQualificationYearBoundaryTests : IDisposable
+{
+    private readonly TerraFusionDbContext _db;
+
+    public SalesQualificationYearBoundaryTests()
+    {
+        var options = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: $"sync-d5-year-{Guid.NewGuid():N}")
+            .Options;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "InMemory",
+            })
+            .Build();
+        _db = new TerraFusionDbContext(options, configuration);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private async Task SeedAsync()
+        => await new SalesQualificationCodesSeeder(
+            _db, NullLogger<SalesQualificationCodesSeeder>.Instance).SeedAsync();
+
+    private DoctrineSalesAuditService BuildAudit()
+        => new(_db, NullLogger<DoctrineSalesAuditService>.Instance);
+
+    [Fact]
+    public async Task Year_2025_returns_post2017_DOR_and_post2018_COUNTY_rules()
+    {
+        await SeedAsync();
+
+        var rules = await BuildAudit().LookupRulesForYearAsync(2025);
+
+        rules.Should().HaveCount(2);
+        rules.Should().Contain(r =>
+            r.SurfaceCode == "DOR_RATIO"
+            && r.SourceField == "sl_county_ratio_cd"
+            && r.EffectiveStartYear == 2017
+            && r.EffectiveEndYear == null
+            && r.QualifiedCodes.SequenceEqual(new[] { "100" }));
+        rules.Should().Contain(r =>
+            r.SurfaceCode == "COUNTY_RATIO"
+            && r.SourceField == "sl_ratio_type_cd"
+            && r.EffectiveStartYear == 2018
+            && r.QualifiedCodes.SequenceEqual(new[] { "00" }));
+    }
+
+    [Fact]
+    public async Task Year_2010_returns_only_pre2017_DOR_rule()
+    {
+        await SeedAsync();
+
+        var rules = await BuildAudit().LookupRulesForYearAsync(2010);
+
+        rules.Should().HaveCount(1);
+        rules[0].SurfaceCode.Should().Be("DOR_RATIO");
+        rules[0].EffectiveStartYear.Should().Be(1990);
+        rules[0].EffectiveEndYear.Should().Be(2016);
+        rules[0].QualifiedCodes.Should().Equal(new[] { "0" });
+    }
+
+    [Fact]
+    public async Task Surface_filter_narrows_to_DOR_only()
+    {
+        await SeedAsync();
+
+        var rules = await BuildAudit().LookupRulesForYearAsync(2025, surface: "DOR_RATIO");
+
+        rules.Should().HaveCount(1);
+        rules[0].SurfaceCode.Should().Be("DOR_RATIO");
+    }
+
+    [Fact]
+    public async Task Year_2017_boundary_returns_post2017_DOR_not_pre2017()
+    {
+        await SeedAsync();
+
+        var rules = await BuildAudit().LookupRulesForYearAsync(2017, surface: "DOR_RATIO");
+
+        // Year 2017: post-2017 rule starts inclusive at 2017; pre-2017
+        // rule ends inclusive at 2016. Only the post-2017 rule applies.
+        rules.Should().HaveCount(1);
+        rules[0].EffectiveStartYear.Should().Be(2017);
+        rules[0].QualifiedCodes.Should().Equal(new[] { "100" });
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing fourth doctrine table from the operator's prescription (`reference_benton_sync_doctrine_corrections.md`):

> "build tf_doctrine_{sales,improvement,property_universe,ratio_policy} tables with effective_start_year + source_field + qualified_codes + evidence_source + confidence."

State before: `tf_doctrine_ratio_policy` (D1) ✅, `tf_doctrine_property_universe` + `tf_doctrine_attribute_dictionary` (D4) ✅, `tf_doctrine_sales_qualification_codes` ❌. This PR closes the last gap.

## What's in this slice

- **Entity + EF config + migration** `SyncDoctrine5SalesQualificationCodes` — new schema `doctrine_tf.tf_doctrine_sales_qualification_codes` with `(SurfaceCode, EffectiveStartYear)` lookup index, `SourceField` index, `ActiveFlag` filter index.
- **Idempotent seeder** with deterministic GUIDs and three Benton rules:
  - `DOR_RATIO` via `sl_county_ratio_cd`, years 2017+, qualified `["100"]`, HIGH
  - `DOR_RATIO` via `sl_county_ratio_cd`, years 1990–2016, qualified `["0"]`, HIGH
  - `COUNTY_RATIO` via `sl_ratio_type_cd`, years 2018+, qualified `["00"]`, MEDIUM
- **Hosted service** runs seeder at backend startup; non-fatal on failure (mirrors D1/D4).
- **Audit service** `IDoctrineSalesAuditService` + `GET /api/sync/doctrine/policy/sales-qualification/audit` — read-only JSON report covering doctrine state, promoter alignment, year-awareness presence checks, operator-actionable notes.
- **Promoter snapshot constant** `PacsSaleTruthPromoterSnapshot` captures the promoter's current hardcoded behavior (`sl_county_ratio_cd` → `["100"]`) so the audit can compare without modifying the promoter.
- **Soft-disable sticky**: deactivated rules are NOT reactivated by re-running the seeder.
- **List endpoint** `GET /api/sync/doctrine/policy/sales-qualification` and **manual-seed endpoint** `POST /api/sync/doctrine/policy/sales-qualification/seed`.

## Test plan

- [x] **23 new tests** under `backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/`
  - 6 seeder (idempotent, three rules inserted, deactivation respected, evidence/confidence carried, deterministic-GUID reproducibility, extra rules preserved)
  - 11 audit service (empty / seeded state, three year-awareness checks, MISSING when deactivated, alignment pass/fail/no-rule, operator notes content, AuditedAt timestamp, inactive-rule counting)
  - 4 year-boundary lookup (2025 → DOR-post + COUNTY-post; 2010 → DOR-pre only; surface filter; 2017-boundary inclusive)
  - 2 endpoint contract (200 OK with report on populated and empty tables)
- [x] **3291 / 3291** full unit suite passes
- [x] Backend build clean — **0 warnings, 0 errors**
- [x] One migration only (`20260508172855_SyncDoctrine5SalesQualificationCodes`)
- [x] `PacsSaleTruthPromoter` behavior unchanged
- [x] `tf_doctrine_ratio_policy` rows / behavior unchanged
- [x] Audit endpoint mirrors D7 pattern (no `[Authorize]`, on `DoctrinePolicyController` route)

## Design notes

- **Promoter alignment without modifying the promoter** — `PacsSaleTruthPromoterSnapshot` is a static class in `IDoctrineSalesAuditService.cs` that captures the column + code-set the promoter qualifies. The audit reads doctrine, computes the union of active DOR codes for `sl_county_ratio_cd`, and reports `aligned=true` iff the snapshot's codes are a subset. Update the snapshot when the promoter's surface changes.
- **Year-aware lookup** filters on `ActiveFlag=true AND EffectiveStartYear<=year AND (EffectiveEndYear IS NULL OR EffectiveEndYear>=year)`. Inclusive on both ends; the 2017 boundary returns the post-2017 rule (start=2017) and excludes the pre-2017 rule (end=2016).
- **Soft-disable sticky** — the seeder keys on `RuleId`, so an existing row (active or deactivated) is left alone. The audit reports `MISSING` for any locked rule that's not currently active. Mirrors the V2 universe-seeder convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added sales-qualification policy endpoints at `api/sync/doctrine/policy/sales-qualification`:
  * GET endpoint to query and filter rules by surface and source field
  * Audit endpoint to verify promoter alignment and year-awareness validation
  * Seed endpoint to initialize qualification rules with evidence and confidence metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->