### PR TITLE
fix(governance): auto-load custody signature policy from evidence index

### DIFF
--- a/tools/registry/autonomy-viewer/src/verify-custody.ts
+++ b/tools/registry/autonomy-viewer/src/verify-custody.ts
@@ -401,7 +401,7 @@ function loadPolicyFromIndex(indexPath: string): ExpectedPolicy | null {
  * Phase 4N20: Verify pins against expected values.
  * Enforces SHA binding for merged/incident tiers when requireShaBinding=true.
  */
-function verifyPins(
+export function verifyPins(
   opts: VerifyOptions,
   verbose: boolean
 ): { pinned: boolean; errors: SignatureError[] } {
@@ -414,8 +414,12 @@ function verifyPins(
   let expectedSha: string | undefined;
   let expectedRef: string | undefined;
 
-  if (opts.policyFromIndex) {
-    const policy = loadPolicyFromIndex(opts.policyFromIndex);
+  const defaultPolicyPath = path.join(opts.inputDir, 'autonomy-evidence-index.json');
+  const policyPath =
+    opts.policyFromIndex || (fs.existsSync(defaultPolicyPath) ? defaultPolicyPath : undefined);
+
+  if (policyPath) {
+    const policy = loadPolicyFromIndex(policyPath);
     if (policy) {
       expectedIssuer = expectedIssuer || policy.issuer;
       expectedIdentity = expectedIdentity || policy.identity;
@@ -423,7 +427,7 @@ function verifyPins(
       expectedSha = policy.sha;
       expectedRef = policy.ref;
       if (verbose) {
-        console.log(`  Loaded pins from index: ${opts.policyFromIndex}`);
+        console.log(`  Loaded pins from index: ${policyPath}`);
         if (requireShaBinding) console.log(`  SHA binding: REQUIRED`);
       }
     }

--- a/tools/registry/autonomy-viewer/src/verify-custody.ts
+++ b/tools/registry/autonomy-viewer/src/verify-custody.ts
@@ -414,9 +414,11 @@ export function verifyPins(
   let expectedSha: string | undefined;
   let expectedRef: string | undefined;
 
+  const explicitPinsProvided = Boolean(expectedIssuer || expectedIdentity);
   const defaultPolicyPath = path.join(opts.inputDir, 'autonomy-evidence-index.json');
   const policyPath =
-    opts.policyFromIndex || (fs.existsSync(defaultPolicyPath) ? defaultPolicyPath : undefined);
+    opts.policyFromIndex ||
+    (!explicitPinsProvided && fs.existsSync(defaultPolicyPath) ? defaultPolicyPath : undefined);
 
   if (policyPath) {
     const policy = loadPolicyFromIndex(policyPath);

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -26,7 +26,7 @@ import {
   validateNoMutableUrls,
   type CustodyAttestation,
 } from '../src/custody-attest.js';
-import { verifyCustodyAttestation } from '../src/verify-custody.js';
+import { verifyCustodyAttestation, verifyPins, type VerifyOptions } from '../src/verify-custody.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test Fixtures
@@ -579,6 +579,46 @@ test('verification: ignores signing identity URL and git refs in evidence index 
     });
 
     assert.ok(verifyResult.ok, 'Signature metadata should not fail mutable artifact URL checks');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+test('signature pins: strict custody verification auto-loads evidence index policy from input directory', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-test-'));
+  createTestArtifacts(tmpDir);
+
+  try {
+    fs.writeFileSync(
+      path.join(tmpDir, 'autonomy-evidence-index.json'),
+      JSON.stringify({
+        schema: 'terrafusion.autonomy.evidence.index.v1',
+        expectedSignaturePolicy: {
+          issuer: 'https://token.actions.githubusercontent.com',
+          identity:
+            'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+          ref: 'refs/heads/main',
+          sha: 'a'.repeat(40),
+          requireShaBinding: true,
+        },
+        records: [],
+      })
+    );
+
+    const opts: VerifyOptions = {
+      inputDir: tmpDir,
+      attestPath: path.join(tmpDir, 'custody-attestation.json'),
+      strict: true,
+      json: false,
+      verbose: false,
+      verifySignatures: true,
+      verifyRekor: true,
+    };
+
+    const result = verifyPins(opts, false);
+
+    assert.equal(result.pinned, true);
+    assert.equal(result.errors.length, 0);
   } finally {
     fs.rmSync(tmpDir, { recursive: true });
   }

--- a/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
+++ b/tools/registry/autonomy-viewer/test/custody-attestation.test.ts
@@ -624,6 +624,48 @@ test('signature pins: strict custody verification auto-loads evidence index poli
   }
 });
 
+test('signature pins: explicit expected pins do not inherit implicit evidence index SHA or ref policy', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-test-'));
+  createTestArtifacts(tmpDir);
+
+  try {
+    fs.writeFileSync(
+      path.join(tmpDir, 'autonomy-evidence-index.json'),
+      JSON.stringify({
+        schema: 'terrafusion.autonomy.evidence.index.v1',
+        expectedSignaturePolicy: {
+          issuer: 'https://token.actions.githubusercontent.com',
+          identity:
+            'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+          ref: 'refs/heads/feature/untrusted',
+          requireShaBinding: true,
+        },
+        records: [],
+      })
+    );
+
+    const opts: VerifyOptions = {
+      inputDir: tmpDir,
+      attestPath: path.join(tmpDir, 'custody-attestation.json'),
+      strict: true,
+      json: false,
+      verbose: false,
+      verifySignatures: true,
+      verifyRekor: true,
+      expectedIssuer: 'https://token.actions.githubusercontent.com',
+      expectedIdentity:
+        'https://github.com/bsvalues/terrafusion_os_1.0/.github/workflows/autonomy-evidence-publisher.yml@refs/heads/main',
+    };
+
+    const result = verifyPins(opts, false);
+
+    assert.equal(result.pinned, true);
+    assert.equal(result.errors.length, 0);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
 test('verification: reports correct filesVerified count', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-test-'));
   createTestArtifacts(tmpDir);


### PR DESCRIPTION
## Summary
- Auto-load `autonomy-evidence-index.json` from the custody verifier input directory when strict signature verification needs pins.
- Keeps Phase 4N21 fail-closed while allowing the existing publisher output directory to provide the signature policy already generated earlier in the job.
- Adds regression coverage for strict custody verification auto-loading the evidence index policy.

## Proof
- `npx tsx --test tools/registry/autonomy-viewer/test/custody-attestation.test.ts` (40/40 pass)
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs` (56/56 pass)

## Context
Post-merge run 26060350421 proved Phase 4N20 signature pins now pass. Phase 4N21 Rekor anchoring itself was OK, but custody strict mode failed with `pins_missing` because verify-custody did not load the nearby evidence-index policy unless passed explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin verification now auto-loads policies from evidence index files in the input directory when no explicit policy is provided
  * Verbose logging now indicates when pin policies were loaded from an evidence index

* **Tests**
  * Added tests for strict custody verification with auto-loaded evidence index policies
  * Added tests ensuring explicit pin expectations override index-derived policies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->