### PR TITLE
fix(governance): parse nested Sigstore bundle certificates

### DIFF
--- a/tools/registry/autonomy-viewer/src/verify-bundle.ts
+++ b/tools/registry/autonomy-viewer/src/verify-bundle.ts
@@ -511,45 +511,108 @@ function parseOpenSslCertificateIdentity(text: string): { identity?: string; iss
   return { identity, issuer };
 }
 
+function decodeCertificateRawBytes(rawBytes: string): Buffer {
+  const normalized = rawBytes.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  return Buffer.from(padded, 'base64');
+}
+
+function extractDerCertificateIdentity(rawBytes: string): {
+  identity?: string;
+  issuer?: string;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), 'tf-verify-bundle-'));
+  const certPath = join(tempDir, 'cert.der');
+
+  try {
+    writeFileSync(certPath, decodeCertificateRawBytes(rawBytes));
+    const certText = execFileSync(
+      'openssl',
+      ['x509', '-inform', 'DER', '-in', certPath, '-noout', '-text'],
+      {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }
+    );
+    return parseOpenSslCertificateIdentity(certText);
+  } catch {
+    return {};
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function pushRawBytesCandidate(candidates: string[], value: unknown): void {
+  if (typeof value === 'string' && value.trim()) {
+    candidates.push(value.trim());
+  }
+}
+
+function pushCertificateChainCandidates(candidates: string[], chain: unknown): void {
+  if (!chain || typeof chain !== 'object') {
+    return;
+  }
+
+  const certificates = (chain as { certificates?: unknown }).certificates;
+  if (!Array.isArray(certificates)) {
+    return;
+  }
+
+  for (const certificate of certificates) {
+    if (certificate && typeof certificate === 'object') {
+      pushRawBytesCandidate(candidates, (certificate as { rawBytes?: unknown }).rawBytes);
+    }
+  }
+}
+
+function collectCertificateRawBytes(bundleJson: unknown): string[] {
+  if (!bundleJson || typeof bundleJson !== 'object') {
+    return [];
+  }
+
+  const candidates: string[] = [];
+  const verificationMaterial = (bundleJson as { verificationMaterial?: unknown })
+    .verificationMaterial;
+  if (!verificationMaterial || typeof verificationMaterial !== 'object') {
+    return candidates;
+  }
+
+  const material = verificationMaterial as {
+    certificate?: { rawBytes?: unknown };
+    x509CertificateChain?: unknown;
+    content?: {
+      certificate?: { rawBytes?: unknown };
+      x509CertificateChain?: unknown;
+    };
+  };
+
+  pushRawBytesCandidate(candidates, material.certificate?.rawBytes);
+  pushCertificateChainCandidates(candidates, material.x509CertificateChain);
+  pushRawBytesCandidate(candidates, material.content?.certificate?.rawBytes);
+  pushCertificateChainCandidates(candidates, material.content?.x509CertificateChain);
+
+  return candidates;
+}
+
 function extractBundleCertificateIdentity(bundlePath: string): {
   identity?: string;
   issuer?: string;
 } {
   try {
-    const bundleJson = JSON.parse(readFileSync(bundlePath, 'utf8')) as {
-      verificationMaterial?: {
-        certificate?: { rawBytes?: string };
-        x509CertificateChain?: { certificates?: Array<{ rawBytes?: string }> };
-      };
-    };
+    const bundleJson = JSON.parse(readFileSync(bundlePath, 'utf8')) as unknown;
+    const candidates = [...new Set(collectCertificateRawBytes(bundleJson))];
 
-    const rawBytes =
-      bundleJson.verificationMaterial?.certificate?.rawBytes ||
-      bundleJson.verificationMaterial?.x509CertificateChain?.certificates?.[0]?.rawBytes;
-    if (!rawBytes) {
-      return {};
-    }
-
-    const tempDir = mkdtempSync(join(tmpdir(), 'tf-verify-bundle-'));
-    const certPath = join(tempDir, 'cert.der');
-
-    try {
-      writeFileSync(certPath, Buffer.from(rawBytes, 'base64'));
-      const certText = execFileSync(
-        'openssl',
-        ['x509', '-inform', 'DER', '-in', certPath, '-noout', '-text'],
-        {
-          encoding: 'utf8',
-          stdio: 'pipe',
-        }
-      );
-      return parseOpenSslCertificateIdentity(certText);
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
+    for (const rawBytes of candidates) {
+      const parsed = extractDerCertificateIdentity(rawBytes);
+      if (parsed.identity || parsed.issuer) {
+        return parsed;
+      }
     }
   } catch {
     return {};
   }
+
+  return {};
 }
 
 function parseCertificateFileWithOpenSsl(

--- a/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
+++ b/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
@@ -8,7 +8,7 @@
 
 import * as assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -84,6 +84,22 @@ subjectAltName = URI:${identity}
     ],
     { stdio: 'pipe' }
   );
+}
+
+function readGitHubOidcCertificateDerBase64(
+  tempDir: string,
+  identity: string,
+  issuer: string
+): string {
+  const certPath = join(tempDir, 'bundle-cert.pem');
+  const derPath = join(tempDir, 'bundle-cert.der');
+
+  writeGitHubOidcCertificate(tempDir, certPath, identity, issuer);
+  execFileSync('openssl', ['x509', '-in', certPath, '-outform', 'DER', '-out', derPath], {
+    stdio: 'pipe',
+  });
+
+  return readFileSync(derPath).toString('base64');
 }
 
 function buildTestIdentity(repo: string, workflow: string, ref: string): string {
@@ -442,6 +458,106 @@ Certificate:
         })
       );
       writeGitHubOidcCertificate(tempDir, crtPath, identity, GITHUB_ISSUER);
+
+      const result = verifySignature(zipPath, {
+        sig: sigPath,
+        crt: crtPath,
+        bundle: bundlePath,
+      });
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.identity, identity);
+      assert.strictEqual(result.issuer, GITHUB_ISSUER);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts identity from nested Sigstore bundle certificate rawBytes', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeGitHubOidcCertificate(
+        tempDir,
+        crtPath,
+        'https://github.com/other/repo/.github/workflows/wrong.yml@refs/heads/main',
+        GITHUB_ISSUER
+      );
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+          verificationMaterial: {
+            content: {
+              $case: 'x509CertificateChain',
+              x509CertificateChain: {
+                certificates: [
+                  {
+                    rawBytes: readGitHubOidcCertificateDerBase64(tempDir, identity, GITHUB_ISSUER),
+                  },
+                ],
+              },
+            },
+          },
+        })
+      );
+
+      const result = verifySignature(zipPath, {
+        sig: sigPath,
+        crt: crtPath,
+        bundle: bundlePath,
+      });
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.identity, identity);
+      assert.strictEqual(result.issuer, GITHUB_ISSUER);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores unrelated rawBytes outside Sigstore certificate paths', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const wrongIdentity =
+      'https://github.com/other/repo/.github/workflows/wrong.yml@refs/heads/main';
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeGitHubOidcCertificate(tempDir, crtPath, wrongIdentity, GITHUB_ISSUER);
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+          untrustedPayload: {
+            rawBytes: readGitHubOidcCertificateDerBase64(tempDir, wrongIdentity, GITHUB_ISSUER),
+          },
+          verificationMaterial: {
+            content: {
+              $case: 'x509CertificateChain',
+              x509CertificateChain: {
+                certificates: [
+                  {
+                    rawBytes: readGitHubOidcCertificateDerBase64(tempDir, identity, GITHUB_ISSUER),
+                  },
+                ],
+              },
+            },
+          },
+        })
+      );
 
       const result = verifySignature(zipPath, {
         sig: sigPath,


### PR DESCRIPTION
## Summary
- parse certificate rawBytes recursively from Sigstore bundle JSON so nested bundle schemas expose issuer/identity pins
- preserve detached certificate fallback without trusting raw text
- add regression coverage for nested x509CertificateChain rawBytes with a mismatched detached cert

## Verification
- npx tsx --test tools/registry/autonomy-viewer/test/signature-pinning.test.ts
- pnpm exec prettier --write tools/registry/autonomy-viewer/src/verify-bundle.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts
- npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts tools/registry/autonomy-viewer/test/signature-pinning.test.ts tools/registry/autonomy-viewer/test/evidence-index.test.ts tools/registry/autonomy-viewer/test/verify-bundle.test.ts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate extraction during signature verification to try multiple embedded certificate locations, normalize base64 variants, and robustly parse identities and issuers even when certificates are nested or encoded differently.

* **Tests**
  * Added tests that embed DER-encoded certificates in signature bundles to verify identity/issuer extraction succeeds across nested and extraneous rawBytes scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->