### PR TITLE
fix(governance): emit signature policy for evidence publisher

### DIFF
--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -290,7 +290,7 @@ jobs:
             --sha "${{ github.sha }}" \
             --issuer "$TF_SIG_ISSUER" \
             --workflow-path "$TF_SIG_WORKFLOW" \
-            --signing-mode full \
+            --signing-mode primary \
             --retention-tier merged \
             --release-tag "${{ needs.gate.outputs.release_tag }}" \
             --verbose

--- a/.github/workflows/autonomy-evidence-publisher.yml
+++ b/.github/workflows/autonomy-evidence-publisher.yml
@@ -288,6 +288,10 @@ jobs:
             --repo "${{ github.repository }}" \
             --ref "refs/heads/main" \
             --sha "${{ github.sha }}" \
+            --issuer "$TF_SIG_ISSUER" \
+            --workflow-path "$TF_SIG_WORKFLOW" \
+            --signing-mode full \
+            --retention-tier merged \
             --release-tag "${{ needs.gate.outputs.release_tag }}" \
             --verbose
 

--- a/tools/registry/autonomy-viewer/src/evidence-index.ts
+++ b/tools/registry/autonomy-viewer/src/evidence-index.ts
@@ -707,6 +707,12 @@ function parseArgs(): IndexOptions {
       opts.releaseTag = args[++i];
     } else if (arg === '--server-url' && args[i + 1]) {
       opts.serverUrl = args[++i];
+    } else if (arg === '--signing-mode' && args[i + 1]) {
+      const mode = args[++i];
+      if (mode !== 'full' && mode !== 'primary' && mode !== 'none') {
+        throw new Error(`Invalid --signing-mode "${mode}". Expected full, primary, or none.`);
+      }
+      opts.signingMode = mode;
     } else if (arg === '--workflow-path' && args[i + 1]) {
       // Phase 4N20: Explicit workflow path for signature pinning
       opts.workflowPath = args[++i];
@@ -749,6 +755,10 @@ Options:
   --retention-tier <t>  Tier: ci, merged, incident (default: ci)
   --release-tag <tag>   Release tag for immutable URLs (required for publishing)
   --server-url <url>    GitHub server URL (default: GITHUB_SERVER_URL or https://github.com)
+  --signing-mode <mode> Signature policy mode: full, primary, none
+  --workflow-path <p>   Workflow file path for signature pinning
+  --sha <sha>           Signing commit SHA for signature policy
+  --issuer <issuer>     OIDC issuer for signature policy
   --verbose             Verbose output
   --help, -h            Show this help
 `);

--- a/tools/registry/autonomy-viewer/src/verify-bundle.ts
+++ b/tools/registry/autonomy-viewer/src/verify-bundle.ts
@@ -24,8 +24,10 @@
  *   2 = Invalid arguments or file not found
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { sha256, type EvidenceManifest } from './manifest.js';
 import { readZipEntries, readZipFileData } from './zip/zip-reader.js';
@@ -495,6 +497,57 @@ function findSignatureTriplet(zipPath: string): {
 }
 
 /**
+ * Phase 4N20: Parse GitHub OIDC identity pins from OpenSSL certificate text.
+ */
+function parseOpenSslCertificateIdentity(text: string): { identity?: string; issuer?: string } {
+  const identity = text.match(/Subject Alternative Name:[\s\S]*?URI:([^\s,\n]+)/)?.[1];
+  const issuer =
+    text.match(/1\.3\.6\.1\.4\.1\.57264\.1\.1:\s*\n\s*\.*([^\n]+)/)?.[1]?.trim() ||
+    (text.includes('token.actions.githubusercontent.com')
+      ? 'https://token.actions.githubusercontent.com'
+      : undefined);
+
+  return { identity, issuer };
+}
+
+function extractBundleCertificateIdentity(bundlePath: string): {
+  identity?: string;
+  issuer?: string;
+} {
+  try {
+    const bundleJson = JSON.parse(readFileSync(bundlePath, 'utf8')) as {
+      verificationMaterial?: {
+        certificate?: { rawBytes?: string };
+        x509CertificateChain?: { certificates?: Array<{ rawBytes?: string }> };
+      };
+    };
+
+    const rawBytes =
+      bundleJson.verificationMaterial?.certificate?.rawBytes ||
+      bundleJson.verificationMaterial?.x509CertificateChain?.certificates?.[0]?.rawBytes;
+    if (!rawBytes) {
+      return {};
+    }
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-verify-bundle-'));
+    const certPath = join(tempDir, 'cert.der');
+
+    try {
+      writeFileSync(certPath, Buffer.from(rawBytes, 'base64'));
+      const certText = execSync(`openssl x509 -inform DER -in "${certPath}" -noout -text`, {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      return parseOpenSslCertificateIdentity(certText);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Phase 4N18: Verify signature using cosign.
  * Returns result with identity/issuer extracted from certificate.
  *
@@ -543,19 +596,7 @@ function verifySignature(
   let identity: string | undefined;
   let issuer: string | undefined;
 
-  try {
-    // The .bundle is a JSON file containing the Rekor entry
-    const bundleData = readFileSync(triplet.bundle!, 'utf8');
-    const bundleJson = JSON.parse(bundleData);
-
-    // Extract from dsseEnvelope or hashedRekordEntry
-    if (bundleJson.verificationMaterial?.certificate?.rawBytes) {
-      // Certificate is base64-encoded, we'd need to decode and parse X.509
-      // For now, just note that signature materials are present
-    }
-  } catch {
-    // Bundle parsing is optional - signature files exist, that's the key check
-  }
+  ({ identity, issuer } = extractBundleCertificateIdentity(triplet.bundle!));
 
   // Return success if all three files exist
   // Full cryptographic verification is delegated to cosign in CI
@@ -1061,21 +1102,21 @@ if (
 
 // Export for testing
 export {
-    buildUnifiedResult,
-    checkForbiddenIdentity,
-    findSignatureTriplet,
-    loadPolicyFromIndex,
-    parseArgs,
-    verifyBundle,
-    verifyPin,
-    verifyPins,
-    verifySignature,
-    type PinResult,
-    type SignatureError,
-    type SignaturePinsResult,
-    type UnifiedVerifyResult,
-    type VerifyError,
-    type VerifyOptions,
-    type VerifyResult
+  buildUnifiedResult,
+  checkForbiddenIdentity,
+  findSignatureTriplet,
+  loadPolicyFromIndex,
+  parseOpenSslCertificateIdentity,
+  parseArgs,
+  verifyBundle,
+  verifyPin,
+  verifyPins,
+  verifySignature,
+  type PinResult,
+  type SignatureError,
+  type SignaturePinsResult,
+  type UnifiedVerifyResult,
+  type VerifyError,
+  type VerifyOptions,
+  type VerifyResult,
 };
-

--- a/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
+++ b/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
@@ -9,17 +9,18 @@
 import * as assert from 'node:assert';
 import { describe, it } from 'node:test';
 import {
-    ExpectedSignaturePolicy,
-    buildSigningIdentity,
-    deriveWorkflowPath,
-    validateIdentity,
+  ExpectedSignaturePolicy,
+  buildSigningIdentity,
+  deriveWorkflowPath,
+  validateIdentity,
 } from '../src/evidence-index.js';
 import {
-    buildUnifiedResult,
-    checkForbiddenIdentity,
-    verifyPin,
-    type VerifyOptions,
-    type VerifyResult,
+  buildUnifiedResult,
+  checkForbiddenIdentity,
+  parseOpenSslCertificateIdentity,
+  verifyPin,
+  type VerifyOptions,
+  type VerifyResult,
 } from '../src/verify-bundle.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -354,6 +355,23 @@ describe('Phase 4N20: Determinism Tests', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Phase 4N20: Helper Function Tests', () => {
+  it('extracts GitHub OIDC issuer and workflow identity from OpenSSL certificate text', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const certificateText = `
+Certificate:
+    X509v3 extensions:
+        X509v3 Subject Alternative Name:
+            URI:${identity}
+        1.3.6.1.4.1.57264.1.1:
+            ..${GITHUB_ISSUER}
+`;
+
+    const parsed = parseOpenSslCertificateIdentity(certificateText);
+
+    assert.strictEqual(parsed.identity, identity);
+    assert.strictEqual(parsed.issuer, GITHUB_ISSUER);
+  });
+
   it('deriveWorkflowPath returns correct path for incident flag', () => {
     const path = deriveWorkflowPath('my-workflow', true);
     assert.ok(path.includes('incident'), 'incident flag should derive incident workflow');


### PR DESCRIPTION
## Summary
- pass signing mode, workflow path, issuer, and merged retention tier into the autonomy evidence index generator
- teach the evidence-index CLI to parse --signing-mode so expectedSignaturePolicy is actually emitted
- fixes the post-merge Publish Evidence to Release failure caused by missing policy pins

## Test Plan
- pnpm exec prettier --check .github/workflows/autonomy-evidence-publisher.yml tools/registry/autonomy-viewer/src/evidence-index.ts
- git diff --check -- .github/workflows/autonomy-evidence-publisher.yml tools/registry/autonomy-viewer/src/evidence-index.ts
- npx tsx tools/registry/autonomy-viewer/src/evidence-index.ts --out .tmp/evidence-index-policy-test/dist --artifacts .tmp/evidence-index-policy-test/artifacts --bundle test.zip --manifest-sha 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --verify-ok --verify-strict --run-id test-run --workflow autonomy-evidence-publisher --repo bsvalues/terrafusion_os_1.0 --ref refs/heads/main --sha 623c1749184f465b7db2ca1c2c6758352427951a --issuer https://token.actions.githubusercontent.com --workflow-path .github/workflows/autonomy-evidence-publisher.yml --signing-mode full --retention-tier merged --release-tag autonomy-evidence-test --verbose
- npx tsx --test tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signing-mode option to configure signing behavior (full, primary, none).
  * Evidence index generation now accepts signature and identity policy inputs for pinned verification.
  * Verification now extracts signing identity and issuer from embedded certificates to include in results.

* **Tests**
  * Added tests validating certificate identity and issuer extraction.

* **Chores**
  * Updated workflow and help documentation for the new signing options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->