### PR TITLE
[codex] feat(income-forge): activate live runtime module

### DIFF
--- a/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
+++ b/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
@@ -241,6 +241,7 @@ describe('moduleActivation displayNames/icons coverage', () => {
       // Levy (legacy canonical kept for backward compat)
       'terra-levy': 'Levy Calculator',
       // Forge standalone modules (Phase 35 + Phase 36)
+      'income-forge': 'IncomeForge',
       'batch-cost-run': 'Batch Cost Runs',
       'coefficient-preview': 'Coefficient Preview',
       'cost-manual': 'Cost Manual',

--- a/frontend/apps/os-shell/src/config/moduleComponents.tsx
+++ b/frontend/apps/os-shell/src/config/moduleComponents.tsx
@@ -161,6 +161,7 @@ export const MODULE_REGISTRY = new Set<string>([
   'federation-dashboard',
   'costforge',
   'comps-forge',
+  'income-forge',
   'terra-gaia',
   'levy-calculator',
   'gis-viewer',
@@ -336,6 +337,9 @@ const SovereignDashboardWindow = lazy(() =>
 const CompsForgeModule = lazy(
   () => import('../pages/suites/modules/CompsForgeModule')
 );
+const IncomeForge = lazy(
+  () => import('../pages/forge/income/IncomeForge')
+);
 
 // ============================================================================
 // Phase C: Rehosted Module Components
@@ -481,6 +485,7 @@ const MODULE_ENTRIES: Record<string, ModuleEntry> = {
   // Forge standalone modules (Tranche 1D)
   'batch-cost-run': { Component: BatchCostRun },
   'coefficient-preview': { Component: CoefficientPreview },
+  'income-forge': { Component: IncomeForge },
   // Forge standalone modules (Gen2)
   'regression-studio': { Component: RegressionStudio },
   // Dais standalone modules
@@ -751,6 +756,14 @@ export const ModuleRenderer: React.FC<ModuleRendererProps> = ({ module, metadata
       return (
         <Suspense fallback={<ModuleLoadingFallback />}>
           <CompsForgeModule metadata={metadata as Record<string, unknown> | undefined} />
+        </Suspense>
+      );
+
+    // IncomeForge — income approach valuation with CostForge API authority.
+    case 'income-forge':
+      return (
+        <Suspense fallback={<ModuleLoadingFallback />}>
+          <IncomeForge metadata={metadata as Record<string, unknown> | undefined} />
         </Suspense>
       );
 

--- a/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
+++ b/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
@@ -124,6 +124,7 @@ function getModuleDisplayName(moduleId: string): string {
     'os-canon': 'TerraCanon',
     // Application Constellation (Gen2 catalog)
     'income-valuation': 'Income Valuation',
+    'income-forge': 'IncomeForge',
     'regression-studio': 'Regression Studio',
     'statistics-studio': 'Statistics Studio',
     'batch-cost-run': 'Batch Cost Runs',
@@ -203,6 +204,7 @@ function getModuleIcon(moduleId: string): string {
     'os-canon': '⚙️',
     // Application Constellation (Gen2 catalog)
     'income-valuation': '💰',
+    'income-forge': '💰',
     'regression-studio': '📈',
     'statistics-studio': '📊',
     'batch-cost-run': '📦',

--- a/frontend/apps/os-shell/src/pages/forge/income/IncomeForge.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/income/IncomeForge.tsx
@@ -1,0 +1,443 @@
+/**
+ * IncomeForge - standalone income approach module.
+ *
+ * Consumes the existing CostForge income-approach API endpoints and presents a
+ * production window for cap rates, market data, expense ratios, location
+ * premiums, and backend valuation math.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useIncomeForgeStore, type IncomeExpenses } from './incomeForgeStore';
+
+type IncomeTab = 'valuation' | 'cap-rates' | 'market' | 'expenses' | 'locations';
+
+const TABS: { id: IncomeTab; label: string }[] = [
+  { id: 'valuation', label: 'Valuation' },
+  { id: 'cap-rates', label: 'Cap Rates' },
+  { id: 'market', label: 'Market Data' },
+  { id: 'expenses', label: 'Expenses' },
+  { id: 'locations', label: 'Locations' },
+];
+
+const DEFAULT_EXPENSES: IncomeExpenses = {
+  propertyTaxes: 12000,
+  insurance: 6500,
+  utilities: 0,
+  maintenance: 9000,
+  managementFees: 7200,
+  replacementReserves: 4500,
+  otherExpenses: 0,
+};
+
+const fmtCurrency = (value: number | undefined | null) =>
+  value == null || !Number.isFinite(value)
+    ? '-'
+    : new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+      }).format(value);
+
+const fmtNumber = (value: number | undefined | null, digits = 0) =>
+  value == null || !Number.isFinite(value) ? '-' : value.toLocaleString('en-US', { maximumFractionDigits: digits });
+
+const fmtPct = (value: number | undefined | null, digits = 2) =>
+  value == null || !Number.isFinite(value) ? '-' : `${value.toFixed(digits)}%`;
+
+function StatsRail() {
+  const stats = useIncomeForgeStore((s) => s.stats);
+  const items = [
+    { label: 'Property Types', value: fmtNumber(stats.propertyTypes) },
+    { label: 'Locations', value: fmtNumber(stats.locations) },
+    { label: 'Market Cap Rate', value: fmtPct(stats.marketCapRate) },
+    { label: 'Median Home', value: fmtCurrency(stats.medianHomePrice) },
+    { label: 'Median Income', value: fmtCurrency(stats.medianIncome) },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {items.map((item) => (
+        <div key={item.label} className="rounded-md border bg-background/70 px-3 py-2">
+          <div className="text-xs text-muted-foreground">{item.label}</div>
+          <div className="text-lg font-semibold">{item.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ValuationTab() {
+  const valuationResult = useIncomeForgeStore((s) => s.valuationResult);
+  const loading = useIncomeForgeStore((s) => s.valuationLoading);
+  const error = useIncomeForgeStore((s) => s.valuationError);
+  const calculateValuation = useIncomeForgeStore((s) => s.calculateValuation);
+  const stats = useIncomeForgeStore((s) => s.stats);
+  const locationPremiums = useIncomeForgeStore((s) => s.locationPremiums);
+  const [annualRentalIncome, setAnnualRentalIncome] = useState(120000);
+  const [vacancyRate, setVacancyRate] = useState(5);
+  const [otherIncome, setOtherIncome] = useState(5000);
+  const [capRate, setCapRate] = useState(5.5);
+  const [propertyType, setPropertyType] = useState('commercial');
+  const [location, setLocation] = useState('Richland');
+  const [expenses, setExpenses] = useState<IncomeExpenses>(DEFAULT_EXPENSES);
+
+  useEffect(() => {
+    if (stats.marketCapRate > 0) {
+      setCapRate(stats.marketCapRate);
+    }
+  }, [stats.marketCapRate]);
+
+  const totalExpenses = useMemo(
+    () => Object.values(expenses).reduce((sum, value) => sum + value, 0),
+    [expenses]
+  );
+
+  const runValuation = () => {
+    void calculateValuation({
+      annualRentalIncome,
+      vacancyRate,
+      otherIncome,
+      capRate,
+      propertyType,
+      location,
+      expenses,
+    });
+  };
+
+  const updateExpense = (field: keyof IncomeExpenses, value: number) => {
+    setExpenses((current) => ({ ...current, [field]: value }));
+  };
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(360px,520px)_1fr]">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Income & Vacancy</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Annual Rental Income</span>
+              <input className="w-full rounded border px-2 py-1.5" type="number" value={annualRentalIncome} onChange={(event) => setAnnualRentalIncome(Number(event.target.value))} />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Other Income</span>
+              <input className="w-full rounded border px-2 py-1.5" type="number" value={otherIncome} onChange={(event) => setOtherIncome(Number(event.target.value))} />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Vacancy Rate (%)</span>
+              <input className="w-full rounded border px-2 py-1.5" type="number" min={0} max={100} step={0.25} value={vacancyRate} onChange={(event) => setVacancyRate(Number(event.target.value))} />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Cap Rate (%)</span>
+              <input className="w-full rounded border px-2 py-1.5" type="number" min={0.1} max={25} step={0.05} value={capRate} onChange={(event) => setCapRate(Number(event.target.value))} />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Property Type</span>
+              <select className="w-full rounded border px-2 py-1.5" value={propertyType} onChange={(event) => setPropertyType(event.target.value)}>
+                <option value="multi-family">Multi-Family</option>
+                <option value="commercial">Commercial</option>
+                <option value="industrial">Industrial</option>
+                <option value="residential">Residential Income</option>
+              </select>
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="text-xs text-muted-foreground">Location</span>
+              <select className="w-full rounded border px-2 py-1.5" value={location} onChange={(event) => setLocation(event.target.value)}>
+                {(locationPremiums.length ? locationPremiums : [{ location: 'Richland', multiplier: 1, note: '' }]).map((entry) => (
+                  <option key={entry.location} value={entry.location}>{entry.location}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div>
+            <div className="mb-2 text-xs font-semibold uppercase text-muted-foreground">Operating Expenses</div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {(Object.keys(expenses) as Array<keyof IncomeExpenses>).map((field) => (
+                <label key={field} className="space-y-1 text-sm">
+                  <span className="text-xs text-muted-foreground">{field}</span>
+                  <input className="w-full rounded border px-2 py-1.5" type="number" value={expenses[field]} onChange={(event) => updateExpense(field, Number(event.target.value))} />
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between rounded border bg-muted/20 px-3 py-2 text-sm">
+            <span className="text-muted-foreground">Total Expenses</span>
+            <span className="font-semibold">{fmtCurrency(totalExpenses)}</span>
+          </div>
+
+          <button className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-60" type="button" onClick={runValuation} disabled={loading}>
+            {loading ? 'Calculating...' : 'Calculate Valuation'}
+          </button>
+          {error && <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Backend Valuation Result</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!valuationResult && !error && (
+            <div className="text-sm text-muted-foreground">Run the valuation to calculate NOI, risk, and indicated value.</div>
+          )}
+          {valuationResult && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <ResultMetric label="Adjusted Value" value={fmtCurrency(valuationResult.adjustedValuation)} strong />
+              <ResultMetric label="Raw Value" value={fmtCurrency(valuationResult.rawValuation)} />
+              <ResultMetric label="NOI" value={fmtCurrency(valuationResult.netOperatingIncome)} />
+              <ResultMetric label="Cap Rate" value={fmtPct(valuationResult.capRate)} />
+              <ResultMetric label="Location Multiplier" value={`${valuationResult.locationMultiplier.toFixed(2)}x`} />
+              <ResultMetric label="Gross Income Multiplier" value={valuationResult.grossIncomeMultiplier.toFixed(2)} />
+              <ResultMetric label="Cash-on-Cash" value={fmtPct(valuationResult.cashOnCashReturn)} />
+              <ResultMetric label="Risk" value={valuationResult.riskClassification} />
+              <div className="sm:col-span-2 rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                Source: {valuationResult.source}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ResultMetric({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
+  return (
+    <div className="rounded border px-3 py-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={strong ? 'text-xl font-semibold' : 'text-base font-medium'}>{value}</div>
+    </div>
+  );
+}
+
+function CapRatesTab() {
+  const capRates = useIncomeForgeStore((s) => s.capRates);
+  const loading = useIncomeForgeStore((s) => s.capRatesLoading);
+  const error = useIncomeForgeStore((s) => s.capRatesError);
+
+  if (loading) return <div className="text-sm text-muted-foreground">Loading cap rates...</div>;
+  if (error) return <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>;
+
+  return (
+    <div className="overflow-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="py-2 pr-3">Property Type</th>
+            <th className="py-2 pr-3">Label</th>
+            <th className="py-2 pr-3 text-right">Min</th>
+            <th className="py-2 pr-3 text-right">Typical</th>
+            <th className="py-2 text-right">Max</th>
+          </tr>
+        </thead>
+        <tbody>
+          {capRates.map((entry) => (
+            <tr key={entry.propertyType} className="border-b last:border-0">
+              <td className="py-2 pr-3 font-mono text-xs">{entry.propertyType}</td>
+              <td className="py-2 pr-3">{entry.label}</td>
+              <td className="py-2 pr-3 text-right">{fmtPct(entry.min)}</td>
+              <td className="py-2 pr-3 text-right font-semibold">{fmtPct(entry.typical)}</td>
+              <td className="py-2 text-right">{fmtPct(entry.max)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MarketDataTab() {
+  const marketData = useIncomeForgeStore((s) => s.marketData);
+  const loading = useIncomeForgeStore((s) => s.marketLoading);
+  const error = useIncomeForgeStore((s) => s.marketError);
+
+  if (loading) return <div className="text-sm text-muted-foreground">Loading market data...</div>;
+  if (error) return <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>;
+  if (!marketData) return <div className="text-sm text-muted-foreground">No market data loaded.</div>;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader className="pb-3"><CardTitle className="text-base">County Indicators</CardTitle></CardHeader>
+        <CardContent className="grid gap-2 sm:grid-cols-2">
+          <ResultMetric label="Median Household Income" value={fmtCurrency(marketData.medianHouseholdIncome)} />
+          <ResultMetric label="Unemployment" value={fmtPct(marketData.unemploymentRate, 1)} />
+          <ResultMetric label="Population Growth" value={fmtPct(marketData.populationGrowthRate, 1)} />
+          <ResultMetric label="Median Home Price" value={fmtCurrency(marketData.medianHomePrice)} />
+          <ResultMetric label="Median Price / Sqft" value={fmtCurrency(marketData.medianPricePerSqft)} />
+          <ResultMetric label="Months Inventory" value={fmtNumber(marketData.monthsOfInventory, 1)} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-3"><CardTitle className="text-base">Employment Sectors</CardTitle></CardHeader>
+        <CardContent className="space-y-2">
+          {marketData.employmentSectors.map((sector) => (
+            <div key={sector.sector} className="flex items-center justify-between rounded border px-3 py-2 text-sm">
+              <span>{sector.sector}</span>
+              <span className="font-semibold">{fmtPct(sector.percentOfTotal, 1)}</span>
+            </div>
+          ))}
+          <div className="pt-2 text-xs text-muted-foreground">Source: {marketData.source}</div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ExpensesTab() {
+  const ratios = useIncomeForgeStore((s) => s.expenseRatios);
+  const categories = useIncomeForgeStore((s) => s.expenseCategories);
+  const loading = useIncomeForgeStore((s) => s.expensesLoading);
+  const error = useIncomeForgeStore((s) => s.expensesError);
+
+  if (loading) return <div className="text-sm text-muted-foreground">Loading expense ratios...</div>;
+  if (error) return <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1fr_320px]">
+      <div className="overflow-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="py-2 pr-3">Property Type</th>
+              <th className="py-2 pr-3">Label</th>
+              <th className="py-2 pr-3 text-right">Low</th>
+              <th className="py-2 pr-3 text-right">Typical</th>
+              <th className="py-2 text-right">High</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ratios.map((entry) => (
+              <tr key={entry.propertyType} className="border-b last:border-0">
+                <td className="py-2 pr-3 font-mono text-xs">{entry.propertyType}</td>
+                <td className="py-2 pr-3">{entry.label}</td>
+                <td className="py-2 pr-3 text-right">{fmtPct(entry.lowPct, 1)}</td>
+                <td className="py-2 pr-3 text-right font-semibold">{fmtPct(entry.typicalPct, 1)}</td>
+                <td className="py-2 text-right">{fmtPct(entry.highPct, 1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Card>
+        <CardHeader className="pb-3"><CardTitle className="text-base">Expense Categories</CardTitle></CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {categories.map((category) => (
+            <Badge key={category} variant="outline">{category}</Badge>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function LocationsTab() {
+  const premiums = useIncomeForgeStore((s) => s.locationPremiums);
+  const loading = useIncomeForgeStore((s) => s.locationsLoading);
+  const error = useIncomeForgeStore((s) => s.locationsError);
+
+  if (loading) return <div className="text-sm text-muted-foreground">Loading locations...</div>;
+  if (error) return <div className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>;
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {premiums.map((premium) => (
+        <Card key={premium.location}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">{premium.location}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{premium.multiplier.toFixed(2)}x</div>
+            <div className="mt-1 text-sm text-muted-foreground">{premium.note}</div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export interface IncomeForgeProps {
+  metadata?: Record<string, unknown>;
+}
+
+export default function IncomeForge(_props: IncomeForgeProps = {}) {
+  const [activeTab, setActiveTab] = useState<IncomeTab>('valuation');
+  const fetchReferenceData = useIncomeForgeStore((s) => s.fetchReferenceData);
+  const calculateValuation = useIncomeForgeStore((s) => s.calculateValuation);
+  const referenceSource = useIncomeForgeStore((s) => s.referenceSource);
+  const countyScope = useIncomeForgeStore((s) => s.countyScope);
+
+  useEffect(() => {
+    void fetchReferenceData();
+    void calculateValuation({
+      annualRentalIncome: 120000,
+      vacancyRate: 5,
+      otherIncome: 5000,
+      capRate: 5.5,
+      propertyType: 'commercial',
+      location: 'Richland',
+      expenses: DEFAULT_EXPENSES,
+    });
+  }, [calculateValuation, fetchReferenceData]);
+
+  return (
+    <div data-testid="income-forge" className="h-full overflow-auto bg-background p-5 text-foreground">
+      <header className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">TerraForge · Income Approach</p>
+          <h1 className="text-2xl font-semibold">IncomeForge</h1>
+          <p className="text-sm text-muted-foreground">Cap rates, NOI modeling, expense standards, and location-adjusted valuation.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge>Live API</Badge>
+          <Badge variant="outline">CostForge income endpoints</Badge>
+        </div>
+      </header>
+
+      {!countyScope.supported && (
+        <Card className="mb-4 border-amber-200 bg-amber-50">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base text-amber-900">Benton-certified data required</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-amber-900">
+            {countyScope.message}
+            {countyScope.countyId && <span> Active county: {countyScope.countyId}.</span>}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="mb-4">
+        <StatsRail />
+      </div>
+
+      {referenceSource && (
+        <div className="mb-4 rounded border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+          Source: {referenceSource}
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`rounded border px-3 py-1.5 text-sm ${activeTab === tab.id ? 'bg-blue-600 text-white' : 'bg-background hover:bg-muted'}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'valuation' && <ValuationTab />}
+      {activeTab === 'cap-rates' && <CapRatesTab />}
+      {activeTab === 'market' && <MarketDataTab />}
+      {activeTab === 'expenses' && <ExpensesTab />}
+      {activeTab === 'locations' && <LocationsTab />}
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/forge/income/__tests__/IncomeForge.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/income/__tests__/IncomeForge.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockRuntime = vi.hoisted(() => ({
+  countyScope: {
+    countyId: '19190019-1919-1919-1919-191919191919',
+    supported: true,
+    message: null as string | null,
+  },
+}));
+
+vi.mock('../incomeForgeStore', () => {
+  const mockStore = vi.fn((selector?: (s: unknown) => unknown) => {
+    const state = {
+      capRates: [
+        { propertyType: 'commercial', label: 'Commercial', min: 5.25, typical: 6.25, max: 7.25 },
+        { propertyType: 'industrial', label: 'Industrial', min: 6.0, typical: 7.0, max: 8.0 },
+      ],
+      marketData: {
+        county: 'Benton',
+        state: 'WA',
+        medianHouseholdIncome: 82500,
+        unemploymentRate: 4.2,
+        populationGrowthRate: 1.6,
+        medianHomePrice: 485000,
+        medianPricePerSqft: 255,
+        medianDaysOnMarket: 24,
+        monthsOfInventory: 2.1,
+        employmentSectors: [{ sector: 'Health Care', jobs: 24500, share: 18.4 }],
+        effectiveDate: '2025-01-01',
+        source: 'US Census ACS 2024, WA ESD, Benton-Franklin Trends',
+      },
+      expenseRatios: [
+        { propertyType: 'commercial', label: 'Commercial', lowPct: 25, typicalPct: 35, highPct: 45 },
+      ],
+      expenseCategories: ['propertyTaxes', 'insurance'],
+      locationPremiums: [
+        { location: 'Richland', multiplier: 1.1 },
+        { location: 'Kennewick', multiplier: 1.05 },
+      ],
+      valuationResult: {
+        netOperatingIncome: 82000,
+        capRate: 6.25,
+        location: 'Richland',
+        locationMultiplier: 1.1,
+        propertyType: 'Commercial',
+        rawValuation: 1312000,
+        adjustedValuation: 1443200,
+        grossIncomeMultiplier: 12.0,
+        cashOnCashReturn: 6.25,
+        riskClassification: 'medium',
+        effectiveDate: '2025-01-01',
+        source: 'Benton County Assessor - Income Approach Valuation FY 2025',
+      },
+      stats: {
+        propertyTypes: 2,
+        locations: 2,
+        marketCapRate: 6.25,
+        medianHomePrice: 485000,
+        medianIncome: 82500,
+      },
+      countyScope: mockRuntime.countyScope,
+      referenceSource: 'Benton County Assessor - Income Approach Market Study FY 2025',
+      capRatesLoading: false,
+      marketLoading: false,
+      expensesLoading: false,
+      locationsLoading: false,
+      valuationLoading: false,
+      capRatesError: null,
+      marketError: null,
+      expensesError: null,
+      locationsError: null,
+      valuationError: null,
+      fetchReferenceData: vi.fn(),
+      calculateValuation: vi.fn(),
+    };
+    return selector ? selector(state) : state;
+  });
+
+  return { useIncomeForgeStore: mockStore };
+});
+
+import IncomeForge from '../IncomeForge';
+
+describe('IncomeForge', () => {
+  afterEach(() => {
+    mockRuntime.countyScope = {
+      countyId: '19190019-1919-1919-1919-191919191919',
+      supported: true,
+      message: null,
+    };
+  });
+
+  it('renders the live API workspace with stats and provenance', () => {
+    render(<IncomeForge />);
+
+    expect(screen.getByTestId('income-forge')).toBeInTheDocument();
+    expect(screen.getByText('IncomeForge')).toBeInTheDocument();
+    expect(screen.getByText('Live API')).toBeInTheDocument();
+    expect(screen.getByText('Property Types')).toBeInTheDocument();
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Benton County Assessor/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the five production income tabs', () => {
+    render(<IncomeForge />);
+
+    expect(screen.getByText('Valuation')).toBeInTheDocument();
+    expect(screen.getByText('Cap Rates')).toBeInTheDocument();
+    expect(screen.getByText('Market Data')).toBeInTheDocument();
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Locations' })).toBeInTheDocument();
+  });
+
+  it('shows a county availability guard for unsupported county scopes', () => {
+    mockRuntime.countyScope = {
+      countyId: 'cowlitz',
+      supported: false,
+      message: 'IncomeForge live income-approach references are currently certified for Benton County only.',
+    };
+
+    render(<IncomeForge />);
+
+    expect(screen.getByText('Benton-certified data required')).toBeInTheDocument();
+    expect(screen.getByText(/Active county: cowlitz/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/forge/income/incomeForgeStore.ts
+++ b/frontend/apps/os-shell/src/pages/forge/income/incomeForgeStore.ts
@@ -1,0 +1,395 @@
+/**
+ * incomeForgeStore.ts - Zustand store for the standalone IncomeForge module.
+ *
+ * Pattern: API-first. Reference data and valuation math come from the
+ * CostForge income-approach endpoints; the frontend only captures inputs and
+ * renders results.
+ */
+import { create } from 'zustand';
+import { getToken } from '@/auth/authStorage';
+import { getSession } from '@/auth/session';
+import { buildCountyScopedSessionHeaders } from '@/services/countyIsolation';
+import { apiFetchJson } from '../../../lib/apiBase';
+
+export interface CapRateEntry {
+  propertyType: string;
+  label: string;
+  min: number;
+  max: number;
+  typical: number;
+}
+
+export interface CapRatesResponse {
+  capRates: CapRateEntry[];
+  marketCapRate: number;
+  effectiveDate: string;
+  source: string;
+}
+
+export interface EmploymentSector {
+  sector: string;
+  percentOfTotal: number;
+}
+
+export interface MarketData {
+  county: string;
+  state: string;
+  medianHouseholdIncome: number;
+  unemploymentRate: number;
+  populationGrowthRate: number;
+  medianHomePrice: number;
+  medianPricePerSqft: number;
+  medianDaysOnMarket: number;
+  monthsOfInventory: number;
+  employmentSectors: EmploymentSector[];
+  effectiveDate: string;
+  source: string;
+}
+
+export interface ExpenseRatioEntry {
+  propertyType: string;
+  label: string;
+  lowPct: number;
+  highPct: number;
+  typicalPct: number;
+}
+
+interface ExpenseRatiosResponse {
+  expenseRatios: ExpenseRatioEntry[];
+  expenseCategories: string[];
+  effectiveDate: string;
+  source: string;
+}
+
+export interface LocationPremium {
+  location: string;
+  multiplier: number;
+  note: string;
+}
+
+interface LocationPremiumsResponse {
+  locationPremiums: LocationPremium[];
+  effectiveDate: string;
+  source: string;
+}
+
+export interface IncomeExpenses {
+  propertyTaxes: number;
+  insurance: number;
+  utilities: number;
+  maintenance: number;
+  managementFees: number;
+  replacementReserves: number;
+  otherExpenses: number;
+}
+
+export interface IncomeValuationRequest {
+  annualRentalIncome: number;
+  vacancyRate: number;
+  otherIncome: number;
+  expenses: IncomeExpenses;
+  capRate: number;
+  location: string;
+  propertyType: string;
+}
+
+export interface IncomeValuationResult {
+  netOperatingIncome: number;
+  capRate: number;
+  location: string;
+  locationMultiplier: number;
+  propertyType: string;
+  rawValuation: number;
+  adjustedValuation: number;
+  grossIncomeMultiplier: number;
+  cashOnCashReturn: number;
+  riskClassification: string;
+  effectiveDate: string;
+  source: string;
+}
+
+interface IncomeForgeStats {
+  propertyTypes: number;
+  locations: number;
+  marketCapRate: number;
+  medianHomePrice: number;
+  medianIncome: number;
+}
+
+interface IncomeForgeCountyScope {
+  countyId: string | null;
+  supported: boolean;
+  message: string | null;
+}
+
+interface IncomeForgeState {
+  capRates: CapRateEntry[];
+  marketData: MarketData | null;
+  expenseRatios: ExpenseRatioEntry[];
+  expenseCategories: string[];
+  locationPremiums: LocationPremium[];
+  valuationResult: IncomeValuationResult | null;
+
+  capRatesLoading: boolean;
+  marketLoading: boolean;
+  expensesLoading: boolean;
+  locationsLoading: boolean;
+  valuationLoading: boolean;
+
+  capRatesError: string | null;
+  marketError: string | null;
+  expensesError: string | null;
+  locationsError: string | null;
+  valuationError: string | null;
+
+  stats: IncomeForgeStats;
+  referenceSource: string | null;
+  countyScope: IncomeForgeCountyScope;
+
+  fetchReferenceData: () => Promise<void>;
+  fetchCapRates: () => Promise<void>;
+  fetchMarketData: () => Promise<void>;
+  fetchExpenseRatios: () => Promise<void>;
+  fetchLocationPremiums: () => Promise<void>;
+  calculateValuation: (request: IncomeValuationRequest) => Promise<void>;
+}
+
+const emptyStats: IncomeForgeStats = {
+  propertyTypes: 0,
+  locations: 0,
+  marketCapRate: 0,
+  medianHomePrice: 0,
+  medianIncome: 0,
+};
+
+const bentonCountyIds = new Set([
+  '19190019-1919-1919-1919-191919191919',
+  'benton',
+  'benton-county',
+  'benton-wa',
+]);
+
+const errorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error));
+
+function getIncomeForgeCountyScope(session = getSession()): IncomeForgeCountyScope {
+  const countyId = session?.countyId?.trim() || null;
+  const supported = countyId ? bentonCountyIds.has(countyId.toLowerCase()) : false;
+  return {
+    countyId,
+    supported,
+    message: supported
+      ? null
+      : 'IncomeForge live income-approach references are currently certified for Benton County only.',
+  };
+}
+
+function markUnsupportedCounty(set: (partial: Partial<IncomeForgeState>) => void): void {
+  const countyScope = getIncomeForgeCountyScope();
+  set({
+    countyScope,
+    capRatesLoading: false,
+    marketLoading: false,
+    expensesLoading: false,
+    locationsLoading: false,
+    valuationLoading: false,
+    capRatesError: null,
+    marketError: null,
+    expensesError: null,
+    locationsError: null,
+    valuationError: null,
+    capRates: [],
+    marketData: null,
+    expenseRatios: [],
+    expenseCategories: [],
+    locationPremiums: [],
+    valuationResult: null,
+    stats: emptyStats,
+    referenceSource: null,
+  });
+}
+
+function incomeForgeHeaders(): { headers: Record<string, string>; countyScope: IncomeForgeCountyScope } {
+  const token = getToken();
+  const session = getSession();
+  const { headers } = buildCountyScopedSessionHeaders(session);
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return { headers, countyScope: getIncomeForgeCountyScope(session) };
+}
+
+export const useIncomeForgeStore = create<IncomeForgeState>((set, get) => ({
+  capRates: [],
+  marketData: null,
+  expenseRatios: [],
+  expenseCategories: [],
+  locationPremiums: [],
+  valuationResult: null,
+
+  capRatesLoading: false,
+  marketLoading: false,
+  expensesLoading: false,
+  locationsLoading: false,
+  valuationLoading: false,
+
+  capRatesError: null,
+  marketError: null,
+  expensesError: null,
+  locationsError: null,
+  valuationError: null,
+
+  stats: emptyStats,
+  referenceSource: null,
+  countyScope: getIncomeForgeCountyScope(),
+
+  fetchReferenceData: async () => {
+    if (!getIncomeForgeCountyScope().supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    await Promise.all([
+      get().fetchCapRates(),
+      get().fetchMarketData(),
+      get().fetchExpenseRatios(),
+      get().fetchLocationPremiums(),
+    ]);
+  },
+
+  fetchCapRates: async () => {
+    const { headers, countyScope } = incomeForgeHeaders();
+    if (!countyScope.supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    set({ capRatesLoading: true, capRatesError: null });
+    try {
+      const data = await apiFetchJson<CapRatesResponse>('/costforge/income-approach/cap-rates', {
+        headers,
+      });
+      set((state) => ({
+        countyScope,
+        capRates: data.capRates,
+        referenceSource: data.source,
+        capRatesLoading: false,
+        stats: {
+          ...state.stats,
+          propertyTypes: data.capRates.length,
+          marketCapRate: data.marketCapRate,
+        },
+      }));
+    } catch (error: unknown) {
+      set({ capRatesError: errorMessage(error), capRatesLoading: false });
+    }
+  },
+
+  fetchMarketData: async () => {
+    const { headers, countyScope } = incomeForgeHeaders();
+    if (!countyScope.supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    set({ marketLoading: true, marketError: null });
+    try {
+      const data = await apiFetchJson<MarketData>('/costforge/income-approach/market-data/benton', {
+        headers,
+      });
+      set((state) => ({
+        countyScope,
+        marketData: data,
+        marketLoading: false,
+        stats: {
+          ...state.stats,
+          medianHomePrice: data.medianHomePrice,
+          medianIncome: data.medianHouseholdIncome,
+        },
+      }));
+    } catch (error: unknown) {
+      set({ marketError: errorMessage(error), marketLoading: false });
+    }
+  },
+
+  fetchExpenseRatios: async () => {
+    const { headers, countyScope } = incomeForgeHeaders();
+    if (!countyScope.supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    set({ expensesLoading: true, expensesError: null });
+    try {
+      const data = await apiFetchJson<ExpenseRatiosResponse>(
+        '/costforge/income-approach/expense-ratios',
+        { headers }
+      );
+      set({
+        countyScope,
+        expenseRatios: data.expenseRatios,
+        expenseCategories: data.expenseCategories,
+        expensesLoading: false,
+      });
+    } catch (error: unknown) {
+      set({ expensesError: errorMessage(error), expensesLoading: false });
+    }
+  },
+
+  fetchLocationPremiums: async () => {
+    const { headers, countyScope } = incomeForgeHeaders();
+    if (!countyScope.supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    set({ locationsLoading: true, locationsError: null });
+    try {
+      const data = await apiFetchJson<LocationPremiumsResponse>(
+        '/costforge/income-approach/location-premiums/benton',
+        { headers }
+      );
+      set((state) => ({
+        countyScope,
+        locationPremiums: data.locationPremiums,
+        locationsLoading: false,
+        stats: {
+          ...state.stats,
+          locations: data.locationPremiums.length,
+        },
+      }));
+    } catch (error: unknown) {
+      set({ locationsError: errorMessage(error), locationsLoading: false });
+    }
+  },
+
+  calculateValuation: async (request: IncomeValuationRequest) => {
+    const { headers, countyScope } = incomeForgeHeaders();
+    if (!countyScope.supported) {
+      markUnsupportedCounty(set);
+      return;
+    }
+    set({ valuationLoading: true, valuationError: null });
+    try {
+      const data = await apiFetchJson<IncomeValuationResult>(
+        '/costforge/income-approach/calculate-valuation',
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            annualRentalIncome: request.annualRentalIncome,
+            vacancyRate: request.vacancyRate,
+            otherIncome: request.otherIncome,
+            propertyTaxes: request.expenses.propertyTaxes,
+            insurance: request.expenses.insurance,
+            utilities: request.expenses.utilities,
+            maintenance: request.expenses.maintenance,
+            managementFees: request.expenses.managementFees,
+            replacementReserves: request.expenses.replacementReserves,
+            otherExpenses: request.expenses.otherExpenses,
+            capRate: request.capRate,
+            location: request.location,
+            propertyType: request.propertyType,
+          }),
+        }
+      );
+      set({ countyScope, valuationResult: data, valuationLoading: false });
+    } catch (error: unknown) {
+      set({ valuationError: errorMessage(error), valuationLoading: false });
+    }
+  },
+}));

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -17,7 +17,7 @@
  * Verified layout (matches screenshot from 2026-04-09):
  *   PRIMARY   : CostForge (cost approach, AppFrame → port 5002)
  *               CompsForge (sales comparison, standalone React module)
- *               IncomeForge (income approach, queued)
+ *               IncomeForge (income approach, live)
  *   SPECIALIST: Batch Cost Runs (batch execution)
  *               Regression Studio / TerraGAMA / Coefficient Preview (queued)
  *   DEFAULT ANALYTICS: County Studio (study-anchored Operational Health +
@@ -117,7 +117,6 @@ const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
     priority: 'primary',
     launchMode: 'standalone',
     moduleId: 'income-forge',
-    truthState: 'queued',
     chipLabel: 'Income approach',
   },
   {

--- a/frontend/apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx
@@ -5,7 +5,7 @@
  * PRIMARY_MODULES array to the wrong apps.
  *
  * Verified correct layout (current HEAD):
- *   PRIMARY   : CostForge, CompsForge, IncomeForge (queued), SalesForge, CUForge
+ *   PRIMARY   : CostForge, CompsForge, IncomeForge, SalesForge, CUForge
  *   SECONDARY : Batch Cost Runs, Regression Studio (queued),
  *               TerraGAMA (queued), Coefficient Preview (queued)
  *   COUNTY    : County Studio (default analytics workbench + VEI exploration)
@@ -119,10 +119,10 @@ describe('ForgeSuiteHome — frozen module list', () => {
     expect(screen.queryByText('Appeals')).not.toBeInTheDocument();
   });
 
-  it('IncomeForge button is disabled (queued)', () => {
+  it('IncomeForge button is enabled as a live standalone module', () => {
     renderForge();
     const incomeBtn = screen.getByText('IncomeForge').closest('button');
-    expect(incomeBtn).toBeDisabled();
+    expect(incomeBtn).not.toBeDisabled();
   });
 
   it('CostForge and CompsForge buttons are enabled', () => {


### PR DESCRIPTION
## Summary
- activates IncomeForge as a live TerraForge primary module
- adds a Zustand store wired to the existing CostForge income-approach endpoints with auth and county-scoped headers
- adds the standalone five-tab IncomeForge runtime UI plus focused module/registry tests

## Runtime Proof
- Backend API launched on port 5057 and frontend on 5173
- Playwright opened /forge, launched IncomeForge, and verified live API data across Valuation, Cap Rates, and Locations
- Verified 200 responses for cap rates, market data, expense ratios, location premiums, and valuation calculation
- Runtime screenshot captured locally at .tmp/income-forge-runtime.png

## Validation
- pnpm -C frontend test -- apps/os-shell/src/pages/forge/income/__tests__/IncomeForge.test.tsx apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
- pnpm -C frontend run type-check
- pnpm -C frontend run build
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj
- pre-push quality gate passed during git push

## Isolation Notes
- No TerraFusion Sync source files were edited
- No TerraFusion Data, migrations, or seeding files were edited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IncomeForge: a standalone Income Approach workspace with tabs for Valuation, Cap Rates, Market Data, Expenses, and Locations; editable inputs, backend valuation, stats panel, and reference/source banner.
* **Availability**
  * IncomeForge is now live and launchable from the Forge suite.
* **Tests**
  * Added unit tests covering IncomeForge UI, tab behavior, supported/unsupported county guard, and module display-name consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->