### PR TITLE
fix(county-studio): keep city inspector handoffs reference-only

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/cost/CostForge.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/cost/CostForge.tsx
@@ -13,6 +13,8 @@
  *   taxYear:       number — swaps the tax year selector.
  *   segmentId:     string — drives the "Scoped From" chip.
  *   segmentLabel:  string — human label for the chip.
+ *   resetValuationScope: true — clears stale neighborhood drill state without
+ *                  promoting reference geography to a rollup scope.
  */
 import React, { Suspense, useEffect, useLayoutEffect, useRef } from 'react';
 import activateModule from '@/orchestration/moduleActivation';
@@ -201,7 +203,7 @@ export default function CostForge({ metadata }: CostForgeProps = {}) {
     if (handoff.rollupScope === 'neighborhood' && handoff.neighborhoodCode) {
       setSelectedHood(handoff.neighborhoodCode);
       setActiveTab('hood-audit');
-    } else if (handoff.rollupScope === 'city') {
+    } else if (handoff.rollupScope === 'city' || handoff.resetValuationScope) {
       setSelectedHood(null);
       if (!stratum && !segmentId) {
         setActiveTab('triage');
@@ -209,6 +211,7 @@ export default function CostForge({ metadata }: CostForgeProps = {}) {
     }
   }, [
     handoff.neighborhoodCode,
+    handoff.resetValuationScope,
     handoff.rollupScope,
     handoff.segmentId,
     handoff.segmentLabel,

--- a/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.deeplink.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.deeplink.test.tsx
@@ -142,6 +142,30 @@ describe('CostForge — County Studio deeplink consumption (Task D2)', () => {
     ).toBeInTheDocument();
   });
 
+  it('clears stale neighborhood scope for city-reference reset handoffs without city rollup scope', () => {
+    act(() => {
+      const s = useCostForgeWorkspaceStore.getState();
+      s.setSelectedHood('NBHD-STALE');
+      s.setActiveTab('hood-audit');
+    });
+
+    render(
+      <CostForge
+        metadata={{
+          countyName: 'Benton County',
+          taxYear: 2026,
+          referenceCity: 'Kennewick',
+          resetValuationScope: true,
+        }}
+      />
+    );
+
+    const s = useCostForgeWorkspaceStore.getState();
+    expect(s.selectedHoodCd).toBeNull();
+    expect(s.activeTab).toBe('triage');
+    expect(screen.queryByText(/City overview · Kennewick/)).not.toBeInTheDocument();
+  });
+
   it('Scoped From chip click fires activateModule("county-studio") with segmentId', () => {
     render(
       <CostForge

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CityInspector.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/CityInspector.test.tsx
@@ -170,21 +170,29 @@ describe('CityInspector', () => {
     expect(dashes.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('routes city scope to Atlas Live', () => {
+  it('routes Atlas handoff with city as reference metadata only', () => {
     act(() => {
       useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);
       useCountyStudioStore.setState({ selectedCity: 'West Richland' });
     });
     render(<CityInspector />);
     fireEvent.click(screen.getByTestId('city-inspector-handoff-atlas'));
+    expect(navigateMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledWith(
       expect.stringContaining('/forge/atlas-live?')
     );
-    expect(navigateMock.mock.calls[0]?.[0]).toContain('countyId=benton');
-    expect(navigateMock.mock.calls[0]?.[0]).toContain('city=West+Richland');
+    const url = String(navigateMock.mock.calls[0]?.[0] ?? '');
+    const params = new URLSearchParams(url.split('?')[1] ?? '');
+    expect(params.get('countyId')).toBe('benton');
+    expect(params.get('referenceCity')).toBe('West Richland');
+    expect(params.get('resetValuationScope')).toBe('true');
+    expect(params.has('city')).toBe(false);
+    expect(params.has('selectedCity')).toBe(false);
+    expect(params.has('cityName')).toBe(false);
+    expect(params.get('rollupScope')).not.toBe('city');
   });
 
-  it('routes city scope into downstream forge modules', () => {
+  it('routes downstream forge handoffs with city as reference metadata only', () => {
     act(() => {
       useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);
       useCountyStudioStore.setState({ selectedCity: 'West Richland' });
@@ -195,31 +203,28 @@ describe('CityInspector', () => {
     fireEvent.click(screen.getByTestId('city-inspector-handoff-costforge'));
     fireEvent.click(screen.getByTestId('city-inspector-handoff-compsforge'));
 
-    expect(activateModuleMock).toHaveBeenNthCalledWith(1, 'sales-forge', expect.objectContaining({
-      source: 'system',
-      metadata: expect.objectContaining({
-        countyId: 'benton',
-        city: 'West Richland',
-        rollupScope: 'city',
-      }),
-    }));
-    expect(activateModuleMock).toHaveBeenNthCalledWith(2, 'costforge', expect.objectContaining({
-      metadata: expect.objectContaining({
-        countyId: 'benton',
-        city: 'West Richland',
-        rollupScope: 'city',
-      }),
-    }));
-    expect(activateModuleMock).toHaveBeenNthCalledWith(3, 'comps-forge', expect.objectContaining({
-      metadata: expect.objectContaining({
-        countyId: 'benton',
-        city: 'West Richland',
-        rollupScope: 'city',
-      }),
-    }));
+    const expectedModules = ['sales-forge', 'costforge', 'comps-forge'];
+    expect(activateModuleMock).toHaveBeenCalledTimes(expectedModules.length);
+    expectedModules.forEach((moduleId, index) => {
+      expect(activateModuleMock).toHaveBeenNthCalledWith(index + 1, moduleId, expect.objectContaining({
+        source: 'system',
+        metadata: expect.objectContaining({
+          countyId: 'benton',
+          countyName: 'Benton County',
+          taxYear: 2026,
+          referenceCity: 'West Richland',
+          resetValuationScope: true,
+        }),
+      }));
+      const metadata = activateModuleMock.mock.calls[index]?.[1]?.metadata as Record<string, unknown>;
+      expect(metadata.city).toBeUndefined();
+      expect(metadata.selectedCity).toBeUndefined();
+      expect(metadata.cityName).toBeUndefined();
+      expect(metadata.rollupScope).not.toBe('city');
+    });
   });
 
-  it('keeps parcel workbench disabled at city scope', () => {
+  it('keeps parcel workbench disabled from the city reference panel', () => {
     act(() => {
       useCountyStudioStore.getState().setCityRollup([MOCK_CITY_ROW]);
       useCountyStudioStore.setState({ selectedCity: 'West Richland' });

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/CityInspector.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/CityInspector.tsx
@@ -99,8 +99,8 @@ export function CityInspector() {
         countyId: activeStudy.countyId,
         countyName: activeStudy.countyName,
         taxYear: activeStudy.taxYear,
-        city: row.city,
-        rollupScope: 'city',
+        referenceCity: row.city,
+        resetValuationScope: true,
       },
     });
   };
@@ -111,7 +111,8 @@ export function CityInspector() {
       studyId: activeStudy.studyId,
       countyId: activeStudy.countyId,
       taxYear: String(activeStudy.taxYear),
-      city: row.city,
+      referenceCity: row.city,
+      resetValuationScope: 'true',
     });
     if (activeStudy.countyName) {
       params.set('countyName', activeStudy.countyName);
@@ -168,7 +169,7 @@ export function CityInspector() {
         >
           <div style={{ fontSize: 12, fontWeight: 700 }}>See city on map</div>
           <div style={{ fontSize: 10, color: 'hsl(var(--tf-muted))', marginTop: 2 }}>
-            Open Atlas Live scoped to {row.city}.
+            Open Atlas Live with {row.city} as reference metadata.
           </div>
         </button>
         <button
@@ -179,7 +180,7 @@ export function CityInspector() {
         >
           <div style={{ fontSize: 12, fontWeight: 700 }}>Review sales in SalesForge</div>
           <div style={{ fontSize: 10, color: 'hsl(var(--tf-muted))', marginTop: 2 }}>
-            Open county-scoped city overview, then narrow into neighborhood and reval-area review.
+            Open county context with city as reference, then narrow into neighborhood and reval-area review.
           </div>
         </button>
         <button
@@ -201,7 +202,7 @@ export function CityInspector() {
         >
           <div style={{ fontSize: 12, fontWeight: 700 }}>Open comps in CompsForge</div>
           <div style={{ fontSize: 10, color: 'hsl(var(--tf-muted))', marginTop: 2 }}>
-            Stay in overview mode until you narrow below the city rollup.
+            Keep city as reference until you narrow into operative valuation evidence.
           </div>
         </button>
         <button

--- a/frontend/apps/os-shell/src/pages/forge/shared/rollupHandoff.ts
+++ b/frontend/apps/os-shell/src/pages/forge/shared/rollupHandoff.ts
@@ -14,6 +14,7 @@ export interface RollupHandoffContext {
   neighborhoodName: string | null;
   revalArea: number | null;
   rollupScope: RollupScope;
+  resetValuationScope: boolean;
   segmentId: string | null;
   segmentLabel: string | null;
   stratumKey: string | null;
@@ -30,6 +31,10 @@ function readNumber(value: unknown): number | null {
 
 function readRollupScope(value: unknown): RollupScope {
   return value === 'city' || value === 'neighborhood' ? value : null;
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true || value === 'true';
 }
 
 function readSampleParcelIds(value: unknown): string[] {
@@ -62,6 +67,7 @@ export function parseRollupHandoff(metadata?: Record<string, unknown>): RollupHa
     neighborhoodName: readString(metadata?.neighborhoodName),
     revalArea: readNumber(metadata?.revalArea),
     rollupScope: readRollupScope(metadata?.rollupScope),
+    resetValuationScope: readBoolean(metadata?.resetValuationScope),
     segmentId: readString(metadata?.segmentId),
     segmentLabel: readString(metadata?.segmentLabel),
     stratumKey: readString(metadata?.stratumKey),


### PR DESCRIPTION
## Purpose
Keep County Studio city-reference handoffs from reintroducing city as a primary analytical key.

## What changed
- Atlas launch from `CityInspector` now carries `referenceCity` instead of `city`.
- SalesForge, CostForge, and CompsForge handoffs now carry `referenceCity` metadata and no `rollupScope: 'city'`.
- Updated CityInspector handoff copy so city remains reference context, not operating scope.
- Added focused regressions asserting no `city`, `selectedCity`, `cityName`, or `rollupScope: 'city'` leaves the city reference panel.

## Architectural note
City remains metadata only. Primary analysis and correction workflows must continue through valuation risk surfaces, neighborhood/reval evidence, model groups, value tiers, taxing district exposure, and parcel evidence.

## Verified
- `pnpm --filter terrafusion-frontend test CityInspector.test`
- `pnpm --filter terrafusion-frontend test CityInspector.test CountyHealthPanel.test AiDiagnosisPanel.test ExportPacketModal.test NeighborhoodInspector.test ObjectInspector.test DrillBreadcrumb.test` (96 tests)
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `pnpm --filter terrafusion-frontend run build`
- `git diff --check`
- CityInspector city-primary handoff search clean
- Runtime smoke: `http://127.0.0.1:5173/forge/county-studio` loaded TerraForge County Studio / County Health Risk Surfaces / Unified Risk Ledger with 0 console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to validate city handoffs and navigation use referenceCity metadata and include resetValuationScope across Atlas Live and downstream flows.

* **Refactor**
  * City routing now treats selected city as referenceCity metadata for consistent handoffs instead of promoting it into rollup scope.

* **New Features**
  * Handoff resetValuationScope clears stale neighborhood selection and returns workflows to the triage tab when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->