### PR TITLE
feat(canon): add tf-canon headless CLI surface

### DIFF
--- a/os-platform/core/canon/tf-canon.mjs
+++ b/os-platform/core/canon/tf-canon.mjs
@@ -1,0 +1,149 @@
+/**
+ * tf canon — headless CLI surface over the read-only Canon runtime.
+ *
+ * A thin command router; all logic lives in the runtime modules. `runCli(argv)`
+ * is pure — it returns { code, lines } and never calls process.exit or writes
+ * to stdout — so it is fully testable. The main guard prints + exits.
+ *
+ * Read-only: no file writes, no commands, no network. Paths are arguments.
+ *
+ * Usage:
+ *   tf-canon query <path> [--json]
+ *   tf-canon risk  <path> [--json]
+ *   tf-canon rules (--task "<intent>" | --path <path>) [--json]
+ *   tf-canon gates <paths...> [--strict] [--json]
+ *   tf-canon help
+ *
+ * @module canon/tf-canon
+ */
+
+import {
+  getOwnerForPath,
+  getRulesForPath,
+  getRulesForTask,
+  getRequiredGatesForPath,
+} from './canon-query.mjs';
+import { scorePathRisk } from './canon-risk.mjs';
+import { runCanonGates } from '../gates/canon-gates.mjs';
+import { fileURLToPath } from 'node:url';
+
+const USAGE = [
+  'usage: tf-canon <command> [options]',
+  '',
+  'commands:',
+  '  query <path> [--json]                  owner + rules + gates + risk for a path',
+  '  risk  <path> [--json]                  risk score for a path',
+  '  rules (--task "<intent>" | --path <p>) [--json]   rules for a task intent or path',
+  '  gates <paths...> [--strict] [--json]   run advisory gates (--strict exits 1 on blocking)',
+  '  help                                   show this help',
+];
+
+/** @param {ReadonlyArray<string>} argv @returns {{flags:Set<string>, opts:Record<string,string>, rest:string[]}} */
+function parse(argv) {
+  const flags = new Set();
+  /** @type {Record<string, string>} */
+  const opts = {};
+  const rest = [];
+  const a = Array.isArray(argv) ? argv : [];
+  for (let i = 0; i < a.length; i++) {
+    const tok = a[i];
+    if (tok === '--json' || tok === '--strict') {
+      flags.add(tok.slice(2));
+    } else if (tok === '--task' || tok === '--path') {
+      opts[tok.slice(2)] = a[++i] ?? '';
+    } else {
+      rest.push(tok);
+    }
+  }
+  return { flags, opts, rest };
+}
+
+/** @param {object} obj @returns {string[]} */
+function jsonLines(obj) {
+  return [JSON.stringify(obj, null, 2)];
+}
+
+/**
+ * Pure CLI dispatcher. Returns an exit code and output lines; never throws,
+ * never exits, never prints.
+ * @param {ReadonlyArray<string>} argv
+ * @returns {Readonly<{ code: number, lines: string[] }>}
+ */
+export function runCli(argv) {
+  try {
+    const { flags, opts, rest } = parse(argv);
+    const cmd = rest[0];
+    const json = flags.has('json');
+
+    if (!cmd || cmd === 'help' || cmd === '--help') {
+      return Object.freeze({ code: 0, lines: USAGE.slice() });
+    }
+
+    if (cmd === 'query') {
+      const path = rest[1];
+      if (!path) return Object.freeze({ code: 2, lines: ['error: query requires <path>', ...USAGE] });
+      const owner = getOwnerForPath(path);
+      const risk = scorePathRisk(path);
+      const requiredGates = getRequiredGatesForPath(path);
+      const rules = getRulesForPath(path).map((r) => r.ruleId);
+      if (json) {
+        return Object.freeze({ code: 0, lines: jsonLines({ path, owner: owner.owner, confidence: owner.confidence, risk, requiredGates, rules }) });
+      }
+      return Object.freeze({
+        code: 0,
+        lines: [
+          `path   : ${path}`,
+          `owner  : ${owner.owner} (${owner.confidence})`,
+          `risk   : ${risk.level}${risk.manualReviewRequired ? ' (manual review)' : ''}`,
+          `gates  : ${requiredGates.join(', ') || '(none)'}`,
+          `rules  : ${rules.join(', ') || '(none)'}`,
+        ],
+      });
+    }
+
+    if (cmd === 'risk') {
+      const path = rest[1];
+      if (!path) return Object.freeze({ code: 2, lines: ['error: risk requires <path>', ...USAGE] });
+      const risk = scorePathRisk(path);
+      return Object.freeze({ code: 0, lines: json ? jsonLines(risk) : [`${path}: ${risk.level}`, ...risk.reasons.map((r) => `  - ${r}`)] });
+    }
+
+    if (cmd === 'rules') {
+      if (opts.task) {
+        const rules = getRulesForTask(opts.task);
+        return Object.freeze({ code: 0, lines: json ? jsonLines(rules) : rules.map((r) => `${r.ruleId} [${r.enforcement.level}]`) });
+      }
+      if (opts.path) {
+        const rules = getRulesForPath(opts.path);
+        return Object.freeze({ code: 0, lines: json ? jsonLines(rules) : rules.map((r) => `${r.ruleId} [${r.enforcement.level}]`) });
+      }
+      return Object.freeze({ code: 2, lines: ['error: rules requires --task "<intent>" or --path <path>', ...USAGE] });
+    }
+
+    if (cmd === 'gates') {
+      const paths = rest.slice(1);
+      if (paths.length === 0) return Object.freeze({ code: 2, lines: ['error: gates requires <paths...>', ...USAGE] });
+      const res = runCanonGates(paths, { strict: flags.has('strict') });
+      if (json) return Object.freeze({ code: res.exitCode, lines: jsonLines({ blocking: res.blocking, advisory: res.advisory, ok: res.ok }) });
+      const lines = [];
+      for (const f of res.blocking) lines.push(`BLOCK   ${f.path}: [${f.gate}] ${f.detail}`);
+      for (const f of res.advisory) lines.push(`advise  ${f.path}: [${f.gate}] ${f.detail}`);
+      if (!lines.length) lines.push(`ok: scanned ${paths.length} path(s); no findings.`);
+      return Object.freeze({ code: res.exitCode, lines });
+    }
+
+    return Object.freeze({ code: 2, lines: [`error: unknown command "${cmd}"`, ...USAGE] });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return Object.freeze({ code: 2, lines: [`error: ${msg}`] });
+  }
+}
+
+// CLI entry (only when run directly).
+const entry = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
+const self = fileURLToPath(import.meta.url).replace(/\\/g, '/');
+if (entry === self) {
+  const { code, lines } = runCli(process.argv.slice(2));
+  process.stdout.write(lines.join('\n') + '\n');
+  process.exitCode = code;
+}

--- a/os-platform/core/tests/tf-canon.test.mjs
+++ b/os-platform/core/tests/tf-canon.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * tf canon CLI — self-test.
+ *
+ * Thin headless command rail over the read-only Canon runtime. runCli(argv) is
+ * pure (returns {code, lines}); the CLI main guard prints + exits.
+ * Run: node --test os-platform/core/tests/tf-canon.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runCli } from '../canon/tf-canon.mjs';
+
+const json = (r) => JSON.parse(r.lines.join('\n'));
+
+test('CLI.1 query <path> reports owner and risk (text)', () => {
+  const r = runCli(['query', 'frontend/apps/os-shell/src/shell/desktop/DesktopIconGrid.tsx']);
+  assert.equal(r.code, 0);
+  const out = r.lines.join('\n');
+  assert.match(out, /os-shell/);
+  assert.match(out, /high/);
+});
+
+test('CLI.2 query --json emits structured owner/risk/gates/rules', () => {
+  const r = runCli(['query', 'os-platform/core/canon/canon-loader.mjs', '--json']);
+  assert.equal(r.code, 0);
+  const o = json(r);
+  assert.equal(o.owner, 'canon-runtime');
+  assert.ok(o.risk && typeof o.risk.level === 'string');
+  assert.ok(Array.isArray(o.requiredGates));
+  assert.ok(Array.isArray(o.rules));
+});
+
+test('CLI.3 risk <path> --json returns level', () => {
+  const r = runCli(['risk', 'docs/TerraCanon/CANON_IDE_REPO_ADAPTATION_PLAN.md', '--json']);
+  assert.equal(r.code, 0);
+  assert.equal(json(r).level, 'low');
+});
+
+test('CLI.4 rules --task matches os-canon surface rules', () => {
+  const r = runCli(['rules', '--task', 'fix os-canon shell launch drift', '--json']);
+  assert.equal(r.code, 0);
+  const rules = json(r);
+  assert.ok(rules.some((x) => x.ruleId === 'surface.os-canon.in-shell'));
+});
+
+test('CLI.5 gates --strict on a protected path exits non-zero', () => {
+  const r = runCli(['gates', '--strict', 'ARCHIVE/old.ts']);
+  assert.equal(r.code, 1);
+});
+
+test('CLI.6 gates (advisory) on a protected path exits 0', () => {
+  const r = runCli(['gates', 'ARCHIVE/old.ts']);
+  assert.equal(r.code, 0);
+});
+
+test('CLI.7 help exits 0 with usage', () => {
+  const r = runCli(['help']);
+  assert.equal(r.code, 0);
+  assert.match(r.lines.join('\n'), /usage/i);
+});
+
+test('CLI.8 no args prints usage (code 0)', () => {
+  const r = runCli([]);
+  assert.equal(r.code, 0);
+  assert.match(r.lines.join('\n'), /usage/i);
+});
+
+test('CLI.9 unknown command exits 2', () => {
+  const r = runCli(['frobnicate']);
+  assert.equal(r.code, 2);
+});
+
+test('CLI.10 query without a path exits 2', () => {
+  const r = runCli(['query']);
+  assert.equal(r.code, 2);
+});
+
+test('CLI.11 runCli never throws on odd input', () => {
+  assert.doesNotThrow(() => runCli(undefined));
+});


### PR DESCRIPTION
## Summary

Adds the **`tf canon` CLI** — the headless command-rail surface from the Canon doctrine — as a thin, read-only router over the merged Canon runtime. `runCli(argv)` is pure (returns `{code, lines}`, no `process.exit`/no stdout) so it is fully unit-tested; the main guard prints + exits.

## Commands (all support `--json`)

- `tf-canon query <path>` — owner + rules + required gates + risk
- `tf-canon risk <path>` — risk score + reasons
- `tf-canon rules (--task "<intent>" | --path <p>)` — matching Canon rules
- `tf-canon gates <paths...> [--strict]` — run the gate aggregator (`--strict` exits 1 on blocking)
- `tf-canon help`

## What changed (2 files)

- `os-platform/core/canon/tf-canon.mjs` — CLI router (read-only; paths are args; no commands/network)
- `os-platform/core/tests/tf-canon.test.mjs` — +11 tests

Placed under `os-platform/core/canon/` (proven-safe governance lane) rather than a new root `cli/` dir.

## Verification

- `node --test tf-canon.test.mjs` → 11/11
- full Canon runtime sweep → **95/95**
- `node scripts/platform-lint.mjs` → 0 violations (checked proactively)
- naming-lint → 5/5; `pnpm run type-check` → clean
- CLI smoke-proven: `query`, `gates --strict` (exit 1), `help`

## Surface status

The runtime is now usable headlessly end-to-end. Remaining doctrine surfaces (later): `os-canon` UI panels, standalone Canon Desktop; and the deliberate enforcement flip (advisory → `--strict` required check).