### PR TITLE
fix(runtime): align Pilot API calls with production contracts

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/api/pilotApi.auth.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/api/pilotApi.auth.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { explain } from '../../services/pilotApi';
+
+vi.mock('@/services/terraTrace', () => ({
+  generateCorrelationId: () => 'corr-auth',
+  emitToolInvoked: vi.fn(),
+  emitToolSucceeded: vi.fn(),
+  emitToolFailed: vi.fn(),
+}));
+
+describe('services/pilotApi auth headers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends bearer auth on protected explain requests', async () => {
+    localStorage.setItem('authToken', 'owner-token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          explanation: 'ok',
+          sources: [],
+          confidence: 0.9,
+          traceId: 'trace-1',
+        }),
+      })
+    );
+
+    await explain({
+      query: 'why did value change?',
+      countyId: 'benton',
+      actorId: 'operator',
+      source: 'terra-pilot',
+    });
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer owner-token',
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/api/pilotApi.traceNormalization.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/api/pilotApi.traceNormalization.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getPilotTrace, listPilotTraces } from '../../api/pilotApi';
+import { getPilotTrace, invokePilotTool, listPilotTraces } from '../../api/pilotApi';
 
 vi.mock('../../auth/session', () => ({
   getSession: () => null,
@@ -69,5 +69,28 @@ describe('pilotApi trace normalization', () => {
     const response = await listPilotTraces({ parcelId: 'P-1' });
 
     expect(response.events[0]?.type).toBe('tool_succeeded');
+  });
+
+  it('invokes tools through the backend /api/pilot/invoke route', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          correlationId: 'corr-invoke',
+          result: { accepted: true },
+        }),
+      })
+    );
+
+    await invokePilotTool({
+      toolId: 'explain_value_change',
+      params: { parcelId: 'P-1' },
+      mode: 'muse',
+    });
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe('/api/pilot/invoke');
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/pilot/buildParcelSummary.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/pilot/buildParcelSummary.test.ts
@@ -1,4 +1,17 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../../stores/companionStore', () => ({
+  useCompanionStore: () => ({
+    activeParcelId: null,
+    activeSuite: null,
+    activeTab: null,
+    activeBranch: null,
+    activeFile: null,
+    buildStatus: 'unknown',
+    editorMarkers: [],
+  }),
+}));
+
 import { buildParcelSummary } from '../../pages/MuseChat';
 import type { Property } from '../../types/domain';
 
@@ -85,6 +98,7 @@ describe('buildParcelSummary', () => {
 
 describe('callExplain parcelSummary wire', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ explanation: 'ok', sources: [], confidence: 0.9, traceId: 'x' }),
@@ -118,5 +132,21 @@ describe('callExplain parcelSummary wire', () => {
     const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     const body = JSON.parse(fetchCall[1].body as string);
     expect(body.parcelSummary).toBeUndefined();
+  });
+
+  it('sends the provisioned operator bearer token to the protected explain endpoint', async () => {
+    localStorage.setItem('authToken', 'owner-token');
+    const { callExplain } = await import('../../pages/MuseChat');
+    const ctx = {
+      activeParcelId: null, activeSuite: null, activeTab: null,
+      activeBranch: null, activeFile: null, buildStatus: 'unknown', editorMarkers: [],
+    };
+
+    await callExplain('test query', 'benton', 'actor', ctx, undefined);
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[1].headers).toMatchObject({
+      Authorization: 'Bearer owner-token',
+    });
   });
 });

--- a/frontend/apps/os-shell/src/api/pilotApi.ts
+++ b/frontend/apps/os-shell/src/api/pilotApi.ts
@@ -3,29 +3,23 @@
  * TERRAFUSION PILOT API CLIENT
  * Phase 5: GovernanceLock - Single Choke Point Integration
  *
- * All tool invocations MUST go through POST /pilot/invoke.
+ * All tool invocations MUST go through POST /api/pilot/invoke.
  * This client enforces the single execution path from the UI.
  *
  * Phase 1 Day 2: Added error normalization helpers to populate
  * correlationId into ErrorInfo for consistent UI display.
  *
- * NOTE: This is the Pilot subsystem (port 5000) - intentionally
- * NOT using centralized apiBase.ts because Pilot has its own
- * URL resolution pattern. Do NOT migrate to buildApiUrl().
- *
  * Government. Transcended.
  * ═══════════════════════════════════════════════════════════════
  */
 
+import { getToken } from '../auth/authStorage';
 import { getSession } from '../auth/session';
 import { ErrorInfo } from '../hooks/useErrorHandler';
-import { getViteEnv } from '../shared/viteEnv';
+import { getApiBase } from '../lib/apiBase';
 
-// Pilot API Base URL — always relative so requests go through the Vite dev proxy.
-// The Vite `/pilot` proxy forwards to the pilot runtime (port 4317 by default).
-// VITE_API_URL points at the .NET backend, NOT the pilot runtime.
-const env = getViteEnv();
-const API_BASE_URL = '';
+// Pilot routes are served by the .NET backend under /api/pilot in production.
+const API_BASE_URL = getApiBase();
 
 /**
  * Build standard Pilot API headers including identity from current session.
@@ -35,6 +29,10 @@ function buildPilotHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
+  const token = getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
   const session = getSession();
   if (session) {
     headers['x-user-id'] = session.userId;

--- a/frontend/apps/os-shell/src/pages/MuseChat.tsx
+++ b/frontend/apps/os-shell/src/pages/MuseChat.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { getToken } from '../auth/authStorage';
 import { getSession } from '../auth/session';
 import { useCompanionStore } from '../stores/companionStore';
 import type { EditorMarker } from '../stores/companionStore';
@@ -203,9 +204,15 @@ export async function callExplain(
   if (context.activeParcelId) body.parcelId = context.activeParcelId;
   if (parcelSummary) body.parcelSummary = parcelSummary;
 
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   const res = await fetch('/api/pilot/explain', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   });
 

--- a/frontend/apps/os-shell/src/services/pilotApi.ts
+++ b/frontend/apps/os-shell/src/services/pilotApi.ts
@@ -12,6 +12,16 @@ import {
   emitToolSucceeded,
   emitToolFailed,
 } from '@/services/terraTrace';
+import { getToken } from '../auth/authStorage';
+
+function buildJsonAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
 
 // ---------------------------------------------------------------------------
 // Request / Response types — Explain
@@ -69,7 +79,7 @@ export async function explain(req: ExplainRequest): Promise<ExplainResponse> {
   try {
     const res = await fetch('/api/pilot/explain', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildJsonAuthHeaders(),
       body: JSON.stringify(req),
     });
 
@@ -174,7 +184,7 @@ export async function createDraft(req: CreateDraftRequest): Promise<DraftRespons
   try {
     const res = await fetch('/api/pilot/drafts', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildJsonAuthHeaders(),
       body: JSON.stringify(req),
     });
     if (!res.ok) {
@@ -230,7 +240,7 @@ export async function approveDraft(draftId: string, req: ApproveDraftRequest): P
   try {
     const res = await fetch(`/api/pilot/drafts/${draftId}/approve`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildJsonAuthHeaders(),
       body: JSON.stringify(req),
     });
     if (!res.ok) {
@@ -286,7 +296,7 @@ export async function rejectDraft(draftId: string, req: RejectDraftRequest): Pro
   try {
     const res = await fetch(`/api/pilot/drafts/${draftId}/reject`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildJsonAuthHeaders(),
       body: JSON.stringify(req),
     });
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Routes OS shell Pilot tool calls through the production backend `/api/pilot/*` contract instead of stale `/pilot/*` SPA paths.
- Adds bearer auth headers to Pilot explain and HITL draft calls so authenticated operators do not hit protected endpoints without JWTs.
- Adds focused regression coverage for `/api/pilot/invoke` routing and protected `/api/pilot/explain` auth headers.

## Live triage result
- `/pilot/invoke` POST: 405 from nginx/static SPA route; fixed by moving client to `/api/pilot/invoke`.
- `/api/pilot/explain` GET: 405 expected; POST with auth reaches backend validation; missing frontend auth header fixed.
- `/api/dais/queue/all` GET: still backend 500 with correlationId `tf-3c1a230049f346e3ab8d5af185890099`; not masked in this slice.

## Verification
- `pnpm exec vitest run frontend/apps/os-shell/src/__tests__/api/pilotApi.traceNormalization.test.ts frontend/apps/os-shell/src/__tests__/api/pilotApi.auth.test.ts frontend/apps/os-shell/src/__tests__/pilot/buildParcelSummary.test.ts`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `pnpm run frontend:build`

## Deployment note
Do not deploy from this PR until the release lane is available or an explicitly approved manual production lane is used. GitHub Actions budget is currently preventing release jobs from starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for API authentication and secure token transmission in API calls
  * Added integration tests validating backend service routing and request parameters
  * Enhanced test isolation with state cleanup between test execution cycles

* **Refactor**
  * Streamlined API request header construction for consistent authentication handling
  * Consolidated base URL resolution across multiple pilot service implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->