### PR TITLE
feat(canon): add gate aggregator + advisory CI enforcement rail

### DIFF
--- a/.github/workflows/canon-gates.yml
+++ b/.github/workflows/canon-gates.yml
@@ -1,0 +1,52 @@
+name: canon-gates
+
+# Advisory enforcement rail for the read-only Canon runtime.
+# Runs the Canon gate aggregator over a PR's changed files and reports findings
+# to the job summary. ADVISORY by default (never blocks) — this is the
+# "advisory-in-CI first" step of the Canon doctrine.
+#
+# To FLIP TO ENFORCEMENT later: add `--strict` to the node invocation below
+# (optionally scoped to Canon-owned paths first). Do not make this a required
+# status check until signal quality is confirmed on real PRs.
+#
+# Push-triggered (not pull_request): platform.json forbids pull_request on
+# non-constitutional workflows (PR_TRIGGER_LEAK). Runs per feature-branch push
+# and on manual dispatch; diffs changed files against origin/main.
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  advisory:
+    name: Canon Gates (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run Canon gates (advisory, non-blocking)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          mapfile -t FILES < <(git diff --name-only origin/main...HEAD)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No changed files to scan." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Canon Gates (advisory)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Advisory: aggregator exits 0 without --strict, so the job never blocks.
+          node os-platform/core/gates/canon-gates.mjs "${FILES[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/os-platform/core/gates/canon-gates.mjs
+++ b/os-platform/core/gates/canon-gates.mjs
@@ -1,0 +1,95 @@
+/**
+ * Canon gates aggregator — the enforcement rail.
+ *
+ * Runs every advisory Canon gate over a changed-file set and classifies
+ * findings:
+ *   - BLOCKING: protected-path edits, hardcoded ports, unowned paths
+ *     (governance blind spots / hard violations);
+ *   - ADVISORY: high/critical-risk OWNED areas (informational — ensure the
+ *     required gates + review happen, but never block on them).
+ *
+ * ADVISORY by default (exit 0, report only). Pass --strict to fail (exit 1)
+ * when any BLOCKING finding exists. Read-only: file paths are passed as args
+ * (CI/lint-staged convention); no git, no command execution.
+ *
+ * CLI:  node os-platform/core/gates/canon-gates.mjs [--strict] [--json] <paths...>
+ *
+ * @module gates/canon-gates
+ */
+
+import { checkProtectedPaths } from './check-protected-paths.mjs';
+import { checkHardcodedPorts } from './check-hardcoded-ports.mjs';
+import { checkWriteLanes } from './canon-write-lane-check.mjs';
+import { printReport, runMain } from './gate-runtime.mjs';
+
+/**
+ * @typedef {Readonly<{ gate: string, path: string, detail: string }>} GateFinding
+ * @typedef {Readonly<{ blocking: ReadonlyArray<GateFinding>, advisory: ReadonlyArray<GateFinding>, ok: boolean, exitCode: number }>} CanonGatesResult
+ */
+
+const CODE_LIKE = /\.(ts|tsx|js|jsx|mjs|cjs|cs|json|ya?ml)$/i;
+
+/**
+ * Run all Canon gates over the given paths and classify findings. Never throws.
+ * @param {ReadonlyArray<string>} paths
+ * @param {{ strict?: boolean }} [opts]
+ * @returns {CanonGatesResult}
+ */
+export function runCanonGates(paths, opts) {
+  const list = Array.isArray(paths) ? paths.filter((p) => typeof p === 'string' && p.length > 0) : [];
+  const strict = !!(opts && opts.strict);
+
+  /** @type {GateFinding[]} */
+  const blocking = [];
+  /** @type {GateFinding[]} */
+  const advisory = [];
+
+  // Protected paths -> blocking.
+  for (const f of checkProtectedPaths(list)) {
+    blocking.push(Object.freeze({ gate: 'protected-paths', path: f.path, detail: `protected by ${f.pattern}` }));
+  }
+
+  // Hardcoded ports -> blocking (only scans code-like files that exist).
+  for (const f of checkHardcodedPorts(list.filter((p) => CODE_LIKE.test(p)))) {
+    blocking.push(
+      Object.freeze({ gate: 'hardcoded-ports', path: f.path, detail: `hardcoded port ${f.port} at line ${f.line}` }),
+    );
+  }
+
+  // Write-lane: unowned -> blocking; high/critical-risk owned -> advisory.
+  const wl = checkWriteLanes(list);
+  for (const a of wl.advisories) {
+    if (/unowned|no write-lane/i.test(a.detail)) {
+      blocking.push(Object.freeze({ gate: 'write-lane', path: a.path, detail: a.detail }));
+    } else {
+      advisory.push(Object.freeze({ gate: 'write-lane', path: a.path, detail: a.detail }));
+    }
+  }
+
+  const ok = blocking.length === 0;
+  const exitCode = ok || !strict ? 0 : 1;
+  return Object.freeze({
+    blocking: Object.freeze(blocking),
+    advisory: Object.freeze(advisory),
+    ok,
+    exitCode,
+  });
+}
+
+runMain(import.meta.url, (o) => {
+  const res = runCanonGates(o.paths, { strict: o.strict });
+  // Surface blocking findings as the report's "findings" (so --strict fails on them);
+  // advisory findings are appended to the message but never affect exit code.
+  const result = printReport({
+    gate: 'gates',
+    json: o.json,
+    strict: o.strict,
+    findings: res.blocking.map((f) => ({ path: f.path, detail: `[${f.gate}] ${f.detail}` })),
+    okMessage: `scanned ${o.paths.length} path(s); no blocking violations.`,
+  });
+  if (!o.json && res.advisory.length) {
+    process.stdout.write(`   advisory (${res.advisory.length}, non-blocking):\n`);
+    for (const a of res.advisory) process.stdout.write(`   · ${a.path}: [${a.gate}] ${a.detail}\n`);
+  }
+  return result;
+});

--- a/os-platform/core/tests/canon-gates.test.mjs
+++ b/os-platform/core/tests/canon-gates.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * Canon gates aggregator — self-test.
+ *
+ * Runs all advisory gates over a changed-file set and classifies findings into
+ * BLOCKING (protected paths, hardcoded ports, unowned paths) vs ADVISORY
+ * (high-risk owned areas). Advisory by default; --strict makes BLOCKING fail.
+ * Run: node --test os-platform/core/tests/canon-gates.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCanonGates } from '../gates/canon-gates.mjs';
+
+test('CG.1 a clean low-risk owned path yields no blocking and no advisory', () => {
+  const r = runCanonGates(['docs/TerraCanon/CANON_IDE_REPO_ADAPTATION_PLAN.md']);
+  assert.equal(r.blocking.length, 0);
+  assert.equal(r.advisory.length, 0);
+  assert.equal(r.ok, true);
+});
+
+test('CG.2 a protected path is BLOCKING', () => {
+  const r = runCanonGates(['ARCHIVE/old.ts']);
+  assert.ok(r.blocking.some((f) => /protected/i.test(f.detail)));
+  assert.equal(r.ok, false);
+});
+
+test('CG.3 an unowned path is BLOCKING', () => {
+  const r = runCanonGates(['some/unmapped/area/file.ts']);
+  assert.ok(r.blocking.some((f) => /unowned|no write-lane/i.test(f.detail)));
+});
+
+test('CG.4 a high-risk OWNED path is ADVISORY, not blocking', () => {
+  const r = runCanonGates(['frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx']);
+  assert.equal(r.blocking.length, 0);
+  assert.ok(r.advisory.some((f) => /high|risk/i.test(f.detail)));
+});
+
+test('CG.5 a hardcoded port is BLOCKING', () => {
+  const p = join(tmpdir(), `canon-gates-hp-${process.pid}.ts`);
+  writeFileSync(p, "const u = 'http://localhost:3000/api';\n", 'utf8');
+  try {
+    const r = runCanonGates([p]);
+    assert.ok(r.blocking.some((f) => /port/i.test(f.detail)));
+  } finally {
+    unlinkSync(p);
+  }
+});
+
+test('CG.6 strict mode exits non-zero on blocking; advisory exits 0', () => {
+  const strict = runCanonGates(['ARCHIVE/old.ts'], { strict: true });
+  assert.equal(strict.exitCode, 1);
+  const advisory = runCanonGates(['ARCHIVE/old.ts'], { strict: false });
+  assert.equal(advisory.exitCode, 0);
+});
+
+test('CG.7 strict mode with only advisory findings still exits 0', () => {
+  const r = runCanonGates(['frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx'], { strict: true });
+  assert.equal(r.exitCode, 0);
+});
+
+test('CG.8 never throws on odd input', () => {
+  assert.doesNotThrow(() => runCanonGates(undefined));
+  assert.doesNotThrow(() => runCanonGates([]));
+});


### PR DESCRIPTION
## Summary

The **enforce** cadence step — introduced **advisory-first** so it is safe for this shared multi-agent repo (it reports, it does not block anyone yet).

## What changed (3 files)

- `os-platform/core/gates/canon-gates.mjs` — aggregates all Canon gates over a changed-file set and classifies findings:
  - **BLOCKING**: protected-path edits (`ARCHIVE/**`, `specialized/**`), hardcoded ports, unowned paths (governance blind spots)
  - **ADVISORY**: high/critical-risk *owned* areas (informational only)
  - Advisory by default (exit 0); `--strict` exits 1 on blocking. Args-only, read-only, never throws.
- `os-platform/core/tests/canon-gates.test.mjs` — +8 tests
- `.github/workflows/canon-gates.yml` — runs the aggregator over each PR's changed files in **ADVISORY** mode, reporting to the job summary. **Never blocks**; not a required check.

## Why advisory-first

Making gates globally blocking on a repo with many concurrent agents would fail unrelated PRs on pre-existing issues. This lands the rail visibly and reversibly; flipping to enforcement is a one-line change (`--strict`) plus a branch-protection decision once signal quality is confirmed.

## Verification

- `node --test canon-gates.test.mjs` → 8/8
- full Canon runtime sweep → **84/84**
- `pnpm run type-check` → clean
- CLI smoke: `--strict` exits 1 on blocking (protected/unowned/ports); advisory exits 0; high-risk-owned stays advisory
- YAML: parses, ≤120 cols per repo `.yamllint.yml`

## Cadence status

Completes the loop: **queryable → fail-loud → report → proof → task-lifecycle → enforce (advisory)**. Next deliberate flip: `--strict` in CI/pre-commit + make it a required check.

## Summary by Sourcery

Add a Canon gates aggregator and wire it into CI in advisory mode to report, but not block on, governance violations in changed files.

New Features:
- Introduce a Canon gates aggregator CLI that classifies gate findings as blocking or advisory over a set of changed files.

Enhancements:
- Aggregate existing Canon checks into a single read-only enforcement rail with structured blocking vs. advisory results.

CI:
- Add a GitHub Actions workflow that runs the Canon gates aggregator on pull requests in advisory (non-blocking) mode and publishes its output to the job summary.

Tests:
- Add tests for the Canon gates aggregator to validate classification and exit-code behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated quality gates scanning that detects code violations including protected paths, hardcoded ports, and unowned code areas during CI/CD.

* **Chores**
  * Added GitHub Actions workflow configuration for quality gates scanning.

* **Tests**
  * Added test suite validating quality gates detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->