### PR TITLE
feat(security): PR-2 — auth criticals (Prometheus T3)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/FullCorpusController.cs
+++ b/backend/src/TerraFusion.API/Controllers/FullCorpusController.cs
@@ -11,11 +11,13 @@ namespace TerraFusion.API.Controllers;
 /// <summary>
 /// SYNC-COMPLETE-2: durable full-corpus sync runner endpoints.
 ///
-/// <para>Mirrors the workbench controller pattern: no
-/// <c>[Authorize]</c>, single-county-per-deployment doctrine, all
-/// state mutations go through the orchestrator service (status
-/// transitions are the orchestrator's responsibility, not the
-/// controller's).</para>
+/// <para>Mirrors the workbench controller pattern: explicitly tagged
+/// <c>[AllowAnonymous]</c> (PR-2 / Prometheus T3 — the global
+/// <c>FallbackPolicy.RequireAuthenticatedUser()</c> requires every
+/// controller to declare its auth posture). Single-county-per-deployment
+/// doctrine; operator-driven via curl. All state mutations go through
+/// the orchestrator service (status transitions are the orchestrator's
+/// responsibility, not the controller's).</para>
 ///
 /// <para>Endpoints:</para>
 /// <list type="bullet">

--- a/backend/src/TerraFusion.API/Controllers/GovernmentComplianceController.cs
+++ b/backend/src/TerraFusion.API/Controllers/GovernmentComplianceController.cs
@@ -9,10 +9,18 @@ namespace TerraFusion.API.Controllers
   /// <summary>
   /// Government compliance API.
   /// Compliance and certification claims must be backed by governed evidence.
+  ///
+  /// <para>PR-2 (Prometheus T3): explicitly tagged <c>[AllowAnonymous]</c>.
+  /// Compliance status is operator-readable surface; the global
+  /// <c>FallbackPolicy.RequireAuthenticatedUser()</c> now requires every
+  /// controller to declare its auth posture explicitly. Pre-PR-2 this
+  /// controller was untagged and silently anonymous — exactly the audit
+  /// surface that motivated the FallbackPolicy fix.</para>
   /// </summary>
   [ApiController]
   [Route("api/compliance")]
   [Produces("application/json")]
+  [AllowAnonymous]
   public class GovernmentComplianceController : ControllerBase
   {
     private readonly IGovernmentComplianceService _complianceService;

--- a/backend/src/TerraFusion.API/Controllers/WorkbenchFController.cs
+++ b/backend/src/TerraFusion.API/Controllers/WorkbenchFController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Sync.Workbench;
@@ -24,9 +25,16 @@ namespace TerraFusion.API.Controllers;
 ///   <item><c>POST /api/sync/workbench/f/quarantine/imprv-attr/{id}/dismiss</c> —
 ///   record a dismissal decision.</item>
 /// </list>
+///
+/// <para>PR-2 (Prometheus T3): explicitly tagged <c>[AllowAnonymous]</c>.
+/// Single-county-per-deployment doctrine; operator-driven via curl. The
+/// global <c>FallbackPolicy.RequireAuthenticatedUser()</c> now requires
+/// every controller to declare its auth posture; this controller's
+/// "no [Authorize]" intent is now explicit instead of implicit.</para>
 /// </summary>
 [ApiController]
 [Route("api/sync/workbench/f")]
+[AllowAnonymous]
 public sealed class WorkbenchFController : ControllerBase
 {
     private readonly IQuarantineTriageService _service;

--- a/backend/src/TerraFusion.API/Controllers/WorkbenchGController.cs
+++ b/backend/src/TerraFusion.API/Controllers/WorkbenchGController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Sync.Workbench;
@@ -25,9 +26,16 @@ namespace TerraFusion.API.Controllers;
 ///   <item><c>GET /api/sync/workbench/g/commits/{commitId}</c> —
 ///   single commit + linked decisions.</item>
 /// </list>
+///
+/// <para>PR-2 (Prometheus T3): explicitly tagged <c>[AllowAnonymous]</c>.
+/// Single-county-per-deployment doctrine; operator-driven via curl. The
+/// global <c>FallbackPolicy.RequireAuthenticatedUser()</c> now requires
+/// every controller to declare its auth posture; this controller's
+/// "no [Authorize]" intent is now explicit instead of implicit.</para>
 /// </summary>
 [ApiController]
 [Route("api/sync/workbench/g")]
+[AllowAnonymous]
 public sealed class WorkbenchGController : ControllerBase
 {
     private readonly IWorkbenchCommitService _service;

--- a/backend/src/TerraFusion.API/Controllers/WorkbenchHController.cs
+++ b/backend/src/TerraFusion.API/Controllers/WorkbenchHController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Sync.Workbench;
@@ -23,9 +24,16 @@ namespace TerraFusion.API.Controllers;
 ///   <item><c>GET /api/sync/workbench/h/evidence/{commitId}/manifest</c> —
 ///   return only the <c>manifest.json</c> bytes for verification.</item>
 /// </list>
+///
+/// <para>PR-2 (Prometheus T3): explicitly tagged <c>[AllowAnonymous]</c>.
+/// Single-county-per-deployment doctrine; operator-driven via curl. The
+/// global <c>FallbackPolicy.RequireAuthenticatedUser()</c> now requires
+/// every controller to declare its auth posture; this controller's
+/// "no [Authorize]" intent is now explicit instead of implicit.</para>
 /// </summary>
 [ApiController]
 [Route("api/sync/workbench/h")]
+[AllowAnonymous]
 public sealed class WorkbenchHController : ControllerBase
 {
     private const string ZipMediaType = "application/zip";

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1161,7 +1161,7 @@ builder.Services.AddSignalR();
 // Register authentication services
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<TerraFusion.Core.Auth.IRequestUserContextAccessor, TerraFusion.API.Auth.HttpContextRequestUserContextAccessor>();
-builder.Services.AddTerraFusionAuthentication(builder.Configuration);
+builder.Services.AddTerraFusionAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddTerraFusionSecurityServices(builder.Configuration, builder.Environment);
 
 // 🎯 SERVICE REGISTRY & DISCOVERY - No more hardcoded ports!

--- a/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
+++ b/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
@@ -19,16 +19,34 @@ namespace TerraFusion.API.Security
 {
     public static class AuthenticationConfiguration
     {
-        public static IServiceCollection AddTerraFusionAuthentication(this IServiceCollection services, IConfiguration configuration)
+        public static IServiceCollection AddTerraFusionAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment? environment = null)
         {
             var jwtSettings = configuration.GetSection("JwtSettings");
-            var secretKey = jwtSettings["SecretKey"] ?? GenerateDefaultKey();
+            var secretKey = jwtSettings["SecretKey"];
             var issuer = jwtSettings["Issuer"] ?? "TerraFusion";
             var audience = jwtSettings["Audience"] ?? "TerraFusionAPI";
 
-            if (secretKey == GenerateDefaultKey())
+            // PR-2 (Prometheus T3 #5): fail-fast in non-Development when JWT key is missing.
+            // Previously a random "TerraFusion-Default-Key-..." key was synthesized at
+            // startup with only a Console.WriteLine warning — producing a working-but-
+            // forgeable JWT signer in any environment that hadn't been explicitly
+            // configured. Production must throw; Development gets a long, fixed
+            // padding key so local dev keeps working without env vars.
+            var isDevelopment = environment?.IsDevelopment() ?? false;
+            if (string.IsNullOrWhiteSpace(secretKey) && !isDevelopment)
             {
-                Console.WriteLine("⚠️  WARNING: Using default JWT key. Configure Jwt:SecretKey in appsettings.json for production!");
+                throw new InvalidOperationException(
+                    "JwtSettings:SecretKey is required in non-Development environments. " +
+                    "Configure via env var JwtSettings__SecretKey or appsettings.{Env}.local.json.");
+            }
+            if (string.IsNullOrWhiteSpace(secretKey))
+            {
+                // Dev-only fallback. 64+ chars to satisfy HS256 minimum.
+                secretKey = "TerraFusion-Dev-Secret-Key-DEV-ONLY-NEVER-USE-IN-PROD-PADDING-XXXXXXXXXXXXXXXXXXXX";
+                Console.WriteLine("⚠️  WARNING: Using Development JWT fallback key. NEVER use this in production.");
             }
 
             services.AddAuthentication(options =>
@@ -91,6 +109,15 @@ namespace TerraFusion.API.Security
 
             services.AddAuthorization(options =>
             {
+                // PR-2 (Prometheus T3 #1): require authentication by default.
+                // Any controller without an explicit [Authorize] or [AllowAnonymous]
+                // attribute now gets 401 instead of silently defaulting to anonymous.
+                // Controllers that intentionally run anonymously (Workbench F/G/H,
+                // FullCorpus, Doctrine*) must be tagged with [AllowAnonymous] explicitly.
+                options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+
                 options.AddPolicy("RequireAdmin", policy =>
                     policy.RequireRole("Admin", "SystemAdmin"));
 
@@ -120,15 +147,14 @@ namespace TerraFusion.API.Security
             return services;
         }
 
-        private static string GenerateDefaultKey()
-        {
-            return "TerraFusion-Default-Key-CHANGE-IN-PRODUCTION-2025-" + Guid.NewGuid().ToString().Substring(0, 8);
-        }
-
         /// <summary>
         /// Registers MFA, Session Management, and LDAP security services.
         /// Phase 5: Security Service Runtime Completeness.
         /// Phase 9: DevelopmentLdapService is now guarded by environment check.
+        /// PR-2 (Prometheus T3 #4): non-Development now registers
+        /// <see cref="FailClosedLdapService"/> (throws on every method) instead
+        /// of the in-memory dev stub, which previously was registered in BOTH
+        /// branches despite a comment claiming "rejects all logins".
         /// </summary>
         public static IServiceCollection AddTerraFusionSecurityServices(
             this IServiceCollection services,
@@ -145,10 +171,11 @@ namespace TerraFusion.API.Security
             }
             else
             {
-                // Production: register a no-op LDAP that rejects all logins
-                // until a real LDAP/AD provider is configured.
-                services.AddSingleton<ILdapService, DevelopmentLdapService>();
-                // TODO: Replace with ProductionLdapService backed by AD/OAuth2
+                // PR-2 (Prometheus T3 #4): fail-closed in non-Development. Every method
+                // throws NotImplementedException so any code path that reaches LDAP in
+                // prod surfaces loud instead of silently succeeding via dev stub.
+                // TODO: Replace with ProductionLdapService backed by AD/OAuth2.
+                services.AddSingleton<ILdapService, FailClosedLdapService>();
             }
 
             return services;
@@ -239,8 +266,16 @@ namespace TerraFusion.API.Security
 
         public Task<bool> ValidateUserCredentialsAsync(string email, string password)
         {
-            var valid = !string.IsNullOrWhiteSpace(email) && !string.IsNullOrWhiteSpace(password);
-            return Task.FromResult(valid);
+            // PR-2 (Prometheus T3 #3): fail-closed default. Previously accepted any
+            // non-empty email + password (silent allow-all). InMemorySecurityService
+            // is the fallback registration (services.TryAddSingleton); a real
+            // credential validator should replace it before any reliance is placed
+            // on this method. Until then, every call is denied + warns.
+            _logger.LogWarning(
+                "InMemorySecurityService.ValidateUserCredentialsAsync called for email-hash {EmailHash}; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                email?.GetHashCode());
+            return Task.FromResult(false);
         }
 
         public Task<IEnumerable<string>> GetUserRolesAsync(string email)
@@ -302,12 +337,28 @@ namespace TerraFusion.API.Security
 
         public Task<bool> HasPermissionAsync(string userId, string permission)
         {
-            return Task.FromResult(true);
+            // PR-2 (Prometheus T3 #2): fail-closed default. Previously returned true
+            // for every (userId, permission) tuple — silent allow-all that defeated
+            // any caller that relied on this method as a real authorization check.
+            // A real ISecurityService implementation should replace this before any
+            // permission decision relies on it; until then, every call is denied.
+            _logger.LogWarning(
+                "InMemorySecurityService.HasPermissionAsync called for permission '{Permission}'; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                permission);
+            return Task.FromResult(false);
         }
 
         public Task<bool> HasModuleAccessAsync(string userId, string moduleId)
         {
-            return Task.FromResult(true);
+            // PR-2 (Prometheus T3 #2 sibling): same fail-closed treatment as
+            // HasPermissionAsync. Module-access checks should go through a real
+            // ISecurityService; the in-memory fallback denies and warns.
+            _logger.LogWarning(
+                "InMemorySecurityService.HasModuleAccessAsync called for module '{ModuleId}'; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                moduleId);
+            return Task.FromResult(false);
         }
     }
 }

--- a/backend/src/TerraFusion.API/Security/Services/FailClosedLdapService.cs
+++ b/backend/src/TerraFusion.API/Security/Services/FailClosedLdapService.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using TerraFusion.API.Security.Interfaces;
+
+namespace TerraFusion.API.Security.Services;
+
+/// <summary>
+/// PR-2 (Prometheus T3 #4): fail-closed <see cref="ILdapService"/> registered
+/// in non-Development environments. Replaces the previous registration of
+/// <see cref="DevelopmentLdapService"/> in production (which silently allowed
+/// the hardcoded dev accounts to log in despite a comment claiming
+/// "rejects all logins").
+///
+/// <para>Every method throws <see cref="NotImplementedException"/>. Any code
+/// path that reaches LDAP in production must surface loudly until a real
+/// AD / OAuth2-backed implementation is wired in.</para>
+///
+/// <para>This is intentionally stricter than the sibling
+/// <see cref="RejectingLdapService"/> (which returns failure results). A
+/// throw guarantees the caller's exception-handling path is exercised
+/// instead of silently treating the absence of LDAP as a "user not found".</para>
+/// </summary>
+public sealed class FailClosedLdapService : ILdapService
+{
+    private const string NotConfigured =
+        "Production LDAP not configured. Register a real ILdapService backed by AD or OAuth2.";
+
+    private readonly ILogger<FailClosedLdapService> _logger;
+
+    public FailClosedLdapService(ILogger<FailClosedLdapService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<LdapAuthResult> AuthenticateAsync(string username, string password)
+    {
+        _logger.LogError("FailClosedLdapService.AuthenticateAsync invoked; refusing login.");
+        throw new NotImplementedException(NotConfigured);
+    }
+
+    public Task<LdapUserInfo?> GetUserAsync(string username)
+    {
+        _logger.LogError("FailClosedLdapService.GetUserAsync invoked; refusing lookup.");
+        throw new NotImplementedException(NotConfigured);
+    }
+
+    public Task<bool> IsUserInGroupAsync(string username, string groupName)
+    {
+        _logger.LogError("FailClosedLdapService.IsUserInGroupAsync invoked; refusing check.");
+        throw new NotImplementedException(NotConfigured);
+    }
+
+    public Task<List<string>> GetUserGroupsAsync(string username)
+    {
+        _logger.LogError("FailClosedLdapService.GetUserGroupsAsync invoked; refusing lookup.");
+        throw new NotImplementedException(NotConfigured);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Phase5/SecurityDIRegistrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Phase5/SecurityDIRegistrationTests.cs
@@ -51,10 +51,15 @@ public sealed class SecurityDIRegistrationTests
     [Fact]
     public void AddTerraFusionSecurityServices_RegistersILdapService()
     {
+        // PR-2 (Prometheus T3 #4): with no IHostEnvironment passed,
+        // AddTerraFusionSecurityServices treats the environment as non-Development
+        // and registers FailClosedLdapService (fail-closed). Pre-PR-2 this
+        // test asserted DevelopmentLdapService for the same input — that was
+        // the silent prod-misregistration the PR fixed.
         using var provider = BuildServiceProvider();
         var service = provider.GetService<ILdapService>();
         service.Should().NotBeNull();
-        service.Should().BeOfType<TerraFusion.API.Security.Services.DevelopmentLdapService>();
+        service.Should().BeOfType<TerraFusion.API.Security.Services.FailClosedLdapService>();
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/ExplicitAllowAnonymousTaggingTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/ExplicitAllowAnonymousTaggingTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using TerraFusion.API.Controllers;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+/// <summary>
+/// PR-2 / Prometheus T3: the controllers that intentionally run anonymously
+/// in the single-county-per-deployment doctrine must declare
+/// <c>[AllowAnonymous]</c> explicitly. With the new global
+/// <c>FallbackPolicy.RequireAuthenticatedUser()</c>, anything untagged
+/// will challenge → 401, breaking the operator workflow.
+///
+/// <para>This is a surface-audit test, not a behavior test. It pins which
+/// controllers are knowingly anonymous so a future addition can't quietly
+/// remove the attribute and ship a regression.</para>
+/// </summary>
+[Trait("Category", "Security")]
+[Trait("Component", "ControllerAuthSurface")]
+[Trait("Slice", "Prometheus-T3")]
+public sealed class ExplicitAllowAnonymousTaggingTests
+{
+    public static IEnumerable<object[]> ExplicitlyAnonymousControllers => new[]
+    {
+        new object[] { typeof(WorkbenchFController) },
+        new object[] { typeof(WorkbenchGController) },
+        new object[] { typeof(WorkbenchHController) },
+        new object[] { typeof(FullCorpusController) },
+        new object[] { typeof(DoctrineDrainController) },
+        new object[] { typeof(DoctrinePolicyController) },
+        new object[] { typeof(DoctrineStatusController) },
+    };
+
+    [Theory]
+    [MemberData(nameof(ExplicitlyAnonymousControllers))]
+    public void Controller_HasClassLevel_AllowAnonymous(Type controllerType)
+    {
+        var attr = controllerType.GetCustomAttribute<AllowAnonymousAttribute>(inherit: false);
+
+        attr.Should().NotBeNull(
+            $"{controllerType.Name} must declare [AllowAnonymous] at the class level. " +
+            "With the global FallbackPolicy in place, untagged controllers will 401 " +
+            "and break the operator-driven curl workflow.");
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitlyAnonymousControllers))]
+    public void Controller_DoesNotAlsoDeclare_Authorize(Type controllerType)
+    {
+        var attr = controllerType.GetCustomAttribute<AuthorizeAttribute>(inherit: false);
+
+        attr.Should().BeNull(
+            $"{controllerType.Name} should not carry both [AllowAnonymous] and [Authorize] " +
+            "at the class level — pick one. PR-2 chose AllowAnonymous to preserve the existing " +
+            "operator workflow; a real auth posture is a future-PR concern.");
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/FailClosedLdapServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/FailClosedLdapServiceTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using TerraFusion.API.Security;
+using TerraFusion.API.Security.Interfaces;
+using TerraFusion.API.Security.Services;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+/// <summary>
+/// PR-2 / Prometheus T3 #4: in non-Development environments,
+/// <c>AddTerraFusionSecurityServices</c> now registers
+/// <see cref="FailClosedLdapService"/> instead of the in-memory dev stub.
+/// Every method on the fail-closed implementation must throw
+/// <see cref="NotImplementedException"/> so a misconfiguration surfaces
+/// loudly instead of allowing dev accounts to log in.
+/// </summary>
+[Trait("Category", "Security")]
+[Trait("Component", "FailClosedLdapService")]
+[Trait("Slice", "Prometheus-T3")]
+public sealed class FailClosedLdapServiceTests
+{
+    private static FailClosedLdapService BuildSut()
+        => new(NullLogger<FailClosedLdapService>.Instance);
+
+    [Fact]
+    public async Task AuthenticateAsync_Throws_NotImplementedException()
+    {
+        var sut = BuildSut();
+
+        var act = async () => await sut.AuthenticateAsync("any-user", "any-password");
+
+        await act.Should().ThrowAsync<NotImplementedException>()
+            .WithMessage("*Production LDAP not configured*");
+    }
+
+    [Fact]
+    public async Task GetUserAsync_Throws_NotImplementedException()
+    {
+        var sut = BuildSut();
+
+        var act = async () => await sut.GetUserAsync("any-user");
+
+        await act.Should().ThrowAsync<NotImplementedException>();
+    }
+
+    [Fact]
+    public async Task IsUserInGroupAsync_Throws_NotImplementedException()
+    {
+        var sut = BuildSut();
+
+        var act = async () => await sut.IsUserInGroupAsync("any-user", "any-group");
+
+        await act.Should().ThrowAsync<NotImplementedException>();
+    }
+
+    [Fact]
+    public async Task GetUserGroupsAsync_Throws_NotImplementedException()
+    {
+        var sut = BuildSut();
+
+        var act = async () => await sut.GetUserGroupsAsync("any-user");
+
+        await act.Should().ThrowAsync<NotImplementedException>();
+    }
+
+    [Fact]
+    public void AddTerraFusionSecurityServices_NonDevelopment_RegistersFailClosedLdap()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build();
+        var env = new TestHostEnvironment("Production");
+
+        services.AddTerraFusionSecurityServices(config, env);
+        using var provider = services.BuildServiceProvider();
+
+        var ldap = provider.GetRequiredService<ILdapService>();
+        ldap.Should().BeOfType<FailClosedLdapService>(
+            "non-Development must register the fail-closed implementation, " +
+            "not the dev stub that previously allowed hardcoded accounts in prod");
+    }
+
+    [Fact]
+    public void AddTerraFusionSecurityServices_Development_StillRegistersDevelopmentLdap()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build();
+        var env = new TestHostEnvironment("Development");
+
+        services.AddTerraFusionSecurityServices(config, env);
+        using var provider = services.BuildServiceProvider();
+
+        var ldap = provider.GetRequiredService<ILdapService>();
+        ldap.Should().BeOfType<DevelopmentLdapService>(
+            "Development environment keeps the in-memory dev stub so local login still works");
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string env) => EnvironmentName = env;
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "TerraFusion.Test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/FallbackPolicyTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/FallbackPolicyTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TerraFusion.API.Security;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+/// <summary>
+/// PR-2 / Prometheus T3 #1: assert that <c>AddTerraFusionAuthentication</c>
+/// installs a global <c>FallbackPolicy.RequireAuthenticatedUser()</c>.
+/// Any controller without <c>[Authorize]</c> or <c>[AllowAnonymous]</c>
+/// gets challenged → 401 in production, instead of silently defaulting
+/// to anonymous (which was the pre-PR-2 behavior).
+/// </summary>
+[Trait("Category", "Security")]
+[Trait("Component", "AuthenticationConfiguration")]
+[Trait("Slice", "Prometheus-T3")]
+public sealed class FallbackPolicyTests
+{
+    private static IServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "test-fallback-policy-key-at-least-32-chars-long-for-hmac-sha256",
+                ["JwtSettings:Issuer"] = "TerraFusion.Test",
+                ["JwtSettings:Audience"] = "TerraFusion.Test",
+            })
+            .Build();
+
+        services.AddTerraFusionAuthentication(config);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task AddTerraFusionAuthentication_InstallsFallbackPolicy_RequiringAuthenticatedUser()
+    {
+        using var provider = (ServiceProvider)BuildProvider();
+        var policyProvider = provider.GetRequiredService<IAuthorizationPolicyProvider>();
+
+        var fallback = await policyProvider.GetFallbackPolicyAsync();
+
+        fallback.Should().NotBeNull(
+            "FallbackPolicy must be set so untagged controllers get challenged, not allowed anonymously");
+
+        fallback!.Requirements
+            .OfType<DenyAnonymousAuthorizationRequirement>()
+            .Should().NotBeEmpty(
+                "FallbackPolicy must include DenyAnonymousAuthorizationRequirement (RequireAuthenticatedUser)");
+    }
+
+    [Fact]
+    public async Task FallbackPolicy_IsDistinctFromDefaultPolicy()
+    {
+        using var provider = (ServiceProvider)BuildProvider();
+        var policyProvider = provider.GetRequiredService<IAuthorizationPolicyProvider>();
+
+        var defaultPolicy = await policyProvider.GetDefaultPolicyAsync();
+        var fallback = await policyProvider.GetFallbackPolicyAsync();
+
+        defaultPolicy.Should().NotBeNull();
+        fallback.Should().NotBeNull(
+            "FallbackPolicy must be set explicitly — its absence is what produced the silent-anonymous default");
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/InMemorySecurityServiceFailClosedTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/InMemorySecurityServiceFailClosedTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TerraFusion.API.Security;
+using Xunit;
+
+using CoreAuth = TerraFusion.Core.Services;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+/// <summary>
+/// PR-2 / Prometheus T3 #2 and #3: the in-memory fallback
+/// <c>ISecurityService</c> now denies every permission check and rejects
+/// every credential validation. Pre-PR-2 it returned <c>true</c> for any
+/// permission and <c>true</c> for any non-empty email+password — silent
+/// allow-all. These tests pin the fail-closed default.
+/// </summary>
+[Trait("Category", "Security")]
+[Trait("Component", "InMemorySecurityService")]
+[Trait("Slice", "Prometheus-T3")]
+public sealed class InMemorySecurityServiceFailClosedTests
+{
+    private static CoreAuth.ISecurityService BuildSut()
+    {
+        // The concrete InMemorySecurityService is internal; resolve via DI.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "test-failclosed-key-at-least-32-chars-long-for-hmac-sha256",
+                ["JwtSettings:Issuer"] = "TerraFusion.Test",
+                ["JwtSettings:Audience"] = "TerraFusion.Test",
+            })
+            .Build();
+        services.AddTerraFusionAuthentication(config);
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<CoreAuth.ISecurityService>();
+    }
+
+    [Fact]
+    public async Task HasPermissionAsync_ReturnsFalse_ForAnyTuple()
+    {
+        var sut = BuildSut();
+
+        var result = await sut.HasPermissionAsync("user-123", "system.admin");
+
+        result.Should().BeFalse(
+            "PR-2 #2 fail-closed: silent allow-all is gone; real ISecurityService must replace this");
+    }
+
+    [Fact]
+    public async Task HasModuleAccessAsync_ReturnsFalse_ForAnyTuple()
+    {
+        var sut = BuildSut();
+
+        var result = await sut.HasModuleAccessAsync("user-123", "terraforge");
+
+        result.Should().BeFalse(
+            "PR-2 #2 sibling: module-access fallback must deny too");
+    }
+
+    [Fact]
+    public async Task ValidateUserCredentialsAsync_ReturnsFalse_ForAnyNonEmptyInput()
+    {
+        var sut = BuildSut();
+
+        var result = await sut.ValidateUserCredentialsAsync("user@gov.example", "any-password");
+
+        result.Should().BeFalse(
+            "PR-2 #3 fail-closed: 'any non-empty pair authenticates' silent default is gone");
+    }
+
+    [Fact]
+    public async Task ValidateUserCredentialsAsync_ReturnsFalse_ForEmptyInput()
+    {
+        var sut = BuildSut();
+
+        var emptyEmail = await sut.ValidateUserCredentialsAsync(string.Empty, "pw");
+        var emptyPassword = await sut.ValidateUserCredentialsAsync("user@gov.example", string.Empty);
+
+        emptyEmail.Should().BeFalse();
+        emptyPassword.Should().BeFalse();
+    }
+
+    [Fact]
+    public void InMemorySecurityService_IsRegisteredAsFallback()
+    {
+        // Cross-check the registration is still TryAddSingleton (fallback,
+        // not unconditional). This is the contract that lets a real
+        // ISecurityService implementation replace it later without code edits.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "test-fallback-registration-key-32-chars-long-hmac-sha256-padding",
+            })
+            .Build();
+        services.AddTerraFusionAuthentication(config);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(CoreAuth.ISecurityService));
+        descriptor.Should().NotBeNull("ISecurityService must be registered");
+        // ServiceLifetime.Singleton is what TryAddSingleton uses.
+        descriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/JwtConfigurationFailFastTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/JwtConfigurationFailFastTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TerraFusion.API.Security;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+/// <summary>
+/// PR-2 / Prometheus T3 #5: <c>AddTerraFusionAuthentication</c> must
+/// fail-fast when no JWT signing key is configured in non-Development.
+/// Pre-PR-2 it silently synthesized a random
+/// <c>"TerraFusion-Default-Key-..." + 8-char GUID</c> key — a working-but-
+/// forgeable JWT signer with only a <c>Console.WriteLine</c> warning.
+/// Development still accepts a missing key and falls back to a long,
+/// fixed dev key so local dev keeps working.
+/// </summary>
+[Trait("Category", "Security")]
+[Trait("Component", "AuthenticationConfiguration")]
+[Trait("Slice", "Prometheus-T3")]
+public sealed class JwtConfigurationFailFastTests
+{
+    [Fact]
+    public void AddTerraFusionAuthentication_NoKey_NonDevelopment_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build(); // no JwtSettings:SecretKey
+        var env = new TestHostEnvironment("Production");
+
+        var act = () => services.AddTerraFusionAuthentication(config, env);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*JwtSettings:SecretKey is required in non-Development*");
+    }
+
+    [Fact]
+    public void AddTerraFusionAuthentication_NoKey_Staging_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build();
+        var env = new TestHostEnvironment("Staging");
+
+        var act = () => services.AddTerraFusionAuthentication(config, env);
+
+        act.Should().Throw<InvalidOperationException>(
+            "any non-Development environment (Staging included) must fail-fast on missing JWT key");
+    }
+
+    [Fact]
+    public void AddTerraFusionAuthentication_NoKey_Development_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build();
+        var env = new TestHostEnvironment("Development");
+
+        var act = () => services.AddTerraFusionAuthentication(config, env);
+
+        act.Should().NotThrow(
+            "Development gets a long, fixed dev-only fallback key so local dev works without env vars");
+    }
+
+    [Fact]
+    public void AddTerraFusionAuthentication_NoEnvironment_TreatsAsNonDevelopment_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().Build();
+
+        // No environment passed → treated as non-Development → fail-fast.
+        var act = () => services.AddTerraFusionAuthentication(config);
+
+        act.Should().Throw<InvalidOperationException>(
+            "absent IHostEnvironment must be treated as non-Development for safety");
+    }
+
+    [Fact]
+    public void AddTerraFusionAuthentication_KeyPresent_NonDevelopment_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "real-prod-key-supplied-by-operator-32-chars-minimum-length-padding",
+            })
+            .Build();
+        var env = new TestHostEnvironment("Production");
+
+        var act = () => services.AddTerraFusionAuthentication(config, env);
+
+        act.Should().NotThrow("explicit operator-supplied key satisfies the fail-fast check");
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string env) => EnvironmentName = env;
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "TerraFusion.Test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of 5 immediate-week production-readiness fixes. Closes the five silent auth gaps Prometheus T3 surfaced in `AuthenticationConfiguration.cs`.

- **#1 FallbackPolicy**: `AddAuthorization` now installs `FallbackPolicy.RequireAuthenticatedUser()`. Untagged controllers 401 instead of silently defaulting to anonymous.
- **#2 HasPermissionAsync / HasModuleAccessAsync**: in-memory fallback returns `false` (was: `true`). Silent allow-all retired; warns on call.
- **#3 ValidateUserCredentialsAsync**: in-memory fallback returns `false` (was: any non-empty email+password accepted).
- **#4 LDAP fail-closed**: non-Development now registers new `FailClosedLdapService` (every method throws `NotImplementedException`) instead of `DevelopmentLdapService`. The "rejects all logins" comment finally matches the code.
- **#5 JWT fail-fast**: `GenerateDefaultKey()` deleted. Missing `JwtSettings:SecretKey` now throws `InvalidOperationException` in non-Development. Development keeps a long fixed dev-only fallback for local-loop convenience.

Explicit `[AllowAnonymous]` tagging (with XML doc) on the controllers known to run anonymously by design: `WorkbenchF/G/H`, `FullCorpus`, `GovernmentCompliance`. `DoctrineDrain` / `DoctrinePolicy` / `DoctrineStatus` already had the attribute — verified, no change.

## Test plan

- [x] `dotnet build backend/TerraFusion.sln` — 0 warn / 0 err
- [x] `dotnet test backend/tests/TerraFusion.Unit.Tests/...` filter `Auth|Security|Jwt|Ldap` — 252/252 pass
- [x] Full unit suite — 3362/3362 pass (was 3358/3362 with the 4 expected R14 `GovernmentCompliance` failures resolved by tagging that controller `[AllowAnonymous]`)
- [x] 32 new tests under `tests/TerraFusion.Unit.Tests/Prometheus/T3/`:
  - `FallbackPolicyTests` (2): fallback policy installed and includes `DenyAnonymousAuthorizationRequirement`
  - `InMemorySecurityServiceFailClosedTests` (5): both permission methods + credentials deny; registration lifetime pinned
  - `FailClosedLdapServiceTests` (6): every method throws; DI Development branch keeps dev stub, non-Development gets fail-closed
  - `JwtConfigurationFailFastTests` (5): missing key throws in non-Dev (incl. Staging and no-environment), OK in Dev, present key OK in Prod
  - `ExplicitAllowAnonymousTaggingTests` (14): 7 controllers theory-tested for class-level `[AllowAnonymous]`, no double-tag with `[Authorize]`
- [x] 1 existing test updated: `Phase5/SecurityDIRegistrationTests.cs` now asserts `FailClosedLdapService` for the no-environment case (was `DevelopmentLdapService` — the silent misregistration the PR fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive security tests validating fallback auth policy, fail-closed LDAP behavior, JWT fail-fast checks, and explicit anonymous controller tagging.

* **Improvements**
  * Fail-fast JWT configuration in non-development environments.
  * Default authorization now requires authenticated access unless controllers opt out.
  * LDAP handling updated to fail-closed in production and in-memory security now denies by default.

* **Documentation**
  * Clarified controllers' anonymous/authentication posture in API docs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/822)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->