### PR TITLE
fix(governance): scan only URL substrings for custody mutability

### DIFF
--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -167,6 +167,10 @@ export function containsMutableRef(value: string): RegExp | null {
   return null;
 }
 
+function extractUrlCandidates(value: string): string[] {
+  return value.match(/https?:\/\/[^\s"'<>)]+/gi) ?? [];
+}
+
 function isSignatureIdentityField(pathParts: string[], value: string): boolean {
   const key = pathParts[pathParts.length - 1];
   const parent = pathParts[pathParts.length - 2];
@@ -189,13 +193,15 @@ function validateJsonValueNoMutableUrls(value: unknown, pathParts: string[] = []
       return errors;
     }
 
-    const mutablePattern = containsMutableRef(value);
-    if (mutablePattern) {
-      errors.push({
-        type: 'mutable_url',
-        artifact: value,
-        message: `Mutable URL detected: "${value}" matches ${mutablePattern}`,
-      });
+    for (const urlCandidate of extractUrlCandidates(value)) {
+      const mutablePattern = containsMutableRef(urlCandidate);
+      if (mutablePattern) {
+        errors.push({
+          type: 'mutable_url',
+          artifact: urlCandidate,
+          message: `Mutable URL detected: "${urlCandidate}" matches ${mutablePattern}`,
+        });
+      }
     }
     return errors;
   }

--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -168,7 +168,9 @@ export function containsMutableRef(value: string): RegExp | null {
 }
 
 function extractUrlCandidates(value: string): string[] {
-  return value.match(/https?:\/\/[^\s"'<>)]+/gi) ?? [];
+  return (value.match(/https?:\/\/[^\s"'<>)]+/gi) ?? []).map(candidate =>
+    candidate.replace(/[.,;:!?]+$/g, '')
+  );
 }
 
 function isSignatureIdentityField(pathParts: string[], value: string): boolean {

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -269,6 +269,17 @@ test('validateNoMutableUrls: detects mutable URL embedded in JSON prose string',
   assert.equal(errors[0].type, 'mutable_url');
 });
 
+test('validateNoMutableUrls: detects mutable URL embedded before prose punctuation', () => {
+  const content = JSON.stringify({
+    note: 'Operator evidence is available at https://github.com/owner/repo/releases/latest.',
+  });
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 1, 'Trailing prose punctuation must not hide mutable URLs');
+  assert.equal(errors[0].type, 'mutable_url');
+});
+
 test('validateNoMutableUrls: ignores non-URL git refs in signature/source metadata', () => {
   const content = JSON.stringify({
     source: {

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -269,6 +269,23 @@ test('validateNoMutableUrls: detects mutable URL embedded in JSON prose string',
   assert.equal(errors[0].type, 'mutable_url');
 });
 
+test('validateNoMutableUrls: ignores non-URL git refs in signature/source metadata', () => {
+  const content = JSON.stringify({
+    source: {
+      ref: 'refs/heads/main',
+    },
+    expectedSignaturePolicy: {
+      ref: 'refs/heads/main',
+      identity:
+        'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+    },
+  });
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 0, 'Git refs are metadata, not mutable artifact URLs');
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Required Fields Tests
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fixes post-merge Autonomy Evidence Publisher failure after #828
- treats plain git refs such as `refs/heads/main` as metadata, not mutable artifact URLs
- continues scanning URL substrings inside JSON prose/string values for mutable release/download refs

## Proof
- `npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts`
- `npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts tools/registry/autonomy-viewer/test/verify-bundle.test.ts`
- `pnpm exec prettier --check tools/registry/autonomy-viewer/src/custody-attest.ts tools/registry/autonomy-viewer/test/custody-attestation.test.ts`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

## Post-merge failure addressed
Autonomy Evidence Publisher run `26034596611` failed at `Generate Custody Attestation` because custody validation rejected non-URL metadata values `refs/heads/main` in the generated evidence index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to extract and evaluate URL-like substrings within text, trimming trailing punctuation and reporting separate mutable-URL errors for each detected candidate.

* **Tests**
  * Added coverage verifying detection of mutable URLs followed by punctuation and ensuring non-URL git-ref patterns are ignored in metadata validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->