### PR TITLE
fix(governance): extract signature pins from detached certificate

### DIFF
--- a/tools/registry/autonomy-viewer/src/verify-bundle.ts
+++ b/tools/registry/autonomy-viewer/src/verify-bundle.ts
@@ -24,7 +24,7 @@
  *   2 = Invalid arguments or file not found
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
@@ -502,6 +502,7 @@ function findSignatureTriplet(zipPath: string): {
 function parseOpenSslCertificateIdentity(text: string): { identity?: string; issuer?: string } {
   const identity = text.match(/Subject Alternative Name:[\s\S]*?URI:([^\s,\n]+)/)?.[1];
   const issuer =
+    text.match(/1\.3\.6\.1\.4\.1\.57264\.1\.1:[\s\S]*?(https?:\/\/[^\s,\n]+)/)?.[1]?.trim() ||
     text.match(/1\.3\.6\.1\.4\.1\.57264\.1\.1:\s*\n\s*\.*([^\n]+)/)?.[1]?.trim() ||
     (text.includes('token.actions.githubusercontent.com')
       ? 'https://token.actions.githubusercontent.com'
@@ -534,10 +535,14 @@ function extractBundleCertificateIdentity(bundlePath: string): {
 
     try {
       writeFileSync(certPath, Buffer.from(rawBytes, 'base64'));
-      const certText = execSync(`openssl x509 -inform DER -in "${certPath}" -noout -text`, {
-        encoding: 'utf8',
-        stdio: 'pipe',
-      });
+      const certText = execFileSync(
+        'openssl',
+        ['x509', '-inform', 'DER', '-in', certPath, '-noout', '-text'],
+        {
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }
+      );
       return parseOpenSslCertificateIdentity(certText);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -545,6 +550,42 @@ function extractBundleCertificateIdentity(bundlePath: string): {
   } catch {
     return {};
   }
+}
+
+function parseCertificateFileWithOpenSsl(
+  certPath: string,
+  formatArgs: string[]
+): {
+  identity?: string;
+  issuer?: string;
+} {
+  try {
+    const certText = execFileSync(
+      'openssl',
+      ['x509', ...formatArgs, '-in', certPath, '-noout', '-text'],
+      {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }
+    );
+    return parseOpenSslCertificateIdentity(certText);
+  } catch {
+    return {};
+  }
+}
+
+function extractCertificateFileIdentity(certPath: string): {
+  identity?: string;
+  issuer?: string;
+} {
+  for (const formatArgs of [[], ['-inform', 'DER']]) {
+    const parsed = parseCertificateFileWithOpenSsl(certPath, formatArgs);
+    if (parsed.identity || parsed.issuer) {
+      return parsed;
+    }
+  }
+
+  return {};
 }
 
 /**
@@ -596,7 +637,15 @@ function verifySignature(
   let identity: string | undefined;
   let issuer: string | undefined;
 
-  ({ identity, issuer } = extractBundleCertificateIdentity(triplet.bundle!));
+  const bundleIdentity = extractBundleCertificateIdentity(triplet.bundle!);
+  if (bundleIdentity.identity && bundleIdentity.issuer) {
+    ({ identity, issuer } = bundleIdentity);
+  } else if (!bundleIdentity.identity && !bundleIdentity.issuer && triplet.crt) {
+    const certIdentity = extractCertificateFileIdentity(triplet.crt);
+    ({ identity, issuer } = certIdentity);
+  } else {
+    ({ identity, issuer } = bundleIdentity);
+  }
 
   // Return success if all three files exist
   // Full cryptographic verification is delegated to cosign in CI

--- a/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
+++ b/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
@@ -7,6 +7,10 @@
  */
 
 import * as assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
   ExpectedSignaturePolicy,
@@ -19,6 +23,7 @@ import {
   checkForbiddenIdentity,
   parseOpenSslCertificateIdentity,
   verifyPin,
+  verifySignature,
   type VerifyOptions,
   type VerifyResult,
 } from '../src/verify-bundle.js';
@@ -33,6 +38,53 @@ const TEST_REF = 'refs/heads/main';
 const TEST_WORKFLOW = '.github/workflows/autonomy-evidence-publisher.yml';
 const TEST_INCIDENT_WORKFLOW = '.github/workflows/autonomy-incident-publisher.yml';
 const TEST_SHA = 'a'.repeat(40);
+
+function writeGitHubOidcCertificate(
+  tempDir: string,
+  certPath: string,
+  identity: string,
+  issuer: string
+): void {
+  const configPath = join(tempDir, 'openssl.cnf');
+  const keyPath = join(tempDir, 'cert.key');
+
+  writeFileSync(
+    configPath,
+    `
+[req]
+distinguished_name = dn
+x509_extensions = v3_req
+prompt = no
+
+[dn]
+CN = TerraFusion test certificate
+
+[v3_req]
+subjectAltName = URI:${identity}
+1.3.6.1.4.1.57264.1.1 = ASN1:UTF8String:${issuer}
+`
+  );
+
+  execFileSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-days',
+      '1',
+      '-nodes',
+      '-config',
+      configPath,
+    ],
+    { stdio: 'pipe' }
+  );
+}
 
 function buildTestIdentity(repo: string, workflow: string, ref: string): string {
   return `https://github.com/${repo}/${workflow}@${ref}`;
@@ -370,6 +422,82 @@ Certificate:
 
     assert.strictEqual(parsed.identity, identity);
     assert.strictEqual(parsed.issuer, GITHUB_ISSUER);
+  });
+
+  it('uses the detached certificate file when cosign bundle lacks certificate bytes', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+        })
+      );
+      writeGitHubOidcCertificate(tempDir, crtPath, identity, GITHUB_ISSUER);
+
+      const result = verifySignature(zipPath, {
+        sig: sigPath,
+        crt: crtPath,
+        bundle: bundlePath,
+      });
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.identity, identity);
+      assert.strictEqual(result.issuer, GITHUB_ISSUER);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects detached certificate text that was not parsed from X.509', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+        })
+      );
+      writeFileSync(
+        crtPath,
+        `
+Certificate:
+    X509v3 extensions:
+        X509v3 Subject Alternative Name:
+            URI:${identity}
+        1.3.6.1.4.1.57264.1.1:
+            ..${GITHUB_ISSUER}
+`
+      );
+
+      const result = verifySignature(zipPath, {
+        sig: sigPath,
+        crt: crtPath,
+        bundle: bundlePath,
+      });
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.identity, undefined);
+      assert.strictEqual(result.issuer, undefined);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('deriveWorkflowPath returns correct path for incident flag', () => {


### PR DESCRIPTION
## Summary
- fall back to the detached `.crt` certificate when the cosign bundle lacks embedded certificate bytes
- preserve strict issuer/identity pinning instead of relaxing policy
- add a regression test for bundle-without-cert plus detached certificate extraction

## Verification
- npx tsx --test tools/registry/autonomy-viewer/test/signature-pinning.test.ts
- npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts tools/registry/autonomy-viewer/test/verify-bundle.test.ts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced signature verification to more robustly derive identity and issuer from detached certificate files when not embedded in the signature bundle; improved parsing across certificate formats and safer execution behavior.

* **Tests**
  * Added tests validating successful identity/issuer extraction from detached certificates and correct handling when certificate content is non-parseable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->