### PR TITLE
fix(county-studio): keep ai diagnosis handoffs city-free

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AiDiagnosisPanel.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AiDiagnosisPanel.test.tsx
@@ -224,15 +224,20 @@ describe('AiDiagnosisPanel — Data-class populated', () => {
     expect(screen.getByTestId('diagnosis-evidence-dict-ZERO_SALES')).toBeInTheDocument();
   });
 
-  it('fires activateModule(property-workbench) on parcel-hint chip click', async () => {
+  it('fires activateModule(property-workbench) with city-free valuation context on parcel-hint chip click', async () => {
     state.diagnosis = dataClassDiagnosis();
     render(<AiDiagnosisPanel segmentId="s1" />);
     const user = userEvent.setup();
     await user.click(screen.getByTestId('diagnosis-parcel-chip-HP-1001'));
     expect(activateModuleMock).toHaveBeenCalledWith('property-workbench', {
       source: 'system',
-      metadata: expect.objectContaining({ parcelId: 'HP-1001', segmentId: 's1' }),
+      metadata: expect.objectContaining({
+        parcelId: 'HP-1001',
+        segmentId: 's1',
+        neighborhoodCode: 'NBHD-K3',
+      }),
     });
+    expect(activateModuleMock.mock.calls.at(-1)?.[1].metadata).not.toHaveProperty('city');
   });
 });
 
@@ -250,6 +255,36 @@ describe('AiDiagnosisPanel — Model-class populated', () => {
         diagnosisActionCode: 'RECALIBRATE_COST_TABLE',
       }),
     });
+  });
+
+  it('removes city metadata from AI action handoffs and preserves valuation context', async () => {
+    state.diagnosis = modelClassDiagnosis();
+    state.diagnosis.recommendedActions[0].prebuiltContext = {
+      segmentId: 's2',
+      city: 'Kennewick',
+      cityName: 'Kennewick',
+      municipality: 'Kennewick',
+      rollupScope: 'city',
+      stratumKey: 'R',
+      revalArea: 7,
+    };
+
+    render(<AiDiagnosisPanel segmentId="s2" />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('diagnosis-action-fire-RECALIBRATE_COST_TABLE'));
+
+    const metadata = activateModuleMock.mock.calls.at(-1)?.[1].metadata;
+    expect(metadata).toMatchObject({
+      segmentId: 's2',
+      neighborhoodCode: 'NBHD-K1',
+      revalArea: 7,
+      stratumKey: 'R',
+      diagnosisActionCode: 'RECALIBRATE_COST_TABLE',
+    });
+    expect(metadata).not.toHaveProperty('city');
+    expect(metadata).not.toHaveProperty('cityName');
+    expect(metadata).not.toHaveProperty('municipality');
+    expect(metadata).not.toHaveProperty('rollupScope');
   });
 
   it('shows priority and target badge', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/AiDiagnosisPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/AiDiagnosisPanel.tsx
@@ -8,8 +8,7 @@
 //   2. Findings — each with code pill, summary, evidence bar, expandable
 //      evidence dictionary, and clickable parcel-hint chips.
 //   3. Recommended actions — priority, target badge, summary, rationale,
-//      a button that fires activateModule() with the backend's
-//      prebuiltContext as metadata.
+//      a button that fires activateModule() with city-free valuation context.
 //   4. Narrative card — the 2–4 sentence service output, monospaced.
 //
 // Loading / error / 409 (not derived) states are handled distinctly.
@@ -100,6 +99,37 @@ function formatValue(v: unknown): string {
     return v.toFixed(1);
   }
   return String(v);
+}
+
+function buildActionMetadata(action: SegmentRecommendedAction, dto: SegmentDiagnosisDto): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    ...(action.prebuiltContext ?? {}),
+  };
+  delete metadata.city;
+  delete metadata.cityName;
+  delete metadata.municipality;
+  if (metadata.rollupScope === 'city') {
+    delete metadata.rollupScope;
+  }
+
+  if (dto.neighborhoodCode) {
+    metadata.neighborhoodCode = dto.neighborhoodCode;
+  }
+
+  metadata.segmentId = dto.segmentId;
+  metadata.diagnosisActionCode = action.actionCode;
+  return metadata;
+}
+
+function buildParcelHintMetadata(parcelId: string, dto: SegmentDiagnosisDto): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    parcelId,
+    segmentId: dto.segmentId,
+  };
+  if (dto.neighborhoodCode) {
+    metadata.neighborhoodCode = dto.neighborhoodCode;
+  }
+  return metadata;
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────
@@ -344,11 +374,7 @@ const ActionRow = ({
           onClick={() => {
             void activateModule(moduleId, {
               source: 'system',
-              metadata: {
-                ...(action.prebuiltContext ?? {}),
-                segmentId: dto.segmentId,
-                diagnosisActionCode: action.actionCode,
-              },
+              metadata: buildActionMetadata(action, dto),
             });
           }}
           style={{
@@ -473,7 +499,7 @@ export function AiDiagnosisPanel({
     }
     void activateModule('property-workbench', {
       source: 'system',
-      metadata: { parcelId: pid, segmentId: diagnosis.segmentId },
+      metadata: buildParcelHintMetadata(pid, diagnosis),
     });
   };
 

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/types/countyStudio.types.ts
@@ -451,7 +451,7 @@ export interface SegmentRecommendedAction {
   /** 1 = highest priority. */
   priority: number;
   rationale: string;
-  /** Passed verbatim as metadata to activateModule() when the user fires the action. */
+  /** Backend-prepared action context; UI removes city fields before downstream activation. */
   prebuiltContext: Record<string, unknown> | null;
 }
 


### PR DESCRIPTION
## Purpose
Stabilize County Studio AI diagnosis handoffs so backend-prepared city metadata cannot re-enter primary valuation workflow routing.

## What changed
- Sanitizes AI recommended-action handoff metadata before `activateModule()`.
- Preserves valuation context: segment, neighborhood, reval/model metadata, and diagnosis action code.
- Sends parcel-hint Workbench handoffs with parcel, segment, and neighborhood context only.
- Updates the action context type comment so future work does not treat `prebuiltContext` as verbatim downstream metadata.

## Architectural note
City remains metadata only. Primary County Studio handoffs run through valuation context: risk surface, segment, neighborhood, reval/model context, and parcel evidence.

## Scope guard
- County Studio frontend only.
- Did not touch TerraFusion Sync.
- Did not touch DB seeding.
- No simulation, forecasting, or feature expansion.

## Verified
- `pnpm -C frontend exec vitest run apps/os-shell/src/pages/forge/county-studio/__tests__/AiDiagnosisPanel.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/DrillBreadcrumb.test.tsx apps/os-shell/src/pages/forge/county-studio/__tests__/riskSurfaces.test.ts apps/os-shell/src/pages/forge/county-studio/__tests__/CountyHealthPanel.test.tsx apps/os-shell/src/stores/__tests__/countyStudioStore.test.ts` — 94 passed
- `pnpm -C frontend run type-check`
- `git diff --check`
- `pnpm -C frontend run build`
- Playwright runtime smoke at `http://localhost:5174/forge/county-studio`: County Studio, Risk Surfaces, Unified Risk Ledger present
- Pre-commit UI token gate passed: 1563 violations <= baseline 1580
- Pre-push gate passed: unit tests, security scan, performance validation, AI monitor, compliance lint, backend build, frontend build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to verify module launch metadata and ensure parcel-click and recommended-action handoffs meet the new expectations.

* **Refactor**
  * Standardized and made deterministic the metadata sent when launching modules from recommended actions and parcel interactions; valuation context now excludes city-level fields and preserves required identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->