### PR TITLE
fix(sync): expose LastCompletedStage on corpus lane snapshot DTO

### DIFF
--- a/backend/src/TerraFusion.Core/Sync/Corpus/IFullCorpusOrchestrator.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/IFullCorpusOrchestrator.cs
@@ -91,7 +91,8 @@ public sealed record CorpusLaneSnapshot(
     string? CountsJson,
     string? GateSummaryJson,
     string? QuarantineDeltaJson,
-    string? ErrorMessage);
+    string? ErrorMessage,
+    string? LastCompletedStage);
 
 public sealed record CorpusReconciliationSnapshot(
     Guid ReconciliationId,

--- a/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestrator.cs
+++ b/backend/src/TerraFusion.Data/Services/Workbench/Corpus/FullCorpusOrchestrator.cs
@@ -197,7 +197,8 @@ public sealed class FullCorpusOrchestrator : IFullCorpusOrchestrator
         l.CountsJson,
         l.GateSummaryJson,
         l.QuarantineDeltaJson,
-        l.ErrorMessage);
+        l.ErrorMessage,
+        l.LastCompletedStage);
 
     private static CorpusReconciliationSnapshot ToSnapshot(FullCorpusReconciliation r) => new(
         r.ReconciliationId,

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/FullCorpusOrchestratorTests.cs
@@ -174,6 +174,35 @@ public sealed class FullCorpusOrchestratorTests : IDisposable
     }
 
     [Fact]
+    public async Task GetStatusAsync_surfaces_LastCompletedStage_from_db_row()
+    {
+        // SYNC-COMPLETE-2-V2: stage-resume persists LastCompletedStage on
+        // the lane row; the API status projection must expose it so
+        // operators querying GET /api/sync/corpus/{runId} see the
+        // checkpoint, not null.
+        var svc = Build();
+        var start = await svc.StartAsync("op", 2026, CancellationToken.None);
+
+        var improvementLane = await _db.FullCorpusLaneResults
+            .SingleAsync(l => l.RunId == start.RunId && l.Lane == "improvement");
+        improvementLane.LastCompletedStage = "promote-truth";
+        await _db.SaveChangesAsync();
+
+        var status = await svc.GetStatusAsync(start.RunId, CancellationToken.None);
+
+        status.Outcome.Should().Be(CorpusOutcome.Ok);
+        status.Lanes.Should().NotBeNull();
+        var snapshot = status.Lanes!.Single(s => s.Lane == "improvement");
+        snapshot.LastCompletedStage.Should().Be("promote-truth");
+
+        // Other lanes still report null — fresh-start sentinel preserved.
+        status.Lanes!
+            .Where(s => s.Lane != "improvement")
+            .Should()
+            .OnlyContain(s => s.LastCompletedStage == null);
+    }
+
+    [Fact]
     public async Task GetReconciliationAsync_returns_empty_when_not_yet_run()
     {
         var run = await SeedRunAsync(FullCorpusOrchestrator.StatusRunning);


### PR DESCRIPTION
## Summary

- SYNC-COMPLETE-2-V2 added a stage-resume checkpoint column (`LastCompletedStage`) on `tf_workbench.full_corpus_lane_result`, but the API status DTO (`CorpusLaneSnapshot`) was not updated to expose it. Operators querying `GET /api/sync/corpus/{runId}` saw the field missing/null even when the DB row had it set.
- Adds `string? LastCompletedStage` to `CorpusLaneSnapshot` (single positional record arg appended; only one call-site).
- Populates it in `FullCorpusOrchestrator.ToSnapshot(FullCorpusLaneResult)`.

## Scope

- 2 source files (DTO record + projection), 1 test file.
- No changes to orchestrator state machine, worker, persistence, reconciliation, drain endpoints, or UI.

## Test plan

- [x] `dotnet build` 0 warnings / 0 errors
- [x] New test `GetStatusAsync_surfaces_LastCompletedStage_from_db_row` passes (seeds `LastCompletedStage='promote-truth'` on improvement lane row, asserts field surfaces and other 5 lanes remain null).
- [x] `FullCorpusOrchestratorTests` 29 -> 30, full unit suite 3315 -> 3316, all green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status reporting for corpus processing now includes the last completed stage for each lane.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/817)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->