### PR TITLE
fix(release): allow cold db-backed auth smoke

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -461,7 +461,7 @@ jobs:
             -d "$LOGIN_PAYLOAD" \
             "${PUBLIC_URL}/api/auth/login")"
 
-          LOGIN_RESPONSE="$LOGIN_RESPONSE" node <<'NODE'
+          TOKEN="$(LOGIN_RESPONSE="$LOGIN_RESPONSE" node <<'NODE'
           const response = JSON.parse(process.env.LOGIN_RESPONSE || "{}");
           const token = response.token || response.Token;
           const email = response.email || response.Email || response.user?.email || response.User?.Email;
@@ -472,7 +472,38 @@ jobs:
           if (email !== process.env.TF_AUTH_BOOTSTRAP_EMAIL) {
             throw new Error(`Provisioned auth smoke returned unexpected email: ${email}`);
           }
-          console.log(`Provisioned login returned token for ${email} with ${Array.isArray(roles) ? roles.length : 0} roles`);
+          console.error(`Provisioned login returned token for ${email} with ${Array.isArray(roles) ? roles.length : 0} roles`);
+          process.stdout.write(token);
+          NODE
+          )"
+
+          PROFILE_RESPONSE="$(curl -fsS --max-time 30 \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "${PUBLIC_URL}/api/auth/profile")"
+
+          PROFILE_RESPONSE="$PROFILE_RESPONSE" node <<'NODE'
+          const profile = JSON.parse(process.env.PROFILE_RESPONSE || "{}");
+          const roles = profile.roles || profile.Roles || [];
+          const permissions = profile.permissions || profile.Permissions || [];
+          const email = profile.email || profile.Email;
+          const countyFipsCode = profile.countyFipsCode || profile.CountyFipsCode;
+          const sessionValid = profile.sessionValid ?? profile.SessionValid;
+          if (email !== process.env.TF_AUTH_BOOTSTRAP_EMAIL) {
+            throw new Error(`Profile returned unexpected email: ${email}`);
+          }
+          if (!Array.isArray(roles) || roles.length === 0) {
+            throw new Error("Profile did not return role claims");
+          }
+          if (!Array.isArray(permissions) || permissions.length === 0) {
+            throw new Error("Profile did not return permission claims");
+          }
+          if (countyFipsCode !== "53005") {
+            throw new Error(`Profile returned unexpected countyFipsCode: ${countyFipsCode}`);
+          }
+          if (sessionValid !== true) {
+            throw new Error("Profile did not report a valid session");
+          }
+          console.log(`Profile identity verified for ${email} in FIPS ${countyFipsCode}`);
           NODE
 
       - name: Finalize current SHA on VPS

--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -456,7 +456,7 @@ jobs:
           NODE
           )"
 
-          LOGIN_RESPONSE="$(curl -fsS --max-time 10 \
+          LOGIN_RESPONSE="$(curl -fsS --max-time 30 \
             -H 'Content-Type: application/json' \
             -d "$LOGIN_PAYLOAD" \
             "${PUBLIC_URL}/api/auth/login")"

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -338,6 +338,10 @@ describe('D. CI release gate coverage', () => {
       !content.includes('/tmp/terrafusion-auth-provisioner.json'),
       'Release lane must stream AuthProvisioner JSON from the one-off container instead of reading a host /tmp file',
     );
+    assert.ok(
+      content.includes('LOGIN_RESPONSE="$(curl -fsS --max-time 30'),
+      'Release lane must give the post-deploy DB-backed login smoke enough time for cold auth/session persistence while still requiring a real token',
+    );
   });
 });
 

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -342,6 +342,14 @@ describe('D. CI release gate coverage', () => {
       content.includes('LOGIN_RESPONSE="$(curl -fsS --max-time 30'),
       'Release lane must give the post-deploy DB-backed login smoke enough time for cold auth/session persistence while still requiring a real token',
     );
+    assert.ok(
+      content.includes('PROFILE_RESPONSE="$(curl -fsS --max-time 30') &&
+        content.includes('${PUBLIC_URL}/api/auth/profile') &&
+        content.includes('Authorization: Bearer ${TOKEN}') &&
+        content.includes('sessionValid') &&
+        content.includes('countyFipsCode'),
+      'Release lane must prove the issued JWT against /api/auth/profile, including session validity and county/FIPS identity',
+    );
   });
 });
 

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -340,7 +340,11 @@ describe('D. CI release gate coverage', () => {
     );
     assert.ok(
       content.includes('LOGIN_RESPONSE="$(curl -fsS --max-time 30'),
-      'Release lane must give the post-deploy DB-backed login smoke enough time for cold auth/session persistence while still requiring a real token',
+      'Release lane must give the post-deploy DB-backed login smoke enough time for cold auth/session persistence',
+    );
+    assert.ok(
+      content.includes('did not receive a token'),
+      'Release lane must still fail the provisioned auth smoke when the login response did not receive a token',
     );
     assert.ok(
       content.includes('PROFILE_RESPONSE="$(curl -fsS --max-time 30') &&


### PR DESCRIPTION
## Summary
- extend the production release login smoke timeout from 10s to 30s
- keep the auth smoke strict: it still requires provisioned-access policy and a real login token
- add deployment truth coverage for the cold DB-backed auth smoke timeout

## Evidence
- Live production `/api/auth/login` with the provisioned operator succeeds but measured ~6s from this workstation after deploy.
- Release run 26404982892 passed DB-backed operator provisioning and then failed at the login smoke with curl exit 28 after 10s.

## Verification
- node --test tests/deployment-truth-gate.test.mjs
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- pre-push quality gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased authentication request timeouts in deployment checks to reduce false failures in slower environments.
  * Switched token/role output to error stream so auth diagnostics appear in failure logs.

* **Tests**
  * Updated deployment verification tests to assert the new timeout behavior and to validate captured login and profile responses (including session and identity fields).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->