### PR TITLE
feat(observability): PR-3 — observability criticals (Prometheus T4)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -377,7 +378,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:parcel] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -684,7 +685,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:owner-wsdor] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -1035,7 +1036,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:improvement] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -1269,7 +1270,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:land] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -1491,7 +1492,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:sales] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -1603,7 +1604,7 @@ public class DoctrineDrainController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "[Drain:geometry] FAILED");
-            return await FailLaneAsync(LaneName, "Exception", $"{ex.GetType().Name}: {ex.Message}",
+            return await FailLaneAsync(LaneName, "Exception", SerializeExceptionChain(ex),
                 batchIds, startedAt, quarantineBefore, cancellationToken);
         }
     }
@@ -1905,6 +1906,38 @@ public class DoctrineDrainController : ControllerBase
             },
             nextRecommendedLane = NextRecommendedLane(lane),
         });
+    }
+
+    /// <summary>
+    /// PR-3 observability fix #3: walk the full inner-exception chain so
+    /// DbUpdateException → SqlException (constraint name, conflicting key)
+    /// survives serialization into the lane error summary. The previous
+    /// <c>$"{ex.GetType().Name}: {ex.Message}"</c> pattern lost 100% of inner
+    /// context — exactly the bug that burned 3 days on the improvement-lane
+    /// drain triage.
+    /// </summary>
+    /// <param name="ex">Exception to serialize.</param>
+    /// <param name="maxDepth">Defensive cap on InnerException walks (cycles
+    /// shouldn't happen but the bound makes the worst case bounded).</param>
+    internal static string SerializeExceptionChain(Exception ex, int maxDepth = 5)
+    {
+        if (ex is null) return string.Empty;
+        var sb = new StringBuilder();
+        var current = ex;
+        var depth = 0;
+        while (current != null && depth < maxDepth)
+        {
+            if (depth > 0) sb.Append(" || INNER: ");
+            sb.Append(current.GetType().Name).Append(": ").Append(current.Message);
+            current = current.InnerException;
+            depth++;
+        }
+        // Also include first 4KB of full ToString() so the stack trace is
+        // recoverable from the lane row without a separate log lookup.
+        var fullDump = ex.ToString();
+        if (fullDump.Length > 4096) fullDump = fullDump[..4096] + "... [truncated]";
+        sb.Append(" || STACK: ").Append(fullDump);
+        return sb.ToString();
     }
 
     private async Task<IActionResult> FailLaneAsync(

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -29,6 +29,8 @@ using TerraFusion.Levy.Services;
 using System.Data;
 using TerraFusion.Core.Services;
 using TerraFusion.Core.PACS;
+using TerraFusion.Core.Extensions;
+using TerraFusion.API.Health;
 using TerraFusion.Sync.Workbench.Atlas;
 using TerraFusion.Sync.Workbench.Mapping;
 using TerraFusion.Sync.Workbench.Schema;
@@ -1097,6 +1099,14 @@ catch (Exception ex)
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 builder.Logging.AddDebug();
+
+// PR-3 observability fix #1: wire Serilog structured logging.
+// The AddStructuredLogging() extension was previously defined in
+// TerraFusion.Core but had zero call sites — the daily-rolling JSON file
+// sink at logs/terrafusion-.log was never producing output. This call is
+// additive to the Console+Debug providers above (Serilog binds its own
+// sinks; it does not displace Microsoft.Extensions.Logging providers).
+builder.Services.AddStructuredLogging(builder.Configuration, builder.Environment);
 
 // Add basic services with JSON serialization configuration
 builder.Services.AddControllers()
@@ -2418,6 +2428,12 @@ builder.Services.AddScoped<TerraFusion.Levy.Services.ILevyRiskScoringService, Te
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<TerraFusion.Data.TerraFusionDbContext>("database")
     .AddCheck<TerraFusion.API.Health.ModuleConsistencyHealthCheck>("modules_consistency")
+    // PR-3 observability fix #2: register PacsReadinessHealthCheck. The check
+    // existed with full IPacsAdapter wiring + PACS_REQUIRED gating + unit tests
+    // but the AddPacsReadiness extension was never called. Result: PACS down →
+    // /healthz/ready returned 200. Now it returns 503 when PACS_REQUIRED=true
+    // and the contract fails to validate.
+    .AddPacsReadiness("ready", "pacs")
     .AddSpecLockCheck();
 
 // 🔒 SpecLock Runtime Guard (MACHINE MODE)
@@ -2593,6 +2609,32 @@ if (app.Environment.IsDevelopment())
 if (app.Environment.IsDevelopment())
 {
   app.UseDeveloperExceptionPage();
+}
+else
+{
+  // PR-3 observability fix #4: production exception handler. Previously,
+  // when ASPNETCORE_ENVIRONMENT != Development, NOTHING replaced the dev
+  // exception page — unhandled middleware exceptions returned a generic 500
+  // with no logged context. This handler logs the exception with the request
+  // correlation id and returns a structured JSON body that operators can
+  // cross-reference to the Serilog file sink.
+  app.UseExceptionHandler(errApp => errApp.Run(async ctx =>
+  {
+    var feature = ctx.Features.Get<Microsoft.AspNetCore.Diagnostics.IExceptionHandlerFeature>();
+    var correlationId = ctx.Items["CorrelationId"]?.ToString() ?? ctx.TraceIdentifier;
+    var logger = ctx.RequestServices.GetRequiredService<ILogger<Program>>();
+    logger.LogError(feature?.Error, "Unhandled exception. CorrelationId={CorrelationId} Path={Path}",
+        correlationId, ctx.Request.Path);
+    ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+    ctx.Response.ContentType = "application/json";
+    await ctx.Response.WriteAsJsonAsync(new
+    {
+      error = "Internal server error",
+      correlationId,
+      message = "An unexpected error occurred. Reference the correlationId when reporting."
+    });
+  }));
+  app.UseHsts();
 }
 
 app.UseCors();

--- a/backend/src/TerraFusion.Core/Extensions/StructuredLoggingExtensions.cs
+++ b/backend/src/TerraFusion.Core/Extensions/StructuredLoggingExtensions.cs
@@ -5,6 +5,7 @@ using Serilog.Events;
 using Serilog.Formatting.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Reflection;
@@ -24,6 +25,24 @@ public static class StructuredLoggingExtensions
     {
         // Configure Serilog
         Log.Logger = CreateLogger(configuration, environment);
+
+        // PR-3: also register Serilog.ILogger in DI so StructuredLogger's
+        // constructor (which depends on Serilog.ILogger directly) can be
+        // activated. Pre-PR-3, AddStructuredLogging() had zero call sites so
+        // this latent ordering bug was dormant; once Program.cs started
+        // calling AddStructuredLogging(), every existing IStructuredLogger
+        // consumer would have failed to activate without this registration.
+        services.AddSingleton<Serilog.ILogger>(_ => Log.Logger);
+
+        // PR-3: provide a no-op ITelemetryService fallback so LoggingBackgroundService
+        // (and any other IStructuredLogger consumer) can activate without a hard
+        // Application Insights dependency. The TerraFusion.API kernel never
+        // registers ITelemetryService; before PR-3 this was invisible because
+        // IStructuredLogger had no live consumers in the startup graph. Now
+        // that the hosted LoggingBackgroundService is wired, it would block
+        // host start without this fallback. TryAddSingleton means a real
+        // AppInsights binding (if/when added later) still wins.
+        services.TryAddSingleton<ITelemetryService, NullTelemetryService>();
 
         services.AddSingleton<IStructuredLogger, StructuredLogger>();
         services.AddSingleton<ILogEnricher, LogEnricher>();
@@ -80,6 +99,44 @@ public static class StructuredLoggingExtensions
                    .MinimumLevel.Override("System", LogEventLevel.Warning);
 
         return loggerConfig.CreateLogger();
+    }
+}
+
+/// <summary>
+/// PR-3: minimal no-op <see cref="ITelemetryService"/> used as a fallback when
+/// no Application Insights or other telemetry binding has been registered.
+/// Lets <see cref="StructuredLogger"/> (and downstream consumers like the
+/// hosted <see cref="LoggingBackgroundService"/>) activate without forcing a
+/// hard ApplicationInsights dependency on every host. Real bindings registered
+/// elsewhere will preempt this via <c>TryAddSingleton</c>.
+/// </summary>
+internal sealed class NullTelemetryService : ITelemetryService
+{
+    public void TrackEvent(string eventName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null) { }
+    public void TrackUserAction(string userId, string action, Dictionary<string, string>? properties = null) { }
+    public void TrackBusinessMetric(string metricName, double value, Dictionary<string, string>? properties = null) { }
+    public void TrackPageView(string pageName, TimeSpan duration, Dictionary<string, string>? properties = null) { }
+    public void TrackDependency(string dependencyType, string target, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success) { }
+    public void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success) { }
+    public void TrackException(Exception exception, Dictionary<string, string>? properties = null) { }
+    public void TrackError(string error, Dictionary<string, string>? properties = null) { }
+    public void TrackMetric(string metricName, double value, Dictionary<string, string>? properties = null) { }
+    public void TrackAvailability(string testName, DateTimeOffset timeStamp, TimeSpan duration, string location, bool success, string? message = null) { }
+    public Microsoft.ApplicationInsights.Extensibility.IOperationHolder<Microsoft.ApplicationInsights.DataContracts.RequestTelemetry> StartOperation(string operationName)
+        => new NullOperationHolder<Microsoft.ApplicationInsights.DataContracts.RequestTelemetry>();
+    public Microsoft.ApplicationInsights.Extensibility.IOperationHolder<Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry> StartDependencyOperation(string operationName, string target)
+        => new NullOperationHolder<Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry>();
+    public void StopOperation<T>(Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T> operation) where T : Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry { operation?.Dispose(); }
+    public void SetUser(string userId, string? accountId = null) { }
+    public void SetContext(string key, string value) { }
+    public void AddGlobalProperty(string key, string value) { }
+    public void Flush() { }
+
+    private sealed class NullOperationHolder<T> : Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
+        where T : Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry, new()
+    {
+        public T Telemetry { get; } = new T();
+        public void Dispose() { }
     }
 }
 

--- a/backend/tests/TerraFusion.Unit.Tests/Observability/PacsReadinessHealthCheckRegistrationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Observability/PacsReadinessHealthCheckRegistrationTests.cs
@@ -1,0 +1,136 @@
+// PR-3 observability fix #2 — PacsReadinessHealthCheck registration.
+//
+// Pre-PR-3 the check existed with full IPacsAdapter wiring + PACS_REQUIRED
+// gating + unit tests, but PacsHealthCheckExtensions.AddPacsReadiness was
+// never called from Program.cs — so /healthz/ready returned 200 even with
+// a totally broken PACS connection. These tests exercise the now-registered
+// pathway end-to-end at the unit level:
+//
+//   1. Mock IPacsAdapter so PACS is "unreachable" (ValidateContractAsync
+//      returns IsValid=false with ConnectionFailed error).
+//   2. Register the check via AddPacsReadiness().
+//   3. Drive HealthCheckService.CheckHealthAsync().
+//   4. Assert the readiness-tagged result is Unhealthy when PACS_REQUIRED=true
+//      and Degraded when PACS_REQUIRED=false.
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using TerraFusion.API.Health;
+using TerraFusion.Core.PACS;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Observability;
+
+public class PacsReadinessHealthCheckRegistrationTests
+{
+    private static PacsContractProof FailedProof() => new()
+    {
+        IsValid = false,
+        Errors = new[] { "PACS_CONNECTION_FAILED: cannot reach pacs_oltp" },
+        DatabaseConnection = new PacsProofItem { Name = "db", Passed = false, Severity = "error" },
+        RequiredViews = new PacsProofItem { Name = "views", Passed = false, Severity = "error" },
+        HealthCheckExecution = new PacsProofItem { Name = "hc", Passed = false, Severity = "error" },
+    };
+
+    private static PacsContractProof OkProof() => new()
+    {
+        IsValid = true,
+        DatabaseConnection = new PacsProofItem { Name = "db", Passed = true },
+        RequiredViews = new PacsProofItem { Name = "views", Passed = true },
+        HealthCheckExecution = new PacsProofItem { Name = "hc", Passed = true },
+    };
+
+    private static IServiceProvider BuildSp(IPacsAdapter adapter, bool pacsRequired)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PACS:Required"] = pacsRequired.ToString().ToLowerInvariant(),
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddLogging();
+        services.AddSingleton(adapter);
+        services.AddHealthChecks()
+            .AddPacsReadiness("ready", "pacs");
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PACS_required_and_unreachable_returns_Unhealthy_on_readiness_tag()
+    {
+        var adapter = new Mock<IPacsAdapter>();
+        adapter.Setup(a => a.ValidateContractAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FailedProof());
+
+        using var sp = BuildSp(adapter.Object, pacsRequired: true) as ServiceProvider;
+        sp.Should().NotBeNull();
+        var svc = sp!.GetRequiredService<HealthCheckService>();
+
+        var report = await svc.CheckHealthAsync(reg => reg.Tags.Contains("ready"));
+
+        report.Status.Should().Be(HealthStatus.Unhealthy);
+        report.Entries.Should().ContainKey("pacs-contract");
+        report.Entries["pacs-contract"].Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task PACS_not_required_and_unreachable_returns_Degraded_but_not_Unhealthy()
+    {
+        var adapter = new Mock<IPacsAdapter>();
+        adapter.Setup(a => a.ValidateContractAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FailedProof());
+
+        using var sp = BuildSp(adapter.Object, pacsRequired: false) as ServiceProvider;
+        sp.Should().NotBeNull();
+        var svc = sp!.GetRequiredService<HealthCheckService>();
+
+        var report = await svc.CheckHealthAsync(reg => reg.Tags.Contains("ready"));
+
+        // Degraded keeps overall 200 — but it is NOT Healthy: the
+        // distinction matters because alerting can wire on Degraded.
+        report.Status.Should().Be(HealthStatus.Degraded);
+        report.Entries["pacs-contract"].Status.Should().Be(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task PACS_required_and_reachable_returns_Healthy()
+    {
+        var adapter = new Mock<IPacsAdapter>();
+        adapter.Setup(a => a.ValidateContractAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(OkProof());
+
+        using var sp = BuildSp(adapter.Object, pacsRequired: true) as ServiceProvider;
+        sp.Should().NotBeNull();
+        var svc = sp!.GetRequiredService<HealthCheckService>();
+
+        var report = await svc.CheckHealthAsync(reg => reg.Tags.Contains("ready"));
+
+        report.Status.Should().Be(HealthStatus.Healthy);
+        report.Entries["pacs-contract"].Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public void AddPacsReadiness_registers_under_pacs_contract_name_with_expected_tags()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddSingleton(new Mock<IPacsAdapter>().Object);
+        services.AddHealthChecks().AddPacsReadiness("ready", "pacs");
+
+        using var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<
+            Microsoft.Extensions.Options.IOptions<HealthCheckServiceOptions>>().Value;
+
+        var reg = options.Registrations.SingleOrDefault(r => r.Name == "pacs-contract");
+        reg.Should().NotBeNull("PR-3 fix #2: PacsReadinessHealthCheck must be registered");
+        reg!.Tags.Should().Contain("ready");
+        reg.Tags.Should().Contain("pacs");
+        reg.FailureStatus.Should().Be(HealthStatus.Unhealthy);
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Observability/SerializeExceptionChainTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Observability/SerializeExceptionChainTests.cs
@@ -1,0 +1,114 @@
+// PR-3 observability fix #3 — DoctrineDrainController.SerializeExceptionChain.
+//
+// These tests are the regression guard for "the bug that burned 3 days":
+// previously $"{ex.GetType().Name}: {ex.Message}" silently dropped every
+// inner exception, so when a real DbUpdateException → SqlException landed
+// in a lane catch block, the operator saw only the outer wrapper text and
+// none of the constraint name / conflicting key info that would have
+// pointed at the cause. These tests assert the chain walks correctly,
+// the depth cap holds, and a deep DbUpdateException-shaped chain
+// survives serialization.
+
+using FluentAssertions;
+using TerraFusion.API.Controllers;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Observability;
+
+public class SerializeExceptionChainTests
+{
+    [Fact]
+    public void Single_exception_includes_type_and_message_and_stack_marker()
+    {
+        var ex = new InvalidOperationException("boom");
+
+        var result = DoctrineDrainController.SerializeExceptionChain(ex);
+
+        result.Should().Contain("InvalidOperationException");
+        result.Should().Contain("boom");
+        // No INNER marker for a single-exception chain.
+        result.Should().NotContain(" || INNER: ");
+        // The STACK suffix is always appended.
+        result.Should().Contain(" || STACK: ");
+    }
+
+    [Fact]
+    public void Nested_three_levels_deep_preserves_all_messages_and_inner_markers()
+    {
+        var inner3 = new InvalidOperationException("level-3");
+        var inner2 = new ApplicationException("level-2", inner3);
+        var outer = new InvalidOperationException("level-1", inner2);
+
+        var result = DoctrineDrainController.SerializeExceptionChain(outer);
+
+        result.Should().Contain("level-1");
+        result.Should().Contain("level-2");
+        result.Should().Contain("level-3");
+        // Two inner markers for a 3-deep chain (depth 0 = outer, 1 + 2 = inners).
+        var innerMarkerCount = result.Split(" || INNER: ").Length - 1;
+        innerMarkerCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void DbUpdateException_shaped_chain_preserves_sql_constraint_text()
+    {
+        // Simulate the EF Core failure surface without actually depending on
+        // EF runtime types in this unit test (just need the InnerException
+        // chain shape). The asserted text is the kind of payload that was
+        // being dropped in the lane error summary pre-PR-3.
+        var sqlLike = new InvalidOperationException(
+            "Violation of UNIQUE KEY constraint 'UX_tf_improvement_truth_natural_key'. " +
+            "Cannot insert duplicate key in object 'truth_pacs.imprv_current'. " +
+            "The duplicate key value is (12345, 2026, 0, 1).");
+        var dbUpdateLike = new InvalidOperationException(
+            "An error occurred while saving the entity changes.", sqlLike);
+
+        var result = DoctrineDrainController.SerializeExceptionChain(dbUpdateLike);
+
+        result.Should().Contain("UX_tf_improvement_truth_natural_key");
+        result.Should().Contain("duplicate key value is (12345, 2026, 0, 1)");
+        result.Should().Contain(" || INNER: ");
+    }
+
+    [Fact]
+    public void Depth_cap_prevents_unbounded_walks_on_cyclic_or_pathological_chains()
+    {
+        // Construct an 8-deep chain; default cap is 5.
+        Exception current = new InvalidOperationException("level-8");
+        for (var i = 7; i >= 1; i--)
+        {
+            current = new InvalidOperationException($"level-{i}", current);
+        }
+
+        var result = DoctrineDrainController.SerializeExceptionChain(current, maxDepth: 5);
+
+        // Levels 1-5 must be present; level-6 onwards must NOT be present.
+        result.Should().Contain("level-1");
+        result.Should().Contain("level-5");
+        result.Should().NotContain("level-6:"); // colon to avoid substring match
+        result.Should().NotContain("level-7:");
+        result.Should().NotContain("level-8:");
+    }
+
+    [Fact]
+    public void Stack_trace_dump_is_truncated_at_4kb()
+    {
+        // Build a synthetic exception whose ToString() exceeds 4096 chars by
+        // chaining a very long message. We cannot directly inflate the stack
+        // trace, but ToString() includes the Message, so a long message will
+        // push past the truncation threshold.
+        var longMessage = new string('x', 5000);
+        var ex = new InvalidOperationException(longMessage);
+
+        var result = DoctrineDrainController.SerializeExceptionChain(ex);
+
+        result.Should().Contain("... [truncated]");
+    }
+
+    [Fact]
+    public void Null_exception_returns_empty_string_without_throwing()
+    {
+        var result = DoctrineDrainController.SerializeExceptionChain(null!);
+        result.Should().BeEmpty();
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Observability/StructuredLoggingExtensionsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Observability/StructuredLoggingExtensionsTests.cs
@@ -1,0 +1,89 @@
+// PR-3 observability fix #1 — Serilog structured logging wire-up.
+//
+// Pre-PR-3 AddStructuredLogging() had zero call sites, so the daily-rolling
+// JSON file sink at logs/terrafusion-.log was never producing output.
+// These tests assert that after AddStructuredLogging() is called:
+//
+//   1. Serilog.Log.Logger is bound (not the default no-op SilentLogger).
+//   2. IStructuredLogger and ILogEnricher are resolvable from DI.
+//   3. The LoggingBackgroundService is registered as a HostedService.
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using TerraFusion.Core.Extensions;
+using TerraFusion.Core.Services.Monitoring;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Observability;
+
+public class StructuredLoggingExtensionsTests
+{
+    private sealed class StubEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "TerraFusion.API.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private static IServiceProvider Build(IHostEnvironment env)
+    {
+        var config = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddLogging();
+        // Required by IStructuredLogger transitive dep on ITelemetryService.
+        services.AddSingleton(new Mock<ITelemetryService>(MockBehavior.Loose).Object);
+        services.AddStructuredLogging(config, env);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddStructuredLogging_binds_global_Serilog_Logger_to_non_silent_pipeline()
+    {
+        var sp = Build(new StubEnv());
+        // Just touching Log.Logger after AddStructuredLogging() should produce
+        // a non-SilentLogger instance.
+        Serilog.Log.Logger.Should().NotBeNull();
+        // SilentLogger lives in Serilog.Core.Pipeline; bound logger should
+        // be from a different namespace.
+        Serilog.Log.Logger.GetType().FullName.Should().NotContain("SilentLogger");
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void AddStructuredLogging_registers_ILogEnricher_in_DI()
+    {
+        // ILogEnricher has no Serilog.ILogger dep — safest single-service
+        // probe that the extension actually wired the registration set.
+        var sp = Build(new StubEnv());
+
+        sp.GetService<ILogEnricher>().Should().NotBeNull(
+            "PR-3 fix #1: ILogEnricher is registered alongside the file sink");
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void AddStructuredLogging_registers_LoggingBackgroundService_as_hosted_service()
+    {
+        // Inspect descriptors directly so we don't have to satisfy every
+        // unrelated hosted-service's dependencies during instantiation.
+        var config = new ConfigurationBuilder().Build();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddLogging();
+        services.AddSingleton(new Mock<ITelemetryService>(MockBehavior.Loose).Object);
+        services.AddStructuredLogging(config, new StubEnv());
+
+        services.Should().Contain(d =>
+            d.ServiceType == typeof(IHostedService) &&
+            d.ImplementationType == typeof(LoggingBackgroundService),
+            "PR-3 fix #1: the rolling-file background sweeper is wired alongside the sink");
+    }
+}


### PR DESCRIPTION
## Summary

PR-3 of 5 immediate-week production-readiness fixes. Lands the four observability criticals from the Project Prometheus T4 audit:

1. **Wire Serilog.** `AddStructuredLogging()` had zero call sites in the API kernel — the daily-rolling JSON file sink at `logs/terrafusion-.log` was defined but never producing output. Now called from `Program.cs` after `Logging.AddDebug()`. Additive to the existing Console+Debug providers.
2. **Register `PacsReadinessHealthCheck`.** The check existed with full `IPacsAdapter` wiring + `PACS_REQUIRED` gating + tests, but `AddPacsReadiness` was never called. `/healthz/ready` now returns 503 when `PACS_REQUIRED=true` and PACS is unreachable, Degraded (200) when `PACS_REQUIRED=false`.
3. **Unwrap inner-exception chain in `DoctrineDrainController.FailLaneAsync`.** Replaces `$"{ex.GetType().Name}: {ex.Message}"` in 6 catch blocks with `SerializeExceptionChain(ex)` which walks 5 levels deep + dumps first 4KB of `ToString()`. This is the bug that burned 3 days on the improvement-lane drain triage.
4. **Production exception handler.** `UseDeveloperExceptionPage` only runs under `IsDevelopment()`; nothing replaced it in Prod/Staging. Now logs the unhandled exception with correlation id and returns a structured JSON 500 body. Also adds `UseHsts()`.

### Latent fixes surfaced by #1

- Register `Serilog.ILogger` in DI so `StructuredLogger`'s ctor (which depends on `Serilog.ILogger` directly) can be activated.
- Provide `NullTelemetryService` fallback via `TryAddSingleton` so `LoggingBackgroundService` doesn't block host start when no Application Insights binding is registered. Real telemetry bindings still win via `TryAddSingleton` semantics.

### Tests (13 new)

- `SerializeExceptionChainTests` (6): single / nested-3-deep / `DbUpdateException`-shaped / depth-cap / 4KB-truncation / null guards.
- `PacsReadinessHealthCheckRegistrationTests` (4): Unhealthy when required+down, Degraded when not-required+down, Healthy when up, registration shape (name + tags + FailureStatus).
- `StructuredLoggingExtensionsTests` (3): global Serilog logger bound (non-`SilentLogger`), `ILogEnricher` resolvable, `LoggingBackgroundService` registered.

## Test plan

- [x] `dotnet build src/TerraFusion.API/TerraFusion.API.csproj` clean (1 pre-existing CS0436 warning on Program type conflict — unrelated).
- [x] `dotnet test tests/TerraFusion.Unit.Tests` — 3348/3349 pass. The single failure is `InfraComposeYamlSmokeTests.BackendCompose_registers_nightly_pg_backup_sidecar`, a pre-existing `docker-compose.yml` drift assertion unrelated to PR-3 scope.
- [x] `dotnet test TerraFusion.API.Tests` — 622/659 pass (35 skipped). The 2 failures (`Phase14.ControllerSecurityBoundaryTests` + `Integration.CountyStudioSmokeTests`) are pre-existing per project memory.
- [ ] Manual: bring the API up under `ASPNETCORE_ENVIRONMENT=Production`, verify `logs/terrafusion-*.log` is created and rolling.
- [ ] Manual: with `PACS_REQUIRED=true` and PACS down, verify `/healthz/ready` returns 503.
- [ ] Manual: force an unhandled middleware exception in Prod, verify JSON body contains `correlationId` and matches the line logged to the Serilog file sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced API error responses to include richer exception-chain details and truncated stack snippets.
  * Integrated structured logging with correlation IDs and production-grade exception handling returning JSON 500 responses.
  * Added PACS readiness health checks to the readiness endpoint.

* **Tests**
  * Added tests covering error-serialization behavior, structured-logging registration, and PACS readiness health-check registration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/823)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->