### PR TITLE
feat(canon): add evidence bundle + tamper-evident trace seal

### DIFF
--- a/os-platform/core/canon/canon-evidence-bundle.schema.json
+++ b/os-platform/core/canon/canon-evidence-bundle.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://terrafusion.local/schemas/canon-evidence-bundle.schema.json",
+  "title": "CanonEvidenceBundle",
+  "description": "Proof artifact for a completed Canon task. Adapted from the Canon/IDE package into the repo-native os-platform/core/canon runtime. Distinct from the frozen Phase 7 trace spine (os-platform/core/trace).",
+  "type": "object",
+  "required": [
+    "taskId",
+    "intent",
+    "surface",
+    "canonRulesLoaded",
+    "filesRead",
+    "filesChanged",
+    "commandsRun",
+    "gateResults",
+    "diffHash",
+    "riskScore",
+    "sealed"
+  ],
+  "properties": {
+    "taskId": { "type": "string" },
+    "intent": { "type": "string" },
+    "surface": { "type": "string" },
+    "agentLanes": { "type": "array", "items": { "type": "string" } },
+    "canonRulesLoaded": { "type": "array", "items": { "type": "string" } },
+    "filesRead": { "type": "array", "items": { "type": "string" } },
+    "filesChanged": { "type": "array", "items": { "type": "string" } },
+    "commandsRun": { "type": "array", "items": { "type": "object" } },
+    "approvals": { "type": "array", "items": { "type": "object" } },
+    "diffHash": { "type": "string" },
+    "gateResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["gateId", "status"],
+        "properties": {
+          "gateId": { "type": "string" },
+          "status": { "enum": ["pass", "fail", "warning", "skipped"] },
+          "command": { "type": "string" },
+          "summary": { "type": "string" },
+          "startedAt": { "type": "string" },
+          "finishedAt": { "type": "string" }
+        }
+      }
+    },
+    "riskScore": { "type": "number" },
+    "commitHash": { "type": "string" },
+    "prUrl": { "type": "string" },
+    "traceHash": { "type": "string" },
+    "sealed": { "type": "boolean" },
+    "sealedAt": { "type": "string" }
+  }
+}

--- a/os-platform/core/canon/canon-evidence.mjs
+++ b/os-platform/core/canon/canon-evidence.mjs
@@ -1,0 +1,161 @@
+/**
+ * Canon Evidence Bundle (Core)
+ *
+ * Builds the proof artifact for a completed Canon task: which rules were loaded,
+ * what was read/changed, which gates ran, the diff hash, and the risk score.
+ * FAIL-LOUD: invalid/incomplete input is a hard error. Deterministic and
+ * read-only — the caller supplies all values (including timestamps); this module
+ * runs no commands and reads no files.
+ *
+ * Distinct from the frozen Phase 7 trace spine (os-platform/core/trace). Sealing
+ * lives in canon-trace-seal.mjs.
+ *
+ * @module canon/canon-evidence
+ * @see os-platform/core/canon/canon-evidence-bundle.schema.json
+ */
+
+const GATE_STATUSES = new Set(['pass', 'fail', 'warning', 'skipped']);
+
+/**
+ * @typedef {Readonly<{ gateId: string, status: 'pass'|'fail'|'warning'|'skipped', command?: string, summary?: string, startedAt?: string, finishedAt?: string }>} GateResult
+ * @typedef {Readonly<{
+ *   taskId: string, intent: string, surface: string,
+ *   agentLanes: ReadonlyArray<string>,
+ *   canonRulesLoaded: ReadonlyArray<string>,
+ *   filesRead: ReadonlyArray<string>,
+ *   filesChanged: ReadonlyArray<string>,
+ *   commandsRun: ReadonlyArray<object>,
+ *   approvals: ReadonlyArray<object>,
+ *   gateResults: ReadonlyArray<GateResult>,
+ *   diffHash: string, riskScore: number,
+ *   commitHash: string, prUrl: string,
+ *   sealed: boolean, traceHash?: string, sealedAt?: string
+ * }>} EvidenceBundle
+ */
+
+/** @param {unknown} v @returns {v is Record<string, unknown>} */
+function isObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** @param {unknown} v @param {string} where @returns {string} */
+function requireNonEmptyString(v, where) {
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`Evidence bundle: ${where} must be a non-empty string`);
+  }
+  return v;
+}
+
+/** @param {unknown} v @param {string} where @returns {string[]} */
+function requireStringArray(v, where) {
+  if (!Array.isArray(v) || v.some((x) => typeof x !== 'string')) {
+    throw new Error(`Evidence bundle: ${where} must be an array of strings`);
+  }
+  return /** @type {string[]} */ (v);
+}
+
+/** @param {unknown} v @param {string} where @returns {object[]} */
+function requireObjectArray(v, where) {
+  if (!Array.isArray(v) || v.some((x) => !isObject(x))) {
+    throw new Error(`Evidence bundle: ${where} must be an array of objects`);
+  }
+  return /** @type {object[]} */ (v);
+}
+
+/** @param {unknown} raw @param {number} i @returns {GateResult} */
+function validateGateResult(raw, i) {
+  if (!isObject(raw)) throw new Error(`Evidence bundle: gateResults[${i}] must be an object`);
+  const gateId = requireNonEmptyString(raw.gateId, `gateResults[${i}].gateId`);
+  if (typeof raw.status !== 'string' || !GATE_STATUSES.has(raw.status)) {
+    throw new Error(`Evidence bundle: gateResults[${i}].status must be one of ${[...GATE_STATUSES].join(', ')}`);
+  }
+  return Object.freeze({
+    gateId,
+    status: /** @type {GateResult['status']} */ (raw.status),
+    command: typeof raw.command === 'string' ? raw.command : undefined,
+    summary: typeof raw.summary === 'string' ? raw.summary : undefined,
+    startedAt: typeof raw.startedAt === 'string' ? raw.startedAt : undefined,
+    finishedAt: typeof raw.finishedAt === 'string' ? raw.finishedAt : undefined,
+  });
+}
+
+/**
+ * Build a frozen, UNSEALED evidence bundle from caller-supplied values.
+ * Fail-loud on missing/invalid fields. `sealed` is always false on build.
+ * @param {Record<string, unknown>} input
+ * @returns {EvidenceBundle}
+ */
+export function buildEvidenceBundle(input) {
+  if (!isObject(input)) throw new Error('Evidence bundle: input must be an object');
+
+  const taskId = requireNonEmptyString(input.taskId, 'taskId');
+  const intent = requireNonEmptyString(input.intent, 'intent');
+  const surface = requireNonEmptyString(input.surface, 'surface');
+  const diffHash = requireNonEmptyString(input.diffHash, 'diffHash');
+
+  if (typeof input.riskScore !== 'number' || !Number.isFinite(input.riskScore)) {
+    throw new Error('Evidence bundle: riskScore must be a finite number');
+  }
+
+  const canonRulesLoaded = requireStringArray(input.canonRulesLoaded, 'canonRulesLoaded');
+  const filesRead = requireStringArray(input.filesRead, 'filesRead');
+  const filesChanged = requireStringArray(input.filesChanged, 'filesChanged');
+  const commandsRun = requireObjectArray(input.commandsRun, 'commandsRun');
+  const gateResultsRaw = Array.isArray(input.gateResults) ? input.gateResults : null;
+  if (!gateResultsRaw) throw new Error('Evidence bundle: gateResults must be an array');
+  const gateResults = gateResultsRaw.map((g, i) => validateGateResult(g, i));
+
+  // Optional fields (typed, never coerced into governance-relevant defaults).
+  const agentLanes = input.agentLanes === undefined ? [] : requireStringArray(input.agentLanes, 'agentLanes');
+  const approvals = input.approvals === undefined ? [] : requireObjectArray(input.approvals, 'approvals');
+  const commitHash = typeof input.commitHash === 'string' ? input.commitHash : '';
+  const prUrl = typeof input.prUrl === 'string' ? input.prUrl : '';
+
+  return Object.freeze({
+    taskId,
+    intent,
+    surface,
+    agentLanes: Object.freeze(agentLanes),
+    canonRulesLoaded: Object.freeze(canonRulesLoaded),
+    filesRead: Object.freeze(filesRead),
+    filesChanged: Object.freeze(filesChanged),
+    commandsRun: Object.freeze(commandsRun),
+    approvals: Object.freeze(approvals),
+    gateResults: Object.freeze(gateResults),
+    diffHash,
+    riskScore: input.riskScore,
+    commitHash,
+    prUrl,
+    sealed: false,
+  });
+}
+
+/**
+ * Deterministic, key-order-independent JSON string. Used for hashing.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function canonicalize(value) {
+  return JSON.stringify(sortDeep(value));
+}
+
+/** @param {unknown} v @returns {unknown} */
+function sortDeep(v) {
+  if (Array.isArray(v)) return v.map(sortDeep);
+  if (v && typeof v === 'object') {
+    /** @type {Record<string, unknown>} */
+    const out = {};
+    for (const k of Object.keys(v).sort()) out[k] = sortDeep(/** @type {Record<string, unknown>} */ (v)[k]);
+    return out;
+  }
+  return v;
+}
+
+/**
+ * Pretty JSON serialization of a bundle (for writing to disk by a caller).
+ * @param {EvidenceBundle} bundle
+ * @returns {string}
+ */
+export function serializeEvidenceBundle(bundle) {
+  return JSON.stringify(bundle, null, 2) + '\n';
+}

--- a/os-platform/core/canon/canon-trace-seal.mjs
+++ b/os-platform/core/canon/canon-trace-seal.mjs
@@ -1,0 +1,71 @@
+/**
+ * Canon Trace Seal (Core)
+ *
+ * Tamper-evident sealing for Canon evidence bundles. The seal is a SHA-256 over
+ * the bundle's CONTENT (excluding the seal fields themselves), so any later edit
+ * to content invalidates verification. Deterministic and read-only — the caller
+ * supplies the sealedAt timestamp (no wall-clock here).
+ *
+ * Fail-loud: a bundle with a failed gate cannot be sealed — you do not seal
+ * proof over a failure.
+ *
+ * @module canon/canon-trace-seal
+ */
+
+import { createHash } from 'node:crypto';
+import { canonicalize } from './canon-evidence.mjs';
+
+/** Seal-only fields excluded from the content hash. */
+const SEAL_FIELDS = new Set(['sealed', 'sealedAt', 'traceHash']);
+
+/**
+ * Compute the content hash of a bundle (excludes seal fields). Never throws on
+ * a well-formed object.
+ * @param {Record<string, unknown>} bundle
+ * @returns {string} `sha256-<64 hex>`
+ */
+export function computeContentHash(bundle) {
+  /** @type {Record<string, unknown>} */
+  const content = {};
+  for (const k of Object.keys(bundle || {})) {
+    if (!SEAL_FIELDS.has(k)) content[k] = /** @type {Record<string, unknown>} */ (bundle)[k];
+  }
+  const hex = createHash('sha256').update(canonicalize(content)).digest('hex');
+  return `sha256-${hex}`;
+}
+
+/**
+ * Seal an evidence bundle: returns a NEW frozen bundle with sealed=true, the
+ * caller-supplied sealedAt, and a content traceHash. Refuses to seal if any gate
+ * failed.
+ * @param {Record<string, unknown>} bundle
+ * @param {string} sealedAt ISO timestamp supplied by the caller
+ * @returns {Readonly<Record<string, unknown>>}
+ */
+export function sealEvidenceBundle(bundle, sealedAt) {
+  if (!bundle || typeof bundle !== 'object') throw new Error('Trace seal: bundle must be an object');
+  if (typeof sealedAt !== 'string' || sealedAt.length === 0) {
+    throw new Error('Trace seal: sealedAt must be a non-empty ISO timestamp string');
+  }
+  const gateResults = Array.isArray(bundle.gateResults) ? bundle.gateResults : [];
+  const failed = gateResults.filter((g) => g && typeof g === 'object' && g.status === 'fail');
+  if (failed.length > 0) {
+    const ids = failed.map((g) => g.gateId || '?').join(', ');
+    throw new Error(`Trace seal: cannot seal — ${failed.length} gate(s) failed: ${ids}`);
+  }
+  const traceHash = computeContentHash(bundle);
+  return Object.freeze({ ...bundle, sealed: true, sealedAt, traceHash });
+}
+
+/**
+ * Verify a sealed bundle: true only if it claims sealed, carries a traceHash,
+ * and that hash matches the recomputed content hash. Never throws.
+ * @param {Record<string, unknown>} bundle
+ * @returns {boolean}
+ */
+export function verifyTraceSeal(bundle) {
+  if (!bundle || typeof bundle !== 'object') return false;
+  if (bundle.sealed !== true) return false;
+  if (typeof bundle.traceHash !== 'string' || bundle.traceHash.length === 0) return false;
+  return computeContentHash(bundle) === bundle.traceHash;
+}

--- a/os-platform/core/tests/canon-evidence.test.mjs
+++ b/os-platform/core/tests/canon-evidence.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * Canon evidence bundle + trace seal — self-test.
+ *
+ * The "proof" half of the doctrine: a deterministic, fail-loud evidence bundle
+ * builder plus a tamper-evident trace seal. Dep-free (node:crypto only).
+ * Run: node --test os-platform/core/tests/canon-evidence.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildEvidenceBundle,
+  canonicalize,
+  serializeEvidenceBundle,
+} from '../canon/canon-evidence.mjs';
+import { computeContentHash, sealEvidenceBundle, verifyTraceSeal } from '../canon/canon-trace-seal.mjs';
+
+/** Minimal valid bundle input. */
+function validInput(overrides = {}) {
+  return {
+    taskId: 'canon-task-demo',
+    intent: 'Prove the Canon runtime end to end.',
+    surface: 'os-canon',
+    canonRulesLoaded: ['surface.os-canon.in-shell'],
+    filesRead: ['os-platform/core/canon/canon-query.mjs'],
+    filesChanged: ['os-platform/core/canon/canon-loader.mjs'],
+    commandsRun: [{ command: 'node --test', status: 'pass' }],
+    gateResults: [
+      { gateId: 'typecheck', status: 'pass', startedAt: '2026-06-05T00:00:00Z', finishedAt: '2026-06-05T00:00:01Z' },
+    ],
+    diffHash: 'sha256-abc',
+    riskScore: 70,
+    ...overrides,
+  };
+}
+
+test('EB.1 builds a frozen, unsealed bundle from valid input', () => {
+  const b = buildEvidenceBundle(validInput());
+  assert.equal(b.sealed, false);
+  assert.equal(b.taskId, 'canon-task-demo');
+  assert.ok(Object.isFrozen(b));
+  assert.ok(Array.isArray(b.gateResults));
+});
+
+test('EB.2 missing taskId fails loudly', () => {
+  const input = validInput();
+  delete input.taskId;
+  assert.throws(() => buildEvidenceBundle(input), /taskId/i);
+});
+
+test('EB.3 non-number riskScore fails loudly', () => {
+  assert.throws(() => buildEvidenceBundle(validInput({ riskScore: 'high' })), /riskScore/i);
+});
+
+test('EB.4 gate result with invalid status fails loudly', () => {
+  const input = validInput({ gateResults: [{ gateId: 'x', status: 'maybe' }] });
+  assert.throws(() => buildEvidenceBundle(input), /status/i);
+});
+
+test('EB.5 build forces sealed=false even if input says true', () => {
+  const b = buildEvidenceBundle(validInput({ sealed: true }));
+  assert.equal(b.sealed, false);
+});
+
+test('EB.6 canonicalize is key-order independent', () => {
+  const a = canonicalize({ b: 1, a: 2, nested: { y: 1, x: 2 } });
+  const c = canonicalize({ nested: { x: 2, y: 1 }, a: 2, b: 1 });
+  assert.equal(a, c);
+});
+
+test('EB.7 computeContentHash is deterministic and content-sensitive', () => {
+  const b1 = buildEvidenceBundle(validInput());
+  const b2 = buildEvidenceBundle(validInput());
+  assert.equal(computeContentHash(b1), computeContentHash(b2));
+  const b3 = buildEvidenceBundle(validInput({ diffHash: 'sha256-different' }));
+  assert.notEqual(computeContentHash(b1), computeContentHash(b3));
+});
+
+test('EB.8 sealing sets sealed/sealedAt/traceHash and leaves original immutable', () => {
+  const b = buildEvidenceBundle(validInput());
+  const sealed = sealEvidenceBundle(b, '2026-06-05T12:00:00Z');
+  assert.equal(sealed.sealed, true);
+  assert.equal(sealed.sealedAt, '2026-06-05T12:00:00Z');
+  assert.match(sealed.traceHash, /^sha256-[0-9a-f]{64}$/);
+  assert.equal(b.sealed, false); // original untouched
+});
+
+test('EB.9 cannot seal a bundle with a failed gate', () => {
+  const b = buildEvidenceBundle(
+    validInput({ gateResults: [{ gateId: 'typecheck', status: 'fail' }] }),
+  );
+  assert.throws(() => sealEvidenceBundle(b, '2026-06-05T12:00:00Z'), /fail/i);
+});
+
+test('EB.10 verifyTraceSeal true for sealed bundle, false after tampering', () => {
+  const sealed = sealEvidenceBundle(buildEvidenceBundle(validInput()), '2026-06-05T12:00:00Z');
+  assert.equal(verifyTraceSeal(sealed), true);
+  const tampered = { ...sealed, riskScore: 5 };
+  assert.equal(verifyTraceSeal(tampered), false);
+});
+
+test('EB.11 verifyTraceSeal false for an unsealed bundle', () => {
+  assert.equal(verifyTraceSeal(buildEvidenceBundle(validInput())), false);
+});
+
+test('EB.12 serialize round-trips to the same content hash', () => {
+  const sealed = sealEvidenceBundle(buildEvidenceBundle(validInput()), '2026-06-05T12:00:00Z');
+  const reparsed = JSON.parse(serializeEvidenceBundle(sealed));
+  assert.equal(verifyTraceSeal(reparsed), true);
+});


### PR DESCRIPTION
## Summary

The **proof** half of the Canon doctrine: a deterministic, fail-loud **evidence bundle** builder plus a tamper-evident **trace seal**. Read-only — the caller supplies all values (including timestamps); no commands, no file IO, no wall-clock.

**Stacked on #894** (chain: #892 → #893 → #894 → this). Placed under `os-platform/core/canon/` to avoid the **frozen Phase 7 trace spine** (`os-platform/core/trace`).

## What changed (4 files)

- `canon-evidence.mjs` — `buildEvidenceBundle` (fail-loud), `canonicalize` (key-order-independent), `serializeEvidenceBundle`
- `canon-trace-seal.mjs` — `computeContentHash` (SHA-256 over content, excluding seal fields), `sealEvidenceBundle`, `verifyTraceSeal`
- `canon-evidence-bundle.schema.json` — adapted from the package
- `canon-evidence.test.mjs` — +12 tests

## Governance behavior

- Build is fail-loud: missing/invalid fields throw; `sealed` forced false on build.
- **Cannot seal over a failed gate** — you do not seal proof over a failure.
- **verifyTraceSeal detects any post-seal mutation** (content hash mismatch).

## End-to-end runtime proof

`query -> risk -> rules -> evidence -> seal -> verify`, tamper rejected:
```
owner: os-shell (pattern) | risk: high | gates: typecheck,launch-surface-contract
rules: surface.os-canon.in-shell, gate.launch-surface-contract.binding, surface.os-canon.module-ownership
traceHash: sha256-64263f912d34147aa446056...
verify seal: true | tamper detect: PASS (mutation rejected)
```

## Verification

- `node --test canon-evidence.test.mjs` -> 12/12
- full canon+gates+evidence sweep -> **55/55**
- launch-surface contract -> 8/8 (untouched)
- `pnpm run type-check` -> clean
- `git diff --check` -> clean

## Out of scope

No frontend, no agents, no worktrees, no enforcement wiring, no command execution. The last cadence step (agent task state machine) and `--strict` enforcement wiring remain.

## Summary by Sourcery

Introduce a deterministic, fail-loud Canon evidence bundle and tamper-evident trace sealing for runtime governance traces.

New Features:
- Add a core module to build and serialize frozen Canon evidence bundles from caller-supplied trace data.
- Add a trace seal module that computes SHA-256 content hashes, seals evidence bundles, and verifies tamper-evident seals.

Tests:
- Add a self-test suite covering evidence bundle validation, canonicalization, sealing rules, and seal verification behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced evidence bundle schema and validation system for structured data representation with required and optional fields.
  * Added canonical JSON serialization ensuring deterministic, key-order-independent output.
  * Implemented SHA-256-based bundle sealing and tamper verification to ensure integrity.

* **Tests**
  * Added comprehensive test suite validating bundle construction, validation, sealing, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->