### PR TITLE
fix(governance): emit compatibility manifest for evidence release assets

### DIFF
--- a/tools/registry/autonomy-viewer/src/bundle.ts
+++ b/tools/registry/autonomy-viewer/src/bundle.ts
@@ -103,6 +103,22 @@ function parseArgs(): BundleOptions {
   return opts;
 }
 
+function resolveZipName(opts: BundleOptions, baseSha: string): string {
+  const shortSha = baseSha.slice(0, 8);
+  const runIdSuffix = opts.runId || 'local';
+  const zipName = opts.name || `autonomy-evidence-${shortSha}-${runIdSuffix}.zip`;
+
+  if (/[\\/:]/.test(zipName) || zipName === '.' || zipName === '..') {
+    throw new Error(`Invalid bundle name: ${zipName}`);
+  }
+
+  if (!zipName.endsWith('.zip')) {
+    throw new Error(`Bundle name must end with .zip: ${zipName}`);
+  }
+
+  return zipName;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // File Loading
 // ─────────────────────────────────────────────────────────────────────────────
@@ -432,9 +448,7 @@ export function main(): void {
   const zipBuf = buildDeterministicZip(files);
 
   // Determine output filename
-  const shortSha = baseSha.slice(0, 8);
-  const runIdSuffix = opts.runId || 'local';
-  const zipName = opts.name || `autonomy-evidence-${shortSha}-${runIdSuffix}.zip`;
+  const zipName = resolveZipName(opts, baseSha);
   const zipPath = join(opts.outDir, zipName);
 
   // Write ZIP

--- a/tools/registry/autonomy-viewer/src/bundle.ts
+++ b/tools/registry/autonomy-viewer/src/bundle.ts
@@ -443,10 +443,14 @@ export function main(): void {
 
   // Write standalone manifest (for quick inspection)
   if (opts.emitManifest) {
+    const manifestJson = JSON.stringify(manifest, null, 2);
     const manifestPath = join(opts.outDir, `${zipName}.manifest.json`);
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+    const compatibilityManifestPath = join(opts.outDir, 'MANIFEST.json');
+    writeFileSync(manifestPath, manifestJson, 'utf8');
+    writeFileSync(compatibilityManifestPath, manifestJson, 'utf8');
     if (opts.verbose) {
       console.log(`✅ Manifest: ${manifestPath}`);
+      console.log(`✅ Compatibility manifest: ${compatibilityManifestPath}`);
     }
   }
 

--- a/tools/registry/autonomy-viewer/test/autonomy-bundle.test.ts
+++ b/tools/registry/autonomy-viewer/test/autonomy-bundle.test.ts
@@ -11,7 +11,11 @@
 
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { main as runBundleCli } from '../src/bundle.js';
 import { buildManifest, sha256, verifyManifest } from '../src/manifest.js';
 import { crc32 } from '../src/zip/crc32.js';
 import { buildDeterministicZip } from '../src/zip/zip-writer.js';
@@ -22,6 +26,24 @@ import { buildDeterministicZip } from '../src/zip/zip-writer.js';
 
 function sha256Buf(buf: Buffer): string {
   return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function makeBundleFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'tf-autonomy-bundle-'));
+  const auditOut = join(root, 'tools', 'registry', 'perf-skill-audit', 'out');
+  const viewerDist = join(root, 'tools', 'registry', 'autonomy-viewer', 'dist');
+  mkdirSync(auditOut, { recursive: true });
+  mkdirSync(viewerDist, { recursive: true });
+
+  writeFileSync(join(auditOut, 'perf.plan.json'), JSON.stringify({ baseSha: 'abc123' }));
+  writeFileSync(
+    join(auditOut, 'apply-proofs.json'),
+    JSON.stringify([{ outcome: 'applied', planItemId: 'proof-1' }])
+  );
+  writeFileSync(join(viewerDist, 'autonomy-dashboard.html'), '<!doctype html><title>test</title>');
+  writeFileSync(join(root, 'AUTONOMY_V1_GOVERNANCE_CONTRACT.md'), '# Contract\n');
+
+  return root;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -292,6 +314,44 @@ node --test os-platform/core/tests/phase83-tools.test.mjs
 
     assert.ok(readme.includes('type-check'), 'README should include type-check gate');
     assert.ok(readme.includes('phase83'), 'README should include phase83 gate');
+  });
+
+  it('emits both bundle-named and compatibility standalone manifests', () => {
+    const root = makeBundleFixture();
+    const outDir = join(root, 'dist');
+    const bundleName = 'autonomy-evidence-test-run.zip';
+    const originalArgv = process.argv;
+
+    try {
+      process.argv = [
+        process.execPath,
+        resolve('tools/registry/autonomy-viewer/src/bundle.ts'),
+        '--in',
+        root,
+        '--out',
+        outDir,
+        '--name',
+        bundleName,
+        '--run-id',
+        'test-run',
+        '--emit-manifest',
+      ];
+      runBundleCli();
+
+      const namedManifestPath = join(outDir, `${bundleName}.manifest.json`);
+      const compatibilityManifestPath = join(outDir, 'MANIFEST.json');
+
+      assert.ok(existsSync(namedManifestPath), 'bundle-named manifest should exist');
+      assert.ok(existsSync(compatibilityManifestPath), 'compatibility MANIFEST.json should exist');
+      assert.equal(
+        readFileSync(compatibilityManifestPath, 'utf8'),
+        readFileSync(namedManifestPath, 'utf8'),
+        'compatibility manifest should match bundle-named manifest'
+      );
+    } finally {
+      process.argv = originalArgv;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tools/registry/autonomy-viewer/test/autonomy-bundle.test.ts
+++ b/tools/registry/autonomy-viewer/test/autonomy-bundle.test.ts
@@ -353,6 +353,31 @@ node --test os-platform/core/tests/phase83-tools.test.mjs
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('rejects bundle names that escape the output directory', () => {
+    const root = makeBundleFixture();
+    const outDir = join(root, 'dist');
+    const originalArgv = process.argv;
+
+    try {
+      process.argv = [
+        process.execPath,
+        resolve('tools/registry/autonomy-viewer/src/bundle.ts'),
+        '--in',
+        root,
+        '--out',
+        outDir,
+        '--name',
+        '../escape.zip',
+        '--emit-manifest',
+      ];
+
+      assert.throws(() => runBundleCli(), /Invalid bundle name/);
+    } finally {
+      process.argv = originalArgv;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Emit a stable standalone `MANIFEST.json` alongside the existing bundle-named manifest from the autonomy evidence bundler.
- Add a regression test proving both external manifest names are written and byte-identical.

## Why
The publisher now passes signature pin and custody verification, then fails in release asset prep because the workflow signs/copies `tools/registry/autonomy-viewer/dist/MANIFEST.json` while the bundler only emitted `<bundle>.zip.manifest.json` outside the zip.

## Proof
- `npx tsx --test tools/registry/autonomy-viewer/test/autonomy-bundle.test.ts`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest output now generates both a bundle-specific manifest file and a `MANIFEST.json` compatibility file with identical contents when `--emit-manifest` is enabled.

* **Improvements**
  * Manifest content is computed once and written to both files; verbose logging now shows both manifest paths.
  * Added validation to reject invalid or path-like bundle names.

* **Tests**
  * Added CLI tests for manifest generation, content parity, name validation, and fixture cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->