### PR TITLE
[codex] County Studio R1 Forge dev smoke

### DIFF
--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,17 +1,17 @@
 {
-  "generatedAtUtc": "2026-06-06T23:47:10.637Z",
+  "generatedAtUtc": "2026-06-07T15:27:49.772Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_DATA_AVAILABLE",
+  "status": "REAL_DEV_SERVER_BLOCKED",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": true,
+    "realDevServerAllowed": false,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
   "maturity": {
     "DATA_TRUTH_FAIL": true,
-    "REAL_DEV_DATA_AVAILABLE": true,
-    "SYNC_DERIVED_PARTIAL": true,
+    "REAL_DEV_DATA_AVAILABLE": false,
+    "SYNC_DERIVED_PARTIAL": false,
     "SYNC_DERIVED_COMPLETE": false,
     "AUTHORITATIVE_RECONCILED": false,
     "PRODUCTION_PROOF_ALLOWED": false
@@ -49,9 +49,9 @@
     },
     {
       "name": "active drain process state",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Drain process state is unknown.",
       "evidence": {
         "pid": null,
         "alive": null,
@@ -60,111 +60,111 @@
     },
     {
       "name": "load_batch current stage",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "load_batch stage is owner-supnum-resume (IN_PROGRESS).",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "load_batch stage is UNKNOWN (UNKNOWN).",
       "evidence": {
-        "stage": "owner-supnum-resume",
-        "status": "IN_PROGRESS",
-        "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63"
+        "stage": "UNKNOWN",
+        "status": "UNKNOWN",
+        "loadBatchId": null
       }
     },
     {
       "name": "landing table counts",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "Property landing rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Property landing rows are missing or unknown.",
       "evidence": {
-        "propertyLanding": 999214,
-        "ownerLanding": 7396857,
-        "suppAssociation": 2887351,
-        "wpov": 1273143,
-        "truthParcel": 83682,
-        "truthOwner": 774760,
-        "truthWsdor": 774696,
-        "canonicalParcel": 3199335,
-        "account": 425186
+        "propertyLanding": 0,
+        "ownerLanding": 0,
+        "suppAssociation": 0,
+        "wpov": 0,
+        "truthParcel": 0,
+        "truthOwner": 0,
+        "truthWsdor": 0,
+        "canonicalParcel": 0,
+        "account": 0
       }
     },
     {
       "name": "truth table counts",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
+      "classification": "UNKNOWN",
+      "passed": false,
       "reason": "Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
       "evidence": {
-        "propertyLanding": 999214,
-        "ownerLanding": 7396857,
-        "suppAssociation": 2887351,
-        "wpov": 1273143,
-        "truthParcel": 83682,
-        "truthOwner": 774760,
-        "truthWsdor": 774696,
-        "canonicalParcel": 3199335,
-        "account": 425186
+        "propertyLanding": 0,
+        "ownerLanding": 0,
+        "suppAssociation": 0,
+        "wpov": 0,
+        "truthParcel": 0,
+        "truthOwner": 0,
+        "truthWsdor": 0,
+        "canonicalParcel": 0,
+        "account": 0
       }
     },
     {
       "name": "canonical parcel counts",
-      "classification": "SEEDED",
-      "passed": true,
-      "reason": "Canonical parcel rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Canonical parcel count is missing.",
       "evidence": {
-        "canonicalParcel": 3199335
+        "canonicalParcel": 0
       }
     },
     {
       "name": "owner truth count",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "Owner truth rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Owner truth count is missing.",
       "evidence": {
-        "truthOwner": 774760,
-        "ownerLanding": 7396857
+        "truthOwner": 0,
+        "ownerLanding": 0
       }
     },
     {
       "name": "account count",
-      "classification": "SEEDED",
-      "passed": true,
-      "reason": "Account rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Account count is missing.",
       "evidence": {
-        "account": 425186
+        "account": 0
       }
     },
     {
       "name": "supp association count",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "Supplement association landing rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Supplement association count is missing.",
       "evidence": {
-        "suppAssociation": 2887351
+        "suppAssociation": 0
       }
     },
     {
       "name": "property landing count",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "Property landing count is present.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Property landing count is missing.",
       "evidence": {
-        "propertyLanding": 999214
+        "propertyLanding": 0
       }
     },
     {
       "name": "WPOV status",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "WPOV landing rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "WPOV landing status is missing.",
       "evidence": {
-        "wpov": 1273143
+        "wpov": 0
       }
     },
     {
       "name": "WSDOR status",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "WSDOR truth rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "WSDOR truth status is missing.",
       "evidence": {
-        "truthWsdor": 774696
+        "truthWsdor": 0
       }
     },
     {
@@ -173,8 +173,8 @@
       "passed": true,
       "reason": "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
       "evidence": {
-        "stage": "owner-supnum-resume",
-        "status": "IN_PROGRESS",
+        "stage": "UNKNOWN",
+        "status": "UNKNOWN",
         "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
         "requiredForCountyStudioForgeDev": false,
         "requiredForPacketProof": true,
@@ -206,36 +206,36 @@
     },
     {
       "name": "map data dependency status",
-      "classification": "PARTIAL_SEEDED",
-      "passed": true,
-      "reason": "Map dependency is classified PARTIAL_SEEDED.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Map dependency is classified UNKNOWN.",
       "evidence": {
-        "classification": "PARTIAL_SEEDED"
+        "classification": "UNKNOWN"
       }
     },
     {
       "name": "ledger data dependency status",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "Ledger dependency is classified SYNC_DERIVED.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Ledger dependency is classified UNKNOWN.",
       "evidence": {
-        "classification": "SYNC_DERIVED"
+        "classification": "UNKNOWN"
       }
     },
     {
       "name": "inspector data dependency status",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "Inspector dependency is classified SYNC_DERIVED.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Inspector dependency is classified UNKNOWN.",
       "evidence": {
-        "classification": "SYNC_DERIVED"
+        "classification": "UNKNOWN"
       }
     }
   ],
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "owner-supnum-resume",
-      "status": "IN_PROGRESS",
+      "stage": "UNKNOWN",
+      "status": "UNKNOWN",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,
       "requiredForPacketProof": true,
@@ -265,7 +265,22 @@
       }
     }
   },
-  "blockers": [],
+  "blockers": [
+    "active drain process state: Drain process state is unknown.",
+    "load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).",
+    "landing table counts: Property landing rows are missing or unknown.",
+    "truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
+    "canonical parcel counts: Canonical parcel count is missing.",
+    "owner truth count: Owner truth count is missing.",
+    "account count: Account count is missing.",
+    "supp association count: Supplement association count is missing.",
+    "property landing count: Property landing count is missing.",
+    "WPOV status: WPOV landing status is missing.",
+    "WSDOR status: WSDOR truth status is missing.",
+    "map data dependency status: Map dependency is classified UNKNOWN.",
+    "ledger data dependency status: Ledger dependency is classified UNKNOWN.",
+    "inspector data dependency status: Inspector dependency is classified UNKNOWN."
+  ],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,19 +1,19 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-06T23:47:10.637Z
-Status: REAL_DEV_DATA_AVAILABLE
+Generated: 2026-06-07T15:27:49.772Z
+Status: REAL_DEV_SERVER_BLOCKED
 
 ## Decision
 
-- Real Dev Server: ALLOWED
+- Real Dev Server: BLOCKED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
 ## Maturity
 
 - DATA_TRUTH_FAIL: true
-- REAL_DEV_DATA_AVAILABLE: true
-- SYNC_DERIVED_PARTIAL: true
+- REAL_DEV_DATA_AVAILABLE: false
+- SYNC_DERIVED_PARTIAL: false
 - SYNC_DERIVED_COMPLETE: false
 - AUTHORITATIVE_RECONCILED: false
 - PRODUCTION_PROOF_ALLOWED: false
@@ -23,26 +23,26 @@ Status: REAL_DEV_DATA_AVAILABLE
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
 | backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
-| active drain process state | SYNC_DERIVED | true | Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS. |
-| load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-resume (IN_PROGRESS). |
-| landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
-| truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
-| canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
-| owner truth count | PARTIAL_SEEDED | true | Owner truth rows exist. |
-| account count | SEEDED | true | Account rows exist. |
-| supp association count | PARTIAL_SEEDED | true | Supplement association landing rows exist. |
-| property landing count | PARTIAL_SEEDED | true | Property landing count is present. |
-| WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
-| WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
+| active drain process state | UNKNOWN | false | Drain process state is unknown. |
+| load_batch current stage | UNKNOWN | false | load_batch stage is UNKNOWN (UNKNOWN). |
+| landing table counts | UNKNOWN | false | Property landing rows are missing or unknown. |
+| truth table counts | UNKNOWN | false | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
+| canonical parcel counts | UNKNOWN | false | Canonical parcel count is missing. |
+| owner truth count | UNKNOWN | false | Owner truth count is missing. |
+| account count | UNKNOWN | false | Account count is missing. |
+| supp association count | UNKNOWN | false | Supplement association count is missing. |
+| property landing count | UNKNOWN | false | Property landing count is missing. |
+| WPOV status | UNKNOWN | false | WPOV landing status is missing. |
+| WSDOR status | UNKNOWN | false | WSDOR truth status is missing. |
 | owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
-| map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
-| ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
-| inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
+| map data dependency status | UNKNOWN | false | Map dependency is classified UNKNOWN. |
+| ledger data dependency status | UNKNOWN | false | Ledger dependency is classified UNKNOWN. |
+| inspector data dependency status | UNKNOWN | false | Inspector dependency is classified UNKNOWN. |
 
 ## Forge Dev Dependency Reclassification
 
-- ownerSupnumBackfillStatus: IN_PROGRESS
-- ownerSupnumBackfillStage: owner-supnum-resume
+- ownerSupnumBackfillStatus: UNKNOWN
+- ownerSupnumBackfillStage: UNKNOWN
 - ownerSupnumBackfillLatestFailedStage: owner-supnum-resume
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
@@ -52,7 +52,20 @@ Status: REAL_DEV_DATA_AVAILABLE
 
 ## Blockers
 
-- None
+- active drain process state: Drain process state is unknown.
+- load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).
+- landing table counts: Property landing rows are missing or unknown.
+- truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.
+- canonical parcel counts: Canonical parcel count is missing.
+- owner truth count: Owner truth count is missing.
+- account count: Account count is missing.
+- supp association count: Supplement association count is missing.
+- property landing count: Property landing count is missing.
+- WPOV status: WPOV landing status is missing.
+- WSDOR status: WSDOR truth status is missing.
+- map data dependency status: Map dependency is classified UNKNOWN.
+- ledger data dependency status: Ledger dependency is classified UNKNOWN.
+- inspector data dependency status: Inspector dependency is classified UNKNOWN.
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,0 +1,84 @@
+{
+  "generatedAtUtc": "2026-06-07T15:28:40.329Z",
+  "gate": "county-studio-r1-forge-dev-smoke",
+  "status": "FORGE_DEV_SMOKE_BLOCKED_BY_REAL_DEV_READINESS",
+  "commandInvoked": "pnpm run dev:county-studio:real-benton",
+  "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
+  "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-r1-forge-dev-smoke-20260607-082434.log",
+  "processCleanup": {
+    "spawnedSmokeProcessStopped": true,
+    "spawnedSmokeChildrenRemaining": false
+  },
+  "preflightGates": [
+    {
+      "command": "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
+      "status": "REAL_DEV_SERVER_BLOCKED",
+      "exitCode": 1,
+      "passed": false,
+      "blockers": 14,
+      "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
+    },
+    {
+      "command": "pnpm run proof:county-studio:real-dev-activation",
+      "status": "NOT_REACHED",
+      "passed": false,
+      "reason": "The real-dev readiness DB preflight failed before activation ran."
+    }
+  ],
+  "devServer": {
+    "started": false,
+    "boundUrls": [],
+    "urlEmitted": false,
+    "reason": "The real Benton Forge dev command stopped at the readiness DB preflight; Vite/dev server did not start."
+  },
+  "modeFlags": {
+    "configured": [
+      "TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton",
+      "TF_COUNTY_STUDIO_PRODUCTION_PROOF=false",
+      "TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false"
+    ],
+    "appliedToDevServer": false,
+    "reason": "The cross-env dev-server stage was not reached."
+  },
+  "postureAfterSmoke": {
+    "forgeDevAllowed": false,
+    "realDevActivationAllowed": true,
+    "countyStudioMode": "FORGE_DEV_BLOCKED",
+    "dataTruthStatus": "DATA_TRUTH_FAIL",
+    "geometryStatus": "SYNC_DERIVED_GEOMETRY",
+    "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
+    "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false
+  },
+  "readinessBlockers": [
+    "active drain process state: Drain process state is unknown.",
+    "load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).",
+    "landing table counts: Property landing rows are missing or unknown.",
+    "truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
+    "canonical parcel counts: Canonical parcel count is missing.",
+    "owner truth count: Owner truth count is missing.",
+    "account count: Account count is missing.",
+    "supp association count: Supplement association count is missing.",
+    "property landing count: Property landing count is missing.",
+    "WPOV status: WPOV landing status is missing.",
+    "WSDOR status: WSDOR truth status is missing.",
+    "map data dependency status: Map dependency is classified UNKNOWN.",
+    "ledger data dependency status: Ledger dependency is classified UNKNOWN.",
+    "inspector data dependency status: Inspector dependency is classified UNKNOWN."
+  ],
+  "startupErrors": [
+    "REAL_DEV_SERVER_BLOCKED from pnpm run proof:county-studio:benton-real-dev-server-readiness:db"
+  ],
+  "missingEnvOrConfigWarnings": [],
+  "interpretation": "The real Benton Forge dev run path was exercised and failed correctly before launching the dev server because the runtime DB evidence path no longer reports readable real-dev data. This is not a County Studio UI failure and does not weaken production or operational proof gates.",
+  "boundaries": [
+    "This smoke did not touch County Studio UI.",
+    "This smoke did not mutate TerraFusion Sync.",
+    "This smoke did not change DB seeding.",
+    "This smoke did not weaken gates.",
+    "This smoke did not set productionProofAllowed=true.",
+    "This smoke did not set operationalProofAllowed=true.",
+    "This smoke did not hide DATA_TRUTH_FAIL."
+  ]
+}

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,0 +1,104 @@
+# County Studio R1 Forge Dev Smoke
+
+Generated: 2026-06-07T15:28:40.329Z
+
+Status: `FORGE_DEV_SMOKE_BLOCKED_BY_REAL_DEV_READINESS`
+
+## Command Invoked
+
+```bash
+pnpm run dev:county-studio:real-benton
+```
+
+Working directory:
+
+```text
+C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
+```
+
+Smoke log:
+
+```text
+C:\Users\bsval\AppData\Local\Temp\county-studio-r1-forge-dev-smoke-20260607-082434.log
+```
+
+## Result
+
+The command was exercised, but the dev server did not start. The run stopped at the first preflight:
+
+```text
+pnpm run proof:county-studio:benton-real-dev-server-readiness:db
+```
+
+That preflight returned:
+
+```text
+REAL_DEV_SERVER_BLOCKED
+realDevServerAllowed=false
+productionProofAllowed=false
+operationalProofAllowed=false
+blockers=14
+```
+
+The `cross-env ... pnpm run dev` stage was not reached, so no Vite URL or bound port was emitted.
+
+## Mode Flags
+
+Configured by the run command:
+
+- `TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton`
+- `TF_COUNTY_STUDIO_PRODUCTION_PROOF=false`
+- `TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false`
+
+Applied to dev server: `false`
+
+Reason: the real-dev readiness DB preflight failed before the dev-server stage.
+
+## Posture After Smoke
+
+- forgeDevAllowed=false
+- realDevActivationAllowed=true
+- countyStudioMode=FORGE_DEV_BLOCKED
+- dataTruthStatus=DATA_TRUTH_FAIL
+- geometryStatus=SYNC_DERIVED_GEOMETRY
+- riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
+- ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
+- productionProofAllowed=false
+- operationalProofAllowed=false
+
+## Readiness Blockers
+
+- active drain process state: Drain process state is unknown.
+- load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).
+- landing table counts: Property landing rows are missing or unknown.
+- truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.
+- canonical parcel counts: Canonical parcel count is missing.
+- owner truth count: Owner truth count is missing.
+- account count: Account count is missing.
+- supp association count: Supplement association count is missing.
+- property landing count: Property landing count is missing.
+- WPOV status: WPOV landing status is missing.
+- WSDOR status: WSDOR truth status is missing.
+- map data dependency status: Map dependency is classified UNKNOWN.
+- ledger data dependency status: Ledger dependency is classified UNKNOWN.
+- inspector data dependency status: Inspector dependency is classified UNKNOWN.
+
+## Interpretation
+
+The real Benton Forge dev run path was exercised and failed correctly before launching the dev server because the runtime DB evidence path no longer reports readable real-dev data.
+
+This is not a County Studio UI failure.
+
+This is not production proof.
+
+This is not operational proof.
+
+## Boundaries
+
+- This smoke did not touch County Studio UI.
+- This smoke did not mutate TerraFusion Sync.
+- This smoke did not change DB seeding.
+- This smoke did not weaken gates.
+- This smoke did not set `productionProofAllowed=true`.
+- This smoke did not set `operationalProofAllowed=true`.
+- This smoke did not hide `DATA_TRUTH_FAIL`.

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
@@ -1,9 +1,9 @@
 {
-  "generatedAtUtc": "2026-06-07T08:03:40.825Z",
+  "generatedAtUtc": "2026-06-07T15:30:00.453Z",
   "gate": "county-studio-r1-forge-dev-status",
-  "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
+  "status": "COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED",
   "summary": {
-    "forgeDevAllowed": true,
+    "forgeDevAllowed": false,
     "realDevActivationAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
@@ -11,7 +11,7 @@
     "geometryStatus": "SYNC_DERIVED_GEOMETRY",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
-    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
+    "countyStudioMode": "FORGE_DEV_BLOCKED",
     "requiredRunCommand": "pnpm run dev:county-studio:real-benton",
     "remainingProductionBlockers": [
       "Canonical Benton source/count reconciliation remains required before production proof.",
@@ -62,7 +62,7 @@
     "geometry": "os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json",
     "riskAudit": "os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json"
   },
-  "blockers": [],
+  "blockers": ["Benton real dev server evidence is not allowed."],
   "boundaries": [
     "This consolidation does not touch County Studio UI.",
     "This consolidation does not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
@@ -1,11 +1,11 @@
 # County Studio R1 Forge Dev Status
 
-Generated: 2026-06-07T08:03:40.825Z
-Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
+Generated: 2026-06-07T15:30:00.453Z
+Status: COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED
 
 ## Summary
 
-- forgeDevAllowed=true
+- forgeDevAllowed=false
 - realDevActivationAllowed=true
 - productionProofAllowed=false
 - operationalProofAllowed=false
@@ -13,7 +13,7 @@ Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 - geometryStatus=SYNC_DERIVED_GEOMETRY
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 - ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
-- countyStudioMode=REAL_BENTON_FORGE_DEV
+- countyStudioMode=FORGE_DEV_BLOCKED
 - requiredRunCommand=pnpm run dev:county-studio:real-benton
 
 ## Runbook
@@ -60,7 +60,7 @@ Owner-supnum remains required for packet/ops proof, not current County Studio Fo
 
 ## Blockers
 
-- None
+- Benton real dev server evidence is not allowed.
 
 ## Boundaries
 


### PR DESCRIPTION
County Studio R1 Forge Dev Smoke Run

This PR records the result of actually invoking the real Benton Forge dev command:

pnpm run dev:county-studio:real-benton

Smoke result:
- status=FORGE_DEV_SMOKE_BLOCKED_BY_REAL_DEV_READINESS
- dev server started=false
- boundUrls=[]
- first preflight reached: pnpm run proof:county-studio:benton-real-dev-server-readiness:db
- first preflight result: REAL_DEV_SERVER_BLOCKED
- realDevServerAllowed=false
- productionProofAllowed=false
- operationalProofAllowed=false
- blockers=14

Important correction:
The prior consolidated evidence allowed Forge dev based on the then-current readable DB posture. The smoke run refreshed readiness evidence and found the current runtime DB evidence path no longer reports readable real-dev data. The command therefore failed before Vite/dev-server startup. This is the right gate behavior, not a UI failure.

Evidence added:
- os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
- os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md

Evidence refreshed by the smoke:
- os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json/md now report REAL_DEV_SERVER_BLOCKED
- os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json/md now report COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED

Current posture after smoke:
- forgeDevAllowed=false
- countyStudioMode=FORGE_DEV_BLOCKED
- dataTruthStatus=DATA_TRUTH_FAIL
- geometryStatus=SYNC_DERIVED_GEOMETRY
- riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
- ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
- productionProofAllowed=false
- operationalProofAllowed=false

Boundaries:
- no UI changes
- no Sync mutation
- no DB seeding changes
- no proof weakening
- DATA_TRUTH_FAIL remains visible

Verification:
- node --test os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs os-platform/core/pilot/county-studio-risk-object-source-audit.test.mjs os-platform/core/pilot/county-studio-forge-real-data-wiring.test.mjs os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.test.mjs
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- git diff --check
- pnpm run proof:county-studio:r1-forge-dev-status was run and correctly exited nonzero with COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED
- strict pre-push gate passed
