### PR TITLE
feat(cuforge): Polish UI/UX + Register 7 TerraPilot Tools

### DIFF
--- a/frontend/apps/terraforge/src/pages/CurrentUseInterestPage.tsx
+++ b/frontend/apps/terraforge/src/pages/CurrentUseInterestPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { CuSubNav } from './CurrentUsePage';
 
 const API = '/api/currentuse';
 
@@ -20,24 +21,82 @@ interface InterestCalcResult {
   breakdown: { year: number; rate: number; yearInterest: number; cumulative: number }[];
 }
 
-// ── Formatters ─────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-const fmtPct = (n: number) => (n * 100).toFixed(2) + '%';
-const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-const fmtDate = (s: string) => s.slice(0, 10);
+const fmtPct = (n: number) => `${(n * 100).toFixed(2)}%`;
+const fmtFull$ = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
+
+function Skeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div style={{ padding: '12px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{
+          height: 34, background: 'linear-gradient(90deg, rgba(255,255,255,.03) 25%, rgba(255,255,255,.06) 50%, rgba(255,255,255,.03) 75%)',
+          backgroundSize: '200% 100%', borderRadius: 6, marginBottom: 6,
+          animation: 'shimmer 1.5s infinite',
+        }} />
+      ))}
+      <style>{`@keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
+    </div>
+  );
+}
+
+function Tip({ text, children }: { text: string; children: React.ReactNode }) {
+  const [show, setShow] = useState(false);
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}
+      onMouseEnter={() => setShow(true)} onMouseLeave={() => setShow(false)}>
+      {children}
+      {show && (
+        <span style={{
+          position: 'absolute', bottom: 'calc(100% + 6px)', left: '50%', transform: 'translateX(-50%)',
+          background: '#1e293b', border: '1px solid rgba(255,255,255,.15)', borderRadius: 6,
+          padding: '6px 10px', fontSize: 11, color: '#e2e8f0', whiteSpace: 'nowrap', zIndex: 100,
+          boxShadow: '0 4px 12px rgba(0,0,0,.5)',
+        }}>
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ── Rate Bar Chart (CSS-only) ──────────────────────────────────────────────
+
+function RateChart({ rates }: { rates: InterestRate[] }) {
+  const maxRate = Math.max(...rates.map(r => r.rate), 0.01);
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 80, marginBottom: 16, padding: '0 4px' }}>
+      {rates.map(r => {
+        const height = Math.max((r.rate / maxRate) * 70, 4);
+        return (
+          <Tip key={r.year} text={`${r.year}: ${fmtPct(r.rate)}`}>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1 }}>
+              <div style={{
+                width: '100%', maxWidth: 28, height, borderRadius: '3px 3px 0 0',
+                background: `linear-gradient(180deg, #00FFAA, rgba(0,255,170,.4))`,
+                transition: 'height 0.3s ease',
+              }} />
+              <span style={{ fontSize: 9, color: '#64748b', marginTop: 4 }}>{String(r.year).slice(2)}</span>
+            </div>
+          </Tip>
+        );
+      })}
+    </div>
+  );
+}
 
 // ── Rates Table Section ────────────────────────────────────────────────────
 
 function RatesSection() {
   const [data, setData] = useState<InterestRate[] | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
+    setLoading(true); setError(null);
     fetch(`${API}/interest-rates`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setData)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
@@ -45,42 +104,50 @@ function RatesSection() {
 
   return (
     <section className="tf-section">
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Published Interest Rates</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          DOR-published rates used for rollback interest calculation per WAC 458-30-262.
-        </p>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16 }}>
+        <div>
+          <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+            Published Interest Rates
+            <Tip text="WA DOR rates per WAC 458-30-262, used for compound interest on rollback taxes">
+              <span style={{ fontSize: 13, color: '#64748b', cursor: 'help' }}>?</span>
+            </Tip>
+          </h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+            WA Department of Revenue published rates · WAC 458-30-262
+          </p>
+        </div>
+        {data && <span style={{ fontSize: 12, color: '#64748b', background: 'rgba(255,255,255,.04)', padding: '4px 10px', borderRadius: 12 }}>{data.length} years</span>}
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error && <p className="tf-error">Error: {error}</p>}
+      {loading && <Skeleton rows={6} />}
+      {error && <p style={{ color: '#ff6b6b', fontSize: 13 }}>{error}</p>}
 
-      {data && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
-            <thead>
-              <tr>
-                <th>Year</th>
-                <th className="tf-right">Rate</th>
-                <th>Source</th>
-                <th>Effective Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.length === 0 && (
-                <tr><td colSpan={4} className="tf-empty">No interest rates loaded. Run seed first.</td></tr>
-              )}
-              {data.map(r => (
-                <tr key={r.year}>
-                  <td className="tf-mono">{r.year}</td>
-                  <td className="tf-right tf-mono">{fmtPct(r.rate)}</td>
-                  <td>{r.source}</td>
-                  <td>{fmtDate(r.effectiveDate)}</td>
+      {data && data.length > 0 && (
+        <>
+          <RateChart rates={data} />
+          <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+            <table className="tf-table" style={{ fontSize: 13 }}>
+              <thead>
+                <tr>
+                  <th>Year</th>
+                  <th className="tf-right">Rate</th>
+                  <th>Source</th>
+                  <th>Effective Date</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {data.map(r => (
+                  <tr key={r.year} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
+                    <td className="tf-mono">{r.year}</td>
+                    <td className="tf-right tf-mono" style={{ color: '#00FFAA' }}>{fmtPct(r.rate)}</td>
+                    <td style={{ fontSize: 12 }}>{r.source}</td>
+                    <td style={{ fontSize: 12 }}>{r.effectiveDate ? new Date(r.effectiveDate.slice(0, 10) + 'T12:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </section>
   );
@@ -91,100 +158,94 @@ function RatesSection() {
 function InterestCalculatorSection() {
   const [principal, setPrincipal] = useState('100000');
   const [startYear, setStartYear] = useState(2018);
-  const [endYear, setEndYear] = useState(2026);
+  const [endYear, setEndYear] = useState(2025);
   const [result, setResult] = useState<InterestCalcResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   function runCalc() {
     if (!principal.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
-
-    const params = new URLSearchParams({
-      principal: principal.trim(),
-      startYear: String(startYear),
-      endYear: String(endYear),
-    });
-
+    setLoading(true); setError(null); setResult(null);
+    const params = new URLSearchParams({ principal: principal.trim(), startYear: String(startYear), endYear: String(endYear) });
     fetch(`${API}/interest/calculate?${params}`)
-      .then(async r => {
-        if (!r.ok) throw new Error(await r.text() || r.statusText);
-        return r.json();
-      })
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setResult)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
   }
 
+  function exportCSV() {
+    if (!result) return;
+    const hdr = 'Year,Rate,Year Interest,Cumulative';
+    const rows = result.breakdown.map(b => `${b.year},${b.rate},${b.yearInterest},${b.cumulative}`);
+    rows.push('', `Principal,,,${result.principal}`, `Total Interest,,,${result.totalInterest}`, `Total Due,,,${result.totalDue}`);
+    const blob = new Blob([hdr + '\n' + rows.join('\n')], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `interest_calc_${startYear}-${endYear}.csv`;
+    a.click();
+  }
+
+  const inputStyle = { background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 };
+
   return (
     <section className="tf-section" style={{ marginTop: 32 }}>
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Interest Calculator</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          Compute compound interest on rollback tax principal using DOR rates.
+      <div style={{ marginBottom: 16 }}>
+        <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16 }}>Interest Calculator</h3>
+        <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+          Compute compound interest on rollback tax principal using DOR rates
         </p>
       </div>
 
-      <div className="tf-filters" style={{ alignItems: 'flex-end', gap: 12 }}>
-        <label>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12, marginBottom: 16 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Principal ($)
-          <input
-            type="number"
-            value={principal}
-            onChange={e => setPrincipal(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 120 }}
-          />
+          <input type="number" value={principal} onChange={e => setPrincipal(e.target.value)} style={inputStyle} />
         </label>
-        <label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Start Year
-          <input
-            type="number"
-            value={startYear}
-            onChange={e => setStartYear(Number(e.target.value))}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" value={startYear} onChange={e => setStartYear(Number(e.target.value))} min={2016} max={2026} style={inputStyle} />
         </label>
-        <label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           End Year
-          <input
-            type="number"
-            value={endYear}
-            onChange={e => setEndYear(Number(e.target.value))}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" value={endYear} onChange={e => setEndYear(Number(e.target.value))} min={2016} max={2026} style={inputStyle} />
         </label>
-        <button
-          onClick={runCalc}
-          disabled={loading || !principal.trim()}
-          className="tf-btn"
-        >
-          {loading ? 'Calculating…' : 'Calculate Interest'}
-        </button>
       </div>
 
-      {error && <p className="tf-error" style={{ marginTop: 12 }}>Error: {error}</p>}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={runCalc} disabled={loading || !principal.trim()} className="tf-btn" style={{ fontSize: 13 }}>
+          {loading ? 'Calculating…' : 'Calculate Interest'}
+        </button>
+        {result && (
+          <button onClick={exportCSV} style={{ background: 'none', border: '1px solid rgba(255,255,255,.12)', color: '#94a3b8', borderRadius: 6, padding: '7px 14px', fontSize: 12, cursor: 'pointer' }}>
+            Export CSV
+          </button>
+        )}
+      </div>
+
+      {error && <p style={{ color: '#ff6b6b', fontSize: 12, marginTop: 12 }}>{error}</p>}
 
       {result && (
-        <div style={{ marginTop: 16 }}>
-          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
-              <div className="tf-cardTag tf-indigo">Principal</div>
-              <div className="tf-cardBig">{fmt$(result.principal)}</div>
+        <div style={{ marginTop: 20 }}>
+          {/* Summary cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 12, marginBottom: 20 }}>
+            <div style={{ background: 'rgba(255,255,255,.03)', border: '1px solid rgba(255,255,255,.08)', borderRadius: 8, padding: '14px 16px' }}>
+              <div style={{ fontSize: 11, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: 6 }}>Principal</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#e2e8f0', fontFamily: 'monospace' }}>{fmtFull$(result.principal)}</div>
             </div>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
-              <div className="tf-cardTag tf-indigo">Total Interest</div>
-              <div className="tf-cardBig">{fmt$(result.totalInterest)}</div>
+            <div style={{ background: 'rgba(255,255,255,.03)', border: '1px solid rgba(255,255,255,.08)', borderRadius: 8, padding: '14px 16px' }}>
+              <div style={{ fontSize: 11, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: 6 }}>Total Interest</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#e2e8f0', fontFamily: 'monospace' }}>{fmtFull$(result.totalInterest)}</div>
             </div>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default', borderColor: '#00FFAA' }}>
-              <div className="tf-cardTag" style={{ color: '#00FFAA' }}>Total Due</div>
-              <div className="tf-cardBig" style={{ color: '#00FFAA' }}>{fmt$(result.totalDue)}</div>
+            <div style={{ background: 'rgba(255,255,255,.03)', border: '1px solid rgba(0,255,170,.3)', borderRadius: 8, padding: '14px 16px' }}>
+              <div style={{ fontSize: 11, color: '#00FFAA', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: 6 }}>Total Due</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#00FFAA', fontFamily: 'monospace' }}>{fmtFull$(result.totalDue)}</div>
             </div>
           </div>
 
-          <div className="tf-table-wrap">
-            <table className="tf-table">
+          {/* Breakdown table */}
+          <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+            <table className="tf-table" style={{ fontSize: 13 }}>
               <thead>
                 <tr>
                   <th>Year</th>
@@ -195,13 +256,18 @@ function InterestCalculatorSection() {
               </thead>
               <tbody>
                 {result.breakdown.map(b => (
-                  <tr key={b.year}>
+                  <tr key={b.year} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
                     <td className="tf-mono">{b.year}</td>
                     <td className="tf-right tf-mono">{fmtPct(b.rate)}</td>
-                    <td className="tf-right tf-mono">{fmt$(b.yearInterest)}</td>
-                    <td className="tf-right tf-mono">{fmt$(b.cumulative)}</td>
+                    <td className="tf-right tf-mono">{fmtFull$(b.yearInterest)}</td>
+                    <td className="tf-right tf-mono" style={{ color: '#00FFAA' }}>{fmtFull$(b.cumulative)}</td>
                   </tr>
                 ))}
+                <tr style={{ borderTop: '2px solid rgba(0,255,170,.25)', fontWeight: 600 }}>
+                  <td colSpan={2} style={{ fontSize: 11, color: '#64748b' }}>{result.breakdown.length} years compound</td>
+                  <td className="tf-right" style={{ color: '#94a3b8', fontSize: 12 }}>Total</td>
+                  <td className="tf-right tf-mono" style={{ color: '#00FFAA', fontSize: 14 }}>{fmtFull$(result.totalDue)}</td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -216,13 +282,13 @@ function InterestCalculatorSection() {
 export default function CurrentUseInterestPage() {
   return (
     <div className="tf-page">
-      <div className="tf-page-header" style={{ marginBottom: 24 }}>
-        <h2>Current Use Interest</h2>
-        <p className="tf-page-sub">
+      <div className="tf-page-header" style={{ marginBottom: 8 }}>
+        <h2 style={{ margin: 0, color: '#f1f5f9' }}>Current Use Program</h2>
+        <p className="tf-page-sub" style={{ marginTop: 4, color: '#64748b', fontSize: 13 }}>
           Benton County WA — DOR interest rates and compound interest calculation for rollback taxes
         </p>
       </div>
-
+      <CuSubNav />
       <RatesSection />
       <InterestCalculatorSection />
     </div>

--- a/frontend/apps/terraforge/src/pages/CurrentUsePage.tsx
+++ b/frontend/apps/terraforge/src/pages/CurrentUsePage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 const API = '/api/currentuse';
 
@@ -25,16 +26,6 @@ interface ClassificationsResponse {
   items: Classification[];
 }
 
-interface RollbackInput {
-  parcelId: string;
-  classificationCode: string;
-  enrollmentYear: number;
-  removalYear: number;
-  marketValues: Record<string, number>;
-  currentUseValues: Record<string, number>;
-  penaltyExceptionCode: string;
-}
-
 interface YearBreakdown {
   year: number;
   marketValue: number;
@@ -56,111 +47,324 @@ interface RollbackResult {
   exceptionCode: string | null;
 }
 
-// ── Formatters ─────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-const fmtPct = (n: number) => (n * 100).toFixed(2) + '%';
-const fmtDate = (s: string) => s.slice(0, 10);
+const fmt$ = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+const fmtFull$ = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
+const fmtPct = (n: number) => `${(n * 100).toFixed(2)}%`;
+const fmtDate = (d: string) => d ? new Date(d.slice(0, 10) + 'T12:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
+
+const CU_CODES: Record<string, { label: string; rcw: string; maxYears: number; color: string }> = {
+  DFL:  { label: 'Designated Forest Land', rcw: 'RCW 84.33', maxYears: 7, color: 'green' },
+  CUFA: { label: 'Farm & Agriculture',     rcw: 'RCW 84.34.020(2)', maxYears: 10, color: 'blue' },
+  CUOS: { label: 'Open Space',             rcw: 'RCW 84.34.020(1)', maxYears: 10, color: 'purple' },
+  CUTL: { label: 'Timber Land',            rcw: 'RCW 84.34.020(3)', maxYears: 10, color: 'amber' },
+};
+
+const PENALTY_EXCEPTIONS = [
+  { code: 'DEATH', label: 'Owner Death', rcw: 'RCW 84.33.140(6)(a)' },
+  { code: 'GOVT_ACQUISITION', label: 'Government Acquisition', rcw: 'RCW 84.33.140(6)(b)' },
+  { code: 'TRADE_LAND_CONSERVATION', label: 'Conservation Trade', rcw: 'RCW 84.34.108(6)(a)' },
+  { code: 'FORCED_SALE', label: 'Forced Sale / Condemnation', rcw: 'RCW 84.34.108(6)(b)' },
+  { code: 'TRANSFER_TO_GOVT', label: 'Transfer to Government', rcw: 'RCW 84.34.108(6)(c)' },
+];
+
+// ── Shared Sub-Navigation ──────────────────────────────────────────────────
+
+export function CuSubNav() {
+  const { pathname } = useLocation();
+  const tabs = [
+    { path: '/current-use', label: 'Classifications & Rollback' },
+    { path: '/current-use/interest', label: 'Interest Rates' },
+    { path: '/current-use/removals', label: 'Removals & Exceptions' },
+  ];
+  return (
+    <nav style={{ display: 'flex', gap: 2, marginBottom: 24, borderBottom: '1px solid rgba(255,255,255,.08)', paddingBottom: 0 }}>
+      {tabs.map(t => {
+        const active = pathname === t.path;
+        return (
+          <Link key={t.path} to={t.path} style={{
+            padding: '10px 18px', fontSize: 13, fontWeight: 500, textDecoration: 'none',
+            color: active ? '#00FFAA' : '#94a3b8',
+            borderBottom: active ? '2px solid #00FFAA' : '2px solid transparent',
+            transition: 'all 0.15s ease',
+          }}>
+            {t.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+// ── Loading Skeleton ───────────────────────────────────────────────────────
+
+function Skeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div style={{ padding: '12px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{
+          height: 38, background: 'linear-gradient(90deg, rgba(255,255,255,.03) 25%, rgba(255,255,255,.06) 50%, rgba(255,255,255,.03) 75%)',
+          backgroundSize: '200% 100%', borderRadius: 6, marginBottom: 6,
+          animation: 'shimmer 1.5s infinite',
+        }} />
+      ))}
+      <style>{`@keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
+    </div>
+  );
+}
+
+// ── Tooltip ────────────────────────────────────────────────────────────────
+
+function Tip({ text, children }: { text: string; children: React.ReactNode }) {
+  const [show, setShow] = useState(false);
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}
+      onMouseEnter={() => setShow(true)} onMouseLeave={() => setShow(false)}>
+      {children}
+      {show && (
+        <span style={{
+          position: 'absolute', bottom: 'calc(100% + 6px)', left: '50%', transform: 'translateX(-50%)',
+          background: '#1e293b', border: '1px solid rgba(255,255,255,.15)', borderRadius: 6,
+          padding: '6px 10px', fontSize: 11, color: '#e2e8f0', whiteSpace: 'nowrap', zIndex: 100,
+          boxShadow: '0 4px 12px rgba(0,0,0,.5)',
+        }}>
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ── New Classification Form ────────────────────────────────────────────────
+
+function NewClassificationForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [form, setForm] = useState({
+    parcelId: '', classificationCode: 'CUFA', description: '',
+    enrollmentDate: new Date().toISOString().slice(0, 10),
+    acreage: '', currentMarketValue: '', currentUseValue: '',
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true); setError(null); setSuccess(false);
+    fetch(`${API}/classifications`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        parcelId: form.parcelId.trim(),
+        classificationCode: form.classificationCode,
+        description: form.description || `${CU_CODES[form.classificationCode]?.label} — ${form.parcelId.trim()}`,
+        enrollmentDate: form.enrollmentDate,
+        acreage: form.acreage ? Number(form.acreage) : null,
+        currentMarketValue: form.currentMarketValue ? Number(form.currentMarketValue) : null,
+        currentUseValue: form.currentUseValue ? Number(form.currentUseValue) : null,
+      }),
+    })
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
+      .then(() => {
+        setSuccess(true);
+        setForm({ parcelId: '', classificationCode: 'CUFA', description: '', enrollmentDate: new Date().toISOString().slice(0, 10), acreage: '', currentMarketValue: '', currentUseValue: '' });
+        onCreated();
+        setTimeout(() => { setSuccess(false); setOpen(false); }, 1500);
+      })
+      .catch(e => setError(String(e)))
+      .finally(() => setSaving(false));
+  }
+
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)} className="tf-btn" style={{ marginBottom: 16, fontSize: 13 }}>
+        + New Enrollment
+      </button>
+    );
+  }
+
+  const inputStyle = { background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13, width: '100%' };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ background: 'rgba(255,255,255,.02)', border: '1px solid rgba(255,255,255,.1)', borderRadius: 10, padding: 20, marginBottom: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <h4 style={{ margin: 0, color: '#e2e8f0', fontSize: 14 }}>New Current Use Enrollment</h4>
+        <button type="button" onClick={() => setOpen(false)} style={{ background: 'none', border: 'none', color: '#64748b', cursor: 'pointer', fontSize: 18, lineHeight: 1 }}>×</button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 14 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Parcel ID <span style={{ color: '#ff6b6b', fontSize: 10 }}>required</span>
+          <input required type="text" value={form.parcelId} onChange={e => setForm(f => ({ ...f, parcelId: e.target.value }))} placeholder="1-0234-100-0001" style={inputStyle} />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Classification <Tip text="DFL = RCW 84.33 (7yr) · Others = RCW 84.34 (10yr)"><span style={{ cursor: 'help', borderBottom: '1px dotted #64748b' }}>?</span></Tip>
+          <select value={form.classificationCode} onChange={e => setForm(f => ({ ...f, classificationCode: e.target.value }))} style={inputStyle}>
+            {Object.entries(CU_CODES).map(([code, info]) => (
+              <option key={code} value={code}>{code} — {info.label}</option>
+            ))}
+          </select>
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Enrollment Date
+          <input type="date" value={form.enrollmentDate} onChange={e => setForm(f => ({ ...f, enrollmentDate: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Acreage
+          <input type="number" step="0.01" value={form.acreage} onChange={e => setForm(f => ({ ...f, acreage: e.target.value }))} placeholder="80.0" style={inputStyle} />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Market Value ($)
+          <input type="number" value={form.currentMarketValue} onChange={e => setForm(f => ({ ...f, currentMarketValue: e.target.value }))} placeholder="450000" style={inputStyle} />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Current Use Value ($)
+          <input type="number" value={form.currentUseValue} onChange={e => setForm(f => ({ ...f, currentUseValue: e.target.value }))} placeholder="52000" style={inputStyle} />
+        </label>
+      </div>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8', marginTop: 14 }}>
+        Description (optional)
+        <input type="text" value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} placeholder="e.g. Designated Forest Land — 80 acres mixed conifer" style={inputStyle} />
+      </label>
+      {error && <p style={{ color: '#ff6b6b', fontSize: 12, margin: '10px 0 0' }}>{error}</p>}
+      {success && <p style={{ color: '#00FFAA', fontSize: 12, margin: '10px 0 0' }}>Enrollment created successfully.</p>}
+      <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+        <button type="submit" disabled={saving || !form.parcelId.trim()} className="tf-btn" style={{ fontSize: 13 }}>
+          {saving ? 'Enrolling…' : 'Enroll Parcel'}
+        </button>
+        <button type="button" onClick={() => setOpen(false)} style={{ background: 'none', border: '1px solid rgba(255,255,255,.12)', color: '#94a3b8', borderRadius: 6, padding: '7px 14px', fontSize: 13, cursor: 'pointer' }}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
 
 // ── Classifications Section ────────────────────────────────────────────────
 
 function ClassificationsSection() {
-  const [status, setStatus] = useState('Active');
-  const [code, setCode] = useState('');
   const [data, setData] = useState<ClassificationsResponse | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState('Active');
+  const [codeFilter, setCodeFilter] = useState('');
+  const [page, setPage] = useState(1);
+  const pageSize = 25;
 
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
-    const params = new URLSearchParams({ pageSize: '50' });
-    if (status) params.set('status', status);
-    if (code) params.set('classificationCode', code);
+  const fetchData = useCallback(() => {
+    setLoading(true); setError(null);
+    const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+    if (statusFilter) params.set('status', statusFilter);
+    if (codeFilter) params.set('classificationCode', codeFilter);
     fetch(`${API}/classifications?${params}`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setData)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
-  }, [status, code]);
+  }, [page, statusFilter, codeFilter]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
 
   return (
     <section className="tf-section">
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Current Use Classifications</h3>
-        <div className="tf-filters">
-          <label>
-            Status
-            <select value={status} onChange={e => setStatus(e.target.value)}>
-              <option value="">All</option>
-              <option value="Active">Active</option>
-              <option value="Removed">Removed</option>
-              <option value="Pending">Pending</option>
-            </select>
-          </label>
-          <label>
-            Code
-            <input
-              type="text"
-              placeholder="e.g. DFL"
-              value={code}
-              onChange={e => setCode(e.target.value)}
-              style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 80 }}
-            />
-          </label>
-          {data && (
-            <span className="tf-count">{data.total.toLocaleString()} classifications</span>
-          )}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16, flexWrap: 'wrap', gap: 12 }}>
+        <div>
+          <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16 }}>Current Use Classifications</h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+            Parcels enrolled under RCW 84.33 (DFL) and RCW 84.34 (CUFA/CUOS/CUTL)
+          </p>
         </div>
+        {data && <span style={{ fontSize: 12, color: '#64748b', background: 'rgba(255,255,255,.04)', padding: '4px 10px', borderRadius: 12 }}>{data.total} enrollment{data.total !== 1 ? 's' : ''}</span>}
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error && <p className="tf-error">Error: {error}</p>}
+      <NewClassificationForm onCreated={fetchData} />
 
-      {data && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
-            <thead>
-              <tr>
-                <th>Parcel</th>
-                <th>Code</th>
-                <th>Description</th>
-                <th>Enrolled</th>
-                <th>Status</th>
-                <th className="tf-right">Acreage</th>
-                <th className="tf-right">Market Value</th>
-                <th className="tf-right">CU Value</th>
-                <th className="tf-right">Tax Savings</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.items.length === 0 && (
-                <tr><td colSpan={9} className="tf-empty">No classifications match these filters.</td></tr>
-              )}
-              {data.items.map(c => (
-                <tr key={c.id}>
-                  <td className="tf-mono">{c.parcelId}</td>
-                  <td>
-                    <span className="tf-badge tf-badge--blue">{c.classificationCode}</span>
-                  </td>
-                  <td>{c.description}</td>
-                  <td>{fmtDate(c.enrollmentDate)}</td>
-                  <td>
-                    <span className={`tf-badge ${c.status === 'Active' ? 'tf-badge--green' : c.status === 'Removed' ? 'tf-badge--red' : 'tf-badge--gray'}`}>
-                      {c.status}
-                    </span>
-                  </td>
-                  <td className="tf-right">{c.acreage?.toFixed(1) ?? '—'}</td>
-                  <td className="tf-right tf-mono">{c.currentMarketValue != null ? fmt$(c.currentMarketValue) : '—'}</td>
-                  <td className="tf-right tf-mono">{c.currentUseValue != null ? fmt$(c.currentUseValue) : '—'}</td>
-                  <td className="tf-right tf-mono" style={{ color: c.taxSavings && c.taxSavings > 0 ? '#00FFAA' : undefined }}>
-                    {c.taxSavings != null ? fmt$(c.taxSavings) : '—'}
-                  </td>
+      {/* Filters */}
+      <div style={{ display: 'flex', gap: 10, marginBottom: 14, flexWrap: 'wrap' }}>
+        <select value={statusFilter} onChange={e => { setStatusFilter(e.target.value); setPage(1); }}
+          style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '6px 10px', fontSize: 12 }}>
+          <option value="">All Statuses</option>
+          <option value="Active">Active</option>
+          <option value="Removed">Removed</option>
+          <option value="Pending">Pending</option>
+        </select>
+        <select value={codeFilter} onChange={e => { setCodeFilter(e.target.value); setPage(1); }}
+          style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '6px 10px', fontSize: 12 }}>
+          <option value="">All Codes</option>
+          {Object.entries(CU_CODES).map(([code, info]) => (
+            <option key={code} value={code}>{code} — {info.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <Skeleton rows={5} />}
+      {error && <p style={{ color: '#ff6b6b', fontSize: 13 }}>{error}</p>}
+      {!loading && data && (
+        <>
+          <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+            <table className="tf-table" style={{ fontSize: 13 }}>
+              <thead>
+                <tr>
+                  <th>Parcel ID</th>
+                  <th>Code</th>
+                  <th>Description</th>
+                  <th>Enrolled</th>
+                  <th>Status</th>
+                  <th className="tf-right">Acreage</th>
+                  <th className="tf-right">Market Value</th>
+                  <th className="tf-right">CU Value</th>
+                  <th className="tf-right">Tax Savings</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {data.items.length === 0 && (
+                  <tr><td colSpan={9} style={{ textAlign: 'center', color: '#64748b', padding: 24 }}>No classifications match these filters.</td></tr>
+                )}
+                {data.items.map(c => (
+                  <tr key={c.id} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
+                    <td className="tf-mono" style={{ fontSize: 12 }}>{c.parcelId}</td>
+                    <td>
+                      <Tip text={`${CU_CODES[c.classificationCode]?.label || c.classificationCode} · ${CU_CODES[c.classificationCode]?.rcw || ''} · ${CU_CODES[c.classificationCode]?.maxYears || '?'}yr lookback`}>
+                        <span className={`tf-badge tf-badge--${CU_CODES[c.classificationCode]?.color || 'gray'}`} style={{ fontSize: 11 }}>
+                          {c.classificationCode}
+                        </span>
+                      </Tip>
+                    </td>
+                    <td style={{ fontSize: 12, maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.description}</td>
+                    <td style={{ fontSize: 12 }}>{fmtDate(c.enrollmentDate)}</td>
+                    <td>
+                      <span className={`tf-badge ${c.status === 'Active' ? 'tf-badge--green' : c.status === 'Removed' ? 'tf-badge--red' : 'tf-badge--gray'}`} style={{ fontSize: 11 }}>
+                        {c.status}
+                      </span>
+                    </td>
+                    <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{c.acreage?.toFixed(1) ?? '—'}</td>
+                    <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{c.currentMarketValue != null ? fmt$(c.currentMarketValue) : '—'}</td>
+                    <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{c.currentUseValue != null ? fmt$(c.currentUseValue) : '—'}</td>
+                    <td className="tf-right tf-mono" style={{ fontSize: 12, color: c.taxSavings && c.taxSavings > 0 ? '#00FFAA' : undefined }}>
+                      {c.taxSavings != null ? fmt$(c.taxSavings) : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', gap: 8, marginTop: 12, justifyContent: 'center', alignItems: 'center' }}>
+              <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}
+                style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 12px', fontSize: 12, cursor: page <= 1 ? 'not-allowed' : 'pointer', opacity: page <= 1 ? 0.4 : 1 }}>
+                Prev
+              </button>
+              <span style={{ fontSize: 12, color: '#94a3b8' }}>Page {page} of {totalPages}</span>
+              <button disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}
+                style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 12px', fontSize: 12, cursor: page >= totalPages ? 'not-allowed' : 'pointer', opacity: page >= totalPages ? 0.4 : 1 }}>
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </section>
   );
@@ -170,172 +374,204 @@ function ClassificationsSection() {
 
 function RollbackCalculatorSection() {
   const [parcelId, setParcelId] = useState('');
-  const [classCode, setClassCode] = useState('DFL');
+  const [classCode, setClassCode] = useState('CUFA');
   const [enrollYear, setEnrollYear] = useState(2018);
-  const [removalYear, setRemovalYear] = useState(2026);
-  const [result, setResult] = useState<RollbackResult | null>(null);
+  const [removalYear, setRemovalYear] = useState(2025);
+  const [penaltyException, setPenaltyException] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RollbackResult | null>(null);
+
+  // Generate realistic Benton County market/CU values
+  const generateValues = useCallback(() => {
+    const baseMarket = 350000;
+    const baseCU = 45000;
+    const marketGrowth = 0.058; // Benton County avg 5.8% appreciation
+    const cuGrowth = 0.018; // CU value grows slowly (timber/ag yield)
+    const marketValues: Record<string, number> = {};
+    const cuValues: Record<string, number> = {};
+    const maxYears = CU_CODES[classCode]?.maxYears || 10;
+    const startYear = Math.max(enrollYear, removalYear - maxYears + 1);
+    for (let y = startYear; y <= removalYear; y++) {
+      const offset = y - enrollYear;
+      marketValues[String(y)] = Math.round(baseMarket * Math.pow(1 + marketGrowth, offset));
+      cuValues[String(y)] = Math.round(baseCU * Math.pow(1 + cuGrowth, offset));
+    }
+    return { marketValues, cuValues };
+  }, [classCode, enrollYear, removalYear]);
 
   function runCalculation() {
-    if (!parcelId.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
-
-    const body: RollbackInput = {
-      parcelId: parcelId.trim(),
-      classificationCode: classCode,
-      enrollmentYear: enrollYear,
-      removalYear: removalYear,
-      marketValues: {},
-      currentUseValues: {},
-      penaltyExceptionCode: '',
-    };
-
-    // Generate sample values for the year range
-    for (let y = enrollYear; y <= removalYear; y++) {
-      body.marketValues[String(y)] = 350000 + (y - enrollYear) * 15000;
-      body.currentUseValues[String(y)] = 45000 + (y - enrollYear) * 2000;
-    }
-
+    setLoading(true); setError(null); setResult(null);
+    const { marketValues, cuValues } = generateValues();
     fetch(`${API}/rollback/calculate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        parcelId: parcelId.trim() || '1-0567-200-0045',
+        classificationCode: classCode,
+        enrollmentYear: enrollYear,
+        removalYear: removalYear,
+        marketValues,
+        currentUseValues: cuValues,
+        penaltyExceptionCode: penaltyException || null,
+      }),
     })
-      .then(async r => {
-        if (!r.ok) {
-          const text = await r.text();
-          throw new Error(text || r.statusText);
-        }
-        return r.json();
-      })
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setResult)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
   }
 
+  function exportCSV() {
+    if (!result) return;
+    const hdr = 'Year,Market Value,CU Value,Difference,Interest Rate,Interest,Subtotal';
+    const rows = result.yearBreakdowns.map(yb =>
+      `${yb.year},${yb.marketValue},${yb.currentUseValue},${yb.difference},${yb.interestRate},${yb.interestAmount},${yb.subtotal}`
+    );
+    rows.push('', `Total Rollback Tax,,,,,,${result.totalRollbackTax}`);
+    rows.push(`Total Interest,,,,,,${result.totalInterest}`);
+    rows.push(`Penalty (20%),,,,,,${result.totalPenalty}`);
+    rows.push(`Grand Total,,,,,,${result.grandTotal}`);
+    const blob = new Blob([hdr + '\n' + rows.join('\n')], { type: 'text/csv' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `rollback_${parcelId || 'estimate'}_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+  }
+
   return (
     <section className="tf-section" style={{ marginTop: 32 }}>
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Rollback Tax Calculator</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          Calculate rollback taxes, interest, and penalties per RCW 84.33/84.34 upon removal from current use.
+      <div style={{ marginBottom: 16 }}>
+        <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+          Rollback Tax Calculator
+          <Tip text="Calculates rollback taxes per RCW 84.33.140 / 84.34.108 when land is removed from current use">
+            <span style={{ fontSize: 13, color: '#64748b', cursor: 'help' }}>?</span>
+          </Tip>
+        </h3>
+        <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+          DFL: 7-year lookback (RCW 84.33) · CUFA/CUOS/CUTL: 10-year lookback (RCW 84.34) · 20% penalty unless exception applies
         </p>
       </div>
 
-      <div className="tf-filters" style={{ alignItems: 'flex-end', gap: 12 }}>
-        <label>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(155px, 1fr))', gap: 12, marginBottom: 16 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Parcel ID
-          <input
-            type="text"
-            placeholder="e.g. 1-0234-100-0001"
-            value={parcelId}
-            onChange={e => setParcelId(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 160 }}
-          />
+          <input type="text" value={parcelId} onChange={e => setParcelId(e.target.value)} placeholder="1-0567-200-0045"
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 }} />
         </label>
-        <label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Classification
-          <select value={classCode} onChange={e => setClassCode(e.target.value)}>
-            <option value="DFL">DFL — Designated Forest Land</option>
-            <option value="CUFA">CUFA — Current Use Farm/Ag</option>
-            <option value="CUOS">CUOS — Current Use Open Space</option>
-            <option value="CUTL">CUTL — Current Use Timber Land</option>
+          <select value={classCode} onChange={e => setClassCode(e.target.value)}
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 }}>
+            {Object.entries(CU_CODES).map(([code, info]) => (
+              <option key={code} value={code}>{code} — {info.label} ({info.maxYears}yr)</option>
+            ))}
           </select>
         </label>
-        <label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Enrollment Year
-          <input
-            type="number"
-            value={enrollYear}
-            onChange={e => setEnrollYear(Number(e.target.value))}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" value={enrollYear} onChange={e => setEnrollYear(Number(e.target.value))} min={2000} max={2025}
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 }} />
         </label>
-        <label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Removal Year
-          <input
-            type="number"
-            value={removalYear}
-            onChange={e => setRemovalYear(Number(e.target.value))}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" value={removalYear} onChange={e => setRemovalYear(Number(e.target.value))} min={2016} max={2026}
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 }} />
         </label>
-        <button
-          onClick={runCalculation}
-          disabled={loading || !parcelId.trim()}
-          className="tf-btn"
-        >
-          {loading ? 'Calculating…' : 'Calculate Rollback'}
-        </button>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Penalty Exception <Tip text="20% penalty waived if qualifying exception applies"><span style={{ cursor: 'help' }}>?</span></Tip>
+          <select value={penaltyException} onChange={e => setPenaltyException(e.target.value)}
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13 }}>
+            <option value="">None (20% penalty applies)</option>
+            {PENALTY_EXCEPTIONS.map(pe => (
+              <option key={pe.code} value={pe.code}>{pe.label}</option>
+            ))}
+          </select>
+        </label>
       </div>
 
-      {error && <p className="tf-error" style={{ marginTop: 12 }}>Error: {error}</p>}
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <button onClick={runCalculation} disabled={loading} className="tf-btn" style={{ fontSize: 13 }}>
+          {loading ? 'Calculating…' : 'Calculate Rollback'}
+        </button>
+        {result && (
+          <>
+            <button onClick={exportCSV} style={{ background: 'none', border: '1px solid rgba(255,255,255,.12)', color: '#94a3b8', borderRadius: 6, padding: '7px 14px', fontSize: 12, cursor: 'pointer' }}>
+              Export CSV
+            </button>
+            <button onClick={() => window.print()} style={{ background: 'none', border: '1px solid rgba(255,255,255,.12)', color: '#94a3b8', borderRadius: 6, padding: '7px 14px', fontSize: 12, cursor: 'pointer' }}>
+              Print
+            </button>
+          </>
+        )}
+      </div>
+
+      {error && <p style={{ color: '#ff6b6b', fontSize: 12, marginTop: 12 }}>{error}</p>}
 
       {result && (
-        <div style={{ marginTop: 16 }}>
+        <div style={{ marginTop: 20 }}>
           {/* Summary cards */}
-          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
-              <div className="tf-cardTag tf-indigo">Rollback Tax</div>
-              <div className="tf-cardBig">{fmt$(result.totalRollbackTax)}</div>
-            </div>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
-              <div className="tf-cardTag tf-indigo">Interest</div>
-              <div className="tf-cardBig">{fmt$(result.totalInterest)}</div>
-            </div>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
-              <div className="tf-cardTag tf-indigo">Penalty (20%)</div>
-              <div className="tf-cardBig">{fmt$(result.totalPenalty)}</div>
-              {result.penaltyExceptionApplied && (
-                <div className="tf-cardSmall" style={{ color: '#00FFAA' }}>
-                  Exception: {result.exceptionCode}
-                </div>
-              )}
-            </div>
-            <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default', borderColor: '#00FFAA' }}>
-              <div className="tf-cardTag" style={{ color: '#00FFAA' }}>Grand Total</div>
-              <div className="tf-cardBig" style={{ color: '#00FFAA' }}>{fmt$(result.grandTotal)}</div>
-            </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 12, marginBottom: 20 }}>
+            {[
+              { label: 'Rollback Tax', value: result.totalRollbackTax, color: '#e2e8f0' },
+              { label: 'Interest', value: result.totalInterest, color: '#e2e8f0' },
+              { label: result.penaltyExceptionApplied ? 'Penalty (WAIVED)' : 'Penalty (20%)', value: result.totalPenalty, color: result.penaltyExceptionApplied ? '#00FFAA' : '#ff6b6b' },
+              { label: 'Grand Total Due', value: result.grandTotal, color: '#00FFAA' },
+            ].map((card, i) => (
+              <div key={i} style={{ background: 'rgba(255,255,255,.03)', border: i === 3 ? '1px solid rgba(0,255,170,.3)' : '1px solid rgba(255,255,255,.08)', borderRadius: 8, padding: '14px 16px' }}>
+                <div style={{ fontSize: 11, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: 6 }}>{card.label}</div>
+                <div style={{ fontSize: 20, fontWeight: 700, color: card.color, fontFamily: 'monospace' }}>{fmtFull$(card.value)}</div>
+                {i === 2 && result.penaltyExceptionApplied && (
+                  <div style={{ fontSize: 11, color: '#00FFAA', marginTop: 4 }}>Exception: {result.exceptionCode}</div>
+                )}
+              </div>
+            ))}
           </div>
 
           {/* Year breakdown table */}
-          <div className="tf-table-wrap">
-            <table className="tf-table">
+          <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+            <table className="tf-table" style={{ fontSize: 13 }}>
               <thead>
                 <tr>
                   <th>Year</th>
                   <th className="tf-right">Market Value</th>
                   <th className="tf-right">CU Value</th>
                   <th className="tf-right">Difference</th>
-                  <th className="tf-right">Interest Rate</th>
+                  <th className="tf-right">Rate</th>
                   <th className="tf-right">Interest</th>
                   <th className="tf-right">Subtotal</th>
                 </tr>
               </thead>
               <tbody>
                 {result.yearBreakdowns.map(yb => (
-                  <tr key={yb.year}>
+                  <tr key={yb.year} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
                     <td className="tf-mono">{yb.year}</td>
                     <td className="tf-right tf-mono">{fmt$(yb.marketValue)}</td>
                     <td className="tf-right tf-mono">{fmt$(yb.currentUseValue)}</td>
                     <td className="tf-right tf-mono">{fmt$(yb.difference)}</td>
                     <td className="tf-right tf-mono">{fmtPct(yb.interestRate)}</td>
-                    <td className="tf-right tf-mono">{fmt$(yb.interestAmount)}</td>
-                    <td className="tf-right tf-mono">{fmt$(yb.subtotal)}</td>
+                    <td className="tf-right tf-mono">{fmtFull$(yb.interestAmount)}</td>
+                    <td className="tf-right tf-mono">{fmtFull$(yb.subtotal)}</td>
                   </tr>
                 ))}
-                <tr style={{ borderTop: '1px solid rgba(255,255,255,.15)', fontWeight: 600 }}>
-                  <td colSpan={5} />
-                  <td className="tf-right" style={{ color: '#e2e8f0' }}>Total</td>
-                  <td className="tf-right tf-mono" style={{ color: '#00FFAA' }}>
-                    {fmt$(result.grandTotal)}
+                <tr style={{ borderTop: '2px solid rgba(0,255,170,.25)', fontWeight: 600 }}>
+                  <td colSpan={5} style={{ fontSize: 11, color: '#64748b' }}>
+                    {result.yearBreakdowns.length} year{result.yearBreakdowns.length !== 1 ? 's' : ''} · {classCode} ({CU_CODES[classCode]?.maxYears}yr max lookback)
                   </td>
+                  <td className="tf-right" style={{ color: '#94a3b8', fontSize: 12 }}>Total</td>
+                  <td className="tf-right tf-mono" style={{ color: '#00FFAA', fontSize: 14 }}>{fmtFull$(result.grandTotal)}</td>
                 </tr>
               </tbody>
             </table>
+          </div>
+
+          {/* Legal disclaimer */}
+          <div style={{ marginTop: 16, padding: '10px 14px', background: 'rgba(255,255,255,.02)', borderRadius: 6, border: '1px solid rgba(255,255,255,.06)' }}>
+            <p style={{ margin: 0, fontSize: 11, color: '#64748b', lineHeight: 1.6 }}>
+              <strong style={{ color: '#94a3b8' }}>Disclaimer:</strong> This calculation is an estimate based on WA DOR published interest rates.
+              Actual rollback amounts are determined by the Benton County Assessor per RCW 84.33.140 / RCW 84.34.108.
+              Penalty exceptions require supporting documentation and county approval.
+            </p>
           </div>
         </div>
       )}
@@ -348,13 +584,13 @@ function RollbackCalculatorSection() {
 export default function CurrentUsePage() {
   return (
     <div className="tf-page">
-      <div className="tf-page-header" style={{ marginBottom: 24 }}>
-        <h2>Current Use</h2>
-        <p className="tf-page-sub">
+      <div className="tf-page-header" style={{ marginBottom: 8 }}>
+        <h2 style={{ margin: 0, color: '#f1f5f9' }}>Current Use Program</h2>
+        <p className="tf-page-sub" style={{ marginTop: 4, color: '#64748b', fontSize: 13 }}>
           Benton County WA — RCW 84.33/84.34 current use classifications, rollback tax calculations, and removal processing
         </p>
       </div>
-
+      <CuSubNav />
       <ClassificationsSection />
       <RollbackCalculatorSection />
     </div>

--- a/frontend/apps/terraforge/src/pages/CurrentUseRemovalsPage.tsx
+++ b/frontend/apps/terraforge/src/pages/CurrentUseRemovalsPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { CuSubNav } from './CurrentUsePage';
 
 const API = '/api/currentuse';
 
@@ -26,46 +27,202 @@ interface PenaltyException {
   reason: string;
 }
 
-// ── Formatters ─────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-const fmtDate = (s: string) => s ? s.slice(0, 10) : '—';
+const fmtFull$ = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
+const fmtDate = (s: string) => s ? new Date(s.slice(0, 10) + 'T12:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '—';
+
+function Skeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div style={{ padding: '12px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{
+          height: 34, background: 'linear-gradient(90deg, rgba(255,255,255,.03) 25%, rgba(255,255,255,.06) 50%, rgba(255,255,255,.03) 75%)',
+          backgroundSize: '200% 100%', borderRadius: 6, marginBottom: 6,
+          animation: 'shimmer 1.5s infinite',
+        }} />
+      ))}
+      <style>{`@keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
+    </div>
+  );
+}
+
+function Tip({ text, children }: { text: string; children: React.ReactNode }) {
+  const [show, setShow] = useState(false);
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}
+      onMouseEnter={() => setShow(true)} onMouseLeave={() => setShow(false)}>
+      {children}
+      {show && (
+        <span style={{
+          position: 'absolute', bottom: 'calc(100% + 6px)', left: '50%', transform: 'translateX(-50%)',
+          background: '#1e293b', border: '1px solid rgba(255,255,255,.15)', borderRadius: 6,
+          padding: '6px 10px', fontSize: 11, color: '#e2e8f0', whiteSpace: 'nowrap', zIndex: 100,
+          boxShadow: '0 4px 12px rgba(0,0,0,.5)',
+        }}>
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}
+
+const REMOVAL_REASONS = [
+  'Voluntary withdrawal',
+  'Change of use',
+  'Sale to non-qualifying buyer',
+  'Subdivision',
+  'Failure to meet requirements',
+  'Government acquisition',
+  'Owner death — estate transfer',
+];
+
+const CU_CODES: Record<string, { label: string; color: string }> = {
+  DFL:  { label: 'Designated Forest Land', color: 'green' },
+  CUFA: { label: 'Farm & Agriculture', color: 'blue' },
+  CUOS: { label: 'Open Space', color: 'purple' },
+  CUTL: { label: 'Timber Land', color: 'amber' },
+};
+
+// ── Initiate Removal Form ──────────────────────────────────────────────────
+
+function InitiateRemovalForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [form, setForm] = useState({
+    parcelId: '', classificationCode: 'CUFA', reason: REMOVAL_REASONS[0],
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true); setError(null); setSuccess(false);
+    fetch(`${API}/removals/initiate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        parcelId: form.parcelId.trim(),
+        classificationCode: form.classificationCode,
+        reason: form.reason,
+      }),
+    })
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
+      .then(() => {
+        setSuccess(true);
+        setForm({ parcelId: '', classificationCode: 'CUFA', reason: REMOVAL_REASONS[0] });
+        onCreated();
+        setTimeout(() => { setSuccess(false); setOpen(false); }, 1500);
+      })
+      .catch(e => setError(String(e)))
+      .finally(() => setSaving(false));
+  }
+
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)} className="tf-btn" style={{ marginBottom: 16, fontSize: 13 }}>
+        + Initiate Removal
+      </button>
+    );
+  }
+
+  const inputStyle = { background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13, width: '100%' };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ background: 'rgba(255,255,255,.02)', border: '1px solid rgba(255,255,255,.1)', borderRadius: 10, padding: 20, marginBottom: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <h4 style={{ margin: 0, color: '#e2e8f0', fontSize: 14 }}>Initiate Removal from Current Use</h4>
+        <button type="button" onClick={() => setOpen(false)} style={{ background: 'none', border: 'none', color: '#64748b', cursor: 'pointer', fontSize: 18, lineHeight: 1 }}>×</button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 14 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Parcel ID <span style={{ color: '#ff6b6b', fontSize: 10 }}>required</span>
+          <input required type="text" value={form.parcelId} onChange={e => setForm(f => ({ ...f, parcelId: e.target.value }))} placeholder="1-0234-100-0001" style={inputStyle} />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Classification
+          <select value={form.classificationCode} onChange={e => setForm(f => ({ ...f, classificationCode: e.target.value }))} style={inputStyle}>
+            {Object.entries(CU_CODES).map(([code, info]) => (
+              <option key={code} value={code}>{code} — {info.label}</option>
+            ))}
+          </select>
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
+          Reason for Removal
+          <select value={form.reason} onChange={e => setForm(f => ({ ...f, reason: e.target.value }))} style={inputStyle}>
+            {REMOVAL_REASONS.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+      </div>
+      {error && <p style={{ color: '#ff6b6b', fontSize: 12, margin: '10px 0 0' }}>{error}</p>}
+      {success && <p style={{ color: '#00FFAA', fontSize: 12, margin: '10px 0 0' }}>Removal initiated successfully.</p>}
+      <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+        <button type="submit" disabled={saving || !form.parcelId.trim()} className="tf-btn" style={{ fontSize: 13 }}>
+          {saving ? 'Initiating…' : 'Initiate Removal'}
+        </button>
+        <button type="button" onClick={() => setOpen(false)} style={{ background: 'none', border: '1px solid rgba(255,255,255,.12)', color: '#94a3b8', borderRadius: 6, padding: '7px 14px', fontSize: 13, cursor: 'pointer' }}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
 
 // ── Removals List Section ──────────────────────────────────────────────────
 
 function RemovalsSection() {
   const [data, setData] = useState<Removal[] | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
+  const fetchData = useCallback(() => {
+    setLoading(true); setError(null);
     fetch(`${API}/removals`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setData)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
   }, []);
 
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const statusColor = (s: string) => {
+    switch (s) {
+      case 'Confirmed': return 'tf-badge--red';
+      case 'Pending': return 'tf-badge--gray';
+      case 'Initiated': return 'tf-badge--blue';
+      default: return 'tf-badge--green';
+    }
+  };
+
   return (
     <section className="tf-section">
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Removal Proceedings</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          Active and completed removals from current use classification with rollback tax obligations.
-        </p>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16 }}>
+        <div>
+          <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+            Removal Proceedings
+            <Tip text="Tracks parcels being removed from current use classification with associated rollback obligations">
+              <span style={{ fontSize: 13, color: '#64748b', cursor: 'help' }}>?</span>
+            </Tip>
+          </h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+            Active and completed removals with rollback tax obligations
+          </p>
+        </div>
+        {data && <span style={{ fontSize: 12, color: '#64748b', background: 'rgba(255,255,255,.04)', padding: '4px 10px', borderRadius: 12 }}>{data.length} removal{data.length !== 1 ? 's' : ''}</span>}
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error && <p className="tf-error">Error: {error}</p>}
+      <InitiateRemovalForm onCreated={fetchData} />
 
-      {data && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
+      {loading && <Skeleton rows={4} />}
+      {error && <p style={{ color: '#ff6b6b', fontSize: 13 }}>{error}</p>}
+
+      {!loading && data && (
+        <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+          <table className="tf-table" style={{ fontSize: 13 }}>
             <thead>
               <tr>
-                <th>Parcel</th>
+                <th>Parcel ID</th>
                 <th>Code</th>
                 <th>Reason</th>
                 <th>Initiated</th>
@@ -79,25 +236,25 @@ function RemovalsSection() {
             </thead>
             <tbody>
               {data.length === 0 && (
-                <tr><td colSpan={10} className="tf-empty">No removal proceedings found.</td></tr>
+                <tr><td colSpan={10} style={{ textAlign: 'center', color: '#64748b', padding: 24 }}>No removal proceedings found. Initiate one above.</td></tr>
               )}
               {data.map(r => (
-                <tr key={r.id}>
-                  <td className="tf-mono">{r.parcelId}</td>
-                  <td><span className="tf-badge tf-badge--blue">{r.classificationCode}</span></td>
-                  <td>{r.reason}</td>
-                  <td>{fmtDate(r.initiatedDate)}</td>
+                <tr key={r.id} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
+                  <td className="tf-mono" style={{ fontSize: 12 }}>{r.parcelId}</td>
                   <td>
-                    <span className={`tf-badge ${r.status === 'Confirmed' ? 'tf-badge--red' : r.status === 'Pending' ? 'tf-badge--gray' : 'tf-badge--green'}`}>
-                      {r.status}
+                    <span className={`tf-badge tf-badge--${CU_CODES[r.classificationCode]?.color || 'gray'}`} style={{ fontSize: 11 }}>
+                      {r.classificationCode}
                     </span>
                   </td>
-                  <td>{fmtDate(r.removalDate ?? '')}</td>
-                  <td className="tf-right tf-mono">{r.rollbackAmount != null ? fmt$(r.rollbackAmount) : '—'}</td>
-                  <td className="tf-right tf-mono">{r.interestAmount != null ? fmt$(r.interestAmount) : '—'}</td>
-                  <td className="tf-right tf-mono">{r.penaltyAmount != null ? fmt$(r.penaltyAmount) : '—'}</td>
-                  <td className="tf-right tf-mono" style={{ color: r.totalDue && r.totalDue > 0 ? '#ff6b6b' : undefined }}>
-                    {r.totalDue != null ? fmt$(r.totalDue) : '—'}
+                  <td style={{ fontSize: 12, maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.reason}</td>
+                  <td style={{ fontSize: 12 }}>{fmtDate(r.initiatedDate)}</td>
+                  <td><span className={`tf-badge ${statusColor(r.status)}`} style={{ fontSize: 11 }}>{r.status}</span></td>
+                  <td style={{ fontSize: 12 }}>{r.removalDate ? fmtDate(r.removalDate) : '—'}</td>
+                  <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{r.rollbackAmount != null ? fmtFull$(r.rollbackAmount) : '—'}</td>
+                  <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{r.interestAmount != null ? fmtFull$(r.interestAmount) : '—'}</td>
+                  <td className="tf-right tf-mono" style={{ fontSize: 12 }}>{r.penaltyAmount != null ? fmtFull$(r.penaltyAmount) : '—'}</td>
+                  <td className="tf-right tf-mono" style={{ fontSize: 12, color: r.totalDue && r.totalDue > 0 ? '#ff6b6b' : undefined, fontWeight: r.totalDue ? 600 : 400 }}>
+                    {r.totalDue != null ? fmtFull$(r.totalDue) : '—'}
                   </td>
                 </tr>
               ))}
@@ -119,14 +276,9 @@ function PenaltyExceptionsSection() {
 
   function checkExceptions() {
     if (!parcelId.trim()) return;
-    setLoading(true);
-    setError(null);
-    setData(null);
+    setLoading(true); setError(null); setData(null);
     fetch(`${API}/penalty-exceptions?parcelId=${encodeURIComponent(parcelId.trim())}`)
-      .then(async r => {
-        if (!r.ok) throw new Error(await r.text() || r.statusText);
-        return r.json();
-      })
+      .then(async r => { if (!r.ok) throw new Error(await r.text() || r.statusText); return r.json(); })
       .then(setData)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
@@ -134,38 +286,34 @@ function PenaltyExceptionsSection() {
 
   return (
     <section className="tf-section" style={{ marginTop: 32 }}>
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Penalty Exception Evaluation</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          Check which 20% penalty exceptions apply per RCW 84.33.140 / 84.34.108.
+      <div style={{ marginBottom: 16 }}>
+        <h3 style={{ margin: 0, color: '#e2e8f0', fontSize: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+          Penalty Exception Evaluation
+          <Tip text="20% penalty can be waived under specific RCW exceptions — check eligibility here">
+            <span style={{ fontSize: 13, color: '#64748b', cursor: 'help' }}>?</span>
+          </Tip>
+        </h3>
+        <p style={{ margin: '4px 0 0', fontSize: 12, color: '#64748b' }}>
+          Check which 20% penalty exceptions apply per RCW 84.33.140 / 84.34.108
         </p>
       </div>
 
-      <div className="tf-filters" style={{ alignItems: 'flex-end', gap: 12 }}>
-        <label>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-end', marginBottom: 16 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#94a3b8' }}>
           Parcel ID
-          <input
-            type="text"
-            placeholder="e.g. 1-0234-100-0001"
-            value={parcelId}
-            onChange={e => setParcelId(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 160 }}
-          />
+          <input type="text" value={parcelId} onChange={e => setParcelId(e.target.value)} placeholder="1-0234-100-0001"
+            style={{ background: 'rgba(255,255,255,.05)', border: '1px solid rgba(255,255,255,.12)', color: '#e2e8f0', borderRadius: 6, padding: '7px 10px', fontSize: 13, width: 180 }} />
         </label>
-        <button
-          onClick={checkExceptions}
-          disabled={loading || !parcelId.trim()}
-          className="tf-btn"
-        >
-          {loading ? 'Checking…' : 'Evaluate Exceptions'}
+        <button onClick={checkExceptions} disabled={loading || !parcelId.trim()} className="tf-btn" style={{ fontSize: 13 }}>
+          {loading ? 'Evaluating…' : 'Evaluate Exceptions'}
         </button>
       </div>
 
-      {error && <p className="tf-error" style={{ marginTop: 12 }}>Error: {error}</p>}
+      {error && <p style={{ color: '#ff6b6b', fontSize: 12 }}>{error}</p>}
 
       {data && (
-        <div className="tf-table-wrap" style={{ marginTop: 16 }}>
-          <table className="tf-table">
+        <div className="tf-table-wrap" style={{ overflowX: 'auto' }}>
+          <table className="tf-table" style={{ fontSize: 13 }}>
             <thead>
               <tr>
                 <th>Code</th>
@@ -177,25 +325,45 @@ function PenaltyExceptionsSection() {
             </thead>
             <tbody>
               {data.length === 0 && (
-                <tr><td colSpan={5} className="tf-empty">No exceptions evaluated.</td></tr>
+                <tr><td colSpan={5} style={{ textAlign: 'center', color: '#64748b', padding: 24 }}>No exceptions evaluated.</td></tr>
               )}
               {data.map(pe => (
-                <tr key={pe.code}>
-                  <td className="tf-mono">{pe.code}</td>
-                  <td>{pe.description}</td>
-                  <td className="tf-mono" style={{ fontSize: 12 }}>{pe.rcwReference}</td>
+                <tr key={pe.code} style={{ borderBottom: '1px solid rgba(255,255,255,.04)' }}>
+                  <td className="tf-mono" style={{ fontSize: 12, fontWeight: 600 }}>{pe.code}</td>
+                  <td style={{ fontSize: 12 }}>{pe.description}</td>
+                  <td className="tf-mono" style={{ fontSize: 11, color: '#94a3b8' }}>{pe.rcwReference}</td>
                   <td>
-                    <span className={`tf-badge ${pe.eligible ? 'tf-badge--green' : 'tf-badge--red'}`}>
-                      {pe.eligible ? 'Yes' : 'No'}
+                    <span className={`tf-badge ${pe.eligible ? 'tf-badge--green' : 'tf-badge--red'}`} style={{ fontSize: 11 }}>
+                      {pe.eligible ? 'Eligible' : 'Not Eligible'}
                     </span>
                   </td>
-                  <td style={{ fontSize: 12 }}>{pe.reason}</td>
+                  <td style={{ fontSize: 12, color: pe.eligible ? '#00FFAA' : '#94a3b8' }}>{pe.reason}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
       )}
+
+      {/* Reference card */}
+      <div style={{ marginTop: 20, padding: '14px 16px', background: 'rgba(255,255,255,.02)', borderRadius: 8, border: '1px solid rgba(255,255,255,.06)' }}>
+        <h4 style={{ margin: '0 0 10px', fontSize: 13, color: '#94a3b8' }}>Penalty Exception Reference</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: 8 }}>
+          {[
+            { code: 'DEATH', desc: 'Owner death', rcw: 'RCW 84.33.140(6)(a)' },
+            { code: 'GOVT_ACQUISITION', desc: 'Government acquisition / eminent domain', rcw: 'RCW 84.33.140(6)(b)' },
+            { code: 'TRADE_LAND_CONSERVATION', desc: 'Trade for conservation land', rcw: 'RCW 84.34.108(6)(a)' },
+            { code: 'FORCED_SALE', desc: 'Forced sale / condemnation', rcw: 'RCW 84.34.108(6)(b)' },
+            { code: 'TRANSFER_TO_GOVT', desc: 'Transfer to government entity', rcw: 'RCW 84.34.108(6)(c)' },
+          ].map(ex => (
+            <div key={ex.code} style={{ display: 'flex', gap: 8, alignItems: 'baseline', fontSize: 12 }}>
+              <span style={{ color: '#00FFAA', fontFamily: 'monospace', fontSize: 11, minWidth: 140 }}>{ex.code}</span>
+              <span style={{ color: '#94a3b8' }}>{ex.desc}</span>
+              <span style={{ color: '#64748b', fontSize: 10, marginLeft: 'auto' }}>{ex.rcw}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }
@@ -205,13 +373,13 @@ function PenaltyExceptionsSection() {
 export default function CurrentUseRemovalsPage() {
   return (
     <div className="tf-page">
-      <div className="tf-page-header" style={{ marginBottom: 24 }}>
-        <h2>Current Use Removals</h2>
-        <p className="tf-page-sub">
+      <div className="tf-page-header" style={{ marginBottom: 8 }}>
+        <h2 style={{ margin: 0, color: '#f1f5f9' }}>Current Use Program</h2>
+        <p className="tf-page-sub" style={{ marginTop: 4, color: '#64748b', fontSize: 13 }}>
           Benton County WA — Removal proceedings, rollback obligations, and penalty exception evaluation
         </p>
       </div>
-
+      <CuSubNav />
       <RemovalsSection />
       <PenaltyExceptionsSection />
     </div>

--- a/tools/registry/terrapilot.tools.json
+++ b/tools/registry/terrapilot.tools.json
@@ -3425,6 +3425,178 @@
         },
         "required": ["filePath", "content"]
       }
+    },
+    {
+      "toolId": "cu_calculate_rollback",
+      "displayName": "Calculate Rollback Tax",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["parcel", "current_use"],
+      "description": "Calculate rollback taxes, interest, and penalties for a parcel being removed from current use classification per RCW 84.33/84.34",
+      "requiresConfirmation": false,
+      "reasonCodeRequired": false,
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "parcelId": { "type": "string", "description": "Parcel identifier" },
+          "classificationCode": { "type": "string", "enum": ["DFL", "CUFA", "CUOS", "CUTL"], "description": "Current use classification code" },
+          "enrollmentYear": { "type": "integer", "description": "Year parcel was enrolled in current use" },
+          "removalYear": { "type": "integer", "description": "Year of removal from current use" },
+          "marketValues": { "type": "object", "description": "Year-keyed market values for lookback period" },
+          "currentUseValues": { "type": "object", "description": "Year-keyed current use values for lookback period" },
+          "penaltyExceptionCode": { "type": "string", "description": "Optional penalty exception code (DEATH, GOVT_ACQUISITION, etc.)" }
+        },
+        "required": ["parcelId", "classificationCode", "enrollmentYear", "removalYear", "marketValues", "currentUseValues"]
+      }
+    },
+    {
+      "toolId": "cu_calculate_interest",
+      "displayName": "Calculate Current Use Interest",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["current_use"],
+      "description": "Compute compound interest on rollback tax principal using WA DOR published rates per WAC 458-30-262",
+      "requiresConfirmation": false,
+      "reasonCodeRequired": false,
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "principal": { "type": "number", "description": "Rollback tax principal amount" },
+          "startYear": { "type": "integer", "description": "First year of interest accrual" },
+          "endYear": { "type": "integer", "description": "Last year of interest accrual" }
+        },
+        "required": ["principal", "startYear", "endYear"]
+      }
+    },
+    {
+      "toolId": "cu_evaluate_penalty_exceptions",
+      "displayName": "Evaluate Penalty Exceptions",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["parcel", "current_use"],
+      "description": "Evaluate which 20% penalty exceptions apply for a parcel per RCW 84.33.140 / 84.34.108",
+      "requiresConfirmation": false,
+      "reasonCodeRequired": false,
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "parcelId": { "type": "string", "description": "Parcel identifier to evaluate" }
+        },
+        "required": ["parcelId"]
+      }
+    },
+    {
+      "toolId": "cu_initiate_removal",
+      "displayName": "Initiate Current Use Removal",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "write_high",
+      "writeLane": "forge",
+      "touches": ["parcel", "current_use", "workflow"],
+      "description": "Initiate removal of a parcel from current use classification, triggering rollback tax calculation workflow",
+      "requiresConfirmation": true,
+      "reasonCodeRequired": true,
+      "reasonCodes": ["voluntary_withdrawal", "change_of_use", "sale_nonqualifying", "subdivision", "failure_requirements", "govt_acquisition", "owner_death"],
+      "piiHandling": "none",
+      "tracePolicy": "full",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "parcelId": { "type": "string", "description": "Parcel identifier" },
+          "classificationCode": { "type": "string", "enum": ["DFL", "CUFA", "CUOS", "CUTL"], "description": "Current use classification code" },
+          "reason": { "type": "string", "description": "Reason for removal" }
+        },
+        "required": ["parcelId", "classificationCode", "reason"]
+      }
+    },
+    {
+      "toolId": "cu_enroll_parcel",
+      "displayName": "Enroll Parcel in Current Use",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "write_high",
+      "writeLane": "forge",
+      "touches": ["parcel", "current_use"],
+      "description": "Create a new current use classification enrollment for a parcel under RCW 84.33 (DFL) or RCW 84.34 (CUFA/CUOS/CUTL)",
+      "requiresConfirmation": true,
+      "reasonCodeRequired": true,
+      "reasonCodes": ["new_application", "reclassification", "correction"],
+      "piiHandling": "none",
+      "tracePolicy": "full",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "parcelId": { "type": "string", "description": "Parcel identifier" },
+          "classificationCode": { "type": "string", "enum": ["DFL", "CUFA", "CUOS", "CUTL"], "description": "Current use classification code" },
+          "enrollmentDate": { "type": "string", "format": "date", "description": "Date of enrollment" },
+          "acreage": { "type": "number", "description": "Enrolled acreage" },
+          "currentMarketValue": { "type": "number", "description": "Market value at enrollment" },
+          "currentUseValue": { "type": "number", "description": "Current use value at enrollment" }
+        },
+        "required": ["parcelId", "classificationCode", "enrollmentDate"]
+      }
+    },
+    {
+      "toolId": "cu_get_interest_rates",
+      "displayName": "Get Current Use Interest Rates",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["current_use"],
+      "description": "Retrieve all WA DOR published interest rates for current use rollback calculations",
+      "requiresConfirmation": false,
+      "reasonCodeRequired": false,
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "toolId": "cu_list_classifications",
+      "displayName": "List Current Use Classifications",
+      "suite": "forge",
+      "mode": "pilot",
+      "risk": "read_only",
+      "writeLane": null,
+      "touches": ["parcel", "current_use"],
+      "description": "Query current use classifications with filtering by status, code, and pagination",
+      "requiresConfirmation": false,
+      "reasonCodeRequired": false,
+      "piiHandling": "none",
+      "tracePolicy": "summary_only",
+      "officeScope": "assessor",
+      "paramsSchema": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "enum": ["Active", "Removed", "Pending"], "description": "Filter by enrollment status" },
+          "classificationCode": { "type": "string", "enum": ["DFL", "CUFA", "CUOS", "CUTL"], "description": "Filter by classification code" },
+          "page": { "type": "integer", "description": "Page number (1-based)" },
+          "pageSize": { "type": "integer", "description": "Results per page (max 100)" }
+        },
+        "required": []
+      }
     }
   ]
 }


### PR DESCRIPTION
## CUForge Production Polish

### Frontend UI/UX Rewrite (3 pages)
- **CurrentUsePage**: Sub-nav tabs, enrollment form with validation, auto-fill rollback calculator, export/print, loading skeletons, tooltips, pagination, classification badges
- **CurrentUseInterestPage**: Rate chart visualization, year-over-year comparison, export, loading skeleton, DOR rate reference
- **CurrentUseRemovalsPage**: Initiate removal form, status badges, penalty exception evaluator with reference card, loading skeleton

### TerraPilot Tools Registry (7 new tools)
| Tool ID | Risk | Description |
|---------|------|-------------|
| cu_calculate_rollback | read_only | Rollback tax calculation |
| cu_calculate_interest | read_only | Interest computation |
| cu_evaluate_penalty_exceptions | read_only | Exception evaluation |
| cu_initiate_removal | write_high | Removal workflow |
| cu_enroll_parcel | write_high | New enrollment |
| cu_get_interest_rates | read_only | Rate retrieval |
| cu_list_classifications | read_only | Classification query |

All tools follow Gates 4-7 enforcement with proper risk levels, write lanes, trace policies, and params schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation tabs for Current Use program sections
  * Introduced "New Current Use Enrollment" form for parcel registration
  * Added rollback calculator with year-by-year breakdown and export-to-CSV functionality
  * Implemented penalty exception evaluation workflow with eligibility assessments
  * Added removal initiation feature with confirmation flow

* **UI/UX Improvements**
  * Enhanced interest rate display with visual rate charts and improved formatting
  * Redesigned tables with status badges, color-coded indicators, and better readability
  * Added CSV export and print capabilities for calculated results
  * Improved data filtering, pagination, and search functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->