### PR TITLE
[codex] County Studio real dev port conflict resolution

### DIFF
--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,16 +1,16 @@
 {
-  "generatedAtUtc": "2026-06-07T16:01:06.247Z",
+  "generatedAtUtc": "2026-06-07T17:00:29.493Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_DATA_AVAILABLE",
+  "status": "REAL_DEV_SERVER_BLOCKED",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": true,
+    "realDevServerAllowed": false,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
   "maturity": {
     "DATA_TRUTH_FAIL": true,
-    "REAL_DEV_DATA_AVAILABLE": true,
+    "REAL_DEV_DATA_AVAILABLE": false,
     "SYNC_DERIVED_PARTIAL": true,
     "SYNC_DERIVED_COMPLETE": false,
     "AUTHORITATIVE_RECONCILED": false,
@@ -78,11 +78,11 @@
         "propertyLanding": 1190834,
         "ownerLanding": 8213706,
         "suppAssociation": 4382985,
-        "wpov": 1658143,
+        "wpov": 1707143,
         "truthParcel": 83326,
         "truthOwner": 816849,
         "truthWsdor": 774696,
-        "canonicalParcel": 3198979,
+        "canonicalParcel": 0,
         "account": 535140
       }
     },
@@ -95,21 +95,21 @@
         "propertyLanding": 1190834,
         "ownerLanding": 8213706,
         "suppAssociation": 4382985,
-        "wpov": 1658143,
+        "wpov": 1707143,
         "truthParcel": 83326,
         "truthOwner": 816849,
         "truthWsdor": 774696,
-        "canonicalParcel": 3198979,
+        "canonicalParcel": 0,
         "account": 535140
       }
     },
     {
       "name": "canonical parcel counts",
-      "classification": "SEEDED",
-      "passed": true,
-      "reason": "Canonical parcel rows exist.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Canonical parcel count is missing.",
       "evidence": {
-        "canonicalParcel": 3198979
+        "canonicalParcel": 0
       }
     },
     {
@@ -155,7 +155,7 @@
       "passed": true,
       "reason": "WPOV landing rows exist.",
       "evidence": {
-        "wpov": 1658143
+        "wpov": 1707143
       }
     },
     {
@@ -206,11 +206,11 @@
     },
     {
       "name": "map data dependency status",
-      "classification": "PARTIAL_SEEDED",
+      "classification": "SYNC_DERIVED",
       "passed": true,
-      "reason": "Map dependency is classified PARTIAL_SEEDED.",
+      "reason": "Map dependency is classified SYNC_DERIVED.",
       "evidence": {
-        "classification": "PARTIAL_SEEDED"
+        "classification": "SYNC_DERIVED"
       }
     },
     {
@@ -265,7 +265,7 @@
       }
     }
   },
-  "blockers": [],
+  "blockers": ["canonical parcel counts: Canonical parcel count is missing."],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,18 +1,18 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T16:01:06.247Z
-Status: REAL_DEV_DATA_AVAILABLE
+Generated: 2026-06-07T17:00:29.493Z
+Status: REAL_DEV_SERVER_BLOCKED
 
 ## Decision
 
-- Real Dev Server: ALLOWED
+- Real Dev Server: BLOCKED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
 ## Maturity
 
 - DATA_TRUTH_FAIL: true
-- REAL_DEV_DATA_AVAILABLE: true
+- REAL_DEV_DATA_AVAILABLE: false
 - SYNC_DERIVED_PARTIAL: true
 - SYNC_DERIVED_COMPLETE: false
 - AUTHORITATIVE_RECONCILED: false
@@ -27,7 +27,7 @@ Status: REAL_DEV_DATA_AVAILABLE
 | load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-v2-activesupp-copy (IN_PROGRESS). |
 | landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
 | truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
-| canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
+| canonical parcel counts | UNKNOWN | false | Canonical parcel count is missing. |
 | owner truth count | PARTIAL_SEEDED | true | Owner truth rows exist. |
 | account count | SEEDED | true | Account rows exist. |
 | supp association count | PARTIAL_SEEDED | true | Supplement association landing rows exist. |
@@ -35,7 +35,7 @@ Status: REAL_DEV_DATA_AVAILABLE
 | WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
 | WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
 | owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
-| map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
+| map data dependency status | SYNC_DERIVED | true | Map dependency is classified SYNC_DERIVED. |
 | ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
 | inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
 
@@ -52,7 +52,7 @@ Status: REAL_DEV_DATA_AVAILABLE
 
 ## Blockers
 
-- None
+- canonical parcel counts: Canonical parcel count is missing.
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,29 +1,33 @@
 {
-  "generatedAtUtc": "2026-06-07T16:25:22.844Z",
+  "generatedAtUtc": "2026-06-07T17:01:28.435Z",
   "gate": "county-studio-r1-forge-dev-smoke",
-  "status": "FORGE_DEV_SMOKE_BLOCKED_BY_PORT_PREFLIGHT",
+  "status": "FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED",
   "commandInvoked": "pnpm run dev:county-studio:real-benton",
   "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
-  "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-real-dev-port-preflight-smoke-20260607-092440.log",
+  "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-port-conflict-resolution-smoke-20260607-095557.log",
   "preflightGates": [
     {
       "command": "pnpm run proof:county-studio:real-dev-port-preflight",
-      "status": "REAL_DEV_PORT_PREFLIGHT_BLOCKED",
-      "exitCode": 1,
-      "passed": false,
+      "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
+      "exitCode": 0,
+      "passed": true,
       "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json"
     },
     {
       "command": "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
-      "status": "NOT_REACHED",
+      "status": "REAL_DEV_SERVER_BLOCKED",
+      "exitCode": 1,
       "passed": false,
-      "reason": "The port preflight failed before DB readiness ran."
+      "blockers": [
+        "canonical parcel counts: Canonical parcel count is missing."
+      ],
+      "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-activation",
       "status": "NOT_REACHED",
       "passed": false,
-      "reason": "The port preflight failed before activation ran."
+      "reason": "The DB readiness gate failed after port preflight passed."
     }
   ],
   "devServer": {
@@ -32,33 +36,38 @@
     "frontendBoundUrls": [],
     "urlEmitted": false,
     "backendStarted": false,
-    "reason": "The real Benton Forge dev command failed fast at the port preflight before Vite, the governed pilot runtime, or the API runtime started."
+    "reason": "The real Benton Forge dev command cleared port preflight, then stopped at DB readiness before Vite, the governed pilot runtime, or the API runtime started."
   },
   "portPreflight": {
-    "portPreflightPassed": false,
-    "occupiedPorts": [
+    "portPreflightPassed": true,
+    "occupiedPorts": [],
+    "resolvedPorts": [
       {
         "serviceName": "governed pilot runtime",
         "port": 4317,
-        "envVar": "TF_PILOT_PORT",
-        "owningProcess": {
-          "processId": 50784,
-          "processName": "node",
-          "path": "C:\\Program Files\\nodejs\\node.exe"
-        }
+        "previousProcessId": 50784,
+        "previousProcessName": "node",
+        "classification": "STALE_CONFLICTING_PROCESS"
       },
       {
         "serviceName": "TerraFusion API runtime",
         "port": 5046,
-        "envVar": "TF_API_PORT",
-        "owningProcess": {
-          "processId": 42020,
-          "processName": "dotnet",
-          "path": "C:\\Program Files\\dotnet\\dotnet.exe"
-        }
+        "previousProcessId": 42020,
+        "previousProcessName": "dotnet",
+        "classification": "STALE_CONFLICTING_PROCESS"
       }
     ]
   },
+  "readinessBlockers": [
+    {
+      "name": "canonical parcel counts",
+      "classification": "UNKNOWN",
+      "reason": "Canonical parcel count is missing.",
+      "evidence": {
+        "canonicalParcel": 0
+      }
+    }
+  ],
   "modeFlags": {
     "configured": [
       "TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton",
@@ -70,15 +79,16 @@
     "reason": "The command stopped before the cross-env dev stage."
   },
   "postureAfterSmoke": {
+    "portPreflightPassed": true,
+    "realDevServerAllowed": false,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
     "cleanFullDevSmokePassed": false
   },
   "startupErrors": [
-    "REAL_DEV_PORT_PREFLIGHT_BLOCKED: governed pilot runtime port 4317 is occupied by node pid 50784",
-    "REAL_DEV_PORT_PREFLIGHT_BLOCKED: TerraFusion API runtime port 5046 is occupied by dotnet pid 42020"
+    "REAL_DEV_SERVER_BLOCKED: canonical parcel count is missing."
   ],
-  "interpretation": "The real Benton Forge dev command no longer fails late with unclear runtime bind errors. It now stops at the port preflight with exact occupied ports, owners, and remediation evidence. This does not claim production proof or operational proof.",
+  "interpretation": "The local port conflict is resolved and no longer blocks the real Benton Forge dev command. The next live blocker is DB readiness: canonical parcel count returned 0 during this smoke. No production or operational proof is claimed.",
   "boundaries": [
     "This smoke did not touch County Studio UI.",
     "This smoke did not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,8 +1,8 @@
 # County Studio R1 Forge Dev Smoke
 
-Generated: 2026-06-07T16:25:22.844Z
+Generated: 2026-06-07T17:01:28.435Z
 
-Status: `FORGE_DEV_SMOKE_BLOCKED_BY_PORT_PREFLIGHT`
+Status: `FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED`
 
 ## Command Invoked
 
@@ -19,41 +19,55 @@ C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
 Smoke log:
 
 ```text
-C:\Users\bsval\AppData\Local\Temp\county-studio-real-dev-port-preflight-smoke-20260607-092440.log
+C:\Users\bsval\AppData\Local\Temp\county-studio-port-conflict-resolution-smoke-20260607-095557.log
 ```
 
-## Result
+## Port Conflict Result
 
-The command now fails fast at the port preflight:
+The prior occupied ports were identified and stopped:
+
+- `4317` governed pilot runtime
+  - pid: `50784`
+  - command: `"C:\Program Files\nodejs\node.exe" os-platform/core/pilot/dev-pilot-runtime.mjs`
+  - classification: `STALE_CONFLICTING_PROCESS`
+
+- `5046` TerraFusion API runtime
+  - pid: `42020`
+  - command: `dotnet backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.dll --urls http://localhost:5046 --skip-dev-seeders`
+  - classification: `STALE_CONFLICTING_PROCESS`
+
+After resolution:
 
 ```text
-pnpm run proof:county-studio:real-dev-port-preflight
-REAL_DEV_PORT_PREFLIGHT_BLOCKED
+REAL_DEV_PORT_PREFLIGHT_PASS
+portPreflightPassed=true
+occupiedPorts=[]
+```
+
+## Current Blocker
+
+The command advanced past the port preflight, then stopped at DB readiness:
+
+```text
+REAL_DEV_SERVER_BLOCKED
+canonical parcel counts: Canonical parcel count is missing.
+canonicalParcel=0
 ```
 
 The command did not reach:
 
 ```text
-pnpm run proof:county-studio:benton-real-dev-server-readiness:db
 pnpm run proof:county-studio:real-dev-activation
 cross-env ... pnpm run dev
 ```
 
 So Vite, the governed pilot runtime, and the TerraFusion API runtime were not launched in this smoke.
 
-## Occupied Ports
-
-- governed pilot runtime: `4317` (`TF_PILOT_PORT`)
-  - owner: `node` pid `50784`
-  - path: `C:\Program Files\nodejs\node.exe`
-
-- TerraFusion API runtime: `5046` (`TF_API_PORT`)
-  - owner: `dotnet` pid `42020`
-  - path: `C:\Program Files\dotnet\dotnet.exe`
-
 ## Interpretation
 
-The real Benton Forge dev command no longer fails late with unclear bind errors. It now stops before runtime startup with exact occupied ports, owners, and remediation evidence.
+The local port conflict is resolved and no longer blocks the real Benton Forge dev command.
+
+The next live blocker is DB readiness: canonical parcel count returned `0` during this smoke.
 
 This is not production proof.
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-conflict-resolution.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-conflict-resolution.json
@@ -1,0 +1,67 @@
+{
+  "generatedAtUtc": "2026-06-07T17:01:28.435Z",
+  "gate": "county-studio-real-dev-port-conflict-resolution",
+  "status": "REAL_DEV_PORT_CONFLICT_RESOLVED_DB_READINESS_BLOCKED",
+  "startingBlock": {
+    "status": "REAL_DEV_PORT_PREFLIGHT_BLOCKED",
+    "occupiedPorts": [
+      {
+        "serviceName": "governed pilot runtime",
+        "port": 4317,
+        "processId": 50784,
+        "processName": "node",
+        "commandLine": "\"C:\\Program Files\\nodejs\\node.exe\" os-platform/core/pilot/dev-pilot-runtime.mjs"
+      },
+      {
+        "serviceName": "TerraFusion API runtime",
+        "port": 5046,
+        "processId": 42020,
+        "processName": "dotnet",
+        "commandLine": "dotnet backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.dll --urls http://localhost:5046 --skip-dev-seeders"
+      }
+    ]
+  },
+  "classification": [
+    {
+      "port": 4317,
+      "serviceName": "governed pilot runtime",
+      "classification": "STALE_CONFLICTING_PROCESS",
+      "reason": "The real Benton dev command launches a fresh governed pilot runtime and does not reuse an existing 4317 listener."
+    },
+    {
+      "port": 5046,
+      "serviceName": "TerraFusion API runtime",
+      "classification": "STALE_CONFLICTING_PROCESS",
+      "reason": "The real Benton dev command launches a fresh API runtime and does not reuse an existing 5046 listener."
+    }
+  ],
+  "resolution": {
+    "action": "Stopped only the identified 4317 and 5046 TerraFusion dev runtime processes.",
+    "portPreflightAfterResolution": "REAL_DEV_PORT_PREFLIGHT_PASS",
+    "occupiedPortsAfterResolution": []
+  },
+  "smokeAfterResolution": {
+    "command": "pnpm run dev:county-studio:real-benton",
+    "status": "FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED",
+    "portPreflightPassed": true,
+    "cleanFullDevSmokePassed": false,
+    "nextBlocker": {
+      "gate": "benton-real-dev-server-readiness",
+      "status": "REAL_DEV_SERVER_BLOCKED",
+      "blocker": "canonical parcel counts: Canonical parcel count is missing.",
+      "canonicalParcel": 0
+    }
+  },
+  "decisions": {
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false
+  },
+  "boundaries": [
+    "No County Studio UI changed.",
+    "No TerraFusion Sync behavior changed.",
+    "No DB seeding changed.",
+    "No proof gate weakened.",
+    "No production proof claimed.",
+    "No operational proof claimed."
+  ]
+}

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-conflict-resolution.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-conflict-resolution.md
@@ -1,0 +1,89 @@
+# County Studio Real Dev Port Conflict Resolution
+
+Generated: 2026-06-07T17:01:28.435Z
+
+Status: `REAL_DEV_PORT_CONFLICT_RESOLVED_DB_READINESS_BLOCKED`
+
+## Starting Block
+
+The real dev port preflight previously blocked on:
+
+```text
+4317 occupied by node pid 50784
+5046 occupied by dotnet pid 42020
+```
+
+## Process Identification
+
+Port `4317`:
+
+```text
+"C:\Program Files\nodejs\node.exe" os-platform/core/pilot/dev-pilot-runtime.mjs
+```
+
+Classification: `STALE_CONFLICTING_PROCESS`
+
+Reason: `pnpm run dev:county-studio:real-benton` launches a fresh governed pilot runtime and does not reuse an existing `4317` listener.
+
+Port `5046`:
+
+```text
+dotnet backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.dll --urls http://localhost:5046 --skip-dev-seeders
+```
+
+Classification: `STALE_CONFLICTING_PROCESS`
+
+Reason: `pnpm run dev:county-studio:real-benton` launches a fresh API runtime and does not reuse an existing `5046` listener.
+
+## Resolution
+
+Stopped only the identified TerraFusion dev runtime processes:
+
+```powershell
+Stop-Process -Id 50784
+Stop-Process -Id 42020
+```
+
+After resolution:
+
+```text
+REAL_DEV_PORT_PREFLIGHT_PASS
+occupiedPorts=[]
+```
+
+## Smoke After Resolution
+
+Command:
+
+```bash
+pnpm run dev:county-studio:real-benton
+```
+
+Result:
+
+```text
+FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED
+```
+
+The command advanced past port preflight, then blocked at DB readiness:
+
+```text
+REAL_DEV_SERVER_BLOCKED
+canonical parcel counts: Canonical parcel count is missing.
+canonicalParcel=0
+```
+
+## Decisions
+
+- productionProofAllowed=false
+- operationalProofAllowed=false
+- cleanFullDevSmokePassed=false
+
+## Boundaries
+
+- No County Studio UI changed.
+- No TerraFusion Sync behavior changed.
+- No DB seeding changed.
+- No proof gate weakened.
+- No production proof claimed.
+- No operational proof claimed.

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
@@ -1,7 +1,7 @@
 {
-  "generatedAtUtc": "2026-06-07T16:24:45.552Z",
+  "generatedAtUtc": "2026-06-07T16:55:59.093Z",
   "gate": "county-studio-real-dev-port-preflight",
-  "status": "REAL_DEV_PORT_PREFLIGHT_BLOCKED",
+  "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
   "requiredPorts": [
     {
       "serviceName": "governed pilot runtime",
@@ -18,33 +18,8 @@
       "purpose": "Local .NET API runtime used by backend:launch and Vite API proxy."
     }
   ],
-  "occupiedPorts": [
-    {
-      "serviceName": "governed pilot runtime",
-      "port": 4317,
-      "envVar": "TF_PILOT_PORT",
-      "requiredForDev": true,
-      "owningProcess": {
-        "processId": 50784,
-        "processName": "node",
-        "path": "C:\\Program Files\\nodejs\\node.exe"
-      },
-      "remediation": "Stop the conflicting process using port 4317, or run the existing cleanup command if it owns this repo. Alternatively configure an unused TF_PILOT_PORT before launching if the service supports that port."
-    },
-    {
-      "serviceName": "TerraFusion API runtime",
-      "port": 5046,
-      "envVar": "TF_API_PORT",
-      "requiredForDev": true,
-      "owningProcess": {
-        "processId": 42020,
-        "processName": "dotnet",
-        "path": "C:\\Program Files\\dotnet\\dotnet.exe"
-      },
-      "remediation": "Stop the conflicting process using port 5046, or run the existing cleanup command if it owns this repo. Alternatively configure an unused TF_API_PORT before launching if the service supports that port."
-    }
-  ],
-  "portPreflightPassed": false,
+  "occupiedPorts": [],
+  "portPreflightPassed": true,
   "productionProofAllowed": false,
   "operationalProofAllowed": false,
   "alternatePortSupport": [

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
@@ -1,8 +1,8 @@
 # County Studio Real Dev Port Preflight
 
-Generated: 2026-06-07T16:24:45.552Z
+Generated: 2026-06-07T16:55:59.093Z
 
-Status: `REAL_DEV_PORT_PREFLIGHT_BLOCKED`
+Status: `REAL_DEV_PORT_PREFLIGHT_PASS`
 
 ## Required Ports
 
@@ -11,12 +11,7 @@ Status: `REAL_DEV_PORT_PREFLIGHT_BLOCKED`
 
 ## Occupied Ports
 
-- governed pilot runtime: 4317 (TF_PILOT_PORT)
-  - owner: node pid=50784
-  - remediation: Stop the conflicting process using port 4317, or run the existing cleanup command if it owns this repo. Alternatively configure an unused TF_PILOT_PORT before launching if the service supports that port.
-- TerraFusion API runtime: 5046 (TF_API_PORT)
-  - owner: dotnet pid=42020
-  - remediation: Stop the conflicting process using port 5046, or run the existing cleanup command if it owns this repo. Alternatively configure an unused TF_API_PORT before launching if the service supports that port.
+- None
 
 ## Reuse Existing Services
 
@@ -26,7 +21,7 @@ pnpm run dev:county-studio:real-benton launches fresh governed pilot/API process
 
 ## Decisions
 
-- portPreflightPassed=false
+- portPreflightPassed=true
 - productionProofAllowed=false
 - operationalProofAllowed=false
 


### PR DESCRIPTION
## Purpose

Resolve and document the local County Studio real-dev port conflict that PR #914 made deterministic.

Starting block:

```text
REAL_DEV_PORT_PREFLIGHT_BLOCKED
4317 occupied by node pid 50784
5046 occupied by dotnet pid 42020
```

## Investigation

Identified the port owners before stopping anything:

```text
4317: "C:\Program Files\nodejs\node.exe" os-platform/core/pilot/dev-pilot-runtime.mjs
5046: dotnet backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.dll --urls http://localhost:5046 --skip-dev-seeders
```

Classification: both were stale/conflicting TerraFusion dev runtime processes for this command path. `pnpm run dev:county-studio:real-benton` launches fresh pilot/API processes and does not reuse existing listeners on these ports.

## Result

Stopped only the two identified TerraFusion dev runtime PIDs.

After resolution:

```text
REAL_DEV_PORT_PREFLIGHT_PASS
portPreflightPassed=true
occupiedPorts=[]
```

The command advanced past the port preflight, then blocked at live DB readiness:

```text
FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED
REAL_DEV_SERVER_BLOCKED
canonical parcel counts: Canonical parcel count is missing.
canonicalParcel=0
```

So the port conflict is no longer the active blocker. The next blocker is DB readiness.

## Boundary

- No County Studio UI changes.
- No TerraFusion Sync mutation.
- No DB seeding changes.
- No proof weakening.
- `productionProofAllowed=false` remains enforced.
- `operationalProofAllowed=false` remains enforced.

## Verification

- `node --test os-platform/core/pilot/county-studio-real-dev-port-preflight.test.mjs`
- `pnpm run proof:county-studio:real-dev-port-preflight`
- `pnpm run dev:county-studio:real-benton` advanced past port preflight and blocked at DB readiness
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `git diff --check`
- Strict pre-push gates passed