### PR TITLE
fix(currentuse): honor sqlite runtime provider

### DIFF
--- a/backend/src/TerraFusion.CurrentUse/CurrentUseServiceExtensions.cs
+++ b/backend/src/TerraFusion.CurrentUse/CurrentUseServiceExtensions.cs
@@ -1,6 +1,9 @@
+using System.Data;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -21,14 +24,27 @@ public static class CurrentUseServiceExtensions
     public static IServiceCollection AddCurrentUseServices(this IServiceCollection services, IConfiguration configuration)
     {
         // Register DbContext — uses same connection string as the host or a dedicated one
-        var connectionString = configuration.GetConnectionString("CurrentUse")
+        var currentUseConnectionString = configuration.GetConnectionString("CurrentUse");
+        var hasDedicatedCurrentUseConnection = !string.IsNullOrWhiteSpace(currentUseConnectionString);
+        var connectionString = currentUseConnectionString
             ?? configuration.GetConnectionString("DefaultConnection")
             ?? "Host=localhost;Database=terrafusion;Username=postgres;Password=postgres";
+
+        var provider = configuration["CurrentUse:DatabaseProvider"]
+            ?? (hasDedicatedCurrentUseConnection ? null : configuration["DatabaseProvider"]);
+        var useSqlite =
+            IsSqliteProvider(provider) ||
+            IsSqliteConnectionString(connectionString);
 
         if (connectionString.Contains("InMemory", StringComparison.OrdinalIgnoreCase))
         {
             services.AddDbContext<CurrentUseDbContext>(options =>
                 options.UseInMemoryDatabase("CurrentUse"));
+        }
+        else if (useSqlite)
+        {
+            services.AddDbContext<CurrentUseDbContext>(options =>
+                options.UseSqlite(connectionString));
         }
         else
         {
@@ -79,14 +95,69 @@ public static class CurrentUseServiceExtensions
         using var scope = services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<CurrentUseDbContext>();
 
-        // Apply migrations if using a real database
-        if (db.Database.ProviderName != "Microsoft.EntityFrameworkCore.InMemory")
+        if (db.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
         {
-            await db.Database.MigrateAsync();
+            await db.Database.EnsureCreatedAsync();
+        }
+        else if (db.Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite")
+        {
+            await EnsureSqliteCurrentUseTablesCreatedAsync(db);
         }
         else
         {
-            await db.Database.EnsureCreatedAsync();
+            await db.Database.MigrateAsync();
+        }
+    }
+
+    private static bool IsSqliteProvider(string? provider)
+    {
+        return string.Equals(provider, "Sqlite", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSqliteConnectionString(string connectionString)
+    {
+        return connectionString.Contains("Data Source=", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task EnsureSqliteCurrentUseTablesCreatedAsync(CurrentUseDbContext db)
+    {
+        if (await SqliteTableExistsAsync(db, "interest_rates"))
+        {
+            return;
+        }
+
+        var creator = db.GetService<IRelationalDatabaseCreator>();
+        await creator.CreateTablesAsync();
+    }
+
+    private static async Task<bool> SqliteTableExistsAsync(CurrentUseDbContext db, string tableName)
+    {
+        var connection = db.Database.GetDbConnection();
+        var shouldClose = connection.State == ConnectionState.Closed;
+
+        if (shouldClose)
+        {
+            await connection.OpenAsync();
+        }
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $tableName;";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "$tableName";
+            parameter.Value = tableName;
+            command.Parameters.Add(parameter);
+
+            var result = await command.ExecuteScalarAsync();
+            return Convert.ToInt64(result) > 0;
+        }
+        finally
+        {
+            if (shouldClose)
+            {
+                await connection.CloseAsync();
+            }
         }
     }
 }

--- a/backend/src/TerraFusion.CurrentUse/TerraFusion.CurrentUse.csproj
+++ b/backend/src/TerraFusion.CurrentUse/TerraFusion.CurrentUse.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />

--- a/backend/tests/TerraFusion.CurrentUse.Tests/ServiceExtensionsTests.cs
+++ b/backend/tests/TerraFusion.CurrentUse.Tests/ServiceExtensionsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TerraFusion.CurrentUse.Data;
@@ -77,7 +78,7 @@ public class ServiceExtensionsTests
             })
             .Build();
         services.AddCurrentUseServices(config);
-        var provider = services.BuildServiceProvider();
+        using var provider = services.BuildServiceProvider();
 
         await provider.InitializeCurrentUseDatabaseAsync();
 
@@ -86,6 +87,128 @@ public class ServiceExtensionsTests
         var rates = await db.InterestRates.ToListAsync();
         rates.Should().NotBeEmpty();
         rates.Should().Contain(r => r.Year == 2024);
+    }
+
+    [Fact]
+    public async Task InitializeCurrentUseDatabaseAsync_SqliteProvider_UsesSqliteAndSeedsInterestRates()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"currentuse-{Guid.NewGuid():N}.db");
+
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DatabaseProvider"] = "Sqlite",
+                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}"
+                })
+                .Build();
+            services.AddCurrentUseServices(config);
+            using var provider = services.BuildServiceProvider();
+
+            await provider.InitializeCurrentUseDatabaseAsync();
+
+            using var scope = provider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<CurrentUseDbContext>();
+            db.Database.ProviderName.Should().Be("Microsoft.EntityFrameworkCore.Sqlite");
+            var rates = await db.InterestRates.ToListAsync();
+            rates.Should().NotBeEmpty();
+            rates.Should().Contain(r => r.Year == DateTime.UtcNow.Year);
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                try
+                {
+                    File.Delete(dbPath);
+                }
+                catch (IOException)
+                {
+                    // SQLite can keep a short-lived file handle on Windows test
+                    // hosts after DbContext disposal; the temp file name is
+                    // unique, so cleanup failure must not mask provider regressions.
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void AddCurrentUseServices_DedicatedPostgresConnection_IgnoresGlobalSqliteProviderHint()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DatabaseProvider"] = "Sqlite",
+                ["ConnectionStrings:DefaultConnection"] = "Data Source=terrafusion.db",
+                ["ConnectionStrings:CurrentUse"] = "Host=localhost;Database=currentuse;Username=postgres;Password=postgres"
+            })
+            .Build();
+
+        services.AddCurrentUseServices(config);
+        using var provider = services.BuildServiceProvider();
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<CurrentUseDbContext>();
+        db.Database.ProviderName.Should().Be("Npgsql.EntityFrameworkCore.PostgreSQL");
+    }
+
+    [Fact]
+    public async Task InitializeCurrentUseDatabaseAsync_SqliteSharedDatabase_CreatesCurrentUseTablesWhenOtherTablesExist()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"currentuse-shared-{Guid.NewGuid():N}.db");
+
+        try
+        {
+            await using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                await connection.OpenAsync();
+                await using var command = connection.CreateCommand();
+                command.CommandText = "CREATE TABLE existing_runtime_table (id INTEGER PRIMARY KEY);";
+                await command.ExecuteNonQueryAsync();
+            }
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DatabaseProvider"] = "Sqlite",
+                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}"
+                })
+                .Build();
+
+            services.AddCurrentUseServices(config);
+            using var provider = services.BuildServiceProvider();
+
+            await provider.InitializeCurrentUseDatabaseAsync();
+
+            using var scope = provider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<CurrentUseDbContext>();
+            db.Database.ProviderName.Should().Be("Microsoft.EntityFrameworkCore.Sqlite");
+            var rates = await db.InterestRates.ToListAsync();
+            rates.Should().NotBeEmpty();
+        }
+        finally
+        {
+            if (File.Exists(dbPath))
+            {
+                try
+                {
+                    File.Delete(dbPath);
+                }
+                catch (IOException)
+                {
+                    // SQLite can keep a short-lived file handle on Windows test
+                    // hosts after DbContext disposal; the temp file name is
+                    // unique, so cleanup failure must not mask provider regressions.
+                }
+            }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Make CurrentUse honor the configured runtime database provider.
- Use SQLite when `DatabaseProvider=Sqlite` or the connection string is SQLite-shaped.
- Use `EnsureCreated` for SQLite/InMemory CurrentUse initialization because the existing CurrentUse migrations are PostgreSQL schema-qualified.
- Add a SQLite regression test covering provider selection and seeded interest-rate data.

## Root Cause
Production runtime uses `DatabaseProvider=Sqlite` and `ConnectionStrings__DefaultConnection=Data Source=data/terrafusion.db`, but CurrentUse assumed every non-InMemory connection was PostgreSQL/Npgsql. After PR #866 included CurrentUse in the release image, the production backend started but became unhealthy during deploy.

## Verification
- `dotnet test backend/tests/TerraFusion.CurrentUse.Tests/TerraFusion.CurrentUse.Tests.csproj`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj --no-restore`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- Pre-push quality gate: unit tests, governed security scan, performance validation, compliance lint, backend Release build + publish

## Scope
CurrentUse provider/runtime startup fix only. No auth, UI, Sync, county data, or release workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite database provider support alongside PostgreSQL and in-memory options.
  * Provider-specific database initialization behavior at startup to handle SQLite, in-memory, and other providers appropriately.

* **Tests**
  * Added and enhanced tests covering SQLite-backed initialization, shared-database scenarios, and provider selection/seed data verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->