### PR TITLE
fix(ci): allow encoded release tag namespaces in evidence URLs

### DIFF
--- a/tools/registry/autonomy-viewer/src/evidence-index.ts
+++ b/tools/registry/autonomy-viewer/src/evidence-index.ts
@@ -869,16 +869,25 @@ function validateEncodedReleaseTagSegment(url: string): string | null {
     return `URL contains encoded path characters (potential traversal): ${url}`;
   }
 
-  const match = parsed.pathname.match(/^\/[^/]+\/[^/]+\/releases\/(?:tag|download)\/([^/]+)(?:\/|$)/i);
-  const encodedTag = match?.[1];
-  if (!encodedTag) {
+  const pathSegments = parsed.pathname.split('/');
+  const encodedTag = pathSegments[5];
+  const hasReleaseTagShape =
+    pathSegments.length >= 6 &&
+    pathSegments[0] === '' &&
+    pathSegments[1] !== '' &&
+    pathSegments[2] !== '' &&
+    pathSegments[3].toLowerCase() === 'releases' &&
+    /^(?:tag|download)$/i.test(pathSegments[4]) &&
+    encodedTag !== '';
+
+  if (!hasReleaseTagShape || !encodedTag) {
     return `URL contains encoded path characters (potential traversal): ${url}`;
   }
 
   const lowerPath = parsed.pathname.toLowerCase();
-  const lowerTag = encodedTag.toLowerCase();
-  const tagStart = lowerPath.indexOf(lowerTag);
-  const tagEnd = tagStart + lowerTag.length;
+  const tagPrefix = `/${pathSegments[1]}/${pathSegments[2]}/releases/${pathSegments[4]}/`;
+  const tagStart = tagPrefix.length;
+  const tagEnd = tagStart + encodedTag.length;
 
   for (let index = lowerPath.indexOf('%2f'); index !== -1; index = lowerPath.indexOf('%2f', index + 1)) {
     if (index < tagStart || index >= tagEnd) {

--- a/tools/registry/autonomy-viewer/src/evidence-index.ts
+++ b/tools/registry/autonomy-viewer/src/evidence-index.ts
@@ -823,10 +823,18 @@ function validateUrlSecurityConstraints(url: string): string | null {
     return `URL contains fragment (not allowed in evidence URLs): ${url}`;
   }
 
-  // Reject URL-encoded traversal attempts (%2f = /, %2e = .)
+  // Reject URL-encoded traversal attempts. GitHub encodes slashes in release
+  // tags such as autonomy-evidence/2026-05, so %2f is allowed only inside the
+  // release tag segment after validating the decoded tag is not a path trick.
   const lowerUrl = url.toLowerCase();
-  if (lowerUrl.includes('%2f') || lowerUrl.includes('%2e')) {
+  if (lowerUrl.includes('%2e')) {
     return `URL contains encoded path characters (potential traversal): ${url}`;
+  }
+  if (lowerUrl.includes('%2f')) {
+    const tagError = validateEncodedReleaseTagSegment(url);
+    if (tagError) {
+      return tagError;
+    }
   }
 
   // Reject double-encoding attempts (%252f = %2f)
@@ -853,6 +861,55 @@ function validateUrlSecurityConstraints(url: string): string | null {
   return null; // Valid
 }
 
+function validateEncodedReleaseTagSegment(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return `URL contains encoded path characters (potential traversal): ${url}`;
+  }
+
+  const match = parsed.pathname.match(/^\/[^/]+\/[^/]+\/releases\/(?:tag|download)\/([^/]+)(?:\/|$)/i);
+  const encodedTag = match?.[1];
+  if (!encodedTag) {
+    return `URL contains encoded path characters (potential traversal): ${url}`;
+  }
+
+  const lowerPath = parsed.pathname.toLowerCase();
+  const lowerTag = encodedTag.toLowerCase();
+  const tagStart = lowerPath.indexOf(lowerTag);
+  const tagEnd = tagStart + lowerTag.length;
+
+  for (let index = lowerPath.indexOf('%2f'); index !== -1; index = lowerPath.indexOf('%2f', index + 1)) {
+    if (index < tagStart || index >= tagEnd) {
+      return `URL contains encoded path characters (potential traversal): ${url}`;
+    }
+  }
+
+  let decodedTag: string;
+  try {
+    decodedTag = decodeURIComponent(encodedTag);
+  } catch {
+    return `URL contains malformed encoded release tag: ${url}`;
+  }
+
+  const decodedLower = decodedTag.toLowerCase();
+  const tagSegments = decodedTag.split('/');
+  if (
+    decodedTag.startsWith('/') ||
+    decodedTag.endsWith('/') ||
+    tagSegments.some(segment => segment === '.' || segment === '..' || segment === '') ||
+    decodedLower.includes('refs/heads') ||
+    decodedLower.includes('refs/tags') ||
+    decodedLower === 'latest' ||
+    decodedLower.endsWith('@latest')
+  ) {
+    return `URL contains encoded path characters (potential traversal): ${url}`;
+  }
+
+  return null;
+}
+
 /**
  * Validate a URL is immutable (no latest, no branch refs, no shorteners).
  * Phase 4N15: Enhanced with security constraints for auditor-grade validation.
@@ -870,8 +927,15 @@ export function validateImmutableUrl(url: string): string | null {
     return `URL is not a GitHub releases URL: ${url}`;
   }
 
+  let decodedUrl: string;
+  try {
+    decodedUrl = decodeURIComponent(url);
+  } catch {
+    return `URL contains malformed encoding: ${url}`;
+  }
+
   for (const pattern of MUTABLE_URL_PATTERNS) {
-    if (pattern.test(url)) {
+    if (pattern.test(url) || pattern.test(decodedUrl)) {
       return `URL contains mutable reference: ${url} (matched ${pattern})`;
     }
   }

--- a/tools/registry/autonomy-viewer/test/evidence-index.test.ts
+++ b/tools/registry/autonomy-viewer/test/evidence-index.test.ts
@@ -790,6 +790,11 @@ describe('Phase 4N14: Immutable URL Wiring', () => {
       assert.ok(url.includes('autonomy-evidence%2F2026-01'));
     });
 
+    it('should accept encoded slash in release tag namespace', () => {
+      const url = buildReleaseUrl('https://github.com', 'owner/repo', 'autonomy-evidence/2026-01');
+      assert.equal(validateImmutableUrl(url), null);
+    });
+
     it('should produce immutable URL (passes validation)', () => {
       const url = buildReleaseUrl('https://github.com', 'owner/repo', 'v1.0.0');
       assert.equal(validateImmutableUrl(url), null);
@@ -811,6 +816,16 @@ describe('Phase 4N14: Immutable URL Wiring', () => {
       );
       assert.ok(url.includes('autonomy-evidence%2F2026-01'));
       assert.ok(url.includes('my%20file.zip'));
+    });
+
+    it('should accept encoded slash in asset download release tag namespace', () => {
+      const url = buildAssetUrl(
+        'https://github.com',
+        'owner/repo',
+        'autonomy-evidence/2026-01',
+        'bundle.zip'
+      );
+      assert.equal(validateImmutableUrl(url), null);
     });
 
     it('should produce immutable URL (passes validation)', () => {

--- a/tools/registry/autonomy-viewer/test/evidence-index.test.ts
+++ b/tools/registry/autonomy-viewer/test/evidence-index.test.ts
@@ -731,6 +731,13 @@ describe('Phase 4N14: Immutable URL Wiring', () => {
       assert.ok(result.includes('encoded path'));
     });
 
+    it('should reject encoded slash outside the release tag segment', () => {
+      const url = 'https://github.com/autonomy-evidence%2F2026-01/repo/releases/tag/autonomy-evidence%2F2026-01';
+      const result = validateImmutableUrl(url);
+      assert.ok(result !== null);
+      assert.ok(result.includes('encoded path'));
+    });
+
     it('should reject URL-encoded traversal (%2e)', () => {
       const url = 'https://github.com/owner/repo/releases/download/v1.0.0/%2e%2e/secret';
       const result = validateImmutableUrl(url);


### PR DESCRIPTION
## Summary
- Allow GitHub release tag URLs to contain encoded slash namespaces such as `autonomy-evidence%2F2026-05`.
- Keep encoded traversal protection for `%2e`, double-encoding, and `%2f` outside the release tag/download tag segment.
- Add regression coverage for namespaced release tag and asset download URLs.

## Verification
- `pnpm run test -- test\evidence-index.test.ts` ✅
- `pnpm run type-check` ✅
- `node --test os-platform/core/tests/phase83-tools.test.mjs` ✅
- `git diff --check HEAD~1..HEAD` ✅
- `node scripts\repo-shape-guard.mjs` ✅

## Note
- Full `pnpm run test` in `tools/registry/autonomy-viewer` was attempted; patch-related tests passed, but the aggregate run hit an existing Node test-runner serialization failure after `test\casefile.test.ts`. That file passes when run directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened evidence URL validation to block encoded path traversal and malformed encodings; added stricter checks on decoded release tag contents (rejecting unsafe or ambiguous tag values) and validate against mutable URL patterns using both raw and decoded inputs.

* **Tests**
  * Added tests covering immutable URL validation and release/asset URL construction when release tags include encoded slashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->