### PR TITLE
feat(canon): add agent task state machine (ADR-005)

### DIFF
--- a/os-platform/core/canon/canon-task.mjs
+++ b/os-platform/core/canon/canon-task.mjs
@@ -1,0 +1,180 @@
+/**
+ * Canon Agent Task State Machine (Core)
+ *
+ * ADR-005: every agent task is an explicit state machine, Draft -> ... ->
+ * TraceSealed/Closed. This module is the FAIL-LOUD, read-only governor of that
+ * lifecycle: it validates transitions, enforces governance guards (approval
+ * before execution; gates must pass before review), and records an append-only
+ * audit history. It performs NO execution, runs NO commands, and touches NO
+ * files — the caller supplies actor + timestamps (no wall-clock here).
+ *
+ * @module canon/canon-task
+ * @see os-platform/core/canon/canon-task.schema.json
+ */
+
+/** Canonical lifecycle order. `Failed` is the off-path terminal. */
+export const STATES = Object.freeze([
+  'Draft',
+  'CanonContextLoaded',
+  'ScopeProposed',
+  'PlanProposed',
+  'RiskScored',
+  'AwaitingApproval',
+  'WorktreeCreated',
+  'Executing',
+  'DiffReady',
+  'GatesRunning',
+  'ReviewRequired',
+  'CommitReady',
+  'TraceSealed',
+  'PRReady',
+  'Closed',
+  'Failed',
+]);
+
+export const INITIAL_STATE = 'Draft';
+const STATE_SET = new Set(STATES);
+const TERMINAL_STATES = new Set(['Closed', 'Failed']);
+const SURFACES = new Set(['os-canon', 'canon-desktop', 'cli', 'ci']);
+const RISKS = new Set(['low', 'medium', 'high', 'critical']);
+
+/** Happy-path successor for each state (linear spine). */
+const NEXT = Object.freeze({
+  Draft: 'CanonContextLoaded',
+  CanonContextLoaded: 'ScopeProposed',
+  ScopeProposed: 'PlanProposed',
+  PlanProposed: 'RiskScored',
+  RiskScored: 'AwaitingApproval',
+  AwaitingApproval: 'WorktreeCreated',
+  WorktreeCreated: 'Executing',
+  Executing: 'DiffReady',
+  DiffReady: 'GatesRunning',
+  GatesRunning: 'ReviewRequired',
+  ReviewRequired: 'CommitReady',
+  CommitReady: 'TraceSealed',
+  TraceSealed: 'PRReady',
+  PRReady: 'Closed',
+});
+
+/** Transitions that require a governance guard in the transition opts. */
+const GUARDS = Object.freeze({
+  // from -> { to, opt, message }
+  'AwaitingApproval->WorktreeCreated': {
+    opt: 'approved',
+    message: 'cannot enter WorktreeCreated: approval (opts.approved=true) is required',
+  },
+  'GatesRunning->ReviewRequired': {
+    opt: 'gatesPassed',
+    message: 'cannot enter ReviewRequired: gates must pass (opts.gatesPassed=true)',
+  },
+});
+
+/** @param {unknown} v @returns {v is Record<string, unknown>} */
+function isObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** @param {unknown} v @param {string} where @returns {string} */
+function requireNonEmptyString(v, where) {
+  if (typeof v !== 'string' || v.length === 0) throw new Error(`Canon task: ${where} must be a non-empty string`);
+  return v;
+}
+
+/** @param {unknown} v @param {string} where @returns {string[]} */
+function requireStringArray(v, where) {
+  if (!Array.isArray(v) || v.some((x) => typeof x !== 'string')) {
+    throw new Error(`Canon task: ${where} must be an array of strings`);
+  }
+  return /** @type {string[]} */ (v);
+}
+
+/** @param {string} state @returns {boolean} */
+export function isTerminal(state) {
+  return TERMINAL_STATES.has(state);
+}
+
+/**
+ * Structural legality of a transition (ignores guards). Every non-terminal
+ * state may advance to its linear successor or to `Failed`.
+ * @param {string} from
+ * @param {string} to
+ * @returns {boolean}
+ */
+export function canTransition(from, to) {
+  if (!STATE_SET.has(from) || !STATE_SET.has(to)) return false;
+  if (TERMINAL_STATES.has(from)) return false;
+  if (to === 'Failed') return true;
+  return NEXT[from] === to;
+}
+
+/**
+ * Create a new task in Draft with a creation history entry. Fail-loud.
+ * @param {Record<string, unknown>} input
+ * @returns {Readonly<Record<string, unknown>>}
+ */
+export function createTask(input) {
+  if (!isObject(input)) throw new Error('Canon task: input must be an object');
+  const taskId = requireNonEmptyString(input.taskId, 'taskId');
+  const intent = requireNonEmptyString(input.intent, 'intent');
+  const surface = requireNonEmptyString(input.surface, 'surface');
+  if (!SURFACES.has(surface)) throw new Error(`Canon task: surface must be one of ${[...SURFACES].join(', ')}`);
+  const risk = requireNonEmptyString(input.risk, 'risk');
+  if (!RISKS.has(risk)) throw new Error(`Canon task: risk must be one of ${[...RISKS].join(', ')}`);
+  if (!isObject(input.scope)) throw new Error('Canon task: scope must be an object');
+  const allowedPaths = requireStringArray(input.scope.allowedPaths, 'scope.allowedPaths');
+  const forbiddenPaths = requireStringArray(input.scope.forbiddenPaths, 'scope.forbiddenPaths');
+  const actor = requireNonEmptyString(input.actor, 'actor');
+  const at = requireNonEmptyString(input.at, 'at');
+  const requiredGates =
+    input.requiredGates === undefined ? [] : requireStringArray(input.requiredGates, 'requiredGates');
+
+  return Object.freeze({
+    taskId,
+    intent,
+    surface,
+    state: INITIAL_STATE,
+    risk,
+    scope: Object.freeze({ allowedPaths: Object.freeze(allowedPaths), forbiddenPaths: Object.freeze(forbiddenPaths) }),
+    requiredGates: Object.freeze(requiredGates),
+    approvals: Object.freeze([]),
+    history: Object.freeze([Object.freeze({ from: null, to: INITIAL_STATE, actor, at, reason: 'created' })]),
+  });
+}
+
+/**
+ * Transition a task to a new state. Fail-loud on illegal transitions, terminal
+ * sources, missing actor/at, or unmet governance guards. Returns a NEW frozen
+ * task with the history entry appended; the input is never mutated.
+ * @param {Record<string, unknown>} task
+ * @param {string} to
+ * @param {{ actor?: string, at?: string, reason?: string, approved?: boolean, gatesPassed?: boolean }} [opts]
+ * @returns {Readonly<Record<string, unknown>>}
+ */
+export function transition(task, to, opts) {
+  if (!isObject(task)) throw new Error('Canon task: task must be an object');
+  const from = /** @type {string} */ (task.state);
+  if (!STATE_SET.has(to)) throw new Error(`Canon task: unknown target state "${to}"`);
+  if (TERMINAL_STATES.has(from)) throw new Error(`Canon task: ${from} is terminal — no transitions allowed`);
+  if (!canTransition(from, to)) throw new Error(`Canon task: invalid transition ${from} -> ${to}`);
+
+  const o = opts || {};
+  const actor = requireNonEmptyString(o.actor, 'transition actor');
+  const at = requireNonEmptyString(o.at, 'transition at');
+
+  const guard = GUARDS[`${from}->${to}`];
+  if (guard && o[guard.opt] !== true) throw new Error(`Canon task: ${guard.message}`);
+
+  const entry = Object.freeze({
+    from,
+    to,
+    actor,
+    at,
+    reason: typeof o.reason === 'string' ? o.reason : '',
+  });
+
+  return Object.freeze({
+    ...task,
+    state: to,
+    history: Object.freeze([.../** @type {ReadonlyArray<object>} */ (task.history), entry]),
+  });
+}

--- a/os-platform/core/canon/canon-task.schema.json
+++ b/os-platform/core/canon/canon-task.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://terrafusion.local/schemas/canon-task.schema.json",
+  "title": "CanonTask",
+  "description": "A governed agent task as an explicit state machine (ADR-005: Draft -> ... -> TraceSealed). Adapted from the Canon/IDE package into the repo-native os-platform/core/canon runtime. Read-only state-machine; no execution.",
+  "type": "object",
+  "required": [
+    "taskId",
+    "intent",
+    "surface",
+    "state",
+    "risk",
+    "scope",
+    "history"
+  ],
+  "properties": {
+    "taskId": { "type": "string" },
+    "intent": { "type": "string" },
+    "surface": { "enum": ["os-canon", "canon-desktop", "cli", "ci"] },
+    "state": {
+      "enum": [
+        "Draft",
+        "CanonContextLoaded",
+        "ScopeProposed",
+        "PlanProposed",
+        "RiskScored",
+        "AwaitingApproval",
+        "WorktreeCreated",
+        "Executing",
+        "DiffReady",
+        "GatesRunning",
+        "ReviewRequired",
+        "CommitReady",
+        "TraceSealed",
+        "PRReady",
+        "Closed",
+        "Failed"
+      ]
+    },
+    "risk": { "enum": ["low", "medium", "high", "critical"] },
+    "scope": {
+      "type": "object",
+      "required": ["allowedPaths", "forbiddenPaths"],
+      "properties": {
+        "allowedPaths": { "type": "array", "items": { "type": "string" } },
+        "forbiddenPaths": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "requiredGates": { "type": "array", "items": { "type": "string" } },
+    "approvals": { "type": "array", "items": { "type": "object" } },
+    "history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["to", "actor", "at"],
+        "properties": {
+          "from": { "type": ["string", "null"] },
+          "to": { "type": "string" },
+          "actor": { "type": "string" },
+          "at": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/os-platform/core/tests/canon-task.test.mjs
+++ b/os-platform/core/tests/canon-task.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Canon agent task state machine — self-test.
+ *
+ * ADR-005: every agent task is an explicit Draft -> ... -> TraceSealed/Closed
+ * state machine. Invalid transitions and governance-guard violations are hard
+ * errors. Deterministic, read-only (caller supplies actor + timestamps).
+ * Run: node --test os-platform/core/tests/canon-task.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createTask,
+  transition,
+  canTransition,
+  isTerminal,
+  STATES,
+  INITIAL_STATE,
+} from '../canon/canon-task.mjs';
+
+function newTask(overrides = {}) {
+  return createTask({
+    taskId: 'canon-task-1',
+    intent: 'fix os-canon shell launch drift',
+    surface: 'os-canon',
+    risk: 'high',
+    scope: { allowedPaths: ['frontend/apps/os-shell/src/**'], forbiddenPaths: ['ARCHIVE/**'] },
+    actor: 'agent:planner',
+    at: '2026-06-06T00:00:00Z',
+    ...overrides,
+  });
+}
+
+const step = (t, to, opts = {}) => transition(t, to, { actor: 'agent:x', at: '2026-06-06T00:00:01Z', ...opts });
+
+test('TS.1 createTask starts in Draft with a creation history entry', () => {
+  const t = newTask();
+  assert.equal(t.state, INITIAL_STATE);
+  assert.equal(t.state, 'Draft');
+  assert.equal(t.history.length, 1);
+  assert.equal(t.history[0].from, null);
+  assert.equal(t.history[0].to, 'Draft');
+  assert.ok(Object.isFrozen(t));
+});
+
+test('TS.2 createTask with invalid surface fails loudly', () => {
+  assert.throws(() => newTask({ surface: 'mainframe' }), /surface/i);
+});
+
+test('TS.3 createTask missing scope.allowedPaths fails loudly', () => {
+  assert.throws(() => newTask({ scope: { forbiddenPaths: [] } }), /allowedPaths/i);
+});
+
+test('TS.4 valid transition advances state and appends immutable history', () => {
+  const t = newTask();
+  const t2 = step(t, 'CanonContextLoaded');
+  assert.equal(t2.state, 'CanonContextLoaded');
+  assert.equal(t2.history.length, 2);
+  assert.equal(t.state, 'Draft'); // original untouched
+  assert.ok(Object.isFrozen(t2));
+});
+
+test('TS.5 invalid (skipping) transition fails loudly', () => {
+  assert.throws(() => step(newTask(), 'Executing'), /invalid transition/i);
+});
+
+test('TS.6 cannot transition out of a terminal state', () => {
+  const failed = step(newTask(), 'Failed');
+  assert.equal(isTerminal('Failed'), true);
+  assert.throws(() => step(failed, 'CanonContextLoaded'), /terminal/i);
+});
+
+test('TS.7 AwaitingApproval -> WorktreeCreated requires approved=true', () => {
+  let t = newTask();
+  for (const s of ['CanonContextLoaded', 'ScopeProposed', 'PlanProposed', 'RiskScored', 'AwaitingApproval']) t = step(t, s);
+  assert.throws(() => step(t, 'WorktreeCreated'), /approv/i);
+  assert.doesNotThrow(() => step(t, 'WorktreeCreated', { approved: true }));
+});
+
+test('TS.8 AwaitingApproval -> Failed (rejection) is allowed', () => {
+  let t = newTask();
+  for (const s of ['CanonContextLoaded', 'ScopeProposed', 'PlanProposed', 'RiskScored', 'AwaitingApproval']) t = step(t, s);
+  assert.doesNotThrow(() => step(t, 'Failed', { reason: 'approval denied' }));
+});
+
+test('TS.9 GatesRunning -> ReviewRequired requires gatesPassed=true', () => {
+  let t = newTask();
+  for (const s of [
+    'CanonContextLoaded', 'ScopeProposed', 'PlanProposed', 'RiskScored', 'AwaitingApproval',
+  ]) t = step(t, s);
+  t = step(t, 'WorktreeCreated', { approved: true });
+  for (const s of ['Executing', 'DiffReady', 'GatesRunning']) t = step(t, s);
+  assert.throws(() => step(t, 'ReviewRequired'), /gate/i);
+  assert.doesNotThrow(() => step(t, 'ReviewRequired', { gatesPassed: true }));
+});
+
+test('TS.10 GatesRunning -> Failed (gate failure) is allowed', () => {
+  let t = newTask();
+  for (const s of ['CanonContextLoaded', 'ScopeProposed', 'PlanProposed', 'RiskScored', 'AwaitingApproval']) t = step(t, s);
+  t = step(t, 'WorktreeCreated', { approved: true });
+  for (const s of ['Executing', 'DiffReady', 'GatesRunning']) t = step(t, s);
+  assert.doesNotThrow(() => step(t, 'Failed', { reason: 'typecheck failed' }));
+});
+
+test('TS.11 transition requires actor and at (fail-loud)', () => {
+  const t = newTask();
+  assert.throws(() => transition(t, 'CanonContextLoaded', { at: '2026-06-06T00:00:01Z' }), /actor/i);
+  assert.throws(() => transition(t, 'CanonContextLoaded', { actor: 'a' }), /at/i);
+});
+
+test('TS.12 full happy path Draft -> Closed walks every state', () => {
+  let t = newTask();
+  const path = [
+    'CanonContextLoaded', 'ScopeProposed', 'PlanProposed', 'RiskScored', 'AwaitingApproval',
+  ];
+  for (const s of path) t = step(t, s);
+  t = step(t, 'WorktreeCreated', { approved: true });
+  for (const s of ['Executing', 'DiffReady', 'GatesRunning']) t = step(t, s);
+  t = step(t, 'ReviewRequired', { gatesPassed: true });
+  for (const s of ['CommitReady', 'TraceSealed', 'PRReady', 'Closed']) t = step(t, s);
+  assert.equal(t.state, 'Closed');
+  assert.equal(isTerminal('Closed'), true);
+  // Happy path visits 15 states (all except the off-path terminal 'Failed'):
+  // 1 creation entry (Draft) + 14 transitions.
+  assert.equal(t.history.length, 15);
+  assert.equal(STATES.length, 16); // includes off-path terminal 'Failed'
+});
+
+test('TS.13 canTransition reflects structural legality', () => {
+  assert.equal(canTransition('Draft', 'CanonContextLoaded'), true);
+  assert.equal(canTransition('Draft', 'Failed'), true);
+  assert.equal(canTransition('Draft', 'Closed'), false);
+  assert.equal(canTransition('Closed', 'Failed'), false);
+});


### PR DESCRIPTION
## Summary

Final read-only cadence slice: every agent task is an explicit **state machine** (ADR-005) — `Draft → … → TraceSealed → PRReady → Closed`, plus `Failed`. Fail-loud, append-only audit history, **no execution / no commands / no file IO** (caller supplies actor + timestamps).

## What changed (3 files, read-only)

- `os-platform/core/canon/canon-task.mjs` — `createTask`, `transition`, `canTransition`, `isTerminal`, `STATES`
- `os-platform/core/canon/canon-task.schema.json` — 16-state lifecycle + history (adapted from the package)
- `os-platform/core/tests/canon-task.test.mjs` — +13 tests

## Governance guards (fail-loud)

- Approval required before `WorktreeCreated` (`opts.approved=true`).
- Gates must pass before `ReviewRequired` (`opts.gatesPassed=true`).
- No transitions out of terminal states; illegal/skip transitions throw.

## End-to-end proof

`lifecycle (Draft→Closed, 15 history entries) → buildEvidenceBundle → sealEvidenceBundle → verifyTraceSeal = true`.

## Verification

- `node --test canon-task.test.mjs` → 13/13
- full Canon sweep (query/risk/loader/gates/evidence/task/launch-surface) → **76/76**
- `pnpm run type-check` → clean
- `git diff --check` → clean

## Cadence status

Completes the read-only Canon runtime: **queryable → fail-loud → report → proof → task-lifecycle**. Remaining: flip advisory gates to `--strict` in pre-commit/CI (the **enforce** step).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced task lifecycle management with defined workflow states and validation
  * Added immutable task history tracking for audit and state transitions

* **Tests**
  * Added comprehensive test suite for task state management and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->