### PR TITLE
feat(canon): add advisory Canon gate scripts

### DIFF
--- a/os-platform/core/gates/canon-write-lane-check.mjs
+++ b/os-platform/core/gates/canon-write-lane-check.mjs
@@ -1,0 +1,91 @@
+/**
+ * Advisory Canon gate: engineering write-lane check.
+ *
+ * For each changed path, resolves the owning write-lane, required gates, and
+ * risk via the read-only Canon query layer, and surfaces advisories:
+ *   - unowned paths (no write-lane) — governance blind spot;
+ *   - high/critical-risk areas — ensure required gates + review happen.
+ *
+ * ADVISORY by default — reports and exits 0. Pass --strict to exit non-zero
+ * when any advisory is raised. Read-only: paths passed as args, no git, no
+ * command execution.
+ *
+ * CLI:  node os-platform/core/gates/canon-write-lane-check.mjs [--strict] [--json] <paths...>
+ *
+ * @module gates/canon-write-lane-check
+ */
+
+import { getOwnerForPath, getRequiredGatesForPath } from '../canon/canon-query.mjs';
+import { scorePathRisk } from '../canon/canon-risk.mjs';
+import { printReport, runMain } from './gate-runtime.mjs';
+
+/**
+ * @typedef {Readonly<{
+ *   path: string,
+ *   owner: string,
+ *   confidence: 'exact' | 'pattern' | 'fallback',
+ *   risk: 'low' | 'medium' | 'high' | 'critical',
+ *   requiredGates: ReadonlyArray<string>,
+ *   manualReviewRequired: boolean
+ * }>} LaneResult
+ *
+ * @typedef {Readonly<{ path: string, detail: string }>} Advisory
+ */
+
+const HIGH_RISK = new Set(['high', 'critical']);
+
+/**
+ * Resolve write-lane info + advisories for a set of changed paths. Never throws.
+ * @param {ReadonlyArray<string>} paths
+ * @returns {Readonly<{ results: ReadonlyArray<LaneResult>, advisories: ReadonlyArray<Advisory> }>}
+ */
+export function checkWriteLanes(paths) {
+  /** @type {LaneResult[]} */
+  const results = [];
+  /** @type {Advisory[]} */
+  const advisories = [];
+
+  for (const path of paths || []) {
+    if (typeof path !== 'string' || path.length === 0) continue;
+    const owner = getOwnerForPath(path);
+    const risk = scorePathRisk(path);
+    const requiredGates = getRequiredGatesForPath(path);
+
+    results.push(
+      Object.freeze({
+        path,
+        owner: owner.owner,
+        confidence: owner.confidence,
+        risk: risk.level,
+        requiredGates,
+        manualReviewRequired: risk.manualReviewRequired,
+      }),
+    );
+
+    if (owner.confidence === 'fallback') {
+      advisories.push(Object.freeze({ path, detail: 'unowned path — no write-lane owns this area' }));
+    }
+    if (HIGH_RISK.has(risk.level)) {
+      const gates = requiredGates.length ? requiredGates.join(', ') : '(none declared)';
+      advisories.push(
+        Object.freeze({
+          path,
+          detail: `${risk.level}-risk (owner ${owner.owner}); required gates: ${gates}; manual review: ${risk.manualReviewRequired}`,
+        }),
+      );
+    }
+  }
+
+  return Object.freeze({ results: Object.freeze(results), advisories: Object.freeze(advisories) });
+}
+
+runMain(import.meta.url, (opts) => {
+  const { advisories } = checkWriteLanes(opts.paths);
+  return printReport({
+    gate: 'write-lane-check',
+    json: opts.json,
+    strict: opts.strict,
+    findings: advisories.map((a) => ({ path: a.path, detail: a.detail })),
+    okMessage: `scanned ${opts.paths.length} path(s); all owned, no high-risk advisories.`,
+  });
+});

--- a/os-platform/core/gates/check-hardcoded-ports.mjs
+++ b/os-platform/core/gates/check-hardcoded-ports.mjs
@@ -1,0 +1,98 @@
+/**
+ * Advisory Canon gate: hardcoded ports.
+ *
+ * Scans the given files for hardcoded network ports (TerraFusion Constitution
+ * Article VI: ports come from environment/config). ADVISORY by default — it
+ * reports findings and exits 0. Pass --strict to exit non-zero on findings
+ * (enforcement is a deliberate later decision, not this slice).
+ *
+ * Read-only: reads file contents, runs NO commands, mutates nothing. File paths
+ * are passed as arguments (lint-staged/CI convention) — no git invocation.
+ *
+ * CLI:  node os-platform/core/gates/check-hardcoded-ports.mjs [--strict] [--json] <paths...>
+ *
+ * @module gates/check-hardcoded-ports
+ */
+
+import { readFileSync } from 'node:fs';
+import { printReport, runMain } from './gate-runtime.mjs';
+
+/**
+ * @typedef {Readonly<{ line: number, port: string, snippet: string }>} PortHit
+ */
+
+const URL_PORT = /(?:https?:\/\/|wss?:\/\/)[^\s'"`]*?:(\d{2,5})\b/gi;
+const LOCALHOST_PORT = /\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d{2,5})\b/gi;
+const PORT_ASSIGN = /\bport\s*[:=]\s*(\d{2,5})\b/gi;
+const ENV_CONTEXT = /process\.env|import\.meta\.env|getenv|\benv\(|configuration|appsettings/i;
+
+/**
+ * True when a line sources its port from env/config (allowed, not a finding).
+ * @param {string} line
+ * @returns {boolean}
+ */
+export function isAllowedPortContext(line) {
+  if (typeof line !== 'string') return false;
+  return ENV_CONTEXT.test(line);
+}
+
+/**
+ * Find hardcoded ports in a blob of source text. Deterministic, never throws.
+ * @param {unknown} text
+ * @returns {ReadonlyArray<PortHit>}
+ */
+export function findHardcodedPorts(text) {
+  if (typeof text !== 'string' || text.length === 0) return Object.freeze([]);
+  const lines = text.split(/\r?\n/);
+  /** @type {PortHit[]} */
+  const hits = [];
+  lines.forEach((line, idx) => {
+    if (isAllowedPortContext(line)) return;
+    const seen = new Set();
+    for (const re of [URL_PORT, LOCALHOST_PORT, PORT_ASSIGN]) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        const port = m[1];
+        if (seen.has(port)) continue;
+        seen.add(port);
+        hits.push(Object.freeze({ line: idx + 1, port, snippet: line.trim().slice(0, 120) }));
+      }
+    }
+  });
+  return Object.freeze(hits);
+}
+
+/**
+ * Scan a set of files. Never throws; unreadable files are skipped.
+ * @param {ReadonlyArray<string>} paths
+ * @returns {ReadonlyArray<Readonly<{ path: string, line: number, port: string, snippet: string }>>}
+ */
+export function checkHardcodedPorts(paths) {
+  /** @type {Array<Readonly<{ path: string, line: number, port: string, snippet: string }>>} */
+  const findings = [];
+  for (const path of paths || []) {
+    let text;
+    try {
+      text = readFileSync(path, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const hit of findHardcodedPorts(text)) {
+      findings.push(Object.freeze({ path, line: hit.line, port: hit.port, snippet: hit.snippet }));
+    }
+  }
+  return Object.freeze(findings);
+}
+
+runMain(import.meta.url, (opts) => {
+  const paths = opts.paths.filter((p) => /\.(ts|tsx|js|jsx|mjs|cjs|cs|json|ya?ml)$/i.test(p));
+  const findings = checkHardcodedPorts(paths);
+  return printReport({
+    gate: 'hardcoded-ports',
+    json: opts.json,
+    strict: opts.strict,
+    findings: findings.map((f) => ({ path: f.path, detail: `port ${f.port} at line ${f.line}: ${f.snippet}` })),
+    okMessage: `scanned ${paths.length} file(s); no hardcoded ports found.`,
+  });
+});

--- a/os-platform/core/gates/check-protected-paths.mjs
+++ b/os-platform/core/gates/check-protected-paths.mjs
@@ -1,0 +1,61 @@
+/**
+ * Advisory Canon gate: protected paths.
+ *
+ * Flags changes under protected, frozen areas (ARCHIVE/**, specialized/**) that
+ * must not be edited without explicit governance approval. ADVISORY by default
+ * — reports findings and exits 0. Pass --strict to exit non-zero.
+ *
+ * Read-only: matches path strings only. Paths are passed as arguments — no git,
+ * no command execution.
+ *
+ * CLI:  node os-platform/core/gates/check-protected-paths.mjs [--strict] [--json] <paths...>
+ *
+ * @module gates/check-protected-paths
+ */
+
+import { pathMatchesPattern } from '../canon/canon-query.mjs';
+import { printReport, runMain } from './gate-runtime.mjs';
+
+/**
+ * Protected glob patterns. Mirrors the protected-path policy from the Canon/IDE
+ * package (docs/TerraCanon). Kept here as an explicit, expandable constant.
+ * @type {ReadonlyArray<string>}
+ */
+export const PROTECTED_PATTERNS = Object.freeze(['ARCHIVE/**', 'specialized/**']);
+
+/**
+ * True when a path falls under a protected pattern. Never throws.
+ * @param {unknown} path
+ * @returns {boolean}
+ */
+export function isProtectedPath(path) {
+  if (typeof path !== 'string' || path.length === 0) return false;
+  return PROTECTED_PATTERNS.some((pat) => pathMatchesPattern(path, pat));
+}
+
+/**
+ * Return one finding per protected path. Never throws.
+ * @param {ReadonlyArray<string>} paths
+ * @returns {ReadonlyArray<Readonly<{ path: string, pattern: string }>>}
+ */
+export function checkProtectedPaths(paths) {
+  /** @type {Array<Readonly<{ path: string, pattern: string }>>} */
+  const findings = [];
+  for (const path of paths || []) {
+    if (typeof path !== 'string') continue;
+    const pattern = PROTECTED_PATTERNS.find((pat) => pathMatchesPattern(path, pat));
+    if (pattern) findings.push(Object.freeze({ path, pattern }));
+  }
+  return Object.freeze(findings);
+}
+
+runMain(import.meta.url, (opts) => {
+  const findings = checkProtectedPaths(opts.paths);
+  return printReport({
+    gate: 'protected-paths',
+    json: opts.json,
+    strict: opts.strict,
+    findings: findings.map((f) => ({ path: f.path, detail: `protected by ${f.pattern}` })),
+    okMessage: `scanned ${opts.paths.length} path(s); none touch protected areas.`,
+  });
+});

--- a/os-platform/core/gates/gate-runtime.mjs
+++ b/os-platform/core/gates/gate-runtime.mjs
@@ -1,0 +1,76 @@
+/**
+ * Shared runtime for advisory Canon gate scripts.
+ *
+ * Pure CLI plumbing: argument parsing and report printing. NO command
+ * execution, NO git, NO network — callers (pre-commit/CI) pass the changed
+ * file paths as arguments (the lint-staged convention). Read-only.
+ *
+ * @module gates/gate-runtime
+ */
+
+import { fileURLToPath } from 'node:url';
+
+/**
+ * @typedef {Readonly<{ strict: boolean, json: boolean, paths: ReadonlyArray<string> }>} GateArgs
+ * @typedef {Readonly<{ path?: string, detail: string }>} Finding
+ */
+
+/**
+ * Parse gate CLI args: flags --strict/--json, everything else is a path.
+ * @param {ReadonlyArray<string>} argv
+ * @returns {GateArgs}
+ */
+export function parseArgs(argv) {
+  const a = Array.isArray(argv) ? argv : [];
+  return Object.freeze({
+    strict: a.includes('--strict'),
+    json: a.includes('--json'),
+    paths: Object.freeze(a.filter((x) => typeof x === 'string' && !x.startsWith('--'))),
+  });
+}
+
+/**
+ * Print a gate report. Advisory by default: findings are reported but exit code
+ * stays 0 unless --strict was passed. Returns { ok, exitCode }.
+ * @param {Readonly<{ gate: string, json?: boolean, strict?: boolean, findings: ReadonlyArray<Finding>, okMessage: string }>} r
+ * @returns {Readonly<{ ok: boolean, exitCode: number }>}
+ */
+export function printReport(r) {
+  const findings = r.findings || [];
+  const ok = findings.length === 0;
+  const exitCode = ok || !r.strict ? 0 : 1;
+
+  if (r.json) {
+    process.stdout.write(
+      JSON.stringify({ gate: r.gate, mode: r.strict ? 'strict' : 'advisory', ok, count: findings.length, findings }) +
+        '\n',
+    );
+    return Object.freeze({ ok, exitCode });
+  }
+
+  const mode = r.strict ? 'STRICT' : 'ADVISORY';
+  if (ok) {
+    process.stdout.write(`✅ canon:${r.gate} [${mode}] — ${r.okMessage}\n`);
+  } else {
+    const verb = r.strict ? '❌' : '⚠️';
+    process.stdout.write(`${verb} canon:${r.gate} [${mode}] — ${findings.length} finding(s):\n`);
+    for (const f of findings) {
+      process.stdout.write(`   - ${f.path ? f.path + ': ' : ''}${f.detail}\n`);
+    }
+    if (!r.strict) process.stdout.write(`   (advisory: not blocking; rerun with --strict to enforce)\n`);
+  }
+  return Object.freeze({ ok, exitCode });
+}
+
+/**
+ * Run a gate as a CLI only when this module is the process entrypoint.
+ * @param {string} metaUrl import.meta.url of the gate module
+ * @param {(opts: GateArgs) => Readonly<{ ok: boolean, exitCode: number }>} fn
+ */
+export function runMain(metaUrl, fn) {
+  const entry = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
+  const self = fileURLToPath(metaUrl).replace(/\\/g, '/');
+  if (entry !== self) return;
+  const result = fn(parseArgs(process.argv.slice(2)));
+  process.exitCode = result.exitCode;
+}

--- a/os-platform/core/tests/canon-write-lane-check.test.mjs
+++ b/os-platform/core/tests/canon-write-lane-check.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Advisory gate: canon-write-lane-check — self-test.
+ *
+ * Resolves owner / required gates / risk for changed paths via the read-only
+ * Canon query layer and surfaces advisories. Advisory by default.
+ * Run: node --test os-platform/core/tests/canon-write-lane-check.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkWriteLanes } from '../gates/canon-write-lane-check.mjs';
+
+test('WL.1 os-shell path resolves owner, high risk, and gates', () => {
+  const { results } = checkWriteLanes(['frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx']);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].owner, 'os-shell');
+  assert.equal(results[0].risk, 'high');
+  assert.ok(results[0].requiredGates.includes('typecheck'));
+});
+
+test('WL.2 unowned path raises an advisory', () => {
+  const { results, advisories } = checkWriteLanes(['some/unmapped/area/file.ts']);
+  assert.equal(results[0].confidence, 'fallback');
+  assert.ok(advisories.some((a) => a.path === 'some/unmapped/area/file.ts' && /unowned|no write-lane/i.test(a.detail)));
+});
+
+test('WL.3 canon-runtime path resolves to canon-runtime owner', () => {
+  const { results } = checkWriteLanes(['os-platform/core/canon/canon-loader.mjs']);
+  assert.equal(results[0].owner, 'canon-runtime');
+});
+
+test('WL.4 returns a result per path and never throws', () => {
+  assert.doesNotThrow(() => {
+    const { results } = checkWriteLanes(['a/b.ts', 'docs/TerraCanon/x.md']);
+    assert.equal(results.length, 2);
+  });
+  assert.doesNotThrow(() => checkWriteLanes(undefined));
+});
+
+test('WL.5 low-risk docs path produces no high-risk advisory', () => {
+  const { advisories } = checkWriteLanes(['docs/TerraCanon/CANON_IDE_REPO_ADAPTATION_PLAN.md']);
+  assert.equal(
+    advisories.filter((a) => a.path === 'docs/TerraCanon/CANON_IDE_REPO_ADAPTATION_PLAN.md').length,
+    0,
+  );
+});

--- a/os-platform/core/tests/hardcoded-ports.test.mjs
+++ b/os-platform/core/tests/hardcoded-ports.test.mjs
@@ -1,0 +1,51 @@
+/**
+ * Advisory gate: hardcoded-ports — self-test.
+ *
+ * Tests the pure detector. Advisory by default (callers report, do not block).
+ * Run: node --test os-platform/core/tests/hardcoded-ports.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { findHardcodedPorts, isAllowedPortContext } from '../gates/check-hardcoded-ports.mjs';
+
+test('HP.1 flags a hardcoded port in a URL', () => {
+  const hits = findHardcodedPorts("const u = 'http://localhost:3000/api';");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].port, '3000');
+  assert.equal(hits[0].line, 1);
+});
+
+test('HP.2 flags a numeric port assignment', () => {
+  const hits = findHardcodedPorts('const port = 5432;');
+  assert.ok(hits.some((h) => h.port === '5432'));
+});
+
+test('HP.3 no false positive on env-sourced port', () => {
+  const hits = findHardcodedPorts('const port = process.env.PORT;');
+  assert.equal(hits.length, 0);
+});
+
+test('HP.4 no false positive on plain non-port number', () => {
+  const hits = findHardcodedPorts('const total = 89247; // parcels');
+  assert.equal(hits.length, 0);
+});
+
+test('HP.5 reports correct line numbers across multiple lines', () => {
+  const text = ['const a = 1;', "fetch('http://127.0.0.1:8080');", 'const b = 2;'].join('\n');
+  const hits = findHardcodedPorts(text);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 2);
+  assert.equal(hits[0].port, '8080');
+});
+
+test('HP.6 isAllowedPortContext lets through env/config references', () => {
+  assert.equal(isAllowedPortContext('port: process.env.PORT'), true);
+  assert.equal(isAllowedPortContext("listen('http://localhost:3000')"), false);
+});
+
+test('HP.7 detector never throws on odd input', () => {
+  assert.doesNotThrow(() => findHardcodedPorts(''));
+  assert.doesNotThrow(() => findHardcodedPorts(undefined));
+});

--- a/os-platform/core/tests/protected-paths.test.mjs
+++ b/os-platform/core/tests/protected-paths.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * Advisory gate: protected-paths — self-test.
+ *
+ * Run: node --test os-platform/core/tests/protected-paths.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isProtectedPath, checkProtectedPaths, PROTECTED_PATTERNS } from '../gates/check-protected-paths.mjs';
+
+test('PP.0 has a non-empty protected pattern list', () => {
+  assert.ok(Array.isArray(PROTECTED_PATTERNS) && PROTECTED_PATTERNS.length > 0);
+});
+
+test('PP.1 ARCHIVE path is protected', () => {
+  assert.equal(isProtectedPath('ARCHIVE/old/thing.ts'), true);
+});
+
+test('PP.2 specialized path is protected', () => {
+  assert.equal(isProtectedPath('specialized/ai-swarm/agent.cs'), true);
+});
+
+test('PP.3 normal runtime path is not protected', () => {
+  assert.equal(isProtectedPath('os-platform/core/canon/canon-query.mjs'), false);
+});
+
+test('PP.4 checkProtectedPaths returns one finding per protected path', () => {
+  const findings = checkProtectedPaths([
+    'ARCHIVE/x.ts',
+    'frontend/apps/os-shell/src/canon/CanonEditor.tsx',
+    'specialized/y.cs',
+  ]);
+  assert.equal(findings.length, 2);
+  assert.ok(findings.every((f) => typeof f.path === 'string' && typeof f.pattern === 'string'));
+});
+
+test('PP.5 never throws on odd input', () => {
+  assert.doesNotThrow(() => checkProtectedPaths(undefined));
+  assert.doesNotThrow(() => isProtectedPath(undefined));
+  assert.equal(isProtectedPath(undefined), false);
+});
+
+test('PP.6 handles Windows-style separators', () => {
+  assert.equal(isProtectedPath('ARCHIVE\\nested\\file.ts'), true);
+});


### PR DESCRIPTION
## Summary

Turns the queryable Canon law into a **reporting rail** — three advisory gate scripts that consume the read-only query layer. **Advisory by default** (exit 0); `--strict` exits non-zero. Enforcement wiring (pre-commit/CI) is a deliberate later decision, not this slice.

**Stacked on #893** (which is stacked on #892). Merge bottom-up: #892 → #893 → this. Retargets to the chain as each merges.

## What changed (read-only, args-only — no git, no command execution)

- `os-platform/core/gates/gate-runtime.mjs` — shared argv parse + report (advisory / `--strict` / `--json`)
- `os-platform/core/gates/canon-write-lane-check.mjs` — owner + required gates + risk per path; flags unowned and high/critical-risk areas
- `os-platform/core/gates/check-protected-paths.mjs` — flags edits under `ARCHIVE/**`, `specialized/**`
- `os-platform/core/gates/check-hardcoded-ports.mjs` — flags hardcoded ports (Constitution Article VI)
- +3 test files

Note: `gate-runtime.mjs` is a small shared helper beyond the originally-listed 6 files (DRY for the three CLIs).

## Why advisory first

Per operating discipline: introduce checks in report mode, prove signal quality, then decide where to enforce. No silent blocking added.

## Verification

- gate + canon tests: **43/43** (`hardcoded-ports` 7, `protected-paths` 7, `write-lane-check` 5, `canon-query` 24)
- launch-surface contract: **8/8** (untouched)
- `pnpm run type-check` -> clean
- `git diff --check` -> clean
- CLI smoke-proven: advisory exit 0, `--strict` exit 1, `--json` shape

## Out of scope

No frontend, no agents, no worktrees, no enforcement hooks wired, no command execution. Read-only advisory only.

## Summary by Sourcery

Introduce advisory Canon gate CLIs for write-lane ownership, protected paths, and hardcoded ports, backed by a shared gate runtime.

New Features:
- Add a shared gate CLI runtime that parses arguments and prints advisory or strict reports in text or JSON modes.
- Add an advisory Canon gate that checks write-lane ownership, risk level, and required gates for changed paths via the Canon query layer.
- Add an advisory Canon gate that flags edits under protected paths such as ARCHIVE/** and specialized/**.
- Add an advisory Canon gate that scans for hardcoded network ports based on TerraFusion policy.

Tests:
- Add tests covering the new write-lane, protected-path, and hardcoded-port Canon gate scripts.