### PR TITLE
[codex] County Studio Forge dev dependency reclassification

### DIFF
--- a/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
@@ -62,9 +62,18 @@ export const REQUIRED_READINESS_CHECKS = [
   "property landing count",
   "WPOV status",
   "WSDOR status",
+  "owner-supnum backfill dependency classification",
   "map data dependency status",
   "ledger data dependency status",
   "inspector data dependency status"
+];
+
+export const OWNER_SUPNUM_DEPENDENCY_CLASSIFICATIONS = [
+  "REQUIRED_FOR_FORGE_DEV",
+  "NOT_REQUIRED_FOR_FORGE_DEV",
+  "REQUIRED_FOR_PACKET_PROOF",
+  "REQUIRED_FOR_OPERATIONAL_PROOF",
+  "UNKNOWN"
 ];
 
 const REAL_DEV_ALLOWED_CLASSIFICATIONS = new Set([
@@ -92,6 +101,11 @@ function asNumber(value) {
 function normalizeClassification(value, fallback = "UNKNOWN") {
   const normalized = String(value ?? fallback).trim().toUpperCase();
   return DEV_READINESS_CLASSIFICATIONS.includes(normalized) ? normalized : fallback;
+}
+
+function normalizeOwnerSupnumDependencyClassification(value, fallback = "UNKNOWN") {
+  const normalized = String(value ?? fallback).trim().toUpperCase();
+  return OWNER_SUPNUM_DEPENDENCY_CLASSIFICATIONS.includes(normalized) ? normalized : fallback;
 }
 
 function healthOk(backendHealth) {
@@ -181,14 +195,78 @@ function makeCheck(name, classification, passed, reason, evidence = {}) {
   };
 }
 
+function isOwnerSupnumBackfillStage(stage) {
+  return String(stage ?? "").trim().toLowerCase().startsWith("owner-supnum");
+}
+
+function isFailed(status) {
+  return String(status ?? "").trim().toUpperCase() === "FAILED";
+}
+
+function buildOwnerSupnumDependency(evidence) {
+  const source = evidence?.countyStudioDependencies?.ownerSupnumBackfill ?? {};
+  const stage = source.stage ?? evidence?.loadBatch?.stage ?? "UNKNOWN";
+  const status = source.status ?? evidence?.loadBatch?.status ?? "UNKNOWN";
+  const consumedByForge = source.ownerIdentityConsumedByForgeSurfaces === true;
+  const requiredForForgeDev = source.requiredForCountyStudioForgeDev === true || consumedByForge;
+  const classification = normalizeOwnerSupnumDependencyClassification(
+    source.classification,
+    requiredForForgeDev
+      ? "REQUIRED_FOR_FORGE_DEV"
+      : isOwnerSupnumBackfillStage(stage)
+        ? "NOT_REQUIRED_FOR_FORGE_DEV"
+        : "UNKNOWN"
+  );
+
+  return {
+    stage,
+    status,
+    classification,
+    requiredForCountyStudioForgeDev: classification === "REQUIRED_FOR_FORGE_DEV" || requiredForForgeDev,
+    requiredForPacketProof: source.requiredForPacketProof !== false,
+    requiredForOperationalProof: source.requiredForOperationalProof !== false,
+    ownerIdentityConsumedByForgeSurfaces: consumedByForge,
+    consumedSurfaces: Array.isArray(source.consumedSurfaces) ? source.consumedSurfaces : [],
+    latestFailed: source.latestFailed ?? null,
+    audit: source.audit ?? {
+      forgeValuationSurfaces: [
+        "parcel/property identity",
+        "property characteristics",
+        "valuation metrics",
+        "ratio-study context",
+        "risk objects",
+        "geometry/map context",
+        "countyId",
+        "taxYear",
+        "studyId"
+      ],
+      packetOperationalSurfaces: [
+        "owner truth",
+        "notice recipient identity",
+        "appeal taxpayer identity",
+        "Dossier packet owner identity",
+        "operational ledger owner references"
+      ]
+    }
+  };
+}
+
 function buildChecks(evidence) {
   const counts = countRows(evidence);
   const countClass = classifyCounts(counts);
   const backendHealthy = healthOk(evidence?.backendHealth);
   const loadBatchStatus = String(evidence?.loadBatch?.status ?? "UNKNOWN").toUpperCase();
+  const ownerSupnumDependency = buildOwnerSupnumDependency(evidence);
+  const ownerSupnumFailedButNotForgeDevRequired =
+    isOwnerSupnumBackfillStage(ownerSupnumDependency.stage)
+    && isFailed(ownerSupnumDependency.status)
+    && ownerSupnumDependency.requiredForCountyStudioForgeDev !== true;
   const drainAlive = evidence?.activeDrain?.alive === true;
   const drainKnownDead = evidence?.activeDrain?.alive === false;
-  const dbBackedDrainStateKnown = loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED";
+  const dbBackedDrainStateKnown =
+    loadBatchStatus === "IN_PROGRESS"
+    || loadBatchStatus === "COMPLETED"
+    || ownerSupnumFailedButNotForgeDevRequired;
   const mapClassification = normalizeClassification(evidence?.countyStudioDependencies?.map);
   const ledgerClassification = normalizeClassification(evidence?.countyStudioDependencies?.ledger);
   const inspectorClassification = normalizeClassification(evidence?.countyStudioDependencies?.inspector);
@@ -208,7 +286,9 @@ function buildChecks(evidence) {
       drainAlive
         ? `Drain process ${evidence.activeDrain?.pid ?? "unknown"} is still alive.`
         : dbBackedDrainStateKnown
-          ? `Client drain process is not alive, but DB load_batch proves server-side state ${loadBatchStatus}.`
+          ? ownerSupnumFailedButNotForgeDevRequired
+            ? "Client drain process is not alive/known, but the failed owner-supnum stage is not required for County Studio Forge valuation dev."
+            : `Client drain process is not alive, but DB load_batch proves server-side state ${loadBatchStatus}.`
         : drainKnownDead
           ? "Drain process is not alive; confirm whether client timeout or backend failure occurred."
           : "Drain process state is unknown.",
@@ -216,10 +296,12 @@ function buildChecks(evidence) {
     ),
     makeCheck(
       "load_batch current stage",
-      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" ? "SYNC_DERIVED" : "UNKNOWN",
-      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED",
+      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired ? "SYNC_DERIVED" : "UNKNOWN",
+      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired,
       evidence?.loadBatch?.stage
-        ? `load_batch stage is ${evidence.loadBatch.stage} (${loadBatchStatus}).`
+        ? ownerSupnumFailedButNotForgeDevRequired
+          ? "load_batch stage is owner-supnum-backfill (FAILED), retained as packet/ops blocker but not a County Studio Forge dev blocker."
+          : `load_batch stage is ${evidence.loadBatch.stage} (${loadBatchStatus}).`
         : "load_batch stage is not proven.",
       evidence?.loadBatch ?? {}
     ),
@@ -285,6 +367,15 @@ function buildChecks(evidence) {
       counts.truthWsdor > 0,
       counts.truthWsdor > 0 ? "WSDOR truth rows exist." : "WSDOR truth status is missing.",
       { truthWsdor: counts.truthWsdor }
+    ),
+    makeCheck(
+      "owner-supnum backfill dependency classification",
+      ownerSupnumDependency.requiredForCountyStudioForgeDev ? "UNKNOWN" : "PARTIAL_SEEDED",
+      ownerSupnumDependency.requiredForCountyStudioForgeDev !== true || !isFailed(ownerSupnumDependency.status),
+      ownerSupnumDependency.requiredForCountyStudioForgeDev
+        ? "owner-supnum backfill is required for a consumed County Studio Forge owner-identity surface."
+        : "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
+      ownerSupnumDependency
     ),
     makeCheck(
       "map data dependency status",
@@ -369,6 +460,9 @@ export function buildBentonRealDevServerReadinessReport({
   const checks = buildChecks(evidence ?? {});
   const blockers = checks.map(blockerFor).filter(Boolean);
   const maturity = buildMaturity(checks);
+  const forgeDevDependency = {
+    ownerSupnumBackfill: buildOwnerSupnumDependency(evidence ?? {})
+  };
   const realDevServerAllowed = maturity.REAL_DEV_DATA_AVAILABLE && blockers.length === 0;
   const status = realDevServerAllowed ? "REAL_DEV_DATA_AVAILABLE" : "REAL_DEV_SERVER_BLOCKED";
 
@@ -385,6 +479,7 @@ export function buildBentonRealDevServerReadinessReport({
     maturity,
     requiredChecks: REQUIRED_READINESS_CHECKS,
     checks,
+    forgeDevDependency,
     blockers,
     classifications: DEV_READINESS_CLASSIFICATIONS,
     rules: [
@@ -392,6 +487,7 @@ export function buildBentonRealDevServerReadinessReport({
       "Backend death is data failure.",
       "Stage stagnation without inserts is investigation.",
       "Partial landing is usable for dev evidence, not production proof.",
+      "Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.",
       "Do not relabel partial seed as authoritative."
     ],
     boundaries: [
@@ -431,6 +527,20 @@ export function renderBentonRealDevServerReadinessMarkdown(report) {
       `| ${check.name} | ${check.classification} | ${check.passed} | ${String(check.reason).replaceAll("\n", " ")} |`
     );
   });
+
+  lines.push(
+    "",
+    "## Forge Dev Dependency Reclassification",
+    "",
+    `- ownerSupnumBackfillStatus: ${report.forgeDevDependency.ownerSupnumBackfill.status}`,
+    `- ownerSupnumBackfillStage: ${report.forgeDevDependency.ownerSupnumBackfill.stage}`,
+    `- ownerSupnumBackfillLatestFailedStage: ${report.forgeDevDependency.ownerSupnumBackfill.latestFailed?.stage ?? "none"}`,
+    `- ownerSupnumBackfillLatestFailedStatus: ${report.forgeDevDependency.ownerSupnumBackfill.latestFailed?.status ?? "none"}`,
+    `- ownerSupnumBackfillClassification: ${report.forgeDevDependency.ownerSupnumBackfill.classification}`,
+    `- ownerSupnumBackfillRequiredForForgeDev: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev}`,
+    `- ownerSupnumBackfillRequiredForPacketProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForPacketProof}`,
+    `- ownerSupnumBackfillRequiredForOperationalProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForOperationalProof}`
+  );
 
   lines.push("", "## Blockers", "");
   if (report.blockers.length === 0) {

--- a/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 
 import {
   DEV_READINESS_CLASSIFICATIONS,
+  OWNER_SUPNUM_DEPENDENCY_CLASSIFICATIONS,
   REQUIRED_READINESS_CHECKS,
   buildBentonRealDevServerReadinessReport
 } from "./benton-real-dev-server-readiness.mjs";
@@ -59,6 +60,14 @@ test("defines the staged real-dev readiness classifications and checks", () => {
     "UNKNOWN"
   ]);
 
+  assert.deepEqual(OWNER_SUPNUM_DEPENDENCY_CLASSIFICATIONS, [
+    "REQUIRED_FOR_FORGE_DEV",
+    "NOT_REQUIRED_FOR_FORGE_DEV",
+    "REQUIRED_FOR_PACKET_PROOF",
+    "REQUIRED_FOR_OPERATIONAL_PROOF",
+    "UNKNOWN"
+  ]);
+
   assert.deepEqual(REQUIRED_READINESS_CHECKS, [
     "backend health",
     "active drain process state",
@@ -72,6 +81,7 @@ test("defines the staged real-dev readiness classifications and checks", () => {
     "property landing count",
     "WPOV status",
     "WSDOR status",
+    "owner-supnum backfill dependency classification",
     "map data dependency status",
     "ledger data dependency status",
     "inspector data dependency status"
@@ -139,6 +149,98 @@ test("does not block real dev readiness solely because the client drain PID is g
   assert.equal(report.decisions.realDevServerAllowed, true);
   assert.equal(report.decisions.productionProofAllowed, false);
   assert.equal(report.decisions.operationalProofAllowed, false);
+});
+
+test("does not block Forge dev when owner-supnum backfill failed but owner identity is not consumed", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.activeDrain = { pid: null, alive: null, status: "UNKNOWN" };
+  evidence.loadBatch = {
+    stage: "owner-supnum-backfill",
+    status: "FAILED",
+    loadBatchId: "batch-owner-supnum-failed"
+  };
+  evidence.countyStudioDependencies.ownerSupnumBackfill = {
+    status: "FAILED",
+    classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: false,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    ownerIdentityConsumedByForgeSurfaces: false
+  };
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.status, "REAL_DEV_DATA_AVAILABLE");
+  assert.equal(report.decisions.realDevServerAllowed, true);
+  assert.equal(report.decisions.productionProofAllowed, false);
+  assert.equal(report.decisions.operationalProofAllowed, false);
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.status, "FAILED");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev, false);
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForPacketProof, true);
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForOperationalProof, true);
+  assert.equal(report.blockers.some((blocker) => /owner-supnum|load_batch|drain process/i.test(blocker)), false);
+});
+
+test("does not block Forge dev when owner-supnum resume failed but owner identity is not consumed", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.activeDrain = { pid: null, alive: null, status: "UNKNOWN" };
+  evidence.loadBatch = {
+    stage: "owner-supnum-resume",
+    status: "FAILED",
+    loadBatchId: "batch-owner-supnum-resume-failed"
+  };
+  evidence.countyStudioDependencies.ownerSupnumBackfill = {
+    status: "FAILED",
+    stage: "owner-supnum-resume",
+    classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: false,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    ownerIdentityConsumedByForgeSurfaces: false
+  };
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.status, "REAL_DEV_DATA_AVAILABLE");
+  assert.equal(report.decisions.realDevServerAllowed, true);
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.status, "FAILED");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev, false);
+  assert.equal(report.blockers.some((blocker) => /owner-supnum|load_batch|drain process/i.test(blocker)), false);
+});
+
+test("blocks Forge dev when owner-supnum backfill is required by a consumed owner identity surface", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.activeDrain = { pid: null, alive: null, status: "UNKNOWN" };
+  evidence.loadBatch = {
+    stage: "owner-supnum-backfill",
+    status: "FAILED",
+    loadBatchId: "batch-owner-supnum-failed"
+  };
+  evidence.countyStudioDependencies.ownerSupnumBackfill = {
+    status: "FAILED",
+    classification: "REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: true,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    ownerIdentityConsumedByForgeSurfaces: true,
+    consumedSurfaces: ["parcel owner inspector"]
+  };
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.status, "REAL_DEV_SERVER_BLOCKED");
+  assert.equal(report.decisions.realDevServerAllowed, false);
+  assert.ok(report.blockers.some((blocker) => /owner-supnum/i.test(blocker)));
 });
 
 test("CLI writes readiness evidence and exits zero for conditional real dev state", () => {

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
@@ -51,6 +51,18 @@ ORDER BY "StartedAt" DESC
 LIMIT 1;
 `;
 
+export const LATEST_OWNER_SUPNUM_FAILURE_QUERY = `
+SELECT
+  "LoadBatchId"::text AS load_batch_id,
+  COALESCE("Operator"::text, 'UNKNOWN') AS stage,
+  COALESCE("Status"::text, 'UNKNOWN') AS status
+FROM sync_bridge.load_batch
+WHERE "Operator" ILIKE 'owner-supnum%'
+  AND "Status" = 'FAILED'
+ORDER BY "StartedAt" DESC
+LIMIT 1;
+`;
+
 function rel(filePath) {
   return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
 }
@@ -150,7 +162,7 @@ function psqlOutputToValue(name, result) {
       reason: String(result.stderr || result.stdout || `psql exited ${result.status}`).trim()
     };
   }
-  if (name === "latestLoadBatch") return parseLoadBatch(result.stdout);
+  if (name === "latestLoadBatch" || name === "latestOwnerSupnumFailure") return parseLoadBatch(result.stdout);
   return parseScalar(result.stdout);
 }
 
@@ -272,6 +284,42 @@ function dependencyClassification({ geometryCount, canonicalParcel, truthParcel 
   return "UNKNOWN";
 }
 
+function ownerSupnumBackfillDependency(loadBatch, latestFailed = null) {
+  return {
+    stage: loadBatch?.stage ?? "UNKNOWN",
+    status: loadBatch?.status ?? "UNKNOWN",
+    latestFailed: latestFailed && !latestFailed.unavailable
+      ? {
+        loadBatchId: latestFailed.loadBatchId ?? null,
+        stage: latestFailed.stage ?? "UNKNOWN",
+        status: latestFailed.status ?? "UNKNOWN"
+      }
+      : null,
+    classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: false,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    ownerIdentityConsumedByForgeSurfaces: false,
+    consumedSurfaces: [],
+    audit: {
+      finding: "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+      forgeValuationSources: [
+        "parcel/property identity",
+        "property characteristics",
+        "valuation metrics",
+        "ratio-study context",
+        "risk objects",
+        "geometry/map context"
+      ],
+      packetOpsSources: [
+        "Dossier packet owner identity",
+        "Dais/notice/appeal taxpayer identity",
+        "operational packet owner references"
+      ]
+    }
+  };
+}
+
 function decisionFor(evidence) {
   const requiredReadable = [
     evidence.queryResults.legacyProperty,
@@ -308,7 +356,8 @@ export async function buildBentonSyncDrainStateEvidence({
   const backendHealth = await backendProbe();
   const activeDrainAlive = aliveProbe(drainPid);
   const queryResults = {
-    latestLoadBatch: await query("latestLoadBatch", LATEST_LOAD_BATCH_QUERY)
+    latestLoadBatch: await query("latestLoadBatch", LATEST_LOAD_BATCH_QUERY),
+    latestOwnerSupnumFailure: await query("latestOwnerSupnumFailure", LATEST_OWNER_SUPNUM_FAILURE_QUERY)
   };
 
   for (const [name, sql] of Object.entries(DB_COUNT_QUERIES)) {
@@ -381,7 +430,11 @@ export async function buildBentonSyncDrainStateEvidence({
         truthParcel: queryResults.truthParcel
       }),
       ledger: countValue(queryResults.truthParcel) > 0 || countValue(queryResults.canonicalParcel) > 0 ? "SYNC_DERIVED" : "UNKNOWN",
-      inspector: countValue(queryResults.truthParcel) > 0 || countValue(queryResults.canonicalParcel) > 0 ? "SYNC_DERIVED" : "UNKNOWN"
+      inspector: countValue(queryResults.truthParcel) > 0 || countValue(queryResults.canonicalParcel) > 0 ? "SYNC_DERIVED" : "UNKNOWN",
+      ownerSupnumBackfill: ownerSupnumBackfillDependency(
+        queryResults.latestLoadBatch,
+        queryResults.latestOwnerSupnumFailure
+      )
     },
     decisions: {
       realDevEvidenceReadable: false,
@@ -458,6 +511,12 @@ function renderMarkdown(evidence) {
     `- Map: ${evidence.countyStudioDependencies.map}`,
     `- Ledger: ${evidence.countyStudioDependencies.ledger}`,
     `- Inspector: ${evidence.countyStudioDependencies.inspector}`,
+    `- Owner-supnum backfill status: ${evidence.countyStudioDependencies.ownerSupnumBackfill.status}`,
+    `- Owner-supnum latest failed stage: ${evidence.countyStudioDependencies.ownerSupnumBackfill.latestFailed?.stage ?? "none"}`,
+    `- Owner-supnum latest failed status: ${evidence.countyStudioDependencies.ownerSupnumBackfill.latestFailed?.status ?? "none"}`,
+    `- Owner-supnum required for Forge dev: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForCountyStudioForgeDev}`,
+    `- Owner-supnum required for packet proof: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForPacketProof}`,
+    `- Owner-supnum required for operational proof: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForOperationalProof}`,
     "",
     "## Rules",
     "",

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
@@ -10,6 +10,7 @@ import { spawnSync } from "node:child_process";
 import {
   DB_COUNT_QUERIES,
   LATEST_LOAD_BATCH_QUERY,
+  LATEST_OWNER_SUPNUM_FAILURE_QUERY,
   buildBentonSyncDrainStateEvidence,
   evidenceToReadinessSource,
   makeRuntimeDbQueryRunner
@@ -40,6 +41,11 @@ test("classifies populated Sync/DB evidence as partial real seed without product
       load_batch_id: "batch-1",
       stage: "Supp-S1",
       status: "IN_PROGRESS"
+    },
+    latestOwnerSupnumFailure: {
+      loadBatchId: "batch-owner-failed",
+      stage: "owner-supnum-backfill",
+      status: "FAILED"
     },
     legacyProperty: 80075,
     legacyOwner: 805000,
@@ -72,6 +78,9 @@ test("classifies populated Sync/DB evidence as partial real seed without product
   assert.equal(evidence.countyStudioDependencies.map, "PARTIAL_SEEDED");
   assert.equal(evidence.countyStudioDependencies.ledger, "SYNC_DERIVED");
   assert.equal(evidence.countyStudioDependencies.inspector, "SYNC_DERIVED");
+  assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.latestFailed.status, "FAILED");
+  assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForPacketProof, true);
   assert.equal(evidence.decisions.productionProofAllowed, false);
   assert.equal(evidence.decisions.operationalProofAllowed, false);
 });
@@ -106,6 +115,7 @@ test("converts adapter evidence into readiness-gate source payload", async () =>
   assert.equal(source.counts.landingTables.property, 10);
   assert.equal(source.counts.truthTables.owner, 10);
   assert.equal(source.countyStudioDependencies.ledger, "SYNC_DERIVED");
+  assert.equal(source.countyStudioDependencies.ownerSupnumBackfill.requiredForCountyStudioForgeDev, false);
 });
 
 test("CLI writes UNKNOWN evidence without psql instead of inventing counts", () => {
@@ -215,6 +225,8 @@ test("load batch query uses the canonical quoted Sync column contract", () => {
   assert.match(LATEST_LOAD_BATCH_QUERY, /"Status"/);
   assert.doesNotMatch(LATEST_LOAD_BATCH_QUERY, /COALESCE\([^)]*\bload_batch_id\b/);
   assert.doesNotMatch(LATEST_LOAD_BATCH_QUERY, /\bfamily\b/);
+  assert.match(LATEST_OWNER_SUPNUM_FAILURE_QUERY, /"Operator"\s+ILIKE\s+'owner-supnum%'/);
+  assert.match(LATEST_OWNER_SUPNUM_FAILURE_QUERY, /"Status"\s*=\s*'FAILED'/);
 });
 
 test("Docker psql runtime uses the configured DB evidence timeout", async () => {

--- a/os-platform/core/pilot/county-studio-r1-data-lineage-reconciliation.mjs
+++ b/os-platform/core/pilot/county-studio-r1-data-lineage-reconciliation.mjs
@@ -159,8 +159,9 @@ function areaReason(dataTruthReport, area, fallback) {
   return proofArea(dataTruthReport, area)?.reason ?? fallback;
 }
 
-function statusFor(classification, productionProofAllowed) {
+function statusFor(classification, productionProofAllowed, dependencyClassification = null) {
   if (productionProofAllowed) return "PRODUCTION_READY";
+  if (dependencyClassification === "NOT_REQUIRED_FOR_FORGE_DEV") return "PACKET_OPS_BLOCKER_NOT_FORGE_DEV";
   if (DEV_REAL_CLASSIFICATIONS.has(classification)) return "REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED";
   return "PRODUCTION_BLOCKER";
 }
@@ -182,7 +183,13 @@ function inventoryEntry({
   studyId = "runtime-selected-study",
   failureReason,
   requiredProofToUpgrade,
-  productionProofAllowed = false
+  productionProofAllowed = false,
+  dependencyClassification = null,
+  requiredForCountyStudioForgeDev = null,
+  requiredForPacketProof = null,
+  requiredForOperationalProof = null,
+  ownerSupnumBackfillStatus = null,
+  ownerSupnumBackfillLatestFailedStatus = null
 }) {
   return {
     surface,
@@ -202,12 +209,27 @@ function inventoryEntry({
     failureReason,
     requiredProofToUpgrade,
     productionProofAllowed,
-    status: statusFor(normalizeClassification(classification), productionProofAllowed)
+    ...(dependencyClassification ? { dependencyClassification } : {}),
+    ...(requiredForCountyStudioForgeDev !== null ? { requiredForCountyStudioForgeDev } : {}),
+    ...(requiredForPacketProof !== null ? { requiredForPacketProof } : {}),
+    ...(requiredForOperationalProof !== null ? { requiredForOperationalProof } : {}),
+    ...(ownerSupnumBackfillStatus !== null ? { ownerSupnumBackfillStatus } : {}),
+    ...(ownerSupnumBackfillLatestFailedStatus !== null ? { ownerSupnumBackfillLatestFailedStatus } : {}),
+    status: statusFor(normalizeClassification(classification), productionProofAllowed, dependencyClassification)
   };
 }
 
 function buildInventory({ readinessReport, dataTruthReport, syncEvidenceReport }) {
   const counts = evidenceCounts(readinessReport, syncEvidenceReport);
+  const ownerSupnumDependency = readinessReport?.forgeDevDependency?.ownerSupnumBackfill
+    ?? syncEvidenceReport?.countyStudioDependencies?.ownerSupnumBackfill
+    ?? {
+      status: "UNKNOWN",
+      classification: "UNKNOWN",
+      requiredForCountyStudioForgeDev: false,
+      requiredForPacketProof: true,
+      requiredForOperationalProof: true
+    };
   const mapDependencyClassification = checkClassification(readinessReport, "map data dependency status");
   const ledgerDependencyClassification = checkClassification(readinessReport, "ledger data dependency status");
   const inspectorDependencyClassification = checkClassification(readinessReport, "inspector data dependency status");
@@ -354,7 +376,13 @@ function buildInventory({ readinessReport, dataTruthReport, syncEvidenceReport }
       joinKey: "parcelId/APN + suppNum + ownerId/accountId",
       failureReason: "Owner/account/supplement rows are readable for real dev, but owner lane reconciliation is not production-complete.",
       requiredProofToUpgrade:
-        "Complete owner/supplement association reconciliation and prove expected Benton owner/account counts before production proof."
+        "Complete owner/supplement association reconciliation and prove expected Benton owner/account counts before production proof.",
+      dependencyClassification: ownerSupnumDependency.classification,
+      requiredForCountyStudioForgeDev: ownerSupnumDependency.requiredForCountyStudioForgeDev,
+      requiredForPacketProof: ownerSupnumDependency.requiredForPacketProof,
+      requiredForOperationalProof: ownerSupnumDependency.requiredForOperationalProof,
+      ownerSupnumBackfillStatus: ownerSupnumDependency.status,
+      ownerSupnumBackfillLatestFailedStatus: ownerSupnumDependency.latestFailed?.status ?? null
     }),
     inventoryEntry({
       surface: "WPOV/WSDOR dependencies",
@@ -393,6 +421,7 @@ function summarize(reportInventory, readinessReport, dataTruthReport) {
   return {
     realDevReadinessStatus: readinessReport?.status ?? "UNKNOWN",
     dataTruthStatus: dataTruthReport?.status ?? "UNKNOWN",
+    forgeDevDependency: readinessReport?.forgeDevDependency ?? null,
     whatIsNowRealEnoughForDev: realEnoughForDev,
     whatRemainsBlockedForProductionProof: blockedForProduction,
     realEnoughForDev,
@@ -503,6 +532,21 @@ export function renderCountyStudioR1DataLineageReconciliationMarkdown(report) {
 
   lines.push("", "## What Is Now Real Enough For Dev", "");
   report.summary.whatIsNowRealEnoughForDev.forEach((item) => lines.push(`- ${item}`));
+
+  lines.push("", "## Forge Dev Dependency Reclassification", "");
+  const ownerSupnum = report.summary.forgeDevDependency?.ownerSupnumBackfill;
+  if (ownerSupnum) {
+    lines.push(
+      `- ownerSupnumBackfillStatus: ${ownerSupnum.status}`,
+      `- ownerSupnumBackfillLatestFailedStatus: ${ownerSupnum.latestFailed?.status ?? "none"}`,
+      `- ownerSupnumBackfillClassification: ${ownerSupnum.classification}`,
+      `- ownerSupnumBackfillRequiredForForgeDev: ${ownerSupnum.requiredForCountyStudioForgeDev}`,
+      `- ownerSupnumBackfillRequiredForPacketProof: ${ownerSupnum.requiredForPacketProof}`,
+      `- ownerSupnumBackfillRequiredForOperationalProof: ${ownerSupnum.requiredForOperationalProof}`
+    );
+  } else {
+    lines.push("- ownerSupnumBackfillClassification: UNKNOWN");
+  }
 
   lines.push("", "## What Remains Blocked For Production Proof", "");
   report.summary.whatRemainsBlockedForProductionProof.forEach((item) => lines.push(`- ${item}`));

--- a/os-platform/core/pilot/county-studio-r1-data-lineage-reconciliation.test.mjs
+++ b/os-platform/core/pilot/county-studio-r1-data-lineage-reconciliation.test.mjs
@@ -64,6 +64,17 @@ function readinessReport(overrides = {}) {
         evidence: { classification: "SYNC_DERIVED" }
       }
     ],
+    forgeDevDependency: {
+      ownerSupnumBackfill: {
+        stage: "owner-supnum-backfill",
+        status: "FAILED",
+        classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+        requiredForCountyStudioForgeDev: false,
+        requiredForPacketProof: true,
+        requiredForOperationalProof: true,
+        ownerIdentityConsumedByForgeSurfaces: false
+      }
+    },
     ...overrides
   };
 }
@@ -193,6 +204,14 @@ test("reconciles real-dev available data without promoting production or operati
   assert.equal(geometry.ownerLane, "Atlas");
   assert.equal(geometry.observedCount, 80075);
   assert.match(geometry.failureReason, /compatibility/i);
+
+  const ownerJoins = report.inventory.find((item) => item.surface === "owner/account/supplement joins");
+  assert.equal(ownerJoins.dependencyClassification, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(ownerJoins.requiredForCountyStudioForgeDev, false);
+  assert.equal(ownerJoins.requiredForPacketProof, true);
+  assert.equal(ownerJoins.requiredForOperationalProof, true);
+  assert.equal(ownerJoins.ownerSupnumBackfillStatus, "FAILED");
+  assert.match(ownerJoins.status, /PACKET_OPS_BLOCKER/);
 });
 
 test("blocks reconciliation when real-dev activation is not ready", () => {

--- a/os-platform/core/pilot/county-studio-real-dev-server-activation.mjs
+++ b/os-platform/core/pilot/county-studio-real-dev-server-activation.mjs
@@ -136,6 +136,15 @@ export function buildCountyStudioRealDevServerActivationReport({
       productionProofAllowed: readinessReport?.decisions?.productionProofAllowed === true,
       operationalProofAllowed: readinessReport?.decisions?.operationalProofAllowed === true
     },
+    forgeDevDependency: readinessReport?.forgeDevDependency ?? {
+      ownerSupnumBackfill: {
+        status: "UNKNOWN",
+        classification: "UNKNOWN",
+        requiredForCountyStudioForgeDev: false,
+        requiredForPacketProof: true,
+        requiredForOperationalProof: true
+      }
+    },
     dataTruthPosture: {
       status: dataTruthReport?.status ?? "UNKNOWN",
       productionProofAllowed: dataTruthReport?.claims?.productionProofAllowed === true,
@@ -183,6 +192,15 @@ export function renderCountyStudioRealDevServerActivationMarkdown(report) {
     `- realDevServerAllowed: ${report.readinessPosture.realDevServerAllowed}`,
     `- productionProofAllowed: ${report.readinessPosture.productionProofAllowed}`,
     `- operationalProofAllowed: ${report.readinessPosture.operationalProofAllowed}`,
+    "",
+    "## Forge Dev Dependency Reclassification",
+    "",
+    `- ownerSupnumBackfillStatus: ${report.forgeDevDependency.ownerSupnumBackfill.status}`,
+    `- ownerSupnumBackfillLatestFailedStatus: ${report.forgeDevDependency.ownerSupnumBackfill.latestFailed?.status ?? "none"}`,
+    `- ownerSupnumBackfillClassification: ${report.forgeDevDependency.ownerSupnumBackfill.classification}`,
+    `- ownerSupnumBackfillRequiredForForgeDev: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev}`,
+    `- ownerSupnumBackfillRequiredForPacketProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForPacketProof}`,
+    `- ownerSupnumBackfillRequiredForOperationalProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForOperationalProof}`,
     "",
     "## Data Truth Posture",
     "",

--- a/os-platform/core/pilot/county-studio-real-dev-server-activation.test.mjs
+++ b/os-platform/core/pilot/county-studio-real-dev-server-activation.test.mjs
@@ -21,6 +21,15 @@ function readinessReport(overrides = {}) {
       productionProofAllowed: false,
       operationalProofAllowed: false
     },
+    forgeDevDependency: {
+      ownerSupnumBackfill: {
+        status: "FAILED",
+        classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+        requiredForCountyStudioForgeDev: false,
+        requiredForPacketProof: true,
+        requiredForOperationalProof: true
+      }
+    },
     checks: [
       { name: "backend health", classification: "SYNC_DERIVED", passed: true },
       { name: "map data dependency status", classification: "PARTIAL_SEEDED", passed: true },
@@ -75,6 +84,8 @@ test("allows real Benton dev activation only when readiness allows it", () => {
   assert.equal(report.decisions.realDevActivationAllowed, true);
   assert.equal(report.decisions.productionProofAllowed, false);
   assert.equal(report.decisions.operationalProofAllowed, false);
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.status, "FAILED");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev, false);
   assert.match(report.runPath.prerequisiteCommand, /benton-real-dev-server-readiness:db/);
   assert.match(report.runPath.launchCommand, /TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton/);
 });

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,10 +1,10 @@
 {
-  "generatedAtUtc": "2026-06-06T22:21:06.872Z",
+  "generatedAtUtc": "2026-06-06T22:47:00.641Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_SERVER_BLOCKED",
+  "status": "REAL_DEV_DATA_AVAILABLE",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": false,
+    "realDevServerAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -29,6 +29,7 @@
     "property landing count",
     "WPOV status",
     "WSDOR status",
+    "owner-supnum backfill dependency classification",
     "map data dependency status",
     "ledger data dependency status",
     "inspector data dependency status"
@@ -43,14 +44,14 @@
         "status": "healthy",
         "ok": true,
         "statusCode": 200,
-        "url": "http://localhost:5046/health"
+        "url": "http://localhost:5000/health"
       }
     },
     {
       "name": "active drain process state",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Drain process state is unknown.",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS.",
       "evidence": {
         "pid": null,
         "alive": null,
@@ -59,13 +60,13 @@
     },
     {
       "name": "load_batch current stage",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "load_batch stage is owner-supnum-backfill (FAILED).",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "load_batch stage is owner-supnum-resume (IN_PROGRESS).",
       "evidence": {
-        "stage": "owner-supnum-backfill",
-        "status": "FAILED",
-        "loadBatchId": "185679de-8dbe-4c16-8cea-7f454081c77d"
+        "stage": "owner-supnum-resume",
+        "status": "IN_PROGRESS",
+        "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63"
       }
     },
     {
@@ -76,7 +77,7 @@
       "evidence": {
         "propertyLanding": 999214,
         "ownerLanding": 7396857,
-        "suppAssociation": 2731351,
+        "suppAssociation": 2772351,
         "wpov": 1273143,
         "truthParcel": 83682,
         "truthOwner": 774760,
@@ -93,7 +94,7 @@
       "evidence": {
         "propertyLanding": 999214,
         "ownerLanding": 7396857,
-        "suppAssociation": 2731351,
+        "suppAssociation": 2772351,
         "wpov": 1273143,
         "truthParcel": 83682,
         "truthOwner": 774760,
@@ -136,7 +137,7 @@
       "passed": true,
       "reason": "Supplement association landing rows exist.",
       "evidence": {
-        "suppAssociation": 2731351
+        "suppAssociation": 2772351
       }
     },
     {
@@ -167,6 +168,43 @@
       }
     },
     {
+      "name": "owner-supnum backfill dependency classification",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
+      "evidence": {
+        "stage": "owner-supnum-resume",
+        "status": "IN_PROGRESS",
+        "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+        "requiredForCountyStudioForgeDev": false,
+        "requiredForPacketProof": true,
+        "requiredForOperationalProof": true,
+        "ownerIdentityConsumedByForgeSurfaces": false,
+        "consumedSurfaces": [],
+        "latestFailed": {
+          "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+          "stage": "owner-supnum-resume",
+          "status": "FAILED"
+        },
+        "audit": {
+          "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+          "forgeValuationSources": [
+            "parcel/property identity",
+            "property characteristics",
+            "valuation metrics",
+            "ratio-study context",
+            "risk objects",
+            "geometry/map context"
+          ],
+          "packetOpsSources": [
+            "Dossier packet owner identity",
+            "Dais/notice/appeal taxpayer identity",
+            "operational packet owner references"
+          ]
+        }
+      }
+    },
+    {
       "name": "map data dependency status",
       "classification": "PARTIAL_SEEDED",
       "passed": true,
@@ -194,10 +232,40 @@
       }
     }
   ],
-  "blockers": [
-    "active drain process state: Drain process state is unknown.",
-    "load_batch current stage: load_batch stage is owner-supnum-backfill (FAILED)."
-  ],
+  "forgeDevDependency": {
+    "ownerSupnumBackfill": {
+      "stage": "owner-supnum-resume",
+      "status": "IN_PROGRESS",
+      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForOperationalProof": true,
+      "ownerIdentityConsumedByForgeSurfaces": false,
+      "consumedSurfaces": [],
+      "latestFailed": {
+        "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+        "stage": "owner-supnum-resume",
+        "status": "FAILED"
+      },
+      "audit": {
+        "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+        "forgeValuationSources": [
+          "parcel/property identity",
+          "property characteristics",
+          "valuation metrics",
+          "ratio-study context",
+          "risk objects",
+          "geometry/map context"
+        ],
+        "packetOpsSources": [
+          "Dossier packet owner identity",
+          "Dais/notice/appeal taxpayer identity",
+          "operational packet owner references"
+        ]
+      }
+    }
+  },
+  "blockers": [],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",
@@ -214,6 +282,7 @@
     "Backend death is data failure.",
     "Stage stagnation without inserts is investigation.",
     "Partial landing is usable for dev evidence, not production proof.",
+    "Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.",
     "Do not relabel partial seed as authoritative."
   ],
   "boundaries": [

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,11 +1,11 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-06T22:21:06.872Z
-Status: REAL_DEV_SERVER_BLOCKED
+Generated: 2026-06-06T22:47:00.641Z
+Status: REAL_DEV_DATA_AVAILABLE
 
 ## Decision
 
-- Real Dev Server: BLOCKED
+- Real Dev Server: ALLOWED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
@@ -23,8 +23,8 @@ Status: REAL_DEV_SERVER_BLOCKED
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
 | backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
-| active drain process state | UNKNOWN | false | Drain process state is unknown. |
-| load_batch current stage | UNKNOWN | false | load_batch stage is owner-supnum-backfill (FAILED). |
+| active drain process state | SYNC_DERIVED | true | Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS. |
+| load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-resume (IN_PROGRESS). |
 | landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
 | truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
 | canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
@@ -34,14 +34,25 @@ Status: REAL_DEV_SERVER_BLOCKED
 | property landing count | PARTIAL_SEEDED | true | Property landing count is present. |
 | WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
 | WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
+| owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
 | map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
 | ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
 | inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
 
+## Forge Dev Dependency Reclassification
+
+- ownerSupnumBackfillStatus: IN_PROGRESS
+- ownerSupnumBackfillStage: owner-supnum-resume
+- ownerSupnumBackfillLatestFailedStage: owner-supnum-resume
+- ownerSupnumBackfillLatestFailedStatus: FAILED
+- ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
+- ownerSupnumBackfillRequiredForForgeDev: false
+- ownerSupnumBackfillRequiredForPacketProof: true
+- ownerSupnumBackfillRequiredForOperationalProof: true
+
 ## Blockers
 
-- active drain process state: Drain process state is unknown.
-- load_batch current stage: load_batch stage is owner-supnum-backfill (FAILED).
+- None
 
 ## Rules
 
@@ -49,6 +60,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 - Backend death is data failure.
 - Stage stagnation without inserts is investigation.
 - Partial landing is usable for dev evidence, not production proof.
+- Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.
 - Do not relabel partial seed as authoritative.
 
 ## Boundaries

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-06T21:48:50.299Z",
+  "generatedAtUtc": "2026-06-06T22:46:55.503Z",
   "adapter": "benton-sync-drain-state-evidence",
   "backendHealth": {
     "status": "healthy",
@@ -8,9 +8,9 @@
     "url": "http://localhost:5000/health"
   },
   "activeDrain": {
-    "pid": 28503,
-    "alive": false,
-    "status": "NOT_RUNNING"
+    "pid": null,
+    "alive": null,
+    "status": "UNKNOWN"
   },
   "runtimeDbAccess": {
     "mode": "docker",
@@ -21,19 +21,24 @@
     "directConnectionConfigured": false
   },
   "loadBatch": {
-    "stage": "owner-supnum-backfill",
+    "stage": "owner-supnum-resume",
     "status": "IN_PROGRESS",
-    "loadBatchId": "185679de-8dbe-4c16-8cea-7f454081c77d"
+    "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63"
   },
   "queryResults": {
     "latestLoadBatch": {
-      "loadBatchId": "185679de-8dbe-4c16-8cea-7f454081c77d",
-      "stage": "owner-supnum-backfill",
+      "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63",
+      "stage": "owner-supnum-resume",
       "status": "IN_PROGRESS"
+    },
+    "latestOwnerSupnumFailure": {
+      "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+      "stage": "owner-supnum-resume",
+      "status": "FAILED"
     },
     "legacyProperty": 999214,
     "legacyOwner": 7396857,
-    "legacyPropSuppAssoc": 2731351,
+    "legacyPropSuppAssoc": 2772351,
     "legacyWashPropOwnerVal": 1273143,
     "legacyAccount": 425186,
     "truthParcel": 83682,
@@ -48,7 +53,7 @@
     "landingTables": {
       "property": 999214,
       "owner": 7396857,
-      "propSuppAssoc": 2731351,
+      "propSuppAssoc": 2772351,
       "washPropOwnerVal": 1273143
     },
     "truthTables": {
@@ -83,7 +88,38 @@
   "countyStudioDependencies": {
     "map": "PARTIAL_SEEDED",
     "ledger": "SYNC_DERIVED",
-    "inspector": "SYNC_DERIVED"
+    "inspector": "SYNC_DERIVED",
+    "ownerSupnumBackfill": {
+      "stage": "owner-supnum-resume",
+      "status": "IN_PROGRESS",
+      "latestFailed": {
+        "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+        "stage": "owner-supnum-resume",
+        "status": "FAILED"
+      },
+      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForOperationalProof": true,
+      "ownerIdentityConsumedByForgeSurfaces": false,
+      "consumedSurfaces": [],
+      "audit": {
+        "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+        "forgeValuationSources": [
+          "parcel/property identity",
+          "property characteristics",
+          "valuation metrics",
+          "ratio-study context",
+          "risk objects",
+          "geometry/map context"
+        ],
+        "packetOpsSources": [
+          "Dossier packet owner identity",
+          "Dais/notice/appeal taxpayer identity",
+          "operational packet owner references"
+        ]
+      }
+    }
   },
   "decisions": {
     "realDevEvidenceReadable": true,

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
@@ -1,6 +1,6 @@
 # Benton Sync Drain State Evidence
 
-Generated: 2026-06-06T21:48:50.299Z
+Generated: 2026-06-06T22:46:55.503Z
 
 ## Decision
 
@@ -11,9 +11,9 @@ Generated: 2026-06-06T21:48:50.299Z
 ## Runtime
 
 - Backend health: healthy
-- Drain PID: 28503
-- Drain alive: false
-- load_batch stage: owner-supnum-backfill
+- Drain PID: none
+- Drain alive: null
+- load_batch stage: owner-supnum-resume
 - load_batch status: IN_PROGRESS
 
 ## DB Runtime Access
@@ -31,7 +31,7 @@ Generated: 2026-06-06T21:48:50.299Z
 | --- | --- | ---: | --- |
 | legacyProperty | PARTIAL_SEEDED | 999214 | count present |
 | legacyOwner | PARTIAL_SEEDED | 7396857 | count present |
-| legacyPropSuppAssoc | PARTIAL_SEEDED | 2731351 | count present |
+| legacyPropSuppAssoc | PARTIAL_SEEDED | 2772351 | count present |
 | legacyWashPropOwnerVal | PARTIAL_SEEDED | 1273143 | count present |
 | legacyAccount | SEEDED | 425186 | count present |
 | truthParcel | SYNC_DERIVED | 83682 | count present |
@@ -47,6 +47,12 @@ Generated: 2026-06-06T21:48:50.299Z
 - Map: PARTIAL_SEEDED
 - Ledger: SYNC_DERIVED
 - Inspector: SYNC_DERIVED
+- Owner-supnum backfill status: IN_PROGRESS
+- Owner-supnum latest failed stage: owner-supnum-resume
+- Owner-supnum latest failed status: FAILED
+- Owner-supnum required for Forge dev: false
+- Owner-supnum required for packet proof: true
+- Owner-supnum required for operational proof: true
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-data-lineage-reconciliation.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-data-lineage-reconciliation.json
@@ -1,10 +1,10 @@
 {
-  "generatedAtUtc": "2026-06-06T22:24:18.941Z",
+  "generatedAtUtc": "2026-06-06T22:47:03.263Z",
   "gate": "county-studio-r1-data-lineage-reconciliation",
-  "status": "DATA_LINEAGE_RECONCILIATION_BLOCKED",
+  "status": "DATA_LINEAGE_RECONCILED_WITH_PRODUCTION_BLOCKERS",
   "decisions": {
-    "realDevActivationAllowed": false,
-    "realDevServerAllowed": false,
+    "realDevActivationAllowed": true,
+    "realDevServerAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -195,7 +195,7 @@
         "truthOwner": 774760,
         "canonicalOwner": 215009,
         "account": 425186,
-        "suppAssociation": 2731351
+        "suppAssociation": 2772351
       },
       "expectedCanonicalCount": null,
       "joinKey": "parcelId/APN + suppNum + ownerId/accountId",
@@ -205,7 +205,13 @@
       "failureReason": "Owner/account/supplement rows are readable for real dev, but owner lane reconciliation is not production-complete.",
       "requiredProofToUpgrade": "Complete owner/supplement association reconciliation and prove expected Benton owner/account counts before production proof.",
       "productionProofAllowed": false,
-      "status": "REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED"
+      "dependencyClassification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForOperationalProof": true,
+      "ownerSupnumBackfillStatus": "IN_PROGRESS",
+      "ownerSupnumBackfillLatestFailedStatus": "FAILED",
+      "status": "PACKET_OPS_BLOCKER_NOT_FORGE_DEV"
     },
     {
       "surface": "WPOV/WSDOR dependencies",
@@ -233,8 +239,41 @@
     }
   ],
   "summary": {
-    "realDevReadinessStatus": "REAL_DEV_SERVER_BLOCKED",
+    "realDevReadinessStatus": "REAL_DEV_DATA_AVAILABLE",
     "dataTruthStatus": "DATA_TRUTH_FAIL",
+    "forgeDevDependency": {
+      "ownerSupnumBackfill": {
+        "stage": "owner-supnum-resume",
+        "status": "IN_PROGRESS",
+        "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+        "requiredForCountyStudioForgeDev": false,
+        "requiredForPacketProof": true,
+        "requiredForOperationalProof": true,
+        "ownerIdentityConsumedByForgeSurfaces": false,
+        "consumedSurfaces": [],
+        "latestFailed": {
+          "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+          "stage": "owner-supnum-resume",
+          "status": "FAILED"
+        },
+        "audit": {
+          "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+          "forgeValuationSources": [
+            "parcel/property identity",
+            "property characteristics",
+            "valuation metrics",
+            "ratio-study context",
+            "risk objects",
+            "geometry/map context"
+          ],
+          "packetOpsSources": [
+            "Dossier packet owner identity",
+            "Dais/notice/appeal taxpayer identity",
+            "operational packet owner references"
+          ]
+        }
+      }
+    },
     "whatIsNowRealEnoughForDev": [
       "map: PARTIAL_SEEDED (County Studio embedded TerraAtlas valuation-risk map)",
       "parcel/property identity: SYNC_DERIVED (Benton parcel/property identity)",
@@ -289,9 +328,7 @@
     "Evidence packet and downstream payload lineage is unknown.",
     "WPOV/WSDOR and owner/account/supplement joins are partial seeded, not reconciled."
   ],
-  "blockers": [
-    "Real dev activation is not ready; run the readiness DB and activation gates first."
-  ],
+  "blockers": [],
   "sourceArtifacts": {
     "readiness": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json",
     "dataTruth": "os-platform/core/pilot/evidence/county-studio-r1-data-truth-gate.latest.json",

--- a/os-platform/core/pilot/evidence/county-studio-r1-data-lineage-reconciliation.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-data-lineage-reconciliation.md
@@ -1,12 +1,12 @@
 # County Studio R1 Data Lineage Reconciliation
 
-Generated: 2026-06-06T22:24:18.941Z
-Status: DATA_LINEAGE_RECONCILIATION_BLOCKED
+Generated: 2026-06-06T22:47:03.263Z
+Status: DATA_LINEAGE_RECONCILED_WITH_PRODUCTION_BLOCKERS
 
 ## Decisions
 
-- realDevActivationAllowed=false
-- realDevServerAllowed=false
+- realDevActivationAllowed=true
+- realDevServerAllowed=true
 - productionProofAllowed=false
 - operationalProofAllowed=false
 
@@ -22,7 +22,7 @@ Status: DATA_LINEAGE_RECONCILIATION_BLOCKED
 | parcel/property identity | SYNC_DERIVED | Forge | 3199335 | REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED | parcel/property source uses or references canonical service/table paths, but no authoritative Benton source/count manifest proves row-level truth. | Compare seeded/sync-derived parcel identity counts to canonical Benton expected counts and prove APN/parcelId reconciliation. |
 | valuation metrics | SYNC_DERIVED | Forge | 83682 | REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED | ratio study population uses or references canonical service/table paths, but no authoritative Benton source/count manifest proves row-level truth. | Prove sale qualification, valuation rows, and ratio metrics against authoritative Benton source counts and direct recomputation. |
 | geometry/layers | FALLBACK | Atlas | 80075 | PRODUCTION_BLOCKER | Atlas layers is served through Atlas compatibility geometry; compatibility/provisional geometry cannot satisfy real TerraAtlas-owned GIS proof. | Replace compatibility proof with TerraAtlas-owned Benton parcel geometry, neighborhoods, segments, reval areas, and taxing district layer contracts. |
-| owner/account/supplement joins | PARTIAL_SEEDED | Forge | {"ownerLanding":7396857,"truthOwner":774760,"canonicalOwner":215009,"account":425186,"suppAssociation":2731351} | REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED | Owner/account/supplement rows are readable for real dev, but owner lane reconciliation is not production-complete. | Complete owner/supplement association reconciliation and prove expected Benton owner/account counts before production proof. |
+| owner/account/supplement joins | PARTIAL_SEEDED | Forge | {"ownerLanding":7396857,"truthOwner":774760,"canonicalOwner":215009,"account":425186,"suppAssociation":2772351} | PACKET_OPS_BLOCKER_NOT_FORGE_DEV | Owner/account/supplement rows are readable for real dev, but owner lane reconciliation is not production-complete. | Complete owner/supplement association reconciliation and prove expected Benton owner/account counts before production proof. |
 | WPOV/WSDOR dependencies | PARTIAL_SEEDED | Forge | {"wpov":1273143,"truthWsdor":774696,"canonicalWsdor":686820} | REAL_DEV_AVAILABLE_PRODUCTION_BLOCKED | WPOV/WSDOR rows are present for real dev, but canonical source/count reconciliation remains incomplete. | Reconcile WPOV/WSDOR counts and joins against canonical Benton expectations and direct source recomputation. |
 
 ## What Is Now Real Enough For Dev
@@ -32,6 +32,15 @@ Status: DATA_LINEAGE_RECONCILIATION_BLOCKED
 - valuation metrics: SYNC_DERIVED (County Studio valuation and ratio metrics)
 - owner/account/supplement joins: PARTIAL_SEEDED (Owner, account, and supplement association joins)
 - WPOV/WSDOR dependencies: PARTIAL_SEEDED (WPOV and WSDOR dependency rows)
+
+## Forge Dev Dependency Reclassification
+
+- ownerSupnumBackfillStatus: IN_PROGRESS
+- ownerSupnumBackfillLatestFailedStatus: FAILED
+- ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
+- ownerSupnumBackfillRequiredForForgeDev: false
+- ownerSupnumBackfillRequiredForPacketProof: true
+- ownerSupnumBackfillRequiredForOperationalProof: true
 
 ## What Remains Blocked For Production Proof
 
@@ -64,7 +73,7 @@ Status: DATA_LINEAGE_RECONCILIATION_BLOCKED
 
 ## Blockers
 
-- Real dev activation is not ready; run the readiness DB and activation gates first.
+- None
 
 ## Boundaries
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-data-truth-gate.latest.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-data-truth-gate.latest.json
@@ -1,11 +1,11 @@
 {
-  "generatedAtUtc": "2026-06-06T22:22:24.751Z",
+  "generatedAtUtc": "2026-06-06T22:47:01.611Z",
   "gate": "county-studio-r1-data-truth",
   "status": "DATA_TRUTH_FAIL",
   "claims": {
     "surfaceRuntimeProofOnly": true,
-    "realDevServerAllowed": false,
-    "realDevBoundary": "County Studio real Benton-backed dev surface is not allowed until the real-dev readiness gate passes.",
+    "realDevServerAllowed": true,
+    "realDevBoundary": "County Studio may run as a real Benton-backed dev surface; this is not production or operational proof.",
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
     "rule": "No data lineage, no production proof. No provenance, no operational claim."

--- a/os-platform/core/pilot/evidence/county-studio-r1-data-truth-gate.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-data-truth-gate.md
@@ -1,6 +1,6 @@
 # County Studio R1 Data Truth Gate
 
-Generated: 2026-06-06T22:22:24.751Z
+Generated: 2026-06-06T22:47:01.611Z
 Status: DATA_TRUTH_FAIL
 
 No data lineage, no production proof. No provenance, no operational claim. No canonical count comparison, no Benton truth. No geometry source, no GIS proof.
@@ -8,10 +8,10 @@ No data lineage, no production proof. No provenance, no operational claim. No ca
 ## Claim Boundary
 
 - Surface runtime proof only: true
-- Real dev server allowed: false
+- Real dev server allowed: true
 - Production proof allowed: false
 - Operational proof allowed: false
-- Real dev boundary: County Studio real Benton-backed dev surface is not allowed until the real-dev readiness gate passes.
+- Real dev boundary: County Studio may run as a real Benton-backed dev surface; this is not production or operational proof.
 
 ## Required Proof Areas
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
@@ -1,9 +1,9 @@
 {
-  "generatedAtUtc": "2026-06-06T22:22:26.092Z",
+  "generatedAtUtc": "2026-06-06T22:47:02.494Z",
   "gate": "county-studio-real-dev-server-activation",
-  "status": "REAL_DEV_ACTIVATION_BLOCKED",
+  "status": "REAL_DEV_ACTIVATION_READY",
   "decisions": {
-    "realDevActivationAllowed": false,
+    "realDevActivationAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -13,10 +13,43 @@
     "launchCommand": "cross-env TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton TF_COUNTY_STUDIO_PRODUCTION_PROOF=false TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false pnpm run dev"
   },
   "readinessPosture": {
-    "status": "REAL_DEV_SERVER_BLOCKED",
-    "realDevServerAllowed": false,
+    "status": "REAL_DEV_DATA_AVAILABLE",
+    "realDevServerAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
+  },
+  "forgeDevDependency": {
+    "ownerSupnumBackfill": {
+      "stage": "owner-supnum-resume",
+      "status": "IN_PROGRESS",
+      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForOperationalProof": true,
+      "ownerIdentityConsumedByForgeSurfaces": false,
+      "consumedSurfaces": [],
+      "latestFailed": {
+        "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",
+        "stage": "owner-supnum-resume",
+        "status": "FAILED"
+      },
+      "audit": {
+        "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume owner name, taxpayer identity, mailing identity, owner-current, or owner-supnum data.",
+        "forgeValuationSources": [
+          "parcel/property identity",
+          "property characteristics",
+          "valuation metrics",
+          "ratio-study context",
+          "risk objects",
+          "geometry/map context"
+        ],
+        "packetOpsSources": [
+          "Dossier packet owner identity",
+          "Dais/notice/appeal taxpayer identity",
+          "operational packet owner references"
+        ]
+      }
+    }
   },
   "dataTruthPosture": {
     "status": "DATA_TRUTH_FAIL",
@@ -100,11 +133,7 @@
       "reason": "County Studio live SignalR payload provenance is not proven for the selected Benton study context."
     }
   ],
-  "blockers": [
-    "Benton real-dev readiness is not allowed.",
-    "active drain process state: Drain process state is unknown.",
-    "load_batch current stage: load_batch stage is owner-supnum-backfill (FAILED)."
-  ],
+  "blockers": [],
   "rules": [
     "Real dev activation requires the Benton real-dev readiness DB gate.",
     "Mock, fixture, generated, fallback, or unknown activation dependencies cannot satisfy real dev mode.",

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
@@ -1,11 +1,11 @@
 # County Studio Real Dev Server Activation
 
-Generated: 2026-06-06T22:22:26.092Z
-Status: REAL_DEV_ACTIVATION_BLOCKED
+Generated: 2026-06-06T22:47:02.494Z
+Status: REAL_DEV_ACTIVATION_READY
 
 ## Decision
 
-- Real Dev Activation: BLOCKED
+- Real Dev Activation: ALLOWED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
@@ -17,10 +17,19 @@ Status: REAL_DEV_ACTIVATION_BLOCKED
 
 ## Readiness Posture
 
-- Status: REAL_DEV_SERVER_BLOCKED
-- realDevServerAllowed: false
+- Status: REAL_DEV_DATA_AVAILABLE
+- realDevServerAllowed: true
 - productionProofAllowed: false
 - operationalProofAllowed: false
+
+## Forge Dev Dependency Reclassification
+
+- ownerSupnumBackfillStatus: IN_PROGRESS
+- ownerSupnumBackfillLatestFailedStatus: FAILED
+- ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
+- ownerSupnumBackfillRequiredForForgeDev: false
+- ownerSupnumBackfillRequiredForPacketProof: true
+- ownerSupnumBackfillRequiredForOperationalProof: true
 
 ## Data Truth Posture
 
@@ -50,9 +59,7 @@ Status: REAL_DEV_ACTIVATION_BLOCKED
 
 ## Activation Blockers
 
-- Benton real-dev readiness is not allowed.
-- active drain process state: Drain process state is unknown.
-- load_batch current stage: load_batch stage is owner-supnum-backfill (FAILED).
+- None
 
 ## Rules
 


### PR DESCRIPTION
## Purpose

Reclassify owner-supnum backfill as a County Studio Forge-dev dependency only when a County Studio Forge valuation surface actually consumes owner identity.

County Studio lives inside TerraForge. Its real Benton-backed Forge valuation dev path depends on parcel/property identity, characteristics, valuation metrics, ratio-study context, risk objects, and map/geometry context. Owner identity remains important for packet, Dossier, Dais, notice, appeal, and operational proof, but it should not globally block Forge valuation dev unless consumed by the current surface.

## What Changed

- Adds owner-supnum dependency classifications:
  - `REQUIRED_FOR_FORGE_DEV`
  - `NOT_REQUIRED_FOR_FORGE_DEV`
  - `REQUIRED_FOR_PACKET_PROOF`
  - `REQUIRED_FOR_OPERATIONAL_PROOF`
  - `UNKNOWN`
- Extends the Sync/DB evidence adapter with a read-only latest owner-supnum failure query.
- Preserves visible owner-supnum failure/resume state in readiness, activation, and lineage evidence.
- Allows real dev readiness/activation when owner-supnum is `NOT_REQUIRED_FOR_FORGE_DEV` and Forge valuation dependencies are available.
- Keeps owner-supnum as packet/ops blocker.
- Keeps production and operational proof blocked.

## Current Evidence Posture

- `SYNC_DB_EVIDENCE_READABLE`
- `REAL_DEV_DATA_AVAILABLE`
- `REAL_DEV_ACTIVATION_READY`
- `DATA_LINEAGE_RECONCILED_WITH_PRODUCTION_BLOCKERS`
- `DATA_TRUTH_FAIL`
- `productionProofAllowed=false`
- `operationalProofAllowed=false`

Owner-supnum status remains visible:

- current stage: `owner-supnum-resume`
- current status: `IN_PROGRESS`
- latest failed owner-supnum stage/status remains recorded from DB evidence
- `ownerSupnumBackfillRequiredForForgeDev=false`
- `ownerSupnumBackfillRequiredForPacketProof=true`
- `ownerSupnumBackfillRequiredForOperationalProof=true`

## Boundaries

- No County Studio UI changes.
- No Sync mutation.
- No DB seeding changes.
- No production proof promotion.
- No operational proof promotion.
- No owner lineage health claim.

## Verification

- `node --test os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs os-platform/core/pilot/county-studio-real-dev-server-activation.test.mjs os-platform/core/pilot/county-studio-r1-data-lineage-reconciliation.test.mjs os-platform/core/pilot/county-studio-r1-data-truth-gate.test.mjs` — 31 tests passed
- `pnpm run type-check` — passed
- `node --test os-platform/core/tests/phase83-tools.test.mjs` — 56 tests passed
- `git diff --check` — passed
- pre-push quality gate — passed