### PR TITLE
fix(sync): SYNC-COMPLETE-2 reconciliation policy — parcel uses DOCTRINE_FILTERED with working-year join

### DIFF
--- a/backend/src/TerraFusion.Core/Sync/Corpus/CorpusReconciliationPolicy.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/CorpusReconciliationPolicy.cs
@@ -10,9 +10,15 @@ namespace TerraFusion.Core.Sync.Corpus;
 /// <c>(ExpectedBasis, TolerancePct)</c>:</para>
 /// <list type="bullet">
 ///   <item><c>RAW_SOURCE</c> — match the raw PACS row count exactly
-///   (parcel: real-property filter; land: per-segment).</item>
+///   (no current lanes; reserved for future raw-row reconciliations).</item>
 ///   <item><c>DOCTRINE_FILTERED</c> — match PACS rows after doctrine
-///   filter (sales, improvement, wsdor).</item>
+///   filter. Parcel: <c>prop_type_cd='R'</c> joined to
+///   <c>property_val</c> at the working year (a historical R-typed
+///   prop_id without a working-year <c>property_val</c> row is not a
+///   parcel-spine candidate). Land: <c>land_detail</c> joined to
+///   <c>property</c> and <c>property_val</c> with the same R-typed +
+///   working-year filter and <c>sup_num=0</c>. Improvement, sales,
+///   and wsdor also doctrine-filtered.</item>
 ///   <item><c>DEDUPED_CANONICAL</c> — canonical de-duped against
 ///   PACS source (owner).</item>
 ///   <item><c>EXTERNAL_FEATURE_COUNT</c> — match an external feature
@@ -20,6 +26,19 @@ namespace TerraFusion.Core.Sync.Corpus;
 /// </list>
 ///
 /// <para>Tolerances LOCKED per the SYNC-COMPLETE-2 spec.</para>
+///
+/// <para>SYNC-COMPLETE-2-RECONCILIATION-POLICY-FIX (2026-05-11):
+/// parcel + land moved from <c>RAW_SOURCE</c> to
+/// <c>DOCTRINE_FILTERED</c>. The pre-fix parcel basis (owner-anchored
+/// at <c>owner_tax_yr&gt;=2018</c>) over-counted by ~13.9% against
+/// <c>tf_parcel</c> because the truth promoter correctly filters out
+/// R-typed prop_ids that have no working-year <c>property_val</c>
+/// row. Real-world drain: PACS R-typed=96,750 vs canonical=83,326,
+/// doctrine-filtered=83,326 (delta=0). Land follows the same shape:
+/// the drain only lands <c>sup_num=0</c> land segments tied to
+/// working-year R-typed parcels in the spine, so the baseline must
+/// mirror that doctrine instead of counting every
+/// <c>land_detail</c> row at <c>prop_val_yr=@yr</c>.</para>
 /// </summary>
 public static class CorpusReconciliationPolicy
 {
@@ -53,10 +72,10 @@ public static class CorpusReconciliationPolicy
     public static IReadOnlyDictionary<string, LanePolicy> Policies { get; } =
         new Dictionary<string, LanePolicy>(StringComparer.OrdinalIgnoreCase)
         {
-            [LaneParcel] = new(ExpectedBasisRawSource, 0.00m),
+            [LaneParcel] = new(ExpectedBasisDoctrineFiltered, 0.00m),
             [LaneOwnerWsdor] = new(ExpectedBasisDedupedCanonical, 2.00m),
             [LaneImprovement] = new(ExpectedBasisDoctrineFiltered, 1.00m),
-            [LaneLand] = new(ExpectedBasisRawSource, 0.10m),
+            [LaneLand] = new(ExpectedBasisDoctrineFiltered, 0.10m),
             [LaneSales] = new(ExpectedBasisDoctrineFiltered, 0.50m),
             [LaneGeometry] = new(ExpectedBasisExternalFeatureCount, 0.00m),
         };

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/PacsBaselineReconciler.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/PacsBaselineReconciler.cs
@@ -20,15 +20,24 @@ namespace TerraFusion.Data.Services.Workbench.Corpus;
 /// lane drains:</para>
 /// <list type="bullet">
 ///   <item><b>parcel</b>: distinct <c>prop_id</c> from
-///   <c>dbo.owner</c> with <c>sup_num=0 AND owner_tax_yr&gt;=2018</c>
-///   — the owner-anchored seed each parcel drain uses.</item>
+///   <c>dbo.property</c> joined to <c>dbo.property_val</c> at the
+///   working year, filtered <c>prop_type_cd='R'</c>. The truth
+///   promoter only keeps R-typed parcels with a working-year
+///   <c>property_val</c> row, so the baseline must mirror that
+///   doctrine (a historical R-typed prop_id without a working-year
+///   property_val row is not a spine candidate).</item>
 ///   <item><b>owner-wsdor</b>: distinct <c>owner_id</c> from
 ///   <c>dbo.owner</c> + WPOV count for the working year. We aggregate
 ///   into one count: <c>distinct owner_id + wash_prop_owner_val(@yr)</c>
 ///   to reconcile against canonical <c>tf_owner + tf_assessment_wsdor</c>.</item>
 ///   <item><b>improvement</b>: <c>dbo.imprv</c> filtered by
 ///   <c>prop_val_yr=@yr</c>.</item>
-///   <item><b>land</b>: <c>dbo.land_detail</c> filtered by
+///   <item><b>land</b>: <c>dbo.land_detail</c> joined to
+///   <c>dbo.property</c> and <c>dbo.property_val</c>, filtered
+///   <c>prop_type_cd='R' AND ld.sup_num=0 AND pv.prop_val_yr=@yr</c>.
+///   The land drain only lands sup_num=0 segments tied to working-year
+///   R-typed spine parcels, so the baseline mirrors that population
+///   rather than counting every <c>land_detail</c> row at
 ///   <c>prop_val_yr=@yr</c>.</item>
 ///   <item><b>sales</b>: <c>dbo.sale</c> doctrine-qualified count
 ///   (<c>sl_county_ratio_cd IN ('100','0') OR sl_ratio_type_cd='00'</c>)
@@ -42,6 +51,11 @@ namespace TerraFusion.Data.Services.Workbench.Corpus;
 /// or ArcGIS misconfigured returns <c>Outcome=Unreachable</c> with
 /// <c>Notes</c>; the orchestrator records that as <c>Investigate</c>
 /// instead of throwing.</para>
+///
+/// <para>SYNC-COMPLETE-2-RECONCILIATION-POLICY-FIX (2026-05-11):
+/// parcel + land queries swapped to the doctrine-filtered joined form.
+/// See <see cref="CorpusReconciliationPolicy"/> for the policy-side
+/// rationale.</para>
 /// </summary>
 public sealed class PacsBaselineReconciler : IPacsBaselineReconciler
 {
@@ -90,7 +104,7 @@ public sealed class PacsBaselineReconciler : IPacsBaselineReconciler
             return lane switch
             {
                 CorpusReconciliationPolicy.LaneParcel =>
-                    await QueryParcelAsync(pacsCs, cancellationToken).ConfigureAwait(false),
+                    await QueryParcelAsync(pacsCs, workingYear, cancellationToken).ConfigureAwait(false),
                 CorpusReconciliationPolicy.LaneOwnerWsdor =>
                     await QueryOwnerWsdorAsync(pacsCs, workingYear, cancellationToken).ConfigureAwait(false),
                 CorpusReconciliationPolicy.LaneImprovement =>
@@ -152,18 +166,26 @@ public sealed class PacsBaselineReconciler : IPacsBaselineReconciler
     // ── PACS queries (per lane) ─────────────────────────────────────
 
     /// <summary>
-    /// Parcel lane reconciles against the owner-anchored seed
-    /// population: distinct prop_id across <c>dbo.owner</c> at
-    /// <c>sup_num=0 AND owner_tax_yr&gt;=2018</c>. This matches the
-    /// row population the parcel drain actually lands.
+    /// Parcel lane reconciles against the doctrine-filtered spine
+    /// population: distinct <c>prop_id</c> across <c>dbo.property</c>
+    /// inner-joined to <c>dbo.property_val</c> at the working year,
+    /// filtered <c>prop_type_cd='R'</c>. This matches the row
+    /// population the parcel-spine truth promoter actually lands —
+    /// historical R-typed prop_ids without a working-year property_val
+    /// row are correctly excluded by the promoter.
     /// </summary>
-    private async Task<PacsBaselineResult> QueryParcelAsync(string cs, CancellationToken ct)
+    private async Task<PacsBaselineResult> QueryParcelAsync(string cs, short yr, CancellationToken ct)
     {
         const string sql =
-            "SELECT COUNT(DISTINCT prop_id) FROM dbo.owner " +
-            "WHERE sup_num = 0 AND owner_tax_yr >= 2018";
-        var count = await ExecuteScalarLongAsync(cs, sql, ct).ConfigureAwait(false);
-        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+            "SELECT COUNT(DISTINCT p.prop_id) FROM dbo.property p " +
+            "INNER JOIN dbo.property_val pv ON p.prop_id = pv.prop_id " +
+            "WHERE p.prop_type_cd = 'R' AND pv.prop_val_yr = @yr";
+        var count = await ExecuteScalarLongAsync(
+            cs, sql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
+        return new PacsBaselineResult(
+            PacsBaselineOutcome.Ok, count,
+            $"Doctrine-filtered: distinct prop_id where prop_type_cd='R' AND " +
+            $"property_val(@yr={yr}) exists. Compared against tf_parcel.");
     }
 
     /// <summary>
@@ -197,11 +219,30 @@ public sealed class PacsBaselineReconciler : IPacsBaselineReconciler
         return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
     }
 
+    /// <summary>
+    /// Land lane reconciles against the doctrine-filtered land
+    /// population: <c>dbo.land_detail</c> joined to <c>dbo.property</c>
+    /// + <c>dbo.property_val</c>, filtered
+    /// <c>p.prop_type_cd='R' AND ld.sup_num=0 AND pv.prop_val_yr=@yr</c>.
+    /// The land drain only lands sup_num=0 segments tied to working-year
+    /// R-typed spine parcels, so the baseline mirrors that population
+    /// rather than counting every <c>land_detail</c> row at
+    /// <c>prop_val_yr=@yr</c>.
+    /// </summary>
     private async Task<PacsBaselineResult> QueryLandAsync(string cs, short yr, CancellationToken ct)
     {
-        const string sql = "SELECT COUNT(*) FROM dbo.land_detail WHERE prop_val_yr = @yr";
-        var count = await ExecuteScalarLongAsync(cs, sql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
-        return new PacsBaselineResult(PacsBaselineOutcome.Ok, count, null);
+        const string sql =
+            "SELECT COUNT(*) FROM dbo.land_detail ld " +
+            "INNER JOIN dbo.property p ON p.prop_id = ld.prop_id " +
+            "INNER JOIN dbo.property_val pv " +
+            "  ON pv.prop_id = ld.prop_id AND pv.prop_val_yr = ld.prop_val_yr " +
+            "WHERE p.prop_type_cd = 'R' AND ld.sup_num = 0 AND pv.prop_val_yr = @yr";
+        var count = await ExecuteScalarLongAsync(
+            cs, sql, ct, ("@yr", (object)(int)yr)).ConfigureAwait(false);
+        return new PacsBaselineResult(
+            PacsBaselineOutcome.Ok, count,
+            $"Doctrine-filtered: land_detail rows where prop_type_cd='R' AND " +
+            $"sup_num=0 AND prop_val_yr={yr}. Compared against tf_land.");
     }
 
     /// <summary>

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/CorpusReconciliationPolicyTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/CorpusReconciliationPolicyTests.cs
@@ -10,11 +10,17 @@ namespace TerraFusion.Unit.Tests.Sync.Corpus;
 /// </summary>
 public sealed class CorpusReconciliationPolicyTests
 {
+    // SYNC-COMPLETE-2-RECONCILIATION-POLICY-FIX (2026-05-11):
+    // parcel + land moved RAW_SOURCE → DOCTRINE_FILTERED. The pre-fix
+    // parcel basis (owner-anchored at owner_tax_yr>=2018) over-counted
+    // by ~13.9% against tf_parcel; doctrine-filtered (R-typed AND
+    // working-year property_val exists) reconciles to delta=0. Land
+    // follows the same shape.
     [Theory]
-    [InlineData("parcel", "RAW_SOURCE", 0.00)]
+    [InlineData("parcel", "DOCTRINE_FILTERED", 0.00)]
     [InlineData("owner-wsdor", "DEDUPED_CANONICAL", 2.00)]
     [InlineData("improvement", "DOCTRINE_FILTERED", 1.00)]
-    [InlineData("land", "RAW_SOURCE", 0.10)]
+    [InlineData("land", "DOCTRINE_FILTERED", 0.10)]
     [InlineData("sales", "DOCTRINE_FILTERED", 0.50)]
     [InlineData("geometry", "EXTERNAL_FEATURE_COUNT", 0.00)]
     public void Policy_table_is_locked_per_spec(string lane, string basis, double tolerance)
@@ -22,6 +28,48 @@ public sealed class CorpusReconciliationPolicyTests
         var policy = CorpusReconciliationPolicy.Policies[lane];
         policy.ExpectedBasis.Should().Be(basis);
         policy.TolerancePct.Should().Be((decimal)tolerance);
+    }
+
+    [Fact]
+    public void Parcel_lane_uses_DOCTRINE_FILTERED_basis()
+    {
+        // Locked: parcel reconciles against PACS R-typed parcels with
+        // a working-year property_val row, not the raw R-typed count.
+        var policy = CorpusReconciliationPolicy.Policies[CorpusReconciliationPolicy.LaneParcel];
+        policy.ExpectedBasis.Should().Be(CorpusReconciliationPolicy.ExpectedBasisDoctrineFiltered);
+        policy.TolerancePct.Should().Be(0.00m);
+    }
+
+    [Fact]
+    public void Land_lane_uses_DOCTRINE_FILTERED_basis()
+    {
+        // Locked: land reconciles against PACS land_detail rows tied
+        // to R-typed spine parcels at sup_num=0 for the working year.
+        var policy = CorpusReconciliationPolicy.Policies[CorpusReconciliationPolicy.LaneLand];
+        policy.ExpectedBasis.Should().Be(CorpusReconciliationPolicy.ExpectedBasisDoctrineFiltered);
+        policy.TolerancePct.Should().Be(0.10m);
+    }
+
+    [Fact]
+    public void Parcel_reconciliation_returns_Match_when_canonical_equals_doctrine_filtered_baseline()
+    {
+        // Fixture: real-world drain at working year 2026.
+        // Doctrine-filtered baseline = canonical count = 83,326.
+        // Pre-fix RAW_SOURCE basis would have been 96,750 → delta = -13,424
+        // → reported "Investigate" falsely. This test pins the corrected
+        // behavior: canonical == doctrine-filtered baseline → Match.
+        const long doctrineFilteredBaseline = 83_326L;
+        const long canonicalCount = 83_326L;
+        var delta = canonicalCount - doctrineFilteredBaseline;
+        var deltaPct = CorpusReconciliationPolicy.ComputeDeltaPct(doctrineFilteredBaseline, delta);
+        var parcelTolerance = CorpusReconciliationPolicy
+            .Policies[CorpusReconciliationPolicy.LaneParcel].TolerancePct;
+
+        var status = CorpusReconciliationPolicy.Classify(delta, deltaPct, parcelTolerance);
+
+        status.Should().Be(CorpusReconciliationPolicy.ReconciliationStatusMatch);
+        delta.Should().Be(0);
+        deltaPct.Should().Be(0m);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Parcel + land reconciliation lanes were locked as `RAW_SOURCE` in `CorpusReconciliationPolicy`. The parcel basis (distinct `prop_id` from `dbo.owner` at `owner_tax_yr>=2018`) over-counted by ~13.9% against `tf_parcel`, so the corpus runner reported `Investigate` falsely on every parcel reconciliation.

The truth promoter is correct — it only keeps R-typed parcels with a working-year `property_val` row. The baseline must mirror that doctrine.

## Real-world drain (WY=2026)

| Basis | Count | Delta vs canonical |
| --- | --: | --: |
| PACS R-typed (all) — old `RAW_SOURCE` | 96,750 | -13.9% (Investigate) |
| canonical_tf.tf_parcel | 83,326 | — |
| PACS R-typed AND has 2026 `property_val` — new `DOCTRINE_FILTERED` | 83,326 | 0 (Match) |

The 13K "missing" parcels are historical R-typed `prop_ids` with no current-year `property_val`. They correctly surface as owner-lane `NO_PARCEL_XREF` quarantine (175,818 rows) — also doctrine-correct.

## Land lane

Confirmed the same shape: the land drain only lands `sup_num=0` segments tied to working-year R-typed spine parcels (via `KeyedSqlServerPacsLandDetailSource` → spine prop_ids). The pre-fix baseline counted every `land_detail` row at `prop_val_yr=@yr`, including non-R + non-sup_num=0 + non-spine rows. Changed `land` to `DOCTRINE_FILTERED` with a 3-way join mirroring the drain.

## Changes

- `CorpusReconciliationPolicy.cs` — `parcel` + `land` basis → `DOCTRINE_FILTERED`. Tolerances unchanged (0.00% / 0.10%). Class doc rewritten with rationale.
- `PacsBaselineReconciler.cs`:
  - `QueryParcelAsync`: now joins `property` → `property_val` at `@yr`, filters `prop_type_cd='R'`.
  - `QueryLandAsync`: now joins `land_detail` → `property` → `property_val` on `(prop_id, prop_val_yr)`, filters `prop_type_cd='R' AND ld.sup_num=0`.
- Tests: locked `[Theory]` updated for parcel + land, three new pinning tests added (per-lane basis, Match-on-equal-baseline behavior using the 83,326 real-drain figures).

## Out of scope

- Live re-replay against PACS (covered by ops follow-up; CI does not touch live MSSQL).
- Drain endpoints themselves — untouched.
- Other lanes (owner-wsdor, improvement, sales, geometry) — no policy change.
- No migration. Schema unchanged.

## Test plan

- [x] `dotnet build backend/TerraFusion.sln` — 0 warn / 0 err
- [x] Targeted: `dotnet test ... --filter "FullyQualifiedName~ReconciliationPolicy|FullyQualifiedName~Baseline"` — 37/37
- [x] Full unit suite: `dotnet test backend/tests/TerraFusion.Unit.Tests` — 3318/3318
- [ ] Operator: re-trigger corpus runner against live PACS (`tf-corpus-runner` worktree) and confirm `parcel` + `land` reconciliations report `Match` with `delta=0` at WY=2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parcel and land data reconciliation by refining baseline calculation methodologies to incorporate filtered, year-specific population counts, ensuring improved data quality and comparison accuracy during reconciliation cycles.

* **Tests**
  * Added unit tests to validate parcel and land reconciliation policies against updated baseline expectations and data filtering standards, ensuring proper classification outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/816)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->