### PR TITLE
fix(release): provision db-backed operator before auth smoke

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -335,6 +335,43 @@ jobs:
           docker compose -f runtime-compose.yml --env-file release.env up -d
           SSH
 
+      - name: Provision DB-backed operator account
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROVISION_JSON="$(ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          set -euo pipefail
+          cd "$APP_ROOT"
+          docker compose -f runtime-compose.yml --env-file release.env run --rm --no-deps \
+            --entrypoint sh \
+            backend \
+            -c 'set -eu
+              dotnet /app/tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.dll \
+                --provider Sqlite \
+                --connection-string "Data Source=/app/data/terrafusion.db" \
+                --email "$TERRAFUSION_BOOTSTRAP_EMAIL" \
+                --password-env TERRAFUSION_BOOTSTRAP_PASSWORD \
+                --roles "${TERRAFUSION_BOOTSTRAP_ROLES:-GovernmentUser,Administrator,FullSystemAccess}" \
+                --permissions "runtime:read,county:read,workbench:access" \
+                --county-name Benton \
+                --county-state WA \
+                --county-fips 53005 \
+                --create-county' >/tmp/terrafusion-auth-provisioner.json
+          cat /tmp/terrafusion-auth-provisioner.json
+          rm -f /tmp/terrafusion-auth-provisioner.json
+          SSH
+          )"
+          PROVISION_JSON="$PROVISION_JSON" node <<'NODE'
+          const receipt = JSON.parse(process.env.PROVISION_JSON || "{}");
+          if (!receipt.passwordHashStored) {
+            throw new Error("AuthProvisioner did not store a password hash");
+          }
+          if (!receipt.countyId) {
+            throw new Error("AuthProvisioner did not bind the operator to a county");
+          }
+          console.log(`DB-backed operator account ${receipt.result}; password hash stored; county bound.`);
+          NODE
+
       - name: Verify public health and release header
         shell: bash
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,10 +18,12 @@ COPY src/TerraFusion.CostForge/*.csproj ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.CurrentUse/*.csproj ./src/TerraFusion.CurrentUse/
 COPY src/TerraFusion.Operations/*.csproj ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/*.csproj ./src/TerraFusion.Levy/
+COPY tools/TerraFusion.AuthProvisioner/*.csproj ./tools/TerraFusion.AuthProvisioner/
 
 # Restore dependencies (project-level restore resolves transitive deps without
 # requiring test projects, which are excluded by .dockerignore)
 RUN dotnet restore src/TerraFusion.API/TerraFusion.API.csproj --verbosity minimal
+RUN dotnet restore tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj --verbosity minimal
 
 # Copy source
 COPY src/TerraFusion.Abstractions/ ./src/TerraFusion.Abstractions/
@@ -35,11 +37,18 @@ COPY src/TerraFusion.CostForge/ ./src/TerraFusion.CostForge/
 COPY src/TerraFusion.CurrentUse/ ./src/TerraFusion.CurrentUse/
 COPY src/TerraFusion.Operations/ ./src/TerraFusion.Operations/
 COPY src/TerraFusion.Levy/ ./src/TerraFusion.Levy/
+COPY tools/TerraFusion.AuthProvisioner/ ./tools/TerraFusion.AuthProvisioner/
 
 # Publish
 RUN dotnet publish src/TerraFusion.API/TerraFusion.API.csproj \
     -c Release \
     -o /app/publish \
+    --no-restore \
+    --verbosity minimal
+
+RUN dotnet publish tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj \
+    -c Release \
+    -o /app/auth-provisioner \
     --no-restore \
     --verbosity minimal
 
@@ -97,6 +106,7 @@ ENV TF_GIT_SHA=${GIT_SHA}
 
 # Copy published app
 COPY --from=build /app/publish ./
+COPY --from=build /app/auth-provisioner ./tools/TerraFusion.AuthProvisioner/
 
 # Expose and healthcheck
 EXPOSE 5000

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -301,6 +301,38 @@ describe('D. CI release gate coverage', () => {
     assert.ok(hasTest, 'PR gate must include test step');
     assert.ok(hasLint, 'PR gate must include lint step');
   });
+
+  it('D8: backend runtime image packages the DB-backed AuthProvisioner', () => {
+    const content = readFileSync(join(ROOT, 'backend', 'Dockerfile'), 'utf8');
+    assert.ok(
+      content.includes('RUN dotnet publish tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj'),
+      'Backend build stage must publish TerraFusion.AuthProvisioner',
+    );
+    assert.ok(
+      content.includes('COPY --from=build /app/auth-provisioner ./tools/TerraFusion.AuthProvisioner/'),
+      'Backend runtime image must package TerraFusion.AuthProvisioner for DB-backed production operator provisioning',
+    );
+  });
+
+  it('D9: release-lane provisions DB-backed operator before auth smoke', () => {
+    const content = readFileSync(join(WORKFLOWS, 'release-lane.yml'), 'utf8');
+    const provisionerIndex = content.indexOf('TerraFusion.AuthProvisioner.dll');
+    const smokeIndex = content.indexOf('Provisioned auth contract smoke');
+    assert.ok(
+      provisionerIndex >= 0,
+      'Release lane must invoke TerraFusion.AuthProvisioner against the runtime TerraFusion DB',
+    );
+    assert.ok(
+      smokeIndex >= 0 && provisionerIndex < smokeIndex,
+      'Release lane must provision/reset the operator account before the provisioned auth smoke',
+    );
+    assert.ok(
+      content.includes('--entrypoint sh') &&
+        content.includes('TERRAFUSION_BOOTSTRAP_EMAIL') &&
+        content.includes('PROVISION_JSON='),
+      'Release lane must expand bootstrap credentials inside the env-file-backed container and validate provisioner JSON on the runner',
+    );
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- package TerraFusion.AuthProvisioner into the backend runtime image
- run the DB-backed operator provision/reset step in release-lane before the production auth smoke
- add deployment truth-gate coverage so the release lane cannot skip DB-backed operator provisioning again

## Proof
- node --test tests/deployment-truth-gate.test.mjs
- dotnet publish backend/tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj -c Release -o .tmp/auth-provisioner-publish-test
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj --no-restore
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- bash scripts/ci/release-lane-safety-lint.sh (PASS; local WSL emitted rg permission warnings after PASS)
- pre-push quality gate passed

## Production Context
Run 26397035165 restored public health and release header for dfc882bea2951e23e522f34f0f8a4bee99d60427, but failed at Provisioned auth contract smoke with 401. This PR makes the release lane provision/reset the DB-backed operator account before that smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated DB-backed operator account provisioning during deployment, with bootstrap credentials and verification of created account and region binding.

* **Tests**
  * Added deployment gate checks to ensure the provisioning step runs and validates the generated provisioning receipt before launch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->