### PR TITLE
fix(ci): align workflow pnpm and checkout gates

### DIFF
--- a/.github/workflows/county-kit-parity.yml
+++ b/.github/workflows/county-kit-parity.yml
@@ -29,6 +29,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -40,7 +45,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/gate-pipeline.yml
+++ b/.github/workflows/gate-pipeline.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
+        with:
+          version: 9.0.0
 
       - name: Create artifacts directory
         run: mkdir -p artifacts/logs
@@ -138,6 +140,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
+        with:
+          version: 9.0.0
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -307,6 +311,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
+        with:
+          version: 9.0.0
 
       - name: Seed CI prerequisites for gate harness
         run: |

--- a/.github/workflows/golden-corpus-compat.yml
+++ b/.github/workflows/golden-corpus-compat.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -88,7 +88,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -131,7 +131,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- pin failing workflow pnpm setup steps to pnpm 9.0.0 to match the v9 lockfile
- enable Windows long paths before checkout in County Kit Parity
- keep the fix scoped to gate wiring only

## Verification
- pnpm install --frozen-lockfile
- pnpm install --frozen-lockfile --dir frontend
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- git diff --check
- pre-push gate completed: unit tests, security scan runner, performance benchmark, compliance lint, backend build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use pnpm package manager version 9.0.0 for improved consistency across all build environments.
  * Enhanced Windows platform compatibility in build pipeline by enabling Git long path support configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->