### PR TITLE
[codex] fix(county-studio): strip city keys from segment handoff queries

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/ObjectInspector.test.tsx
@@ -484,6 +484,85 @@ describe('ObjectInspector — Action tab', () => {
     ));
   });
 
+  it('strips city-primary query keys from Dais and Dossier segment handoffs', async () => {
+    recordSegmentInspectorReceiptMock
+      .mockResolvedValueOnce({
+        receiptId: 'receipt-direct-dais',
+        exceptionSetId: null,
+        studyId: 'study-1',
+        countyId: 'benton',
+        sourceType: 'SegmentInspector',
+        destination: 'Dais',
+        template: 'SegmentReview',
+        segmentId: 's1',
+        segmentLabel: 'NBHD-WR',
+        status: 'Drafted',
+        downstreamEntityId: null,
+        evidenceRef: null,
+        notes: null,
+        draftedAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        updatedBy: 'router',
+      })
+      .mockResolvedValueOnce({
+        receiptId: 'receipt-direct-dossier',
+        exceptionSetId: null,
+        studyId: 'study-1',
+        countyId: 'benton',
+        sourceType: 'SegmentInspector',
+        destination: 'Dossier',
+        template: 'SegmentEvidence',
+        segmentId: 's1',
+        segmentLabel: 'NBHD-WR',
+        status: 'Drafted',
+        downstreamEntityId: null,
+        evidenceRef: null,
+        notes: null,
+        draftedAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        updatedBy: 'router',
+      });
+    state.context =baseContext({
+      dais: {
+        workflowTemplate: 'SegmentReview',
+        deeplinkQuery: '?template=SegmentReview&segmentId=s1&city=Kennewick&selectedCity=Kennewick&rollupScope=city&neighborhoodCode=NBHD-WR&revalArea=7',
+      },
+      dossier: {
+        packetTemplate: 'SegmentEvidence',
+        deeplinkQuery: '?template=SegmentEvidence&segmentId=s1&cityName=Kennewick&rollupScope=city&neighborhoodCode=NBHD-WR&revalArea=7',
+      },
+    });
+    render(<MemoryRouter><ObjectInspector /></MemoryRouter>);
+    await switchToTab('inspector-tab-action');
+
+    fireEvent.click(screen.getByTestId('inspector-handoff-dais'));
+    fireEvent.click(screen.getByTestId('inspector-handoff-dossier'));
+
+    await waitFor(() => expect(activateModuleMock).toHaveBeenCalledTimes(2));
+    const activatedByModuleId = new Map(
+      activateModuleMock.mock.calls.map(([moduleId, payload]) => [moduleId, payload]),
+    );
+    const daisQuery = activatedByModuleId.get('suite-dais')?.metadata.deeplinkQuery as string;
+    const dossierQuery = activatedByModuleId.get('suite-dossier')?.metadata.deeplinkQuery as string;
+    const daisParams = new URLSearchParams(daisQuery.slice(1));
+    const dossierParams = new URLSearchParams(dossierQuery.slice(1));
+
+    expect(daisParams.get('template')).toBe('SegmentReview');
+    expect(daisParams.get('segmentId')).toBe('s1');
+    expect(daisParams.get('neighborhoodCode')).toBe('NBHD-WR');
+    expect(daisParams.get('revalArea')).toBe('7');
+    expect(daisParams.get('city')).toBeNull();
+    expect(daisParams.get('selectedCity')).toBeNull();
+    expect(daisParams.get('rollupScope')).toBeNull();
+
+    expect(dossierParams.get('template')).toBe('SegmentEvidence');
+    expect(dossierParams.get('segmentId')).toBe('s1');
+    expect(dossierParams.get('neighborhoodCode')).toBe('NBHD-WR');
+    expect(dossierParams.get('revalArea')).toBe('7');
+    expect(dossierParams.get('cityName')).toBeNull();
+    expect(dossierParams.get('rollupScope')).toBeNull();
+  });
+
   it('shows a visible handoff error when direct receipt persistence fails', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     recordSegmentInspectorReceiptMock.mockRejectedValueOnce(new Error('receipt write failed'));

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/AiDiagnosisPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/AiDiagnosisPanel.tsx
@@ -24,6 +24,7 @@ import type {
   SegmentDiagnosisFinding,
   SegmentRecommendedAction,
 } from '../types/countyStudio.types';
+import { stripCityPrimaryKeys } from '../utils/cityPrimarySanitizer';
 
 // ── Visual tokens ─────────────────────────────────────────────────────────
 //
@@ -102,15 +103,7 @@ function formatValue(v: unknown): string {
 }
 
 function buildActionMetadata(action: SegmentRecommendedAction, dto: SegmentDiagnosisDto): Record<string, unknown> {
-  const metadata: Record<string, unknown> = {
-    ...(action.prebuiltContext ?? {}),
-  };
-  delete metadata.city;
-  delete metadata.cityName;
-  delete metadata.municipality;
-  if (metadata.rollupScope === 'city') {
-    delete metadata.rollupScope;
-  }
+  const metadata: Record<string, unknown> = stripCityPrimaryKeys(action.prebuiltContext ?? {});
 
   if (dto.neighborhoodCode) {
     metadata.neighborhoodCode = dto.neighborhoodCode;

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/ExportPacketModal.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/ExportPacketModal.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect } from 'react';
 import { evidencePacketApi, type EvidencePacketDto } from '../countyStudyApi';
 import { evidencePacketToMarkdown } from '../utils/evidencePacketMarkdown';
+import { stripCityPrimaryKeys } from '../utils/cityPrimarySanitizer';
 
 interface Props {
   studyId: string;
@@ -11,24 +12,8 @@ interface Props {
   onClose: () => void;
 }
 
-const CITY_PRIMARY_KEYS = new Set(['city', 'cityName', 'selectedCity']);
-
-function stripCityPrimaryKeys(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stripCityPrimaryKeys);
-  }
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([key, item]) => !CITY_PRIMARY_KEYS.has(key) && !(key === 'rollupScope' && item === 'city'))
-        .map(([key, item]) => [key, stripCityPrimaryKeys(item)]),
-    );
-  }
-  return value;
-}
-
 function sanitizeEvidencePacketForExport(packet: EvidencePacketDto): EvidencePacketDto {
-  return stripCityPrimaryKeys(packet) as EvidencePacketDto;
+  return stripCityPrimaryKeys(packet);
 }
 
 export function ExportPacketModal({ studyId, scenarioId, onClose }: Props) {

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/ObjectInspector.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/ObjectInspector.tsx
@@ -35,6 +35,7 @@ import type {
   SegmentActionContextDto,
   SegmentYearPoint,
 } from '../types/countyStudio.types';
+import { sanitizeCountyStudioHandoffQuery } from '../utils/cityPrimarySanitizer';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 // ── Presentation atoms ────────────────────────────────────────────────────
@@ -639,6 +640,11 @@ const ActionPanel = ({
   const fireModule = (moduleId: string, metadata: Record<string, unknown>) => {
     void activateModule(moduleId, { source: 'system', metadata });
   };
+  const salesForgeDeeplinkQuery = sanitizeCountyStudioHandoffQuery(context.salesForge.deeplinkQuery);
+  const costForgeDeeplinkQuery = sanitizeCountyStudioHandoffQuery(context.costForge.deeplinkQuery);
+  const compsForgeDeeplinkQuery = sanitizeCountyStudioHandoffQuery(context.compsForge.deeplinkQuery);
+  const daisDeeplinkQuery = sanitizeCountyStudioHandoffQuery(context.dais.deeplinkQuery);
+  const dossierDeeplinkQuery = sanitizeCountyStudioHandoffQuery(context.dossier.deeplinkQuery);
   const findReceipt = (destination: 'Dais' | 'Dossier') =>
     directReceipts.find((receipt) =>
       receipt.sourceType === 'SegmentInspector'
@@ -713,10 +719,10 @@ const ActionPanel = ({
         label="Reconcile sales in SalesForge"
         subtitle={`Open the ${context.salesForge.qualifiedSaleCount} qualified sales for stratum ${context.salesForge.stratumKey} in ${context.salesForge.taxYear}`}
         disabledTooltip="SalesForge integration not yet active."
-        deeplinkQuery={context.salesForge.deeplinkQuery}
+        deeplinkQuery={salesForgeDeeplinkQuery}
         onClick={() => fireModule('sales-forge', {
           countyId:      context.countyId,
-          deeplinkQuery: context.salesForge.deeplinkQuery,
+          deeplinkQuery: salesForgeDeeplinkQuery,
           stratumKey:    context.salesForge.stratumKey,
           taxYear:       context.salesForge.taxYear,
           segmentId:     context.segmentId,
@@ -727,10 +733,10 @@ const ActionPanel = ({
         label="Calibrate cost in CostForge"
         subtitle={`Open stratum ${context.costForge.stratumKey}, ${context.costForge.taxYear} cost review`}
         disabledTooltip="CostForge integration not yet active."
-        deeplinkQuery={context.costForge.deeplinkQuery}
+        deeplinkQuery={costForgeDeeplinkQuery}
         onClick={() => fireModule('costforge', {
           countyId:      context.countyId,
-          deeplinkQuery: context.costForge.deeplinkQuery,
+          deeplinkQuery: costForgeDeeplinkQuery,
           stratumKey:    context.costForge.stratumKey,
           taxYear:       context.costForge.taxYear,
           segmentId:     context.segmentId,
@@ -741,10 +747,10 @@ const ActionPanel = ({
         label="Review comps in CompsForge"
         subtitle={`Open ${context.compsForge.sampleParcelIds.length} sample parcels for comparison`}
         disabledTooltip="CompsForge integration not yet active."
-        deeplinkQuery={context.compsForge.deeplinkQuery}
+        deeplinkQuery={compsForgeDeeplinkQuery}
         onClick={() => fireModule('comps-forge', {
           countyId:        context.countyId,
-          deeplinkQuery:   context.compsForge.deeplinkQuery,
+          deeplinkQuery:   compsForgeDeeplinkQuery,
           sampleParcelIds: context.compsForge.sampleParcelIds,
           segmentId:       context.segmentId,
         })}
@@ -754,11 +760,11 @@ const ActionPanel = ({
         label="Create Dais review packet"
         subtitle={`Dispatch ${context.dais.workflowTemplate} workflow with ${context.totalParcels.toLocaleString()} parcels`}
         disabledTooltip="Dais integration not yet active."
-        deeplinkQuery={context.dais.deeplinkQuery}
+        deeplinkQuery={daisDeeplinkQuery}
         receiptLabel={receiptLabel(findReceipt('Dais'))}
         onClick={() => void fireSegmentReceiptModule('suite-dais', 'Dais', 'SegmentReview', {
           countyId:         context.countyId,
-          deeplinkQuery:     context.dais.deeplinkQuery,
+          deeplinkQuery:     daisDeeplinkQuery,
           workflowTemplate:  context.dais.workflowTemplate,
           segmentId:         context.segmentId,
           studyId:           context.studyId,
@@ -769,11 +775,11 @@ const ActionPanel = ({
         label="Generate Dossier evidence packet"
         subtitle={`Prepare ${context.dossier.packetTemplate} packet for this segment`}
         disabledTooltip="Dossier integration not yet active."
-        deeplinkQuery={context.dossier.deeplinkQuery}
+        deeplinkQuery={dossierDeeplinkQuery}
         receiptLabel={receiptLabel(findReceipt('Dossier'))}
         onClick={() => void fireSegmentReceiptModule('suite-dossier', 'Dossier', 'SegmentEvidence', {
           countyId:       context.countyId,
-          deeplinkQuery:   context.dossier.deeplinkQuery,
+          deeplinkQuery:   dossierDeeplinkQuery,
           packetTemplate:  context.dossier.packetTemplate,
           segmentId:       context.segmentId,
           studyId:         context.studyId,

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/utils/cityPrimarySanitizer.ts
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/utils/cityPrimarySanitizer.ts
@@ -1,0 +1,30 @@
+const CITY_PRIMARY_KEYS = new Set(['city', 'cityName', 'selectedCity', 'municipality']);
+
+export function stripCityPrimaryKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripCityPrimaryKeys) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key, item]) => !CITY_PRIMARY_KEYS.has(key) && !(key === 'rollupScope' && item === 'city'))
+        .map(([key, item]) => [key, stripCityPrimaryKeys(item)]),
+    ) as T;
+  }
+  return value;
+}
+
+export function sanitizeCountyStudioHandoffQuery(raw: string | null): string | null {
+  if (!raw) return null;
+  const params = new URLSearchParams(raw.startsWith('?') ? raw.slice(1) : raw);
+
+  for (const key of CITY_PRIMARY_KEYS) {
+    params.delete(key);
+  }
+  if (params.get('rollupScope') === 'city') {
+    params.delete('rollupScope');
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : null;
+}


### PR DESCRIPTION
## Purpose

Replace the remaining segment corrective handoff query leak with County Studio's Benton valuation operating model: segment/neighborhood/reval context stays primary, and city-primary query keys are stripped before downstream module activation.

## What changed

- Added a County Studio handoff query sanitizer in `ObjectInspector`.
- Applied it to corrective handoff deeplink payloads for SalesForge, CostForge, CompsForge, Dais, and Dossier.
- Added a regression test proving Dais and Dossier segment handoffs preserve valuation context while removing stale city query keys.

## Architectural note

City remains reference metadata only. Primary analysis and correction handoffs continue through risk surface, segment/neighborhood evidence, and reval context; `rollupScope=city` is removed from primary-path handoff queries.

## Verified

- RED regression reproduced stale `city` query leakage before implementation.
- `pnpm --filter terrafusion-frontend test CityInspector.test CountyHealthPanel.test AiDiagnosisPanel.test ExportPacketModal.test NeighborhoodInspector.test ObjectInspector.test DrillBreadcrumb.test CostForge.deeplink.test CompsForgeModule.deeplink.test DossierSuiteHome.deeplink.test DaisSuiteHome.deeplink.test` - 11 files, 126 tests passed.
- `pnpm run type-check` - passed.
- `node --test os-platform/core/tests/phase83-tools.test.mjs` - 56 tests passed.
- `pnpm --filter terrafusion-frontend run build` - passed.
- `git diff --check` - passed.
- Runtime smoke at `http://127.0.0.1:5174/forge/county-studio` - County Studio, Risk Surfaces, and Unified Risk Ledger rendered with 0 browser console errors.
- Pre-push gate - 164 unit tests passed, backend build passed, frontend build passed.

## Scope guard

No TerraFusion Sync files were modified. No DB seeding files were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Handoff queries are sanitized to remove city-specific keys so downstream module handoffs no longer receive interfering city parameters.

* **New Features**
  * Added a shared sanitizer for handoff query strings and exported packet exports to ensure consistent removal of city-primary fields.

* **Refactor**
  * Replaced scattered inline sanitization with the centralized sanitizer across handoff, metadata construction, and export flows.

* **Tests**
  * Added test coverage validating query sanitization and correct metadata produced during handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->