### PR TITLE
fix(governance): apply custody URL semantics during strict verification

### DIFF
--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -396,24 +396,14 @@ export function validateNoMutableUrls(content: string | object): AttestError[] {
 
   const text = content;
 
-  // Find all URL-like strings
-  const urlPatterns = [
-    /https?:\/\/[^\s"'<>]+/g,
-    /"(ledgerUrl|releaseUrl|bundleDownloadUrl|dashboardUrl|custodyUrl)":\s*"([^"]+)"/g,
-  ];
-
-  for (const pattern of urlPatterns) {
-    let match;
-    while ((match = pattern.exec(text)) !== null) {
-      const url = match[2] ?? match[0];
-      const mutablePattern = containsMutableRef(url);
-      if (mutablePattern) {
-        errors.push({
-          type: 'mutable_url',
-          artifact: url,
-          message: `Mutable URL detected: "${url}" matches ${mutablePattern}`,
-        });
-      }
+  for (const urlCandidate of extractUrlCandidates(text)) {
+    const mutablePattern = containsMutableRef(urlCandidate);
+    if (mutablePattern) {
+      errors.push({
+        type: 'mutable_url',
+        artifact: urlCandidate,
+        message: `Mutable URL detected: "${urlCandidate}" matches ${mutablePattern}`,
+      });
     }
   }
 

--- a/tools/registry/autonomy-viewer/src/custody-attest.ts
+++ b/tools/registry/autonomy-viewer/src/custody-attest.ts
@@ -173,6 +173,32 @@ function extractUrlCandidates(value: string): string[] {
   );
 }
 
+const MUTABLE_ARTIFACT_URL_FIELDS = new Set([
+  'ledgerUrl',
+  'releaseUrl',
+  'bundleDownloadUrl',
+  'dashboardUrl',
+  'custodyUrl',
+]);
+
+function isMutableArtifactUrlField(pathParts: string[]): boolean {
+  const key = pathParts[pathParts.length - 1];
+  return MUTABLE_ARTIFACT_URL_FIELDS.has(key);
+}
+
+function extractArtifactFieldCandidates(value: string): string[] {
+  const candidates: string[] = [];
+  const fieldPattern =
+    /["']?(ledgerUrl|releaseUrl|bundleDownloadUrl|dashboardUrl|custodyUrl)["']?\s*:\s*["']([^"']+)["']/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = fieldPattern.exec(value)) !== null) {
+    candidates.push(match[2].replace(/[.,;:!?]+$/g, ''));
+  }
+
+  return candidates;
+}
+
 function isSignatureIdentityField(pathParts: string[], value: string): boolean {
   const key = pathParts[pathParts.length - 1];
   const parent = pathParts[pathParts.length - 2];
@@ -193,6 +219,17 @@ function validateJsonValueNoMutableUrls(value: unknown, pathParts: string[] = []
   if (typeof value === 'string') {
     if (isSignatureIdentityField(pathParts, value)) {
       return errors;
+    }
+
+    if (isMutableArtifactUrlField(pathParts)) {
+      const mutablePattern = containsMutableRef(value);
+      if (mutablePattern) {
+        errors.push({
+          type: 'mutable_url',
+          artifact: value,
+          message: `Mutable URL detected: "${value}" matches ${mutablePattern}`,
+        });
+      }
     }
 
     for (const urlCandidate of extractUrlCandidates(value)) {
@@ -395,8 +432,17 @@ export function validateNoMutableUrls(content: string | object): AttestError[] {
   }
 
   const text = content;
+  const scannedCandidates = new Set<string>();
 
-  for (const urlCandidate of extractUrlCandidates(text)) {
+  for (const urlCandidate of [
+    ...extractArtifactFieldCandidates(text),
+    ...extractUrlCandidates(text),
+  ]) {
+    if (scannedCandidates.has(urlCandidate)) {
+      continue;
+    }
+    scannedCandidates.add(urlCandidate);
+
     const mutablePattern = containsMutableRef(urlCandidate);
     if (mutablePattern) {
       errors.push({

--- a/tools/registry/autonomy-viewer/src/verify-custody.ts
+++ b/tools/registry/autonomy-viewer/src/verify-custody.ts
@@ -31,10 +31,10 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
-    ATTESTATION_SCHEMA,
-    containsMutableRef,
-    REQUIRED_ARTIFACTS,
-    type CustodyAttestation,
+  ATTESTATION_SCHEMA,
+  REQUIRED_ARTIFACTS,
+  validateNoMutableUrls,
+  type CustodyAttestation,
 } from './custody-attest.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -274,20 +274,14 @@ export function verifyCustodyAttestation(opts: VerifyAttestationOptions): Verify
       if (fs.existsSync(filePath)) {
         try {
           const content = fs.readFileSync(filePath, 'utf8');
-          // Simple URL extraction
-          const urlMatch = content.match(/https?:\/\/[^\s"'<>]+/g);
-          if (urlMatch) {
-            for (const url of urlMatch) {
-              const mutable = containsMutableRef(url);
-              if (mutable) {
-                errors.push({
-                  type: 'mutable_url',
-                  path: entry.name,
-                  actual: url,
-                  message: `Mutable URL in ${entry.name}: ${url}`,
-                });
-              }
-            }
+          const mutableUrlErrors = validateNoMutableUrls(content);
+          for (const mutableUrlError of mutableUrlErrors) {
+            errors.push({
+              type: 'mutable_url',
+              path: entry.name,
+              actual: mutableUrlError.artifact,
+              message: `Mutable URL in ${entry.name}: ${mutableUrlError.artifact}`,
+            });
           }
         } catch {
           // Skip unreadable files

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -297,6 +297,32 @@ test('validateNoMutableUrls: ignores non-URL git refs in signature/source metada
   assert.equal(errors.length, 0, 'Git refs are metadata, not mutable artifact URLs');
 });
 
+test('validateNoMutableUrls: detects mutable artifact fields in non-JSON evidence', () => {
+  const content = `
+    <script>
+      window.__evidence = { "releaseUrl": "refs/heads/main" };
+    </script>
+  `;
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 1, 'Keyed artifact URL refs in non-JSON evidence must be detected');
+  assert.equal(errors[0].type, 'mutable_url');
+  assert.equal(errors[0].artifact, 'refs/heads/main');
+});
+
+test('validateNoMutableUrls: detects mutable artifact fields in parsed JSON evidence', () => {
+  const content = JSON.stringify({
+    releaseUrl: 'refs/heads/main',
+  });
+
+  const errors = validateNoMutableUrls(content);
+
+  assert.equal(errors.length, 1, 'Artifact URL fields must not accept bare mutable refs');
+  assert.equal(errors[0].type, 'mutable_url');
+  assert.equal(errors[0].artifact, 'refs/heads/main');
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Required Fields Tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -522,6 +522,42 @@ test('round-trip: build then verify succeeds', () => {
   }
 });
 
+test('verification: ignores signing identity URL and git refs in evidence index metadata', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-test-'));
+  createTestArtifacts(tmpDir);
+
+  try {
+    fs.writeFileSync(
+      path.join(tmpDir, 'autonomy-evidence-index.json'),
+      JSON.stringify({
+        schema: 'terrafusion.autonomy.evidence.index.v1',
+        source: {
+          ref: 'refs/heads/main',
+        },
+        expectedSignaturePolicy: {
+          identity:
+            'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+          ref: 'refs/heads/main',
+        },
+        records: [],
+      })
+    );
+
+    const result = buildAttestation({ inputDir: tmpDir, runId: 'test-123' });
+    createTestAttestationFile(tmpDir, result.attestation);
+
+    const verifyResult = verifyCustodyAttestation({
+      inputDir: tmpDir,
+      attestPath: path.join(tmpDir, 'custody-attestation.json'),
+      strict: false,
+    });
+
+    assert.ok(verifyResult.ok, 'Signature metadata should not fail mutable artifact URL checks');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
 test('verification: reports correct filesVerified count', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-test-'));
   createTestArtifacts(tmpDir);


### PR DESCRIPTION
## Summary
- fixes the post-merge Autonomy Evidence Publisher strict verification failure after #829
- makes `verify-custody.ts` use the same field-aware mutable URL validator as custody generation
- keeps mutable artifact/prose URLs blocked, including `.../releases/latest.`
- allows signing identity URL and plain `refs/heads/main` values only as evidence-index metadata, not artifact URLs

## Proof
- `pnpm exec prettier --check tools/registry/autonomy-viewer/src/custody-attest.ts tools/registry/autonomy-viewer/src/verify-custody.ts tools/registry/autonomy-viewer/test/custody-attestation.test.ts`
- `npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts`
- `npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts tools/registry/autonomy-viewer/test/verify-bundle.test.ts`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

## Post-merge failure addressed
Autonomy Evidence Publisher run `26039842833` failed at `Verify Custody Attestation (strict)` because `verify-custody.ts` still used raw URL scanning and rejected the signing identity metadata URL in `autonomy-evidence-index.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved custody attestation validation to more reliably detect mutable artifact URLs across both structured (JSON) and unstructured content, reducing false negatives during verification.

* **Tests**
  * Expanded coverage for custody attestation to include cases with git ref values in evidence and identity URLs, verifying detection and overall verification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->