### PR TITLE
fix(county-studio): route health alerts through city-free risk surface drill

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/forge/countyStudioSovereignty.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/forge/countyStudioSovereignty.contract.test.ts
@@ -58,7 +58,7 @@ describe('County Studio sovereignty contract', () => {
     expect(hub).toContain('Study not available for active county scope.');
   });
 
-  it('County Studio still hands parcel-level work off to Atlas and Property Workbench with county context', () => {
+  it('County Studio still hands parcel-level work off to Atlas and Property Workbench with valuation context', () => {
     const page = read('../../pages/forge/county-studio/CountyStudyPage.tsx');
     const inspector = read('../../pages/forge/county-studio/components/ObjectInspector.tsx');
 
@@ -67,7 +67,14 @@ describe('County Studio sovereignty contract', () => {
     expect(page).toContain('countyId: activeStudy.countyId');
     expect(page).toContain('navigate(`/forge/atlas-live?${params.toString()}`)');
     expect(inspector).toContain("activateModule('property-workbench'");
-    expect(inspector).toContain('metadata: { segmentId: seg.segmentId, countyId: activeStudy?.countyId }');
+    expect(inspector).toContain('metadata: {');
+    expect(inspector).toContain('segmentId: seg.segmentId');
+    expect(inspector).toContain('countyId: activeStudy?.countyId');
+    expect(inspector).toContain('studyId: activeStudy?.studyId');
+    expect(inspector).toContain('taxYear: activeStudy?.taxYear');
+    expect(inspector).toContain('neighborhoodCode: segmentNeighborhoodCode');
+    expect(inspector).toContain('revalArea: segmentRevalArea');
+    expect(inspector).not.toContain('city: activeStudy');
     expect(inspector).toContain('countyId:      context.countyId');
     expect(inspector).toContain('countyId:         context.countyId');
   });

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
@@ -1,9 +1,8 @@
 // frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
 //
-// Task B — drill-lattice rewrite. The previous flat tab strip
-// (Overview / Ratio Study / Neighborhoods / Adjustments / Exceptions /
-// Compliance) has been replaced with a County → City → Neighborhood →
-// Segment drill driven by countyStudioStore.drillLevel.
+// County Studio opens on Benton valuation risk surfaces. Legacy city rollup
+// routes remain available as reference metadata, but primary command work
+// drills through risk surface → neighborhood/reval evidence → segment.
 //
 // The tab-filter concept is preserved as compact compliance/severity pills
 // that live ABOVE whichever rollup or segment table is active (inside the

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyHealthPanel.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyHealthPanel.test.tsx
@@ -177,7 +177,7 @@ describe('CountyHealthPanel', () => {
     expect(pills[2].getAttribute('data-bucket')).toBe('low');    // 22
   });
 
-  it('clicking a top-5 alert drills to its segment', () => {
+  it('clicking a top-5 alert drills to city-free risk-surface segment evidence', () => {
     act(() => {
       useCountyStudioStore.getState().setHealthSummary(summary());
       useCountyStudioStore.getState().setLoadStatus('healthSummary', 'success');
@@ -187,7 +187,7 @@ describe('CountyHealthPanel', () => {
     fireEvent.click(rows[1]); // Seg2 @ Richland / NBHD-R1
     const s = useCountyStudioStore.getState();
     expect(s.drillLevel).toBe('neighborhood');
-    expect(s.selectedCity).toBe('Richland');
+    expect(s.selectedCity).toBeNull();
     expect(s.selectedNeighborhood).toBe('NBHD-R1');
     expect(s.selectedNeighborhoodRevalArea).toBe(2);
     expect(s.selectedSegmentId).toBe('s2');
@@ -228,7 +228,7 @@ describe('CountyHealthPanel', () => {
     expect(screen.getByTestId('severity-bar-healthy')).toHaveTextContent('10');
   });
 
-  it('clicking Critical bar drills to the highest-risk critical segment with the critical filter active', () => {
+  it('clicking Critical bar drills to the highest-risk critical segment without restoring city scope', () => {
     act(() => {
       useCountyStudioStore.getState().drillToCity('Kennewick');
       useCountyStudioStore.getState().setHealthSummary(summary());
@@ -238,8 +238,9 @@ describe('CountyHealthPanel', () => {
     fireEvent.click(screen.getByTestId('severity-bar-critical'));
     const state = useCountyStudioStore.getState();
     expect(state.drillLevel).toBe('neighborhood');
-    expect(state.selectedCity).toBe('Kennewick');
+    expect(state.selectedCity).toBeNull();
     expect(state.selectedNeighborhood).toBe('NBHD-K1');
+    expect(state.selectedNeighborhoodRevalArea).toBe(2);
     expect(state.selectedSegmentId).toBe('s1');
     expect(state.segmentSeverityFilter).toBe('critical');
   });

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
@@ -201,7 +201,7 @@ describe('CountyStudyPage', () => {
     expect(screen.getByTestId('crumb-county')).toBeInTheDocument();
   });
 
-  it('county level renders Benton valuation risk surfaces instead of a city-first table', () => {
+  it('county level renders Benton valuation risk surfaces instead of a city-priority table', () => {
     act(() => {
       useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG]);
       useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx
@@ -380,16 +380,78 @@ describe('ObjectInspector — Action tab', () => {
     expect(params.get('segmentId')).toBe('s1');
     expect(params.get('countyId')).toBe('benton');
     expect(params.get('taxYear')).toBe('2026');
+    expect(params.get('neighborhoodCode')).toBe('NBHD-WR');
+    expect(params.get('revalArea')).toBeNull();
+    expect(params.get('city')).toBeNull();
   });
 
-  it('Find Parcels in Workbench still activates the workbench module (regression)', async () => {
+  it('Pop Out Map preserves risk-surface reval context without a city query param', async () => {
+    state.detail = baseDetail({ neighborhoodCode: 'NBHD-RISK', revalArea: 7, city: 'Kennewick' });
+    render(<MemoryRouter><ObjectInspector /></MemoryRouter>);
+    await switchToTab('inspector-tab-action');
+    fireEvent.click(screen.getByTestId('inspector-handoff-atlas'));
+
+    const atlasHref = mockNavigate.mock.calls.at(-1)?.[0] as string;
+    const params = new URLSearchParams(atlasHref.split('?')[1]);
+    expect(params.get('neighborhoodCode')).toBe('NBHD-RISK');
+    expect(params.get('revalArea')).toBe('7');
+    expect(params.get('segmentId')).toBe('s1');
+    expect(params.get('city')).toBeNull();
+  });
+
+  it('Find Parcels in Workbench carries valuation context without city metadata', async () => {
+    state.detail = baseDetail({ neighborhoodCode: 'NBHD-RISK', revalArea: 7, city: 'Kennewick' });
     render(<MemoryRouter><ObjectInspector /></MemoryRouter>);
     await switchToTab('inspector-tab-action');
     fireEvent.click(screen.getByTestId('inspector-handoff-workbench'));
     expect(activateModuleMock).toHaveBeenCalledWith('property-workbench', expect.objectContaining({
       source: 'system',
-      metadata: expect.objectContaining({ segmentId: 's1', countyId: 'benton' }),
+      metadata: expect.objectContaining({
+        segmentId: 's1',
+        countyId: 'benton',
+        studyId: 'study-1',
+        taxYear: 2026,
+        neighborhoodCode: 'NBHD-RISK',
+        revalArea: 7,
+      }),
     }));
+    expect(activateModuleMock.mock.calls.at(-1)?.[1].metadata).not.toHaveProperty('city');
+  });
+
+  it('spatial handoffs ignore stale detail from the previously selected segment', async () => {
+    const nextSegment = {
+      ...MOCK_SEG,
+      segmentId: 's2',
+      name: 'Current Risk Segment',
+      geographyRef: 'NBHD-CURRENT',
+      revalArea: 9,
+    };
+    state.detail = baseDetail({
+      segmentId: 's1',
+      neighborhoodCode: 'NBHD-STALE',
+      revalArea: 1,
+    });
+    setup([MOCK_SEG, nextSegment], 's2');
+    render(<MemoryRouter><ObjectInspector /></MemoryRouter>);
+    await switchToTab('inspector-tab-action');
+
+    fireEvent.click(screen.getByTestId('inspector-handoff-atlas'));
+    const atlasHref = mockNavigate.mock.calls.at(-1)?.[0] as string;
+    const params = new URLSearchParams(atlasHref.split('?')[1]);
+    expect(params.get('segmentId')).toBe('s2');
+    expect(params.get('neighborhoodCode')).toBe('NBHD-CURRENT');
+    expect(params.get('revalArea')).toBe('9');
+    expect(params.get('neighborhoodCode')).not.toBe('NBHD-STALE');
+
+    fireEvent.click(screen.getByTestId('inspector-handoff-workbench'));
+    expect(activateModuleMock).toHaveBeenCalledWith('property-workbench', expect.objectContaining({
+      metadata: expect.objectContaining({
+        segmentId: 's2',
+        neighborhoodCode: 'NBHD-CURRENT',
+        revalArea: 9,
+      }),
+    }));
+    expect(activateModuleMock.mock.calls.at(-1)?.[1].metadata.neighborhoodCode).not.toBe('NBHD-STALE');
   });
 
   it('persists direct Dais handoff receipt before activating the downstream suite', async () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/CityRollupTable.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/CityRollupTable.tsx
@@ -1,8 +1,8 @@
 // frontend/apps/os-shell/src/pages/forge/county-studio/components/CityRollupTable.tsx
 //
-// County → City rollup, rendered at drillLevel === 'county'. Visual language
-// matches SegmentTable (same Th, color scales, stability chip) so the three
-// tables in the drill lattice feel like one family.
+// Reference-only city metadata rollup. It is retained for legacy/admin lookup,
+// while County Studio's primary command path starts from Benton valuation risk
+// surfaces and drills into neighborhood/reval evidence.
 //
 // Clicking a row advances the drill to that city via drillToCity.
 // Filter pills above the table narrow by IAAO ComplianceStatus.

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/CountyHealthPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/CountyHealthPanel.tsx
@@ -1,10 +1,8 @@
 // frontend/apps/os-shell/src/pages/forge/county-studio/components/CountyHealthPanel.tsx
 //
 // Task C — County-level "is my county healthy?" single-screen answer.
-// Rendered at drillLevel === 'county' above (or in place of) the city
-// rollup. Dense, numbers-first, matches the visual language of SegmentTable
-// / CityRollupTable / NeighborhoodRollupTable so the suite reads as one
-// family.
+// Rendered at drillLevel === 'county' above the Benton risk surfaces. Dense,
+// numbers-first, and aligned with valuation-risk drill paths.
 //
 // Source of truth for the composite-risk formula is the BACKEND
 // (CountyStudyHealthService.ComputeCompositeRisk). This component only
@@ -27,7 +25,7 @@ import type {
   HealthAlertDto,
 } from '../types/countyStudio.types';
 
-// ── Color helpers — reuse the same scale as SegmentTable / CityRollupTable. ──
+// ── Color helpers — reuse the same scale as segment and risk-surface tables. ──
 
 function ratioColor(ratio: number | null): string {
   if (ratio === null) return 'hsl(var(--tf-muted))';
@@ -262,7 +260,7 @@ export function CountyHealthPanel() {
   const {
     activeStudy, healthSummary,
     loadStatus, loadErrors,
-    drillToSegment, drillToCounty, setSegmentSeverityFilter,
+    drillToRiskSurfaceSegment, drillToCounty, setSegmentSeverityFilter,
   } = useCountyStudioStore();
   const { retryHealthSummary } = useStudyData();
   const status = loadStatus.healthSummary;
@@ -382,30 +380,26 @@ export function CountyHealthPanel() {
     <PopulatedPanel
       summary={healthSummary}
       onAlertClick={(a) => {
-        // If the clicked alert belongs to a different neighborhood / city than
-        // the current drill scope, this jumps to it in one step. drillToSegment
-        // takes the city + neighborhood + segment so the state machine never
-        // lands in a neighborhood-without-city configuration.
-        drillToSegment(
-          a.city ?? 'Unincorporated',
+        // County-health alerts are primary valuation-risk drills; city remains
+        // display metadata and must not become the selected parent.
+        drillToRiskSurfaceSegment(
           a.neighborhoodCode ?? 'UNKNOWN',
           a.segmentId,
           a.revalArea,
         );
       }}
       onCriticalClick={() => {
-        setSegmentSeverityFilter('critical');
         const target = healthSummary.topAlerts
           .filter((alert) => alert.compositeRisk >= 67)
           .sort((a, b) => b.compositeRisk - a.compositeRisk)[0]
           ?? healthSummary.topAlerts[0];
         if (target) {
-          drillToSegment(
-            target.city ?? 'Unincorporated',
+          drillToRiskSurfaceSegment(
             target.neighborhoodCode ?? 'UNKNOWN',
             target.segmentId,
             target.revalArea,
           );
+          setSegmentSeverityFilter('critical');
           return;
         }
         drillToCounty();

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/ObjectInspector.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/ObjectInspector.tsx
@@ -821,10 +821,12 @@ export function ObjectInspector() {
     );
   }
 
-  const segmentNeighborhoodCode = detail?.neighborhoodCode ?? seg.geographyRef;
-  const segmentRevalArea = detail?.revalArea ?? seg.revalArea;
-  const segmentBuildingType = detail?.buildingType ?? seg.buildingType;
-  const segmentQualityGrade = detail?.qualityGrade ?? seg.qualityGrade;
+  const currentDetail = detail?.segmentId === seg.segmentId ? detail : null;
+  const currentContext = context?.segmentId === seg.segmentId ? context : null;
+  const segmentNeighborhoodCode = currentDetail?.neighborhoodCode ?? seg.geographyRef;
+  const segmentRevalArea = currentDetail?.revalArea ?? seg.revalArea;
+  const segmentBuildingType = currentDetail?.buildingType ?? seg.buildingType;
+  const segmentQualityGrade = currentDetail?.qualityGrade ?? seg.qualityGrade;
   const segmentScopeLabel = [
     segmentNeighborhoodCode ? `Neighborhood ${segmentNeighborhoodCode}` : null,
     segmentRevalArea !== null && segmentRevalArea !== undefined ? `Reval ${segmentRevalArea}` : null,
@@ -845,8 +847,8 @@ export function ObjectInspector() {
     if (activeStudy.countyName) {
       params.set('countyName', activeStudy.countyName);
     }
-    if (seg.geographyRef) {
-      params.set('neighborhoodCode', seg.geographyRef);
+    if (segmentNeighborhoodCode) {
+      params.set('neighborhoodCode', segmentNeighborhoodCode);
     }
     if (segmentRevalArea !== null && segmentRevalArea !== undefined) {
       params.set('revalArea', String(segmentRevalArea));
@@ -856,7 +858,14 @@ export function ObjectInspector() {
   const handleFindParcels = () => {
     void activateModule('property-workbench', {
       source: 'system',
-      metadata: { segmentId: seg.segmentId, countyId: activeStudy?.countyId },
+      metadata: {
+        segmentId: seg.segmentId,
+        countyId: activeStudy?.countyId,
+        studyId: activeStudy?.studyId,
+        taxYear: activeStudy?.taxYear,
+        neighborhoodCode: segmentNeighborhoodCode,
+        revalArea: segmentRevalArea,
+      },
     });
   };
 
@@ -885,7 +894,7 @@ export function ObjectInspector() {
 
         <TabsContent value="metrics" data-testid="inspector-panel-metrics">
           <MetricsPanel
-            detail={detail}
+            detail={currentDetail}
             loading={detailLoading}
             error={detailError}
             onRetry={retryDetail}
@@ -894,7 +903,7 @@ export function ObjectInspector() {
 
         <TabsContent value="trend" data-testid="inspector-panel-trend">
           <TrendPanel
-            detail={detail}
+            detail={currentDetail}
             loading={detailLoading}
             error={detailError}
             onRetry={retryDetail}
@@ -903,7 +912,7 @@ export function ObjectInspector() {
 
         <TabsContent value="action" data-testid="inspector-panel-action">
           <ActionPanel
-            context={context}
+            context={currentContext}
             loading={contextLoading}
             error={contextError}
             onRetry={retryContext}

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/hooks/useInspectorData.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/hooks/useInspectorData.ts
@@ -83,6 +83,8 @@ export function useInspectorData(segmentId: string | null): UseInspectorDataResu
       setContextLoading(false);
       return;
     }
+    setDetail(null);
+    setContext(null);
     void loadDetail(segmentId);
     void loadContext(segmentId);
   }, [segmentId, loadDetail, loadContext]);

--- a/frontend/apps/os-shell/src/stores/__tests__/countyStudioStore.test.ts
+++ b/frontend/apps/os-shell/src/stores/__tests__/countyStudioStore.test.ts
@@ -146,6 +146,20 @@ describe('countyStudioStore — drill lattice', () => {
     expect(s.selectedNeighborhood).toBe('NBHD-R1');
   });
 
+  it('drillToRiskSurfaceSegment preserves valuation context without selecting city', () => {
+    act(() => {
+      useCountyStudioStore.getState().drillToCity('Kennewick');
+      useCountyStudioStore.getState().drillToRiskSurfaceSegment('NBHD-K1', 'seg-risk-1', 2);
+    });
+    const s = useCountyStudioStore.getState();
+    expect(s.drillLevel).toBe('neighborhood');
+    expect(s.selectedCity).toBeNull();
+    expect(s.selectedNeighborhood).toBe('NBHD-K1');
+    expect(s.selectedNeighborhoodRevalArea).toBe(2);
+    expect(s.selectedSegmentId).toBe('seg-risk-1');
+    expect(s.segmentSeverityFilter).toBe('all');
+  });
+
   it('drillToCounty collapses all drill state (from neighborhood)', () => {
     act(() => {
       useCountyStudioStore.getState().drillToNeighborhood('Richland', 'NBHD-R1');

--- a/frontend/apps/os-shell/src/stores/countyStudioStore.ts
+++ b/frontend/apps/os-shell/src/stores/countyStudioStore.ts
@@ -151,8 +151,7 @@ export interface CountyStudioState {
   drillToCity: (city: string) => void;
   /**
    * Advance drill to a specific neighborhood within a city. Both city and
-   * neighborhood are required so the state machine can never land at
-   * drillLevel='neighborhood' without a parent city.
+   * neighborhood are required for this legacy city-scoped route.
    * Legacy/reference path: new County Studio command work should prefer
    * drillToRiskSurfaceNeighborhood so city does not become the operating lens.
    */
@@ -166,12 +165,21 @@ export interface CountyStudioState {
     revalArea?: number | null,
     segmentId?: string | null
   ) => void;
+  /**
+   * Open specific segment evidence from a Benton risk surface. This is the
+   * primary county-health alert path: it preserves valuation context while
+   * keeping city as metadata only.
+   */
+  drillToRiskSurfaceSegment: (
+    neighborhoodCode: string,
+    segmentId: string,
+    revalArea?: number | null
+  ) => void;
   setSegmentSeverityFilter: (filter: SegmentSeverityFilter) => void;
   /**
-   * Jump straight to a specific segment — parent city + neighborhood are both
-   * required so the drill state stays consistent. Used by CountyHealthPanel
-   * top-5 alerts to navigate directly from the county-landing to a segment
-   * that lives in a different city/neighborhood than the current selection.
+   * Legacy/reference path that jumps straight to a specific segment under a
+   * city scope. New County Studio command work should prefer
+   * drillToRiskSurfaceSegment so primary drill paths do not depend on city.
    * Sets drillLevel='neighborhood' (so the SegmentTable renders) and pre-selects
    * the segment via selectedSegmentId (so RightRail shows its detail).
    */
@@ -360,6 +368,19 @@ export const useCountyStudioStore = create<CountyStudioState>()(
           },
           false,
           `drillToRiskSurfaceNeighborhood/${neighborhoodCode}/${revalArea ?? 'na'}/${segmentId ?? 'na'}`
+        ),
+      drillToRiskSurfaceSegment: (neighborhoodCode, segmentId, revalArea = null) =>
+        set(
+          {
+            drillLevel: 'neighborhood',
+            selectedCity: null,
+            selectedNeighborhood: neighborhoodCode,
+            selectedNeighborhoodRevalArea: revalArea,
+            selectedSegmentId: segmentId,
+            segmentSeverityFilter: 'all',
+          },
+          false,
+          `drillToRiskSurfaceSegment/${neighborhoodCode}/${revalArea ?? 'na'}/${segmentId}`
         ),
       drillToSegment: (city, neighborhoodCode, segmentId, revalArea = null) =>
         set(


### PR DESCRIPTION
## Purpose
Replace the remaining health-alert city-scoped drill behavior with the Benton valuation risk-surface path.

## What Changed
- Routes CountyHealthPanel top alerts through a city-free risk-surface segment drill.
- Preserves reval/cycle, neighborhood, and segment context while forcing `selectedCity` to `null`.
- Carries valuation context into Atlas and Workbench handoffs without reintroducing city metadata.
- Tightens stale city-first comments so primary-path doctrine stays explicit.

## Architectural Note
City remains metadata/reference only. Primary County Studio analysis continues through risk surfaces, reval/cycle context, neighborhood evidence, segment evidence, and taxing-district exposure.

## Verified
- `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/DrillBreadcrumb.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts apps/os-shell/src/pages/forge/county-studio/__tests__/CountyHealthPanel.test.tsx apps/os-shell/src/stores/__tests__/countyStudioStore.test.ts apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx` - 78 tests passed
- `pnpm -C frontend run type-check` - passed
- `rg` stale city-path scan - no matches
- `git diff --check` - passed
- Runtime smoke: opened `http://127.0.0.1:5173/forge/county-studio` in the OS desktop and confirmed County Studio Operational Health/Risk Surfaces loaded
- Pre-commit UI token gate passed: 1563 violations <= baseline 1580

## Scope Guard
Did not touch TerraFusion Sync, DB seeding, generated core JS, or County Studio expansion features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * County alerts now drill from county valuation risk surfaces into neighborhood/reval and segment context, preserving valuation metadata and keeping city as reference-only.

* **Changes**
  * County view surfaces valuation-first tables instead of city-first.
  * Atlas/Workbench and parcel handoffs now include richer valuation/segment context and omit active city selection.

* **Documentation**
  * Updated County Studio navigation and drill behavior descriptions.

* **Tests**
  * Updated and added tests to reflect new drill and handoff behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->