### PR TITLE
fix(county-studio): sanitize evidence packet export artifacts

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ExportPacketModal.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ExportPacketModal.test.tsx
@@ -9,6 +9,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ExportPacketModal } from '../components/ExportPacketModal';
 import { evidencePacketApi } from '../countyStudyApi';
 import type { EvidencePacketDto } from '../countyStudyApi';
+import { evidencePacketToMarkdown } from '../utils/evidencePacketMarkdown';
 
 vi.mock('../countyStudyApi', () => ({
   evidencePacketApi: { get: vi.fn() },
@@ -17,7 +18,7 @@ vi.mock('../countyStudyApi', () => ({
 }));
 
 vi.mock('../utils/evidencePacketMarkdown', () => ({
-  evidencePacketToMarkdown: () => '# Markdown stub',
+  evidencePacketToMarkdown: vi.fn(() => '# Markdown stub'),
 }));
 
 const MOCK_PACKET: EvidencePacketDto = {
@@ -71,6 +72,7 @@ const MOCK_PACKET: EvidencePacketDto = {
 };
 
 const mockGet = evidencePacketApi.get as ReturnType<typeof vi.fn>;
+const mockEvidencePacketToMarkdown = vi.mocked(evidencePacketToMarkdown);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -113,6 +115,51 @@ describe('ExportPacketModal', () => {
     expect(screen.getByTestId('export-copy-markdown')).toBeInTheDocument();
   });
 
+  it('Download JSON strips city-primary keys from runtime packet artifacts', async () => {
+    const packetWithRuntimeCityLeak = {
+      ...MOCK_PACKET,
+      city: 'Kennewick',
+      selectedCity: 'Kennewick',
+      topRiskSegments: [
+        {
+          ...MOCK_PACKET.topRiskSegments[0],
+          city: 'Kennewick',
+          cityName: 'Kennewick',
+          rollupScope: 'city',
+        },
+      ],
+    } as unknown as EvidencePacketDto;
+    mockGet.mockResolvedValueOnce(packetWithRuntimeCityLeak);
+
+    const originalBlob = globalThis.Blob;
+    let downloadedJson = '';
+    const blobSpy = vi.spyOn(globalThis, 'Blob').mockImplementation(((parts: BlobPart[], options?: BlobPropertyBag) => {
+      downloadedJson = String(parts[0]);
+      return new originalBlob(parts, options);
+    }) as typeof Blob);
+    const originalCreateObjectUrl = URL.createObjectURL;
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:evidence-packet');
+    URL.revokeObjectURL = vi.fn();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+    render(<ExportPacketModal studyId="study-1" onClose={vi.fn()} />);
+    await screen.findByTestId('export-download-json');
+    fireEvent.click(screen.getByTestId('export-download-json'));
+
+    const exported = JSON.parse(downloadedJson);
+    expect(exported.city).toBeUndefined();
+    expect(exported.selectedCity).toBeUndefined();
+    expect(exported.topRiskSegments[0].city).toBeUndefined();
+    expect(exported.topRiskSegments[0].cityName).toBeUndefined();
+    expect(exported.topRiskSegments[0].rollupScope).toBeUndefined();
+
+    blobSpy.mockRestore();
+    clickSpy.mockRestore();
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  });
+
   it('Copy Markdown button shows "✓ Copied!" feedback then resets', async () => {
     mockGet.mockResolvedValueOnce(MOCK_PACKET);
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -125,6 +172,40 @@ describe('ExportPacketModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('export-copy-markdown')).toHaveTextContent('✓ Copied!');
     });
+    expect(writeText).toHaveBeenCalledWith('# Markdown stub');
+  });
+
+  it('Copy Markdown strips city-primary keys before generating packet narrative', async () => {
+    const packetWithRuntimeCityLeak = {
+      ...MOCK_PACKET,
+      city: 'Kennewick',
+      selectedCity: 'Kennewick',
+      topRiskSegments: [
+        {
+          ...MOCK_PACKET.topRiskSegments[0],
+          city: 'Kennewick',
+          cityName: 'Kennewick',
+          rollupScope: 'city',
+        },
+      ],
+    } as unknown as EvidencePacketDto;
+    mockGet.mockResolvedValueOnce(packetWithRuntimeCityLeak);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<ExportPacketModal studyId="study-1" onClose={vi.fn()} />);
+    await screen.findByTestId('export-copy-markdown');
+    fireEvent.click(screen.getByTestId('export-copy-markdown'));
+
+    expect(mockEvidencePacketToMarkdown).toHaveBeenCalledOnce();
+    const exported = mockEvidencePacketToMarkdown.mock.calls[0][0] as unknown as Record<string, unknown> & {
+      topRiskSegments: Array<Record<string, unknown>>;
+    };
+    expect(exported.city).toBeUndefined();
+    expect(exported.selectedCity).toBeUndefined();
+    expect(exported.topRiskSegments[0].city).toBeUndefined();
+    expect(exported.topRiskSegments[0].cityName).toBeUndefined();
+    expect(exported.topRiskSegments[0].rollupScope).toBeUndefined();
     expect(writeText).toHaveBeenCalledWith('# Markdown stub');
   });
 

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/ExportPacketModal.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/ExportPacketModal.tsx
@@ -11,6 +11,26 @@ interface Props {
   onClose: () => void;
 }
 
+const CITY_PRIMARY_KEYS = new Set(['city', 'cityName', 'selectedCity']);
+
+function stripCityPrimaryKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripCityPrimaryKeys);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key, item]) => !CITY_PRIMARY_KEYS.has(key) && !(key === 'rollupScope' && item === 'city'))
+        .map(([key, item]) => [key, stripCityPrimaryKeys(item)]),
+    );
+  }
+  return value;
+}
+
+function sanitizeEvidencePacketForExport(packet: EvidencePacketDto): EvidencePacketDto {
+  return stripCityPrimaryKeys(packet) as EvidencePacketDto;
+}
+
 export function ExportPacketModal({ studyId, scenarioId, onClose }: Props) {
   const [packet, setPacket] = useState<EvidencePacketDto | null>(null);
   const [loading, setLoading] = useState(true);
@@ -26,7 +46,7 @@ export function ExportPacketModal({ studyId, scenarioId, onClose }: Props) {
 
   const handleDownloadJson = () => {
     if (!packet) return;
-    const blob = new Blob([JSON.stringify(packet, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(sanitizeEvidencePacketForExport(packet), null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -37,7 +57,7 @@ export function ExportPacketModal({ studyId, scenarioId, onClose }: Props) {
 
   const handleCopyMarkdown = async () => {
     if (!packet) return;
-    const md = evidencePacketToMarkdown(packet);
+    const md = evidencePacketToMarkdown(sanitizeEvidencePacketForExport(packet));
     await navigator.clipboard.writeText(md);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);


### PR DESCRIPTION
## Purpose
Replace the last confirmed evidence/export artifact city-primary leak with a city-free export sanitizer. Runtime packet objects can carry backend-added city fields even when the TypeScript DTO is valuation-context-first; JSON and Markdown exports now strip those city-primary keys before leaving County Studio.

## What changed
- Sanitize evidence packet artifacts before JSON download and Markdown copy.
- Remove runtime `city`, `cityName`, `selectedCity`, and `rollupScope: "city"` keys recursively from exported packet artifacts.
- Add a regression test that injects a runtime city leak and asserts the downloaded JSON artifact stays valuation-context-only.

## Architectural note
City remains reference/display metadata only. Primary evidence artifacts must preserve the Benton operating model through risk surface, reval/cycle, neighborhood, segment, value-tier, taxing-district, and parcel evidence context.

## Verified
- TDD red/green for the runtime city-leak export regression.
- `node_modules\.bin\vitest.CMD run frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ExportPacketModal.test.tsx frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/evidencePacketMarkdown.test.ts --reporter=dot` — 21 passed.
- `pnpm -C frontend type-check` — passed.
- `pnpm run type-check` — passed.
- `node --test os-platform/core/tests/phase83-tools.test.mjs` — 56 passed.
- `pnpm -C frontend build` — passed with existing Vite/font/chunk warnings.
- Runtime smoke: `http://localhost:5173/forge/county-studio` rendered County Studio risk surfaces in the in-app browser with no console errors.
- Pre-push gate passed: unit tests, governed security scan, performance validation, AI coordination, government compliance lint, backend build, frontend build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export behavior now sanitizes exported packets by removing city-related metadata and nested city keys before producing JSON downloads or Markdown copies.

* **Tests**
  * New unit tests verify sanitization during JSON download and Markdown copy flows, including clipboard/download interactions and asserting city-related fields are stripped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bsvalues/terrafusion_os_1.0/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->