### PR TITLE
fix(dais): repair queue schema for SQLite migration drift

### DIFF
--- a/backend/src/TerraFusion.API/HostedServices/AutoMigrateHostedService.cs
+++ b/backend/src/TerraFusion.API/HostedServices/AutoMigrateHostedService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using System.Data;
 using TerraFusion.Data;
 
 namespace TerraFusion.API.HostedServices;
@@ -54,8 +55,101 @@ public sealed class AutoMigrateHostedService : IHostedService
         {
             // Non-fatal: log and continue. Operator can fix and restart.
             _logger.LogError(ex, "AutoMigrate failed; backend will continue but DB may be out of sync");
+            await TryRepairSqliteDaisQueueSchemaAsync(ex, ct);
         }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+    private async Task TryRepairSqliteDaisQueueSchemaAsync(Exception migrationError, CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<TerraFusionDbContext>();
+            if (!db.Database.IsSqlite())
+                return;
+
+            var message = migrationError.ToString();
+            if (!message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            if (!await TableExistsAsync(db, "Counties", ct))
+            {
+                _logger.LogWarning(
+                    "AutoMigrate: SQLite DAIS QueueItems schema repair skipped because Counties table is missing");
+                return;
+            }
+
+            if (await TableExistsAsync(db, "QueueItems", ct))
+                return;
+
+            foreach (var statement in SqliteQueueItemsSchemaStatements)
+                await db.Database.ExecuteSqlRawAsync(statement, ct);
+
+            _logger.LogWarning(
+                "AutoMigrate: repaired SQLite DAIS QueueItems schema after migration-history drift");
+        }
+        catch (Exception repairError)
+        {
+            _logger.LogError(
+                repairError,
+                "AutoMigrate: SQLite DAIS QueueItems schema repair failed; queue endpoints may remain unavailable");
+        }
+    }
+
+    private static async Task<bool> TableExistsAsync(TerraFusionDbContext db, string tableName, CancellationToken ct)
+    {
+        var connection = db.Database.GetDbConnection();
+        var shouldClose = connection.State == ConnectionState.Closed;
+        if (shouldClose)
+            await connection.OpenAsync(ct);
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $tableName;";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "$tableName";
+            parameter.Value = tableName;
+            command.Parameters.Add(parameter);
+
+            var result = await command.ExecuteScalarAsync(ct);
+            return Convert.ToInt64(result) > 0;
+        }
+        finally
+        {
+            if (shouldClose)
+                await connection.CloseAsync();
+        }
+    }
+
+    private static readonly string[] SqliteQueueItemsSchemaStatements =
+    [
+        """
+        CREATE TABLE IF NOT EXISTS "QueueItems" (
+            "Id" TEXT NOT NULL CONSTRAINT "PK_QueueItems" PRIMARY KEY,
+            "ParcelId" TEXT NOT NULL,
+            "TaskType" TEXT NOT NULL,
+            "Priority" TEXT NOT NULL,
+            "Status" TEXT NOT NULL,
+            "AssignedTo" TEXT NULL,
+            "SlaHours" INTEGER NULL,
+            "SlaDeadline" TEXT NULL,
+            "StartedAt" TEXT NULL,
+            "CompletedAt" TEXT NULL,
+            "Notes" TEXT NULL,
+            "CountyId" TEXT NOT NULL,
+            "CreatedBy" TEXT NULL,
+            "UpdatedBy" TEXT NULL,
+            "CreatedAt" TEXT NOT NULL,
+            "UpdatedAt" TEXT NOT NULL,
+            CONSTRAINT "FK_QueueItems_Counties_CountyId" FOREIGN KEY ("CountyId") REFERENCES "Counties" ("Id") ON DELETE RESTRICT
+        );
+        """,
+        """CREATE INDEX IF NOT EXISTS "IX_QueueItems_CountyId_Id" ON "QueueItems" ("CountyId", "Id");""",
+        """CREATE INDEX IF NOT EXISTS "IX_QueueItems_CountyId_Status_CreatedAt" ON "QueueItems" ("CountyId", "Status", "CreatedAt");""",
+        """CREATE INDEX IF NOT EXISTS "IX_QueueItems_CountyId_AssignedTo_Status" ON "QueueItems" ("CountyId", "AssignedTo", "Status");""",
+        """CREATE INDEX IF NOT EXISTS "IX_QueueItems_CountyId_TaskType_Status" ON "QueueItems" ("CountyId", "TaskType", "Status");""",
+    ];
 }

--- a/backend/tests/TerraFusion.Unit.Tests/HostedServices/AutoMigrateHostedServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/HostedServices/AutoMigrateHostedServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -119,6 +120,77 @@ public sealed class AutoMigrateHostedServiceTests
         await task; // sanity: does not throw.
         logger.Entries.Should().BeEmpty(
             because: "StopAsync should not log anything");
+    }
+
+    [Fact]
+    public async Task StartAsync_when_sqlite_partial_schema_blocks_migration_repairs_queue_table()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"tf-auto-migrate-partial-{Guid.NewGuid():N}.db");
+        try
+        {
+            await using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                await connection.OpenAsync();
+                var command = connection.CreateCommand();
+                command.CommandText = """
+                    CREATE TABLE "__EFMigrationsHistory" (
+                        "MigrationId" TEXT NOT NULL CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY,
+                        "ProductVersion" TEXT NOT NULL
+                    );
+                    CREATE TABLE "AIAgents" (
+                        "Id" TEXT NOT NULL CONSTRAINT "PK_AIAgents" PRIMARY KEY,
+                        "Name" TEXT NOT NULL
+                    );
+                    CREATE TABLE "Counties" (
+                        "Id" TEXT NOT NULL CONSTRAINT "PK_Counties" PRIMARY KEY,
+                        "Name" TEXT NOT NULL,
+                        "State" TEXT NOT NULL,
+                        "FipsCode" TEXT NULL
+                    );
+                    """;
+                await command.ExecuteNonQueryAsync();
+            }
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(
+                new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}",
+                    })
+                    .Build());
+            services.AddDbContext<TerraFusionDbContext>(o => o.UseSqlite($"Data Source={dbPath}"));
+            var provider = services.BuildServiceProvider();
+            var logger = new CapturingLogger<AutoMigrateHostedService>();
+            var svc = new AutoMigrateHostedService(provider.GetRequiredService<IServiceScopeFactory>(), logger);
+
+            await svc.StartAsync(CancellationToken.None);
+
+            await using var verify = new SqliteConnection($"Data Source={dbPath}");
+            await verify.OpenAsync();
+            var tableCheck = verify.CreateCommand();
+            tableCheck.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'QueueItems';";
+            var queueTableCount = (long)(await tableCheck.ExecuteScalarAsync() ?? 0L);
+
+            queueTableCount.Should().Be(1, "the production SQLite drift path must repair the DAIS queue schema");
+            logger.Entries.Should().Contain(e =>
+                e.Level == LogLevel.Warning &&
+                e.Message.Contains("repaired SQLite DAIS QueueItems schema"));
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(dbPath))
+                    File.Delete(dbPath);
+            }
+            catch (IOException)
+            {
+                // The SQLite provider can release temp files slightly after
+                // DbContext disposal on Windows; leaked temp files must not mask
+                // the assertion that proves the schema repair behavior.
+            }
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/backend/tests/TerraFusion.Unit.Tests/Stage2/DaisEndpointContractTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Stage2/DaisEndpointContractTests.cs
@@ -468,6 +468,22 @@ public sealed class DaisEndpointContractTests
     }
 
     [Fact]
+    public async Task GetAllQueueItems_WhenQueueTableExistsAndNoRows_ReturnsOkEmptyList()
+    {
+        await using var db = CreateDbContext(nameof(GetAllQueueItems_WhenQueueTableExistsAndNoRows_ReturnsOkEmptyList));
+        await SeedCounty(db, BentonCountyId);
+
+        var realQueueSvc = new QueueService(db, NullLogger<QueueService>.Instance);
+        var controller = CreateDaisController(db, queueSvc: realQueueSvc);
+
+        var result = await controller.GetAllQueueItems(status: null, assignedTo: null, taskType: null);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var items = ok.Value.Should().BeAssignableTo<IEnumerable<QueueItem>>().Subject;
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetCertificationStatus_WhenNoRowsExist_PersistsCanonicalSteps()
     {
         await using var db = CreateDbContext(nameof(GetCertificationStatus_WhenNoRowsExist_PersistsCanonicalSteps));


### PR DESCRIPTION
## Summary

Fixes the DAIS queue 500 root cause without touching PR #871 Pilot fixes.

Root cause:
- Production auth succeeds.
- Authenticated `/api/dais/queue/*` endpoints return 500.
- Production logs show `SQLite Error 1: 'no such table: QueueItems'`.
- Production DB has `Counties`, missing `QueueItems`, and `__EFMigrationsHistory` has 0 rows.
- AutoMigrate attempts all migrations, hits existing partial schema (`table "AIAgents" already exists`), then aborts before DAIS queue migration.

Fix:
- Add a narrow SQLite repair path in `AutoMigrateHostedService` after existing-schema migration drift.
- Repair only when SQLite + migration failed on `already exists` + `Counties` exists + `QueueItems` is missing.
- Create `QueueItems` and current indexes. No fake empty response, no 500 masking.

## Verification

- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "AutoMigrateHostedServiceTests|DaisEndpointContractTests" --no-restore`
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter QueueServiceTests --no-restore`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj --no-restore`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- Pre-push quality gate passed, including backend Release build/publish.

## Deployment

Not deployed from this PR. GitHub Actions budget is an external release-lane blocker; deploy only through restored Actions or an explicitly approved manual release lane with recorded evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite database migration resilience with automatic schema repair for queue table detection and recovery from partial initialization states.

* **Tests**
  * Added test coverage for SQLite schema repair behavior and queue data retrieval functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->