### PR TITLE
fix(county-studio): keep atlas and neighborhood handoffs city-free

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx
@@ -73,7 +73,6 @@ export function CountyStudyPage() {
     activeStudy,
     syncState,
     drillLevel,
-    selectedCity,
     selectedNeighborhood,
     selectedNeighborhoodRevalArea,
     selectedSegmentId,
@@ -98,9 +97,6 @@ export function CountyStudyPage() {
     });
     if (activeStudy.countyName) {
       params.set('countyName', activeStudy.countyName);
-    }
-    if (selectedCity) {
-      params.set('city', selectedCity);
     }
     if (selectedNeighborhood) {
       params.set('neighborhoodCode', selectedNeighborhood);

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CountyStudyPage.test.tsx
@@ -13,6 +13,15 @@ import type {
   NeighborhoodRollupRowDto,
 } from '../types/countyStudio.types';
 
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importActual) => {
+  const actual = await importActual<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 vi.mock('../hooks/useCountyStudyHub', () => ({ useCountyStudyHub: () => ({}) }));
 vi.mock('../hooks/useStudyData', () => ({ useStudyData: () => ({ retryAll: vi.fn() }) }));
 vi.mock('../components/CohortCreationDialog', () => ({ CohortCreationDialog: () => null }));
@@ -140,6 +149,7 @@ const MOCK_HEALTH: CountyHealthSummaryDto = {
 describe('CountyStudyPage', () => {
   beforeEach(() => {
     act(() => {
+      mockNavigate.mockClear();
       useCountyStudioStore.getState().setStudy(null);
       useCountyStudioStore.getState().setSegments([]);
       useCountyStudioStore.getState().setCityRollup([]);
@@ -175,6 +185,33 @@ describe('CountyStudyPage', () => {
     });
     render(<CountyStudyPage />, { wrapper: Wrapper });
     expect(screen.getByRole('button', { name: /pop out map/i })).toBeInTheDocument();
+  });
+
+  it('page-level Atlas handoff preserves valuation context without city as a primary key', () => {
+    act(() => {
+      useCountyStudioStore.getState().setStudy({
+        studyId: 'study-1', countyId: 'benton', countyName: 'Benton County', taxYear: 2026,
+        studyType: 'RatioStudy', status: 'Active', baselineVersion: null,
+        activeSegmentSetId: 'ss1', createdAt: '', updatedAt: '', createdBy: '', updatedBy: '',
+      });
+      useCountyStudioStore.getState().setSegments([MOCK_SEG, FAILING_SEG]);
+      useCountyStudioStore.getState().drillToNeighborhood('Kennewick', 'NBHD-K1', 2);
+      useCountyStudioStore.getState().selectSegment('s2');
+    });
+
+    render(<CountyStudyPage />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /pop out map/i }));
+
+    const atlasHref = mockNavigate.mock.calls.at(-1)?.[0] as string;
+    const params = new URLSearchParams(atlasHref.split('?')[1]);
+    expect(params.get('studyId')).toBe('study-1');
+    expect(params.get('countyId')).toBe('benton');
+    expect(params.get('countyName')).toBe('Benton County');
+    expect(params.get('taxYear')).toBe('2026');
+    expect(params.get('neighborhoodCode')).toBe('NBHD-K1');
+    expect(params.get('revalArea')).toBe('2');
+    expect(params.get('segmentId')).toBe('s2');
+    expect(params.get('city')).toBeNull();
   });
 
   it('opens the native County Studio analytics workbench mode', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/NeighborhoodInspector.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/NeighborhoodInspector.test.tsx
@@ -164,6 +164,8 @@ describe('NeighborhoodInspector', () => {
     expect(navigateMock.mock.calls[0]?.[0]).toContain('countyId=benton');
     expect(navigateMock.mock.calls[0]?.[0]).toContain('neighborhoodCode=NBHD-WR01');
     expect(navigateMock.mock.calls[0]?.[0]).toContain('revalArea=4');
+    const params = new URLSearchParams((navigateMock.mock.calls[0]?.[0] as string).split('?')[1]);
+    expect(params.get('city')).toBeNull();
   });
 
   it('routes neighborhood scope into downstream forge modules', () => {
@@ -183,6 +185,7 @@ describe('NeighborhoodInspector', () => {
         rollupScope: 'neighborhood',
       }),
     }));
+    expect(activateModuleMock.mock.calls[0]?.[1].metadata).not.toHaveProperty('city');
     expect(activateModuleMock).toHaveBeenNthCalledWith(2, 'costforge', expect.objectContaining({
       metadata: expect.objectContaining({
         countyId: 'benton',
@@ -191,6 +194,7 @@ describe('NeighborhoodInspector', () => {
         rollupScope: 'neighborhood',
       }),
     }));
+    expect(activateModuleMock.mock.calls[1]?.[1].metadata).not.toHaveProperty('city');
     expect(activateModuleMock).toHaveBeenNthCalledWith(3, 'comps-forge', expect.objectContaining({
       metadata: expect.objectContaining({
         countyId: 'benton',
@@ -199,6 +203,7 @@ describe('NeighborhoodInspector', () => {
         rollupScope: 'neighborhood',
       }),
     }));
+    expect(activateModuleMock.mock.calls[2]?.[1].metadata).not.toHaveProperty('city');
   });
 
   it('keeps parcel workbench disabled at neighborhood rollup scope', () => {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/NeighborhoodInspector.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/NeighborhoodInspector.tsx
@@ -91,7 +91,6 @@ export function NeighborhoodInspector() {
         countyId: activeStudy.countyId,
         countyName: activeStudy.countyName,
         taxYear: activeStudy.taxYear,
-        city: row.city,
         neighborhoodCode: row.neighborhoodCode,
         neighborhoodName: row.neighborhoodName,
         revalArea: row.revalArea,
@@ -106,7 +105,6 @@ export function NeighborhoodInspector() {
       studyId: activeStudy.studyId,
       countyId: activeStudy.countyId,
       taxYear: String(activeStudy.taxYear),
-      city: row.city,
       neighborhoodCode: row.neighborhoodCode,
     });
     if (row.revalArea !== null) {


### PR DESCRIPTION
## Purpose
Close the remaining County Studio R1 primary-path city leak in Atlas and neighborhood handoff payloads.

## What changed
- Page-level Atlas pop-out now carries study/county/tax year/neighborhood/reval/segment context without `city`.
- Neighborhood Inspector handoffs to Atlas, SalesForge, CostForge, and CompsForge no longer emit `city` as a primary analytical key.
- Added focused regressions asserting city-free payloads while preserving valuation context.

## Verified
- Focused County Studio tests: 24 passed
- Frontend type-check: passed
- Core type-check: passed
- Phase 8.3 tools gate: 56 passed
- Runtime smoke: `http://localhost:5174/` returned 200
- Pre-commit UI token gate: passed, violations improved 1580 -> 1563
- Pre-push gate: unit tests 164 passed, security scan passed, performance passed, AI-swarm monitor passed, government compliance passed, backend build passed, frontend production build passed

## Architectural note
City remains display/reference metadata. Primary County Studio handoff payloads continue through valuation context: county, study, tax year, neighborhood, reval area, segment, and parcel evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated county studio map navigation to exclude city-level context from URL parameters, ensuring county-level operations maintain proper context.
  * Removed city metadata from neighborhood-level module launches in county studio, streamlining data passed to downstream components.

* **Tests**
  * Added test coverage verifying map navigation preserves county and neighborhood context.
  * Updated tests confirming city is excluded from neighborhood-scope operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->