### PR TITLE
docs(security): retract premature FISMA-HIGH claim + add honest baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-**TerraFusion OS 1.0** is a complete government operating system - NOT a web application. It's a production platform with 1,008 operational AI agents, real county property data (89,247 Benton County parcels), and FISMA-HIGH compliance serving 39+ Washington State counties.
+**TerraFusion OS 1.0** is a government operating system targeting Washington State counties — .NET 8 backend, React 18 frontend, AI swarm coordination, real Benton County property data (89,247 parcels). FISMA-HIGH is a **posture target, not a current accreditation** — controls are in progress; see [`docs/security/baseline.md`](docs/security/baseline.md) for the honest current-vs-target table.
 
 **CRITICAL**: Read `.github/copilot-instructions.md` FIRST - contains essential government compliance requirements, AI swarm coordination rules, and testing architecture.
 
@@ -175,16 +175,22 @@ npm run gates                  # Verify coverage (97%+), LCP (<2500ms), a11y (0 
 
 ## Critical Development Rules
 
-### 1. Government Compliance (FISMA-HIGH)
+### 1. Government Compliance (FISMA-HIGH posture target)
 
-**NEVER modify audit fields** - Auto-populated for FISMA compliance:
+> **Status:** FISMA-HIGH is the destination, not the current state. See [`docs/security/baseline.md`](docs/security/baseline.md) for open gaps (AC-3, AU-2, SC-12, IA-2, AC-4). Treat the rules below as **forward contracts** for new code — do not interpret them as proof that today's runtime is compliant.
+
+**NEVER modify audit fields** — they exist on entities as the contract surface for the planned audit-stamping interceptor:
 
 ```csharp
-// Backend entities - automatically set by AuditableEntityInterceptor
-public DateTime CreatedAt { get; set; }  // Auto-set on insert
-public DateTime UpdatedAt { get; set; }  // Auto-set on update
-public string CreatedBy { get; set; }    // Auto-set from HttpContext
-public string UpdatedBy { get; set; }    // Auto-set from HttpContext
+// Backend entities - audit fields are the forward contract.
+// NOTE: An `AuditableEntityInterceptor` is referenced in older docs but is
+// NOT currently implemented (Prometheus audit, AU-2). Today these fields
+// are stamped inconsistently or left at defaults. Do not rely on them for
+// real attribution until PR-2 (auth criticals) lands the interceptor.
+public DateTime CreatedAt { get; set; }  // Target: auto-set on insert
+public DateTime UpdatedAt { get; set; }  // Target: auto-set on update
+public string CreatedBy { get; set; }    // Target: auto-set from HttpContext
+public string UpdatedBy { get; set; }    // Target: auto-set from HttpContext
 ```
 
 **County data isolation** - Sovereign County model (multi-county operations require approval):
@@ -488,7 +494,7 @@ npm run ai-agent-briefing
 
 **THE TERRAFUSION WAY**: Execute with excellence. This is production government infrastructure serving real citizens with real property data. Quality, compliance, and reliability are non-negotiable. Every decision must consider:
 
-1. **Government compliance** (FISMA-HIGH, NIST 800-53)
+1. **Government compliance posture** (FISMA-HIGH / NIST 800-53 as target — current gaps tracked in [`docs/security/baseline.md`](docs/security/baseline.md))
 2. **Citizen data protection** (Sovereign County isolation)
 3. **AI swarm coordination** (1,008 agents in production)
 4. **Real-world integration** (Harris PACS as the legacy source database; Aumentum and other county-specific systems where applicable; Tyler Vision is NOT in Benton's stack)
@@ -499,4 +505,4 @@ npm run ai-agent-briefing
 **Last Updated**: February 2026
 **Version**: TerraFusion OS 1.0
 **Classification**: Government Operating System Platform
-**Compliance**: FISMA-HIGH, NIST 800-53, WCAG 2.1 AA
+**Compliance posture target** (not current accreditation): FISMA-HIGH, NIST 800-53, WCAG 2.1 AA — see [`docs/security/baseline.md`](docs/security/baseline.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TerraFusion OS 1.0
 
-**Government property-assessment operating system** — .NET 8 backend, React 18 frontend, AI swarm coordination, FISMA-HIGH compliance.
+**Government property-assessment operating system** — .NET 8 backend, React 18 frontend, AI swarm coordination. FISMA-HIGH is a **posture target**, not a current accreditation — see [`docs/security/baseline.md`](docs/security/baseline.md) for the honest current-vs-target table.
 
 [![Seal Gate](https://img.shields.io/badge/CI-Seal%20Gate-green?logo=githubactions)](https://github.com/bsvalues/terrafusion_os_1.0/actions)
 [![.NET 8](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
@@ -179,11 +179,11 @@ See [AGENTS.md](./AGENTS.md) for full governance rules.
 
 ## Security & Compliance
 
-- **FISMA-HIGH** compliance target (NIST 800-53)
-- **Sovereign County model** — data isolation per county
-- **Audit fields** auto-populated on all entities (CreatedAt, UpdatedAt, CreatedBy, UpdatedBy)
-- **PII redaction** in TerraTrace feed (SSN, email, phone patterns)
-- **Snyk** scanning on every PR (594 security tests)
+- **FISMA-HIGH** is a **posture target** (NIST 800-53) — controls in progress; current open gaps are itemised in [`docs/security/baseline.md`](docs/security/baseline.md).
+- **Sovereign County model** — per-deployment data isolation; defense-in-depth EF query filters are partial (AC-4 open).
+- **Audit fields** exist as a forward contract on entities; the `AuditableEntityInterceptor` that would auto-populate them is **not yet implemented** (AU-2 open).
+- **PII redaction** at canonical write-time for confidential owners (`PacsOwnerCanonicalProjector` blanks FirstName/LastName/BirthDt when ConfidentialFlag=true) — implemented.
+- **Snyk** scanning on every PR.
 
 ---
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-**TerraFusion OS Backend** is the .NET 8 microservices architecture for a government operating system with AI-powered property assessment, tax processing, and public sector management. This is NOT a simple web application - it's a complete operating system with 1,008 AI agents, real Harris PACS integration, and FISMA-HIGH compliance.
+**TerraFusion OS Backend** is the .NET 8 microservices architecture for a government operating system with AI-powered property assessment, tax processing, and public sector management. AI swarm coordination, real Harris PACS integration, FISMA-HIGH **posture target** (NOT a current accreditation — see [`../docs/security/baseline.md`](../docs/security/baseline.md) for the open-gap table).
 
 **Critical Context**: Read `.github/copilot-instructions.md` first - it contains essential government compliance requirements and AI swarm coordination rules.
 
@@ -167,7 +167,7 @@ public class Entity
 }
 ```
 
-These are automatically populated by `AuditableEntityInterceptor` in `TerraFusionDbContext.SaveChangesAsync()`.
+**Planned**: these fields will be automatically populated by an `AuditableEntityInterceptor` registered on `TerraFusionDbContext.SaveChangesAsync()`. **Current state**: the interceptor is NOT yet implemented (Prometheus audit AU-2; tracked for PR-2 of the immediate-week tranche). Today these fields are stamped inconsistently across services — `AuditLogs` writes hardcoded `UserId="System"`. Do not treat existing audit columns as proof of attribution; see [`../docs/security/baseline.md`](../docs/security/baseline.md).
 
 ### 2. Service Registration Pattern
 
@@ -286,7 +286,7 @@ app.MapHub<MyHub>("/hubs/my-hub");
 2. **Authorization**: Role-based access control (RBAC)
 3. **Audit Logging**: All operations logged to `AuditLogs` table
 4. **Encryption**: Data at rest and in transit
-5. **Compliance**: FISMA-HIGH, NIST 800-53
+5. **Compliance posture target** (NOT current accreditation): FISMA-HIGH, NIST 800-53 — see [`../docs/security/baseline.md`](../docs/security/baseline.md) for open gaps
 
 ### County Data Isolation
 

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -1,0 +1,58 @@
+# TerraFusion Security Baseline — Current vs Target
+
+**Status as of 2026-05-12.** This document is the honest source of truth for TerraFusion's current security posture. Where `CLAUDE.md` / `README.md` aspirational language ever differs from this file, **this file wins**.
+
+This file was created as part of PR-1 of the immediate-week production-readiness tranche, in response to the Project Prometheus T3 (Security) audit conducted 2026-05-12. The audit determined that prior "FISMA-HIGH compliant" framing was not defensible as written. Inaccurate FISMA claims are themselves a compliance incident, so the documentation is being retracted to "posture target" language while the underlying controls are remediated in parallel PRs (PR-2 through PR-5).
+
+## Target posture
+
+- **FISMA-HIGH** per NIST SP 800-53 Rev 5
+- **WCAG 2.1 AA** accessibility (frontend)
+- **Sovereign-county data isolation** (per-deployment + defense-in-depth query filters)
+
+## Current posture: OPEN gaps (Prometheus T3 — 13 CRITICAL findings)
+
+| # | NIST Control | Finding | Status | Planned remediation |
+|---|---|---|---|---|
+| 1 | **AC-3** Access Enforcement | No global `FallbackPolicy` on the main API; Workbench and Drain controllers reachable anonymously | **OPEN** | PR-2 (auth criticals) |
+| 2 | **AU-2** Audit Events | `AuditLogs` writes hardcoded `UserId="System"`; no real user attribution. The `AuditableEntityInterceptor` referenced in older docs is **not implemented** | **OPEN** | PR-2 (auth criticals) — implement interceptor; route `HttpContext` user identity into `SaveChangesAsync` |
+| 3 | **SC-12** Cryptographic Key Establishment | JWT signing key falls back to a hardcoded-prefix default if configuration is missing | **OPEN** | PR-2 (auth criticals) — fail-closed on missing key |
+| 4 | **IA-2** Identification & Authentication | `DevelopmentLdapService` registered in both Development AND Production DI branches | **OPEN** | PR-2 (auth criticals) — env-gate registration |
+| 5 | **AC-3 / SC-8** Transport Security | Main API host does NOT call `UseHttpsRedirection()` | **OPEN** | PR-3 (observability criticals — host-level surface) |
+| 6 | **AC-4** Information Flow / County Isolation | EF `HasQueryFilter` for county scoping is commented out; isolation depends entirely on per-controller `Where(p => p.CountyId == …)` discipline | **OPEN** | PR-2 (auth criticals) — restore query filter as defense-in-depth |
+| 7 | **AC-3** Permission Checks | `InMemorySecurityService.HasPermissionAsync` always returns `true` — bypasses authorization entirely | **OPEN** | PR-2 (auth criticals) — replace with real RBAC evaluator OR refuse to register in non-Test environments |
+| 8 | **SC-23** Session Authenticity | JWT stored in `localStorage` (XSS-exposed) | **PARTIAL / KNOWN-ACCEPTED** | Tracked as F-07 in `frontend/.../securityBaseline.ts`; httpOnly cookie migration scheduled post-immediate-week |
+| 9 | **AU-12** Audit Generation (immutable artifact) | Production deploy script builds local container images with no immutable tags; rollback evidence is unreliable | **OPEN** | PR-4 (infra criticals) |
+| 10 | **CM-3 / SA-10** Configuration Change Control | No required-status-check enforcement on `main`; force-push possible | **OPEN** | PR-5 (CI/CD criticals) |
+| 11 | **SC-12 / SI-7** Secrets in Config | `appsettings.{Env}.local.json` files commit-able in worktree (gitignored, but discovered by audit); historic JWT/DB secrets in older configs | **OPEN** | PR-2 + repo-hygiene sweep |
+| 12 | **AU-9** Protection of Audit Information | Audit log write path is in-band with the request lifecycle; an unhandled exception in business logic can drop the audit row | **OPEN** | PR-3 (observability criticals) |
+| 13 | **IR-4** Incident Handling | No documented incident-response runbook for security events in the SOC backlog | **OPEN** | Out-of-scope for immediate-week; tracked separately |
+
+## What IS implemented today
+
+These controls are real, verified by the Prometheus audit, and should be preserved as-is:
+
+- **PII redaction at canonical write-time** — `PacsOwnerCanonicalProjector` blanks `FirstName` / `LastName` / `BirthDt` whenever `ConfidentialFlag = true`. This is fail-closed (the redaction happens at the projector boundary, not at the read API).
+- **HMAC-signed evidence packets** (Workbench-H) — signature is length-checked and fail-closed; cannot be silently downgraded.
+- **Per-row `AuditLogs` rows exist** — every write goes through the audit path. The *attribution columns are fake* (gap #2 above), but the row volume and timing data are real and recoverable.
+- **Migrations have real `Down()` methods** — verified by the audit; no `NotImplementedException` stubs that would block rollback.
+- **Snyk** dependency scanning on every PR.
+
+## In-flight remediations (immediate-week tranche)
+
+This baseline is PR-1 of 5. Parallel PRs landing the actual fixes:
+
+- **PR-2** — Auth criticals (gaps 1, 2, 3, 4, 6, 7, 11)
+- **PR-3** — Observability criticals (gaps 5, 12)
+- **PR-4** — Infra criticals (gap 9)
+- **PR-5** — CI/CD criticals (gap 10)
+
+This file MUST be updated as each PR lands — a gap moves from **OPEN** to **CLOSED** only when a PR with the fix is merged AND a regression test exists in the gate.
+
+## Reference
+
+Project Prometheus audit, conducted **2026-05-12** by the Elite Engineering Cloud Coach orchestrator (T3 Security workstream). Full findings available on request from the assessor's office or the audit owner.
+
+## Doc-truth contract
+
+Any markdown file in this repository that claims "FISMA-HIGH compliant" or "FISMA-HIGH compliance" (rather than "FISMA-HIGH posture target") without linking to this baseline is **stale by definition** and should be corrected on sight. The destination is FISMA-HIGH; the present is "in flight."


### PR DESCRIPTION
## Summary

PR-1 of 5 immediate-week production-readiness fixes. **Docs-only retraction** — no code changes.

The Project Prometheus T3 (Security) audit on 2026-05-12 determined that prior "FISMA-HIGH compliant" framing in `CLAUDE.md` / `README.md` is not defensible as written. Specific gaps include: no global FallbackPolicy, no implemented `AuditableEntityInterceptor` (despite being documented as if it existed), `InMemorySecurityService.HasPermissionAsync` always returns true, `DevelopmentLdapService` registered in production DI, no `UseHttpsRedirection` on main API, JWT signing falls back to a hardcoded-prefix key, and more.

Inaccurate FISMA claims are themselves a compliance incident. This PR retracts the over-claim and introduces `docs/security/baseline.md` as the honest current-vs-target source of truth. The underlying control fixes ship in parallel PRs (PR-2 auth, PR-3 obs, PR-4 infra, PR-5 CI/CD).

### What changed (4 files, +83 / -19)

- `CLAUDE.md` — top blurb, Critical Development Rules §1, Development Philosophy, footer; the `AuditableEntityInterceptor` claim is qualified as planned-not-implemented per AU-2.
- `README.md` — top blurb + Security & Compliance section reflect actual state (PII redaction is real, audit-field interceptor is not).
- `backend/CLAUDE.md` — top blurb, audit-fields paragraph, footer.
- `docs/security/baseline.md` (new) — 13 OPEN gaps mapped to NIST controls + remediation PR, "what IS implemented" section, doc-truth contract.

### Out of scope

No `appsettings*.json`, no controllers, no DI registration, no auth code. Those land in PR-2 through PR-5.

## Test plan

- [x] `grep` confirms no remaining unqualified "FISMA-HIGH compliant" / "FISMA-HIGH compliance" in root `CLAUDE.md`, `backend/CLAUDE.md`, `frontend/CLAUDE.md`, `README.md`
- [x] Relative markdown link `docs/security/baseline.md` resolves from repo root; `../docs/security/baseline.md` resolves from `backend/`
- [x] New `baseline.md` contains the 13-row gap table (rows 1–13, with NIST control + status + remediation PR)
- [x] `AuditableEntityInterceptor` claim is now qualified as "planned, not implemented" rather than deleted (preserves the design intent for PR-2 to fulfill)
- [ ] Reviewer: confirm no aspirational claims remain on the changed surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security and compliance documentation to clarify that FISMA-HIGH represents a compliance posture target rather than current accreditation status
  * Added new security baseline document providing an honest assessment of current vs. planned compliance status with detailed remediation roadmap
  * Revised audit field and control documentation to accurately reflect actual current implementation status and planned future enhancements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/819)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->