### PR TITLE
feat(coefficient-preview): activate live runtime module

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/MassAppraisalController.cs
+++ b/backend/src/TerraFusion.API/Controllers/MassAppraisalController.cs
@@ -4,6 +4,8 @@ using System;
 using System.Threading.Tasks;
 using TerraFusion.API.Interfaces;
 using TerraFusion.API.Seeds;
+using ICountyResolver = TerraFusion.Core.Services.ICountyResolver;
+using CountyNotFoundException = TerraFusion.Core.Services.CountyNotFoundException;
 
 namespace TerraFusion.API.Controllers
 {
@@ -20,6 +22,7 @@ namespace TerraFusion.API.Controllers
   {
     private readonly IMassAppraisalService _massAppraisalService;
     private readonly IForgeStatisticsService _statisticsService;
+    private readonly ICountyResolver _countyResolver;
     private readonly ILogger<MassAppraisalController> _logger;
 
     private static readonly Guid FallbackCountyId = DatabaseSeeder.BentonCountyId;
@@ -27,32 +30,36 @@ namespace TerraFusion.API.Controllers
     public MassAppraisalController(
         IMassAppraisalService massAppraisalService,
         IForgeStatisticsService statisticsService,
+        ICountyResolver countyResolver,
         ILogger<MassAppraisalController> logger)
     {
       _massAppraisalService = massAppraisalService;
       _statisticsService = statisticsService;
+      _countyResolver = countyResolver;
       _logger = logger;
     }
 
-    private Guid ResolveCountyId()
+    private string? ResolveCountyScopeToken()
     {
       var candidates = new[]
       {
+        User.FindFirst("county_id")?.Value,
         User.FindFirst("countyId")?.Value,
         Request.Headers["x-county-id"].FirstOrDefault(),
         Request.Headers["X-County-Id"].FirstOrDefault(),
         Request.Headers["X-TerraFusion-County"].FirstOrDefault(),
       };
 
-      foreach (var candidate in candidates)
-      {
-        if (Guid.TryParse(candidate, out var countyId))
-        {
-          return countyId;
-        }
-      }
+      return candidates.FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate))?.Trim();
+    }
 
-      return FallbackCountyId;
+    private async Task<Guid> ResolveCountyIdAsync(CancellationToken ct = default)
+    {
+      var countyToken = ResolveCountyScopeToken();
+      if (string.IsNullOrWhiteSpace(countyToken))
+        return FallbackCountyId;
+
+      return await _countyResolver.ResolveAsync(countyToken, ct);
     }
 
     /// <summary>
@@ -187,8 +194,13 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var strata = await _statisticsService.GetStrataAsync(modelId, ResolveCountyId());
+        var countyId = await ResolveCountyIdAsync();
+        var strata = await _statisticsService.GetStrataAsync(modelId, countyId);
         return Ok(strata);
+      }
+      catch (CountyNotFoundException ex)
+      {
+        return BadRequest(new { error = ex.Message, field = "countyId" });
       }
       catch (Exception ex)
       {
@@ -208,8 +220,13 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var outliers = await _statisticsService.GetOutliersAsync(modelId, ResolveCountyId());
+        var countyId = await ResolveCountyIdAsync();
+        var outliers = await _statisticsService.GetOutliersAsync(modelId, countyId);
         return Ok(outliers);
+      }
+      catch (CountyNotFoundException ex)
+      {
+        return BadRequest(new { error = ex.Message, field = "countyId" });
       }
       catch (Exception ex)
       {
@@ -233,8 +250,13 @@ namespace TerraFusion.API.Controllers
 
       try
       {
-        var comparison = await _statisticsService.CompareModelsAsync(request, ResolveCountyId());
+        var countyId = await ResolveCountyIdAsync();
+        var comparison = await _statisticsService.CompareModelsAsync(request, countyId);
         return Ok(comparison);
+      }
+      catch (CountyNotFoundException ex)
+      {
+        return BadRequest(new { error = ex.Message, field = "countyId" });
       }
       catch (Exception ex)
       {
@@ -254,8 +276,13 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var segments = await _statisticsService.DiscoverSegmentsAsync(modelId, ResolveCountyId());
+        var countyId = await ResolveCountyIdAsync();
+        var segments = await _statisticsService.DiscoverSegmentsAsync(modelId, countyId);
         return Ok(segments);
+      }
+      catch (CountyNotFoundException ex)
+      {
+        return BadRequest(new { error = ex.Message, field = "countyId" });
       }
       catch (Exception ex)
       {

--- a/backend/src/TerraFusion.API/Controllers/MassAppraisalController.cs
+++ b/backend/src/TerraFusion.API/Controllers/MassAppraisalController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
 using TerraFusion.API.Interfaces;
+using TerraFusion.API.Seeds;
 
 namespace TerraFusion.API.Controllers
 {
@@ -21,7 +22,7 @@ namespace TerraFusion.API.Controllers
     private readonly IForgeStatisticsService _statisticsService;
     private readonly ILogger<MassAppraisalController> _logger;
 
-    private static readonly Guid FallbackCountyId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid FallbackCountyId = DatabaseSeeder.BentonCountyId;
 
     public MassAppraisalController(
         IMassAppraisalService massAppraisalService,
@@ -31,6 +32,27 @@ namespace TerraFusion.API.Controllers
       _massAppraisalService = massAppraisalService;
       _statisticsService = statisticsService;
       _logger = logger;
+    }
+
+    private Guid ResolveCountyId()
+    {
+      var candidates = new[]
+      {
+        User.FindFirst("countyId")?.Value,
+        Request.Headers["x-county-id"].FirstOrDefault(),
+        Request.Headers["X-County-Id"].FirstOrDefault(),
+        Request.Headers["X-TerraFusion-County"].FirstOrDefault(),
+      };
+
+      foreach (var candidate in candidates)
+      {
+        if (Guid.TryParse(candidate, out var countyId))
+        {
+          return countyId;
+        }
+      }
+
+      return FallbackCountyId;
     }
 
     /// <summary>
@@ -165,7 +187,7 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var strata = await _statisticsService.GetStrataAsync(modelId, FallbackCountyId);
+        var strata = await _statisticsService.GetStrataAsync(modelId, ResolveCountyId());
         return Ok(strata);
       }
       catch (Exception ex)
@@ -186,7 +208,7 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var outliers = await _statisticsService.GetOutliersAsync(modelId, FallbackCountyId);
+        var outliers = await _statisticsService.GetOutliersAsync(modelId, ResolveCountyId());
         return Ok(outliers);
       }
       catch (Exception ex)
@@ -211,7 +233,7 @@ namespace TerraFusion.API.Controllers
 
       try
       {
-        var comparison = await _statisticsService.CompareModelsAsync(request, FallbackCountyId);
+        var comparison = await _statisticsService.CompareModelsAsync(request, ResolveCountyId());
         return Ok(comparison);
       }
       catch (Exception ex)
@@ -232,7 +254,7 @@ namespace TerraFusion.API.Controllers
     {
       try
       {
-        var segments = await _statisticsService.DiscoverSegmentsAsync(modelId, FallbackCountyId);
+        var segments = await _statisticsService.DiscoverSegmentsAsync(modelId, ResolveCountyId());
         return Ok(segments);
       }
       catch (Exception ex)

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1526,6 +1526,8 @@ builder.Services.AddScoped<IQuantumConsciousnessService, QuantumConsciousnessSer
 builder.Services.AddScoped<IResearchAnalyticsService, ResearchAnalyticsService>();
 builder.Services.AddScoped<IStatisticalAnalysisService, StatisticalAnalysisService>();
 builder.Services.AddScoped<IForgeStatisticsService, ForgeStatisticsService>();
+builder.Services.AddScoped<TerraFusion.API.Controllers.IMassAppraisalService,
+    TerraFusion.API.Controllers.MassAppraisalServiceStub>();
 builder.Services.AddScoped<ISalesAiDiagnosticService, SalesAiDiagnosticService>();
 // Dev stub: returns empty until a real CAMA service is registered
 builder.Services.AddScoped<IPredictiveModelingService, PredictiveModelingService>();

--- a/backend/src/TerraFusion.API/Services/CountyResolver.cs
+++ b/backend/src/TerraFusion.API/Services/CountyResolver.cs
@@ -51,7 +51,24 @@ public class CountyResolver : ICountyResolver
         if (lookup.NameToId.TryGetValue(input, out var byName))
             return byName;
 
+        // Precedence 3: county slug, e.g. "benton-wa" -> "Benton".
+        var slugName = TryGetCountyNameFromSlug(input);
+        if (slugName is not null && lookup.NameToId.TryGetValue(slugName, out var bySlug))
+            return bySlug;
+
         return null;
+    }
+
+    private static string? TryGetCountyNameFromSlug(string input)
+    {
+        var parts = input.Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 2 || !string.Equals(parts[^1], "wa", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return string.Join(
+            ' ',
+            parts[..^1].Select(part =>
+                char.ToUpperInvariant(part[0]) + part[1..].ToLowerInvariant()));
     }
 
     private async Task<CountyLookup> GetLookupAsync(CancellationToken ct)

--- a/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
+++ b/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
@@ -83,70 +83,64 @@ public class ForgeStatisticsService : IForgeStatisticsService
 
     /// <summary>
     /// Pull qualified sales with assessed values and neighborhood codes for the given year window.
-    /// Neighborhood is resolved from CamaCharacteristics (same pattern as TerraForgeController).
+    /// Uses the same final-decision/recommendation qualification posture as TerraForge regression.
     /// Returns a flat projection used by all stat methods.
     /// </summary>
     private async Task<List<SaleRow>> FetchSaleRowsAsync(
-        int taxYear, int windowYears, CancellationToken ct)
+        int taxYear, int windowYears, Guid countyId, CancellationToken ct)
     {
         var cutoff = taxYear - (windowYears - 1);
-
-        // Step 1: pull sales
-        var rawSales = await _db.ComparableSales
+        var valuationTaxYear = await _db.Properties
             .AsNoTracking()
-            .Where(s => s.SaleQualification == "qualified"
-                     && s.SalesYear >= cutoff
-                     && s.SalesYear <= taxYear
-                     && s.SalePrice > 10_000)
-            .Select(s => new
+            .Where(p => p.CountyId == countyId)
+            .MaxAsync(p => (int?)p.TaxYear, ct) ?? taxYear;
+
+        var rows = await (
+            from s in _db.ComparableSales.AsNoTracking()
+            join p in _db.Properties.AsNoTracking()
+              on new { ParcelId = s.ParcelId, s.CountyId, TaxYear = valuationTaxYear }
+              equals new { ParcelId = p.ParcelNumber!, p.CountyId, p.TaxYear }
+            where s.CountyId == countyId
+               && s.SalesYear >= cutoff
+               && s.SalesYear <= taxYear
+               && s.SalePrice > 10_000
+               && p.AssessedValue > 0
+               && (s.QualificationDecision == "qualified"
+                   || (s.QualificationDecision == null
+                       && (s.QualificationRecommendation == "qualified"
+                           || s.QualificationRecommendation == null)))
+               && s.SuppressOnRatioRptCd != "T"
+               && s.IncludeNoCalc != true
+            select new
             {
                 s.ParcelId,
                 s.Address,
                 s.PropertyType,
+                s.Neighborhood,
                 SalePrice = s.AdjustedSalePrice > 0 ? s.AdjustedSalePrice!.Value : s.SalePrice,
+                p.AssessedValue,
                 s.SaleDate,
             })
             .ToListAsync(ct);
 
-        if (rawSales.Count == 0) return new List<SaleRow>();
-
-        var parcelIds = rawSales.Select(s => s.ParcelId).Distinct().ToHashSet();
-
-        // Step 2: AV from Properties (ParcelNumber matches ParcelId)
-        var avMap = await _db.Properties
-            .AsNoTracking()
-            .Where(p => parcelIds.Contains(p.ParcelNumber) && p.TaxYear == taxYear && p.AssessedValue > 0)
-            .Select(p => new { p.ParcelNumber, p.AssessedValue })
-            .ToDictionaryAsync(p => p.ParcelNumber!, p => p.AssessedValue, ct);
-
-        // Step 3: neighborhood from CamaCharacteristics
-        var hoodMap = await _db.CamaCharacteristics
-            .AsNoTracking()
-            .Where(c => parcelIds.Contains(c.ParcelId) && c.NeighborhoodCode != null && c.NeighborhoodCode != "")
-            .Select(c => new { c.ParcelId, c.NeighborhoodCode })
-            .ToDictionaryAsync(c => c.ParcelId, c => c.NeighborhoodCode!, ct);
-
-        // Step 4: build SaleRow list
-        var rows = new List<SaleRow>(rawSales.Count);
-        foreach (var s in rawSales)
-        {
-            if (s.ParcelId == null) continue;
-            if (!avMap.TryGetValue(s.ParcelId, out var av) || av <= 0) continue;
-            if (s.SalePrice <= 0) continue;
-            var ratio = Math.Clamp((double)(av / s.SalePrice), 0.5, 2.0);
-            rows.Add(new SaleRow
+        return rows
+            .Where(s => s.SalePrice > 0)
+            .Select(s =>
             {
-                ParcelId      = s.ParcelId,
-                Address       = s.Address ?? "",
-                Neighborhood  = hoodMap.TryGetValue(s.ParcelId, out var hood) ? hood : "Unknown",
-                PropertyType  = s.PropertyType ?? "residential",
-                SalePrice     = s.SalePrice,
-                AssessedValue = av,
-                SaleDate      = s.SaleDate,
-                Ratio         = ratio,
-            });
-        }
-        return rows;
+                var ratio = Math.Clamp((double)(s.AssessedValue / s.SalePrice), 0.5, 2.0);
+                return new SaleRow
+                {
+                    ParcelId      = s.ParcelId,
+                    Address       = s.Address ?? "",
+                    Neighborhood  = string.IsNullOrWhiteSpace(s.Neighborhood) ? "Unknown" : s.Neighborhood,
+                    PropertyType  = s.PropertyType ?? "residential",
+                    SalePrice     = s.SalePrice,
+                    AssessedValue = s.AssessedValue,
+                    SaleDate      = s.SaleDate,
+                    Ratio         = ratio,
+                };
+            })
+            .ToList();
     }
 
     private sealed class SaleRow
@@ -169,7 +163,7 @@ public class ForgeStatisticsService : IForgeStatisticsService
         var taxYear = ParseTaxYear(modelId);
         _logger.LogInformation("GetStrataAsync: taxYear={TaxYear} countyId={CountyId}", taxYear, countyId);
 
-        var rows = await FetchSaleRowsAsync(taxYear, 3, ct);
+        var rows = await FetchSaleRowsAsync(taxYear, 3, countyId, ct);
         _logger.LogInformation("GetStrataAsync: {Count} qualified sale rows loaded", rows.Count);
 
         // Normalize PropertyType → readable label
@@ -227,7 +221,7 @@ public class ForgeStatisticsService : IForgeStatisticsService
         var taxYear = ParseTaxYear(modelId);
         _logger.LogInformation("GetOutliersAsync: taxYear={TaxYear}", taxYear);
 
-        var rows = await FetchSaleRowsAsync(taxYear, 3, ct);
+        var rows = await FetchSaleRowsAsync(taxYear, 3, countyId, ct);
         if (rows.Count == 0) return new List<OutlierRecordDto>();
 
         // Global IQR fence
@@ -292,16 +286,16 @@ public class ForgeStatisticsService : IForgeStatisticsService
         if (yearA == yearB)
         {
             // Same year: compare 1-year vs 3-year rolling windows
-            rowsA  = await FetchSaleRowsAsync(yearA, 1, ct);
-            rowsB  = await FetchSaleRowsAsync(yearB, 3, ct);
+            rowsA  = await FetchSaleRowsAsync(yearA, 1, countyId, ct);
+            rowsB  = await FetchSaleRowsAsync(yearB, 3, countyId, ct);
             labelA = $"{yearA} (1-year)";
             labelB = $"{yearB} (3-year)";
         }
         else
         {
             // Different years: compare each year's 3-year window
-            rowsA  = await FetchSaleRowsAsync(yearA, 3, ct);
-            rowsB  = await FetchSaleRowsAsync(yearB, 3, ct);
+            rowsA  = await FetchSaleRowsAsync(yearA, 3, countyId, ct);
+            rowsB  = await FetchSaleRowsAsync(yearB, 3, countyId, ct);
             labelA = $"{yearA} study";
             labelB = $"{yearB} study";
         }

--- a/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
+++ b/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
@@ -95,39 +95,47 @@ public class ForgeStatisticsService : IForgeStatisticsService
             .Where(p => p.CountyId == countyId)
             .MaxAsync(p => (int?)p.TaxYear, ct) ?? taxYear;
 
-        var rows = await (
-            from s in _db.ComparableSales.AsNoTracking()
-            join p in _db.Properties.AsNoTracking()
-              on new { ParcelId = s.ParcelId, s.CountyId, TaxYear = valuationTaxYear }
-              equals new { ParcelId = p.ParcelNumber!, p.CountyId, p.TaxYear }
-            where s.CountyId == countyId
-               && s.SalesYear >= cutoff
-               && s.SalesYear <= taxYear
-               && s.SalePrice > 10_000
-               && p.AssessedValue > 0
-               && (s.QualificationDecision == "qualified"
-                   || (s.QualificationDecision == null
-                       && (s.QualificationRecommendation == "qualified"
-                           || s.QualificationRecommendation == null)))
-               && s.SuppressOnRatioRptCd != "T"
-               && s.IncludeNoCalc != true
-            select new
+        var sales = await _db.ComparableSales.AsNoTracking()
+            .Where(s => s.CountyId == countyId
+                && s.SalesYear >= cutoff
+                && s.SalesYear <= taxYear
+                && s.SalePrice > 10_000
+                && (s.QualificationDecision == "qualified"
+                    || (s.QualificationDecision == null
+                        && (s.QualificationRecommendation == "qualified"
+                            || s.QualificationRecommendation == null)))
+                && s.SuppressOnRatioRptCd != "T"
+                && s.IncludeNoCalc != true)
+            .Select(s => new
             {
                 s.ParcelId,
                 s.Address,
                 s.PropertyType,
                 s.Neighborhood,
                 SalePrice = s.AdjustedSalePrice > 0 ? s.AdjustedSalePrice!.Value : s.SalePrice,
-                p.AssessedValue,
                 s.SaleDate,
             })
             .ToListAsync(ct);
 
-        return rows
-            .Where(s => s.SalePrice > 0)
+        var assessedValues = await _db.Properties.AsNoTracking()
+            .Where(p => p.CountyId == countyId
+                && p.TaxYear == valuationTaxYear
+                && p.AssessedValue > 0
+                && p.ParcelNumber != null
+                && p.ParcelNumber != "")
+            .Select(p => new { p.ParcelNumber, p.AssessedValue })
+            .ToListAsync(ct);
+
+        var assessedValueByParcel = assessedValues
+            .GroupBy(p => p.ParcelNumber, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().AssessedValue, StringComparer.OrdinalIgnoreCase);
+
+        return sales
+            .Where(s => s.SalePrice > 0 && assessedValueByParcel.ContainsKey(s.ParcelId))
             .Select(s =>
             {
-                var ratio = Math.Clamp((double)(s.AssessedValue / s.SalePrice), 0.5, 2.0);
+                var assessedValue = assessedValueByParcel[s.ParcelId];
+                var ratio = Math.Clamp((double)(assessedValue / s.SalePrice), 0.5, 2.0);
                 return new SaleRow
                 {
                     ParcelId      = s.ParcelId,
@@ -135,7 +143,7 @@ public class ForgeStatisticsService : IForgeStatisticsService
                     Neighborhood  = string.IsNullOrWhiteSpace(s.Neighborhood) ? "Unknown" : s.Neighborhood,
                     PropertyType  = s.PropertyType ?? "residential",
                     SalePrice     = s.SalePrice,
-                    AssessedValue = s.AssessedValue,
+                    AssessedValue = assessedValue,
                     SaleDate      = s.SaleDate,
                     Ratio         = ratio,
                 };

--- a/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
+++ b/backend/src/TerraFusion.API/Services/ForgeStatisticsService.cs
@@ -90,10 +90,6 @@ public class ForgeStatisticsService : IForgeStatisticsService
         int taxYear, int windowYears, Guid countyId, CancellationToken ct)
     {
         var cutoff = taxYear - (windowYears - 1);
-        var valuationTaxYear = await _db.Properties
-            .AsNoTracking()
-            .Where(p => p.CountyId == countyId)
-            .MaxAsync(p => (int?)p.TaxYear, ct) ?? taxYear;
 
         var sales = await _db.ComparableSales.AsNoTracking()
             .Where(s => s.CountyId == countyId
@@ -117,16 +113,26 @@ public class ForgeStatisticsService : IForgeStatisticsService
             })
             .ToListAsync(ct);
 
+        if (sales.Count == 0) return new List<SaleRow>();
+
+        var saleParcelIds = sales
+            .Where(s => !string.IsNullOrWhiteSpace(s.ParcelId))
+            .Select(s => s.ParcelId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         var assessedValues = await _db.Properties.AsNoTracking()
             .Where(p => p.CountyId == countyId
-                && p.TaxYear == valuationTaxYear
+                && p.TaxYear == taxYear
                 && p.AssessedValue > 0
                 && p.ParcelNumber != null
-                && p.ParcelNumber != "")
-            .Select(p => new { p.ParcelNumber, p.AssessedValue })
+                && p.ParcelNumber != ""
+                && saleParcelIds.Contains(p.ParcelNumber))
+            .Select(p => new { ParcelNumber = p.ParcelNumber!, p.AssessedValue })
             .ToListAsync(ct);
 
         var assessedValueByParcel = assessedValues
+            .AsEnumerable()
             .GroupBy(p => p.ParcelNumber, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.First().AssessedValue, StringComparer.OrdinalIgnoreCase);
 

--- a/backend/tests/TerraFusion.SalesForge.Tests/CoefficientPreviewRuntimeContractTests.cs
+++ b/backend/tests/TerraFusion.SalesForge.Tests/CoefficientPreviewRuntimeContractTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Xunit;
+
+namespace TerraFusion.SalesForge.Tests;
+
+public class CoefficientPreviewRuntimeContractTests
+{
+    private static readonly string ControllerSource = ReadSource(
+        "src", "TerraFusion.API", "Controllers", "MassAppraisalController.cs");
+
+    private static readonly string CountyResolverSource = ReadSource(
+        "src", "TerraFusion.API", "Services", "CountyResolver.cs");
+
+    private static readonly string StatisticsSource = ReadSource(
+        "src", "TerraFusion.API", "Services", "ForgeStatisticsService.cs");
+
+    [Fact]
+    public void MassAppraisal_ResolvesCountyScopeThroughCountyResolver()
+    {
+        ControllerSource.Should().Contain("ICountyResolver");
+        ControllerSource.Should().Contain("_countyResolver.ResolveAsync(countyToken");
+        ControllerSource.Should().Contain("X-TerraFusion-County");
+    }
+
+    [Fact]
+    public void CountyResolver_AcceptsWashingtonCountySlugTokens()
+    {
+        CountyResolverSource.Should().Contain("TryGetCountyNameFromSlug");
+        CountyResolverSource.Should().Contain("\"wa\", StringComparison.OrdinalIgnoreCase");
+    }
+
+    [Fact]
+    public void ForgeStatistics_JoinsPropertiesOnRequestedStudyTaxYear()
+    {
+        StatisticsSource.Should().Contain("p.TaxYear == taxYear");
+        StatisticsSource.Should().Contain("saleParcelIds.Contains(p.ParcelNumber)");
+        StatisticsSource.Should().NotContain("MaxAsync(p => (int?)p.TaxYear");
+    }
+
+    private static string ReadSource(params string[] relativePath)
+    {
+        var testDir = AppDomain.CurrentDomain.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", ".."));
+        return File.ReadAllText(Path.Combine(new[] { repoRoot }.Concat(relativePath).ToArray()));
+    }
+}

--- a/docs/superpowers/plans/2026-05-24-coefficient-preview-runtime.md
+++ b/docs/superpowers/plans/2026-05-24-coefficient-preview-runtime.md
@@ -1,0 +1,59 @@
+# Coefficient Preview Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate Coefficient Preview as a live read-only Forge module backed by TerraForge/MassAppraisal API data.
+
+**Architecture:** Keep the module self-contained. Replace raw fetch/model-registry logic with county-scoped `apiFetchJson` calls, normalize two regression responses plus one comparison response into the existing preview display model, and keep apply operations blocked.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, TerraFusion `apiFetchJson`, county isolation/session helpers.
+
+---
+
+## File Structure
+
+- Modify `frontend/apps/os-shell/src/pages/forge/batch/CoefficientPreview.tsx`: live API calls, normalization, unavailable state, read-only apply messaging.
+- Modify `frontend/apps/os-shell/src/pages/forge/batch/__tests__/CoefficientPreview.test.tsx`: red/green tests for live endpoints and unavailable state.
+- Modify `frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx`: remove queued state from Coefficient Preview and update chip.
+- Modify `frontend/apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx`: assert Coefficient Preview is enabled and TerraGAMA remains queued.
+
+## Tasks
+
+### Task 1: Prove Live Preview Contract
+
+- [ ] Write failing tests in `CoefficientPreview.test.tsx` that mock `apiFetchJson`, session, token, and county headers.
+- [ ] Assert Generate Preview calls `/terraforge/regression` for 2026 and 2025 and `/MassAppraisal/compare` with county headers.
+- [ ] Assert coefficient deltas render for `intercept` and `GLA_sqft`.
+- [ ] Run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/batch/__tests__/CoefficientPreview.test.tsx`; expected failure because current component uses raw fetch and model registry.
+
+### Task 2: Implement Live Preview
+
+- [ ] Replace raw `fetch` usage in `CoefficientPreview.tsx` with `apiFetchJson`.
+- [ ] Build request headers from `getSession`, `getToken`, and `buildCountyScopedSessionHeaders`.
+- [ ] Normalize source/candidate regression responses into coefficient delta rows.
+- [ ] Normalize `MassAppraisal/compare` into COD, PRD, median ratio, and sample-size deltas.
+- [ ] Run the CoefficientPreview test and confirm it passes.
+
+### Task 3: Activate Launcher
+
+- [ ] Update `ForgeSuiteHome.tsx` to remove `truthState: 'queued'` from Coefficient Preview and set `chipLabel: 'Live preview'`.
+- [ ] Update the Forge suite module-list test to expect Coefficient Preview enabled while TerraGAMA remains queued.
+- [ ] Run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx`; confirm pass.
+
+### Task 4: Verify Slice
+
+- [ ] Run focused tests for Coefficient Preview and ForgeSuiteHome.
+- [ ] Run `pnpm run type-check`.
+- [ ] Run `node --test os-platform/core/tests/phase83-tools.test.mjs`.
+- [ ] Run `pnpm -C frontend run type-check`.
+- [ ] Run `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -p:DotNetWatchBuild=true`.
+- [ ] Run `pnpm -C frontend run build`.
+- [ ] Start local backend/frontend, open `/forge`, launch Coefficient Preview, and prove live data renders.
+
+### Task 5: Publish
+
+- [ ] Commit the design and plan.
+- [ ] Commit implementation separately.
+- [ ] Push branch `codex/coefficient-preview-runtime`.
+- [ ] Open PR and enable squash auto-merge.
+- [ ] Watch CI; fix any actionable failures or review threads.

--- a/docs/superpowers/specs/2026-05-24-coefficient-preview-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-24-coefficient-preview-runtime-design.md
@@ -1,0 +1,39 @@
+# Coefficient Preview Runtime Design
+
+## Goal
+
+Promote Coefficient Preview from a queued Forge surface to a live, read-only runtime module that proves coefficient comparison with production API data and does not imply coefficients can be applied.
+
+## Scope
+
+This slice only touches the Forge suite launcher, the Coefficient Preview frontend module, and focused tests. It does not modify TerraFusion Sync, data seeding, migrations, or backend write lanes.
+
+## Runtime Contract
+
+Coefficient Preview will compare two tax-year regression windows. It will fetch:
+
+- `GET /api/terraforge/regression?taxYear=<year>&countyId=<countyId>` for source and candidate coefficient vectors.
+- `POST /api/MassAppraisal/compare` for IAAO summary deltas.
+
+Requests must use the existing `apiFetchJson` API wrapper, county-scoped session headers, and bearer token when present. The component must not use raw `fetch`.
+
+## UI Behavior
+
+The launcher card becomes live with a `Live preview` chip. The module defaults to source year 2026 and candidate year 2025. Generate Preview loads live data, displays source/candidate model labels, COD/PRD/median ratio deltas, coefficient deltas by predictor, and impact counts from the compare endpoint.
+
+If either regression cannot be fit, the component renders an honest unavailable message with the backend reason and leaves Apply blocked.
+
+Apply remains read-only. The button may record an audit-trail event, but it must say the write backend is unavailable and must not call an apply endpoint.
+
+## Testing
+
+Tests must prove:
+
+- The launcher enables Coefficient Preview while TerraGAMA remains queued.
+- The component calls live county-scoped endpoints and maps regression coefficients into visible deltas.
+- The component does not use legacy raw `fetch` or `/api/MassAppraisal/models`.
+- The unavailable path displays backend insufficiency without fake rows.
+
+## Acceptance
+
+Local focused tests, core type-check, Phase 83 gate, frontend type-check, backend API build, frontend production build, and browser runtime proof must pass before PR.

--- a/frontend/apps/os-shell/src/pages/forge/batch/CoefficientPreview.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/batch/CoefficientPreview.tsx
@@ -1,29 +1,22 @@
 /**
- * CoefficientPreview.tsx (Tranche 1D → 1E audit-proof)
+ * CoefficientPreview.tsx
  *
  * Standalone Forge module: Coefficient Application Preview.
- * Shows current vs proposed coefficients, impacted parcel count,
- * COD/PRD delta, and top impact buckets. Preview-only, non-destructive.
- *
- * Write lane: Read-only preview (Forge scope).
- * No parcelId routing — cross-parcel / county-wide.
- *
- * 1E additions: ForgeApplyMode lifecycle, preview-only enforcement,
- * backend-capability gate, blocker display, and audit event emission.
- *
- * DATA POSTURE:
- * - No model list or preview result is fabricated when the backend is unavailable.
- * - `BACKEND_APPLY_CAPABLE = false`: the coefficient apply endpoint is not yet
- *   wired. Apply is blocked at the UI layer until this flag is set to true.
+ * Read-only county-scoped comparison of source and candidate tax-year
+ * regressions before any coefficient table publication.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import React, { useCallback, useState } from 'react';
+import { getToken } from '@/auth/authStorage';
+import { getSession } from '@/auth/session';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { apiFetchJson } from '@/lib/apiBase';
+import { buildCountyScopedSessionHeaders } from '@/services/countyIsolation';
 
 // ---------------------------------------------------------------------------
-// 1E: Apply-mode types & audit event emitter
+// Apply-mode types & audit event emitter
 // ---------------------------------------------------------------------------
 
 type ForgeApplyMode = 'preview_only' | 'apply_pending_backend' | 'apply_executed';
@@ -38,15 +31,17 @@ interface AuditEvent {
   timestamp: string;
 }
 
-/** Backend capability flag — false until real backend is wired */
 const BACKEND_APPLY_CAPABLE = false;
+const YEAR_OPTIONS = [2026, 2025, 2024] as const;
+const DEFAULT_SOURCE_YEAR = 2026;
+const DEFAULT_CANDIDATE_YEAR = 2025;
 
 let _auditSeq = 0;
 function emitAuditEvent(
   mode: ForgeApplyMode,
   outcome: AuditEvent['outcome'],
 ): AuditEvent {
-  const evt: AuditEvent = {
+  return {
     eventId: `coeff-audit-${++_auditSeq}`,
     requestId: `coeff-req-${Date.now()}`,
     suite: 'forge',
@@ -55,8 +50,52 @@ function emitAuditEvent(
     outcome,
     timestamp: new Date().toISOString(),
   };
-  // eslint-disable-next-line no-console
-  return evt;
+}
+
+// ---------------------------------------------------------------------------
+// API DTOs
+// ---------------------------------------------------------------------------
+
+interface RegressionModelDto {
+  predictors: string[];
+  beta: number[];
+  rSquared?: number;
+  rSquaredAdj?: number;
+  rmse?: number;
+  n?: number;
+}
+
+interface TerraForgeRegressionDto {
+  taxYear: number;
+  totalPool?: number;
+  usedForFit?: number;
+  excludedCount?: number;
+  insufficientData?: boolean;
+  minimumRequired?: number;
+  model: RegressionModelDto | null;
+}
+
+interface ModelSummaryDto {
+  label: string;
+  medianRatio: number;
+  cod: number;
+  prd: number;
+  prb: number;
+  sampleSize: number;
+}
+
+interface ModelComparisonDto {
+  modelA: ModelSummaryDto;
+  modelB: ModelSummaryDto;
+  deltas: {
+    cod: number;
+    prd: number;
+    prb: number;
+    medianRatio: number;
+    sampleSize: number;
+  };
+  improvedMetrics: string[];
+  degradedMetrics: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -96,83 +135,184 @@ interface PreviewResult {
   impactBuckets: ImpactBucket[];
 }
 
+interface CountyScope {
+  countyId: string;
+  headers: Record<string, string>;
+}
+
+function getHeaderValue(headers: Record<string, string>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const exact = headers[key];
+    if (exact) return exact;
+    const insensitive = Object.entries(headers).find(
+      ([candidate]) => candidate.toLowerCase() === key.toLowerCase(),
+    );
+    if (insensitive?.[1]) return insensitive[1];
+  }
+  return undefined;
+}
+
+function getCoefficientPreviewScope(): CountyScope {
+  const session = getSession();
+  const token = getToken();
+  const { headers } = buildCountyScopedSessionHeaders(session);
+  const countyId = session?.countyId
+    ?? getHeaderValue(headers, ['X-TerraFusion-County', 'X-County-Id', 'x-county-id'])
+    ?? 'benton-wa';
+
+  return {
+    countyId,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers,
+    },
+  };
+}
+
+function formatUnavailable(label: 'source' | 'candidate', regression: TerraForgeRegressionDto): string | null {
+  if (!regression.insufficientData && regression.model) return null;
+
+  const usedForFit = regression.usedForFit ?? regression.model?.n ?? 0;
+  const minimumRequired = regression.minimumRequired ?? 5;
+  return `Insufficient observations for ${label} regression: ${usedForFit} available, ${minimumRequired} required`;
+}
+
+function coefficientAt(model: RegressionModelDto, predictor: string): number {
+  const index = model.predictors.findIndex((candidate) => candidate === predictor);
+  if (index < 0) return 0;
+  return model.beta[index] ?? 0;
+}
+
+function buildCoefficientDeltas(
+  source: RegressionModelDto,
+  candidate: RegressionModelDto,
+): CoefficientDelta[] {
+  const predictors = Array.from(new Set([...source.predictors, ...candidate.predictors]))
+    .filter((predictor) => predictor.toLowerCase() !== 'intercept');
+
+  return predictors.map((variable) => {
+    const currentValue = coefficientAt(source, variable);
+    const proposedValue = coefficientAt(candidate, variable);
+    const delta = proposedValue - currentValue;
+    const deltaPct = currentValue === 0 ? 0 : (delta / currentValue) * 100;
+    return { variable, currentValue, proposedValue, delta, deltaPct };
+  });
+}
+
+function buildImpactBuckets(deltas: CoefficientDelta[], sampleSize: number): ImpactBucket[] {
+  return deltas
+    .slice()
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, 4)
+    .map((delta) => ({
+      label: delta.variable,
+      count: sampleSize,
+      meanDollarImpact: Math.round(delta.delta),
+    }));
+}
+
+function normalizePreview(
+  sourceYear: number,
+  candidateYear: number,
+  sourceRegression: TerraForgeRegressionDto,
+  candidateRegression: TerraForgeRegressionDto,
+  comparison: ModelComparisonDto,
+): PreviewResult {
+  const sourceModel = sourceRegression.model;
+  const candidateModel = candidateRegression.model;
+
+  if (!sourceModel || !candidateModel) {
+    throw new Error('Regression coefficient model unavailable.');
+  }
+
+  const deltas = buildCoefficientDeltas(sourceModel, candidateModel);
+  const sampleSize = Math.max(0, comparison.modelB?.sampleSize ?? candidateRegression.usedForFit ?? 0);
+
+  return {
+    sourceModelId: String(sourceYear),
+    sourceModelName: comparison.modelA?.label || `${sourceYear} regression`,
+    candidateModelId: String(candidateYear),
+    candidateModelName: comparison.modelB?.label || `${candidateYear} regression`,
+    deltas,
+    metrics: {
+      codDelta: comparison.deltas?.cod ?? 0,
+      prdDelta: comparison.deltas?.prd ?? 0,
+      meanRatioDelta: comparison.deltas?.medianRatio ?? 0,
+      medianRatioDelta: comparison.deltas?.medianRatio ?? 0,
+    },
+    impactedParcelCount: sampleSize,
+    totalParcelsEvaluated: Math.max(
+      sampleSize,
+      comparison.modelA?.sampleSize ?? sourceRegression.usedForFit ?? sampleSize,
+    ),
+    impactBuckets: buildImpactBuckets(deltas, sampleSize),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 export function CoefficientPreview() {
-  const [sourceId, setSourceId] = useState('');
-  const [candidateId, setCandidateId] = useState('');
+  const [sourceYear, setSourceYear] = useState<number>(DEFAULT_SOURCE_YEAR);
+  const [candidateYear, setCandidateYear] = useState<number>(DEFAULT_CANDIDATE_YEAR);
   const [preview, setPreview] = useState<PreviewResult | null>(null);
-  const [models, setModels] = useState<{ id: string; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/api/MassAppraisal/models')
-      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
-      .then((data: Array<{ modelId?: string; id?: string; name?: string; Name?: string }>) => {
-        if (Array.isArray(data) && data.length > 0) {
-          const mapped = data.map((m) => ({
-            id: m.modelId ?? m.id ?? '',
-            name: m.name ?? m.Name ?? m.modelId ?? m.id ?? 'Unknown',
-          }));
-          setModels(mapped);
-          setSourceId(mapped[0].id);
-          if (mapped.length > 1) setCandidateId(mapped[1].id);
-          setError(null);
-        }
-      })
-      .catch((err) => {
-        setModels([]);
-        setSourceId('');
-        setCandidateId('');
-        setError(`Model registry unavailable: ${err instanceof Error ? err.message : String(err)}`);
-      });
-  }, []);
-
-  // 1E: Apply mode lifecycle
   const [applyMode, setApplyMode] = useState<ForgeApplyMode>('preview_only');
   const [auditLog, setAuditLog] = useState<AuditEvent[]>([]);
 
   const handlePreview = useCallback(async () => {
+    setLoading(true);
     setError(null);
+    setPreview(null);
+
     try {
-      const response = await fetch('/api/MassAppraisal/compare', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ModelIdA: sourceId, ModelIdB: candidateId }),
-      });
-      if (response.ok) {
-        const data = await response.json();
-        const livePreview: PreviewResult = {
-          sourceModelId: sourceId,
-          sourceModelName: data.modelA?.label ?? sourceId,
-          candidateModelId: candidateId,
-          candidateModelName: data.modelB?.label ?? candidateId,
-          deltas: [],
-          metrics: {
-            codDelta: data.deltas?.cod ?? 0,
-            prdDelta: data.deltas?.prd ?? 0,
-            meanRatioDelta: data.deltas?.medianRatio ?? 0,
-            medianRatioDelta: data.deltas?.medianRatio ?? 0,
+      const scope = getCoefficientPreviewScope();
+      const requestInit = { headers: scope.headers };
+      const [sourceRegression, candidateRegression, comparison] = await Promise.all([
+        apiFetchJson<TerraForgeRegressionDto>(
+          `/terraforge/regression?taxYear=${sourceYear}&countyId=${encodeURIComponent(scope.countyId)}`,
+          requestInit,
+        ),
+        apiFetchJson<TerraForgeRegressionDto>(
+          `/terraforge/regression?taxYear=${candidateYear}&countyId=${encodeURIComponent(scope.countyId)}`,
+          requestInit,
+        ),
+        apiFetchJson<ModelComparisonDto>('/MassAppraisal/compare', {
+          method: 'POST',
+          headers: {
+            ...scope.headers,
+            'Content-Type': 'application/json',
           },
-          impactedParcelCount: data.modelA?.sampleSize ?? 0,
-          totalParcelsEvaluated: data.modelA?.sampleSize ?? 0,
-          impactBuckets: [],
-        };
-        setPreview(livePreview);
-      } else {
-        setPreview(null);
-        setError(`Coefficient preview request failed: ${response.status}`);
+          body: JSON.stringify({ ModelIdA: String(sourceYear), ModelIdB: String(candidateYear) }),
+        }),
+      ]);
+
+      const unavailable =
+        formatUnavailable('source', sourceRegression)
+        ?? formatUnavailable('candidate', candidateRegression);
+      if (unavailable) {
+        setError(unavailable);
+        return;
       }
+
+      setPreview(normalizePreview(
+        sourceYear,
+        candidateYear,
+        sourceRegression,
+        candidateRegression,
+        comparison,
+      ));
+      setApplyMode('preview_only');
+      const evt = emitAuditEvent('preview_only', 'preview_generated');
+      setAuditLog((prev) => [...prev, evt]);
     } catch (err) {
-      setPreview(null);
       setError(`Coefficient preview unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setLoading(false);
     }
-    setApplyMode('preview_only');
-    const evt = emitAuditEvent('preview_only', 'preview_generated');
-    setAuditLog((prev) => [...prev, evt]);
-  }, [sourceId, candidateId]);
+  }, [sourceYear, candidateYear]);
 
   const handleApplyRequest = useCallback(() => {
     if (BACKEND_APPLY_CAPABLE) {
@@ -188,7 +328,7 @@ export function CoefficientPreview() {
 
   const fmtNum = (n: number) => n.toLocaleString();
   const fmtCurrency = (n: number) => {
-    const sign = n >= 0 ? '+' : '';
+    const sign = n >= 0 ? '+' : '-';
     return `${sign}$${Math.abs(n).toLocaleString()}`;
   };
   const fmtPct = (n: number) => {
@@ -206,8 +346,10 @@ export function CoefficientPreview() {
   return (
     <div data-testid="coefficient-preview" className="space-y-4 p-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold" style={{ color: 'hsl(var(--tf-fg))' }}>Coefficient Application Preview</h1>
-        <Badge variant="outline">Preview Only</Badge>
+        <h1 className="text-2xl font-bold" style={{ color: 'hsl(var(--tf-fg))' }}>
+          Coefficient Application Preview
+        </h1>
+        <Badge variant="outline">Live Preview</Badge>
       </div>
       {error && (
         <div className="text-xs px-2 py-1 rounded" style={{
@@ -218,23 +360,21 @@ export function CoefficientPreview() {
         </div>
       )}
 
-      {/* Model selector */}
       <Card>
-        <CardHeader><CardTitle>Compare Models</CardTitle></CardHeader>
+        <CardHeader><CardTitle>Compare Tax-Year Regressions</CardTitle></CardHeader>
         <CardContent className="space-y-3">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
               <label className="text-sm font-medium block mb-1" style={{ color: 'hsl(var(--tf-muted))' }}>Current (Baseline)</label>
               <select
                 data-testid="coeff-source-select"
-                value={sourceId}
-                onChange={(e) => setSourceId(e.target.value)}
+                value={String(sourceYear)}
+                onChange={(e) => setSourceYear(Number(e.target.value))}
                 className="w-full px-3 py-2 rounded border text-sm"
                 style={{ background: 'hsl(var(--tf-card-bg) / 0.5)', borderColor: 'hsl(var(--tf-border) / 0.3)', color: 'hsl(var(--tf-fg))' }}
               >
-                {models.length === 0 && <option value="">No governed models returned</option>}
-                {models.map((m) => (
-                  <option key={m.id} value={m.id}>{m.name}</option>
+                {YEAR_OPTIONS.map((year) => (
+                  <option key={year} value={year}>Tax Year {year} regression</option>
                 ))}
               </select>
             </div>
@@ -242,25 +382,40 @@ export function CoefficientPreview() {
               <label className="text-sm font-medium block mb-1" style={{ color: 'hsl(var(--tf-muted))' }}>Proposed (Candidate)</label>
               <select
                 data-testid="coeff-candidate-select"
-                value={candidateId}
-                onChange={(e) => setCandidateId(e.target.value)}
+                value={String(candidateYear)}
+                onChange={(e) => setCandidateYear(Number(e.target.value))}
                 className="w-full px-3 py-2 rounded border text-sm"
                 style={{ background: 'hsl(var(--tf-card-bg) / 0.5)', borderColor: 'hsl(var(--tf-border) / 0.3)', color: 'hsl(var(--tf-fg))' }}
               >
-                {models.length === 0 && <option value="">No governed models returned</option>}
-                {models.map((m) => (
-                  <option key={m.id} value={m.id}>{m.name}</option>
+                {YEAR_OPTIONS.map((year) => (
+                  <option key={year} value={year}>Tax Year {year} regression</option>
                 ))}
               </select>
             </div>
           </div>
-          <Button data-testid="coeff-preview-btn" onClick={handlePreview} disabled={!sourceId || !candidateId || sourceId === candidateId} className="w-full">
-            Generate Preview
+          <Button
+            data-testid="coeff-preview-btn"
+            onClick={handlePreview}
+            disabled={loading || sourceYear === candidateYear}
+            className="w-full"
+          >
+            {loading ? 'Generating Preview...' : 'Generate Preview'}
           </Button>
 
-          {/* 1E: Apply request + mode banner */}
           {preview && (
             <div className="space-y-2 pt-2">
+              <div
+                data-testid="coeff-preview-summary"
+                className="text-xs px-2 py-1 rounded"
+                style={{
+                  background: 'hsl(200 60% 30% / 0.2)',
+                  color: 'hsl(200 60% 70%)',
+                }}
+              >
+                <span>{preview.sourceModelName}</span>
+                <span> to </span>
+                <span>{preview.candidateModelName}</span>
+              </div>
               <Button
                 data-testid="coeff-apply-btn"
                 variant={applyMode === 'apply_executed' ? 'default' : 'outline'}
@@ -287,9 +442,9 @@ export function CoefficientPreview() {
                     ? 'hsl(40 80% 70%)'
                     : 'hsl(120 60% 60%)',
               }}>
-                {applyMode === 'preview_only' && 'Mode: Preview Only — coefficients NOT applied'}
-                {applyMode === 'apply_pending_backend' && 'Mode: Apply Blocked — backend capability not available. Request recorded.'}
-                {applyMode === 'apply_executed' && 'Mode: Applied — coefficients committed to target model'}
+                {applyMode === 'preview_only' && 'Mode: Preview Only - coefficients NOT applied'}
+                {applyMode === 'apply_pending_backend' && 'Mode: Apply Blocked - backend capability not available. Request recorded.'}
+                {applyMode === 'apply_executed' && 'Mode: Applied - coefficients committed to target model'}
               </div>
             </div>
           )}
@@ -298,7 +453,6 @@ export function CoefficientPreview() {
 
       {preview && (
         <>
-          {/* Metrics summary */}
           <div data-testid="coeff-metrics" className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <Card>
               <CardContent className="pt-4 text-center">
@@ -342,7 +496,6 @@ export function CoefficientPreview() {
             </Card>
           </div>
 
-          {/* Coefficient delta table */}
           <Card>
             <CardHeader><CardTitle>Coefficient Deltas</CardTitle></CardHeader>
             <CardContent>
@@ -371,19 +524,18 @@ export function CoefficientPreview() {
             </CardContent>
           </Card>
 
-          {/* Impact distribution */}
           <Card>
             <CardHeader><CardTitle>Impact Distribution</CardTitle></CardHeader>
             <CardContent>
               <div data-testid="coeff-impact-buckets" className="space-y-2">
                 {preview.impactBuckets.map((bucket) => {
-                  const maxCount = Math.max(...preview.impactBuckets.map((b) => b.count));
+                  const maxCount = Math.max(1, ...preview.impactBuckets.map((b) => b.count));
                   const widthPct = (bucket.count / maxCount) * 100;
                   const isNegative = bucket.meanDollarImpact < 0;
                   return (
                     <div key={bucket.label} className="flex items-center gap-3">
                       <div className="w-28 text-xs text-right shrink-0" style={{ color: 'hsl(var(--tf-muted))' }}>
-                        {bucket.label}
+                        {bucket.label} impact
                       </div>
                       <div className="flex-1 h-6 rounded overflow-hidden" style={{ background: 'hsl(var(--tf-card-bg) / 0.3)' }}>
                         <div
@@ -409,7 +561,6 @@ export function CoefficientPreview() {
         </>
       )}
 
-      {/* 1E: Audit Trail */}
       {auditLog.length > 0 && (
         <Card>
           <CardHeader><CardTitle>Audit Trail</CardTitle></CardHeader>

--- a/frontend/apps/os-shell/src/pages/forge/batch/__tests__/CoefficientPreview.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/batch/__tests__/CoefficientPreview.test.tsx
@@ -1,35 +1,190 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetchJsonMock = vi.hoisted(() => vi.fn());
+const getSessionMock = vi.hoisted(() => vi.fn());
+const getTokenMock = vi.hoisted(() => vi.fn());
+const buildHeadersMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/apiBase', () => ({
+  apiFetchJson: apiFetchJsonMock,
+}));
+
+vi.mock('@/auth/session', () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock('@/auth/authStorage', () => ({
+  getToken: getTokenMock,
+}));
+
+vi.mock('@/services/countyIsolation', () => ({
+  buildCountyScopedSessionHeaders: buildHeadersMock,
+}));
 
 import { CoefficientPreview } from '../CoefficientPreview';
 
-describe('CoefficientPreview', () => {
-  it('keeps baseline/candidate framing and never claims live production data', () => {
-    // CoefficientPreview no longer shows a fabricated DEMO DATA badge or
-    // "displaying sample fixtures" copy — it pulls from the model registry
-    // and surfaces an explicit "unavailable" error when the backend is
-    // missing. The honesty contract today is the absence of "(Production)"
-    // claims plus the explicit Baseline/Candidate framing.
-    render(<CoefficientPreview />);
+const sourceRegression = {
+  taxYear: 2026,
+  totalPool: 42,
+  usedForFit: 35,
+  insufficientData: false,
+  model: {
+    predictors: ['intercept', 'GLA_sqft', 'YearBuilt'],
+    beta: [350000, 245.5, -1825],
+    rSquared: 0.72,
+    rSquaredAdj: 0.69,
+    rmse: 41250,
+    n: 35,
+  },
+  residuals: [],
+};
 
-    expect(screen.getByText('Current (Baseline)')).toBeInTheDocument();
-    expect(screen.getByText('Proposed (Candidate)')).toBeInTheDocument();
-    expect(screen.queryByText('Current (Production)')).not.toBeInTheDocument();
-    expect(screen.queryByText(/Residential OLS 2024 \(Production\)/i)).not.toBeInTheDocument();
+const candidateRegression = {
+  taxYear: 2025,
+  totalPool: 37,
+  usedForFit: 31,
+  insufficientData: false,
+  model: {
+    predictors: ['intercept', 'GLA_sqft', 'YearBuilt'],
+    beta: [341000, 231.25, -1710],
+    rSquared: 0.68,
+    rSquaredAdj: 0.64,
+    rmse: 43750,
+    n: 31,
+  },
+  residuals: [],
+};
+
+const comparison = {
+  modelA: {
+    label: '2026 study',
+    medianRatio: 0.991,
+    cod: 8.4,
+    prd: 1.012,
+    prb: -0.01,
+    sampleSize: 35,
+  },
+  modelB: {
+    label: '2025 study',
+    medianRatio: 0.978,
+    cod: 9.1,
+    prd: 1.018,
+    prb: -0.02,
+    sampleSize: 31,
+  },
+  deltas: {
+    cod: 0.7,
+    prd: 0.006,
+    prb: -0.01,
+    medianRatio: -0.013,
+    sampleSize: -4,
+  },
+  improvedMetrics: [],
+  degradedMetrics: ['cod', 'prd', 'medianRatio'],
+};
+
+describe('CoefficientPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockReturnValue({ countyId: 'benton-wa' });
+    getTokenMock.mockReturnValue('token-1');
+    buildHeadersMock.mockReturnValue({
+      isolated: true,
+      headers: { 'X-TerraFusion-County': 'benton-wa' },
+    });
   });
 
-  it('keeps apply-state messaging away from production-model claims', async () => {
+  it('generates a live county-scoped coefficient preview from TerraForge regression data', async () => {
+    const rawFetchSpy = vi.spyOn(window, 'fetch');
+    apiFetchJsonMock.mockImplementation((path: string) => {
+      if (path === '/terraforge/regression?taxYear=2026&countyId=benton-wa') {
+        return Promise.resolve(sourceRegression);
+      }
+      if (path === '/terraforge/regression?taxYear=2025&countyId=benton-wa') {
+        return Promise.resolve(candidateRegression);
+      }
+      if (path === '/MassAppraisal/compare') {
+        return Promise.resolve(comparison);
+      }
+      throw new Error(`Unexpected path ${path}`);
+    });
+
     render(<CoefficientPreview />);
 
-    // The preview button only fires when a candidate model is loaded from
-    // the registry. Under jsdom the model registry fetch returns nothing,
-    // so the preview-then-apply flow never runs — assert instead that the
-    // surface refuses to claim it is on a production model when the
-    // backend is unavailable.
-    expect(screen.queryByText(/production model/i)).not.toBeInTheDocument();
-    // Test imports referenced but not used inline; touch them to satisfy
-    // tsc strict-unused-imports while we keep the original API:
-    void fireEvent;
-    void waitFor;
+    const previewButton = screen.getByTestId('coeff-preview-btn');
+    expect(previewButton).not.toBeDisabled();
+    fireEvent.click(previewButton);
+
+    await waitFor(() => {
+      expect(apiFetchJsonMock).toHaveBeenCalledWith(
+        '/terraforge/regression?taxYear=2026&countyId=benton-wa',
+        {
+          headers: {
+            Authorization: 'Bearer token-1',
+            'X-TerraFusion-County': 'benton-wa',
+          },
+        },
+      );
+    });
+
+    expect(apiFetchJsonMock).toHaveBeenCalledWith(
+      '/terraforge/regression?taxYear=2025&countyId=benton-wa',
+      {
+        headers: {
+          Authorization: 'Bearer token-1',
+          'X-TerraFusion-County': 'benton-wa',
+        },
+      },
+    );
+    expect(apiFetchJsonMock).toHaveBeenCalledWith('/MassAppraisal/compare', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer token-1',
+        'Content-Type': 'application/json',
+        'X-TerraFusion-County': 'benton-wa',
+      },
+      body: JSON.stringify({ ModelIdA: '2026', ModelIdB: '2025' }),
+    });
+    expect(rawFetchSpy).not.toHaveBeenCalled();
+
+    expect(await screen.findByText('2026 study')).toBeInTheDocument();
+    expect(screen.getByText('2025 study')).toBeInTheDocument();
+    expect(screen.getByText('GLA_sqft')).toBeInTheDocument();
+    expect(screen.getByText('-14.25')).toBeInTheDocument();
+    expect(screen.getByText('YearBuilt')).toBeInTheDocument();
+    expect(screen.getByText('+115.00')).toBeInTheDocument();
+    expect(screen.getByTestId('coeff-apply-mode')).toHaveTextContent(
+      'Mode: Preview Only',
+    );
+  });
+
+  it('renders backend insufficiency as unavailable instead of fabricating coefficient rows', async () => {
+    apiFetchJsonMock.mockImplementation((path: string) => {
+      if (path.includes('taxYear=2026')) {
+        return Promise.resolve({
+          ...sourceRegression,
+          usedForFit: 3,
+          minimumRequired: 5,
+          insufficientData: true,
+          model: null,
+        });
+      }
+      if (path.includes('taxYear=2025')) {
+        return Promise.resolve(candidateRegression);
+      }
+      if (path === '/MassAppraisal/compare') {
+        return Promise.resolve(comparison);
+      }
+      throw new Error(`Unexpected path ${path}`);
+    });
+
+    render(<CoefficientPreview />);
+    fireEvent.click(screen.getByTestId('coeff-preview-btn'));
+
+    expect(
+      await screen.findByText(/Insufficient observations for source regression: 3 available, 5 required/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('coeff-delta-table')).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -19,7 +19,7 @@
  *               CompsForge (sales comparison, standalone React module)
  *               IncomeForge (income approach, live)
  *   SPECIALIST: Batch Cost Runs (batch execution)
- *               Regression Studio / TerraGAMA live, Coefficient Preview queued
+ *               Regression Studio / TerraGAMA / Coefficient Preview live
  *   DEFAULT ANALYTICS: County Studio (study-anchored Operational Health +
  *                      Statistics Compat + VEI exploration)
  */
@@ -176,8 +176,7 @@ const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
     priority: 'secondary',
     launchMode: 'standalone',
     moduleId: 'coefficient-preview',
-    truthState: 'queued',
-    chipLabel: 'Planned scene',
+    chipLabel: 'Live preview',
   },
 ] as const;
 

--- a/frontend/apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx
@@ -7,7 +7,7 @@
  * Verified correct layout (current HEAD):
  *   PRIMARY   : CostForge, CompsForge, IncomeForge, SalesForge, CUForge
  *   SECONDARY : Batch Cost Runs, Regression Studio, TerraGAMA,
- *               Coefficient Preview (queued)
+ *               Coefficient Preview
  *   COUNTY    : County Studio (default analytics workbench + VEI exploration)
  *
  * GeoForge and Atlas Live View are not launcher products. Atlas is County
@@ -93,14 +93,14 @@ describe('ForgeSuiteHome — frozen module list', () => {
     expect(secondarySection).not.toHaveTextContent(/legacy specialist/i);
   });
 
-  it('Regression Studio and TerraGAMA are enabled as live specialist modules while Coefficient Preview remains queued', () => {
+  it('Regression Studio, TerraGAMA, and Coefficient Preview are enabled as live specialist modules', () => {
     renderForge();
     expect(screen.getByText('Regression Studio')).toBeInTheDocument();
     expect(screen.getByText('TerraGAMA')).toBeInTheDocument();
     expect(screen.getByText('Coefficient Preview')).toBeInTheDocument();
     expect(screen.getByText('Regression Studio').closest('button')).not.toBeDisabled();
     expect(screen.getByText('TerraGAMA').closest('button')).not.toBeDisabled();
-    expect(screen.getByText('Coefficient Preview').closest('button')).toBeDisabled();
+    expect(screen.getByText('Coefficient Preview').closest('button')).not.toBeDisabled();
   });
 
   it('does NOT render fabricated apps that were never in v1 scope', () => {


### PR DESCRIPTION
## Summary
- Activates Coefficient Preview as a live Forge module instead of a queued scene.
- Replaces raw mock/model-registry fetches with county-scoped `apiFetchJson` calls to TerraForge regression and MassAppraisal compare APIs.
- Fixes MassAppraisal compare runtime wiring and aligns Forge statistics with the live qualified-sale population.

## Runtime proof
- API `GET /api/terraforge/regression?taxYear=2026`: 35 fitted observations, predictors `intercept,GLA_sqft,LotSizeSqft,YearBuilt`.
- API `GET /api/terraforge/regression?taxYear=2025`: 2,937 fitted observations, same predictor shape.
- API `POST /api/MassAppraisal/compare`: `2026 study` vs `2025 study`, sampleB 8,891, PRD delta 0.004.
- Browser proof through `http://127.0.0.1:5179/forge`: launched Coefficient Preview, generated live deltas, rendered GLA/LotSize/YearBuilt rows, and stayed `Mode: Preview Only - coefficients NOT applied`.

## Test plan
- [x] `pnpm run type-check`
- [x] `node --test os-platform/core/tests/phase83-tools.test.mjs`
- [x] `pnpm -C frontend run type-check`
- [x] `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/batch/__tests__/CoefficientPreview.test.tsx apps/os-shell/src/pages/suites/__tests__/ForgeSuiteHome.moduleList.test.tsx`
- [x] `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -p:DotNetWatchBuild=true`
- [x] `pnpm -C frontend run build`
- [x] pre-push hook: 164 unit tests, governed Snyk scan, benchmark, compliance lint, backend release build/publish

## Notes
- Apply remains blocked/read-only; this slice does not add a coefficient apply endpoint.
- Did not modify Sync, DB seeding, migrations, `TerraFusion.Sync`, or `TerraFusion.Data` source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coefficient Preview is now a live, read-only Forge module with tax-year selectors, live regressions, and a “Live Preview” badge.

* **Behavior**
  * Forge statistics, model-compare, and preview flows now use a resolved county identifier so results are county-scoped and consistent.
  * County token parsing now accepts WA-style slugs.

* **Bug Fixes**
  * Endpoints return a clear 400 error when an invalid county is provided.

* **Tests**
  * Added runtime/contract tests and updated component tests to validate county-scoped API calls and insufficient-data handling.

* **Documentation**
  * Added implementation plan and runtime design spec for live Coefficient Preview.

* **Chores**
  * Registered a mass-appraisal service stub for local/hosted runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->