### PR TITLE
fix(governance): exempt signing identities from custody URL mutability

### DIFF
--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -167,6 +167,59 @@ export function containsMutableRef(value: string): RegExp | null {
   return null;
 }
 
+function isSignatureIdentityField(pathParts: string[], value: string): boolean {
+  const key = pathParts[pathParts.length - 1];
+  const parent = pathParts[pathParts.length - 2];
+  const looksLikeGitHubOidcIdentity =
+    value.startsWith('https://github.com/') &&
+    value.includes('/.github/workflows/') &&
+    value.includes('@refs/heads/');
+
+  return (
+    looksLikeGitHubOidcIdentity &&
+    ((parent === 'expectedSignaturePolicy' && key === 'identity') || key === 'signingIdentity')
+  );
+}
+
+function validateJsonValueNoMutableUrls(value: unknown, pathParts: string[] = []): AttestError[] {
+  const errors: AttestError[] = [];
+
+  if (typeof value === 'string') {
+    if (isSignatureIdentityField(pathParts, value)) {
+      return errors;
+    }
+
+    if (!/^https?:\/\//.test(value)) {
+      return errors;
+    }
+
+    const mutablePattern = containsMutableRef(value);
+    if (mutablePattern) {
+      errors.push({
+        type: 'mutable_url',
+        artifact: value,
+        message: `Mutable URL detected: "${value}" matches ${mutablePattern}`,
+      });
+    }
+    return errors;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      errors.push(...validateJsonValueNoMutableUrls(item, [...pathParts, String(index)]));
+    });
+    return errors;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      errors.push(...validateJsonValueNoMutableUrls(child, [...pathParts, key]));
+    }
+  }
+
+  return errors;
+}
+
 /**
  * Extract manifest.json SHA256 from inside a ZIP bundle.
  */
@@ -326,7 +379,18 @@ function createEmptyAttestation(opts: BuildAttestOptions): CustodyAttestation {
  */
 export function validateNoMutableUrls(content: string | object): AttestError[] {
   const errors: AttestError[] = [];
-  const text = typeof content === 'string' ? content : JSON.stringify(content);
+
+  if (typeof content !== 'string') {
+    return validateJsonValueNoMutableUrls(content);
+  }
+
+  try {
+    return validateJsonValueNoMutableUrls(JSON.parse(content));
+  } catch {
+    // Non-JSON evidence such as HTML falls back to URL scanning below.
+  }
+
+  const text = content;
 
   // Find all URL-like strings
   const urlPatterns = [

--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -189,10 +189,6 @@ function validateJsonValueNoMutableUrls(value: unknown, pathParts: string[] = []
       return errors;
     }
 
-    if (!/^https?:\/\//.test(value)) {
-      return errors;
-    }
-
     const mutablePattern = containsMutableRef(value);
     if (mutablePattern) {
       errors.push({

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -18,13 +18,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import test from 'node:test';
 import {
-    ATTESTATION_SCHEMA,
-    buildAttestation,
-    containsMutableRef,
-    REQUIRED_ARTIFACTS,
-    TOOL_VERSION,
-    validateNoMutableUrls,
-    type CustodyAttestation,
+  ATTESTATION_SCHEMA,
+  buildAttestation,
+  containsMutableRef,
+  REQUIRED_ARTIFACTS,
+  TOOL_VERSION,
+  validateNoMutableUrls,
+  type CustodyAttestation,
 } from '../src/custody-attest.js';
 import { verifyCustodyAttestation } from '../src/verify-custody.js';
 
@@ -241,6 +241,21 @@ test('validateNoMutableUrls: accepts immutable URLs in JSON', () => {
   });
   const errors = validateNoMutableUrls(content);
   assert.equal(errors.length, 0, 'Should accept all immutable URLs');
+});
+
+test('validateNoMutableUrls: ignores GitHub OIDC signing identity refs', () => {
+  const content = JSON.stringify({
+    expectedSignaturePolicy: {
+      identity:
+        'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+      issuer: 'https://token.actions.githubusercontent.com',
+    },
+    releaseUrl: 'https://github.com/owner/repo/releases/tag/v1.0.0',
+  });
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 0, 'Signing identity is not an artifact URL');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -258,6 +258,17 @@ test('validateNoMutableUrls: ignores GitHub OIDC signing identity refs', () => {
   assert.equal(errors.length, 0, 'Signing identity is not an artifact URL');
 });
 
+test('validateNoMutableUrls: detects mutable URL embedded in JSON prose string', () => {
+  const content = JSON.stringify({
+    note: 'Operator evidence is available at https://github.com/owner/repo/releases/latest',
+  });
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 1, 'Mutable URLs embedded in prose must still be detected');
+  assert.equal(errors[0].type, 'mutable_url');
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Required Fields Tests
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix custody attestation URL validation so GitHub OIDC signing identities are treated as certificate metadata, not mutable artifact URLs.
- Keep mutable artifact URL rejection intact for release/download/dashboard/custody URLs.
- Adds a regression test for the post-merge Autonomy Evidence Publisher failure seen in run 26029331137.

## Proof
- pnpm exec prettier --check tools/registry/autonomy-viewer/src/custody-attest.ts tools/registry/autonomy-viewer/test/custody-attestation.test.ts
- npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts tools/registry/autonomy-viewer/test/verify-bundle.test.ts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of mutable references within JSON by validating string leaves and excluding specific signature-identity fields to avoid false positives
  * Preserves existing scanning behavior for non-JSON strings as a fallback

* **Tests**
  * Added tests covering signature-identity exemption and detection of mutable URLs embedded in JSON prose

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->