### PR TITLE
[codex] Replace County Studio city rollups with Benton risk surfaces

### DIFF
--- a/docs/superpowers/plans/2026-05-28-county-studio-risk-surfaces.md
+++ b/docs/superpowers/plans/2026-05-28-county-studio-risk-surfaces.md
@@ -1,0 +1,49 @@
+# County Studio Risk Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorient County Studio around Benton valuation risk surfaces and a unified command queue instead of city-first drill analytics.
+
+**Architecture:** Add a focused frontend derivation utility that transforms active `CountySegmentDto` rows into risk board rows and ledger rows. Render the board on the county landing surface ahead of parcel evidence drill-down, leaving backend APIs, Sync, and DB seeding untouched.
+
+**Tech Stack:** React 18, TypeScript, Zustand, Vitest, Testing Library.
+
+---
+
+## Files
+
+- Create: `frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts`
+- Create: `frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx`
+- Create: `frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts`
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts`
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx`
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/components/DrillBreadcrumb.tsx`
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx`
+- Modify: `frontend/apps/os-shell/src/stores/countyStudioStore.ts`
+
+## Task 1: Risk Surface Derivation
+
+- [x] Write failing tests in `riskSurfaces.test.ts` for reval, neighborhood, model group, district, value tier, and unified ledger aggregation.
+- [x] Run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts` and verify the module is missing.
+- [x] Implement `riskSurfaces.ts` with null-safe weighted metric aggregation, board generation, contract gap detection, and ledger ranking.
+- [x] Re-run the same Vitest command and verify it passes.
+
+## Task 2: County Landing Command Center
+
+- [x] Add a failing `CountyStudyPage.test.tsx` assertion that county landing renders `Revaluation Cycle Risk`, `Neighborhood Risk`, `Model Group Risk`, `Taxing District Exposure`, `Value Tier Equity`, and `Unified Risk Ledger`.
+- [x] Add a failing assertion that `Kennewick` city rollup is not the primary county landing table.
+- [x] Implement `RiskSurfaceCommandCenter.tsx` and replace the county landing city table in `CountyStudyPage.tsx`.
+- [x] Re-run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx`.
+
+## Task 3: Drill Copy And Store Compatibility
+
+- [x] Add failing tests that the breadcrumb exposes `Risk Surface` copy after selecting a neighborhood risk object.
+- [x] Update the breadcrumb comments and visible copy so the primary path reads as county risk surface to parcel evidence.
+- [x] Keep city drill methods for compatibility, but update comments to state they are legacy/reference-only.
+- [x] Re-run County Studio focused tests.
+
+## Task 4: Verification
+
+- [x] Run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/DrillBreadcrumb.test.tsx`.
+- [x] Run `pnpm -C frontend run type-check`.
+- [x] Inspect `git diff --stat` and confirm no Sync or DB seeding files changed.

--- a/docs/superpowers/plans/2026-05-28-unified-risk-ledger-command-queue.md
+++ b/docs/superpowers/plans/2026-05-28-unified-risk-ledger-command-queue.md
@@ -1,0 +1,47 @@
+# Unified Risk Ledger Command Queue Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the Unified Risk Ledger into County Studio's primary sortable command queue.
+
+**Architecture:** Keep risk aggregation in `utils/riskSurfaces.ts`, keep ledger rendering inside `RiskSurfaceCommandCenter.tsx`, and preserve the existing store drill method for city-free neighborhood evidence. The five boards remain supporting decomposition below the command queue.
+
+**Tech Stack:** React, Zustand store, Vitest, Testing Library, TypeScript.
+
+---
+
+### Task 1: Risk Surface Ledger Semantics
+
+**Files:**
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts`
+- Test: `frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts`
+
+- [x] Add a failing test proving severity bands are `Critical`, `High`, `Medium`, `Low`.
+- [x] Add a failing test proving district exposure groups by taxing district even when segments carry different city metadata.
+- [x] Change `RiskLevel` and threshold mapping from `Moderate/Healthy` to `Medium/Low`.
+- [x] Run `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts`.
+
+### Task 2: Ledger Command UI
+
+**Files:**
+- Modify: `frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx`
+- Test: `frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx`
+
+- [x] Add a failing test proving the ledger appears before the supporting boards.
+- [x] Add a failing test proving severity filtering hides nonmatching rows.
+- [x] Add a failing test proving parcel exposure sorting can move a larger exposure row above a higher-risk row.
+- [x] Add stateful filter/sort controls scoped to the ledger component.
+- [x] Keep all action buttons drilling through `drillToRiskSurfaceNeighborhood`.
+
+### Task 3: Verification And Publish
+
+**Files:**
+- Modify: PR branch only.
+
+- [x] Run focused County Studio tests.
+- [x] Run `pnpm -C frontend run type-check`.
+- [x] Run browser smoke for `/forge/county-studio`.
+- [x] Run `pnpm -C frontend run build`.
+- [x] Run `git diff --check`.
+- [x] Commit the slice.
+- [x] Push the existing PR branch.

--- a/docs/superpowers/specs/2026-05-28-county-studio-risk-surfaces-design.md
+++ b/docs/superpowers/specs/2026-05-28-county-studio-risk-surfaces-design.md
@@ -1,0 +1,102 @@
+# County Studio Risk Surfaces Design
+
+## Doctrine
+
+County Studio is organized around how valuation decisions are made, corrected, and defended. For Benton County, the primary operating model is valuation structure, not municipal geography.
+
+The county landing surface is a risk surface, not a navigation tree:
+
+```text
+County Health
+Revaluation Cycle Risk
+Neighborhood Risk
+Model Group Risk
+District Exposure
+Value Tier Equity
+Unified Risk Ledger
+```
+
+City remains reference metadata only. It must not be the default drill path, command queue, or analytical lens.
+
+## Phase 1 Scope
+
+This implementation creates the five Benton command boards from active County Studio segment data:
+
+- Revaluation Cycle Health Board
+- Neighborhood Risk Board
+- Model Group Risk Board
+- Taxing District Exposure Board
+- Value Tier Equity Board
+
+The boards summarize parcel counts, ratio sample counts, median ratio, COD, PRD, PRB, exception burden, and composite risk where data is available. Missing dimensions are shown as explicit data contract gaps, not substituted with city or ZIP.
+
+## Phase 2 Scope
+
+This implementation adds a Unified Risk Ledger that ranks all available risk objects across the five boards. The ledger becomes the county command queue:
+
+```text
+Rank | Object | Type | Risk | Reason | Next Action
+```
+
+Selecting a neighborhood ledger item drills into its parcel evidence through the existing neighborhood/segment table. Selecting a segment-backed item selects the strongest evidence segment.
+
+## Phase 3 Preparation
+
+The implementation does not build simulation, recalibration, appeal prediction, or forecasting. It only prepares clean AI/workflow inputs by attaching Benton context to risk objects:
+
+- revaluation cycle
+- market area
+- neighborhood
+- model group
+- property class
+- value tier
+- taxing district
+- segment id
+
+Existing Inspector, Dais, Dossier, Atlas, SalesForge, CostForge, and CompsForge handoffs remain the working correction surfaces.
+
+## Data Contract
+
+Current segment data already contains:
+
+- `revalArea`
+- `geographyRef`
+- `buildingType`
+- `qualityGrade`
+- `segmentType`
+- ratio metrics
+- parcel and exception counts
+
+The UI accepts these optional future Benton fields when the backend provides them:
+
+- `marketArea`
+- `modelGroup`
+- `propertyClass`
+- `valueTier`
+- `taxingDistrict`
+
+Until those fields are available, the corresponding board shows a contract gap or a conservative derived label. City is never used as a replacement analytical key.
+
+## UI Behavior
+
+County view opens with County Health followed by the Benton risk surface board and Unified Risk Ledger. The city rollup is removed from the primary county landing surface.
+
+The breadcrumb copy changes from `County -> City -> Neighborhood -> Segment` to `County -> Risk Surface -> Parcel Evidence`. Existing city drill functions remain in the store as compatibility code for older rollup components and tests, but new county-level work does not route through them.
+
+## Testing
+
+Focused tests cover:
+
+- risk surface aggregation
+- missing Benton dimensions producing explicit contract gaps
+- county landing rendering risk boards instead of city rollup as the primary table
+- ledger selection drilling into neighborhood evidence without city-first routing
+
+## Non-Goals
+
+- No database seeding work.
+- No TerraFusion Sync work.
+- No forecasting engine.
+- No recalibration lab.
+- No appeal prediction AI.
+- No replacement of the existing downstream correction workbenches.

--- a/docs/superpowers/specs/2026-05-28-unified-risk-ledger-command-queue-design.md
+++ b/docs/superpowers/specs/2026-05-28-unified-risk-ledger-command-queue-design.md
@@ -1,0 +1,30 @@
+# Unified Risk Ledger Command Queue Design
+
+## Purpose
+
+Make County Studio's Unified Risk Ledger the first operational command queue for Benton valuation review. The ledger must sit above the supporting boards, show every risk object across valuation surfaces, and let an appraiser filter/sort without falling back to city-first thinking.
+
+## Scope
+
+This slice promotes the existing ledger into the primary county command queue. It covers revaluation cycles, neighborhoods, model groups, value tiers, and taxing district exposure. It does not add simulation, forecasting, recalibration labs, or new downstream workflow generation.
+
+## Behavior
+
+- County landing shows the Unified Risk Ledger before the individual risk boards.
+- Ledger rows use the severity bands `Critical`, `High`, `Medium`, and `Low`.
+- Users can filter the ledger by severity band and return to `All`.
+- Users can sort by priority, risk score, parcel exposure, or object type.
+- Ledger actions open neighborhood evidence using the strongest evidence segment where possible.
+- City remains metadata only and is not a grouping, filter, breadcrumb parent, or primary command dimension.
+
+## Testing
+
+Focused tests should prove:
+
+- ledger severity bands are `Critical/High/Medium/Low`
+- city metadata does not create ledger objects
+- taxing district exposure groups by district, not city
+- the County Studio landing renders the ledger as the first command queue
+- severity filtering and sorting operate on the same cross-surface ledger
+- neighborhood evidence drill preserves reval/cycle context and has no City crumb
+

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
@@ -14,7 +14,6 @@ import { useNavigate } from 'react-router-dom';
 import { useCountyStudioStore } from '@/stores/countyStudioStore';
 import { LeftRail } from './components/LeftRail';
 import { SegmentTable } from './components/SegmentTable';
-import { CityRollupTable } from './components/CityRollupTable';
 import { NeighborhoodRollupTable } from './components/NeighborhoodRollupTable';
 import { DrillBreadcrumb } from './components/DrillBreadcrumb';
 import { RightRail } from './components/RightRail';
@@ -25,6 +24,7 @@ import { LoadErrorBanner } from './components/LoadErrorBanner';
 import { CountyHealthPanel } from './components/CountyHealthPanel';
 import { CountyCommandStrip } from './components/CountyCommandStrip';
 import { CountyStatisticsWorkbenchPanel } from './components/CountyStatisticsWorkbenchPanel';
+import { RiskSurfaceCommandCenter } from './components/RiskSurfaceCommandCenter';
 import { useCountyStudyHub } from './hooks/useCountyStudyHub';
 import { useStudyData } from './hooks/useStudyData';
 import type { CountySegmentDto, SegmentSeverityFilter } from './types/countyStudio.types';
@@ -267,10 +267,10 @@ export function CountyStudyPage() {
                       color: 'hsl(var(--tf-muted))',
                     }}
                   >
-                    Cities stay overview-only here. Counties actually defend values and route action by neighborhood and reval-area segment.
+                    County Studio opens by how valuation decisions are made and defended: reval cycles, neighborhoods, model groups, districts, value tiers, and parcel evidence.
                   </div>
                   <div style={{ flex: 1, minHeight: 0 }}>
-                    <CityRollupTable />
+                    <RiskSurfaceCommandCenter />
                   </div>
                 </div>
               )}

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
@@ -195,8 +195,15 @@ describe('CountyStudyPage', () => {
   });
 
   it('risk ledger opens neighborhood evidence without routing through a city crumb', () => {
+    const sameNeighborhoodWrongCycle: CountySegmentDto = {
+      ...MOCK_SEG,
+      segmentId: 's-wrong-cycle',
+      name: 'NBHD-K1 - R5 - STANDARD',
+      revalArea: 5,
+    };
+
     act(() => {
-      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG]);
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG, sameNeighborhoodWrongCycle]);
       useCountyStudioStore.getState().drillToCounty();
     });
 
@@ -206,9 +213,12 @@ describe('CountyStudyPage', () => {
     const panel = screen.getByTestId('cs-drill-panel');
     expect(panel.dataset.drillLevel).toBe('neighborhood');
     expect(screen.getByTestId('crumb-risk-surface')).toHaveTextContent('Risk Surface');
-    expect(screen.getByTestId('crumb-neighborhood')).toHaveTextContent(/Neighborhood NBHD-K1/i);
+    expect(screen.getByTestId('crumb-neighborhood')).toHaveTextContent(/Neighborhood NBHD-K1 · Reval 2/i);
     expect(screen.queryByTestId('crumb-city')).not.toBeInTheDocument();
     expect(screen.getByText('Commercial · R1 · GOOD')).toBeInTheDocument();
+    expect(screen.queryByText('NBHD-K1 - R5 - STANDARD')).not.toBeInTheDocument();
+    expect(useCountyStudioStore.getState().selectedCity).toBeNull();
+    expect(useCountyStudioStore.getState().selectedNeighborhoodRevalArea).toBe(2);
   });
 
   it('city level renders the NeighborhoodRollupTable for selectedCity', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { act } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
@@ -50,6 +50,32 @@ const FAILING_SEG: CountySegmentDto = {
   segmentType: 'Commercial', parcelCount: 89, medianRatio: 0.84,
   cod: 22.8, prd: 1.06, stabilityScore: 48, riskScore: 78,
   exceptionCount: 22, geographyRef: 'NBHD-K1',
+};
+
+const LARGE_EXPOSURE_SEG: CountySegmentDto = {
+  segmentId: 's3', segmentSetId: 'ss1', name: 'NBHD-LOW - R1 - STANDARD',
+  revalArea: 7,
+  buildingType: 'R1',
+  qualityGrade: 'STANDARD',
+  modelGroup: 'MG-LOW',
+  valueTier: 'Entry',
+  taxingDistrict: 'Large Rural District',
+  segmentType: 'Residential', parcelCount: 2000, medianRatio: 0.98,
+  cod: 10.1, prd: 1.01, stabilityScore: 90, riskScore: 18,
+  exceptionCount: 0, geographyRef: 'NBHD-LOW',
+};
+
+const HIGH_RISK_SEG: CountySegmentDto = {
+  segmentId: 's4', segmentSetId: 'ss1', name: 'NBHD-HIGH - R1 - AVERAGE',
+  revalArea: 8,
+  buildingType: 'R1',
+  qualityGrade: 'AVERAGE',
+  modelGroup: 'MG-HIGH',
+  valueTier: 'Middle',
+  taxingDistrict: 'Mid County District',
+  segmentType: 'Residential', parcelCount: 120, medianRatio: 0.91,
+  cod: 18.5, prd: 1.04, stabilityScore: 58, riskScore: 64,
+  exceptionCount: 8, geographyRef: 'NBHD-HIGH',
 };
 
 const MOCK_CITY_ROW: CityRollupRowDto = {
@@ -192,6 +218,45 @@ describe('CountyStudyPage', () => {
     expect(screen.getByText('Unified Risk Ledger')).toBeInTheDocument();
     expect(screen.queryByText('Kennewick')).not.toBeInTheDocument();
     expect(screen.getByTestId('county-operational-scope-note')).toHaveTextContent(/valuation decisions are made and defended/i);
+  });
+
+  it('renders the unified risk ledger as the first command queue before supporting boards', () => {
+    act(() => {
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG, LARGE_EXPOSURE_SEG, HIGH_RISK_SEG]);
+    });
+    render(<CountyStudyPage />, { wrapper: Wrapper });
+
+    const commandCenter = screen.getByTestId('risk-surface-command-center');
+    const ledger = screen.getByTestId('unified-risk-ledger');
+    const firstBoard = screen.getByTestId('risk-board-revaluation-cycle');
+
+    expect(commandCenter.compareDocumentPosition(ledger) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ledger.compareDocumentPosition(firstBoard) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ledger).toHaveTextContent('Critical');
+    expect(ledger).toHaveTextContent('High');
+    expect(ledger).toHaveTextContent('Medium');
+    expect(ledger).toHaveTextContent('Low');
+  });
+
+  it('filters and sorts the unified risk ledger without introducing city grouping', () => {
+    act(() => {
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG, LARGE_EXPOSURE_SEG, HIGH_RISK_SEG]);
+      useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);
+    });
+    render(<CountyStudyPage />, { wrapper: Wrapper });
+
+    const ledger = screen.getByTestId('unified-risk-ledger');
+    fireEvent.click(screen.getByTestId('risk-ledger-filter-critical'));
+
+    expect(ledger).toHaveTextContent('MG-12');
+    expect(ledger).not.toHaveTextContent('Neighborhood NBHD-LOW');
+    expect(ledger).not.toHaveTextContent('Kennewick');
+
+    fireEvent.click(screen.getByTestId('risk-ledger-filter-all'));
+    fireEvent.click(screen.getByTestId('risk-ledger-sort-exposure'));
+
+    const labels = within(ledger).getAllByTestId('risk-ledger-object').map((node) => node.textContent);
+    expect(labels[0]).toBe('Neighborhood NBHD-LOW');
   });
 
   it('risk ledger opens neighborhood evidence without routing through a city crumb', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
@@ -44,6 +44,9 @@ const FAILING_SEG: CountySegmentDto = {
   revalArea: 2,
   buildingType: 'R1',
   qualityGrade: 'GOOD',
+  modelGroup: 'MG-12',
+  valueTier: 'Upper',
+  taxingDistrict: 'Kiona-Benton SD #52',
   segmentType: 'Commercial', parcelCount: 89, medianRatio: 0.84,
   cod: 22.8, prd: 1.06, stabilityScore: 48, riskScore: 78,
   exceptionCount: 22, geographyRef: 'NBHD-K1',
@@ -172,15 +175,40 @@ describe('CountyStudyPage', () => {
     expect(screen.getByTestId('crumb-county')).toBeInTheDocument();
   });
 
-  it('county level renders the CityRollupTable', () => {
+  it('county level renders Benton valuation risk surfaces instead of a city-first table', () => {
     act(() => {
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG]);
       useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);
     });
     render(<CountyStudyPage />, { wrapper: Wrapper });
     const panel = screen.getByTestId('cs-drill-panel');
     expect(panel.dataset.drillLevel).toBe('county');
-    expect(screen.getByText('Kennewick')).toBeInTheDocument();
-    expect(screen.getByTestId('county-operational-scope-note')).toHaveTextContent(/neighborhood and reval-area segment/i);
+    expect(screen.getByTestId('risk-surface-command-center')).toBeInTheDocument();
+    expect(screen.getByText('Revaluation Cycle Risk')).toBeInTheDocument();
+    expect(screen.getByText('Neighborhood Risk')).toBeInTheDocument();
+    expect(screen.getByText('Model Group Risk')).toBeInTheDocument();
+    expect(screen.getByText('Taxing District Exposure')).toBeInTheDocument();
+    expect(screen.getByText('Value Tier Equity')).toBeInTheDocument();
+    expect(screen.getByText('Unified Risk Ledger')).toBeInTheDocument();
+    expect(screen.queryByText('Kennewick')).not.toBeInTheDocument();
+    expect(screen.getByTestId('county-operational-scope-note')).toHaveTextContent(/valuation decisions are made and defended/i);
+  });
+
+  it('risk ledger opens neighborhood evidence without routing through a city crumb', () => {
+    act(() => {
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG]);
+      useCountyStudioStore.getState().drillToCounty();
+    });
+
+    render(<CountyStudyPage />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /open neighborhood evidence for neighborhood NBHD-K1/i }));
+
+    const panel = screen.getByTestId('cs-drill-panel');
+    expect(panel.dataset.drillLevel).toBe('neighborhood');
+    expect(screen.getByTestId('crumb-risk-surface')).toHaveTextContent('Risk Surface');
+    expect(screen.getByTestId('crumb-neighborhood')).toHaveTextContent(/Neighborhood NBHD-K1/i);
+    expect(screen.queryByTestId('crumb-city')).not.toBeInTheDocument();
+    expect(screen.getByText('Commercial · R1 · GOOD')).toBeInTheDocument();
   });
 
   it('city level renders the NeighborhoodRollupTable for selectedCity', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/DrillBreadcrumb.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/DrillBreadcrumb.test.tsx
@@ -39,6 +39,17 @@ describe('DrillBreadcrumb', () => {
     expect(screen.getByTestId('crumb-neighborhood')).toHaveTextContent('Neighborhood NBHD-R1 · Reval 2');
   });
 
+  it('renders the primary risk-surface path without a city crumb', () => {
+    act(() => {
+      useCountyStudioStore.getState().drillToRiskSurfaceNeighborhood('NBHD-R1', 2, 'seg-1');
+    });
+    render(<DrillBreadcrumb />);
+    expect(screen.getByTestId('crumb-county')).toBeInTheDocument();
+    expect(screen.getByTestId('crumb-risk-surface')).toHaveTextContent('Risk Surface');
+    expect(screen.getByTestId('crumb-neighborhood')).toHaveTextContent('Neighborhood NBHD-R1 · Reval 2');
+    expect(screen.queryByTestId('crumb-city')).not.toBeInTheDocument();
+  });
+
   it('renders segment crumb when a segment is selected', () => {
     const segment: CountySegmentDto = {
       segmentId: 'seg-1', segmentSetId: 'ss-1',

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
@@ -1,4 +1,5 @@
 import type { CountySegmentDto } from '../types/countyStudio.types';
+import { COUNTY_STUDIO_PRIMARY_DRILL_INVARIANT } from '../countyStudioInvariants';
 import { buildRiskSurfaceCommandCenter } from '../utils/riskSurfaces';
 
 function segment(overrides: Partial<CountySegmentDto> & Record<string, unknown> = {}): CountySegmentDto {
@@ -124,6 +125,40 @@ describe('risk surface command center', () => {
         'No taxing district field is available on active segments.',
         'No value tier field is available on active segments.',
       ]),
+    );
+  });
+
+  it('locks the primary drill invariant that city remains metadata only', () => {
+    expect(COUNTY_STUDIO_PRIMARY_DRILL_INVARIANT).toBe('Primary drill paths must not depend on city.');
+
+    const commandCenter = buildRiskSurfaceCommandCenter([
+      segment({
+        segmentId: 'seg-kennewick',
+        geographyRef: 'NBHD-420',
+        taxingDistrict: 'Benton SD #17',
+        valueTier: 'Upper',
+        riskScore: 82,
+        city: 'Kennewick',
+      }),
+      segment({
+        segmentId: 'seg-richland',
+        geographyRef: 'NBHD-421',
+        taxingDistrict: 'Benton SD #17',
+        valueTier: 'Upper',
+        riskScore: 78,
+        city: 'Richland',
+      }),
+    ]);
+
+    expect(commandCenter.boards.districtExposure).toHaveLength(1);
+    expect(commandCenter.boards.districtExposure[0]).toMatchObject({
+      key: 'Benton SD #17',
+      label: 'Benton SD #17',
+      type: 'taxingDistrict',
+    });
+    expect(commandCenter.boards.districtExposure[0].segmentCount).toBe(2);
+    expect(commandCenter.ledger.map((row) => row.label)).not.toEqual(
+      expect.arrayContaining(['Kennewick', 'Richland']),
     );
   });
 });

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
@@ -1,0 +1,129 @@
+import type { CountySegmentDto } from '../types/countyStudio.types';
+import { buildRiskSurfaceCommandCenter } from '../utils/riskSurfaces';
+
+function segment(overrides: Partial<CountySegmentDto> & Record<string, unknown> = {}): CountySegmentDto {
+  return {
+    segmentId: 'seg-1',
+    segmentSetId: 'set-1',
+    name: 'NBHD-100 - R1 - STANDARD',
+    segmentType: 'Residential',
+    geographyRef: 'NBHD-100',
+    revalArea: 2026,
+    buildingType: 'R1',
+    qualityGrade: 'STANDARD',
+    parcelCount: 100,
+    ratioCount: 20,
+    salesCount: 20,
+    medianRatio: 0.95,
+    cod: 15,
+    prd: 1.01,
+    prb: 0.02,
+    weightedMeanRatio: 0.96,
+    yoyMedianRatioDelta: 0.01,
+    stabilityScore: 80,
+    riskScore: 20,
+    exceptionCount: 2,
+    ...overrides,
+  } as CountySegmentDto;
+}
+
+describe('risk surface command center', () => {
+  it('aggregates Benton valuation risk surfaces without using city as an analytical key', () => {
+    const commandCenter = buildRiskSurfaceCommandCenter([
+      segment({
+        segmentId: 'seg-critical',
+        name: 'NBHD-420 - R2 - GOOD',
+        geographyRef: 'NBHD-420',
+        revalArea: 2026,
+        buildingType: 'R2',
+        qualityGrade: 'GOOD',
+        riskScore: 88,
+        cod: 22.1,
+        prd: 1.11,
+        prb: 0.14,
+        parcelCount: 80,
+        ratioCount: 16,
+        exceptionCount: 18,
+        modelGroup: 'MG-12',
+        valueTier: 'Upper',
+        taxingDistrict: 'Kiona-Benton SD #52',
+      }),
+      segment({
+        segmentId: 'seg-stable',
+        name: 'NBHD-110 - R1 - STANDARD',
+        geographyRef: 'NBHD-110',
+        revalArea: 2025,
+        buildingType: 'R1',
+        qualityGrade: 'STANDARD',
+        riskScore: 24,
+        cod: 11.2,
+        prd: 1.01,
+        prb: 0.01,
+        modelGroup: 'MG-01',
+        valueTier: 'Middle',
+        taxingDistrict: 'Richland SD #400',
+      }),
+    ]);
+
+    expect(commandCenter.boards.revaluationCycles[0]).toMatchObject({
+      key: '2026',
+      label: 'Cycle 2026',
+      type: 'revalCycle',
+      riskLevel: 'Critical',
+      primaryReason: 'COD 22.1',
+    });
+    expect(commandCenter.boards.neighborhoods[0]).toMatchObject({
+      key: 'NBHD-420',
+      label: 'Neighborhood NBHD-420',
+      type: 'neighborhood',
+      action: 'Drill parcel evidence',
+    });
+    expect(commandCenter.boards.modelGroups[0]).toMatchObject({
+      key: 'MG-12',
+      label: 'MG-12',
+      type: 'modelGroup',
+    });
+    expect(commandCenter.boards.districtExposure[0]).toMatchObject({
+      key: 'Kiona-Benton SD #52',
+      label: 'Kiona-Benton SD #52',
+      type: 'taxingDistrict',
+    });
+    expect(commandCenter.boards.valueTiers[0]).toMatchObject({
+      key: 'Upper',
+      label: 'Upper',
+      type: 'valueTier',
+    });
+    expect(commandCenter.ledger[0]).toMatchObject({
+      rank: 1,
+      key: 'NBHD-420',
+      type: 'neighborhood',
+      riskLevel: 'Critical',
+      nextAction: 'Open neighborhood evidence',
+      evidenceSegmentId: 'seg-critical',
+    });
+    expect(commandCenter.ledger.some((row) => row.type === 'city')).toBe(false);
+  });
+
+  it('surfaces missing district and value-tier data as contract gaps instead of substituting city', () => {
+    const commandCenter = buildRiskSurfaceCommandCenter([
+      segment({
+        segmentId: 'seg-gap',
+        geographyRef: 'NBHD-500',
+        revalArea: null,
+        riskScore: 72,
+        cod: 19.8,
+        prd: 1.07,
+        prb: 0.11,
+      }),
+    ]);
+
+    expect(commandCenter.boards.districtExposure).toEqual([]);
+    expect(commandCenter.boards.valueTiers).toEqual([]);
+    expect(commandCenter.contractGaps).toEqual(
+      expect.arrayContaining([
+        'No taxing district field is available on active segments.',
+        'No value tier field is available on active segments.',
+      ]),
+    );
+  });
+});

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts
@@ -161,4 +161,23 @@ describe('risk surface command center', () => {
       expect.arrayContaining(['Kennewick', 'Richland']),
     );
   });
+
+  it('uses command-queue severity bands instead of dashboard health labels', () => {
+    const commandCenter = buildRiskSurfaceCommandCenter([
+      segment({ segmentId: 'seg-critical', modelGroup: 'MG-Critical', riskScore: 88 }),
+      segment({ segmentId: 'seg-high', modelGroup: 'MG-High', riskScore: 64 }),
+      segment({ segmentId: 'seg-medium', modelGroup: 'MG-Medium', riskScore: 45 }),
+      segment({ segmentId: 'seg-low', modelGroup: 'MG-Low', riskScore: 18 }),
+    ]);
+
+    const modelBands = new Map(
+      commandCenter.boards.modelGroups.map((row) => [row.key, row.riskLevel]),
+    );
+
+    expect(modelBands.get('MG-Critical')).toBe('Critical');
+    expect(modelBands.get('MG-High')).toBe('High');
+    expect(modelBands.get('MG-Medium')).toBe('Medium');
+    expect(modelBands.get('MG-Low')).toBe('Low');
+    expect([...modelBands.values()]).not.toEqual(expect.arrayContaining(['Moderate', 'Healthy']));
+  });
 });

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/DrillBreadcrumb.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/DrillBreadcrumb.tsx
@@ -1,10 +1,8 @@
 // frontend/apps/os-shell/src/pages/forge/county-studio/components/DrillBreadcrumb.tsx
 //
-// County → City → Neighborhood → Segment breadcrumb. Each crumb is a
-// button that collapses the drill back to that level when clicked. The
-// final segment crumb (if any) is driven by selectedSegmentId — when set,
-// shows the segment name but is non-clickable (clicking it would be a no-op
-// because we're already at the leaf).
+// County -> Risk Surface -> Parcel Evidence breadcrumb. Legacy city crumbs
+// can still appear when old city rollup routes call drillToCity, but the
+// primary Benton command path keeps city out of the analytical hierarchy.
 
 import React from 'react';
 import { useCountyStudioStore } from '@/stores/countyStudioStore';
@@ -69,6 +67,18 @@ export function DrillBreadcrumb() {
           >
             {selectedCity}
           </button>
+        </>
+      )}
+
+      {selectedNeighborhood && !selectedCity && (
+        <>
+          <Separator />
+          <span
+            data-testid="crumb-risk-surface"
+            style={crumbStyle(false, false)}
+          >
+            Risk Surface
+          </span>
         </>
       )}
 

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx
@@ -1,0 +1,241 @@
+import React, { useMemo } from 'react';
+import { useCountyStudioStore } from '@/stores/countyStudioStore';
+import {
+  buildRiskSurfaceCommandCenter,
+  type RiskLevel,
+  type RiskSurfaceRow,
+  type UnifiedRiskLedgerRow,
+} from '../utils/riskSurfaces';
+
+const riskColor: Record<RiskLevel, string> = {
+  Critical: '#ef4444',
+  High: '#f59e0b',
+  Moderate: '#3b82f6',
+  Healthy: '#22c55e',
+};
+
+function formatNumber(value: number | null, digits = 2): string {
+  return value === null ? 'n/a' : value.toFixed(digits);
+}
+
+function BoardTable({ title, rows, empty }: { title: string; rows: RiskSurfaceRow[]; empty: string }) {
+  return (
+    <section
+      style={{
+        minWidth: 0,
+        overflowX: 'auto',
+        borderTop: '1px solid hsl(var(--tf-border))',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 10px',
+          borderBottom: '1px solid hsl(var(--tf-border))',
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: 12, fontWeight: 800 }}>{title}</h3>
+        <span style={{ fontSize: 10, color: 'hsl(var(--tf-muted))' }}>{rows.length} objects</span>
+      </div>
+      {rows.length === 0 ? (
+        <div style={{ padding: '14px 10px', fontSize: 11, color: 'hsl(var(--tf-muted))' }}>{empty}</div>
+      ) : (
+        <table style={{ width: '100%', minWidth: 520, borderCollapse: 'collapse', fontSize: 11 }}>
+          <thead>
+            <tr style={{ color: 'hsl(var(--tf-muted))', textAlign: 'left' }}>
+              <th style={{ padding: '6px 10px', fontWeight: 700 }}>Object</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Risk</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>COD</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>PRD</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(0, 4).map((row) => (
+              <tr key={`${row.type}:${row.key}`} style={{ borderTop: '1px solid hsl(var(--tf-border))' }}>
+                <td style={{ padding: '7px 10px', fontWeight: 700 }}>{row.label}</td>
+                <td style={{ padding: '7px 8px', color: riskColor[row.riskLevel], fontWeight: 800 }}>
+                  {row.riskLevel}
+                </td>
+                <td style={{ padding: '7px 8px' }}>{formatNumber(row.cod, 1)}</td>
+                <td style={{ padding: '7px 8px' }}>{formatNumber(row.prd, 3)}</td>
+                <td style={{ padding: '7px 8px', color: 'hsl(var(--tf-muted))' }}>{row.primaryReason}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+function UnifiedRiskLedger({
+  rows,
+  onOpenEvidence,
+}: {
+  rows: UnifiedRiskLedgerRow[];
+  onOpenEvidence: (row: UnifiedRiskLedgerRow) => void;
+}) {
+  return (
+    <section style={{ minWidth: 0, overflowX: 'auto', borderTop: '1px solid hsl(var(--tf-border))' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 10px',
+          borderBottom: '1px solid hsl(var(--tf-border))',
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: 12, fontWeight: 800 }}>Unified Risk Ledger</h3>
+        <span style={{ fontSize: 10, color: 'hsl(var(--tf-muted))' }}>county command queue</span>
+      </div>
+      {rows.length === 0 ? (
+        <div style={{ padding: '14px 10px', fontSize: 11, color: 'hsl(var(--tf-muted))' }}>
+          No active segment risk evidence yet. Derive segment metrics to populate the county command queue.
+        </div>
+      ) : (
+        <table style={{ width: '100%', minWidth: 680, borderCollapse: 'collapse', fontSize: 11 }}>
+          <thead>
+            <tr style={{ color: 'hsl(var(--tf-muted))', textAlign: 'left' }}>
+              <th style={{ padding: '6px 10px', width: 44, fontWeight: 700 }}>Rank</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Object</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Type</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Risk</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Reason</th>
+              <th style={{ padding: '6px 8px', fontWeight: 700 }}>Next Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(0, 8).map((row) => (
+              <tr key={`${row.type}:${row.key}`} style={{ borderTop: '1px solid hsl(var(--tf-border))' }}>
+                <td style={{ padding: '7px 10px', fontWeight: 800 }}>{row.rank}</td>
+                <td style={{ padding: '7px 8px', fontWeight: 700 }}>{row.label}</td>
+                <td style={{ padding: '7px 8px', color: 'hsl(var(--tf-muted))' }}>{row.type}</td>
+                <td style={{ padding: '7px 8px', color: riskColor[row.riskLevel], fontWeight: 800 }}>
+                  {row.riskLevel}
+                </td>
+                <td style={{ padding: '7px 8px' }}>{row.primaryReason}</td>
+                <td style={{ padding: '7px 8px' }}>
+                  <button
+                    type="button"
+                    aria-label={`${row.nextAction} for ${row.label}`}
+                    onClick={() => onOpenEvidence(row)}
+                    style={{
+                      padding: 0,
+                      border: 0,
+                      background: 'transparent',
+                      color: 'hsl(var(--tf-accent))',
+                      fontSize: 11,
+                      fontWeight: 700,
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                    }}
+                  >
+                    {row.nextAction}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+export function RiskSurfaceCommandCenter() {
+  const segments = useCountyStudioStore((state) => state.segments);
+  const drillToRiskSurfaceNeighborhood = useCountyStudioStore((state) => state.drillToRiskSurfaceNeighborhood);
+  const commandCenter = useMemo(() => buildRiskSurfaceCommandCenter(segments), [segments]);
+
+  const openLedgerRow = (row: UnifiedRiskLedgerRow) => {
+    const evidenceSegment = row.evidenceSegmentId
+      ? segments.find((segment) => segment.segmentId === row.evidenceSegmentId) ?? null
+      : null;
+    const neighborhood = row.context.neighborhood ?? evidenceSegment?.geographyRef ?? null;
+    if (!neighborhood) return;
+    drillToRiskSurfaceNeighborhood(
+      neighborhood,
+      evidenceSegment?.revalArea ?? null,
+      row.evidenceSegmentId,
+    );
+  };
+
+  return (
+    <div data-testid="risk-surface-command-center" style={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{
+          padding: '10px 12px',
+          borderBottom: '1px solid hsl(var(--tf-border))',
+          background: 'hsl(var(--tf-surface))',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 14, fontWeight: 900 }}>County Health Risk Surfaces</h2>
+            <p style={{ margin: '4px 0 0', fontSize: 11, color: 'hsl(var(--tf-muted))' }}>
+              Organized by how valuation decisions are made, corrected, and defended.
+            </p>
+          </div>
+          <div style={{ textAlign: 'right', fontSize: 11, color: 'hsl(var(--tf-muted))' }}>
+            <div>{segments.length} segments</div>
+            <div>{commandCenter.ledger.length} risk objects</div>
+          </div>
+        </div>
+        {commandCenter.contractGaps.length > 0 && (
+          <div
+            data-testid="risk-surface-contract-gaps"
+            style={{
+              marginTop: 8,
+              padding: '7px 8px',
+              border: '1px solid #f59e0b66',
+              background: '#f59e0b14',
+              color: '#f59e0b',
+              fontSize: 11,
+            }}
+          >
+            {commandCenter.contractGaps.join(' ')}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          alignItems: 'start',
+        }}
+      >
+        <BoardTable
+          title="Revaluation Cycle Risk"
+          rows={commandCenter.boards.revaluationCycles}
+          empty="No revaluation-cycle metadata is available on active segments."
+        />
+        <BoardTable
+          title="Neighborhood Risk"
+          rows={commandCenter.boards.neighborhoods}
+          empty="No neighborhood evidence is available on active segments."
+        />
+        <BoardTable
+          title="Model Group Risk"
+          rows={commandCenter.boards.modelGroups}
+          empty="No model group or building-type evidence is available on active segments."
+        />
+        <BoardTable
+          title="Taxing District Exposure"
+          rows={commandCenter.boards.districtExposure}
+          empty="No taxing district field is available on active segments."
+        />
+        <BoardTable
+          title="Value Tier Equity"
+          rows={commandCenter.boards.valueTiers}
+          empty="No value tier field is available on active segments."
+        />
+        <UnifiedRiskLedger rows={commandCenter.ledger} onOpenEvidence={openLedgerRow} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/RiskSurfaceCommandCenter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useCountyStudioStore } from '@/stores/countyStudioStore';
 import {
   buildRiskSurfaceCommandCenter,
@@ -10,17 +10,34 @@ import {
 const riskColor: Record<RiskLevel, string> = {
   Critical: '#ef4444',
   High: '#f59e0b',
-  Moderate: '#3b82f6',
-  Healthy: '#22c55e',
+  Medium: '#3b82f6',
+  Low: '#22c55e',
+};
+
+type LedgerFilter = 'All' | RiskLevel;
+type LedgerSort = 'priority' | 'risk' | 'exposure' | 'type';
+
+const riskFilters: LedgerFilter[] = ['All', 'Critical', 'High', 'Medium', 'Low'];
+
+const sortLabels: Record<LedgerSort, string> = {
+  priority: 'Priority',
+  risk: 'Risk',
+  exposure: 'Exposure',
+  type: 'Type',
 };
 
 function formatNumber(value: number | null, digits = 2): string {
   return value === null ? 'n/a' : value.toFixed(digits);
 }
 
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
 function BoardTable({ title, rows, empty }: { title: string; rows: RiskSurfaceRow[]; empty: string }) {
   return (
     <section
+      data-testid={`risk-board-${slug(title.replace(' Risk', ''))}`}
       style={{
         minWidth: 0,
         overflowX: 'auto',
@@ -78,8 +95,31 @@ function UnifiedRiskLedger({
   rows: UnifiedRiskLedgerRow[];
   onOpenEvidence: (row: UnifiedRiskLedgerRow) => void;
 }) {
+  const [filter, setFilter] = useState<LedgerFilter>('All');
+  const [sort, setSort] = useState<LedgerSort>('priority');
+
+  const visibleRows = useMemo(() => {
+    const filtered = filter === 'All' ? rows : rows.filter((row) => row.riskLevel === filter);
+    return [...filtered].sort((a, b) => {
+      switch (sort) {
+        case 'risk':
+          return b.riskScore - a.riskScore || a.rank - b.rank;
+        case 'exposure':
+          return b.parcelCount - a.parcelCount || b.riskScore - a.riskScore || a.rank - b.rank;
+        case 'type':
+          return a.type.localeCompare(b.type) || a.rank - b.rank;
+        case 'priority':
+        default:
+          return a.rank - b.rank;
+      }
+    });
+  }, [filter, rows, sort]);
+
   return (
-    <section style={{ minWidth: 0, overflowX: 'auto', borderTop: '1px solid hsl(var(--tf-border))' }}>
+    <section
+      data-testid="unified-risk-ledger"
+      style={{ minWidth: 0, overflowX: 'auto', borderTop: '1px solid hsl(var(--tf-border))' }}
+    >
       <div
         style={{
           display: 'flex',
@@ -92,6 +132,65 @@ function UnifiedRiskLedger({
         <h3 style={{ margin: 0, fontSize: 12, fontWeight: 800 }}>Unified Risk Ledger</h3>
         <span style={{ fontSize: 10, color: 'hsl(var(--tf-muted))' }}>county command queue</span>
       </div>
+      {rows.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+            gap: 8,
+            padding: '8px 10px',
+            borderBottom: '1px solid hsl(var(--tf-border))',
+          }}
+        >
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            {riskFilters.map((item) => (
+              <button
+                key={item}
+                type="button"
+                data-testid={`risk-ledger-filter-${item.toLowerCase()}`}
+                aria-pressed={filter === item}
+                onClick={() => setFilter(item)}
+                style={{
+                  padding: '3px 7px',
+                  border: '1px solid hsl(var(--tf-border))',
+                  borderRadius: 4,
+                  background: filter === item ? 'hsl(var(--tf-surface))' : 'transparent',
+                  color: filter === item ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))',
+                  fontSize: 10,
+                  fontWeight: 800,
+                  cursor: 'pointer',
+                }}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            {(Object.keys(sortLabels) as LedgerSort[]).map((item) => (
+              <button
+                key={item}
+                type="button"
+                data-testid={`risk-ledger-sort-${item}`}
+                aria-pressed={sort === item}
+                onClick={() => setSort(item)}
+                style={{
+                  padding: '3px 7px',
+                  border: '1px solid hsl(var(--tf-border))',
+                  borderRadius: 4,
+                  background: sort === item ? 'hsl(var(--tf-surface))' : 'transparent',
+                  color: sort === item ? 'hsl(var(--tf-fg))' : 'hsl(var(--tf-muted))',
+                  fontSize: 10,
+                  fontWeight: 800,
+                  cursor: 'pointer',
+                }}
+              >
+                {sortLabels[item]}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       {rows.length === 0 ? (
         <div style={{ padding: '14px 10px', fontSize: 11, color: 'hsl(var(--tf-muted))' }}>
           No active segment risk evidence yet. Derive segment metrics to populate the county command queue.
@@ -109,10 +208,10 @@ function UnifiedRiskLedger({
             </tr>
           </thead>
           <tbody>
-            {rows.slice(0, 8).map((row) => (
+            {visibleRows.map((row) => (
               <tr key={`${row.type}:${row.key}`} style={{ borderTop: '1px solid hsl(var(--tf-border))' }}>
                 <td style={{ padding: '7px 10px', fontWeight: 800 }}>{row.rank}</td>
-                <td style={{ padding: '7px 8px', fontWeight: 700 }}>{row.label}</td>
+                <td data-testid="risk-ledger-object" style={{ padding: '7px 8px', fontWeight: 700 }}>{row.label}</td>
                 <td style={{ padding: '7px 8px', color: 'hsl(var(--tf-muted))' }}>{row.type}</td>
                 <td style={{ padding: '7px 8px', color: riskColor[row.riskLevel], fontWeight: 800 }}>
                   {row.riskLevel}
@@ -202,6 +301,8 @@ export function RiskSurfaceCommandCenter() {
         )}
       </div>
 
+      <UnifiedRiskLedger rows={commandCenter.ledger} onOpenEvidence={openLedgerRow} />
+
       <div
         style={{
           display: 'grid',
@@ -234,7 +335,6 @@ export function RiskSurfaceCommandCenter() {
           rows={commandCenter.boards.valueTiers}
           empty="No value tier field is available on active segments."
         />
-        <UnifiedRiskLedger rows={commandCenter.ledger} onOpenEvidence={openLedgerRow} />
       </div>
     </div>
   );

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/countyStudioInvariants.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/countyStudioInvariants.ts
@@ -1,0 +1,2 @@
+export const COUNTY_STUDIO_PRIMARY_DRILL_INVARIANT = 'Primary drill paths must not depend on city.';
+

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
@@ -65,9 +65,14 @@ export interface CountySegmentDto {
   name: string;
   segmentType: string;
   geographyRef: string | null;
+  marketArea?: string | null;
   revalArea: number | null;
   buildingType: string | null;
   qualityGrade: string | null;
+  modelGroup?: string | null;
+  propertyClass?: string | null;
+  valueTier?: string | null;
+  taxingDistrict?: string | null;
   parcelCount: number;
   /** Nullable on server for sparse-sample segments — UI must null-guard. */
   medianRatio: number | null;

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
@@ -181,10 +181,8 @@ export interface NeighborhoodRollupRowDto {
 
 /**
  * Drill level for the County Studio center panel.
- *   'county'       — County health + city overview visible. Cities are overview
- *                    geography only; the operative assessment units remain
- *                    neighborhood and reval-area segments.
- *   'city'         — NeighborhoodRollupTable filtered to selectedCity.
+ *   'county'       — County health + primary Benton risk surfaces visible.
+ *   'city'         — legacy/reference-only NeighborhoodRollupTable filtered to selectedCity.
  *   'neighborhood' — SegmentTable filtered to selectedNeighborhood's GeographyRef.
  * Segment-level detail lives in the RightRail's ObjectInspector, selected via
  * selectedSegmentId; it is not a separate drillLevel because the segment table

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts
@@ -7,7 +7,7 @@ export type RiskSurfaceType =
   | 'taxingDistrict'
   | 'valueTier';
 
-export type RiskLevel = 'Critical' | 'High' | 'Moderate' | 'Healthy';
+export type RiskLevel = 'Critical' | 'High' | 'Medium' | 'Low';
 
 export interface RiskSurfaceRow {
   key: string;
@@ -104,8 +104,8 @@ function normalizeLabel(value: string | null | undefined): string | null {
 function riskLevel(score: number): RiskLevel {
   if (score >= 75) return 'Critical';
   if (score >= 60) return 'High';
-  if (score >= 35) return 'Moderate';
-  return 'Healthy';
+  if (score >= 35) return 'Medium';
+  return 'Low';
 }
 
 function primaryReason(row: Pick<RiskSurfaceRow, 'cod' | 'prd' | 'prb' | 'medianRatio' | 'exceptionCount' | 'riskScore'>): string {
@@ -198,7 +198,7 @@ function buildRows(
         prb: round(weightedAverage(group.segments, (segment) => segment.prb), 3),
         exceptionCount: sum(group.segments, (segment) => segment.exceptionCount),
         riskScore: Math.round(weightedAverage(group.segments, (segment) => segment.riskScore) ?? 0),
-        riskLevel: 'Healthy' as RiskLevel,
+        riskLevel: 'Low' as RiskLevel,
         primaryReason: '',
         action: actionFor(group.type),
         evidenceSegmentId: evidence?.segmentId ?? null,

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/utils/riskSurfaces.ts
@@ -1,0 +1,311 @@
+import type { CountySegmentDto } from '../types/countyStudio.types';
+
+export type RiskSurfaceType =
+  | 'revalCycle'
+  | 'neighborhood'
+  | 'modelGroup'
+  | 'taxingDistrict'
+  | 'valueTier';
+
+export type RiskLevel = 'Critical' | 'High' | 'Moderate' | 'Healthy';
+
+export interface RiskSurfaceRow {
+  key: string;
+  label: string;
+  type: RiskSurfaceType;
+  segmentCount: number;
+  parcelCount: number;
+  ratioCount: number;
+  medianRatio: number | null;
+  cod: number | null;
+  prd: number | null;
+  prb: number | null;
+  exceptionCount: number;
+  riskScore: number;
+  riskLevel: RiskLevel;
+  primaryReason: string;
+  action: string;
+  evidenceSegmentId: string | null;
+  context: {
+    revalCycle?: string;
+    marketArea?: string;
+    neighborhood?: string;
+    modelGroup?: string;
+    propertyClass?: string;
+    valueTier?: string;
+    taxingDistrict?: string;
+  };
+}
+
+export interface UnifiedRiskLedgerRow extends RiskSurfaceRow {
+  rank: number;
+  nextAction: string;
+}
+
+export interface RiskSurfaceCommandCenter {
+  boards: {
+    revaluationCycles: RiskSurfaceRow[];
+    neighborhoods: RiskSurfaceRow[];
+    modelGroups: RiskSurfaceRow[];
+    districtExposure: RiskSurfaceRow[];
+    valueTiers: RiskSurfaceRow[];
+  };
+  ledger: UnifiedRiskLedgerRow[];
+  contractGaps: string[];
+}
+
+interface GroupAccumulator {
+  key: string;
+  label: string;
+  type: RiskSurfaceType;
+  segments: CountySegmentDto[];
+  context: RiskSurfaceRow['context'];
+}
+
+type GroupKeySelector = (segment: CountySegmentDto) => { key: string; label: string; context?: RiskSurfaceRow['context'] } | null;
+
+function numeric(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function round(value: number | null, digits = 2): number | null {
+  if (value === null) return null;
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function weightedAverage(
+  segments: CountySegmentDto[],
+  selector: (segment: CountySegmentDto) => number | null | undefined,
+): number | null {
+  let weightedTotal = 0;
+  let weightTotal = 0;
+
+  for (const segment of segments) {
+    const value = numeric(selector(segment));
+    if (value === null) continue;
+    const weight = Math.max(1, numeric(segment.ratioCount) ?? numeric(segment.salesCount) ?? segment.parcelCount);
+    weightedTotal += value * weight;
+    weightTotal += weight;
+  }
+
+  return weightTotal > 0 ? weightedTotal / weightTotal : null;
+}
+
+function sum(segments: CountySegmentDto[], selector: (segment: CountySegmentDto) => number | null | undefined): number {
+  return segments.reduce((total, segment) => total + (numeric(selector(segment)) ?? 0), 0);
+}
+
+function normalizeLabel(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function riskLevel(score: number): RiskLevel {
+  if (score >= 75) return 'Critical';
+  if (score >= 60) return 'High';
+  if (score >= 35) return 'Moderate';
+  return 'Healthy';
+}
+
+function primaryReason(row: Pick<RiskSurfaceRow, 'cod' | 'prd' | 'prb' | 'medianRatio' | 'exceptionCount' | 'riskScore'>): string {
+  if (row.cod !== null && row.cod > 20) return `COD ${row.cod.toFixed(1)}`;
+  if (row.prd !== null && (row.prd < 0.98 || row.prd > 1.03)) return `PRD ${row.prd.toFixed(2)}`;
+  if (row.prb !== null && Math.abs(row.prb) > 0.10) return `PRB ${row.prb.toFixed(2)}`;
+  if (row.medianRatio !== null && (row.medianRatio < 0.90 || row.medianRatio > 1.10)) {
+    return `Median ${row.medianRatio.toFixed(2)}`;
+  }
+  if (row.exceptionCount > 0) return `${row.exceptionCount} exceptions`;
+  return `Risk ${Math.round(row.riskScore)}`;
+}
+
+function actionFor(type: RiskSurfaceType): string {
+  switch (type) {
+    case 'revalCycle':
+      return 'Audit cycle strata';
+    case 'neighborhood':
+      return 'Drill parcel evidence';
+    case 'modelGroup':
+      return 'Review model calibration';
+    case 'taxingDistrict':
+      return 'Review district exposure';
+    case 'valueTier':
+      return 'Audit vertical equity';
+    default:
+      return 'Review evidence';
+  }
+}
+
+function nextActionFor(type: RiskSurfaceType): string {
+  switch (type) {
+    case 'neighborhood':
+      return 'Open neighborhood evidence';
+    case 'modelGroup':
+      return 'Open model group evidence';
+    case 'revalCycle':
+      return 'Open revaluation cycle evidence';
+    case 'taxingDistrict':
+      return 'Open district exposure evidence';
+    case 'valueTier':
+      return 'Open value tier equity evidence';
+    default:
+      return 'Open parcel evidence';
+  }
+}
+
+function strongestEvidenceSegment(segments: CountySegmentDto[]): CountySegmentDto | null {
+  return [...segments].sort((a, b) => b.riskScore - a.riskScore)[0] ?? null;
+}
+
+function buildRows(
+  segments: CountySegmentDto[],
+  type: RiskSurfaceType,
+  selectGroup: GroupKeySelector,
+): RiskSurfaceRow[] {
+  const groups = new Map<string, GroupAccumulator>();
+
+  for (const segment of segments) {
+    const selected = selectGroup(segment);
+    if (!selected) continue;
+    const existing = groups.get(selected.key);
+    if (existing) {
+      existing.segments.push(segment);
+      continue;
+    }
+    groups.set(selected.key, {
+      key: selected.key,
+      label: selected.label,
+      type,
+      segments: [segment],
+      context: selected.context ?? {},
+    });
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const evidence = strongestEvidenceSegment(group.segments);
+      const ratioCount = sum(group.segments, (segment) => segment.ratioCount ?? segment.salesCount ?? 0);
+      const row = {
+        key: group.key,
+        label: group.label,
+        type: group.type,
+        segmentCount: group.segments.length,
+        parcelCount: sum(group.segments, (segment) => segment.parcelCount),
+        ratioCount,
+        medianRatio: round(weightedAverage(group.segments, (segment) => segment.medianRatio), 3),
+        cod: round(weightedAverage(group.segments, (segment) => segment.cod), 1),
+        prd: round(weightedAverage(group.segments, (segment) => segment.prd), 3),
+        prb: round(weightedAverage(group.segments, (segment) => segment.prb), 3),
+        exceptionCount: sum(group.segments, (segment) => segment.exceptionCount),
+        riskScore: Math.round(weightedAverage(group.segments, (segment) => segment.riskScore) ?? 0),
+        riskLevel: 'Healthy' as RiskLevel,
+        primaryReason: '',
+        action: actionFor(group.type),
+        evidenceSegmentId: evidence?.segmentId ?? null,
+        context: group.context,
+      };
+      row.riskLevel = riskLevel(row.riskScore);
+      row.primaryReason = primaryReason(row);
+      return row;
+    })
+    .sort(compareRiskRows);
+}
+
+function compareRiskRows(a: RiskSurfaceRow, b: RiskSurfaceRow): number {
+  if (b.riskScore !== a.riskScore) return b.riskScore - a.riskScore;
+  const typeDelta = riskSurfacePriority(a.type) - riskSurfacePriority(b.type);
+  if (typeDelta !== 0) return typeDelta;
+  if (b.parcelCount !== a.parcelCount) return b.parcelCount - a.parcelCount;
+  return a.label.localeCompare(b.label);
+}
+
+function riskSurfacePriority(type: RiskSurfaceType): number {
+  switch (type) {
+    case 'neighborhood':
+      return 1;
+    case 'modelGroup':
+      return 2;
+    case 'valueTier':
+      return 3;
+    case 'revalCycle':
+      return 4;
+    case 'taxingDistrict':
+      return 5;
+    default:
+      return 10;
+  }
+}
+
+function modelGroupLabel(segment: CountySegmentDto): string | null {
+  const explicit = normalizeLabel(segment.modelGroup);
+  if (explicit) return explicit;
+
+  const buildingType = normalizeLabel(segment.buildingType);
+  const qualityGrade = normalizeLabel(segment.qualityGrade);
+  if (!buildingType && !qualityGrade) return null;
+  return [buildingType, qualityGrade].filter(Boolean).join(' / ');
+}
+
+export function buildRiskSurfaceCommandCenter(segments: CountySegmentDto[]): RiskSurfaceCommandCenter {
+  const revaluationCycles = buildRows(segments, 'revalCycle', (segment) => {
+    if (segment.revalArea === null || segment.revalArea === undefined) return null;
+    const key = String(segment.revalArea);
+    return { key, label: `Cycle ${key}`, context: { revalCycle: key } };
+  });
+
+  const neighborhoods = buildRows(segments, 'neighborhood', (segment) => {
+    const key = normalizeLabel(segment.geographyRef);
+    if (!key) return null;
+    return { key, label: `Neighborhood ${key}`, context: { neighborhood: key } };
+  });
+
+  const modelGroups = buildRows(segments, 'modelGroup', (segment) => {
+    const key = modelGroupLabel(segment);
+    if (!key) return null;
+    return { key, label: key, context: { modelGroup: key, propertyClass: normalizeLabel(segment.propertyClass) ?? undefined } };
+  });
+
+  const districtExposure = buildRows(segments, 'taxingDistrict', (segment) => {
+    const key = normalizeLabel(segment.taxingDistrict);
+    if (!key) return null;
+    return { key, label: key, context: { taxingDistrict: key } };
+  });
+
+  const valueTiers = buildRows(segments, 'valueTier', (segment) => {
+    const key = normalizeLabel(segment.valueTier);
+    if (!key) return null;
+    return { key, label: key, context: { valueTier: key } };
+  });
+
+  const contractGaps: string[] = [];
+  if (segments.length > 0 && districtExposure.length === 0) {
+    contractGaps.push('No taxing district field is available on active segments.');
+  }
+  if (segments.length > 0 && valueTiers.length === 0) {
+    contractGaps.push('No value tier field is available on active segments.');
+  }
+
+  const allRows = [
+    ...revaluationCycles,
+    ...neighborhoods,
+    ...modelGroups,
+    ...districtExposure,
+    ...valueTiers,
+  ].sort(compareRiskRows);
+
+  return {
+    boards: {
+      revaluationCycles,
+      neighborhoods,
+      modelGroups,
+      districtExposure,
+      valueTiers,
+    },
+    ledger: allRows.map((row, index) => ({
+      ...row,
+      rank: index + 1,
+      nextAction: nextActionFor(row.type),
+    })),
+    contractGaps,
+  };
+}

--- a/frontend/apps/os-shell/src/stores/countyStudioStore.ts
+++ b/frontend/apps/os-shell/src/stores/countyStudioStore.ts
@@ -80,8 +80,8 @@ export interface CountyStudioState {
   // ── Drill-lattice state (Task B) ───────────────────────────────────────
   /**
    * Current drill level — governs which table the center panel renders.
-   *   'county'       — CityRollupTable visible, selectedCity/selectedNeighborhood null.
-   *   'city'         — NeighborhoodRollupTable filtered to selectedCity.
+   *   'county'       — Benton risk surfaces + unified risk ledger visible.
+   *   'city'         — legacy/reference-only NeighborhoodRollupTable filtered to selectedCity.
    *   'neighborhood' — SegmentTable filtered to segments with GeographyRef ===
    *     selectedNeighborhood and, when present, segment.RevalArea ===
    *     selectedNeighborhoodRevalArea.
@@ -135,7 +135,7 @@ export interface CountyStudioState {
   /** Store the most recent health summary response. null = never-loaded or 409. */
   setHealthSummary: (summary: CountyHealthSummaryDto | null) => void;
   /**
-   * Collapse drill back to the county view (CityRollupTable). Clears both
+   * Collapse drill back to the county risk-surface view. Clears both
    * selectedCity and selectedNeighborhood so the "stale selection" class of
    * bug (e.g. filtered segment table showing no rows after breadcrumb click)
    * is mechanically impossible.
@@ -146,14 +146,26 @@ export interface CountyStudioState {
    * stale selectedNeighborhood. Also clears selectedSegmentId so the
    * RightRail's ObjectInspector doesn't show a detail for a segment that
    * isn't in the new scope.
+   * Legacy/reference-only path retained for older city rollup components.
    */
   drillToCity: (city: string) => void;
   /**
    * Advance drill to a specific neighborhood within a city. Both city and
    * neighborhood are required so the state machine can never land at
    * drillLevel='neighborhood' without a parent city.
+   * Legacy/reference path: new County Studio command work should prefer
+   * drillToRiskSurfaceNeighborhood so city does not become the operating lens.
    */
   drillToNeighborhood: (city: string, neighborhoodCode: string, revalArea?: number | null) => void;
+  /**
+   * Open neighborhood parcel evidence from a Benton risk surface. City remains
+   * null because city is reference metadata, not a primary analytical parent.
+   */
+  drillToRiskSurfaceNeighborhood: (
+    neighborhoodCode: string,
+    revalArea?: number | null,
+    segmentId?: string | null
+  ) => void;
   setSegmentSeverityFilter: (filter: SegmentSeverityFilter) => void;
   /**
    * Jump straight to a specific segment — parent city + neighborhood are both
@@ -335,6 +347,19 @@ export const useCountyStudioStore = create<CountyStudioState>()(
           },
           false,
           `drillToNeighborhood/${city}/${neighborhoodCode}/${revalArea ?? 'na'}`
+        ),
+      drillToRiskSurfaceNeighborhood: (neighborhoodCode, revalArea = null, segmentId = null) =>
+        set(
+          {
+            drillLevel: 'neighborhood',
+            selectedCity: null,
+            selectedNeighborhood: neighborhoodCode,
+            selectedNeighborhoodRevalArea: revalArea,
+            selectedSegmentId: segmentId,
+            segmentSeverityFilter: 'all',
+          },
+          false,
+          `drillToRiskSurfaceNeighborhood/${neighborhoodCode}/${revalArea ?? 'na'}/${segmentId ?? 'na'}`
         ),
       drillToSegment: (city, neighborhoodCode, segmentId, revalArea = null) =>
         set(


### PR DESCRIPTION
## Purpose

Replace city-first drill behavior with the Benton valuation risk-surface operating model, then promote the Unified Risk Ledger into the primary County Studio command queue.

## What changed

- County Studio opens on valuation risk surfaces instead of city rollups.
- Added revaluation cycle, neighborhood, model group, taxing district exposure, value tier equity, and unified risk ledger boards.
- Promoted the Unified Risk Ledger above supporting boards as the sortable county command queue.
- Added severity filters across `Critical`, `High`, `Medium`, and `Low`.
- Added priority, risk, exposure, and type sorting without introducing city grouping.
- Added a direct primary drill path from risk surface to neighborhood evidence without a City crumb.
- Locked the County Studio invariant: `Primary drill paths must not depend on city.`

## Verified

- 25 focused County Studio tests passed.
- `pnpm -C frontend run type-check` passed.
- `/forge/county-studio` browser smoke passed with 0 captured page or console errors.
- `pnpm -C frontend run build` passed.
- `git diff --check` passed.
- UI token gate passed and improved baseline by 17 violations.

## Architectural note

City remains metadata only; primary analysis runs through risk surface, reval/cycle, neighborhood evidence, model group risk, value tier equity, and taxing district exposure. The ledger is now the operational command queue for finding the highest-priority review target before drilling to evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * County Studio now displays risk surfaces with a unified command center for managing county-level valuation risk
  * Unified risk ledger displays and filters risk evidence with sorting by rank, risk level, and exposure
  * Risk surface boards show categorized summaries including revaluation cycles, neighborhoods, model groups, taxing districts, and value tiers
  * New navigation flow enables drilling from county risk view directly to neighborhood parcel evidence

* **Documentation**
  * Added design specifications and implementation plans for risk surfaces and unified risk ledger features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->