### PR TITLE
[codex] fix(county-studio): carry sanitized valuation scope into apply handoffs

### DIFF
--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AdjustmentSetPanel.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AdjustmentSetPanel.test.tsx
@@ -185,6 +185,62 @@ describe('AdjustmentSetPanel', () => {
     expect(screen.getByTestId('apply-posture-adj-001')).toHaveTextContent('Handed off for apply');
   });
 
+  test('Apply handoff metadata carries valuation scope without city-primary keys', async () => {
+    mockList.mockResolvedValueOnce([
+      makeAdj({
+        approvalState: 'Approved',
+        effectiveScope: JSON.stringify({
+          cohortId: 'cohort-007',
+          rollupScope: 'city',
+          city: 'Kennewick',
+          cityName: 'Kennewick',
+          selectedCity: 'Kennewick',
+          municipality: 'Kennewick',
+          neighborhoodCode: 'NBHD-420',
+          revalArea: 2026,
+          modelGroup: 'MG-12',
+          valueTier: 'Upper',
+          nested: {
+            city: 'Kennewick',
+            segmentId: 'seg-420',
+          },
+        }),
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<AdjustmentSetPanel />);
+    await screen.findByTestId('btn-PrepareApply-adj-001');
+
+    await user.click(screen.getByTestId('btn-PrepareApply-adj-001'));
+
+    await waitFor(() => expect(activateModuleMock).toHaveBeenCalled());
+    const metadata = activateModuleMock.mock.calls[0]?.[1].metadata as Record<string, unknown>;
+    expect(metadata).toMatchObject({
+      applyTemplate: 'AdjustmentApplyPacket',
+      adjustmentSetId: 'adj-001',
+      scenarioId: 'scen-001',
+      studyId: STUDY_ID,
+      effectiveScope: {
+        cohortId: 'cohort-007',
+        neighborhoodCode: 'NBHD-420',
+        revalArea: 2026,
+        modelGroup: 'MG-12',
+        valueTier: 'Upper',
+        nested: {
+          segmentId: 'seg-420',
+        },
+      },
+    });
+    expect(metadata.effectiveScope).not.toMatchObject({
+      city: expect.anything(),
+      cityName: expect.anything(),
+      selectedCity: expect.anything(),
+      municipality: expect.anything(),
+      rollupScope: 'city',
+    });
+    expect((metadata.effectiveScope as { nested: Record<string, unknown> }).nested).not.toHaveProperty('city');
+  });
+
   test('loads durable apply handoff receipts from the backend', async () => {
     mockList.mockResolvedValueOnce([makeAdj({ approvalState: 'Approved' })]);
     mockListReceipts.mockResolvedValueOnce([{

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AdjustmentSetPanel.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/__tests__/AdjustmentSetPanel.test.tsx
@@ -215,6 +215,24 @@ describe('AdjustmentSetPanel', () => {
 
     await waitFor(() => expect(activateModuleMock).toHaveBeenCalled());
     const metadata = activateModuleMock.mock.calls[0]?.[1].metadata as Record<string, unknown>;
+    expect(useAdjustmentApplyHandoffStore.getState().activeHandoffId).toBe('adj-001');
+    expect(useAdjustmentApplyHandoffStore.getState().handoffs['adj-001'].effectiveScope).toMatchObject({
+      cohortId: 'cohort-007',
+      neighborhoodCode: 'NBHD-420',
+      revalArea: 2026,
+      modelGroup: 'MG-12',
+      valueTier: 'Upper',
+      nested: {
+        segmentId: 'seg-420',
+      },
+    });
+    expect(useAdjustmentApplyHandoffStore.getState().handoffs['adj-001'].effectiveScope).not.toMatchObject({
+      city: expect.anything(),
+      cityName: expect.anything(),
+      selectedCity: expect.anything(),
+      municipality: expect.anything(),
+      rollupScope: 'city',
+    });
     expect(metadata).toMatchObject({
       applyTemplate: 'AdjustmentApplyPacket',
       adjustmentSetId: 'adj-001',

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/AdjustmentSetPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/AdjustmentSetPanel.tsx
@@ -346,6 +346,7 @@ export function AdjustmentSetPanel() {
           adjustmentSetId: adj.adjustmentSetId,
           scenarioId: adj.scenarioId,
           studyId: adj.studyId,
+          effectiveScope,
         });
         void activateModule('suite-dossier', {
           source: 'system',

--- a/frontend/apps/os-shell/src/pages/forge/county-studio/components/AdjustmentSetPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/county-studio/components/AdjustmentSetPanel.tsx
@@ -12,6 +12,7 @@ import { adjustmentSetApi } from '../countyStudyApi';
 import type { CountyAdjustmentSetDto, AdjustmentSetApprovalState } from '../types/countyStudio.types';
 import activateModule from '@/orchestration/moduleActivation';
 import { useAdjustmentApplyHandoffStore, type AdjustmentApplyHandoff } from '@/pages/suites/adjustmentApplyHandoffStore';
+import { stripCityPrimaryKeys } from '../utils/cityPrimarySanitizer';
 
 // ── State badge ───────────────────────────────────────────────────────────────
 
@@ -87,6 +88,19 @@ function applyPostureFor(adj: CountyAdjustmentSetDto, handoff?: AdjustmentApplyH
   if (handoff?.status === 'AppliedExternally') return 'applied';
   if (handoff?.status === 'RolledBack') return 'rolledBack';
   return handoff ? 'handedOff' : 'ready';
+}
+
+function parseSanitizedEffectiveScope(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    const sanitized = stripCityPrimaryKeys(parsed) as Record<string, unknown>;
+    return Object.keys(sanitized).length > 0 ? sanitized : null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Legal next-state map ──────────────────────────────────────────────────────
@@ -318,6 +332,16 @@ export function AdjustmentSetPanel() {
     })
       .then((receipt) => {
         ingestApplyReceipt(receipt);
+        const effectiveScope = parseSanitizedEffectiveScope(adj.effectiveScope);
+        const metadata: Record<string, unknown> = {
+          applyTemplate: 'AdjustmentApplyPacket',
+          adjustmentSetId: adj.adjustmentSetId,
+          scenarioId: adj.scenarioId,
+          studyId: adj.studyId,
+        };
+        if (effectiveScope) {
+          metadata.effectiveScope = effectiveScope;
+        }
         prepareApplyHandoff({
           adjustmentSetId: adj.adjustmentSetId,
           scenarioId: adj.scenarioId,
@@ -325,12 +349,7 @@ export function AdjustmentSetPanel() {
         });
         void activateModule('suite-dossier', {
           source: 'system',
-          metadata: {
-            applyTemplate: 'AdjustmentApplyPacket',
-            adjustmentSetId: adj.adjustmentSetId,
-            scenarioId: adj.scenarioId,
-            studyId: adj.studyId,
-          },
+          metadata,
         });
       })
       .catch((receiptError) => {

--- a/frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx
@@ -113,6 +113,31 @@ export interface DossierSuiteHomeProps {
   metadata?: Record<string, unknown>;
 }
 
+function getObjectMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function formatApplyScope(scope?: Record<string, unknown> | null): string[] {
+  if (!scope) return [];
+  const orderedKeys = [
+    'cohortId',
+    'revalArea',
+    'revaluationCycle',
+    'marketArea',
+    'neighborhoodCode',
+    'modelGroup',
+    'propertyClass',
+    'valueTier',
+  ];
+
+  return orderedKeys
+    .map((key) => scope[key])
+    .filter((value): value is string | number => typeof value === 'string' || typeof value === 'number')
+    .map((value) => String(value))
+    .slice(0, 6);
+}
+
 function ApplyHandoffBanner({ adjustmentSetId }: { adjustmentSetId: string | null }) {
   const handoff = useAdjustmentApplyHandoffStore((s) =>
     adjustmentSetId ? s.handoffs[adjustmentSetId] : undefined,
@@ -125,6 +150,7 @@ function ApplyHandoffBanner({ adjustmentSetId }: { adjustmentSetId: string | nul
 
   const appliedEvidenceRef = `dossier-apply-return:${adjustmentSetId}`;
   const rollbackNote = 'Rollback reported by Dossier apply packet review.';
+  const scopeLabels = formatApplyScope(handoff.effectiveScope);
 
   const handleRecordApplied = () => {
     markAppliedExternally(
@@ -178,6 +204,11 @@ function ApplyHandoffBanner({ adjustmentSetId }: { adjustmentSetId: string | nul
         <p data-testid="dossier-apply-handoff-status" className="mt-2 text-xs" style={{ color: 'hsl(var(--tf-suite-dossier))' }}>
           Handoff receipt: {handoff.status} · updated {new Date(handoff.updatedAt).toLocaleString()}
         </p>
+        {scopeLabels.length > 0 && (
+          <p data-testid="dossier-apply-handoff-scope" className="mt-1 text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>
+            Valuation scope: {scopeLabels.join(' · ')}
+          </p>
+        )}
         {handoff.evidenceRef && (
           <p data-testid="dossier-apply-handoff-evidence" className="mt-1 text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>
             Evidence: {handoff.evidenceRef}
@@ -226,6 +257,7 @@ export default function DossierSuiteHome({ metadata }: DossierSuiteHomeProps = {
   const prepareApplyHandoff = useAdjustmentApplyHandoffStore((s) => s.prepareHandoff);
   const markApplyHandoffOpened = useAdjustmentApplyHandoffStore((s) => s.markOpened);
   const ingestApplyReceipt = useAdjustmentApplyHandoffStore((s) => s.ingestReceipt);
+  const activeStoredApplyHandoffId = useAdjustmentApplyHandoffStore((s) => s.activeHandoffId);
   const [activeApplyHandoffId, setActiveApplyHandoffId] = useState<string | null>(null);
 
   // ── Consume County Studio handoff metadata on mount (Task D3) ───────────
@@ -286,7 +318,12 @@ export default function DossierSuiteHome({ metadata }: DossierSuiteHomeProps = {
     const scenarioId = typeof metadata.scenarioId === 'string' ? metadata.scenarioId : null;
     const studyId = typeof metadata.studyId === 'string' ? metadata.studyId : null;
     if (applyTemplate === 'AdjustmentApplyPacket' && adjustmentSetId && scenarioId && studyId) {
-      prepareApplyHandoff({ adjustmentSetId, scenarioId, studyId });
+      prepareApplyHandoff({
+        adjustmentSetId,
+        scenarioId,
+        studyId,
+        effectiveScope: getObjectMetadata(metadata.effectiveScope),
+      });
       markApplyHandoffOpened(adjustmentSetId);
       void adjustmentSetApi.recordApplyHandoffReceipt(adjustmentSetId, {
         status: 'Opened',
@@ -298,6 +335,7 @@ export default function DossierSuiteHome({ metadata }: DossierSuiteHomeProps = {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  const displayedApplyHandoffId = activeApplyHandoffId ?? activeStoredApplyHandoffId;
   const [appealId, setAppealId] = useState('BOE-2026-001');
   const [draftVersion, setDraftVersion] = useState('benton-2026-working');
   const [packetState, setPacketState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: OpenAppealPacketSummary; correlationId?: string; error?: string }>({ status: 'idle' });
@@ -402,7 +440,7 @@ export default function DossierSuiteHome({ metadata }: DossierSuiteHomeProps = {
 
       {/* Task D3 — County Studio handoff: segment evidence draft */}
       <DossierEvidenceDraftPanel />
-      <ApplyHandoffBanner adjustmentSetId={activeApplyHandoffId} />
+      <ApplyHandoffBanner adjustmentSetId={displayedApplyHandoffId} />
 
       {/* Source disclosure — only when not live */}
       {stats && sourceDisclosure && (

--- a/frontend/apps/os-shell/src/pages/suites/__tests__/DossierSuiteHome.deeplink.test.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/__tests__/DossierSuiteHome.deeplink.test.tsx
@@ -279,6 +279,30 @@ describe('DossierSuiteHome — County Studio deeplink consumption (Task D3)', ()
     expect(screen.getByTestId('dossier-apply-handoff-status')).toHaveTextContent('Opened');
   });
 
+  it('renders an active apply handoff from the store when the Dossier window is already open', () => {
+    act(() => {
+      useAdjustmentApplyHandoffStore.getState().prepareHandoff({
+        adjustmentSetId: 'adj-apply',
+        scenarioId: 'scenario-apply',
+        studyId: 'study-apply',
+        effectiveScope: {
+          cohortId: 'cohort-007',
+          neighborhoodCode: 'NBHD-420',
+          modelGroup: 'MG-12',
+          valueTier: 'Upper',
+          nested: { segmentId: 'seg-420' },
+        },
+      });
+    });
+
+    render(<DossierSuiteHome />);
+
+    expect(screen.getByTestId('dossier-apply-handoff')).toHaveTextContent('County Studio Handoff · Apply Packet');
+    expect(screen.getByTestId('dossier-apply-handoff')).toHaveTextContent('NBHD-420');
+    expect(screen.getByTestId('dossier-apply-handoff')).toHaveTextContent('MG-12');
+    expect(screen.getByTestId('dossier-apply-handoff')).not.toHaveTextContent('Kennewick');
+  });
+
   it('records external apply return status without mutating values in County Studio', () => {
     render(
       <DossierSuiteHome

--- a/frontend/apps/os-shell/src/pages/suites/adjustmentApplyHandoffStore.ts
+++ b/frontend/apps/os-shell/src/pages/suites/adjustmentApplyHandoffStore.ts
@@ -11,16 +11,19 @@ export interface AdjustmentApplyHandoff {
   status: AdjustmentApplyHandoffStatus;
   preparedAt: string;
   updatedAt: string;
+  effectiveScope?: Record<string, unknown> | null;
   evidenceRef?: string | null;
   notes?: string | null;
 }
 
 interface AdjustmentApplyHandoffState {
   handoffs: Record<string, AdjustmentApplyHandoff>;
+  activeHandoffId: string | null;
   prepareHandoff: (handoff: {
     adjustmentSetId: string;
     scenarioId: string;
     studyId: string;
+    effectiveScope?: Record<string, unknown> | null;
   }) => void;
   ingestReceipt: (receipt: CountyApplyHandoffReceiptDto) => void;
   ingestReceipts: (receipts: CountyApplyHandoffReceiptDto[]) => void;
@@ -35,12 +38,14 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
   persist(
     (set) => ({
       handoffs: {},
+      activeHandoffId: null,
 
-      prepareHandoff: ({ adjustmentSetId, scenarioId, studyId }) =>
+      prepareHandoff: ({ adjustmentSetId, scenarioId, studyId, effectiveScope }) =>
         set((state) => {
           const existing = state.handoffs[adjustmentSetId];
           const now = new Date().toISOString();
           return {
+            activeHandoffId: adjustmentSetId,
             handoffs: {
               ...state.handoffs,
               [adjustmentSetId]: {
@@ -50,6 +55,9 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
                 status: existing?.status ?? 'Prepared',
                 preparedAt: existing?.preparedAt ?? now,
                 updatedAt: now,
+                effectiveScope: effectiveScope ?? existing?.effectiveScope ?? null,
+                evidenceRef: existing?.evidenceRef,
+                notes: existing?.notes,
               },
             },
           };
@@ -68,6 +76,7 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
                 status: receipt.status,
                 preparedAt: existing?.preparedAt ?? receipt.preparedAt,
                 updatedAt: receipt.updatedAt,
+                effectiveScope: existing?.effectiveScope ?? null,
                 evidenceRef: receipt.evidenceRef,
                 notes: receipt.notes,
               },
@@ -87,6 +96,7 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
               status: receipt.status,
               preparedAt: existing?.preparedAt ?? receipt.preparedAt,
               updatedAt: receipt.updatedAt,
+              effectiveScope: existing?.effectiveScope ?? null,
               evidenceRef: receipt.evidenceRef,
               notes: receipt.notes,
             };
@@ -114,6 +124,7 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
               status: receipt.status,
               preparedAt: existing?.preparedAt ?? receipt.preparedAt,
               updatedAt: receipt.updatedAt,
+              effectiveScope: existing?.effectiveScope ?? null,
               evidenceRef: receipt.evidenceRef,
               notes: receipt.notes,
             };
@@ -177,7 +188,10 @@ export const useAdjustmentApplyHandoffStore = create<AdjustmentApplyHandoffState
       clearHandoff: (adjustmentSetId) =>
         set((state) => {
           const { [adjustmentSetId]: _removed, ...rest } = state.handoffs;
-          return { handoffs: rest };
+          return {
+            handoffs: rest,
+            activeHandoffId: state.activeHandoffId === adjustmentSetId ? null : state.activeHandoffId,
+          };
         }),
     }),
     {


### PR DESCRIPTION
## Purpose

County Studio R1 outbound payload stabilization. Adjustment apply handoffs now carry sanitized valuation `effectiveScope` metadata into Dossier apply packets, so downstream evidence/action surfaces receive Benton valuation context without reintroducing city-primary keys.

## What changed

- Parse each approved adjustment set's `effectiveScope` during Prepare Apply Handoff.
- Strip city-primary keys recursively before attaching scope metadata.
- Preserve valuation context such as cohort, neighborhood, reval area, model group, value tier, and nested segment evidence.
- Add a focused regression test proving city, selectedCity, cityName, municipality, and `rollupScope: city` do not leave County Studio as primary analytical keys.

## R1 boundary

- No TerraFusion Sync changes.
- No DB seeding changes.
- No County Studio scope expansion.

## Verified

- `pnpm --filter terrafusion-frontend test AdjustmentSetPanel.test.tsx ExportPacketModal.test.tsx DossierSuiteHome.deeplink.test.tsx ScenarioWorksheet.test.tsx ScenarioCompareGrid.test.tsx` — 59 tests passed.
- `pnpm run type-check` — passed.
- `node --test os-platform/core/tests/phase83-tools.test.mjs` — 56 tests passed.
- `git diff --check` — passed.
- `pnpm --filter terrafusion-frontend run build` — passed with existing font/chunk/CSS warnings.
- Runtime smoke at `http://127.0.0.1:5175/forge/county-studio` — County Studio, Risk Surfaces, and Unified Risk Ledger visible; `City Rollups` absent; console errors 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply handoffs now display compact valuation scope labels and will surface stored handoffs when a local active id is absent.
  * Handoffs can persist and carry an optional effective scope for consistent display across sessions.

* **Bug Fixes**
  * Sanitized adjustment effective scope to ensure only valuation-relevant metadata is sent during handoff activation.

* **Tests**
  * Added tests to cover sanitized scope handling and handoff display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->