### PR TITLE
fix(governance): verify signature pins with cosign fallback

### DIFF
--- a/tools/registry/autonomy-viewer/src/verify-bundle.ts
+++ b/tools/registry/autonomy-viewer/src/verify-bundle.ts
@@ -83,6 +83,17 @@ interface SignaturePinsResult {
   sha?: PinResult;
 }
 
+type ExpectedSignaturePins = {
+  issuer?: string;
+  identity?: string;
+  repo?: string;
+  workflowPath?: string;
+  ref?: string;
+  sha?: string;
+};
+
+type CosignRunner = typeof execFileSync;
+
 /**
  * Phase 4N18: Unified verification result with both hashes and signatures.
  * Phase 4N20: Extended with identity & issuer pinning.
@@ -660,7 +671,12 @@ function extractCertificateFileIdentity(certPath: string): {
  */
 function verifySignature(
   zipPath: string,
-  triplet: { sig: string | null; crt: string | null; bundle: string | null }
+  triplet: { sig: string | null; crt: string | null; bundle: string | null },
+  expectedPins?: {
+    expectedIdentity?: string;
+    expectedIssuer?: string;
+    cosignRunner?: CosignRunner;
+  }
 ): { ok: boolean; identity?: string; issuer?: string; errors: SignatureError[] } {
   const errors: SignatureError[] = [];
 
@@ -710,14 +726,79 @@ function verifySignature(
     ({ identity, issuer } = bundleIdentity);
   }
 
+  if ((!identity || !issuer) && expectedPins?.expectedIdentity && expectedPins.expectedIssuer) {
+    const cosignError = verifyExpectedPinsWithCosign(
+      zipPath,
+      triplet as { sig: string; crt: string; bundle: string },
+      expectedPins.expectedIdentity,
+      expectedPins.expectedIssuer,
+      expectedPins.cosignRunner
+    );
+
+    if (cosignError) {
+      errors.push(cosignError);
+    } else {
+      identity = expectedPins.expectedIdentity;
+      issuer = expectedPins.expectedIssuer;
+    }
+  }
+
   // Return success if all three files exist
-  // Full cryptographic verification is delegated to cosign in CI
+  // Full cryptographic verification is delegated to cosign in CI. When
+  // certificate parsing cannot extract keyless identity pins, the verifier
+  // requires cosign to prove the expected issuer and identity before using them.
   return {
-    ok: true,
+    ok: errors.length === 0,
     identity,
     issuer,
-    errors: [],
+    errors,
   };
+}
+
+function verifyExpectedPinsWithCosign(
+  zipPath: string,
+  triplet: { sig: string; crt: string; bundle: string },
+  expectedIdentity: string,
+  expectedIssuer: string,
+  cosignRunner: CosignRunner = execFileSync
+): SignatureError | null {
+  try {
+    cosignRunner(
+      'cosign',
+      [
+        'verify-blob',
+        '--bundle',
+        triplet.bundle,
+        '--certificate',
+        triplet.crt,
+        '--signature',
+        triplet.sig,
+        '--certificate-identity',
+        expectedIdentity,
+        '--certificate-oidc-issuer',
+        expectedIssuer,
+        zipPath,
+      ],
+      { encoding: 'utf8', stdio: 'pipe' }
+    );
+    return null;
+  } catch (error) {
+    const maybeNodeError = error as { code?: string; message?: string };
+    if (maybeNodeError.code === 'ENOENT') {
+      return {
+        type: 'cosign_not_found',
+        message:
+          'Could not extract certificate identity and cosign was not available to verify expected signature pins.',
+      };
+    }
+
+    return {
+      type: 'verification_failed',
+      expected: `${expectedIssuer} ${expectedIdentity}`,
+      actual: '(cosign rejected signature pins)',
+      message: 'Cosign verification failed for expected signature identity and issuer pins.',
+    };
+  }
 }
 
 /**
@@ -749,6 +830,36 @@ function loadPolicyFromIndex(indexPath: string): {
   } catch {
     return null;
   }
+}
+
+function resolveExpectedSignaturePins(opts: VerifyOptions): {
+  expected: ExpectedSignaturePins;
+  policyLoadError?: SignatureError;
+} {
+  let policy: ReturnType<typeof loadPolicyFromIndex> = null;
+  if (opts.policyFromIndex) {
+    policy = loadPolicyFromIndex(opts.policyFromIndex);
+    if (!policy) {
+      return {
+        expected: {},
+        policyLoadError: {
+          type: 'policy_load_failed',
+          message: `Failed to load policy from: ${opts.policyFromIndex}`,
+        },
+      };
+    }
+  }
+
+  return {
+    expected: {
+      issuer: opts.expectedIssuer || policy?.issuer,
+      identity: opts.expectedIdentity || policy?.identity,
+      repo: opts.expectedRepo || policy?.repo,
+      workflowPath: opts.expectedWorkflow || policy?.workflowPath,
+      ref: opts.expectedRef || policy?.ref,
+      sha: opts.expectedSha || policy?.sha,
+    },
+  };
 }
 
 /**
@@ -799,28 +910,12 @@ function verifyPins(
 ): { pinned: boolean; pins?: SignaturePinsResult; errors: SignatureError[] } {
   const errors: SignatureError[] = [];
 
-  // Load policy from index if specified
-  let policy: ReturnType<typeof loadPolicyFromIndex> = null;
-  if (opts.policyFromIndex) {
-    policy = loadPolicyFromIndex(opts.policyFromIndex);
-    if (!policy) {
-      errors.push({
-        type: 'policy_load_failed',
-        message: `Failed to load policy from: ${opts.policyFromIndex}`,
-      });
-      return { pinned: false, errors };
-    }
+  const resolved = resolveExpectedSignaturePins(opts);
+  if (resolved.policyLoadError) {
+    errors.push(resolved.policyLoadError);
+    return { pinned: false, errors };
   }
-
-  // Merge CLI options with policy (CLI takes precedence)
-  const expected = {
-    issuer: opts.expectedIssuer || policy?.issuer,
-    identity: opts.expectedIdentity || policy?.identity,
-    repo: opts.expectedRepo || policy?.repo,
-    workflowPath: opts.expectedWorkflow || policy?.workflowPath,
-    ref: opts.expectedRef || policy?.ref,
-    sha: opts.expectedSha || policy?.sha,
-  };
+  const { expected } = resolved;
 
   // If no pins provided, return unpinned
   const hasPins =
@@ -1163,10 +1258,14 @@ function main(): void {
   if (options.verifySignatures) {
     const triplet = findSignatureTriplet(options.zipPath);
     tripletFound = triplet.allPresent;
+    const { expected } = resolveExpectedSignaturePins(options);
 
     if (triplet.allPresent || triplet.sig || triplet.crt || triplet.bundle) {
       // At least one signature file exists, try to verify
-      sigResult = verifySignature(options.zipPath, triplet);
+      sigResult = verifySignature(options.zipPath, triplet, {
+        expectedIdentity: expected.identity,
+        expectedIssuer: expected.issuer,
+      });
     } else {
       // No signature files at all
       sigResult = {

--- a/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
+++ b/tools/registry/autonomy-viewer/test/signature-pinning.test.ts
@@ -616,6 +616,112 @@ Certificate:
     }
   });
 
+  it('uses cosign verification before accepting expected pins when certificate identity is unavailable', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+    const observedArgs: string[][] = [];
+    const cosignRunner = ((command: string, args?: readonly string[]) => {
+      assert.strictEqual(command, 'cosign');
+      observedArgs.push([...(args ?? [])]);
+      return '';
+    }) as typeof execFileSync;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeFileSync(crtPath, 'not-a-certificate');
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+        })
+      );
+
+      const result = verifySignature(
+        zipPath,
+        {
+          sig: sigPath,
+          crt: crtPath,
+          bundle: bundlePath,
+        },
+        {
+          expectedIdentity: identity,
+          expectedIssuer: GITHUB_ISSUER,
+          cosignRunner,
+        }
+      );
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.identity, identity);
+      assert.strictEqual(result.issuer, GITHUB_ISSUER);
+      assert.deepStrictEqual(observedArgs[0], [
+        'verify-blob',
+        '--bundle',
+        bundlePath,
+        '--certificate',
+        crtPath,
+        '--signature',
+        sigPath,
+        '--certificate-identity',
+        identity,
+        '--certificate-oidc-issuer',
+        GITHUB_ISSUER,
+        zipPath,
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not accept expected pins when cosign rejects them', () => {
+    const identity = buildTestIdentity(TEST_REPO, TEST_WORKFLOW, TEST_REF);
+    const tempDir = mkdtempSync(join(tmpdir(), 'tf-signature-pinning-'));
+    const zipPath = join(tempDir, 'autonomy-evidence.zip');
+    const bundlePath = `${zipPath}.bundle`;
+    const crtPath = `${zipPath}.crt`;
+    const sigPath = `${zipPath}.sig`;
+    const cosignRunner = (() => {
+      throw new Error('signature mismatch');
+    }) as typeof execFileSync;
+
+    try {
+      writeFileSync(zipPath, 'zip-content');
+      writeFileSync(sigPath, 'sig-content');
+      writeFileSync(crtPath, 'not-a-certificate');
+      writeFileSync(
+        bundlePath,
+        JSON.stringify({
+          mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+        })
+      );
+
+      const result = verifySignature(
+        zipPath,
+        {
+          sig: sigPath,
+          crt: crtPath,
+          bundle: bundlePath,
+        },
+        {
+          expectedIdentity: identity,
+          expectedIssuer: GITHUB_ISSUER,
+          cosignRunner,
+        }
+      );
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.identity, undefined);
+      assert.strictEqual(result.issuer, undefined);
+      assert.strictEqual(result.errors[0]?.type, 'verification_failed');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('deriveWorkflowPath returns correct path for incident flag', () => {
     const path = deriveWorkflowPath('my-workflow', true);
     assert.ok(path.includes('incident'), 'incident flag should derive incident workflow');


### PR DESCRIPTION
## Summary
- Verify strict signature identity/issuer pins with `cosign verify-blob` when local bundle/certificate parsing cannot extract keyless identity metadata.
- Keep expected pins fail-closed: expected identity/issuer are only accepted after cosign validates the signature against those exact pins.
- Add regression coverage for cosign-accepted and cosign-rejected fallback paths.

## Proof
- `npx tsx --test tools/registry/autonomy-viewer/test/signature-pinning.test.ts` (28/28 pass)
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs` (56/56 pass)

## Notes
- Governance-only slice under `tools/registry/**`.
- Does not touch product runtime, data sync, or unrelated backend/evidence work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signature verification now supports pinning and validation of expected identities and issuers
  * Verification policies can be loaded from an external index to enforce signature requirements
  * Enhanced error reporting provides clearer feedback on verification tool availability and signature validation failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->