### PR TITLE
fix(release): bind production runtime to TerraFusion DB config

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -168,13 +168,55 @@ jobs:
             set +e
             ssh -o ConnectTimeout=30 -o ServerAliveInterval=15 \
                 -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-                "APP_ROOT='$APP_ROOT' bash -s" <<'SSH'
+                "APP_ROOT='$APP_ROOT' TARGET_ENV='$TARGET_ENV' bash -s" <<'SSH'
           set -euo pipefail
           command -v docker >/dev/null
           docker compose version >/dev/null
           test -d "$APP_ROOT"
           test -w "$APP_ROOT"
           test -f "$APP_ROOT/app.env"
+          if ! grep -q '^ConnectionStrings__DefaultConnection=' "$APP_ROOT/app.env"; then
+            echo "APP_ENV_MISSING_CONNECTION_STRING"
+            exit 1
+          fi
+          if ! grep -q '^DatabaseProvider=' "$APP_ROOT/app.env"; then
+            echo "APP_ENV_MISSING_DATABASE_PROVIDER"
+            exit 1
+          fi
+
+          provider="$(grep '^DatabaseProvider=' "$APP_ROOT/app.env" | tail -n1 | cut -d= -f2- | tr -d '\r' | xargs)"
+          provider_key="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+          connection="$(grep '^ConnectionStrings__DefaultConnection=' "$APP_ROOT/app.env" | tail -n1 | cut -d= -f2- | tr -d '\r')"
+          connection_key="$(printf '%s' "$connection" | tr '[:upper:]' '[:lower:]')"
+
+          if [ "$TARGET_ENV" = "production" ]; then
+            case "$provider_key" in
+              postgres|postgresql|npgsql) ;;
+              sqlite)
+                echo "APP_ENV_PRODUCTION_DB_PROVIDER_SQLITE"
+                exit 1
+                ;;
+              *)
+                echo "APP_ENV_PRODUCTION_DB_PROVIDER_UNSUPPORTED_FOR_RELEASE_LANE"
+                exit 1
+                ;;
+            esac
+
+            case "$connection_key" in
+              *"data source="*".db"*|*"data source="*"/app/data/"*|*"data source="*"\\app\\data\\"*)
+                echo "APP_ENV_PRODUCTION_DB_CONNECTION_SQLITE"
+                exit 1
+                ;;
+            esac
+
+            case "$connection_key" in
+              *"host="*|*"server="*) ;;
+              *)
+                echo "APP_ENV_PRODUCTION_DB_CONNECTION_NOT_SERVER_BACKED"
+                exit 1
+                ;;
+            esac
+          fi
           SSH
             rc=$?
             set -e
@@ -415,9 +457,9 @@ jobs:
             --entrypoint sh \
             backend \
             -c 'set -eu
+              : "${DatabaseProvider:?DatabaseProvider missing from runtime environment}"
+              : "${ConnectionStrings__DefaultConnection:?ConnectionStrings__DefaultConnection missing from runtime environment}"
               dotnet /app/tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.dll \
-                --provider Sqlite \
-                --connection-string "Data Source=/app/data/terrafusion.db" \
                 --email "$TERRAFUSION_BOOTSTRAP_EMAIL" \
                 --password-env TERRAFUSION_BOOTSTRAP_PASSWORD \
                 --roles "${TERRAFUSION_BOOTSTRAP_ROLES:-GovernmentUser,Administrator,FullSystemAccess}" \

--- a/ops/prod/docker-compose.prod.server.yml
+++ b/ops/prod/docker-compose.prod.server.yml
@@ -63,7 +63,6 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - TF_STATE_MESH_ENFORCE=true
-      - DatabaseProvider=Sqlite
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     healthcheck:
@@ -92,8 +91,6 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       - TF_STATE_MESH_ENFORCE=true
       - TF_PROVENANCE_PATH=/app/provenance.json
-      - DatabaseProvider=Sqlite
-      # Neural Link: Connect to Host MSSQL
       # Connection string injected via secrets.prod.env
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/ops/prod/runtime-compose.template.yml
+++ b/ops/prod/runtime-compose.template.yml
@@ -28,8 +28,6 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: http://0.0.0.0:5000
-      DatabaseProvider: Sqlite
-      ConnectionStrings__DefaultConnection: Data Source=data/terrafusion.db
       TF_STATE_MESH_ENFORCE: 'true'
     volumes:
       - ./data:/app/data

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -339,6 +339,73 @@ describe('D. CI release gate coverage', () => {
       'Release lane must stream AuthProvisioner JSON from the one-off container instead of reading a host /tmp file',
     );
   });
+
+  it('D10: production runtime compose does not override app.env TerraFusion DB binding', () => {
+    const content = readFileSync(join(ROOT, 'ops', 'prod', 'runtime-compose.template.yml'), 'utf8');
+    assert.ok(
+      content.includes('- ./app.env'),
+      'Production runtime compose must load operator-managed app.env',
+    );
+    assert.ok(
+      !content.includes('DatabaseProvider: Sqlite'),
+      'Production runtime compose must not force SQLite over app.env',
+    );
+    assert.ok(
+      !content.includes('ConnectionStrings__DefaultConnection: Data Source=data/terrafusion.db'),
+      'Production runtime compose must not force the local SQLite file over app.env',
+    );
+  });
+
+  it('D11: no production compose file pins runtime to SQLite', () => {
+    for (const composeFile of [
+      'ops/prod/runtime-compose.template.yml',
+      'ops/prod/docker-compose.prod.server.yml',
+    ]) {
+      const content = readFileSync(join(ROOT, composeFile), 'utf8');
+      assert.ok(
+        !content.includes('DatabaseProvider=Sqlite') &&
+          !content.includes('DatabaseProvider: Sqlite'),
+        `${composeFile} must not force SQLite over its production env file`,
+      );
+      assert.ok(
+        !content.includes('ConnectionStrings__DefaultConnection: Data Source=data/terrafusion.db'),
+        `${composeFile} must not pin the runtime connection string to local SQLite`,
+      );
+    }
+  });
+
+  it('D12: release-lane provisions auth against the same configured TerraFusion DB as runtime', () => {
+    const content = readFileSync(join(WORKFLOWS, 'release-lane.yml'), 'utf8');
+    assert.ok(
+      content.includes('ConnectionStrings__DefaultConnection') &&
+        content.includes('DatabaseProvider'),
+      'Release lane must validate the runtime DB provider and connection string from app.env',
+    );
+    assert.ok(
+      !content.includes('--provider Sqlite') &&
+        !content.includes('--connection-string "Data Source=/app/data/terrafusion.db"'),
+      'AuthProvisioner must not be pinned to a separate SQLite DB in production',
+    );
+  });
+
+  it('D13: release-lane production DB preflight rejects SQLite without blocking Postgres aliases', () => {
+    const content = readFileSync(join(WORKFLOWS, 'release-lane.yml'), 'utf8');
+    assert.ok(
+      content.includes('provider_key=') &&
+        content.includes('postgres|postgresql|npgsql'),
+      'Release lane must normalize and accept governed Postgres provider aliases',
+    );
+    assert.ok(
+      content.includes('APP_ENV_PRODUCTION_DB_PROVIDER_SQLITE') &&
+        content.includes('APP_ENV_PRODUCTION_DB_CONNECTION_SQLITE'),
+      'Release lane must explicitly reject SQLite provider and local-file DB bindings',
+    );
+    assert.ok(
+      content.includes('connection_key=') &&
+        content.includes('*"host="*|*"server="*'),
+      'Release lane must evaluate server-backed connection keys case-insensitively',
+    );
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- stop production compose from overriding app.env with SQLite
- make release preflight reject production SQLite/local-file DB bindings
- run AuthProvisioner against the same runtime DB config used by the backend
- add deployment truth tests for runtime DB binding and auth provisioning parity

## Root Cause
Production runtime and auth provisioning were pinned to SQLite even though TerraFusion runtime truth data lives in the configured TerraFusion DB. That split let auth pass while runtime truth and county row endpoints 500'd against the wrong database.

## Verification
- node --test tests/deployment-truth-gate.test.mjs
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- git diff --check
- pre-push gate: unit tests, security scan, performance validation, compliance lint, backend build

## Production Notes
This does not mutate production data. Live production will remain on the old DB binding until this PR is merged and the release lane deploys the new SHA with a valid production app.env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deployment validation tests to ensure production environments load runtime DB settings and prevent accidental SQLite/local-file DB bindings.

* **Chores**
  * Updated release and deployment workflow behavior and compose configurations to remove hardcoded SQLite defaults and rely on runtime environment-provided DB configuration.

* **Bug Fixes**
  * Strengthened preflight checks to reject SQLite-like providers/connection strings for production targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->