### PR TITLE
fix(release): stream auth provisioner receipt from container

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -339,7 +339,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PROVISION_JSON="$(ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+          PROVISION_OUTPUT="$(ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
           set -euo pipefail
           cd "$APP_ROOT"
           docker compose -f runtime-compose.yml --env-file release.env run --rm --no-deps \
@@ -356,11 +356,10 @@ jobs:
                 --county-name Benton \
                 --county-state WA \
                 --county-fips 53005 \
-                --create-county' >/tmp/terrafusion-auth-provisioner.json
-          cat /tmp/terrafusion-auth-provisioner.json
-          rm -f /tmp/terrafusion-auth-provisioner.json
+                --create-county'
           SSH
           )"
+          PROVISION_JSON="$(printf '%s\n' "$PROVISION_OUTPUT" | awk '/^\{/{line=$0} END{print line}')"
           PROVISION_JSON="$PROVISION_JSON" node <<'NODE'
           const receipt = JSON.parse(process.env.PROVISION_JSON || "{}");
           if (!receipt.passwordHashStored) {

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -329,8 +329,14 @@ describe('D. CI release gate coverage', () => {
     assert.ok(
       content.includes('--entrypoint sh') &&
         content.includes('TERRAFUSION_BOOTSTRAP_EMAIL') &&
-        content.includes('PROVISION_JSON='),
+        content.includes('PROVISION_OUTPUT=') &&
+        content.includes('PROVISION_JSON=') &&
+        content.includes("awk '/^\\{/{line=$0} END{print line}'"),
       'Release lane must expand bootstrap credentials inside the env-file-backed container and validate provisioner JSON on the runner',
+    );
+    assert.ok(
+      !content.includes('/tmp/terrafusion-auth-provisioner.json'),
+      'Release lane must stream AuthProvisioner JSON from the one-off container instead of reading a host /tmp file',
     );
   });
 });


### PR DESCRIPTION
## Summary
- stream AuthProvisioner JSON directly from the one-off backend container to the release runner
- remove the broken host `/tmp` receipt handoff that caused empty provisioner JSON
- tighten deployment truth coverage so the release lane cannot reintroduce host `/tmp` receipt reads

## Verification
- node --test tests/deployment-truth-gate.test.mjs
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- bash scripts/ci/release-lane-safety-lint.sh (PASS; WSL rg permission warnings from bundled Codex path)
- pre-push quality gate passed

## Production Impact
Fix-forward for release run 26402054488, which failed at `Provision DB-backed operator account` because the receipt was captured from the wrong filesystem boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the database operator account provisioning workflow by improving credential expansion and output handling in the release pipeline.
  * Strengthened release procedure validation with comprehensive test coverage to verify provisioning behavior and ensure more robust deployments.
  * Enhanced infrastructure automation standards and testing practices across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->