### PR TITLE
[codex] County Studio runtime evidence drift reconciliation

### DIFF
--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -64,6 +65,12 @@ const DEFAULT_OUT_MD = path.join(
   "evidence",
   "county-studio-r1-forge-dev-status.md"
 );
+const DEFAULT_REFRESH_READINESS_COMMAND = [
+  process.execPath,
+  path.join(repoRoot, "os-platform", "core", "pilot", "benton-real-dev-server-readiness.mjs"),
+  "--db-runtime",
+  "docker"
+];
 
 export const REQUIRED_FORGE_DEV_PREFLIGHT_CHAIN = [
   "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
@@ -167,8 +174,20 @@ function operationalBlockers() {
   ];
 }
 
-function buildBlockers({ realDevServerAllowed, realDevActivationAllowed, coreForgeValuationWiringReady, geometryIsReady, riskIsReady, ownerStatus }) {
+function buildBlockers({
+  realDevServerAllowed,
+  realDevActivationAllowed,
+  coreForgeValuationWiringReady,
+  geometryIsReady,
+  riskIsReady,
+  ownerStatus,
+  liveReadinessRefresh
+}) {
   const blockers = [];
+  if (liveReadinessRefresh?.attempted === true && liveReadinessRefresh.exitCode !== 0) {
+    blockers.push("Live readiness refresh failed; stale readiness evidence cannot allow Forge dev.");
+    blockers.push("Benton real dev server evidence is not allowed because live readiness refresh failed.");
+  }
   if (!realDevServerAllowed) blockers.push("Benton real dev server evidence is not allowed.");
   if (!realDevActivationAllowed) blockers.push("County Studio real dev activation is not ready.");
   if (!coreForgeValuationWiringReady) blockers.push("Core Forge valuation wiring is not ready.");
@@ -186,6 +205,7 @@ export function buildCountyStudioR1ForgeDevStatusReport({
   forgeWiringReport = null,
   geometryReport = null,
   riskAuditReport = null,
+  liveReadinessRefresh = null,
   generatedAtUtc = new Date().toISOString()
 } = {}) {
   const realDevServerAllowed = readinessReport?.decisions?.realDevServerAllowed === true;
@@ -204,7 +224,8 @@ export function buildCountyStudioR1ForgeDevStatusReport({
     coreForgeValuationWiringReady,
     geometryIsReady,
     riskIsReady,
-    ownerStatus: owner
+    ownerStatus: owner,
+    liveReadinessRefresh
   });
   const forgeDevAllowed = blockers.length === 0;
 
@@ -246,6 +267,12 @@ export function buildCountyStudioR1ForgeDevStatusReport({
       forgeWiring: "os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json",
       geometry: "os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json",
       riskAudit: "os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json"
+    },
+    liveReadinessRefresh: liveReadinessRefresh ?? {
+      attempted: false,
+      exitCode: null,
+      command: null,
+      interpretation: "Live readiness refresh was not requested for this in-memory report."
     },
     blockers,
     boundaries: [
@@ -313,6 +340,16 @@ export function renderCountyStudioR1ForgeDevStatusMarkdown(report) {
   lines.push("", "## Source Artifacts", "");
   Object.entries(report.sourceArtifacts).forEach(([key, value]) => lines.push(`- ${key}: ${value}`));
 
+  lines.push(
+    "",
+    "## Live Readiness Refresh",
+    "",
+    `- attempted: ${report.liveReadinessRefresh.attempted}`,
+    `- exitCode: ${report.liveReadinessRefresh.exitCode ?? "n/a"}`,
+    `- command: ${report.liveReadinessRefresh.command ?? "n/a"}`,
+    `- interpretation: ${report.liveReadinessRefresh.interpretation}`
+  );
+
   lines.push("", "## Blockers", "");
   if (report.blockers.length === 0) {
     lines.push("- None");
@@ -335,6 +372,9 @@ function parseArgs(argv) {
     riskAudit: DEFAULT_RISK_AUDIT_JSON,
     outJson: DEFAULT_OUT_JSON,
     outMd: DEFAULT_OUT_MD,
+    refreshReadiness: true,
+    refreshReadinessCommand: null,
+    refreshReadinessTimeoutMs: 240000,
     write: true
   };
 
@@ -345,6 +385,9 @@ function parseArgs(argv) {
     else if (arg === "--forge-wiring") args.forgeWiring = path.resolve(argv[++i]);
     else if (arg === "--geometry") args.geometry = path.resolve(argv[++i]);
     else if (arg === "--risk-audit") args.riskAudit = path.resolve(argv[++i]);
+    else if (arg === "--refresh-readiness-command") args.refreshReadinessCommand = argv[++i];
+    else if (arg === "--refresh-readiness-timeout-ms") args.refreshReadinessTimeoutMs = Number(argv[++i]);
+    else if (arg === "--no-refresh-readiness") args.refreshReadiness = false;
     else if (arg === "--out-json") args.outJson = path.resolve(argv[++i]);
     else if (arg === "--out-md") args.outMd = path.resolve(argv[++i]);
     else if (arg === "--no-write") args.write = false;
@@ -353,14 +396,61 @@ function parseArgs(argv) {
   return args;
 }
 
+function refreshReadinessEvidence(args) {
+  if (!args.refreshReadiness) {
+    return {
+      attempted: false,
+      exitCode: null,
+      command: null,
+      stdout: "",
+      stderr: "",
+      interpretation: "Live readiness refresh was skipped by --no-refresh-readiness."
+    };
+  }
+
+  const commandLabel = args.refreshReadinessCommand
+    ?? DEFAULT_REFRESH_READINESS_COMMAND.map((part) => part.includes(" ") ? `"${part}"` : part).join(" ");
+  const result = args.refreshReadinessCommand
+    ? spawnSync(args.refreshReadinessCommand, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        shell: true,
+        timeout: args.refreshReadinessTimeoutMs,
+        killSignal: "SIGKILL"
+      })
+    : spawnSync(DEFAULT_REFRESH_READINESS_COMMAND[0], DEFAULT_REFRESH_READINESS_COMMAND.slice(1), {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: args.refreshReadinessTimeoutMs,
+        killSignal: "SIGKILL"
+      });
+  const exitCode = result.status ?? 1;
+  return {
+    attempted: true,
+    exitCode,
+    timedOut: result.error?.code === "ETIMEDOUT",
+    timeoutMs: args.refreshReadinessTimeoutMs,
+    command: commandLabel,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    interpretation: result.error?.code === "ETIMEDOUT"
+      ? "Live readiness refresh timed out; stale readiness evidence cannot allow Forge dev."
+      : exitCode === 0
+      ? "Live readiness refresh passed; consolidated status may use the refreshed readiness artifact."
+      : "Live readiness refresh failed; stale readiness evidence cannot allow Forge dev."
+  };
+}
+
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
+  const liveReadinessRefresh = refreshReadinessEvidence(args);
   const report = buildCountyStudioR1ForgeDevStatusReport({
     readinessReport: readJson(args.readiness),
     activationReport: readJson(args.activation),
     forgeWiringReport: readJson(args.forgeWiring),
     geometryReport: readJson(args.geometry),
-    riskAuditReport: readJson(args.riskAudit)
+    riskAuditReport: readJson(args.riskAudit),
+    liveReadinessRefresh
   });
 
   if (args.write) {

--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
@@ -247,6 +247,7 @@ test("CLI writes consolidated Forge-dev status JSON and markdown runbook", () =>
       geometry,
       "--risk-audit",
       riskAudit,
+      "--no-refresh-readiness",
       "--out-json",
       outJson,
       "--out-md",
@@ -268,4 +269,79 @@ test("CLI writes consolidated Forge-dev status JSON and markdown runbook", () =>
   assert.match(markdown, /pnpm run dev:county-studio:real-benton/);
   assert.match(markdown, /This is not production proof/);
   assert.match(markdown, /This is not operational proof/);
+});
+
+test("CLI refreshes live readiness before status so stale ready evidence cannot override blocked runtime evidence", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tf-r1-forge-dev-live-status-"));
+  const readiness = path.join(tmp, "readiness.json");
+  const activation = path.join(tmp, "activation.json");
+  const forgeWiring = path.join(tmp, "forge-wiring.json");
+  const geometry = path.join(tmp, "geometry.json");
+  const riskAudit = path.join(tmp, "risk-audit.json");
+  const refreshScript = path.join(tmp, "refresh-readiness.mjs");
+  const outJson = path.join(tmp, "status.json");
+  const outMd = path.join(tmp, "status.md");
+
+  fs.writeFileSync(readiness, `${JSON.stringify(readinessReport(), null, 2)}\n`);
+  fs.writeFileSync(activation, `${JSON.stringify(activationReport(), null, 2)}\n`);
+  fs.writeFileSync(forgeWiring, `${JSON.stringify(forgeWiringReport(), null, 2)}\n`);
+  fs.writeFileSync(geometry, `${JSON.stringify(geometryReport(), null, 2)}\n`);
+  fs.writeFileSync(riskAudit, `${JSON.stringify(riskAuditReport(), null, 2)}\n`);
+  fs.writeFileSync(
+    refreshScript,
+    `
+      import fs from 'node:fs';
+      const readinessPath = process.argv[2];
+      const blocked = {
+        status: 'REAL_DEV_SERVER_BLOCKED',
+        decisions: {
+          realDevServerAllowed: false,
+          productionProofAllowed: false,
+          operationalProofAllowed: false
+        },
+        forgeDevDependency: ${JSON.stringify(readinessReport().forgeDevDependency)},
+        blockers: ['live DB counts are UNKNOWN/zero']
+      };
+      fs.writeFileSync(readinessPath, JSON.stringify(blocked, null, 2) + '\\n');
+      process.exit(1);
+    `
+  );
+
+  const result = spawnSync(
+    "node",
+    [
+      "os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs",
+      "--readiness",
+      readiness,
+      "--activation",
+      activation,
+      "--forge-wiring",
+      forgeWiring,
+      "--geometry",
+      geometry,
+      "--risk-audit",
+      riskAudit,
+      "--refresh-readiness-command",
+      `${JSON.stringify(process.execPath)} ${JSON.stringify(refreshScript)} ${JSON.stringify(readiness)}`,
+      "--out-json",
+      outJson,
+      "--out-md",
+      outMd
+    ],
+    { cwd: repoRoot, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED/);
+
+  const report = JSON.parse(fs.readFileSync(outJson, "utf8"));
+  assert.equal(report.status, "COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED");
+  assert.equal(report.summary.forgeDevAllowed, false);
+  assert.equal(report.summary.countyStudioMode, "FORGE_DEV_BLOCKED");
+  assert.equal(report.liveReadinessRefresh.attempted, true);
+  assert.equal(report.liveReadinessRefresh.exitCode, 1);
+  assert.match(report.liveReadinessRefresh.interpretation, /Live readiness refresh failed/i);
+  assert.ok(report.blockers.some((item) => /real dev server evidence/i.test(item)));
+  assert.equal(report.summary.productionProofAllowed, false);
+  assert.equal(report.summary.operationalProofAllowed, false);
 });

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,17 +1,17 @@
 {
-  "generatedAtUtc": "2026-06-07T15:27:49.772Z",
+  "generatedAtUtc": "2026-06-07T16:01:06.247Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_SERVER_BLOCKED",
+  "status": "REAL_DEV_DATA_AVAILABLE",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": false,
+    "realDevServerAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
   "maturity": {
     "DATA_TRUTH_FAIL": true,
-    "REAL_DEV_DATA_AVAILABLE": false,
-    "SYNC_DERIVED_PARTIAL": false,
+    "REAL_DEV_DATA_AVAILABLE": true,
+    "SYNC_DERIVED_PARTIAL": true,
     "SYNC_DERIVED_COMPLETE": false,
     "AUTHORITATIVE_RECONCILED": false,
     "PRODUCTION_PROOF_ALLOWED": false
@@ -49,9 +49,9 @@
     },
     {
       "name": "active drain process state",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Drain process state is unknown.",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS.",
       "evidence": {
         "pid": null,
         "alive": null,
@@ -60,111 +60,111 @@
     },
     {
       "name": "load_batch current stage",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "load_batch stage is UNKNOWN (UNKNOWN).",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "load_batch stage is owner-supnum-v2-activesupp-copy (IN_PROGRESS).",
       "evidence": {
-        "stage": "UNKNOWN",
-        "status": "UNKNOWN",
-        "loadBatchId": null
+        "stage": "owner-supnum-v2-activesupp-copy",
+        "status": "IN_PROGRESS",
+        "loadBatchId": "a0fd1bdc-11c5-475f-b700-3ecd73f7e7e1"
       }
     },
     {
       "name": "landing table counts",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Property landing rows are missing or unknown.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "Property landing rows exist.",
       "evidence": {
-        "propertyLanding": 0,
-        "ownerLanding": 0,
-        "suppAssociation": 0,
-        "wpov": 0,
-        "truthParcel": 0,
-        "truthOwner": 0,
-        "truthWsdor": 0,
-        "canonicalParcel": 0,
-        "account": 0
+        "propertyLanding": 1190834,
+        "ownerLanding": 8213706,
+        "suppAssociation": 4382985,
+        "wpov": 1658143,
+        "truthParcel": 83326,
+        "truthOwner": 816849,
+        "truthWsdor": 774696,
+        "canonicalParcel": 3198979,
+        "account": 535140
       }
     },
     {
       "name": "truth table counts",
-      "classification": "UNKNOWN",
-      "passed": false,
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
       "reason": "Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
       "evidence": {
-        "propertyLanding": 0,
-        "ownerLanding": 0,
-        "suppAssociation": 0,
-        "wpov": 0,
-        "truthParcel": 0,
-        "truthOwner": 0,
-        "truthWsdor": 0,
-        "canonicalParcel": 0,
-        "account": 0
+        "propertyLanding": 1190834,
+        "ownerLanding": 8213706,
+        "suppAssociation": 4382985,
+        "wpov": 1658143,
+        "truthParcel": 83326,
+        "truthOwner": 816849,
+        "truthWsdor": 774696,
+        "canonicalParcel": 3198979,
+        "account": 535140
       }
     },
     {
       "name": "canonical parcel counts",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Canonical parcel count is missing.",
+      "classification": "SEEDED",
+      "passed": true,
+      "reason": "Canonical parcel rows exist.",
       "evidence": {
-        "canonicalParcel": 0
+        "canonicalParcel": 3198979
       }
     },
     {
       "name": "owner truth count",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Owner truth count is missing.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "Owner truth rows exist.",
       "evidence": {
-        "truthOwner": 0,
-        "ownerLanding": 0
+        "truthOwner": 816849,
+        "ownerLanding": 8213706
       }
     },
     {
       "name": "account count",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Account count is missing.",
+      "classification": "SEEDED",
+      "passed": true,
+      "reason": "Account rows exist.",
       "evidence": {
-        "account": 0
+        "account": 535140
       }
     },
     {
       "name": "supp association count",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Supplement association count is missing.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "Supplement association landing rows exist.",
       "evidence": {
-        "suppAssociation": 0
+        "suppAssociation": 4382985
       }
     },
     {
       "name": "property landing count",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Property landing count is missing.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "Property landing count is present.",
       "evidence": {
-        "propertyLanding": 0
+        "propertyLanding": 1190834
       }
     },
     {
       "name": "WPOV status",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "WPOV landing status is missing.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "WPOV landing rows exist.",
       "evidence": {
-        "wpov": 0
+        "wpov": 1658143
       }
     },
     {
       "name": "WSDOR status",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "WSDOR truth status is missing.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "WSDOR truth rows exist.",
       "evidence": {
-        "truthWsdor": 0
+        "truthWsdor": 774696
       }
     },
     {
@@ -173,8 +173,8 @@
       "passed": true,
       "reason": "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
       "evidence": {
-        "stage": "UNKNOWN",
-        "status": "UNKNOWN",
+        "stage": "owner-supnum-v2-activesupp-copy",
+        "status": "IN_PROGRESS",
         "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
         "requiredForCountyStudioForgeDev": false,
         "requiredForPacketProof": true,
@@ -206,36 +206,36 @@
     },
     {
       "name": "map data dependency status",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Map dependency is classified UNKNOWN.",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "Map dependency is classified PARTIAL_SEEDED.",
       "evidence": {
-        "classification": "UNKNOWN"
+        "classification": "PARTIAL_SEEDED"
       }
     },
     {
       "name": "ledger data dependency status",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Ledger dependency is classified UNKNOWN.",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "Ledger dependency is classified SYNC_DERIVED.",
       "evidence": {
-        "classification": "UNKNOWN"
+        "classification": "SYNC_DERIVED"
       }
     },
     {
       "name": "inspector data dependency status",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Inspector dependency is classified UNKNOWN.",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "Inspector dependency is classified SYNC_DERIVED.",
       "evidence": {
-        "classification": "UNKNOWN"
+        "classification": "SYNC_DERIVED"
       }
     }
   ],
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "UNKNOWN",
-      "status": "UNKNOWN",
+      "stage": "owner-supnum-v2-activesupp-copy",
+      "status": "IN_PROGRESS",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,
       "requiredForPacketProof": true,
@@ -265,22 +265,7 @@
       }
     }
   },
-  "blockers": [
-    "active drain process state: Drain process state is unknown.",
-    "load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).",
-    "landing table counts: Property landing rows are missing or unknown.",
-    "truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
-    "canonical parcel counts: Canonical parcel count is missing.",
-    "owner truth count: Owner truth count is missing.",
-    "account count: Account count is missing.",
-    "supp association count: Supplement association count is missing.",
-    "property landing count: Property landing count is missing.",
-    "WPOV status: WPOV landing status is missing.",
-    "WSDOR status: WSDOR truth status is missing.",
-    "map data dependency status: Map dependency is classified UNKNOWN.",
-    "ledger data dependency status: Ledger dependency is classified UNKNOWN.",
-    "inspector data dependency status: Inspector dependency is classified UNKNOWN."
-  ],
+  "blockers": [],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,19 +1,19 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T15:27:49.772Z
-Status: REAL_DEV_SERVER_BLOCKED
+Generated: 2026-06-07T16:01:06.247Z
+Status: REAL_DEV_DATA_AVAILABLE
 
 ## Decision
 
-- Real Dev Server: BLOCKED
+- Real Dev Server: ALLOWED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
 ## Maturity
 
 - DATA_TRUTH_FAIL: true
-- REAL_DEV_DATA_AVAILABLE: false
-- SYNC_DERIVED_PARTIAL: false
+- REAL_DEV_DATA_AVAILABLE: true
+- SYNC_DERIVED_PARTIAL: true
 - SYNC_DERIVED_COMPLETE: false
 - AUTHORITATIVE_RECONCILED: false
 - PRODUCTION_PROOF_ALLOWED: false
@@ -23,26 +23,26 @@ Status: REAL_DEV_SERVER_BLOCKED
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
 | backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
-| active drain process state | UNKNOWN | false | Drain process state is unknown. |
-| load_batch current stage | UNKNOWN | false | load_batch stage is UNKNOWN (UNKNOWN). |
-| landing table counts | UNKNOWN | false | Property landing rows are missing or unknown. |
-| truth table counts | UNKNOWN | false | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
-| canonical parcel counts | UNKNOWN | false | Canonical parcel count is missing. |
-| owner truth count | UNKNOWN | false | Owner truth count is missing. |
-| account count | UNKNOWN | false | Account count is missing. |
-| supp association count | UNKNOWN | false | Supplement association count is missing. |
-| property landing count | UNKNOWN | false | Property landing count is missing. |
-| WPOV status | UNKNOWN | false | WPOV landing status is missing. |
-| WSDOR status | UNKNOWN | false | WSDOR truth status is missing. |
+| active drain process state | SYNC_DERIVED | true | Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS. |
+| load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-v2-activesupp-copy (IN_PROGRESS). |
+| landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
+| truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
+| canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
+| owner truth count | PARTIAL_SEEDED | true | Owner truth rows exist. |
+| account count | SEEDED | true | Account rows exist. |
+| supp association count | PARTIAL_SEEDED | true | Supplement association landing rows exist. |
+| property landing count | PARTIAL_SEEDED | true | Property landing count is present. |
+| WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
+| WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
 | owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
-| map data dependency status | UNKNOWN | false | Map dependency is classified UNKNOWN. |
-| ledger data dependency status | UNKNOWN | false | Ledger dependency is classified UNKNOWN. |
-| inspector data dependency status | UNKNOWN | false | Inspector dependency is classified UNKNOWN. |
+| map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
+| ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
+| inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
 
 ## Forge Dev Dependency Reclassification
 
-- ownerSupnumBackfillStatus: UNKNOWN
-- ownerSupnumBackfillStage: UNKNOWN
+- ownerSupnumBackfillStatus: IN_PROGRESS
+- ownerSupnumBackfillStage: owner-supnum-v2-activesupp-copy
 - ownerSupnumBackfillLatestFailedStage: owner-supnum-resume
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
@@ -52,20 +52,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 
 ## Blockers
 
-- active drain process state: Drain process state is unknown.
-- load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).
-- landing table counts: Property landing rows are missing or unknown.
-- truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.
-- canonical parcel counts: Canonical parcel count is missing.
-- owner truth count: Owner truth count is missing.
-- account count: Account count is missing.
-- supp association count: Supplement association count is missing.
-- property landing count: Property landing count is missing.
-- WPOV status: WPOV landing status is missing.
-- WSDOR status: WSDOR truth status is missing.
-- map data dependency status: Map dependency is classified UNKNOWN.
-- ledger data dependency status: Ledger dependency is classified UNKNOWN.
-- inspector data dependency status: Inspector dependency is classified UNKNOWN.
+- None
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-06T23:47:05.120Z",
+  "generatedAtUtc": "2026-06-07T15:51:02.540Z",
   "adapter": "benton-sync-drain-state-evidence",
   "backendHealth": {
     "status": "healthy",
@@ -21,14 +21,14 @@
     "directConnectionConfigured": false
   },
   "loadBatch": {
-    "stage": "owner-supnum-resume",
+    "stage": "owner-supnum-v2-activesupp-copy",
     "status": "IN_PROGRESS",
-    "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63"
+    "loadBatchId": "a0fd1bdc-11c5-475f-b700-3ecd73f7e7e1"
   },
   "queryResults": {
     "latestLoadBatch": {
-      "loadBatchId": "cc68d086-4125-4808-bcdd-1f96fa0a9a63",
-      "stage": "owner-supnum-resume",
+      "loadBatchId": "a0fd1bdc-11c5-475f-b700-3ecd73f7e7e1",
+      "stage": "owner-supnum-v2-activesupp-copy",
       "status": "IN_PROGRESS"
     },
     "latestOwnerSupnumFailure": {
@@ -36,35 +36,38 @@
       "stage": "owner-supnum-resume",
       "status": "FAILED"
     },
-    "legacyProperty": 999214,
-    "legacyOwner": 7396857,
-    "legacyPropSuppAssoc": 2887351,
-    "legacyWashPropOwnerVal": 1273143,
-    "legacyAccount": 425186,
-    "truthParcel": 83682,
-    "truthOwner": 774760,
-    "truthWsdor": 774696,
-    "canonicalParcel": 3199335,
-    "canonicalOwner": 215009,
+    "legacyProperty": 1190834,
+    "legacyOwner": 8213706,
+    "legacyPropSuppAssoc": 4382985,
+    "legacyWashPropOwnerVal": 1654143,
+    "legacyAccount": 535140,
+    "truthParcel": 83326,
+    "truthOwner": 816849,
+    "truthWsdor": {
+      "unavailable": true,
+      "reason": "No readable DB runtime path. docker psql: spawnSync docker ETIMEDOUT"
+    },
+    "canonicalParcel": 3198979,
+    "canonicalOwner": 312532,
     "canonicalWsdor": 686820,
     "gisParcelGeometry": 80075
   },
   "counts": {
     "landingTables": {
-      "property": 999214,
-      "owner": 7396857,
-      "propSuppAssoc": 2887351,
-      "washPropOwnerVal": 1273143
+      "property": 1190834,
+      "owner": 8213706,
+      "propSuppAssoc": 4382985,
+      "washPropOwnerVal": 1654143
     },
     "truthTables": {
-      "parcel": 83682,
-      "owner": 774760,
-      "wsdor": 774696
+      "parcel": 83326,
+      "owner": 816849,
+      "wsdor": 0
     },
     "canonical": {
-      "parcel": 3199335,
-      "owner": 215009,
-      "account": 425186,
+      "parcel": 3198979,
+      "owner": 312532,
+      "account": 535140,
       "wsdor": 686820
     },
     "gis": {
@@ -79,7 +82,7 @@
     "legacyAccount": "SEEDED",
     "truthParcel": "SYNC_DERIVED",
     "truthOwner": "SYNC_DERIVED",
-    "truthWsdor": "SYNC_DERIVED",
+    "truthWsdor": "UNKNOWN",
     "canonicalParcel": "SEEDED",
     "canonicalOwner": "SEEDED",
     "canonicalWsdor": "SEEDED",
@@ -90,7 +93,7 @@
     "ledger": "SYNC_DERIVED",
     "inspector": "SYNC_DERIVED",
     "ownerSupnumBackfill": {
-      "stage": "owner-supnum-resume",
+      "stage": "owner-supnum-v2-activesupp-copy",
       "status": "IN_PROGRESS",
       "latestFailed": {
         "loadBatchId": "581cb948-936b-40e2-b478-364b28dfd0e3",

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
@@ -1,6 +1,6 @@
 # Benton Sync Drain State Evidence
 
-Generated: 2026-06-06T23:47:05.120Z
+Generated: 2026-06-07T15:51:02.540Z
 
 ## Decision
 
@@ -13,7 +13,7 @@ Generated: 2026-06-06T23:47:05.120Z
 - Backend health: healthy
 - Drain PID: none
 - Drain alive: null
-- load_batch stage: owner-supnum-resume
+- load_batch stage: owner-supnum-v2-activesupp-copy
 - load_batch status: IN_PROGRESS
 
 ## DB Runtime Access
@@ -29,16 +29,16 @@ Generated: 2026-06-06T23:47:05.120Z
 
 | Source | Classification | Count | Reason |
 | --- | --- | ---: | --- |
-| legacyProperty | PARTIAL_SEEDED | 999214 | count present |
-| legacyOwner | PARTIAL_SEEDED | 7396857 | count present |
-| legacyPropSuppAssoc | PARTIAL_SEEDED | 2887351 | count present |
-| legacyWashPropOwnerVal | PARTIAL_SEEDED | 1273143 | count present |
-| legacyAccount | SEEDED | 425186 | count present |
-| truthParcel | SYNC_DERIVED | 83682 | count present |
-| truthOwner | SYNC_DERIVED | 774760 | count present |
-| truthWsdor | SYNC_DERIVED | 774696 | count present |
-| canonicalParcel | SEEDED | 3199335 | count present |
-| canonicalOwner | SEEDED | 215009 | count present |
+| legacyProperty | PARTIAL_SEEDED | 1190834 | count present |
+| legacyOwner | PARTIAL_SEEDED | 8213706 | count present |
+| legacyPropSuppAssoc | PARTIAL_SEEDED | 4382985 | count present |
+| legacyWashPropOwnerVal | PARTIAL_SEEDED | 1654143 | count present |
+| legacyAccount | SEEDED | 535140 | count present |
+| truthParcel | SYNC_DERIVED | 83326 | count present |
+| truthOwner | SYNC_DERIVED | 816849 | count present |
+| truthWsdor | UNKNOWN | 0 | No readable DB runtime path. docker psql: spawnSync docker ETIMEDOUT |
+| canonicalParcel | SEEDED | 3198979 | count present |
+| canonicalOwner | SEEDED | 312532 | count present |
 | canonicalWsdor | SEEDED | 686820 | count present |
 | gisParcelGeometry | PARTIAL_SEEDED | 80075 | count present |
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,10 +1,10 @@
 {
-  "generatedAtUtc": "2026-06-07T15:28:40.329Z",
+  "generatedAtUtc": "2026-06-07T15:57:14.591Z",
   "gate": "county-studio-r1-forge-dev-smoke",
-  "status": "FORGE_DEV_SMOKE_BLOCKED_BY_REAL_DEV_READINESS",
+  "status": "FORGE_DEV_SMOKE_FRONTEND_STARTED_BACKEND_PORT_BLOCKED",
   "commandInvoked": "pnpm run dev:county-studio:real-benton",
   "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
-  "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-r1-forge-dev-smoke-20260607-082434.log",
+  "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-r1-forge-dev-smoke-20260607-085321.log",
   "processCleanup": {
     "spawnedSmokeProcessStopped": true,
     "spawnedSmokeChildrenRemaining": false
@@ -12,24 +12,28 @@
   "preflightGates": [
     {
       "command": "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
-      "status": "REAL_DEV_SERVER_BLOCKED",
-      "exitCode": 1,
-      "passed": false,
-      "blockers": 14,
+      "status": "REAL_DEV_DATA_AVAILABLE",
+      "exitCode": 0,
+      "passed": true,
+      "blockers": 0,
       "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-activation",
-      "status": "NOT_REACHED",
-      "passed": false,
-      "reason": "The real-dev readiness DB preflight failed before activation ran."
+      "status": "REAL_DEV_ACTIVATION_READY",
+      "exitCode": 0,
+      "passed": true,
+      "blockers": 0,
+      "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json"
     }
   ],
   "devServer": {
     "started": false,
-    "boundUrls": [],
-    "urlEmitted": false,
-    "reason": "The real Benton Forge dev command stopped at the readiness DB preflight; Vite/dev server did not start."
+    "frontendStarted": true,
+    "frontendBoundUrls": ["http://localhost:5174/"],
+    "urlEmitted": true,
+    "backendStarted": false,
+    "reason": "The real Benton Forge dev command passed readiness and activation, and Vite emitted http://localhost:5174/, but the governed pilot/backend runtime failed because ports 4317 and 5046 were already in use."
   },
   "modeFlags": {
     "configured": [
@@ -37,13 +41,15 @@
       "TF_COUNTY_STUDIO_PRODUCTION_PROOF=false",
       "TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false"
     ],
-    "appliedToDevServer": false,
-    "reason": "The cross-env dev-server stage was not reached."
+    "appliedToFrontendStage": true,
+    "appliedToCleanFullDevServer": false,
+    "reason": "The command reached the cross-env dev stage and Vite started, but the full dev runtime exited on port conflicts before a clean end-to-end server state could be accepted."
   },
   "postureAfterSmoke": {
-    "forgeDevAllowed": false,
+    "forgeDevAllowed": true,
+    "realDevServerAllowed": true,
     "realDevActivationAllowed": true,
-    "countyStudioMode": "FORGE_DEV_BLOCKED",
+    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
     "dataTruthStatus": "DATA_TRUTH_FAIL",
     "geometryStatus": "SYNC_DERIVED_GEOMETRY",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
@@ -51,27 +57,13 @@
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
-  "readinessBlockers": [
-    "active drain process state: Drain process state is unknown.",
-    "load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).",
-    "landing table counts: Property landing rows are missing or unknown.",
-    "truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.",
-    "canonical parcel counts: Canonical parcel count is missing.",
-    "owner truth count: Owner truth count is missing.",
-    "account count: Account count is missing.",
-    "supp association count: Supplement association count is missing.",
-    "property landing count: Property landing count is missing.",
-    "WPOV status: WPOV landing status is missing.",
-    "WSDOR status: WSDOR truth status is missing.",
-    "map data dependency status: Map dependency is classified UNKNOWN.",
-    "ledger data dependency status: Ledger dependency is classified UNKNOWN.",
-    "inspector data dependency status: Inspector dependency is classified UNKNOWN."
-  ],
+  "readinessBlockers": [],
   "startupErrors": [
-    "REAL_DEV_SERVER_BLOCKED from pnpm run proof:county-studio:benton-real-dev-server-readiness:db"
+    "Governed pilot runtime: EADDRINUSE 127.0.0.1:4317",
+    "TerraFusion API runtime: failed to bind http://127.0.0.1:5046 because the address was already in use"
   ],
   "missingEnvOrConfigWarnings": [],
-  "interpretation": "The real Benton Forge dev run path was exercised and failed correctly before launching the dev server because the runtime DB evidence path no longer reports readable real-dev data. This is not a County Studio UI failure and does not weaken production or operational proof gates.",
+  "interpretation": "The prior readiness-blocked smoke evidence was stale after the live DB adapter was refreshed. Current live readiness and activation pass, so County Studio Forge dev mode is allowed again. The smoke still does not prove a clean full dev launch because the local runtime had occupied pilot/API ports. This is runtime environment drift, not a County Studio UI failure, and it does not unlock production or operational proof.",
   "boundaries": [
     "This smoke did not touch County Studio UI.",
     "This smoke did not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,8 +1,8 @@
 # County Studio R1 Forge Dev Smoke
 
-Generated: 2026-06-07T15:28:40.329Z
+Generated: 2026-06-07T15:57:14.591Z
 
-Status: `FORGE_DEV_SMOKE_BLOCKED_BY_REAL_DEV_READINESS`
+Status: `FORGE_DEV_SMOKE_FRONTEND_STARTED_BACKEND_PORT_BLOCKED`
 
 ## Command Invoked
 
@@ -19,28 +19,32 @@ C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
 Smoke log:
 
 ```text
-C:\Users\bsval\AppData\Local\Temp\county-studio-r1-forge-dev-smoke-20260607-082434.log
+C:\Users\bsval\AppData\Local\Temp\county-studio-r1-forge-dev-smoke-20260607-085321.log
 ```
 
 ## Result
 
-The command was exercised, but the dev server did not start. The run stopped at the first preflight:
+The real Benton Forge dev command reached the live dev stage:
 
 ```text
 pnpm run proof:county-studio:benton-real-dev-server-readiness:db
+REAL_DEV_DATA_AVAILABLE
+
+pnpm run proof:county-studio:real-dev-activation
+REAL_DEV_ACTIVATION_READY
+
+Vite emitted:
+http://localhost:5174/
 ```
 
-That preflight returned:
+The full dev command still cannot be accepted as a clean launch because local runtime ports were already occupied:
 
 ```text
-REAL_DEV_SERVER_BLOCKED
-realDevServerAllowed=false
-productionProofAllowed=false
-operationalProofAllowed=false
-blockers=14
+Governed pilot runtime: EADDRINUSE 127.0.0.1:4317
+TerraFusion API runtime: failed to bind http://127.0.0.1:5046
 ```
 
-The `cross-env ... pnpm run dev` stage was not reached, so no Vite URL or bound port was emitted.
+So this smoke proves the readiness drift is reconciled, but it does not claim a clean full dev server startup.
 
 ## Mode Flags
 
@@ -50,15 +54,18 @@ Configured by the run command:
 - `TF_COUNTY_STUDIO_PRODUCTION_PROOF=false`
 - `TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false`
 
-Applied to dev server: `false`
+Applied to frontend stage: `true`
 
-Reason: the real-dev readiness DB preflight failed before the dev-server stage.
+Applied to clean full dev server: `false`
+
+Reason: the command reached the `cross-env ... pnpm run dev` stage and Vite started, but the governed pilot/API runtime exited on port conflicts.
 
 ## Posture After Smoke
 
-- forgeDevAllowed=false
+- forgeDevAllowed=true
+- realDevServerAllowed=true
 - realDevActivationAllowed=true
-- countyStudioMode=FORGE_DEV_BLOCKED
+- countyStudioMode=REAL_BENTON_FORGE_DEV
 - dataTruthStatus=DATA_TRUTH_FAIL
 - geometryStatus=SYNC_DERIVED_GEOMETRY
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
@@ -66,28 +73,16 @@ Reason: the real-dev readiness DB preflight failed before the dev-server stage.
 - productionProofAllowed=false
 - operationalProofAllowed=false
 
-## Readiness Blockers
+## Startup Errors
 
-- active drain process state: Drain process state is unknown.
-- load_batch current stage: load_batch stage is UNKNOWN (UNKNOWN).
-- landing table counts: Property landing rows are missing or unknown.
-- truth table counts: Truth table counts are evaluated as partial until all expected Benton counts are reconciled.
-- canonical parcel counts: Canonical parcel count is missing.
-- owner truth count: Owner truth count is missing.
-- account count: Account count is missing.
-- supp association count: Supplement association count is missing.
-- property landing count: Property landing count is missing.
-- WPOV status: WPOV landing status is missing.
-- WSDOR status: WSDOR truth status is missing.
-- map data dependency status: Map dependency is classified UNKNOWN.
-- ledger data dependency status: Ledger dependency is classified UNKNOWN.
-- inspector data dependency status: Inspector dependency is classified UNKNOWN.
+- Governed pilot runtime: `EADDRINUSE 127.0.0.1:4317`
+- TerraFusion API runtime: `Failed to bind to address http://127.0.0.1:5046`
 
 ## Interpretation
 
-The real Benton Forge dev run path was exercised and failed correctly before launching the dev server because the runtime DB evidence path no longer reports readable real-dev data.
+The prior readiness-blocked smoke evidence was stale after the live DB adapter was refreshed. Current live readiness and activation pass, so County Studio Forge dev mode is allowed again.
 
-This is not a County Studio UI failure.
+The smoke still does not prove a clean full dev launch because the local runtime had occupied pilot/API ports. This is runtime environment drift, not a County Studio UI failure.
 
 This is not production proof.
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
@@ -1,9 +1,9 @@
 {
-  "generatedAtUtc": "2026-06-07T15:30:00.453Z",
+  "generatedAtUtc": "2026-06-07T16:01:06.277Z",
   "gate": "county-studio-r1-forge-dev-status",
-  "status": "COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED",
+  "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
   "summary": {
-    "forgeDevAllowed": false,
+    "forgeDevAllowed": true,
     "realDevActivationAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
@@ -11,7 +11,7 @@
     "geometryStatus": "SYNC_DERIVED_GEOMETRY",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
-    "countyStudioMode": "FORGE_DEV_BLOCKED",
+    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
     "requiredRunCommand": "pnpm run dev:county-studio:real-benton",
     "remainingProductionBlockers": [
       "Canonical Benton source/count reconciliation remains required before production proof.",
@@ -62,7 +62,17 @@
     "geometry": "os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json",
     "riskAudit": "os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json"
   },
-  "blockers": ["Benton real dev server evidence is not allowed."],
+  "liveReadinessRefresh": {
+    "attempted": true,
+    "exitCode": 0,
+    "timedOut": false,
+    "timeoutMs": 240000,
+    "command": "\"C:\\Program Files\\nodejs\\node.exe\" C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads\\os-platform\\core\\pilot\\benton-real-dev-server-readiness.mjs --db-runtime docker",
+    "stdout": "{\n  \"status\": \"REAL_DEV_DATA_AVAILABLE\",\n  \"realDevServerAllowed\": true,\n  \"productionProofAllowed\": false,\n  \"operationalProofAllowed\": false,\n  \"blockers\": 0,\n  \"output\": \"os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json\"\n}\n",
+    "stderr": "",
+    "interpretation": "Live readiness refresh passed; consolidated status may use the refreshed readiness artifact."
+  },
+  "blockers": [],
   "boundaries": [
     "This consolidation does not touch County Studio UI.",
     "This consolidation does not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
@@ -1,11 +1,11 @@
 # County Studio R1 Forge Dev Status
 
-Generated: 2026-06-07T15:30:00.453Z
-Status: COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED
+Generated: 2026-06-07T16:01:06.277Z
+Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 
 ## Summary
 
-- forgeDevAllowed=false
+- forgeDevAllowed=true
 - realDevActivationAllowed=true
 - productionProofAllowed=false
 - operationalProofAllowed=false
@@ -13,7 +13,7 @@ Status: COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED
 - geometryStatus=SYNC_DERIVED_GEOMETRY
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 - ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
-- countyStudioMode=FORGE_DEV_BLOCKED
+- countyStudioMode=REAL_BENTON_FORGE_DEV
 - requiredRunCommand=pnpm run dev:county-studio:real-benton
 
 ## Runbook
@@ -58,9 +58,16 @@ Owner-supnum remains required for packet/ops proof, not current County Studio Fo
 - geometry: os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json
 - riskAudit: os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json
 
+## Live Readiness Refresh
+
+- attempted: true
+- exitCode: 0
+- command: "C:\Program Files\nodejs\node.exe" C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads\os-platform\core\pilot\benton-real-dev-server-readiness.mjs --db-runtime docker
+- interpretation: Live readiness refresh passed; consolidated status may use the refreshed readiness artifact.
+
 ## Blockers
 
-- Benton real dev server evidence is not allowed.
+- None
 
 ## Boundaries
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-06T23:47:12.796Z",
+  "generatedAtUtc": "2026-06-07T15:53:50.612Z",
   "gate": "county-studio-real-dev-server-activation",
   "status": "REAL_DEV_ACTIVATION_READY",
   "decisions": {
@@ -20,7 +20,7 @@
   },
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "owner-supnum-resume",
+      "stage": "owner-supnum-v2-activesupp-copy",
       "status": "IN_PROGRESS",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Server Activation
 
-Generated: 2026-06-06T23:47:12.796Z
+Generated: 2026-06-07T15:53:50.612Z
 Status: REAL_DEV_ACTIVATION_READY
 
 ## Decision

--- a/os-platform/core/pilot/evidence/county-studio-runtime-evidence-drift.json
+++ b/os-platform/core/pilot/evidence/county-studio-runtime-evidence-drift.json
@@ -1,0 +1,77 @@
+{
+  "generatedAtUtc": "2026-06-07T15:57:14.591Z",
+  "gate": "county-studio-runtime-evidence-drift",
+  "status": "RUNTIME_EVIDENCE_DRIFT_RECONCILED",
+  "drift": {
+    "priorConsolidatedEvidence": {
+      "source": "os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json",
+      "claim": "forgeDevAllowed=true",
+      "problem": "The prior consolidated status could be derived from stored readiness evidence without forcing a live DB readiness refresh."
+    },
+    "priorSmokeEvidence": {
+      "source": "os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json",
+      "claim": "REAL_DEV_SERVER_BLOCKED",
+      "problem": "The smoke caught a live preflight contradiction where readiness returned unknown/zero DB state."
+    },
+    "currentLiveReadiness": {
+      "source": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json",
+      "status": "REAL_DEV_DATA_AVAILABLE",
+      "realDevServerAllowed": true,
+      "blockers": 0
+    },
+    "currentStatusGate": {
+      "source": "os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json",
+      "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
+      "forgeDevAllowed": true,
+      "liveReadinessRefreshRequired": true
+    },
+    "currentSmoke": {
+      "source": "os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json",
+      "status": "FORGE_DEV_SMOKE_FRONTEND_STARTED_BACKEND_PORT_BLOCKED",
+      "preflightPassed": true,
+      "frontendUrlEmitted": "http://localhost:5174/",
+      "cleanFullDevLaunch": false
+    }
+  },
+  "confirmedFindings": [
+    {
+      "finding": "Stale readiness evidence could previously carry a ready claim.",
+      "resolution": "The consolidated Forge dev status CLI now refreshes live Benton DB readiness by default before reading readiness-dependent status."
+    },
+    {
+      "finding": "Live DB evidence collection can exceed a short status refresh timeout.",
+      "resolution": "The status gate refresh timeout is 240000 ms so the docker DB evidence path can complete instead of leaving stale or unknown readiness in place."
+    },
+    {
+      "finding": "The unknown/zero DB readiness record was not confirmed empty DB state.",
+      "resolution": "Direct read-only DB evidence later returned nonzero Benton counts and the readiness gate returned REAL_DEV_DATA_AVAILABLE."
+    },
+    {
+      "finding": "The latest smoke reached Vite but did not complete a clean full dev launch.",
+      "resolution": "The smoke is recorded as blocked by occupied local ports 4317 and 5046, not by DB readiness."
+    }
+  ],
+  "rootCause": {
+    "primary": "Consolidated Forge dev status did not require live readiness refresh before reporting forgeDevAllowed=true.",
+    "secondary": "The runtime DB evidence path is slower than the original short refresh window, creating false blocked/unknown evidence when the collection path was interrupted or stale.",
+    "currentRuntimeBlocker": "Local port conflicts on 127.0.0.1:4317 and http://127.0.0.1:5046 prevent a clean full dev smoke launch."
+  },
+  "enforcedRule": "No live DB readiness, no Forge dev ready claim.",
+  "finalStatuses": {
+    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
+    "forgeDevAllowed": true,
+    "realDevServerAllowed": true,
+    "realDevActivationAllowed": true,
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false,
+    "cleanFullDevSmokePassed": false
+  },
+  "boundaries": [
+    "No County Studio UI changed.",
+    "No TerraFusion Sync behavior changed.",
+    "No DB seeding changed.",
+    "No proof gate weakened.",
+    "productionProofAllowed remains false.",
+    "operationalProofAllowed remains false."
+  ]
+}

--- a/os-platform/core/pilot/evidence/county-studio-runtime-evidence-drift.md
+++ b/os-platform/core/pilot/evidence/county-studio-runtime-evidence-drift.md
@@ -1,0 +1,102 @@
+# County Studio Runtime Evidence Drift
+
+Generated: 2026-06-07T15:57:14.591Z
+
+Status: `RUNTIME_EVIDENCE_DRIFT_RECONCILED`
+
+## Drift
+
+The repo had two conflicting records:
+
+```text
+Prior consolidated evidence:
+forgeDevAllowed=true
+
+Prior live smoke:
+REAL_DEV_SERVER_BLOCKED
+realDevServerAllowed=false
+runtime DB counts unknown/zero
+```
+
+That was not acceptable because a consolidated County Studio Forge-dev status must not pass on stale readiness evidence while the live real-dev preflight fails.
+
+## Root Cause
+
+Primary:
+
+```text
+The consolidated Forge dev status gate could report forgeDevAllowed=true from stored readiness evidence without forcing a live Benton DB readiness refresh.
+```
+
+Secondary:
+
+```text
+The live docker DB evidence path is slow enough that a short refresh window can leave readiness as unknown/blocked even when the DB is later readable.
+```
+
+Current runtime smoke blocker:
+
+```text
+Local port conflicts prevent a clean full dev launch:
+- governed pilot runtime: 127.0.0.1:4317 already in use
+- TerraFusion API runtime: http://127.0.0.1:5046 already in use
+```
+
+## Correction
+
+The consolidated Forge-dev status now refreshes live Benton readiness by default before it reads readiness-dependent status.
+
+```text
+Default refresh command:
+node os-platform/core/pilot/benton-real-dev-server-readiness.mjs --db-runtime docker
+
+Default refresh timeout:
+240000 ms
+```
+
+If live readiness fails or times out, stale readiness evidence cannot allow Forge dev.
+
+## Current Live Status
+
+```text
+benton-real-dev-server-readiness:
+REAL_DEV_DATA_AVAILABLE
+realDevServerAllowed=true
+blockers=0
+
+county-studio-r1-forge-dev-status:
+COUNTY_STUDIO_R1_FORGE_DEV_READY
+forgeDevAllowed=true
+liveReadinessRefresh.attempted=true
+liveReadinessRefresh.exitCode=0
+
+county-studio-r1-forge-dev-smoke:
+FORGE_DEV_SMOKE_FRONTEND_STARTED_BACKEND_PORT_BLOCKED
+frontend URL emitted: http://localhost:5174/
+clean full dev launch: false
+```
+
+## Final Status
+
+- countyStudioMode=REAL_BENTON_FORGE_DEV
+- forgeDevAllowed=true
+- realDevServerAllowed=true
+- realDevActivationAllowed=true
+- productionProofAllowed=false
+- operationalProofAllowed=false
+- cleanFullDevSmokePassed=false
+
+## Rule
+
+```text
+No live DB readiness, no Forge dev ready claim.
+```
+
+## Boundaries
+
+- No County Studio UI changed.
+- No TerraFusion Sync behavior changed.
+- No DB seeding changed.
+- No proof gate weakened.
+- `productionProofAllowed` remains false.
+- `operationalProofAllowed` remains false.


### PR DESCRIPTION
## Purpose

Reconcile the County Studio Forge-dev evidence drift caught by the live smoke run.

Prior posture had conflicting records:

```text
Static/consolidated evidence: forgeDevAllowed=true
Live smoke evidence: REAL_DEV_SERVER_BLOCKED / realDevServerAllowed=false
```

This PR makes the consolidated Forge-dev status live-dependent so stale readiness artifacts cannot carry a ready claim.

## Changes

- `county-studio-r1-forge-dev-status` now refreshes live Benton readiness by default before reading readiness-dependent status.
- Adds `--no-refresh-readiness` for test-only/static report use and `--refresh-readiness-command` for controlled tests.
- Adds a focused regression test proving stale ready evidence is blocked when the live refresh returns blocked readiness.
- Updates evidence artifacts to record the reconciled state.
- Adds `county-studio-runtime-evidence-drift.{md,json}`.

## Current truth

```text
COUNTY_STUDIO_R1_FORGE_DEV_READY
REAL_DEV_DATA_AVAILABLE
REAL_DEV_ACTIVATION_READY
forgeDevAllowed=true
realDevServerAllowed=true
productionProofAllowed=false
operationalProofAllowed=false
```

The latest smoke reached the frontend stage and Vite emitted:

```text
http://localhost:5174/
```

But the full dev command is not a clean launch yet because local runtime ports were occupied:

```text
127.0.0.1:4317 already in use
http://127.0.0.1:5046 already in use
```

So this PR restores the correct evidence posture but does not claim a clean full dev smoke pass, production proof, or operational proof.

## Boundary

- No County Studio UI changes.
- No TerraFusion Sync mutation.
- No DB seeding changes.
- No proof weakening.
- `productionProofAllowed=false` remains enforced.
- `operationalProofAllowed=false` remains enforced.

## Verification

- `node --test os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs`
- `pnpm run proof:county-studio:r1-forge-dev-status`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `git diff --check`
- Pre-push strict gates passed, including unit tests, security scan runner, performance benchmark, government compliance lint, and backend build.