### PR TITLE
fix(release): include CurrentUse project in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,7 @@ COPY src/TerraFusion.API/*.csproj ./src/TerraFusion.API/
 COPY src/TerraFusion.Sync/*.csproj ./src/TerraFusion.Sync/
 COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
+COPY src/TerraFusion.CurrentUse/*.csproj ./src/TerraFusion.CurrentUse/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
 
@@ -31,6 +32,7 @@ COPY src/TerraFusion.API/ ./src/TerraFusion.API/
 COPY src/TerraFusion.Sync/ ./src/TerraFusion.Sync/
 COPY src/TerraFusion.Consciousness/ ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/ ./src/TerraFusion.CostForge/
+COPY src/TerraFusion.CurrentUse/ ./src/TerraFusion.CurrentUse/
 COPY src/TerraFusion.Operations/ ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/ ./src/TerraFusion.Levy/
 
@@ -56,6 +58,7 @@ COPY src/TerraFusion.API/*.csproj ./src/TerraFusion.API/
 COPY src/TerraFusion.Sync/*.csproj ./src/TerraFusion.Sync/
 COPY src/TerraFusion.Consciousness/*.csproj ./src/TerraFusion.Consciousness/
 COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
+COPY src/TerraFusion.CurrentUse/*.csproj ./src/TerraFusion.CurrentUse/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
 


### PR DESCRIPTION
## Summary
- Include `TerraFusion.CurrentUse` in backend Docker restore, build, and development copy stages.
- Fixes the production release-lane backend image build failure where `TerraFusion.API` references `TerraFusion.CurrentUse` but the Docker context did not copy that project.

## Root Cause
The API project references `../TerraFusion.CurrentUse/TerraFusion.CurrentUse.csproj` and `Program.cs` imports `TerraFusion.CurrentUse`, but `backend/Dockerfile` omitted `src/TerraFusion.CurrentUse` from the explicit project/source copy lists used by the release image.

## Verification
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj --no-restore`
- Dockerfile/API project-reference static check
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- Pre-push quality gate: unit tests, governed security scan, performance validation, compliance lint, backend Release build + publish

## Scope
Release packaging only. No auth, UI, data, Sync, runtime gate, or product workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to properly include project dependencies across all build stages (build, development, and runtime environments). This ensures consistent and reliable deployment workflows without impacting end-user functionality or runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->