### PR TITLE
polish(terraforge): Full UI/UX overhaul — all pages production-ready

### DIFF
--- a/frontend/apps/terraforge/src/pages/CompsPage.tsx
+++ b/frontend/apps/terraforge/src/pages/CompsPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 const API = '/api/terraforge/comps-pool';
 
+// ── Types ──────────────────────────────────────────────────────────────────
+
 interface CompSale {
   saleId: string;
   parcelId: string;
@@ -30,10 +32,29 @@ interface CompsResponse {
   items: CompSale[];
 }
 
-const fmt$ = (n: number) =>
-  '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
 const fmtDate = (s: string) => s.slice(0, 10);
 const fmtR = (n: number | null) => (n == null ? '—' : n.toFixed(3));
+
+function Skeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────
 
 export default function CompsPage() {
   const [taxYear, setTaxYear]     = useState(2026);
@@ -43,14 +64,17 @@ export default function CompsPage() {
   const [maxPrice, setMaxPrice]   = useState('');
   const [minGla, setMinGla]       = useState('');
   const [maxGla, setMaxGla]       = useState('');
+  const [page, setPage]           = useState(1);
   const [data, setData]           = useState<CompsResponse | null>(null);
   const [loading, setLoading]     = useState(false);
   const [error, setError]         = useState<string | null>(null);
 
+  const pageSize = 50;
+
   useEffect(() => {
     setLoading(true);
     setError(null);
-    const p = new URLSearchParams({ taxYear: String(taxYear), pageSize: '50' });
+    const p = new URLSearchParams({ taxYear: String(taxYear), pageSize: String(pageSize), page: String(page) });
     if (hood)     p.set('hood', hood);
     if (propType) p.set('propertyType', propType);
     if (minPrice) p.set('minPrice', minPrice);
@@ -63,135 +87,131 @@ export default function CompsPage() {
       .then((d: CompsResponse) => setData(d))
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
-  }, [taxYear, hood, propType, minPrice, maxPrice, minGla, maxGla]);
+  }, [taxYear, hood, propType, minPrice, maxPrice, minGla, maxGla, page]);
+
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
+
+  const exportCsv = () => {
+    if (!data?.items.length) return;
+    const header = 'Parcel,Sale Date,Sale Price,GLA,Lot Sqft,Year Built,Condition,Grade,Hood,Sales Ratio,Source\n';
+    const rows = data.items.map(s =>
+      `${s.parcelId},${fmtDate(s.saleDate)},${s.salePrice},${s.gla ?? ''},${s.lotSizeSqft ?? ''},${s.yearBuilt ?? ''},${s.condition ?? ''},${s.qualityGrade ?? ''},${s.hood ?? ''},${s.salesRatio?.toFixed(4) ?? ''},${s.qualificationSource}`
+    ).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `comps_pool_${taxYear}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13 };
 
   return (
     <div className="tf-page">
-      <div className="tf-page-header">
-        <h2>Comparable Sales</h2>
-        <p className="tf-page-sub">Effective qualified comps pool — Benton County WA</p>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
+        <h2>Comparable Sales<Tooltip text="Qualified comparable sales pool used for ratio studies and mass appraisal. Per IAAO Standard on Ratio Studies." /></h2>
+        <p className="tf-page-sub">Benton County WA — Effective qualified comps pool</p>
       </div>
 
       {/* Filters */}
-      <div className="tf-filters">
-        <label>
-          Tax year
-          <select value={taxYear} onChange={e => setTaxYear(Number(e.target.value))}>
+      <div className="tf-filters" style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 16 }}>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Tax Year
+          <select value={taxYear} onChange={e => { setTaxYear(Number(e.target.value)); setPage(1); }} style={inputStyle}>
             {[2026, 2025, 2024].map(y => <option key={y} value={y}>{y}</option>)}
           </select>
         </label>
-        <label>
-          Hood
-          <input
-            type="text"
-            placeholder="e.g. 15112"
-            value={hood}
-            onChange={e => setHood(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 80 }}
-          />
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Neighborhood
+          <input type="text" placeholder="e.g. 15112" value={hood} onChange={e => { setHood(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 80 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Type
-          <input
-            type="text"
-            placeholder="e.g. 11"
-            value={propType}
-            onChange={e => setPropType(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 60 }}
-          />
+          <input type="text" placeholder="e.g. 11" value={propType} onChange={e => { setPropType(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 60 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Min $
-          <input
-            type="number"
-            placeholder="100000"
-            value={minPrice}
-            onChange={e => setMinPrice(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 90 }}
-          />
+          <input type="number" placeholder="100000" value={minPrice} onChange={e => { setMinPrice(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 90 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Max $
-          <input
-            type="number"
-            placeholder="1000000"
-            value={maxPrice}
-            onChange={e => setMaxPrice(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 90 }}
-          />
+          <input type="number" placeholder="1000000" value={maxPrice} onChange={e => { setMaxPrice(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 90 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Min GLA
-          <input
-            type="number"
-            placeholder="800"
-            value={minGla}
-            onChange={e => setMinGla(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" placeholder="800" value={minGla} onChange={e => { setMinGla(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 70 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Max GLA
-          <input
-            type="number"
-            placeholder="5000"
-            value={maxGla}
-            onChange={e => setMaxGla(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 70 }}
-          />
+          <input type="number" placeholder="5000" value={maxGla} onChange={e => { setMaxGla(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 70 }} />
         </label>
-        {data != null && (
-          <span className="tf-count">{data.total.toLocaleString()} qualified sales</span>
-        )}
+        <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px', alignSelf: 'flex-end' }}>⬇ CSV</button>
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error   && <p className="tf-error">Error: {error}</p>}
-
+      {/* Summary bar */}
       {data && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
-            <thead>
-              <tr>
-                <th>Parcel</th>
-                <th>Sale Date</th>
-                <th className="tf-right">Sale Price</th>
-                <th className="tf-right">GLA</th>
-                <th className="tf-right">Lot sqft</th>
-                <th>Year</th>
-                <th>Cond</th>
-                <th>Grade</th>
-                <th>Hood</th>
-                <th className="tf-right">PACS Ratio</th>
-                <th>Source</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.items.length === 0 && (
-                <tr><td colSpan={11} className="tf-empty">No sales match these filters.</td></tr>
-              )}
-              {data.items.map(s => (
-                <tr key={s.saleId}>
-                  <td className="tf-mono">{s.parcelId}</td>
-                  <td>{fmtDate(s.saleDate)}</td>
-                  <td className="tf-right tf-mono">{fmt$(s.salePrice)}</td>
-                  <td className="tf-right">{s.gla?.toLocaleString() ?? '—'}</td>
-                  <td className="tf-right">{s.lotSizeSqft?.toLocaleString() ?? '—'}</td>
-                  <td>{s.yearBuilt ?? '—'}</td>
-                  <td>{s.condition ?? '—'}</td>
-                  <td>{s.qualityGrade ?? '—'}</td>
-                  <td>{s.hood ?? '—'}</td>
-                  <td className="tf-right tf-mono">{fmtR(s.salesRatio)}</td>
-                  <td>
-                    <span className={`tf-badge ${s.qualificationSource === 'decision' ? 'tf-badge--blue' : 'tf-badge--gray'}`}>
-                      {s.qualificationSource}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>
+          <span>{data.total.toLocaleString()} qualified sales · Page {page} of {totalPages}</span>
         </div>
+      )}
+
+      {loading && <Skeleton rows={10} />}
+      {error && <p className="tf-error">Error: {error}</p>}
+
+      {!loading && !error && data && (
+        <>
+          <div className="tf-table-wrap" style={{ maxHeight: 520, overflow: 'auto' }}>
+            <table className="tf-table">
+              <thead>
+                <tr>
+                  <th>Parcel</th>
+                  <th>Sale Date</th>
+                  <th className="tf-right">Sale Price</th>
+                  <th className="tf-right">GLA</th>
+                  <th className="tf-right">Lot sqft</th>
+                  <th>Year</th>
+                  <th>Cond</th>
+                  <th>Grade</th>
+                  <th>Hood</th>
+                  <th className="tf-right">Sales Ratio</th>
+                  <th>Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.length === 0 && (
+                  <tr><td colSpan={11} className="tf-empty">No sales match these filters.</td></tr>
+                )}
+                {data.items.map(s => (
+                  <tr key={s.saleId}>
+                    <td className="tf-mono">{s.parcelId}</td>
+                    <td>{fmtDate(s.saleDate)}</td>
+                    <td className="tf-right tf-mono">{fmt$(s.salePrice)}</td>
+                    <td className="tf-right">{s.gla?.toLocaleString() ?? '—'}</td>
+                    <td className="tf-right">{s.lotSizeSqft?.toLocaleString() ?? '—'}</td>
+                    <td>{s.yearBuilt ?? '—'}</td>
+                    <td>{s.condition ?? '—'}</td>
+                    <td>{s.qualityGrade ?? '—'}</td>
+                    <td>{s.hood ?? '—'}</td>
+                    <td className="tf-right tf-mono">{fmtR(s.salesRatio)}</td>
+                    <td>
+                      <span className={`tf-badge ${s.qualificationSource === 'decision' ? 'tf-badge--blue' : 'tf-badge--gray'}`}>
+                        {s.qualificationSource}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 12 }}>
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>← Prev</button>
+              <span style={{ fontSize: 12, color: 'rgba(226,232,240,.6)', alignSelf: 'center' }}>Page {page} of {totalPages}</span>
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>Next →</button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/apps/terraforge/src/pages/CostSchedulesPage.tsx
+++ b/frontend/apps/terraforge/src/pages/CostSchedulesPage.tsx
@@ -1,8 +1,540 @@
+import { useEffect, useState } from 'react';
+
+const API = '/api/costforge';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface CostMatrixEntry {
+  buildingType: string;
+  qualityGrade: string;
+  baseCostPerSqft: number;
+  effectiveYear: number;
+  region: string;
+}
+
+interface DepreciationBracket {
+  ageMin: number;
+  ageMax: number;
+  conditionGrade: string;
+  depreciationPct: number;
+}
+
+interface CostEstimateResult {
+  baseCost: number;
+  regionFactor: number;
+  qualityFactor: number;
+  conditionFactor: number;
+  depreciatedCost: number;
+  effectiveAge: number;
+  depreciationPct: number;
+  replacementCostNew: number;
+  landValue: number;
+  totalEstimate: number;
+}
+
+interface IncomeApproachResult {
+  grossIncome: number;
+  effectiveGrossIncome: number;
+  operatingExpenses: number;
+  netOperatingIncome: number;
+  capRate: number;
+  indicatedValue: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+const fmtPct = (n: number) => (n * 100).toFixed(1) + '%';
+const fmtDec = (n: number) => n.toFixed(4);
+
+function Skeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
+}
+
+// ── Sub-Navigation ─────────────────────────────────────────────────────────
+
+type Tab = 'matrix' | 'calculator' | 'depreciation' | 'income' | 'analytics';
+
+function SubNav({ active, onChange }: { active: Tab; onChange: (t: Tab) => void }) {
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'matrix', label: 'Cost Matrix' },
+    { id: 'calculator', label: 'Cost Estimate' },
+    { id: 'depreciation', label: 'Depreciation' },
+    { id: 'income', label: 'Income Approach' },
+    { id: 'analytics', label: 'Analytics' },
+  ];
+  return (
+    <nav style={{ display: 'flex', gap: 2, marginBottom: 20, borderBottom: '1px solid rgba(255,255,255,.08)', paddingBottom: 0 }}>
+      {tabs.map(t => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          style={{
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: active === t.id ? 700 : 500,
+            color: active === t.id ? '#00FFAA' : 'rgba(226,232,240,.6)',
+            background: active === t.id ? 'rgba(0,255,170,.06)' : 'transparent',
+            border: 'none',
+            borderBottom: active === t.id ? '2px solid #00FFAA' : '2px solid transparent',
+            cursor: 'pointer',
+            borderRadius: '6px 6px 0 0',
+            transition: 'all .15s',
+          }}
+        >
+          {t.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+// ── Cost Matrix Tab ────────────────────────────────────────────────────────
+
+function CostMatrixTab() {
+  const [data, setData] = useState<CostMatrixEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filterType, setFilterType] = useState('');
+  const [filterRegion, setFilterRegion] = useState('');
+
+  useEffect(() => {
+    fetch(`${API}/cost-matrix/benton`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(d => setData(d.entries || d))
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = data?.filter(e =>
+    (!filterType || e.buildingType.toLowerCase().includes(filterType.toLowerCase())) &&
+    (!filterRegion || e.region.toLowerCase().includes(filterRegion.toLowerCase()))
+  ) ?? [];
+
+  const exportCsv = () => {
+    if (!filtered.length) return;
+    const header = 'Building Type,Quality Grade,Base Cost/Sqft,Effective Year,Region\n';
+    const rows = filtered.map(e => `${e.buildingType},${e.qualityGrade},${e.baseCostPerSqft},${e.effectiveYear},${e.region}`).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'cost_matrix_benton.csv'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: 16 }}>Benton County 2025 Cost Matrix<Tooltip text="Unit costs per square foot by building type and quality grade. Source: WA DOR Cost Manual + local calibration." /></h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>{filtered.length} entries</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input type="text" placeholder="Filter type…" value={filterType} onChange={e => setFilterType(e.target.value)}
+            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 12, width: 120 }} />
+          <input type="text" placeholder="Filter region…" value={filterRegion} onChange={e => setFilterRegion(e.target.value)}
+            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 12, width: 100 }} />
+          <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px' }}>⬇ CSV</button>
+        </div>
+      </div>
+
+      {loading && <Skeleton rows={8} />}
+      {error && <p className="tf-error">Error: {error}</p>}
+
+      {!loading && !error && (
+        <div className="tf-table-wrap" style={{ maxHeight: 480, overflow: 'auto' }}>
+          <table className="tf-table">
+            <thead><tr>
+              <th>Building Type</th><th>Quality Grade</th><th className="tf-right">Base Cost/Sqft</th><th>Year</th><th>Region</th>
+            </tr></thead>
+            <tbody>
+              {filtered.length === 0 && <tr><td colSpan={5} className="tf-empty">No entries match filter.</td></tr>}
+              {filtered.map((e, i) => (
+                <tr key={i}>
+                  <td>{e.buildingType}</td>
+                  <td><span className="tf-badge tf-badge--gray">{e.qualityGrade}</span></td>
+                  <td className="tf-right tf-mono">{fmt$(e.baseCostPerSqft)}</td>
+                  <td>{e.effectiveYear}</td>
+                  <td>{e.region}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── Cost Estimate Calculator Tab ───────────────────────────────────────────
+
+function CostEstimateTab() {
+  const [form, setForm] = useState({
+    buildingType: 'SFR', squareFeet: '2000', qualityGrade: 'Average',
+    conditionGrade: 'Average', yearBuilt: '2005', region: 'Richland', landValue: '80000'
+  });
+  const [result, setResult] = useState<CostEstimateResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildingTypes = ['SFR', 'Duplex', 'Triplex', 'Fourplex', 'MFR', 'Commercial', 'Industrial', 'Agricultural', 'Mobile Home', 'Condo', 'Townhouse'];
+  const qualityGrades = ['Low', 'Fair', 'Average', 'Good', 'Very Good', 'Excellent'];
+  const conditionGrades = ['Poor', 'Fair', 'Average', 'Good', 'Very Good', 'Excellent'];
+  const regions = ['Richland', 'Kennewick', 'West Richland', 'Benton City', 'Prosser', 'Rural'];
+
+  function calculate() {
+    setLoading(true); setError(null); setResult(null);
+    fetch(`${API}/cost-estimate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        buildingType: form.buildingType,
+        squareFeet: Number(form.squareFeet),
+        qualityGrade: form.qualityGrade,
+        conditionGrade: form.conditionGrade,
+        yearBuilt: Number(form.yearBuilt),
+        region: form.region,
+        landValue: Number(form.landValue),
+      })
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(setResult)
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false));
+  }
+
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 13, width: '100%' };
+  const labelStyle: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600 };
+
+  return (
+    <section>
+      <h3 style={{ margin: '0 0 4px', fontSize: 16 }}>Cost Estimate Calculator<Tooltip text="Calculates replacement cost new less depreciation (RCNLD) using the Benton County cost matrix and depreciation schedules." /></h3>
+      <p style={{ margin: '0 0 16px', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>Enter property characteristics to compute the cost approach value.</p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 12, marginBottom: 16 }}>
+        <label style={labelStyle}>Building Type
+          <select value={form.buildingType} onChange={e => setForm(f => ({ ...f, buildingType: e.target.value }))} style={inputStyle}>
+            {buildingTypes.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </label>
+        <label style={labelStyle}>Square Feet
+          <input type="number" value={form.squareFeet} onChange={e => setForm(f => ({ ...f, squareFeet: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={labelStyle}>Quality Grade
+          <select value={form.qualityGrade} onChange={e => setForm(f => ({ ...f, qualityGrade: e.target.value }))} style={inputStyle}>
+            {qualityGrades.map(g => <option key={g} value={g}>{g}</option>)}
+          </select>
+        </label>
+        <label style={labelStyle}>Condition
+          <select value={form.conditionGrade} onChange={e => setForm(f => ({ ...f, conditionGrade: e.target.value }))} style={inputStyle}>
+            {conditionGrades.map(g => <option key={g} value={g}>{g}</option>)}
+          </select>
+        </label>
+        <label style={labelStyle}>Year Built
+          <input type="number" value={form.yearBuilt} onChange={e => setForm(f => ({ ...f, yearBuilt: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={labelStyle}>Region
+          <select value={form.region} onChange={e => setForm(f => ({ ...f, region: e.target.value }))} style={inputStyle}>
+            {regions.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+        <label style={labelStyle}>Land Value ($)
+          <input type="number" value={form.landValue} onChange={e => setForm(f => ({ ...f, landValue: e.target.value }))} style={inputStyle} />
+        </label>
+      </div>
+
+      <button onClick={calculate} disabled={loading} className="tf-btn" style={{ marginBottom: 16 }}>
+        {loading ? 'Calculating…' : 'Calculate Cost Estimate'}
+      </button>
+
+      {error && <p className="tf-error">Error: {error}</p>}
+
+      {result && (
+        <div style={{ background: 'rgba(0,255,170,.03)', border: '1px solid rgba(0,255,170,.15)', borderRadius: 10, padding: 16 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 12, marginBottom: 16 }}>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Replacement Cost New</span><br /><strong style={{ fontSize: 18, color: '#e2e8f0' }}>{fmt$(result.replacementCostNew)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Depreciation</span><br /><strong style={{ fontSize: 18, color: '#fbbf24' }}>{fmtPct(result.depreciationPct)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Depreciated Cost</span><br /><strong style={{ fontSize: 18, color: '#e2e8f0' }}>{fmt$(result.depreciatedCost)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Land Value</span><br /><strong style={{ fontSize: 18, color: '#e2e8f0' }}>{fmt$(result.landValue)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Total Estimate</span><br /><strong style={{ fontSize: 22, color: '#00FFAA' }}>{fmt$(result.totalEstimate)}</strong></div>
+          </div>
+
+          <table className="tf-table" style={{ fontSize: 12 }}>
+            <thead><tr><th>Factor</th><th className="tf-right">Value</th></tr></thead>
+            <tbody>
+              <tr><td>Base Cost</td><td className="tf-right tf-mono">{fmt$(result.baseCost)}</td></tr>
+              <tr><td>Region Factor</td><td className="tf-right tf-mono">{fmtDec(result.regionFactor)}</td></tr>
+              <tr><td>Quality Factor</td><td className="tf-right tf-mono">{fmtDec(result.qualityFactor)}</td></tr>
+              <tr><td>Condition Factor</td><td className="tf-right tf-mono">{fmtDec(result.conditionFactor)}</td></tr>
+              <tr><td>Effective Age</td><td className="tf-right tf-mono">{result.effectiveAge} yrs</td></tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── Depreciation Tab ───────────────────────────────────────────────────────
+
+function DepreciationTab() {
+  const [data, setData] = useState<DepreciationBracket[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API}/depreciation-schedule`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(d => setData(d.brackets || d))
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const exportCsv = () => {
+    if (!data?.length) return;
+    const header = 'Age Min,Age Max,Condition Grade,Depreciation %\n';
+    const rows = data.map(b => `${b.ageMin},${b.ageMax},${b.conditionGrade},${(b.depreciationPct * 100).toFixed(1)}`).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'depreciation_schedule.csv'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: 16 }}>Depreciation Schedule<Tooltip text="Age-life depreciation brackets by condition grade. Applied to replacement cost new to derive depreciated value." /></h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>Residential and commercial brackets</p>
+        </div>
+        <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px' }}>⬇ CSV</button>
+      </div>
+
+      {loading && <Skeleton rows={10} />}
+      {error && <p className="tf-error">Error: {error}</p>}
+
+      {!loading && !error && data && (
+        <div className="tf-table-wrap" style={{ maxHeight: 480, overflow: 'auto' }}>
+          <table className="tf-table">
+            <thead><tr>
+              <th>Age Range</th><th>Condition</th><th className="tf-right">Depreciation %</th>
+              <th style={{ width: 200 }}>Visual</th>
+            </tr></thead>
+            <tbody>
+              {data.map((b, i) => (
+                <tr key={i}>
+                  <td className="tf-mono">{b.ageMin}–{b.ageMax} yrs</td>
+                  <td><span className="tf-badge tf-badge--gray">{b.conditionGrade}</span></td>
+                  <td className="tf-right tf-mono">{(b.depreciationPct * 100).toFixed(1)}%</td>
+                  <td>
+                    <div style={{ background: 'rgba(255,255,255,.05)', borderRadius: 3, height: 14, width: '100%', overflow: 'hidden' }}>
+                      <div style={{ background: b.depreciationPct > 0.5 ? '#ef4444' : b.depreciationPct > 0.3 ? '#fbbf24' : '#00FFAA', height: '100%', width: `${b.depreciationPct * 100}%`, borderRadius: 3, transition: 'width .3s' }} />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── Income Approach Tab ────────────────────────────────────────────────────
+
+function IncomeApproachTab() {
+  const [form, setForm] = useState({
+    grossIncome: '48000', vacancyRate: '5', operatingExpenseRatio: '35', capRate: '6.5'
+  });
+  const [result, setResult] = useState<IncomeApproachResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [capRates, setCapRates] = useState<{ propertyType: string; rate: number }[] | null>(null);
+
+  useEffect(() => {
+    fetch(`${API}/income-approach/cap-rates`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(d => setCapRates(d.rates || d))
+      .catch(() => {});
+  }, []);
+
+  function calculate() {
+    setLoading(true); setError(null); setResult(null);
+    fetch(`${API}/income-approach/calculate-noi`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grossIncome: Number(form.grossIncome),
+        vacancyRate: Number(form.vacancyRate) / 100,
+        operatingExpenseRatio: Number(form.operatingExpenseRatio) / 100,
+        capRate: Number(form.capRate) / 100,
+      })
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(setResult)
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false));
+  }
+
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 13, width: '100%' };
+  const labelStyle: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600 };
+
+  return (
+    <section>
+      <h3 style={{ margin: '0 0 4px', fontSize: 16 }}>Income Approach Valuation<Tooltip text="Capitalizes net operating income (NOI) to derive property value. Used primarily for income-producing properties." /></h3>
+      <p style={{ margin: '0 0 16px', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>Direct capitalization method — NOI ÷ Cap Rate = Value</p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 12, marginBottom: 16 }}>
+        <label style={labelStyle}>Gross Annual Income ($)
+          <input type="number" value={form.grossIncome} onChange={e => setForm(f => ({ ...f, grossIncome: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={labelStyle}>Vacancy Rate (%)
+          <input type="number" step="0.5" value={form.vacancyRate} onChange={e => setForm(f => ({ ...f, vacancyRate: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={labelStyle}>Operating Expense Ratio (%)
+          <input type="number" step="1" value={form.operatingExpenseRatio} onChange={e => setForm(f => ({ ...f, operatingExpenseRatio: e.target.value }))} style={inputStyle} />
+        </label>
+        <label style={labelStyle}>Cap Rate (%)
+          <input type="number" step="0.1" value={form.capRate} onChange={e => setForm(f => ({ ...f, capRate: e.target.value }))} style={inputStyle} />
+        </label>
+      </div>
+
+      <button onClick={calculate} disabled={loading} className="tf-btn" style={{ marginBottom: 16 }}>
+        {loading ? 'Calculating…' : 'Calculate Income Value'}
+      </button>
+
+      {error && <p className="tf-error">Error: {error}</p>}
+
+      {result && (
+        <div style={{ background: 'rgba(99,102,241,.04)', border: '1px solid rgba(99,102,241,.15)', borderRadius: 10, padding: 16 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 12 }}>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Gross Income</span><br /><strong style={{ color: '#e2e8f0' }}>{fmt$(result.grossIncome)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Effective Gross Income</span><br /><strong style={{ color: '#e2e8f0' }}>{fmt$(result.effectiveGrossIncome)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Operating Expenses</span><br /><strong style={{ color: '#fbbf24' }}>−{fmt$(result.operatingExpenses)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Net Operating Income</span><br /><strong style={{ color: '#e2e8f0' }}>{fmt$(result.netOperatingIncome)}</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Cap Rate</span><br /><strong style={{ color: '#e2e8f0' }}>{(result.capRate * 100).toFixed(2)}%</strong></div>
+            <div><span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Indicated Value</span><br /><strong style={{ fontSize: 22, color: '#00FFAA' }}>{fmt$(result.indicatedValue)}</strong></div>
+          </div>
+        </div>
+      )}
+
+      {capRates && capRates.length > 0 && (
+        <div style={{ marginTop: 20 }}>
+          <h4 style={{ fontSize: 13, color: 'rgba(226,232,240,.7)', marginBottom: 8 }}>Reference Cap Rates — Benton County</h4>
+          <div className="tf-table-wrap">
+            <table className="tf-table" style={{ fontSize: 12 }}>
+              <thead><tr><th>Property Type</th><th className="tf-right">Cap Rate</th></tr></thead>
+              <tbody>
+                {capRates.map((cr, i) => (
+                  <tr key={i}><td>{cr.propertyType}</td><td className="tf-right tf-mono">{(cr.rate * 100).toFixed(2)}%</td></tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── Analytics Tab ──────────────────────────────────────────────────────────
+
+function AnalyticsTab() {
+  const [buildingTypes, setBuildingTypes] = useState<string[]>([]);
+  const [regions, setRegions] = useState<string[]>([]);
+  const [status, setStatus] = useState<{ totalValuations: number; lastSync: string; engineVersion: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`${API}/building-types`).then(r => r.ok ? r.json() : []),
+      fetch(`${API}/regions`).then(r => r.ok ? r.json() : []),
+      fetch(`${API}/status`).then(r => r.ok ? r.json() : null),
+    ]).then(([bt, rg, st]) => {
+      setBuildingTypes(bt.types || bt || []);
+      setRegions(rg.regions || rg || []);
+      setStatus(st);
+    }).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <Skeleton rows={6} />;
+
+  return (
+    <section>
+      <h3 style={{ margin: '0 0 16px', fontSize: 16 }}>CostForge Analytics & Status<Tooltip text="System status, supported building types, and regional coverage for the cost approach engine." /></h3>
+
+      {status && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12, marginBottom: 20 }}>
+          <div style={{ background: 'rgba(255,255,255,.03)', borderRadius: 8, padding: 12 }}>
+            <span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Total Valuations</span><br />
+            <strong style={{ fontSize: 20, color: '#e2e8f0' }}>{status.totalValuations?.toLocaleString() ?? '—'}</strong>
+          </div>
+          <div style={{ background: 'rgba(255,255,255,.03)', borderRadius: 8, padding: 12 }}>
+            <span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Engine Version</span><br />
+            <strong style={{ fontSize: 20, color: '#e2e8f0' }}>{status.engineVersion ?? '—'}</strong>
+          </div>
+          <div style={{ background: 'rgba(255,255,255,.03)', borderRadius: 8, padding: 12 }}>
+            <span style={{ fontSize: 11, color: 'rgba(148,163,184,.6)' }}>Last Sync</span><br />
+            <strong style={{ fontSize: 14, color: '#e2e8f0' }}>{status.lastSync ?? '—'}</strong>
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+        <div>
+          <h4 style={{ fontSize: 13, color: 'rgba(226,232,240,.7)', marginBottom: 8 }}>Supported Building Types ({buildingTypes.length})</h4>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {buildingTypes.map(t => (
+              <span key={t} className="tf-badge tf-badge--gray" style={{ fontSize: 11 }}>{t}</span>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h4 style={{ fontSize: 13, color: 'rgba(226,232,240,.7)', marginBottom: 8 }}>Supported Regions ({regions.length})</h4>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {regions.map(r => (
+              <span key={r} className="tf-badge tf-badge--blue" style={{ fontSize: 11 }}>{r}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────
+
 export default function CostSchedulesPage() {
+  const [tab, setTab] = useState<Tab>('matrix');
+
   return (
     <div className="tf-page">
-      <h2>Cost Schedules</h2>
-      <p className="tf-page-sub">Depreciation &amp; unit cost matrices — Phase 2</p>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
+        <h2>Cost Approach</h2>
+        <p className="tf-page-sub">
+          Benton County WA — Replacement cost new less depreciation (RCNLD) · WA DOR Cost Manual 2025
+        </p>
+      </div>
+
+      <SubNav active={tab} onChange={setTab} />
+
+      {tab === 'matrix' && <CostMatrixTab />}
+      {tab === 'calculator' && <CostEstimateTab />}
+      {tab === 'depreciation' && <DepreciationTab />}
+      {tab === 'income' && <IncomeApproachTab />}
+      {tab === 'analytics' && <AnalyticsTab />}
     </div>
   );
 }

--- a/frontend/apps/terraforge/src/pages/LevyPage.tsx
+++ b/frontend/apps/terraforge/src/pages/LevyPage.tsx
@@ -35,18 +35,70 @@ interface CalcResponse {
   breakdown: BreakdownLine[];
 }
 
-// ── Formatters ─────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-const fmtRate  = (r: number) => r.toFixed(4);
-const fmt$     = (n: number) => '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const fmtRate = (r: number) => r.toFixed(4);
+const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
-// ── Rate Table ─────────────────────────────────────────────────────────────
+function Skeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
+}
+
+// ── Sub-Navigation ─────────────────────────────────────────────────────────
+
+type Tab = 'rates' | 'calculator';
+
+function SubNav({ active, onChange }: { active: Tab; onChange: (t: Tab) => void }) {
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'rates', label: 'Levy Rates' },
+    { id: 'calculator', label: 'Bill Calculator' },
+  ];
+  return (
+    <nav style={{ display: 'flex', gap: 2, marginBottom: 20, borderBottom: '1px solid rgba(255,255,255,.08)', paddingBottom: 0 }}>
+      {tabs.map(t => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          style={{
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: active === t.id ? 700 : 500,
+            color: active === t.id ? '#00FFAA' : 'rgba(226,232,240,.6)',
+            background: active === t.id ? 'rgba(0,255,170,.06)' : 'transparent',
+            border: 'none',
+            borderBottom: active === t.id ? '2px solid #00FFAA' : '2px solid transparent',
+            cursor: 'pointer',
+            borderRadius: '6px 6px 0 0',
+            transition: 'all .15s',
+          }}
+        >
+          {t.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+// ── Rate Table Section ─────────────────────────────────────────────────────
 
 function RatesSection() {
-  const [year,    setYear]    = useState(2026);
-  const [data,    setData]    = useState<RatesResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error,   setError]   = useState<string | null>(null);
+  const [year, setYear] = useState(2026);
+  const [data, setData] = useState<RatesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
 
   useEffect(() => {
     setLoading(true);
@@ -58,30 +110,48 @@ function RatesSection() {
       .finally(() => setLoading(false));
   }, [year]);
 
+  const filtered = data?.rates.filter(r =>
+    !filter || r.levyCd.toLowerCase().includes(filter.toLowerCase()) ||
+    (r.levyDescription ?? '').toLowerCase().includes(filter.toLowerCase())
+  ) ?? [];
+
+  const totalRate = filtered.reduce((sum, r) => sum + r.levyRate, 0);
+
+  const exportCsv = () => {
+    if (!filtered.length) return;
+    const header = 'Levy Code,Description,Type,Rate per $1000,Certified\n';
+    const rows = filtered.map(r => `${r.levyCd},"${r.levyDescription ?? ''}",${r.levyTypeCd ?? ''},${r.levyRate.toFixed(4)},${r.includeInCertification}`).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `levy_rates_${year}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <section className="tf-section">
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Levy Rates</h3>
-        <div className="tf-filters">
-          <label>
-            Tax year
-            <select value={year} onChange={e => setYear(Number(e.target.value))}>
-              {[2026, 2025, 2024].map(y => <option key={y} value={y}>{y}</option>)}
-            </select>
-          </label>
-          {data && (
-            <span className="tf-count">
-              {data.count} levy codes · {year}
-            </span>
-          )}
+    <section>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: 16 }}>Certified Levy Rates<Tooltip text="Levy rates per $1,000 of assessed value as certified by the Benton County Assessor. Per RCW 84.52." /></h3>
+          <p style={{ margin: '4px 0 0', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>
+            {filtered.length} levy codes · Total composite rate: {fmtRate(totalRate)} / $1,000
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <select value={year} onChange={e => setYear(Number(e.target.value))}
+            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 12 }}>
+            {[2026, 2025, 2024, 2023].map(y => <option key={y} value={y}>{y}</option>)}
+          </select>
+          <input type="text" placeholder="Filter…" value={filter} onChange={e => setFilter(e.target.value)}
+            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 12, width: 120 }} />
+          <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px' }}>⬇ CSV</button>
         </div>
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error   && <p className="tf-error">Error: {error}</p>}
+      {loading && <Skeleton rows={10} />}
+      {error && <p className="tf-error" style={{ marginTop: 8 }}>Error: {error}</p>}
 
-      {data && (
-        <div className="tf-table-wrap">
+      {!loading && !error && (
+        <div className="tf-table-wrap" style={{ maxHeight: 480, overflow: 'auto' }}>
           <table className="tf-table">
             <thead>
               <tr>
@@ -93,16 +163,14 @@ function RatesSection() {
               </tr>
             </thead>
             <tbody>
-              {data.rates.length === 0 && (
-                <tr><td colSpan={5} className="tf-empty">No levy rates seeded for {year}. Run sync first.</td></tr>
+              {filtered.length === 0 && (
+                <tr><td colSpan={5} className="tf-empty">No levy rates found for {year}.</td></tr>
               )}
-              {data.rates.map(r => (
+              {filtered.map(r => (
                 <tr key={r.levyCd}>
                   <td className="tf-mono">{r.levyCd}</td>
                   <td>{r.levyDescription ?? '—'}</td>
-                  <td>
-                    <span className="tf-badge tf-badge--gray">{r.levyTypeCd ?? '—'}</span>
-                  </td>
+                  <td><span className="tf-badge tf-badge--gray">{r.levyTypeCd ?? '—'}</span></td>
                   <td className="tf-right tf-mono">{fmtRate(r.levyRate)}</td>
                   <td style={{ textAlign: 'center' }}>
                     {r.includeInCertification ? (
@@ -113,6 +181,13 @@ function RatesSection() {
                   </td>
                 </tr>
               ))}
+              {filtered.length > 0 && (
+                <tr style={{ borderTop: '1px solid rgba(255,255,255,.15)', fontWeight: 600 }}>
+                  <td colSpan={3} style={{ textAlign: 'right', paddingRight: 16, color: '#e2e8f0' }}>Total Composite Rate</td>
+                  <td className="tf-right tf-mono" style={{ color: '#00FFAA' }}>{fmtRate(totalRate)}</td>
+                  <td />
+                </tr>
+              )}
             </tbody>
           </table>
         </div>
@@ -121,26 +196,20 @@ function RatesSection() {
   );
 }
 
-// ── Bill Calculator ────────────────────────────────────────────────────────
+// ── Bill Calculator Section ────────────────────────────────────────────────
 
 function CalculatorSection() {
-  const [year,          setYear]          = useState(2026);
+  const [year, setYear] = useState(2026);
   const [taxAreaNumber, setTaxAreaNumber] = useState('');
   const [assessedValue, setAssessedValue] = useState('');
-  const [result,        setResult]        = useState<CalcResponse | null>(null);
-  const [loading,       setLoading]       = useState(false);
-  const [error,         setError]         = useState<string | null>(null);
+  const [result, setResult] = useState<CalcResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   function runCalc() {
     if (!taxAreaNumber.trim() || !assessedValue.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
-    const params = new URLSearchParams({
-      taxAreaNumber: taxAreaNumber.trim(),
-      assessedValue:  assessedValue.trim(),
-      year:           String(year)
-    });
+    setLoading(true); setError(null); setResult(null);
+    const params = new URLSearchParams({ taxAreaNumber: taxAreaNumber.trim(), assessedValue: assessedValue.trim(), year: String(year) });
     fetch(`${API}/calculate?${params}`)
       .then(async r => {
         if (r.status === 404) throw new Error(`Tax area ${taxAreaNumber} not found for ${year}`);
@@ -152,68 +221,63 @@ function CalculatorSection() {
       .finally(() => setLoading(false));
   }
 
-  return (
-    <section className="tf-section" style={{ marginTop: 32 }}>
-      <div className="tf-page-header">
-        <h3 style={{ margin: 0 }}>Levy Bill Calculator</h3>
-        <p className="tf-page-sub" style={{ marginTop: 4 }}>
-          Enter a tax area code and assessed value to compute the itemized levy bill.
-        </p>
-      </div>
+  const exportCsv = () => {
+    if (!result) return;
+    const header = 'Levy Code,Description,Type,Rate per $1000,Amount\n';
+    const rows = result.breakdown.map(l => `${l.levyCd},"${l.levyDescription ?? ''}",${l.levyTypeCd ?? ''},${l.levyRate.toFixed(4)},${l.amount.toFixed(2)}`).join('\n');
+    const blob = new Blob([header + rows + `\nTOTAL,,,, ${result.totalLevy.toFixed(2)}`], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `levy_bill_${result.taxAreaNumber}_${result.year}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
 
-      <div className="tf-filters" style={{ alignItems: 'flex-end', gap: 12 }}>
-        <label>
-          Tax year
-          <select value={year} onChange={e => setYear(Number(e.target.value))}>
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '5px 9px', fontSize: 13 };
+
+  return (
+    <section>
+      <h3 style={{ margin: '0 0 4px', fontSize: 16 }}>Levy Bill Calculator<Tooltip text="Computes the itemized property tax bill by applying all certified levy rates to the assessed value for a given tax area." /></h3>
+      <p style={{ margin: '0 0 16px', fontSize: 12, color: 'rgba(148,163,184,.7)' }}>Enter a tax area code and assessed value to compute the itemized levy bill.</p>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-end', flexWrap: 'wrap', marginBottom: 16 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600 }}>
+          Tax Year
+          <select value={year} onChange={e => setYear(Number(e.target.value))} style={inputStyle}>
             {[2026, 2025, 2024].map(y => <option key={y} value={y}>{y}</option>)}
           </select>
         </label>
-        <label>
-          Tax area number
-          <input
-            type="text"
-            placeholder="e.g. 1210"
-            value={taxAreaNumber}
-            onChange={e => setTaxAreaNumber(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 100 }}
-          />
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600 }}>
+          Tax Area Number
+          <input type="text" placeholder="e.g. 1210" value={taxAreaNumber} onChange={e => setTaxAreaNumber(e.target.value)} style={{ ...inputStyle, width: 100 }} />
         </label>
-        <label>
-          Assessed value ($)
-          <input
-            type="number"
-            placeholder="e.g. 400000"
-            value={assessedValue}
-            onChange={e => setAssessedValue(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 120 }}
-          />
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600 }}>
+          Assessed Value ($)
+          <input type="number" placeholder="e.g. 400000" value={assessedValue} onChange={e => setAssessedValue(e.target.value)} style={{ ...inputStyle, width: 130 }} />
         </label>
-        <button
-          onClick={runCalc}
-          disabled={loading || !taxAreaNumber.trim() || !assessedValue.trim()}
-          className="tf-btn"
-        >
+        <button onClick={runCalc} disabled={loading || !taxAreaNumber.trim() || !assessedValue.trim()} className="tf-btn">
           {loading ? 'Calculating…' : 'Calculate'}
         </button>
       </div>
 
-      {error  && <p className="tf-error" style={{ marginTop: 12 }}>Error: {error}</p>}
+      {error && <p className="tf-error">Error: {error}</p>}
 
       {result && (
-        <div style={{ marginTop: 16 }}>
-          <div style={{ marginBottom: 12, color: '#94a3b8', fontSize: 13 }}>
-            Tax area <strong style={{ color: '#e2e8f0' }}>{result.taxAreaNumber}</strong> · AV {fmt$(result.assessedValue)} · Year {result.year}
+        <div style={{ background: 'rgba(0,255,170,.03)', border: '1px solid rgba(0,255,170,.15)', borderRadius: 10, padding: 16 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <div style={{ color: '#94a3b8', fontSize: 13 }}>
+              Tax area <strong style={{ color: '#e2e8f0' }}>{result.taxAreaNumber}</strong> · AV {fmt$(result.assessedValue)} · Year {result.year}
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '4px 8px' }}>⬇ CSV</button>
+              <button onClick={() => window.print()} className="tf-btn" style={{ fontSize: 11, padding: '4px 8px' }}>🖨 Print</button>
+            </div>
           </div>
 
           <div className="tf-table-wrap">
             <table className="tf-table">
               <thead>
                 <tr>
-                  <th>Levy Code</th>
-                  <th>Description</th>
-                  <th>Type</th>
-                  <th className="tf-right">Rate / $1,000</th>
-                  <th className="tf-right">Amount</th>
+                  <th>Levy Code</th><th>Description</th><th>Type</th>
+                  <th className="tf-right">Rate / $1,000</th><th className="tf-right">Amount</th>
                 </tr>
               </thead>
               <tbody>
@@ -227,12 +291,8 @@ function CalculatorSection() {
                   </tr>
                 ))}
                 <tr style={{ borderTop: '1px solid rgba(255,255,255,.15)', fontWeight: 600 }}>
-                  <td colSpan={4} style={{ textAlign: 'right', paddingRight: 16, color: '#e2e8f0' }}>
-                    Total Levy
-                  </td>
-                  <td className="tf-right tf-mono" style={{ color: '#00FFAA' }}>
-                    {fmt$(result.totalLevy)}
-                  </td>
+                  <td colSpan={4} style={{ textAlign: 'right', paddingRight: 16, color: '#e2e8f0' }}>Total Levy</td>
+                  <td className="tf-right tf-mono" style={{ color: '#00FFAA', fontSize: 16 }}>{fmt$(result.totalLevy)}</td>
                 </tr>
               </tbody>
             </table>
@@ -246,17 +306,21 @@ function CalculatorSection() {
 // ── Page ───────────────────────────────────────────────────────────────────
 
 export default function LevyPage() {
+  const [tab, setTab] = useState<Tab>('rates');
+
   return (
     <div className="tf-page">
-      <div className="tf-page-header" style={{ marginBottom: 24 }}>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
         <h2>Levy Rates</h2>
         <p className="tf-page-sub">
-          Benton County WA — certified levy rates per $1,000 assessed value · Source: PACS dbo.levy
+          Benton County WA — Certified levy rates per $1,000 assessed value · Per RCW 84.52
         </p>
       </div>
 
-      <RatesSection />
-      <CalculatorSection />
+      <SubNav active={tab} onChange={setTab} />
+
+      {tab === 'rates' && <RatesSection />}
+      {tab === 'calculator' && <CalculatorSection />}
     </div>
   );
 }

--- a/frontend/apps/terraforge/src/pages/RatioStudyPage.tsx
+++ b/frontend/apps/terraforge/src/pages/RatioStudyPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 const API = '/api/terraforge/ratio-study';
 
+// ── Types ──────────────────────────────────────────────────────────────────
+
 interface Stats {
   medianRatio: number | null;
   meanRatio: number | null;
@@ -33,34 +35,62 @@ interface RatioStudyResponse {
   pageSize: number;
 }
 
-const fmt$  = (n: number) => '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
-const fmtR  = (n: number | null) => n == null ? '—' : n.toFixed(4);
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+const fmtR = (n: number | null) => n == null ? '—' : n.toFixed(4);
 const fmtPct = (n: number | null) => n == null ? '—' : n.toFixed(2) + '%';
 const fmtDate = (s: string) => s.slice(0, 10);
+
+function Skeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
+}
 
 function IaaoGate({ label, value, lo, hi }: { label: string; value: number | null; lo: number; hi: number }) {
   if (value == null) return null;
   const pass = value >= lo && value <= hi;
   return (
-    <span className={`tf-badge ${pass ? 'tf-badge--green' : 'tf-badge--red'}`}>
-      {label}: {typeof value === 'number' && label === 'COD' ? fmtPct(value) : fmtR(value)}
-      {pass ? ' ✓' : ' ✗'}
-    </span>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span className={`tf-badge ${pass ? 'tf-badge--green' : 'tf-badge--red'}`}>
+        {label}: {label === 'COD' ? fmtPct(value) : fmtR(value)}
+        {pass ? ' PASS' : ' FAIL'}
+      </span>
+      <span style={{ fontSize: 10, color: 'rgba(148,163,184,.5)' }}>
+        (target: {label === 'COD' ? `≤${hi}%` : `${lo}–${hi}`})
+      </span>
+    </div>
   );
 }
 
+// ── Main Page ──────────────────────────────────────────────────────────────
+
 export default function RatioStudyPage() {
-  const [taxYear,   setTaxYear]   = useState(2026);
-  const [hood,      setHood]      = useState('');
-  const [propType,  setPropType]  = useState('');
-  const [data,      setData]      = useState<RatioStudyResponse | null>(null);
-  const [loading,   setLoading]   = useState(false);
-  const [error,     setError]     = useState<string | null>(null);
+  const [taxYear, setTaxYear]   = useState(2026);
+  const [hood, setHood]         = useState('');
+  const [propType, setPropType] = useState('');
+  const [page, setPage]         = useState(1);
+  const [data, setData]         = useState<RatioStudyResponse | null>(null);
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState<string | null>(null);
+
+  const pageSize = 50;
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    const params = new URLSearchParams({ taxYear: String(taxYear), pageSize: '50' });
+    const params = new URLSearchParams({ taxYear: String(taxYear), pageSize: String(pageSize), page: String(page) });
     if (hood)     params.set('hood', hood);
     if (propType) params.set('propertyType', propType);
     fetch(`${API}?${params}`)
@@ -68,58 +98,62 @@ export default function RatioStudyPage() {
       .then(setData)
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
-  }, [taxYear, hood, propType]);
+  }, [taxYear, hood, propType, page]);
 
   const { stats, total, countWithRatio, outliersExcluded, items } = data ?? {};
+  const totalPages = total ? Math.ceil(total / pageSize) : 0;
+
+  const exportCsv = () => {
+    if (!items?.length) return;
+    const header = 'Parcel,Sale Date,Sale Price,GLA,Year Built,Hood,Sales Ratio,Source\n';
+    const rows = items.map(r =>
+      `${r.parcelId},${fmtDate(r.saleDate)},${r.salePrice},${r.gla ?? ''},${r.yearBuilt ?? ''},${r.hood ?? ''},${r.salesRatio?.toFixed(4) ?? ''},${r.qualificationSource}`
+    ).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `ratio_study_${taxYear}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13 };
 
   return (
     <div className="tf-page">
-      <div className="tf-page-header">
-        <h2>Ratio Study</h2>
-        <p className="tf-page-sub">County-wide IAAO ratio analysis — Benton County WA</p>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
+        <h2>Ratio Study<Tooltip text="IAAO Standard on Ratio Studies — measures assessment uniformity and equity. Median ratio target: 0.95–1.05, COD ≤ 15%, PRD 0.98–1.03." /></h2>
+        <p className="tf-page-sub">Benton County WA — IAAO ratio analysis for assessment equity</p>
       </div>
 
       {/* Filters */}
-      <div className="tf-filters">
-        <label>
-          Tax year
-          <select value={taxYear} onChange={e => setTaxYear(Number(e.target.value))}>
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 16 }}>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Tax Year
+          <select value={taxYear} onChange={e => { setTaxYear(Number(e.target.value)); setPage(1); }} style={inputStyle}>
             {[2026, 2025, 2024].map(y => <option key={y} value={y}>{y}</option>)}
           </select>
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Neighborhood
-          <input
-            type="text"
-            placeholder="e.g. 15112"
-            value={hood}
-            onChange={e => setHood(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 100 }}
-          />
+          <input type="text" placeholder="e.g. 15112" value={hood} onChange={e => { setHood(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 100 }} />
         </label>
-        <label>
-          Prop type
-          <input
-            type="text"
-            placeholder="e.g. R"
-            value={propType}
-            onChange={e => setPropType(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 60 }}
-          />
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Prop Type
+          <input type="text" placeholder="e.g. R" value={propType} onChange={e => { setPropType(e.target.value); setPage(1); }} style={{ ...inputStyle, width: 60 }} />
         </label>
-        {total != null && (
-          <span className="tf-count">
-            {total.toLocaleString()} qualified · {countWithRatio?.toLocaleString()} with ratio
-            {outliersExcluded != null && outliersExcluded > 0 && (
-              <span style={{ color: 'rgba(226,232,240,.45)', marginLeft: 6 }}>
-                · {outliersExcluded} IQR outliers excluded from stats
-              </span>
-            )}
-          </span>
-        )}
+        <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px', alignSelf: 'flex-end' }}>⬇ CSV</button>
       </div>
 
-      {/* IAAO stats */}
+      {/* Summary stats */}
+      {data && (
+        <div style={{ fontSize: 12, color: 'rgba(148,163,184,.7)', marginBottom: 12 }}>
+          {total?.toLocaleString()} qualified · {countWithRatio?.toLocaleString()} with ratio
+          {outliersExcluded != null && outliersExcluded > 0 && (
+            <span style={{ marginLeft: 8 }}>· {outliersExcluded} IQR outliers excluded from stats</span>
+          )}
+        </div>
+      )}
+
+      {/* IAAO stats cards */}
       {stats && (
         <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 20 }}>
           <div className="tf-card" style={{ padding: '14px 18px', cursor: 'default' }}>
@@ -142,54 +176,65 @@ export default function RatioStudyPage() {
             <div className="tf-cardSmall">IAAO 0.98–1.03</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, justifyContent: 'center' }}>
-            <IaaoGate label="COD" value={stats.cod}       lo={0}    hi={15}   />
-            <IaaoGate label="PRD" value={stats.prd}       lo={0.98} hi={1.03} />
+            <IaaoGate label="COD" value={stats.cod} lo={0} hi={15} />
+            <IaaoGate label="PRD" value={stats.prd} lo={0.98} hi={1.03} />
           </div>
         </div>
       )}
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error   && <p className="tf-error">Error: {error}</p>}
+      {loading && <Skeleton rows={10} />}
+      {error && <p className="tf-error">Error: {error}</p>}
 
       {/* Sales table */}
-      {items && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
-            <thead>
-              <tr>
-                <th>Parcel</th>
-                <th>Sale Date</th>
-                <th className="tf-right">Sale Price</th>
-                <th className="tf-right">GLA</th>
-                <th>Year Built</th>
-                <th>Hood</th>
-                <th className="tf-right">Ratio</th>
-                <th>Source</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.length === 0 && (
-                <tr><td className="tf-empty" colSpan={8}>No qualified sales in this window.</td></tr>
-              )}
-              {items.map(r => (
-                <tr key={r.saleId}>
-                  <td className="tf-mono">{r.parcelId}</td>
-                  <td>{fmtDate(r.saleDate)}</td>
-                  <td className="tf-right tf-mono">{fmt$(r.salePrice)}</td>
-                  <td className="tf-right">{r.gla?.toLocaleString() ?? '—'}</td>
-                  <td>{r.yearBuilt ?? '—'}</td>
-                  <td>{r.hood ?? '—'}</td>
-                  <td className="tf-right tf-mono">{fmtR(r.salesRatio)}</td>
-                  <td>
-                    <span className={`tf-badge ${r.qualificationSource === 'decision' ? 'tf-badge--blue' : 'tf-badge--gray'}`}>
-                      {r.qualificationSource}
-                    </span>
-                  </td>
+      {!loading && !error && items && (
+        <>
+          <div className="tf-table-wrap" style={{ maxHeight: 480, overflow: 'auto' }}>
+            <table className="tf-table">
+              <thead>
+                <tr>
+                  <th>Parcel</th>
+                  <th>Sale Date</th>
+                  <th className="tf-right">Sale Price</th>
+                  <th className="tf-right">GLA</th>
+                  <th>Year Built</th>
+                  <th>Hood</th>
+                  <th className="tf-right">Sales Ratio</th>
+                  <th>Source</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {items.length === 0 && (
+                  <tr><td className="tf-empty" colSpan={8}>No qualified sales in this window.</td></tr>
+                )}
+                {items.map(r => (
+                  <tr key={r.saleId}>
+                    <td className="tf-mono">{r.parcelId}</td>
+                    <td>{fmtDate(r.saleDate)}</td>
+                    <td className="tf-right tf-mono">{fmt$(r.salePrice)}</td>
+                    <td className="tf-right">{r.gla?.toLocaleString() ?? '—'}</td>
+                    <td>{r.yearBuilt ?? '—'}</td>
+                    <td>{r.hood ?? '—'}</td>
+                    <td className="tf-right tf-mono">{fmtR(r.salesRatio)}</td>
+                    <td>
+                      <span className={`tf-badge ${r.qualificationSource === 'decision' ? 'tf-badge--blue' : 'tf-badge--gray'}`}>
+                        {r.qualificationSource}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 12 }}>
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>← Prev</button>
+              <span style={{ fontSize: 12, color: 'rgba(226,232,240,.6)', alignSelf: 'center' }}>Page {page} of {totalPages}</span>
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>Next →</button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/apps/terraforge/src/pages/RegressionPage.tsx
+++ b/frontend/apps/terraforge/src/pages/RegressionPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 const API = '/api/terraforge/regression';
 
+// ── Types ──────────────────────────────────────────────────────────────────
+
 interface RegressionModel {
   predictors: string[];
   beta: number[];
@@ -38,8 +40,9 @@ interface RegressionResponse {
   residuals: ResidualRow[];
 }
 
-const fmt$ = (n: number) =>
-  '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const fmt$ = (n: number) => '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
 const fmtDate = (s: string) => s.slice(0, 10);
 
 function fmtBeta(name: string, value: number) {
@@ -49,6 +52,24 @@ function fmtBeta(name: string, value: number) {
   }
   return (value >= 0 ? '+' : '') + '$' + value.toFixed(2) + '/yr';
 }
+
+function Skeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────
 
 export default function RegressionPage() {
   const [taxYear, setTaxYear]   = useState(2026);
@@ -74,61 +95,66 @@ export default function RegressionPage() {
 
   const m = data?.model;
 
+  const exportCsv = () => {
+    if (!data?.residuals.length) return;
+    const header = 'Parcel,Sale Date,Sale Price,Fitted,Residual,% Residual,GLA,Year Built,Hood\n';
+    const rows = data.residuals.map(r =>
+      `${r.parcelId},${fmtDate(r.saleDate)},${r.salePrice},${r.fitted.toFixed(0)},${r.residual.toFixed(0)},${r.percentResidual?.toFixed(2) ?? ''},${r.gla ?? ''},${r.yearBuilt ?? ''},${r.hood ?? ''}`
+    ).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `regression_residuals_${taxYear}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13 };
+
   return (
     <div className="tf-page">
-      <div className="tf-page-header">
-        <h2>OLS Regression</h2>
-        <p className="tf-page-sub">County-wide hedonic model — SalePrice ~ GLA + LotSqft + YearBuilt</p>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
+        <h2>OLS Regression<Tooltip text="Ordinary Least Squares hedonic model. Estimates property value as a function of GLA, lot size, and year built. Per IAAO Standard on Mass Appraisal." /></h2>
+        <p className="tf-page-sub">Benton County WA — Hedonic model: SalePrice ~ GLA + LotSqft + YearBuilt</p>
       </div>
 
       {/* Filters */}
-      <div className="tf-filters">
-        <label>
-          Tax year
-          <select value={taxYear} onChange={e => setTaxYear(Number(e.target.value))}>
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 16 }}>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Tax Year
+          <select value={taxYear} onChange={e => setTaxYear(Number(e.target.value))} style={inputStyle}>
             {[2026, 2025, 2024].map(y => <option key={y} value={y}>{y}</option>)}
           </select>
         </label>
-        <label>
-          Hood
-          <input
-            type="text"
-            placeholder="e.g. 15112"
-            value={hood}
-            onChange={e => setHood(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 80 }}
-          />
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Neighborhood
+          <input type="text" placeholder="e.g. 15112" value={hood} onChange={e => setHood(e.target.value)} style={{ ...inputStyle, width: 80 }} />
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Type
-          <input
-            type="text"
-            placeholder="e.g. 11"
-            value={propType}
-            onChange={e => setPropType(e.target.value)}
-            style={{ background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13, width: 60 }}
-          />
+          <input type="text" placeholder="e.g. 11" value={propType} onChange={e => setPropType(e.target.value)} style={{ ...inputStyle, width: 60 }} />
         </label>
-        {data && (
-          <span className="tf-count">
-            pool: {data.totalPool.toLocaleString()} · fit: {data.usedForFit.toLocaleString()} · excluded: {data.excludedCount}
-          </span>
-        )}
+        <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px', alignSelf: 'flex-end' }}>⬇ CSV</button>
       </div>
 
-      {loading && <p className="tf-loading">Running regression…</p>}
-      {error   && <p className="tf-error">Error: {error}</p>}
+      {/* Pool stats */}
+      {data && (
+        <div style={{ fontSize: 12, color: 'rgba(148,163,184,.7)', marginBottom: 12 }}>
+          Pool: {data.totalPool.toLocaleString()} · Fit: {data.usedForFit.toLocaleString()} · Excluded: {data.excludedCount}
+        </div>
+      )}
+
+      {loading && <Skeleton rows={8} />}
+      {error && <p className="tf-error">Error: {error}</p>}
 
       {data?.insufficientData && (
-        <p className="tf-error">
-          Insufficient data — need ≥ 5 qualified observations with valid GLA (found {data.usedForFit}).
-        </p>
+        <div style={{ background: 'rgba(239,68,68,.08)', border: '1px solid rgba(239,68,68,.2)', borderRadius: 8, padding: 12, marginBottom: 16, fontSize: 13, color: '#fca5a5' }}>
+          Insufficient data — need at least 5 qualified observations with valid GLA (found {data.usedForFit}).
+        </div>
       )}
 
       {data?.singularMatrix && (
-        <p className="tf-error">
+        <div style={{ background: 'rgba(239,68,68,.08)', border: '1px solid rgba(239,68,68,.2)', borderRadius: 8, padding: 12, marginBottom: 16, fontSize: 13, color: '#fca5a5' }}>
           Singular predictor matrix — check for collinear variables in this stratum.
-        </p>
+        </div>
       )}
 
       {/* Model summary cards */}
@@ -160,12 +186,22 @@ export default function RegressionPage() {
               <div className="tf-cardSmall">β[{i}] = {m.beta[i].toFixed(4)}</div>
             </div>
           ))}
+
+          {/* Model quality gate */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, justifyContent: 'center' }}>
+            <span className={`tf-badge ${m.rSquared >= 0.7 ? 'tf-badge--green' : m.rSquared >= 0.5 ? 'tf-badge--yellow' : 'tf-badge--red'}`}>
+              R² {m.rSquared >= 0.7 ? 'GOOD' : m.rSquared >= 0.5 ? 'FAIR' : 'POOR'} ({(m.rSquared * 100).toFixed(1)}%)
+            </span>
+            <span style={{ fontSize: 10, color: 'rgba(148,163,184,.5)' }}>
+              target: R² ≥ 0.70 for mass appraisal
+            </span>
+          </div>
         </div>
       )}
 
       {/* Residuals table */}
-      {data && data.residuals.length > 0 && (
-        <div className="tf-table-wrap">
+      {!loading && !error && data && data.residuals.length > 0 && (
+        <div className="tf-table-wrap" style={{ maxHeight: 480, overflow: 'auto' }}>
           <table className="tf-table">
             <thead>
               <tr>
@@ -183,7 +219,6 @@ export default function RegressionPage() {
             <tbody>
               {data.residuals.map(r => {
                 const absPct = r.percentResidual != null ? Math.abs(r.percentResidual) : null;
-                const pctClass = absPct == null ? '' : absPct > 20 ? 'tf-badge--red' : absPct > 10 ? 'tf-badge--yellow' : '';
                 return (
                   <tr key={r.parcelId + r.saleDate}>
                     <td className="tf-mono">{r.parcelId}</td>
@@ -195,7 +230,7 @@ export default function RegressionPage() {
                     </td>
                     <td className="tf-right">
                       {r.percentResidual != null ? (
-                        <span className={pctClass ? `tf-badge ${pctClass}` : undefined}>
+                        <span className={`tf-badge ${absPct! > 20 ? 'tf-badge--red' : absPct! > 10 ? 'tf-badge--yellow' : ''}`}>
                           {r.percentResidual >= 0 ? '+' : ''}{r.percentResidual.toFixed(1)}%
                         </span>
                       ) : '—'}

--- a/frontend/apps/terraforge/src/pages/SaleQualificationPage.tsx
+++ b/frontend/apps/terraforge/src/pages/SaleQualificationPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-const API      = '/api/terraforge/sale-qualification';
+const API       = '/api/terraforge/sale-qualification';
 const PATCH_API = (id: string) => `/api/terraforge/sale-qualification/${id}`;
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -40,6 +40,22 @@ interface PatchBody {
 
 function fmt$(n: number) {
   return '$' + n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+function Skeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 0' }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} style={{ height: 18, background: 'rgba(255,255,255,.04)', borderRadius: 4, width: `${70 + Math.random() * 30}%`, animation: 'pulse 1.5s infinite' }} />
+      ))}
+    </div>
+  );
+}
+
+function Tooltip({ text }: { text: string }) {
+  return (
+    <span title={text} style={{ cursor: 'help', marginLeft: 6, fontSize: 12, color: 'rgba(148,163,184,.7)' }}>ⓘ</span>
+  );
 }
 
 function recBadge(rec: string | null) {
@@ -113,12 +129,12 @@ function DecisionPanel({ sale, onSave, onClose }: DecisionPanelProps) {
   };
 
   const labelStyle: React.CSSProperties = {
-    display:   'flex',
+    display:       'flex',
     flexDirection: 'column',
-    gap:       4,
-    fontSize:  12,
-    color:     'rgba(226,232,240,.65)',
-    fontWeight: 600,
+    gap:           4,
+    fontSize:      12,
+    color:         'rgba(226,232,240,.65)',
+    fontWeight:    600,
   };
 
   const btnStyle = (primary: boolean): React.CSSProperties => ({
@@ -207,12 +223,15 @@ function DecisionPanel({ sale, onSave, onClose }: DecisionPanelProps) {
 // ── Main page ──────────────────────────────────────────────────────────────
 
 export default function SaleQualificationPage() {
-  const [data,      setData]      = useState<SaleQualificationResponse | null>(null);
-  const [loading,   setLoading]   = useState(false);
-  const [error,     setError]     = useState<string | null>(null);
-  const [taxYear,   setTaxYear]   = useState(2026);
-  const [status,    setStatus]    = useState('pending');
+  const [data,       setData]       = useState<SaleQualificationResponse | null>(null);
+  const [loading,    setLoading]    = useState(false);
+  const [error,      setError]      = useState<string | null>(null);
+  const [taxYear,    setTaxYear]    = useState(2026);
+  const [status,     setStatus]     = useState('pending');
+  const [page,       setPage]       = useState(1);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const pageSize = 50;
 
   // ── Load list ────────────────────────────────────────────────────────────
 
@@ -220,13 +239,13 @@ export default function SaleQualificationPage() {
     setLoading(true);
     setError(null);
     setSelectedId(null);
-    const p = new URLSearchParams({ taxYear: String(taxYear), status, pageSize: '50' });
+    const p = new URLSearchParams({ taxYear: String(taxYear), status, pageSize: String(pageSize), page: String(page) });
     fetch(`${API}?${p}`)
       .then(r => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}: ${r.statusText}`))
       .then((d: SaleQualificationResponse) => setData(d))
       .catch(e => setError(String(e)))
       .finally(() => setLoading(false));
-  }, [taxYear, status]);
+  }, [taxYear, status, page]);
 
   // ── PATCH decision ───────────────────────────────────────────────────────
 
@@ -240,19 +259,13 @@ export default function SaleQualificationPage() {
       const txt = await res.text().catch(() => res.statusText);
       throw new Error(`HTTP ${res.status}: ${txt}`);
     }
-    // Update the row in place so the table reflects the new decision immediately.
     setData(prev => {
       if (!prev) return prev;
       return {
         ...prev,
         items: prev.items.map(s =>
           s.saleId === saleId
-            ? {
-                ...s,
-                qualificationDecision:   body.qualificationDecision,
-                qualificationDecisionBy: body.decidedBy,
-                researchNotes:           body.researchNotes,
-              }
+            ? { ...s, qualificationDecision: body.qualificationDecision, qualificationDecisionBy: body.decidedBy, researchNotes: body.researchNotes }
             : s
         ),
       };
@@ -260,110 +273,140 @@ export default function SaleQualificationPage() {
     setSelectedId(null);
   }
 
+  // ── Export CSV ───────────────────────────────────────────────────────────
+
+  const exportCsv = () => {
+    if (!data?.items.length) return;
+    const header = 'Parcel,Sale Date,Sale Price,GLA,Hood,Ratio Cd,WAC,Recommendation,Reason,Decision,Decided By,Notes\n';
+    const rows = data.items.map(s =>
+      `${s.parcelId},${s.saleDate.slice(0,10)},${s.salePrice},${s.gla ?? ''},${s.hood ?? ''},${s.rawCountyRatioCd ?? ''},${s.rawWacCd ?? ''},${s.qualificationRecommendation ?? ''},"${(s.recommendationReason ?? '').replace(/"/g, '""')}",${s.qualificationDecision ?? ''},${s.qualificationDecisionBy ?? ''},"${(s.researchNotes ?? '').replace(/"/g, '""')}"`
+    ).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = `sale_qualification_${taxYear}_${status || 'all'}.csv`; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const totalPages = data ? Math.ceil(data.total / pageSize) : 0;
+  const inputStyle: React.CSSProperties = { background: 'rgba(255,255,255,.06)', border: '1px solid rgba(255,255,255,.1)', color: '#e2e8f0', borderRadius: 6, padding: '4px 8px', fontSize: 13 };
+
   // ── Render ───────────────────────────────────────────────────────────────
 
   return (
     <div className="tf-page">
-      <div className="tf-page-header">
-        <h2>Sale Qualification</h2>
+      <div className="tf-page-header" style={{ marginBottom: 16 }}>
+        <h2>Sale Qualification<Tooltip text="Three-tier workflow: System recommends qualification based on WAC/DOR codes, staff researches, appraiser makes final decision. Per WA DOR guidelines." /></h2>
         <p className="tf-page-sub">
           System recommends · staff researches · appraiser decides — Benton County WA
         </p>
       </div>
 
       {/* Filters */}
-      <div className="tf-filters">
-        <label>
-          Tax year
-          <select value={taxYear} onChange={e => setTaxYear(Number(e.target.value))}>
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', marginBottom: 16 }}>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
+          Tax Year
+          <select value={taxYear} onChange={e => { setTaxYear(Number(e.target.value)); setPage(1); }} style={inputStyle}>
             {[2026, 2025, 2024, 2023].map(y => <option key={y} value={y}>{y}</option>)}
           </select>
         </label>
-        <label>
+        <label style={{ fontSize: 12, color: 'rgba(226,232,240,.65)', fontWeight: 600, display: 'flex', flexDirection: 'column', gap: 3 }}>
           Status
-          <select value={status} onChange={e => setStatus(e.target.value)}>
+          <select value={status} onChange={e => { setStatus(e.target.value); setPage(1); }} style={inputStyle}>
             <option value="pending">Pending (no decision yet)</option>
             <option value="staff-confirmed">Staff confirmed</option>
             <option value="appraiser-final">Appraiser final</option>
             <option value="">All</option>
           </select>
         </label>
-        {data && (
-          <span className="tf-count">
-            {data.total.toLocaleString()} sales · click a row to record decision
-          </span>
-        )}
+        <button onClick={exportCsv} className="tf-btn" style={{ fontSize: 11, padding: '5px 10px', alignSelf: 'flex-end' }}>⬇ CSV</button>
       </div>
 
-      {loading && <p className="tf-loading">Loading…</p>}
-      {error   && <p className="tf-error">Error: {error}</p>}
+      {/* Summary */}
+      {data && (
+        <div style={{ fontSize: 12, color: 'rgba(148,163,184,.7)', marginBottom: 8 }}>
+          {data.total.toLocaleString()} sales · Click a row to record decision · Page {page} of {totalPages}
+        </div>
+      )}
+
+      {loading && <Skeleton rows={10} />}
+      {error && <p className="tf-error">Error: {error}</p>}
 
       {!loading && !error && data && (
-        <div className="tf-table-wrap">
-          <table className="tf-table">
-            <thead>
-              <tr>
-                <th>Parcel</th>
-                <th>Sale Date</th>
-                <th className="tf-right">Sale Price</th>
-                <th className="tf-right">GLA</th>
-                <th>Hood</th>
-                <th>Ratio Cd</th>
-                <th>WAC</th>
-                <th>Recommendation</th>
-                <th>Reason</th>
-                <th>Decision</th>
-                <th>By</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.items.length === 0 && (
+        <>
+          <div className="tf-table-wrap" style={{ maxHeight: 520, overflow: 'auto' }}>
+            <table className="tf-table">
+              <thead>
                 <tr>
-                  <td colSpan={11} className="tf-empty">No sales match this filter.</td>
+                  <th>Parcel</th>
+                  <th>Sale Date</th>
+                  <th className="tf-right">Sale Price</th>
+                  <th className="tf-right">GLA</th>
+                  <th>Hood</th>
+                  <th>Ratio Cd</th>
+                  <th>WAC</th>
+                  <th>Recommendation</th>
+                  <th>Reason</th>
+                  <th>Decision</th>
+                  <th>By</th>
                 </tr>
-              )}
-              {data.items.map(s => {
-                const isOpen = selectedId === s.saleId;
-                return (
-                  <>
-                    <tr
-                      key={s.saleId}
-                      onClick={() => setSelectedId(isOpen ? null : s.saleId)}
-                      style={{ cursor: 'pointer', background: isOpen ? 'rgba(99,102,241,.06)' : undefined }}
-                    >
-                      <td className="tf-mono">{s.parcelId}</td>
-                      <td>{s.saleDate.slice(0, 10)}</td>
-                      <td className="tf-right tf-mono">{fmt$(s.salePrice)}</td>
-                      <td className="tf-right">{s.gla?.toLocaleString() ?? '—'}</td>
-                      <td>{s.hood ?? '—'}</td>
-                      <td className="tf-mono">{s.rawCountyRatioCd ?? '—'}</td>
-                      <td className="tf-mono">{s.rawWacCd ?? '—'}</td>
-                      <td>{recBadge(s.qualificationRecommendation)}</td>
-                      <td style={{ maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 11, color: 'rgba(226,232,240,.55)' }}>
-                        {s.recommendationReason ?? '—'}
-                      </td>
-                      <td>{decBadge(s.qualificationDecision)}</td>
-                      <td style={{ fontSize: 11, color: 'rgba(226,232,240,.5)' }}>
-                        {s.qualificationDecisionBy ?? '—'}
-                      </td>
-                    </tr>
-                    {isOpen && (
-                      <tr key={s.saleId + '-panel'}>
-                        <td colSpan={11} style={{ padding: '6px 10px 12px', borderBottom: '1px solid rgba(99,102,241,.15)' }}>
-                          <DecisionPanel
-                            sale={s}
-                            onSave={handleSave}
-                            onClose={() => setSelectedId(null)}
-                          />
+              </thead>
+              <tbody>
+                {data.items.length === 0 && (
+                  <tr>
+                    <td colSpan={11} className="tf-empty">No sales match this filter.</td>
+                  </tr>
+                )}
+                {data.items.map(s => {
+                  const isOpen = selectedId === s.saleId;
+                  return (
+                    <tbody key={s.saleId}>
+                      <tr
+                        onClick={() => setSelectedId(isOpen ? null : s.saleId)}
+                        style={{ cursor: 'pointer', background: isOpen ? 'rgba(99,102,241,.06)' : undefined }}
+                      >
+                        <td className="tf-mono">{s.parcelId}</td>
+                        <td>{s.saleDate.slice(0, 10)}</td>
+                        <td className="tf-right tf-mono">{fmt$(s.salePrice)}</td>
+                        <td className="tf-right">{s.gla?.toLocaleString() ?? '—'}</td>
+                        <td>{s.hood ?? '—'}</td>
+                        <td className="tf-mono">{s.rawCountyRatioCd ?? '—'}</td>
+                        <td className="tf-mono">{s.rawWacCd ?? '—'}</td>
+                        <td>{recBadge(s.qualificationRecommendation)}</td>
+                        <td style={{ maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 11, color: 'rgba(226,232,240,.55)' }}>
+                          {s.recommendationReason ?? '—'}
+                        </td>
+                        <td>{decBadge(s.qualificationDecision)}</td>
+                        <td style={{ fontSize: 11, color: 'rgba(226,232,240,.5)' }}>
+                          {s.qualificationDecisionBy ?? '—'}
                         </td>
                       </tr>
-                    )}
-                  </>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                      {isOpen && (
+                        <tr>
+                          <td colSpan={11} style={{ padding: '6px 10px 12px', borderBottom: '1px solid rgba(99,102,241,.15)' }}>
+                            <DecisionPanel
+                              sale={s}
+                              onSave={handleSave}
+                              onClose={() => setSelectedId(null)}
+                            />
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 12 }}>
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>← Prev</button>
+              <span style={{ fontSize: 12, color: 'rgba(226,232,240,.6)', alignSelf: 'center' }}>Page {page} of {totalPages}</span>
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="tf-btn" style={{ fontSize: 11, padding: '4px 10px' }}>Next →</button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Complete UI/UX polish for all 6 TerraForge pages. Removes all PACS references, placeholder stubs, and 'coming soon' text. Every page now has consistent production-quality patterns.

## Changes

| Page | Before | After |
|------|--------|-------|
| CostSchedulesPage | 8-line stub | 600+ line full page with 5 tabs |
| LevyPage | Had PACS ref, basic loading | Skeleton, export, tooltips, pagination |
| CompsPage | 'PACS Ratio' header, no export | Clean headers, skeleton, CSV, pagination |
| RatioStudyPage | Basic loading text | Skeleton, CSV export, pagination, tooltips |
| RegressionPage | Basic loading text | Skeleton, CSV export, R² quality gate |
| SaleQualificationPage | Basic loading, no export | Skeleton, CSV, pagination, tooltips, fixed React key |

## Consistent Patterns Now Applied

- Loading skeletons (animated pulse, not text)
- CSV export on every page
- Pagination for all paginated endpoints
- Tooltips with IAAO/RCW context
- Consistent label/input styling (dark theme)
- No PACS references anywhere
- No 'coming soon' or 'Phase 2' placeholders

## Testing

All existing contract tests pass (no API changes, frontend-only polish).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to Comps, Ratio Study, and Sale Qualification pages
  * CSV export functionality added across multiple pages
  * Introduced tabbed navigation interfaces for Cost Schedules and Levy pages
  * Enhanced filtering with better UI organization and result summaries
  * Added quality assessment badges for model and valuation data

* **Style**
  * Improved loading placeholders and error messaging across pages
  * Added contextual tooltips for headers and form inputs
  * Refined table layouts and styling for better data presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->