### PR TITLE
feat(sync): SYNC-COMPLETE-2-V3 — year-sliced ImprvAttr-S1 stage

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -928,7 +928,26 @@ public class DoctrineDrainController : ControllerBase
                 await resume.CheckpointAsync("ImprvDetail-S1", batchIds, cancellationToken);
             }
 
-            // Stage 10: ImprvAttr-S1.
+            // Stage 10: ImprvAttr-S1 (SYNC-COMPLETE-2-V3 year-sliced).
+            //
+            // Empirically, draining all years of imprv_attr in a single
+            // EF-buffered landing call exhausts ChangeTracker memory
+            // (~1.9 GB) and saturates postgres I/O before completion at
+            // full-corpus scale (~6M imprv_attr rows). Year-slice the
+            // stage so each commit covers a single prop_val_yr, keeping
+            // the working set bounded and allowing mid-stage resume.
+            //
+            // Substages are named ImprvAttr-S1-Y{year}. Year list is
+            // queried from legacy_pacs_raw.imprv after Imprv-S1 lands
+            // (so we only iterate years that actually have improvement
+            // rows). The substages slot logically between ImprvDetail-S1
+            // and Imprv-Truth — see LaneStageOrder.ShouldSkip.
+            //
+            // batchIds gets exactly ONE entry appended for the entire
+            // ImprvAttr-S1 stage at completion (the last year's batch id,
+            // occupying the static ImprvAttr-S1 slot for position-mapping
+            // of downstream stages). Per-year batch ids are observable
+            // via LoadBatch rows + structured logs.
             int attrS1RowsLanded = 0;
             if (resume.ShouldSkip("ImprvAttr-S1"))
             {
@@ -936,13 +955,25 @@ public class DoctrineDrainController : ControllerBase
             }
             else
             {
-                var attrSrc = new KeyedSqlServerPacsImprvAttrSource(pacsCs!, imprvKeys);
-                var attrS1 = await imprvAttrSvc.LandImprvAttrsAsync(attrSrc, operatorName, cancellationToken);
-                batchIds.Add(attrS1.LoadBatchId);
-                if (!IsCompleted(attrS1.Status))
-                    return await FailLaneAsync(LaneName, "ImprvAttr-S1", attrS1.ErrorSummary,
-                        batchIds, startedAt, quarantineBefore, cancellationToken);
-                attrS1RowsLanded = attrS1.RowsLanded;
+                var yearSliced = await RunYearSlicedImprvAttrStageAsync(
+                    imprvAttrSvc, pacsCs!, spinePropIds, resume, batchIds,
+                    operatorName, startedAt, quarantineBefore,
+                    cancellationToken);
+                attrS1RowsLanded = yearSliced.TotalRowsLanded;
+                if (yearSliced.FailureResponse is not null)
+                {
+                    return yearSliced.FailureResponse;
+                }
+                if (yearSliced.LastBatchId is { } finalBatchId)
+                {
+                    // Year-sliced stage completed successfully → record
+                    // the parent-stage checkpoint with the final batch
+                    // id appended to batchIds. (Per-year batch ids are
+                    // intentionally NOT in batchIds; position-mapping
+                    // for downstream stages depends on ImprvAttr-S1
+                    // occupying exactly one slot.)
+                    batchIds.Add(finalBatchId);
+                }
                 await resume.CheckpointAsync("ImprvAttr-S1", batchIds, cancellationToken);
             }
 
@@ -1642,6 +1673,141 @@ public class DoctrineDrainController : ControllerBase
 
     private static bool IsCompleted(string? status) =>
         string.Equals(status, "COMPLETED", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// SYNC-COMPLETE-2-V3: outcome of a year-sliced ImprvAttr-S1 stage.
+    /// Exactly one of <see cref="FailureResponse"/> / <see cref="LastBatchId"/>
+    /// will be set (mutually exclusive). <see cref="TotalRowsLanded"/> is
+    /// the cumulative landed-row count across every year-substage that
+    /// ran (skipped years do not contribute).
+    /// </summary>
+    private sealed class YearSlicedImprvAttrResult
+    {
+        public Guid? LastBatchId { get; init; }
+        public int TotalRowsLanded { get; init; }
+        public IActionResult? FailureResponse { get; init; }
+    }
+
+    /// <summary>
+    /// SYNC-COMPLETE-2-V3: year-slice the <c>ImprvAttr-S1</c> stage of
+    /// the improvement lane. Runs one landing batch per distinct
+    /// <c>prop_val_yr</c> in <c>legacy_pacs_raw.imprv</c> for the seed
+    /// prop_ids, ascending. After each year completes, persists
+    /// <c>LastCompletedStage = "ImprvAttr-S1-Y{year}"</c> so a crash
+    /// resumes at the next un-completed year.
+    ///
+    /// <para>Returns a result object whose <c>LastBatchId</c> (the last
+    /// year's batch id) is the single representative slot to append to
+    /// <c>batchIds</c> for the parent <c>ImprvAttr-S1</c> stage position.
+    /// On any year-substage failure, <c>FailureResponse</c> holds the
+    /// pre-built <c>FailLaneAsync</c> result and the caller should
+    /// propagate it directly.</para>
+    ///
+    /// <para>Function-preserving: same landing service, same hashing,
+    /// same gates, same quarantine semantics. Only the per-call working
+    /// set is smaller and resume granularity is finer.</para>
+    /// </summary>
+    private async Task<YearSlicedImprvAttrResult> RunYearSlicedImprvAttrStageAsync(
+        IPacsImprvAttrLandingService imprvAttrSvc,
+        string pacsConnectionString,
+        IReadOnlyList<int> seedPropIds,
+        StageResumeContext resume,
+        List<Guid> batchIds,
+        string operatorName,
+        DateTime startedAt,
+        int quarantineBefore,
+        CancellationToken cancellationToken)
+    {
+        const string LaneName = "improvement";
+
+        // Year list: from legacy_pacs_raw.imprv for the seed prop_ids,
+        // ascending. Querying the post-Imprv-S1 landing table (rather
+        // than PACS directly) is faster and avoids round-tripping to
+        // MSSQL just to enumerate years. It guarantees we only iterate
+        // years that actually have improvement rows — and therefore
+        // potentially imprv_attr rows.
+        var years = await _db.LegacyPacsRawImprvs
+            .AsNoTracking()
+            .Where(i => seedPropIds.Contains(i.PropId))
+            .Select(i => i.PropValYr)
+            .Distinct()
+            .OrderBy(y => y)
+            .ToListAsync(cancellationToken);
+
+        if (years.Count == 0)
+        {
+            // No imprv rows for the seed → nothing to land.
+            // Functionally equivalent to the legacy single-call path
+            // with an empty key list (zero rows landed, one batch).
+            _logger.LogInformation(
+                "[Drain:improvement] ImprvAttr-S1 year-list is empty; nothing to land.");
+            return new YearSlicedImprvAttrResult
+            {
+                LastBatchId = null,
+                TotalRowsLanded = 0,
+                FailureResponse = null,
+            };
+        }
+
+        _logger.LogInformation(
+            "[Drain:improvement] ImprvAttr-S1 year-sliced; years={Count} (range {Min}..{Max})",
+            years.Count, years[0], years[^1]);
+
+        Guid? lastBatchId = null;
+        var totalRowsLanded = 0;
+
+        foreach (var year in years)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var stageName = LaneStageOrder.FormatImprvAttrYearSubstage(year);
+            if (resume.ShouldSkip(stageName))
+            {
+                _logger.LogInformation(
+                    "[Drain:improvement] SKIP {Stage} (resume past it)",
+                    stageName);
+                continue;
+            }
+
+            var yearKeys = seedPropIds.Select(p => (p, (short)year)).ToList();
+            var attrSrc = new KeyedSqlServerPacsImprvAttrSource(pacsConnectionString, yearKeys);
+            var attrSlice = await imprvAttrSvc.LandImprvAttrsAsync(attrSrc, operatorName, cancellationToken);
+            if (!IsCompleted(attrSlice.Status))
+            {
+                // Per-year failure → fail the lane at this substage so
+                // the persisted LastCompletedStage reflects the exact
+                // year that failed and resume picks up there.
+                var failResponse = await FailLaneAsync(LaneName, stageName, attrSlice.ErrorSummary,
+                    batchIds, startedAt, quarantineBefore, cancellationToken);
+                return new YearSlicedImprvAttrResult
+                {
+                    LastBatchId = null,
+                    TotalRowsLanded = totalRowsLanded,
+                    FailureResponse = failResponse,
+                };
+            }
+
+            totalRowsLanded += attrSlice.RowsLanded;
+            lastBatchId = attrSlice.LoadBatchId;
+
+            _logger.LogInformation(
+                "[Drain:improvement] {Stage} OK; batchId={Bid} rowsLanded={Rows}",
+                stageName, attrSlice.LoadBatchId, attrSlice.RowsLanded);
+
+            // Persist substage checkpoint without appending the per-year
+            // batch id to batchIds — the parent ImprvAttr-S1 slot stays
+            // empty until the entire year loop completes, preserving
+            // position-mapping for downstream named stages.
+            await resume.CheckpointAsync(stageName, batchIds, cancellationToken);
+        }
+
+        return new YearSlicedImprvAttrResult
+        {
+            LastBatchId = lastBatchId,
+            TotalRowsLanded = totalRowsLanded,
+            FailureResponse = null,
+        };
+    }
 
     /// <summary>
     /// Sum of the six quarantine tables exposed by <c>/api/sync/doctrine/state</c>.

--- a/backend/src/TerraFusion.Core/Sync/Corpus/LaneStageOrder.cs
+++ b/backend/src/TerraFusion.Core/Sync/Corpus/LaneStageOrder.cs
@@ -24,9 +24,37 @@ namespace TerraFusion.Core.Sync.Corpus;
 /// <para>Unknown lanes / unknown stage names → no skip (fail-safe).
 /// A typo in <c>ResumeFromStage</c> means we re-run the lane from
 /// the start, which is equivalent to today's behavior.</para>
+///
+/// <para>SYNC-COMPLETE-2-V3: the improvement lane's <c>ImprvAttr-S1</c>
+/// stage is year-sliced internally to fix ChangeTracker bloat on
+/// full-corpus drains. The substages are named
+/// <c>ImprvAttr-S1-Y{year}</c> and are NOT enumerated in
+/// <see cref="Stages"/> because the year list is determined at runtime
+/// from the seed corpus. The substages slot logically between
+/// <c>ImprvDetail-S1</c> and <c>Imprv-Truth</c>, ordered ascending by
+/// numeric year (NOT lexically — <c>Y1995</c> &lt; <c>Y2010</c> &lt;
+/// <c>Y2026</c>). <see cref="ShouldSkip"/> recognizes the substage
+/// pattern and applies chronological ordering rules; cross-comparisons
+/// with named stages place the substages in the same logical position
+/// as the parent <c>ImprvAttr-S1</c> entry.</para>
 /// </summary>
 public static class LaneStageOrder
 {
+    /// <summary>
+    /// SYNC-COMPLETE-2-V3 substage name prefix for the year-sliced
+    /// <c>ImprvAttr-S1</c> stage of the improvement lane. Substage
+    /// names are <c>ImprvAttr-S1-Y{year}</c> (e.g.
+    /// <c>ImprvAttr-S1-Y2026</c>).
+    /// </summary>
+    public const string ImprvAttrYearSubstagePrefix = "ImprvAttr-S1-Y";
+
+    /// <summary>
+    /// Parent stage name for the year-sliced substages. Used as the
+    /// logical anchor when comparing a year-substage with a named
+    /// stage in <see cref="ShouldSkip"/>.
+    /// </summary>
+    public const string ImprvAttrParentStage = "ImprvAttr-S1";
+
     /// <summary>
     /// Per-lane ordered list of stage names. Ordering matters: skip
     /// is "stage index ≤ resume index" so stages that have already
@@ -66,6 +94,14 @@ public static class LaneStageOrder
             // improvement: owner-anchored seed → parcel chain → supp +
             // (non-blocking) propertyVal + landDetail → imprv landings
             // → imprv truth → imprv canonical.
+            //
+            // SYNC-COMPLETE-2-V3 note: ImprvAttr-S1 is the static
+            // parent slot in this list, but the controller runs it as
+            // a dynamic sequence of ImprvAttr-S1-Y{year} substages
+            // internally. The substages are NOT listed here because
+            // the year list is determined at runtime from
+            // legacy_pacs_raw.imprv. ShouldSkip handles substage names
+            // specially via chronological year comparison.
             ["improvement"] = new[]
             {
                 "Owner-Seed-S1",
@@ -130,6 +166,16 @@ public static class LaneStageOrder
     ///   <item>Otherwise: skip iff <c>stageIndex ≤ resumeIndex</c> (stages
     ///   at or before the last-completed checkpoint are already done).</item>
     /// </list>
+    ///
+    /// <para>SYNC-COMPLETE-2-V3: when either argument is a year-substage
+    /// of the form <c>ImprvAttr-S1-Y{year}</c>, the substage is anchored
+    /// at the same logical position as <c>ImprvAttr-S1</c> for
+    /// cross-comparisons with named stages. Substage-vs-substage uses
+    /// chronological year comparison (numeric, not lexical: Y2010 &lt;
+    /// Y2026, NOT "Y10" &lt; "Y2"). The legacy monolithic LCS value
+    /// <c>"ImprvAttr-S1"</c> (no year suffix) is treated as "before all
+    /// year-substages" so every year runs from the start of the stage on
+    /// resume.</para>
     /// </summary>
     public static bool ShouldSkip(string laneName, string stageName, string? resumeFromStage)
     {
@@ -137,11 +183,75 @@ public static class LaneStageOrder
         if (string.IsNullOrEmpty(laneName) || string.IsNullOrEmpty(stageName)) return false;
         if (!Stages.TryGetValue(laneName, out var order)) return false;
 
-        var stageIdx = IndexOf(order, stageName);
-        var resumeIdx = IndexOf(order, resumeFromStage);
-        if (stageIdx < 0 || resumeIdx < 0) return false;
-        return stageIdx <= resumeIdx;
+        var stageIsSubstage = IsImprvAttrYearSubstage(stageName, out var stageYear);
+        var resumeIsSubstage = IsImprvAttrYearSubstage(resumeFromStage, out var resumeYear);
+
+        // Both year-substages → chronological year compare. The
+        // substage range is "open" — Y{lower} ≤ Y{higher} → skip.
+        if (stageIsSubstage && resumeIsSubstage)
+        {
+            return stageYear <= resumeYear;
+        }
+
+        // Resume is a named stage AND the stageName is a year-substage:
+        // the substage lives at the ImprvAttr-S1 anchor index. Skip iff
+        // the named resume stage is at-or-after that anchor index.
+        // Special case: legacy LCS "ImprvAttr-S1" (no year) means
+        // "before any year ran" → year-substages do NOT skip.
+        if (stageIsSubstage)
+        {
+            if (string.Equals(resumeFromStage, ImprvAttrParentStage, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            var anchorIdx = IndexOf(order, ImprvAttrParentStage);
+            var resumeIdx = IndexOf(order, resumeFromStage);
+            if (anchorIdx < 0 || resumeIdx < 0) return false;
+            return anchorIdx <= resumeIdx;
+        }
+
+        // stageName is a named stage AND resume is a year-substage:
+        // any named stage at-or-before the ImprvAttr-S1 anchor index
+        // is "already done"; named stages AFTER the anchor are NOT
+        // skipped (they haven't run yet — Imprv-Truth hasn't fired).
+        if (resumeIsSubstage)
+        {
+            var anchorIdx = IndexOf(order, ImprvAttrParentStage);
+            var stageIdx = IndexOf(order, stageName);
+            if (anchorIdx < 0 || stageIdx < 0) return false;
+            return stageIdx < anchorIdx;
+        }
+
+        // Both are named stages → original position-based skip math.
+        var sIdx = IndexOf(order, stageName);
+        var rIdx = IndexOf(order, resumeFromStage);
+        if (sIdx < 0 || rIdx < 0) return false;
+        return sIdx <= rIdx;
     }
+
+    /// <summary>
+    /// Parses a stage name as an <c>ImprvAttr-S1-Y{year}</c> substage.
+    /// Returns true when the name matches the prefix and the suffix
+    /// parses as a valid integer year; the parsed year is returned via
+    /// <paramref name="year"/>. Case-insensitive on the prefix.
+    /// </summary>
+    public static bool IsImprvAttrYearSubstage(string? stageName, out int year)
+    {
+        year = 0;
+        if (string.IsNullOrEmpty(stageName)) return false;
+        if (!stageName.StartsWith(ImprvAttrYearSubstagePrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+        var suffix = stageName.Substring(ImprvAttrYearSubstagePrefix.Length);
+        return int.TryParse(suffix, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out year);
+    }
+
+    /// <summary>
+    /// Build a year-substage name from a numeric year. Inverse of
+    /// <see cref="IsImprvAttrYearSubstage"/>.
+    /// </summary>
+    public static string FormatImprvAttrYearSubstage(int year)
+        => ImprvAttrYearSubstagePrefix + year.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     private static int IndexOf(IReadOnlyList<string> list, string value)
     {

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/LaneStageOrderTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Corpus/LaneStageOrderTests.cs
@@ -99,4 +99,184 @@ public sealed class LaneStageOrderTests
             .And.Contain("Sale-Parcel-Canonical")
             .And.Contain("Sale-Canonical");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // SYNC-COMPLETE-2-V3 — ImprvAttr-S1 year-sliced substages.
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ImprvAttr_year_substage_ordering_is_chronological_not_lexical()
+    {
+        // The substages must compare numerically by year, NOT as strings.
+        // String compare would put "Y2026" before "Y2010" (because '0' < '2'
+        // after the third digit — actually they tie until the fourth char,
+        // making lexical equivalent here). The dangerous case is mixed
+        // widths: "Y10" lex-sorts BEFORE "Y2" because '1' < '2', which
+        // would skip 2-digit years incorrectly when comparing against 4-digit.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y1995", "ImprvAttr-S1-Y2010")
+            .Should().BeTrue("1995 < 2010 chronologically → skip");
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2010", "ImprvAttr-S1-Y2026")
+            .Should().BeTrue("2010 < 2026 chronologically → skip");
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2026", "ImprvAttr-S1-Y1995")
+            .Should().BeFalse("2026 > 1995 chronologically → do not skip");
+    }
+
+    [Fact]
+    public void ShouldSkip_returns_true_for_year_substages_at_or_before_resume_year()
+    {
+        // Resume from Y2025 → every year ≤ 2025 should skip.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2020", "ImprvAttr-S1-Y2025")
+            .Should().BeTrue();
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2025", "ImprvAttr-S1-Y2025")
+            .Should().BeTrue("equal year is at-or-before resume → skip");
+    }
+
+    [Fact]
+    public void ShouldSkip_returns_false_for_year_substages_after_resume_year()
+    {
+        // Resume from Y2025 → year 2026 has NOT run yet → don't skip.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2026", "ImprvAttr-S1-Y2025")
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Year_substring_sort_does_not_false_skip_smaller_year_with_more_digits()
+    {
+        // The "Y10 vs Y2" hazard: with lexical sort, "Y10" < "Y2"
+        // because '1' < '2'. With numeric sort, 10 > 2. Make sure
+        // we use numeric comparison.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y10", "ImprvAttr-S1-Y2")
+            .Should().BeFalse("year 10 > year 2 numerically → do not skip");
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2", "ImprvAttr-S1-Y10")
+            .Should().BeTrue("year 2 < year 10 numerically → skip");
+    }
+
+    [Fact]
+    public void Named_stage_after_ImprvAttr_S1_is_not_skipped_when_resume_is_a_year_substage()
+    {
+        // Resume from a year-substage means we're mid-ImprvAttr-S1, so
+        // Imprv-Truth (which comes AFTER ImprvAttr-S1) has NOT run yet
+        // and must not be skipped. This is the safety property that
+        // prevents accidentally jumping over Imprv-Truth when resuming
+        // from a mid-substage checkpoint.
+        LaneStageOrder.ShouldSkip("improvement", "Imprv-Truth", "ImprvAttr-S1-Y2026")
+            .Should().BeFalse();
+        LaneStageOrder.ShouldSkip("improvement", "Imprv-Canonical", "ImprvAttr-S1-Y2026")
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Named_stage_before_ImprvAttr_S1_is_skipped_when_resume_is_a_year_substage()
+    {
+        // Anything at-or-before ImprvDetail-S1 has definitely completed
+        // by the time we're inside any year-substage.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvDetail-S1", "ImprvAttr-S1-Y2020")
+            .Should().BeTrue();
+        LaneStageOrder.ShouldSkip("improvement", "Imprv-S1", "ImprvAttr-S1-Y2020")
+            .Should().BeTrue();
+        LaneStageOrder.ShouldSkip("improvement", "Owner-Seed-S1", "ImprvAttr-S1-Y2020")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Legacy_monolithic_ImprvAttr_S1_LCS_does_not_skip_year_substages()
+    {
+        // Old runs (pre-V3) persisted LCS="ImprvAttr-S1" only on full
+        // success of the monolithic stage. On a re-run with a V3-aware
+        // controller, that legacy value should mean "ImprvAttr-S1 fully
+        // complete" → SKIP every year-substage (we're past the entire
+        // stage). The parent stage itself is also skipped.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1", "ImprvAttr-S1")
+            .Should().BeTrue("parent stage equal to LCS → skip");
+
+        // Mid-stage resume from the legacy bare name is impossible to
+        // produce post-V3 (V3 only writes year-substage names mid-flight,
+        // and writes "ImprvAttr-S1" only on full success). But if it
+        // were ever set, year-substages would NOT skip — meaning we'd
+        // safely re-run all years. Per spec: "If the resumed LCS is
+        // ImprvAttr-S1 (legacy monolithic, from old runs) or empty,
+        // run all years from start of ImprvAttr-S1."
+        //
+        // BUT — note that in practice, with LCS="ImprvAttr-S1", the
+        // parent stage itself is skipped by the position-based check
+        // above, so the year loop never runs anyway. The semantics here
+        // protect against any future path that tries to run substages
+        // with this LCS: each substage is treated as "after" the legacy
+        // LCS → no skip → re-runs. This is the spec-mandated safe
+        // re-run behavior.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2020", "ImprvAttr-S1")
+            .Should().BeFalse("legacy LCS → year-substages do not skip (spec)");
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2026", "ImprvAttr-S1")
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_LCS_does_not_skip_any_year_substage()
+    {
+        // Empty / null LCS → fresh run, every year-substage executes.
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2020", null)
+            .Should().BeFalse();
+        LaneStageOrder.ShouldSkip("improvement", "ImprvAttr-S1-Y2020", "")
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsImprvAttrYearSubstage_parses_well_formed_names_and_rejects_others()
+    {
+        // Positive cases.
+        LaneStageOrder.IsImprvAttrYearSubstage("ImprvAttr-S1-Y2026", out var y1).Should().BeTrue();
+        y1.Should().Be(2026);
+        LaneStageOrder.IsImprvAttrYearSubstage("ImprvAttr-S1-Y1995", out var y2).Should().BeTrue();
+        y2.Should().Be(1995);
+        LaneStageOrder.IsImprvAttrYearSubstage("imprvattr-s1-y2026", out var y3).Should().BeTrue("case-insensitive on prefix");
+        y3.Should().Be(2026);
+
+        // Negative cases.
+        LaneStageOrder.IsImprvAttrYearSubstage("ImprvAttr-S1", out _).Should().BeFalse("bare parent — no suffix");
+        LaneStageOrder.IsImprvAttrYearSubstage("ImprvAttr-S1-Y", out _).Should().BeFalse("empty year suffix");
+        LaneStageOrder.IsImprvAttrYearSubstage("ImprvAttr-S1-YABC", out _).Should().BeFalse("non-numeric suffix");
+        LaneStageOrder.IsImprvAttrYearSubstage("Imprv-Truth", out _).Should().BeFalse("unrelated stage");
+        LaneStageOrder.IsImprvAttrYearSubstage(null, out _).Should().BeFalse();
+        LaneStageOrder.IsImprvAttrYearSubstage("", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FormatImprvAttrYearSubstage_is_inverse_of_parser()
+    {
+        // Round-trip property: format then parse recovers the same year.
+        foreach (var year in new[] { 1985, 2010, 2017, 2026, 1 })
+        {
+            var name = LaneStageOrder.FormatImprvAttrYearSubstage(year);
+            LaneStageOrder.IsImprvAttrYearSubstage(name, out var parsed).Should().BeTrue();
+            parsed.Should().Be(year);
+        }
+    }
+
+    [Fact]
+    public void ImprvAttr_S1_static_slot_is_preserved_after_V3_for_position_mapping()
+    {
+        // Critical contract: the static Stages["improvement"] list must
+        // retain ImprvAttr-S1 (the legacy/parent name) in its original
+        // position so position-indexed BatchIdsJson recovery for stages
+        // AFTER ImprvAttr-S1 (Imprv-Truth, Imprv-Canonical) continues
+        // to work unchanged. Year-substages are dynamic and live OUTSIDE
+        // this static list; they appear only via ShouldSkip pattern
+        // recognition.
+        var imp = LaneStageOrder.Stages["improvement"];
+        imp.Should().Contain("ImprvAttr-S1");
+        imp.Should().Contain("ImprvDetail-S1");
+        imp.Should().Contain("Imprv-Truth");
+
+        // Ordering invariant: ImprvDetail-S1 < ImprvAttr-S1 < Imprv-Truth.
+        var idxDetail = -1; var idxAttr = -1; var idxTruth = -1;
+        for (var i = 0; i < imp.Count; i++)
+        {
+            if (imp[i] == "ImprvDetail-S1") idxDetail = i;
+            if (imp[i] == "ImprvAttr-S1") idxAttr = i;
+            if (imp[i] == "Imprv-Truth") idxTruth = i;
+        }
+        idxDetail.Should().BeGreaterOrEqualTo(0);
+        idxAttr.Should().BeGreaterThan(idxDetail);
+        idxTruth.Should().BeGreaterThan(idxAttr);
+    }
 }


### PR DESCRIPTION
## Summary

- Year-slices the `ImprvAttr-S1` stage of the improvement lane drain into per-`prop_val_yr` substages (`ImprvAttr-S1-Y{year}`). Same landing service, same hashing, same gates, same quarantine semantics — only granularity changes.
- Each year persists its own checkpoint (`LastCompletedStage = ImprvAttr-S1-Y{year}`) so a mid-stage crash resumes at the next un-completed year instead of re-running the entire monolithic stage. Solves the empirically-observed ChangeTracker bloat / postgres broken-pipe pattern on full-corpus drains.
- Extends `LaneStageOrder.ShouldSkip` to recognize the year-substage pattern with chronological (numeric) year comparison. Substages live OUTSIDE the static `Stages["improvement"]` list — they slot logically between `ImprvDetail-S1` and `Imprv-Truth` via pattern recognition, preserving position-mapping for downstream named stages.

## Design notes

- **Year list source**: queried from `legacy_pacs_raw.imprv` (just landed by Imprv-S1), ascending. Avoids round-tripping to MSSQL and guarantees we only iterate years that have improvement rows.
- **Static `Stages` list unchanged**: `ImprvAttr-S1` parent slot remains the one position-indexed entry; year-substages are dynamic and recognized by `ShouldSkip` pattern. Per-year batch ids stay out of `batchIds` so positions for `Imprv-Truth` / `Imprv-Canonical` lookups stay valid.
- **Legacy LCS handling**: `LastCompletedStage = "ImprvAttr-S1"` (no year) is treated per spec as "before all year-substages" — year-substages do not skip; safe re-run.
- **Numeric year compare**: `Y10` does not false-skip `Y2` (parses suffix as int, not lexical).
- **Function-preserving**: only the controller's invocation pattern changed; `PacsImprvAttrLandingService` and `KeyedSqlServerPacsImprvAttrSource` untouched. No new migration. No bulk-load tricks.

## Test plan

- [x] Build clean (0 warn / 0 err) — `dotnet build TerraFusion.sln`
- [x] Unit tests: 3330/3330 pass (+11 new SYNC-COMPLETE-2-V3 tests, from 3319 baseline)
- [x] New `LaneStageOrderTests` coverage: chronological substage ordering, LCS skip math (both directions), `Y10`-vs-`Y2` numeric-not-lexical hazard, legacy `ImprvAttr-S1` LCS treatment, named-stage cross-comparisons (skip stages BEFORE the anchor, never skip Imprv-Truth from a mid-substage LCS), parser/formatter round-trip, static-slot preservation invariant
- [ ] Live drain replay against Harris PACS (deferred — operator will exercise on `tf-corpus-runner`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data synchronization processing for improved reliability and checkpoint recovery capabilities.

* **Tests**
  * Added comprehensive test coverage for synchronization stage ordering and resume functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/818)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->