### PR TITLE
feat(canon): make Canon loader validation fail-loud

### DIFF
--- a/os-platform/core/canon/canon-loader.mjs
+++ b/os-platform/core/canon/canon-loader.mjs
@@ -2,12 +2,18 @@
  * Canon Runtime Loader (Core)
  *
  * Reads the static Canon law (rule index, engineering write-lanes, gate
- * registry) from JSON on disk, performs light structural validation, freezes
- * the result, and memoizes it. Read-only. No agents, no commands, no network.
+ * registry) from JSON on disk, validates it FAIL-LOUD, freezes the result, and
+ * memoizes it. Read-only. No agents, no commands, no network.
  *
- * Config files are build-time data: if a config file is missing or structurally
- * invalid, load throws a descriptive Error (fail loud at load). Query-time
- * inputs never throw — see canon-query.mjs / canon-risk.mjs.
+ * Fail-loud contract: Canon law is governance. Invalid or incomplete config is
+ * a hard error, never a silent default that softens governance. Specifically:
+ *   - required arrays must be present and be arrays of strings;
+ *   - boolean governance fields must be real booleans (no coercion);
+ *   - risk / enforcement levels must be known enum values;
+ *   - every referenced gate id must exist in the gate registry;
+ *   - ruleIds, lane owners, and gate ids must be unique;
+ *   - a rule that applies to nothing (no paths/intents/surfaces) is invalid.
+ * Query-time inputs (paths, task intents) never throw — see canon-query.mjs.
  *
  * @module canon/canon-loader
  * @see docs/TerraCanon/CANON_IDE_REPO_ADAPTATION_PLAN.md
@@ -49,155 +55,232 @@ import { readFileSync } from 'node:fs';
  *   lanes: ReadonlyArray<WriteLane>,
  *   gates: ReadonlyArray<Gate>
  * }>} Canon
+ *
+ * @typedef {Readonly<{ index: unknown, lanes: unknown, gates: unknown }>} RawCanonConfig
  */
 
-/** @param {string} fileName @returns {unknown} */
-function readJson(fileName) {
-  const url = new URL(`./${fileName}`, import.meta.url);
-  let raw;
-  try {
-    raw = readFileSync(url, 'utf8');
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`Canon loader: cannot read ${fileName}: ${msg}`);
-  }
-  try {
-    return JSON.parse(raw);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`Canon loader: ${fileName} is not valid JSON: ${msg}`);
-  }
-}
+const RULE_LEVELS = new Set(['block', 'warn', 'require-approval', 'inform']);
+const RISK_LEVELS = new Set(['low', 'medium', 'high', 'critical']);
+const RULE_STATUSES = new Set(['active', 'draft', 'deprecated']);
+const RULE_AUTHORITIES = new Set(['constitutional', 'os-platform', 'engineering-policy', 'advisory']);
 
 /** @param {unknown} v @returns {v is Record<string, unknown>} */
 function isObject(v) {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-/** @param {unknown} v @param {string} where @returns {string[]} */
-function asStringArray(v, where) {
-  if (v === undefined) return [];
-  if (!Array.isArray(v) || v.some((x) => typeof x !== 'string')) {
-    throw new Error(`Canon loader: ${where} must be an array of strings`);
+/** @param {unknown} v @param {string} where @returns {string} */
+function requireNonEmptyString(v, where) {
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`Canon config: ${where} must be a non-empty string`);
+  }
+  return v;
+}
+
+/** @param {unknown} v @param {string} where @returns {string} */
+function requireString(v, where) {
+  if (typeof v !== 'string') throw new Error(`Canon config: ${where} must be a string`);
+  return v;
+}
+
+/**
+ * Require a present array of strings. Absent or wrong-typed → throw (fail-loud).
+ * @param {unknown} v @param {string} where @returns {string[]}
+ */
+function requireStringArray(v, where) {
+  if (!Array.isArray(v)) throw new Error(`Canon config: ${where} must be a present array of strings`);
+  if (v.some((x) => typeof x !== 'string')) {
+    throw new Error(`Canon config: ${where} must contain only strings`);
   }
   return /** @type {string[]} */ (v);
 }
 
-const RULE_LEVELS = new Set(['block', 'warn', 'require-approval', 'inform']);
-const RISK_LEVELS = new Set(['low', 'medium', 'high', 'critical']);
+/**
+ * Require a real boolean. No coercion of truthy/falsy values (fail-loud).
+ * @param {unknown} v @param {string} where @returns {boolean}
+ */
+function requireBoolean(v, where) {
+  if (typeof v !== 'boolean') throw new Error(`Canon config: ${where} must be a boolean`);
+  return v;
+}
 
-/** @param {unknown} raw @returns {CanonRule} */
-function validateRule(raw) {
-  if (!isObject(raw)) throw new Error('Canon loader: rule must be an object');
-  const { ruleId, version, status, authority, title, description, source, appliesTo, enforcement } = raw;
-  if (typeof ruleId !== 'string' || ruleId.length === 0) {
-    throw new Error('Canon loader: rule.ruleId is required');
+/** @param {unknown} v @param {Set<string>} allowed @param {string} where @returns {string} */
+function requireEnum(v, allowed, where) {
+  if (typeof v !== 'string' || !allowed.has(v)) {
+    throw new Error(`Canon config: ${where} must be one of ${[...allowed].join(', ')}`);
   }
-  if (typeof version !== 'string') throw new Error(`Canon loader: ${ruleId}.version is required`);
-  if (status !== 'active' && status !== 'draft' && status !== 'deprecated') {
-    throw new Error(`Canon loader: ${ruleId}.status is invalid`);
+  return v;
+}
+
+/** @param {string[]} gateRefs @param {Set<string>} known @param {string} where */
+function assertGatesKnown(gateRefs, known, where) {
+  for (const g of gateRefs) {
+    if (!known.has(g)) {
+      throw new Error(`Canon config: ${where} references unknown gate "${g}"`);
+    }
   }
-  if (
-    authority !== 'constitutional' &&
-    authority !== 'os-platform' &&
-    authority !== 'engineering-policy' &&
-    authority !== 'advisory'
-  ) {
-    throw new Error(`Canon loader: ${ruleId}.authority is invalid`);
+}
+
+/** @param {unknown} raw @param {Set<string>} seenGateIds @returns {Gate} */
+function validateGate(raw, seenGateIds) {
+  if (!isObject(raw)) throw new Error('Canon config: gate must be an object');
+  const gateId = requireNonEmptyString(raw.gateId, 'gate.gateId');
+  if (seenGateIds.has(gateId)) throw new Error(`Canon config: duplicate gate id "${gateId}"`);
+  seenGateIds.add(gateId);
+  return Object.freeze({
+    gateId,
+    label: typeof raw.label === 'string' ? raw.label : gateId,
+    command: typeof raw.command === 'string' ? raw.command : '',
+    kind: typeof raw.kind === 'string' ? raw.kind : undefined,
+  });
+}
+
+/** @param {unknown} raw @param {Set<string>} gateIds @param {Set<string>} seenRuleIds @returns {CanonRule} */
+function validateRule(raw, gateIds, seenRuleIds) {
+  if (!isObject(raw)) throw new Error('Canon config: rule must be an object');
+  const ruleId = requireNonEmptyString(raw.ruleId, 'rule.ruleId');
+  if (seenRuleIds.has(ruleId)) throw new Error(`Canon config: duplicate ruleId "${ruleId}"`);
+  seenRuleIds.add(ruleId);
+
+  const version = requireString(raw.version, `${ruleId}.version`);
+  const status = requireEnum(raw.status, RULE_STATUSES, `${ruleId}.status`);
+  const authority = requireEnum(raw.authority, RULE_AUTHORITIES, `${ruleId}.authority`);
+  const title = requireString(raw.title, `${ruleId}.title`);
+  const description = requireString(raw.description, `${ruleId}.description`);
+
+  if (!isObject(raw.appliesTo)) throw new Error(`Canon config: ${ruleId}.appliesTo must be an object`);
+  const paths = requireStringArray(raw.appliesTo.paths, `${ruleId}.appliesTo.paths`);
+  const taskIntents = requireStringArray(raw.appliesTo.taskIntents, `${ruleId}.appliesTo.taskIntents`);
+  const surfaces = requireStringArray(raw.appliesTo.surfaces, `${ruleId}.appliesTo.surfaces`);
+  if (paths.length === 0 && taskIntents.length === 0 && surfaces.length === 0) {
+    throw new Error(`Canon config: ${ruleId}.appliesTo matches nothing (paths, taskIntents and surfaces all empty)`);
   }
-  if (typeof title !== 'string') throw new Error(`Canon loader: ${ruleId}.title is required`);
-  if (typeof description !== 'string') throw new Error(`Canon loader: ${ruleId}.description is required`);
-  if (!isObject(appliesTo)) throw new Error(`Canon loader: ${ruleId}.appliesTo is required`);
-  if (!isObject(enforcement)) throw new Error(`Canon loader: ${ruleId}.enforcement is required`);
-  if (typeof enforcement.level !== 'string' || !RULE_LEVELS.has(enforcement.level)) {
-    throw new Error(`Canon loader: ${ruleId}.enforcement.level is invalid`);
-  }
+
+  if (!isObject(raw.enforcement)) throw new Error(`Canon config: ${ruleId}.enforcement must be an object`);
+  const level = requireEnum(raw.enforcement.level, RULE_LEVELS, `${ruleId}.enforcement.level`);
+  const requiredGates = requireStringArray(raw.enforcement.requiredGates, `${ruleId}.enforcement.requiredGates`);
+  assertGatesKnown(requiredGates, gateIds, `${ruleId}.enforcement.requiredGates`);
+  const requiresManualReview = requireBoolean(
+    raw.enforcement.requiresManualReview,
+    `${ruleId}.enforcement.requiresManualReview`,
+  );
+
   return Object.freeze({
     ruleId,
     version,
-    status,
-    authority,
+    status: /** @type {CanonRule['status']} */ (status),
+    authority: /** @type {CanonRule['authority']} */ (authority),
     title,
     description,
-    source: typeof source === 'string' ? source : undefined,
+    source: typeof raw.source === 'string' ? raw.source : undefined,
     appliesTo: Object.freeze({
-      paths: Object.freeze(asStringArray(appliesTo.paths, `${ruleId}.appliesTo.paths`)),
-      taskIntents: Object.freeze(asStringArray(appliesTo.taskIntents, `${ruleId}.appliesTo.taskIntents`)),
-      surfaces: Object.freeze(asStringArray(appliesTo.surfaces, `${ruleId}.appliesTo.surfaces`)),
+      paths: Object.freeze(paths),
+      taskIntents: Object.freeze(taskIntents),
+      surfaces: Object.freeze(surfaces),
     }),
     enforcement: Object.freeze({
-      level: /** @type {RuleEnforcement['level']} */ (enforcement.level),
-      requiredGates: Object.freeze(asStringArray(enforcement.requiredGates, `${ruleId}.enforcement.requiredGates`)),
-      requiresManualReview: enforcement.requiresManualReview === true,
+      level: /** @type {RuleEnforcement['level']} */ (level),
+      requiredGates: Object.freeze(requiredGates),
+      requiresManualReview,
     }),
   });
 }
 
-/** @param {unknown} raw @returns {WriteLane} */
-function validateLane(raw) {
-  if (!isObject(raw)) throw new Error('Canon loader: write-lane must be an object');
-  const { owner, paths, risk, requiredGates, manualReviewRequired } = raw;
-  if (typeof owner !== 'string' || owner.length === 0) {
-    throw new Error('Canon loader: write-lane.owner is required');
-  }
-  if (typeof risk !== 'string' || !RISK_LEVELS.has(risk)) {
-    throw new Error(`Canon loader: write-lane ${owner}.risk is invalid`);
-  }
+/** @param {unknown} raw @param {Set<string>} gateIds @param {Set<string>} seenOwners @returns {WriteLane} */
+function validateLane(raw, gateIds, seenOwners) {
+  if (!isObject(raw)) throw new Error('Canon config: write-lane must be an object');
+  const owner = requireNonEmptyString(raw.owner, 'write-lane.owner');
+  if (seenOwners.has(owner)) throw new Error(`Canon config: duplicate write-lane owner "${owner}"`);
+  seenOwners.add(owner);
+
+  const paths = requireStringArray(raw.paths, `write-lane ${owner}.paths`);
+  if (paths.length === 0) throw new Error(`Canon config: write-lane ${owner}.paths must not be empty`);
+  const risk = requireEnum(raw.risk, RISK_LEVELS, `write-lane ${owner}.risk`);
+  const requiredGates = requireStringArray(raw.requiredGates, `write-lane ${owner}.requiredGates`);
+  assertGatesKnown(requiredGates, gateIds, `write-lane ${owner}.requiredGates`);
+  const manualReviewRequired = requireBoolean(raw.manualReviewRequired, `write-lane ${owner}.manualReviewRequired`);
+
   return Object.freeze({
     owner,
-    paths: Object.freeze(asStringArray(paths, `write-lane ${owner}.paths`)),
+    paths: Object.freeze(paths),
     risk: /** @type {WriteLane['risk']} */ (risk),
-    requiredGates: Object.freeze(asStringArray(requiredGates, `write-lane ${owner}.requiredGates`)),
-    manualReviewRequired: manualReviewRequired === true,
+    requiredGates: Object.freeze(requiredGates),
+    manualReviewRequired,
   });
 }
 
-/** @param {unknown} raw @returns {Gate} */
-function validateGate(raw) {
-  if (!isObject(raw)) throw new Error('Canon loader: gate must be an object');
-  const { gateId, label, command, kind } = raw;
-  if (typeof gateId !== 'string' || gateId.length === 0) {
-    throw new Error('Canon loader: gate.gateId is required');
+/**
+ * Pure fail-loud validator. Validates the three raw config documents, freezes
+ * them into a Canon, and throws a descriptive Error on the first violation.
+ * Gates are validated first so rule/lane gate references can be cross-checked.
+ *
+ * @param {RawCanonConfig} raw
+ * @returns {Canon}
+ */
+export function validateCanonConfig(raw) {
+  if (!isObject(raw)) throw new Error('Canon config: raw config must be an object');
+  const { index, lanes, gates } = raw;
+
+  if (!isObject(gates) || !Array.isArray(gates.gates)) {
+    throw new Error('Canon config: gate-registry must have a gates array');
   }
+  if (!isObject(index) || !Array.isArray(index.rules)) {
+    throw new Error('Canon config: canon-index must have a rules array');
+  }
+  if (!isObject(lanes) || !Array.isArray(lanes.lanes)) {
+    throw new Error('Canon config: engineering-write-lanes must have a lanes array');
+  }
+
+  const seenGateIds = new Set();
+  const validatedGates = gates.gates.map((g) => validateGate(g, seenGateIds));
+  const gateIds = new Set(validatedGates.map((g) => g.gateId));
+
+  const seenRuleIds = new Set();
+  const validatedRules = index.rules.map((r) => validateRule(r, gateIds, seenRuleIds));
+
+  const seenOwners = new Set();
+  const validatedLanes = lanes.lanes.map((l) => validateLane(l, gateIds, seenOwners));
+
   return Object.freeze({
-    gateId,
-    label: typeof label === 'string' ? label : gateId,
-    command: typeof command === 'string' ? command : '',
-    kind: typeof kind === 'string' ? kind : undefined,
+    rules: Object.freeze(validatedRules),
+    lanes: Object.freeze(validatedLanes),
+    gates: Object.freeze(validatedGates),
   });
+}
+
+/** @param {string} fileName @returns {unknown} */
+function readJson(fileName) {
+  const url = new URL(`./${fileName}`, import.meta.url);
+  let rawText;
+  try {
+    rawText = readFileSync(url, 'utf8');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Canon loader: cannot read ${fileName}: ${msg}`);
+  }
+  try {
+    return JSON.parse(rawText);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Canon loader: ${fileName} is not valid JSON: ${msg}`);
+  }
 }
 
 /** @type {Canon | null} */
 let cached = null;
 
 /**
- * Load, validate, freeze, and memoize the Canon law.
+ * Load, validate (fail-loud), freeze, and memoize the Canon law from disk.
  * @param {{ reload?: boolean }} [opts]
  * @returns {Canon}
  */
 export function loadCanon(opts) {
   if (cached && !(opts && opts.reload)) return cached;
-
-  const indexRaw = readJson('canon-index.json');
-  const lanesRaw = readJson('engineering-write-lanes.json');
-  const gatesRaw = readJson('gate-registry.json');
-
-  if (!isObject(indexRaw) || !Array.isArray(indexRaw.rules)) {
-    throw new Error('Canon loader: canon-index.json must have a rules array');
-  }
-  if (!isObject(lanesRaw) || !Array.isArray(lanesRaw.lanes)) {
-    throw new Error('Canon loader: engineering-write-lanes.json must have a lanes array');
-  }
-  if (!isObject(gatesRaw) || !Array.isArray(gatesRaw.gates)) {
-    throw new Error('Canon loader: gate-registry.json must have a gates array');
-  }
-
-  const canon = Object.freeze({
-    rules: Object.freeze(indexRaw.rules.map(validateRule)),
-    lanes: Object.freeze(lanesRaw.lanes.map(validateLane)),
-    gates: Object.freeze(gatesRaw.gates.map(validateGate)),
+  const canon = validateCanonConfig({
+    index: readJson('canon-index.json'),
+    lanes: readJson('engineering-write-lanes.json'),
+    gates: readJson('gate-registry.json'),
   });
-
   cached = canon;
   return canon;
 }

--- a/os-platform/core/tests/canon-query.test.mjs
+++ b/os-platform/core/tests/canon-query.test.mjs
@@ -17,6 +17,56 @@ import {
   getRequiredGatesForPath,
   scorePathRisk,
 } from '../canon/index.mjs';
+import { loadCanon, validateCanonConfig } from '../canon/canon-loader.mjs';
+
+/**
+ * A minimal VALID raw config (the shape read from the three JSON files).
+ * Tests deep-clone this and mutate copies to assert fail-loud behavior.
+ */
+function validRawConfig() {
+  return {
+    index: {
+      version: '0.1.0',
+      rules: [
+        {
+          ruleId: 'test.rule.one',
+          version: '1.0.0',
+          status: 'active',
+          authority: 'os-platform',
+          title: 'Test rule',
+          description: 'A valid test rule.',
+          source: 'unit test',
+          appliesTo: {
+            paths: ['frontend/apps/os-shell/src/**'],
+            taskIntents: ['shell-launch'],
+            surfaces: ['os-canon'],
+          },
+          enforcement: {
+            level: 'block',
+            requiredGates: ['typecheck'],
+            requiresManualReview: true,
+          },
+        },
+      ],
+    },
+    lanes: {
+      version: '0.1.0',
+      lanes: [
+        {
+          owner: 'os-shell',
+          paths: ['frontend/apps/os-shell/src/**'],
+          risk: 'high',
+          requiredGates: ['typecheck'],
+          manualReviewRequired: true,
+        },
+      ],
+    },
+    gates: {
+      version: '0.1.0',
+      gates: [{ gateId: 'typecheck', label: 'Type Check', command: 'pnpm run type-check' }],
+    },
+  };
+}
 
 test('1. moduleActivation path resolves to os-shell owner', () => {
   const res = getOwnerForPath('frontend/apps/os-shell/src/orchestration/moduleActivation.ts');
@@ -86,4 +136,97 @@ test('10. task intent "fix os-canon shell launch drift" returns shell surface ru
 test('bonus: getRulesForPath returns the in-shell rule for os-shell paths', () => {
   const rules = getRulesForPath('frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx');
   assert.ok(rules.some((r) => r.ruleId === 'surface.os-canon.in-shell'));
+});
+
+// ---------------------------------------------------------------------------
+// Fail-loud loader hardening: invalid Canon config must throw, never silently
+// soften governance. validateCanonConfig({index, lanes, gates}) is the pure
+// validator that loadCanon() runs after reading the JSON files.
+// ---------------------------------------------------------------------------
+
+test('FL.0 real on-disk config loads without throwing', () => {
+  assert.doesNotThrow(() => {
+    const canon = loadCanon({ reload: true });
+    assert.ok(canon.rules.length > 0);
+    assert.ok(canon.lanes.length > 0);
+    assert.ok(canon.gates.length > 0);
+  });
+});
+
+test('FL.1 valid config validates and returns a frozen canon', () => {
+  const raw = validRawConfig();
+  const canon = validateCanonConfig(raw);
+  assert.equal(canon.rules.length, 1);
+  assert.equal(canon.lanes.length, 1);
+  assert.equal(canon.gates.length, 1);
+  assert.ok(Object.isFrozen(canon));
+  assert.ok(Object.isFrozen(canon.rules));
+});
+
+test('FL.2 rule missing appliesTo.paths array fails loudly', () => {
+  const raw = validRawConfig();
+  delete raw.index.rules[0].appliesTo.paths;
+  assert.throws(() => validateCanonConfig(raw), /paths/i);
+});
+
+test('FL.3 rule with non-boolean requiresManualReview fails loudly (no silent coerce)', () => {
+  const raw = validRawConfig();
+  raw.index.rules[0].enforcement.requiresManualReview = 'yes';
+  assert.throws(() => validateCanonConfig(raw), /requiresManualReview/i);
+});
+
+test('FL.4 rule that applies to nothing (all appliesTo arrays empty) fails loudly', () => {
+  const raw = validRawConfig();
+  raw.index.rules[0].appliesTo.paths = [];
+  raw.index.rules[0].appliesTo.taskIntents = [];
+  raw.index.rules[0].appliesTo.surfaces = [];
+  assert.throws(() => validateCanonConfig(raw), /appliesTo|matches nothing/i);
+});
+
+test('FL.5 enforcement missing requiredGates array fails loudly', () => {
+  const raw = validRawConfig();
+  delete raw.index.rules[0].enforcement.requiredGates;
+  assert.throws(() => validateCanonConfig(raw), /requiredGates/i);
+});
+
+test('FL.6 lane with unknown risk level fails loudly', () => {
+  const raw = validRawConfig();
+  raw.lanes.lanes[0].risk = 'spicy';
+  assert.throws(() => validateCanonConfig(raw), /risk/i);
+});
+
+test('FL.7 lane missing owner fails loudly', () => {
+  const raw = validRawConfig();
+  delete raw.lanes.lanes[0].owner;
+  assert.throws(() => validateCanonConfig(raw), /owner/i);
+});
+
+test('FL.8 lane with non-boolean manualReviewRequired fails loudly', () => {
+  const raw = validRawConfig();
+  raw.lanes.lanes[0].manualReviewRequired = 1;
+  assert.throws(() => validateCanonConfig(raw), /manualReviewRequired/i);
+});
+
+test('FL.9 requiredGates referencing an unknown gate id fails loudly', () => {
+  const raw = validRawConfig();
+  raw.lanes.lanes[0].requiredGates = ['no-such-gate'];
+  assert.throws(() => validateCanonConfig(raw), /no-such-gate|unknown gate/i);
+});
+
+test('FL.10 duplicate ruleId fails loudly', () => {
+  const raw = validRawConfig();
+  raw.index.rules.push(structuredClone(raw.index.rules[0]));
+  assert.throws(() => validateCanonConfig(raw), /duplicate|ruleId/i);
+});
+
+test('FL.11 duplicate lane owner fails loudly', () => {
+  const raw = validRawConfig();
+  raw.lanes.lanes.push(structuredClone(raw.lanes.lanes[0]));
+  assert.throws(() => validateCanonConfig(raw), /duplicate|owner/i);
+});
+
+test('FL.12 rule referencing unknown gate id fails loudly', () => {
+  const raw = validRawConfig();
+  raw.index.rules[0].enforcement.requiredGates = ['ghost-gate'];
+  assert.throws(() => validateCanonConfig(raw), /ghost-gate|unknown gate/i);
 });


### PR DESCRIPTION
## Summary

Hardens the Canon Runtime loader so invalid or incomplete Canon law is a **hard error**, never a silent default that softens governance. Addresses the CodeRabbit note on #892 as its own deliberate micro-slice (not a 4th commit on the foundation PR).

**Stacked on #892** (`feat/terracanon-ide-package`) — the loader it hardens only exists there. Retarget to `main` after #892 merges.

## What changed (2 files, read-only runtime)

- `os-platform/core/canon/canon-loader.mjs`
  - Extracts a pure `validateCanonConfig({index,lanes,gates})` used by `loadCanon`.
  - Required arrays must be present `string[]` (no `undefined -> []`).
  - Boolean governance fields must be real booleans (no truthy/falsy coercion).
  - `risk`/`status`/`authority`/`enforcement.level` must be known enum values.
  - Every referenced gate id must exist in the gate registry (cross-ref).
  - `ruleId`, lane `owner`, and `gateId` must be unique.
  - A rule that applies to nothing (empty paths/intents/surfaces) is invalid.
- `os-platform/core/tests/canon-query.test.mjs`
  - +13 fail-loud cases feeding malformed config to `validateCanonConfig`.

## Out of scope

No frontend, no agents, no gate scripts, no command execution, no enforcement hooks. Read-only runtime only.

## Verification

- `node --test os-platform/core/tests/canon-query.test.mjs` -> 24/24 pass
- `node os-platform/core/tests/launch-surface-contract.test.mjs` -> 8/8 (untouched)
- `pnpm run type-check` -> clean
- `git diff --check` -> clean
- pre-commit + pre-push quality gates -> passed

## Summary by Sourcery

Harden Canon runtime loader validation to fail loudly on invalid governance config and add coverage for malformed Canon configurations.

New Features:
- Introduce a pure validateCanonConfig function to validate Canon index, lanes, and gate registry data before loading.

Enhancements:
- Tighten Canon config validation to require explicit string arrays, strict booleans, known enum values, unique identifiers, and valid gate references, ensuring rules and lanes cannot apply to empty scopes.

Tests:
- Add a suite of fail-loud tests validating that malformed Canon configurations cause descriptive errors rather than silently defaulting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive validation for governance configuration with stricter enforcement rules and clearer error messages.

* **Tests**
  * Added extensive test coverage for configuration validation scenarios, including edge cases and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->