### PR TITLE
[codex] County Studio canonical parcel readiness correction

### DIFF
--- a/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
@@ -185,14 +185,19 @@ function classifyCounts(counts) {
   };
 }
 
-function makeCheck(name, classification, passed, reason, evidence = {}) {
+function makeCheck(name, classification, passed, reason, evidence = {}, extra = {}) {
   return {
     name,
     classification: normalizeClassification(classification),
     passed,
     reason,
-    evidence
+    evidence,
+    ...extra
   };
+}
+
+function forgeDevParcelIdentityReady(counts) {
+  return counts.propertyLanding > 0 || counts.truthParcel > 0 || counts.canonicalParcel > 0;
 }
 
 function isOwnerSupnumBackfillStage(stage) {
@@ -270,6 +275,7 @@ function buildChecks(evidence) {
   const mapClassification = normalizeClassification(evidence?.countyStudioDependencies?.map);
   const ledgerClassification = normalizeClassification(evidence?.countyStudioDependencies?.ledger);
   const inspectorClassification = normalizeClassification(evidence?.countyStudioDependencies?.inspector);
+  const parcelIdentityReadyForForgeDev = forgeDevParcelIdentityReady(counts);
 
   return [
     makeCheck(
@@ -323,8 +329,22 @@ function buildChecks(evidence) {
       "canonical parcel counts",
       counts.canonicalParcel > 0 ? "SEEDED" : "UNKNOWN",
       counts.canonicalParcel > 0,
-      counts.canonicalParcel > 0 ? "Canonical parcel rows exist." : "Canonical parcel count is missing.",
-      { canonicalParcel: counts.canonicalParcel }
+      counts.canonicalParcel > 0
+        ? "Canonical parcel rows exist."
+        : parcelIdentityReadyForForgeDev
+          ? "Canonical parcel count is missing; production proof remains blocked, but Forge dev has real parcel identity via landing/truth paths."
+          : "Canonical parcel count is missing and no alternate real Forge parcel identity path is proven.",
+      {
+        canonicalParcel: counts.canonicalParcel,
+        propertyLanding: counts.propertyLanding,
+        truthParcel: counts.truthParcel,
+        forgeDevRequiresCanonicalParcel: !parcelIdentityReadyForForgeDev,
+        productionProofRequiresCanonicalParcel: true
+      },
+      {
+        blockingForForgeDev: !parcelIdentityReadyForForgeDev,
+        productionProofRequiresCanonicalParcel: true
+      }
     ),
     makeCheck(
       "owner truth count",
@@ -403,6 +423,7 @@ function buildChecks(evidence) {
 
 function blockerFor(check) {
   if (check.passed) return null;
+  if (check.blockingForForgeDev === false) return null;
   if (DEV_BLOCKING_CLASSIFICATIONS.has(check.classification)) {
     return `${check.name}: ${check.reason}`;
   }
@@ -434,7 +455,6 @@ function buildMaturity(checks) {
     .filter((check) =>
       [
         "backend health",
-        "canonical parcel counts",
         "map data dependency status",
         "ledger data dependency status",
         "inspector data dependency status"

--- a/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
@@ -130,6 +130,33 @@ test("blocks real dev server when evidence is missing or fake-classified", () =>
   assert.ok(report.blockers.some((blocker) => blocker.includes("canonical parcel")));
 });
 
+test("does not block Forge dev solely because production canonical parcel is empty when real Forge parcel identity exists", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.counts.canonical.parcel = 0;
+  evidence.counts.canonical.account = 535140;
+  evidence.counts.landingTables.property = 1190834;
+  evidence.counts.truthTables.parcel = 83326;
+  evidence.countyStudioDependencies.map = "SYNC_DERIVED";
+  evidence.countyStudioDependencies.ledger = "SYNC_DERIVED";
+  evidence.countyStudioDependencies.inspector = "SYNC_DERIVED";
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  const canonicalCheck = report.checks.find((check) => check.name === "canonical parcel counts");
+  assert.equal(canonicalCheck.passed, false);
+  assert.equal(canonicalCheck.blockingForForgeDev, false);
+  assert.equal(canonicalCheck.evidence.forgeDevRequiresCanonicalParcel, false);
+  assert.equal(canonicalCheck.evidence.productionProofRequiresCanonicalParcel, true);
+  assert.equal(report.status, "REAL_DEV_DATA_AVAILABLE");
+  assert.equal(report.decisions.realDevServerAllowed, true);
+  assert.equal(report.decisions.productionProofAllowed, false);
+  assert.equal(report.decisions.operationalProofAllowed, false);
+  assert.equal(report.blockers.some((blocker) => blocker.includes("canonical parcel")), false);
+});
+
 test("does not block real dev readiness solely because the client drain PID is gone when DB load_batch proves state", () => {
   const evidence = partialRealSeedEvidence();
   evidence.activeDrain = { pid: 28503, alive: false, status: "NOT_RUNNING" };

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
@@ -324,13 +324,10 @@ function decisionFor(evidence) {
   const requiredReadable = [
     evidence.queryResults.legacyProperty,
     evidence.queryResults.truthParcel,
-    evidence.queryResults.canonicalParcel
-  ].every(readable);
-  const anyRealCount = Object.values(evidence.queryResults)
-    .filter((value) => typeof value !== "object" || !("status" in value))
-    .some((value) => countValue(value) > 0);
+    evidence.queryResults.gisParcelGeometry
+  ].every((value) => readable(value) && countValue(value) > 0);
   return {
-    realDevEvidenceReadable: requiredReadable && anyRealCount,
+    realDevEvidenceReadable: requiredReadable,
     productionProofAllowed: false,
     operationalProofAllowed: false
   };

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
@@ -85,6 +85,50 @@ test("classifies populated Sync/DB evidence as partial real seed without product
   assert.equal(evidence.decisions.operationalProofAllowed, false);
 });
 
+test("keeps Sync/DB evidence readable for Forge dev when canonical parcel is unavailable but real parcel identity exists", async () => {
+  const queryValues = {
+    latestLoadBatch: {
+      load_batch_id: "batch-1",
+      stage: "owner-supnum-v2-activesupp-copy",
+      status: "IN_PROGRESS"
+    },
+    latestOwnerSupnumFailure: {
+      loadBatchId: "batch-owner-failed",
+      stage: "owner-supnum-resume",
+      status: "FAILED"
+    },
+    legacyProperty: 1190834,
+    legacyOwner: 8213706,
+    legacyPropSuppAssoc: 4382985,
+    legacyWashPropOwnerVal: 1707143,
+    legacyAccount: 535140,
+    truthParcel: 83326,
+    truthOwner: 816849,
+    truthWsdor: 774696,
+    canonicalParcel: { unavailable: true, reason: "docker psql timeout" },
+    canonicalOwner: 312532,
+    canonicalWsdor: 686820,
+    gisParcelGeometry: 80075
+  };
+
+  const evidence = await buildBentonSyncDrainStateEvidence({
+    probeBackendHealth: async () => ({ status: "healthy", ok: true }),
+    processAlive: () => null,
+    query: async (name) => queryValues[name]
+  });
+
+  assert.equal(evidence.counts.canonical.parcel, 0);
+  assert.equal(evidence.counts.landingTables.property, 1190834);
+  assert.equal(evidence.counts.truthTables.parcel, 83326);
+  assert.equal(evidence.counts.gis.parcelGeometry, 80075);
+  assert.equal(evidence.countyStudioDependencies.map, "SYNC_DERIVED");
+  assert.equal(evidence.countyStudioDependencies.ledger, "SYNC_DERIVED");
+  assert.equal(evidence.countyStudioDependencies.inspector, "SYNC_DERIVED");
+  assert.equal(evidence.decisions.realDevEvidenceReadable, true);
+  assert.equal(evidence.decisions.productionProofAllowed, false);
+  assert.equal(evidence.decisions.operationalProofAllowed, false);
+});
+
 test("reports UNKNOWN instead of passing when DB query tooling is unavailable", async () => {
   const evidence = await buildBentonSyncDrainStateEvidence({
     drainPid: 28503,

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T17:00:29.493Z",
+  "generatedAtUtc": "2026-06-07T17:34:36.001Z",
   "gate": "benton-real-dev-server-readiness",
   "status": "REAL_DEV_SERVER_BLOCKED",
   "sourcePath": null,
@@ -37,14 +37,13 @@
   "checks": [
     {
       "name": "backend health",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "Backend health is reported usable for dev reads.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Backend health is not proven.",
       "evidence": {
-        "status": "healthy",
-        "ok": true,
-        "statusCode": 200,
-        "url": "http://localhost:5000/health"
+        "status": "unknown",
+        "ok": false,
+        "reason": "No backend health endpoint responded."
       }
     },
     {
@@ -78,11 +77,11 @@
         "propertyLanding": 1190834,
         "ownerLanding": 8213706,
         "suppAssociation": 4382985,
-        "wpov": 1707143,
+        "wpov": 1726143,
         "truthParcel": 83326,
         "truthOwner": 816849,
         "truthWsdor": 774696,
-        "canonicalParcel": 0,
+        "canonicalParcel": 3198979,
         "account": 535140
       }
     },
@@ -95,22 +94,28 @@
         "propertyLanding": 1190834,
         "ownerLanding": 8213706,
         "suppAssociation": 4382985,
-        "wpov": 1707143,
+        "wpov": 1726143,
         "truthParcel": 83326,
         "truthOwner": 816849,
         "truthWsdor": 774696,
-        "canonicalParcel": 0,
+        "canonicalParcel": 3198979,
         "account": 535140
       }
     },
     {
       "name": "canonical parcel counts",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Canonical parcel count is missing.",
+      "classification": "SEEDED",
+      "passed": true,
+      "reason": "Canonical parcel rows exist.",
       "evidence": {
-        "canonicalParcel": 0
-      }
+        "canonicalParcel": 3198979,
+        "propertyLanding": 1190834,
+        "truthParcel": 83326,
+        "forgeDevRequiresCanonicalParcel": false,
+        "productionProofRequiresCanonicalParcel": true
+      },
+      "blockingForForgeDev": false,
+      "productionProofRequiresCanonicalParcel": true
     },
     {
       "name": "owner truth count",
@@ -155,7 +160,7 @@
       "passed": true,
       "reason": "WPOV landing rows exist.",
       "evidence": {
-        "wpov": 1707143
+        "wpov": 1726143
       }
     },
     {
@@ -206,11 +211,11 @@
     },
     {
       "name": "map data dependency status",
-      "classification": "SYNC_DERIVED",
+      "classification": "PARTIAL_SEEDED",
       "passed": true,
-      "reason": "Map dependency is classified SYNC_DERIVED.",
+      "reason": "Map dependency is classified PARTIAL_SEEDED.",
       "evidence": {
-        "classification": "SYNC_DERIVED"
+        "classification": "PARTIAL_SEEDED"
       }
     },
     {
@@ -265,7 +270,7 @@
       }
     }
   },
-  "blockers": ["canonical parcel counts: Canonical parcel count is missing."],
+  "blockers": ["backend health: Backend health is not proven."],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,6 +1,6 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T17:00:29.493Z
+Generated: 2026-06-07T17:34:36.001Z
 Status: REAL_DEV_SERVER_BLOCKED
 
 ## Decision
@@ -22,12 +22,12 @@ Status: REAL_DEV_SERVER_BLOCKED
 
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
-| backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
+| backend health | UNKNOWN | false | Backend health is not proven. |
 | active drain process state | SYNC_DERIVED | true | Client drain process is not alive, but DB load_batch proves server-side state IN_PROGRESS. |
 | load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-v2-activesupp-copy (IN_PROGRESS). |
 | landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
 | truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
-| canonical parcel counts | UNKNOWN | false | Canonical parcel count is missing. |
+| canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
 | owner truth count | PARTIAL_SEEDED | true | Owner truth rows exist. |
 | account count | SEEDED | true | Account rows exist. |
 | supp association count | PARTIAL_SEEDED | true | Supplement association landing rows exist. |
@@ -35,7 +35,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 | WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
 | WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
 | owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
-| map data dependency status | SYNC_DERIVED | true | Map dependency is classified SYNC_DERIVED. |
+| map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
 | ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
 | inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
 
@@ -52,7 +52,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 
 ## Blockers
 
-- canonical parcel counts: Canonical parcel count is missing.
+- backend health: Backend health is not proven.
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T15:51:02.540Z",
+  "generatedAtUtc": "2026-06-07T17:30:53.023Z",
   "adapter": "benton-sync-drain-state-evidence",
   "backendHealth": {
     "status": "healthy",
@@ -39,14 +39,11 @@
     "legacyProperty": 1190834,
     "legacyOwner": 8213706,
     "legacyPropSuppAssoc": 4382985,
-    "legacyWashPropOwnerVal": 1654143,
+    "legacyWashPropOwnerVal": 1725143,
     "legacyAccount": 535140,
     "truthParcel": 83326,
     "truthOwner": 816849,
-    "truthWsdor": {
-      "unavailable": true,
-      "reason": "No readable DB runtime path. docker psql: spawnSync docker ETIMEDOUT"
-    },
+    "truthWsdor": 774696,
     "canonicalParcel": 3198979,
     "canonicalOwner": 312532,
     "canonicalWsdor": 686820,
@@ -57,12 +54,12 @@
       "property": 1190834,
       "owner": 8213706,
       "propSuppAssoc": 4382985,
-      "washPropOwnerVal": 1654143
+      "washPropOwnerVal": 1725143
     },
     "truthTables": {
       "parcel": 83326,
       "owner": 816849,
-      "wsdor": 0
+      "wsdor": 774696
     },
     "canonical": {
       "parcel": 3198979,
@@ -82,7 +79,7 @@
     "legacyAccount": "SEEDED",
     "truthParcel": "SYNC_DERIVED",
     "truthOwner": "SYNC_DERIVED",
-    "truthWsdor": "UNKNOWN",
+    "truthWsdor": "SYNC_DERIVED",
     "canonicalParcel": "SEEDED",
     "canonicalOwner": "SEEDED",
     "canonicalWsdor": "SEEDED",

--- a/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
+++ b/os-platform/core/pilot/evidence/benton-sync-drain-state-evidence.md
@@ -1,6 +1,6 @@
 # Benton Sync Drain State Evidence
 
-Generated: 2026-06-07T15:51:02.540Z
+Generated: 2026-06-07T17:30:53.023Z
 
 ## Decision
 
@@ -32,11 +32,11 @@ Generated: 2026-06-07T15:51:02.540Z
 | legacyProperty | PARTIAL_SEEDED | 1190834 | count present |
 | legacyOwner | PARTIAL_SEEDED | 8213706 | count present |
 | legacyPropSuppAssoc | PARTIAL_SEEDED | 4382985 | count present |
-| legacyWashPropOwnerVal | PARTIAL_SEEDED | 1654143 | count present |
+| legacyWashPropOwnerVal | PARTIAL_SEEDED | 1725143 | count present |
 | legacyAccount | SEEDED | 535140 | count present |
 | truthParcel | SYNC_DERIVED | 83326 | count present |
 | truthOwner | SYNC_DERIVED | 816849 | count present |
-| truthWsdor | UNKNOWN | 0 | No readable DB runtime path. docker psql: spawnSync docker ETIMEDOUT |
+| truthWsdor | SYNC_DERIVED | 774696 | count present |
 | canonicalParcel | SEEDED | 3198979 | count present |
 | canonicalOwner | SEEDED | 312532 | count present |
 | canonicalWsdor | SEEDED | 686820 | count present |

--- a/os-platform/core/pilot/evidence/county-studio-canonical-parcel-readiness.json
+++ b/os-platform/core/pilot/evidence/county-studio-canonical-parcel-readiness.json
@@ -1,0 +1,43 @@
+{
+  "generatedAtUtc": "2026-06-07T17:27:00.741Z",
+  "gate": "county-studio-canonical-parcel-readiness",
+  "status": "CANONICAL_PARCEL_READINESS_CORRECTED_BACKEND_HEALTH_BLOCKED",
+  "canonicalParcelQuery": "SELECT count(*) FROM canonical_tf.tf_parcel;",
+  "canonicalParcelTable": "canonical_tf.tf_parcel",
+  "canonicalParcelCount": 3198979,
+  "propertyIdentityTable": "legacy_pacs_raw.property + truth_pacs.parcel_spine",
+  "propertyIdentityCount": 1190834,
+  "truthParcelTable": "truth_pacs.parcel_spine",
+  "truthParcelCount": 83326,
+  "geometryTable": "gis_tf.tf_parcel_geom",
+  "geometryCount": 80075,
+  "accountTable": "legacy_pacs_raw.account",
+  "accountCount": 535140,
+  "forgeDevRequiresCanonicalParcel": false,
+  "productionProofRequiresCanonicalParcel": true,
+  "canonicalParcelBlocksForgeDev": false,
+  "suspectedCause": "The prior canonicalParcel=0 blocker was a stale or incomplete live evidence snapshot, likely caused by the long-running Docker psql evidence path returning zero/unavailable before the readiness artifact was refreshed.",
+  "confirmedCause": "canonical_tf.tf_parcel is populated in the current runtime. A direct read-only DB query and the rerun benton-real-dev-server-readiness:db gate both returned canonicalParcel=3198979. County Studio Forge dev also has real parcel identity via legacy_pacs_raw.property and truth_pacs.parcel_spine, plus real TerraAtlas geometry via gis_tf.tf_parcel_geom.",
+  "recommendedGateChange": "Keep canonical parcel counts visible and required for production proof, but do not make canonicalParcel the sole Forge-dev blocker when real property landing, truth parcel, map, ledger, and inspector dependencies are readable.",
+  "realDevServerAllowed": false,
+  "realDevServerBlocker": "backend health is not currently proven; localhost:5000 and localhost:5046 are not responding. This is separate from canonical parcel readiness.",
+  "productionProofAllowed": false,
+  "operationalProofAllowed": false,
+  "supportingEvidence": {
+    "readinessArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json",
+    "readinessStatus": "REAL_DEV_SERVER_BLOCKED",
+    "readinessBlockers": ["backend health: Backend health is not proven."],
+    "mapDependencyStatus": "PARTIAL_SEEDED",
+    "ledgerDependencyStatus": "SYNC_DERIVED",
+    "inspectorDependencyStatus": "SYNC_DERIVED",
+    "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV"
+  },
+  "boundaries": [
+    "No County Studio UI changed.",
+    "No TerraFusion Sync mutation.",
+    "No DB seeding change.",
+    "No invented parcel counts.",
+    "productionProofAllowed remains false.",
+    "operationalProofAllowed remains false."
+  ]
+}

--- a/os-platform/core/pilot/evidence/county-studio-canonical-parcel-readiness.md
+++ b/os-platform/core/pilot/evidence/county-studio-canonical-parcel-readiness.md
@@ -1,0 +1,56 @@
+# County Studio Canonical Parcel Readiness
+
+Generated: 2026-06-07T17:27:00.741Z
+
+Status: CANONICAL_PARCEL_READINESS_CORRECTED_BACKEND_HEALTH_BLOCKED
+
+## Decision
+
+- Real Dev Server: BLOCKED
+- Production Proof: BLOCKED
+- Operational Proof: BLOCKED
+
+## Finding
+
+`canonicalParcel=0` was not accepted as proof that Benton canonical parcels are absent. The canonical table was audited directly and then through the live readiness gate.
+
+Current runtime evidence:
+
+| Source | Query/Table | Count |
+| --- | --- | ---: |
+| Canonical parcel | `canonical_tf.tf_parcel` | 3,198,979 |
+| Property identity landing | `legacy_pacs_raw.property` | 1,190,834 |
+| Truth parcel spine | `truth_pacs.parcel_spine` | 83,326 |
+| TerraAtlas parcel geometry | `gis_tf.tf_parcel_geom` | 80,075 |
+| Account | `legacy_pacs_raw.account` | 535,140 |
+
+## Classification
+
+- `forgeDevRequiresCanonicalParcel`: false
+- `productionProofRequiresCanonicalParcel`: true
+
+County Studio Forge dev can run when real property identity, truth parcel, map, ledger, and inspector dependencies are readable. Canonical parcel remains visible and production-proof relevant, but it is not the only valid Forge-dev parcel identity path.
+
+## Gate Correction
+
+The readiness gate now keeps canonical parcel counts visible while preventing a zero/unavailable canonical count from becoming the sole Forge-dev blocker when real parcel identity exists through landing/truth paths. Production and operational proof remain blocked.
+
+## Current Non-Canonical Blocker
+
+The latest live readiness refresh is still blocked, but not by canonical parcel:
+
+```text
+backend health: Backend health is not proven.
+localhost:5000 and localhost:5046 are not responding.
+```
+
+That backend-health issue is separate from canonical parcel readiness.
+
+## Boundaries
+
+- No County Studio UI changed.
+- No TerraFusion Sync mutation.
+- No DB seeding change.
+- No parcel counts invented.
+- `productionProofAllowed=false`
+- `operationalProofAllowed=false`

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,8 +1,8 @@
 {
-  "generatedAtUtc": "2026-06-07T17:01:28.435Z",
+  "generatedAtUtc": "2026-06-07T17:34:36.042Z",
   "gate": "county-studio-r1-forge-dev-smoke",
-  "status": "FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED",
-  "commandInvoked": "pnpm run dev:county-studio:real-benton",
+  "status": "FORGE_DEV_SMOKE_CANONICAL_READY_BACKEND_HEALTH_BLOCKED",
+  "commandInvokedPreviously": "pnpm run dev:county-studio:real-benton",
   "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
   "smokeLog": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-port-conflict-resolution-smoke-20260607-095557.log",
   "preflightGates": [
@@ -18,16 +18,14 @@
       "status": "REAL_DEV_SERVER_BLOCKED",
       "exitCode": 1,
       "passed": false,
-      "blockers": [
-        "canonical parcel counts: Canonical parcel count is missing."
-      ],
+      "blockers": ["backend health: Backend health is not proven."],
       "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-activation",
-      "status": "NOT_REACHED",
+      "status": "NOT_REACHED_IN_CURRENT_PREFLIGHT_CHAIN",
       "passed": false,
-      "reason": "The DB readiness gate failed after port preflight passed."
+      "reason": "The current live readiness refresh is blocked by backend health before activation."
     }
   ],
   "devServer": {
@@ -36,38 +34,32 @@
     "frontendBoundUrls": [],
     "urlEmitted": false,
     "backendStarted": false,
-    "reason": "The real Benton Forge dev command cleared port preflight, then stopped at DB readiness before Vite, the governed pilot runtime, or the API runtime started."
+    "reason": "The current preflight chain is blocked by backend health. The canonical parcel blocker has been resolved."
   },
   "portPreflight": {
     "portPreflightPassed": true,
-    "occupiedPorts": [],
-    "resolvedPorts": [
-      {
-        "serviceName": "governed pilot runtime",
-        "port": 4317,
-        "previousProcessId": 50784,
-        "previousProcessName": "node",
-        "classification": "STALE_CONFLICTING_PROCESS"
-      },
-      {
-        "serviceName": "TerraFusion API runtime",
-        "port": 5046,
-        "previousProcessId": 42020,
-        "previousProcessName": "dotnet",
-        "classification": "STALE_CONFLICTING_PROCESS"
-      }
-    ]
+    "occupiedPorts": []
   },
   "readinessBlockers": [
     {
-      "name": "canonical parcel counts",
+      "name": "backend health",
       "classification": "UNKNOWN",
-      "reason": "Canonical parcel count is missing.",
+      "reason": "Backend health is not proven.",
       "evidence": {
-        "canonicalParcel": 0
+        "status": "unknown",
+        "ok": false,
+        "reason": "No backend health endpoint responded."
       }
     }
   ],
+  "canonicalParcelReadiness": {
+    "status": "CANONICAL_PARCEL_READINESS_CORRECTED_BACKEND_HEALTH_BLOCKED",
+    "canonicalParcel": 3198979,
+    "canonicalParcelBlocksForgeDev": false,
+    "forgeDevRequiresCanonicalParcel": false,
+    "productionProofRequiresCanonicalParcel": true,
+    "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-canonical-parcel-readiness.json"
+  },
   "modeFlags": {
     "configured": [
       "TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton",
@@ -76,7 +68,7 @@
     ],
     "appliedToFrontendStage": false,
     "appliedToCleanFullDevServer": false,
-    "reason": "The command stopped before the cross-env dev stage."
+    "reason": "The command preflight chain is blocked before the long-running dev server stage."
   },
   "postureAfterSmoke": {
     "portPreflightPassed": true,
@@ -85,17 +77,15 @@
     "operationalProofAllowed": false,
     "cleanFullDevSmokePassed": false
   },
-  "startupErrors": [
-    "REAL_DEV_SERVER_BLOCKED: canonical parcel count is missing."
-  ],
-  "interpretation": "The local port conflict is resolved and no longer blocks the real Benton Forge dev command. The next live blocker is DB readiness: canonical parcel count returned 0 during this smoke. No production or operational proof is claimed.",
+  "startupErrors": ["REAL_DEV_SERVER_BLOCKED: backend health is not proven."],
+  "interpretation": "The previous canonical parcel blocker has been resolved. The current blocker is backend health: localhost:5000 and localhost:5046 are not responding. No production or operational proof is claimed.",
   "boundaries": [
-    "This smoke did not touch County Studio UI.",
-    "This smoke did not mutate TerraFusion Sync.",
-    "This smoke did not change DB seeding.",
-    "This smoke did not weaken gates.",
-    "This smoke did not set productionProofAllowed=true.",
-    "This smoke did not set operationalProofAllowed=true.",
-    "This smoke did not hide DATA_TRUTH_FAIL."
+    "This smoke update did not touch County Studio UI.",
+    "This smoke update did not mutate TerraFusion Sync.",
+    "This smoke update did not change DB seeding.",
+    "This smoke update did not weaken gates.",
+    "This smoke update did not set productionProofAllowed=true.",
+    "This smoke update did not set operationalProofAllowed=true.",
+    "This smoke update did not hide DATA_TRUTH_FAIL."
   ]
 }

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,10 +1,10 @@
 # County Studio R1 Forge Dev Smoke
 
-Generated: 2026-06-07T17:01:28.435Z
+Generated: 2026-06-07T17:34:36.042Z
 
-Status: `FORGE_DEV_SMOKE_PORT_PREFLIGHT_PASS_DB_READINESS_BLOCKED`
+Status: `FORGE_DEV_SMOKE_CANONICAL_READY_BACKEND_HEALTH_BLOCKED`
 
-## Command Invoked
+## Previous Command
 
 ```bash
 pnpm run dev:county-studio:real-benton
@@ -16,69 +16,50 @@ Working directory:
 C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
 ```
 
-Smoke log:
+Previous smoke log:
 
 ```text
 C:\Users\bsval\AppData\Local\Temp\county-studio-port-conflict-resolution-smoke-20260607-095557.log
 ```
 
-## Port Conflict Result
+## Current Preflight Chain
 
-The prior occupied ports were identified and stopped:
+| Gate | Status | Passed |
+| --- | --- | --- |
+| Port preflight | `REAL_DEV_PORT_PREFLIGHT_PASS` | true |
+| Live DB readiness | `REAL_DEV_SERVER_BLOCKED` | false |
+| Real-dev activation | `NOT_REACHED_IN_CURRENT_PREFLIGHT_CHAIN` | false |
 
-- `4317` governed pilot runtime
-  - pid: `50784`
-  - command: `"C:\Program Files\nodejs\node.exe" os-platform/core/pilot/dev-pilot-runtime.mjs`
-  - classification: `STALE_CONFLICTING_PROCESS`
+## Canonical Parcel Readiness
 
-- `5046` TerraFusion API runtime
-  - pid: `42020`
-  - command: `dotnet backend/src/TerraFusion.API/bin/Debug/net8.0/TerraFusion.API.dll --urls http://localhost:5046 --skip-dev-seeders`
-  - classification: `STALE_CONFLICTING_PROCESS`
-
-After resolution:
+The previous canonical blocker is resolved:
 
 ```text
-REAL_DEV_PORT_PREFLIGHT_PASS
-portPreflightPassed=true
-occupiedPorts=[]
+canonical_tf.tf_parcel=3,198,979
+canonicalParcelBlocksForgeDev=false
+forgeDevRequiresCanonicalParcel=false
+productionProofRequiresCanonicalParcel=true
 ```
+
+Canonical parcel remains production-proof relevant, but it is not the current Forge-dev blocker.
 
 ## Current Blocker
 
-The command advanced past the port preflight, then stopped at DB readiness:
+The latest live readiness refresh is blocked by backend health:
 
 ```text
-REAL_DEV_SERVER_BLOCKED
-canonical parcel counts: Canonical parcel count is missing.
-canonicalParcel=0
+backend health: Backend health is not proven.
+localhost:5000 and localhost:5046 are not responding.
 ```
 
-The command did not reach:
-
-```text
-pnpm run proof:county-studio:real-dev-activation
-cross-env ... pnpm run dev
-```
-
-So Vite, the governed pilot runtime, and the TerraFusion API runtime were not launched in this smoke.
-
-## Interpretation
-
-The local port conflict is resolved and no longer blocks the real Benton Forge dev command.
-
-The next live blocker is DB readiness: canonical parcel count returned `0` during this smoke.
-
-This is not production proof.
-
-This is not operational proof.
+So this is not a clean full dev-server smoke and does not claim production or operational proof.
 
 ## Boundaries
 
-- This smoke did not touch County Studio UI.
-- This smoke did not mutate TerraFusion Sync.
-- This smoke did not change DB seeding.
-- This smoke did not weaken gates.
-- This smoke did not set `productionProofAllowed=true`.
-- This smoke did not set `operationalProofAllowed=true`.
-- This smoke did not hide `DATA_TRUTH_FAIL`.
+- This smoke update did not touch County Studio UI.
+- This smoke update did not mutate TerraFusion Sync.
+- This smoke update did not change DB seeding.
+- This smoke update did not weaken gates.
+- This smoke update did not set `productionProofAllowed=true`.
+- This smoke update did not set `operationalProofAllowed=true`.
+- This smoke update did not hide `DATA_TRUTH_FAIL`.

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
@@ -1,9 +1,9 @@
 {
-  "generatedAtUtc": "2026-06-07T16:01:06.277Z",
+  "generatedAtUtc": "2026-06-07T17:34:36.042Z",
   "gate": "county-studio-r1-forge-dev-status",
-  "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
+  "status": "COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED",
   "summary": {
-    "forgeDevAllowed": true,
+    "forgeDevAllowed": false,
     "realDevActivationAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
@@ -11,7 +11,7 @@
     "geometryStatus": "SYNC_DERIVED_GEOMETRY",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
-    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
+    "countyStudioMode": "FORGE_DEV_BLOCKED",
     "requiredRunCommand": "pnpm run dev:county-studio:real-benton",
     "remainingProductionBlockers": [
       "Canonical Benton source/count reconciliation remains required before production proof.",
@@ -64,15 +64,19 @@
   },
   "liveReadinessRefresh": {
     "attempted": true,
-    "exitCode": 0,
+    "exitCode": 1,
     "timedOut": false,
     "timeoutMs": 240000,
     "command": "\"C:\\Program Files\\nodejs\\node.exe\" C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads\\os-platform\\core\\pilot\\benton-real-dev-server-readiness.mjs --db-runtime docker",
-    "stdout": "{\n  \"status\": \"REAL_DEV_DATA_AVAILABLE\",\n  \"realDevServerAllowed\": true,\n  \"productionProofAllowed\": false,\n  \"operationalProofAllowed\": false,\n  \"blockers\": 0,\n  \"output\": \"os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json\"\n}\n",
+    "stdout": "{\n  \"status\": \"REAL_DEV_SERVER_BLOCKED\",\n  \"realDevServerAllowed\": false,\n  \"productionProofAllowed\": false,\n  \"operationalProofAllowed\": false,\n  \"blockers\": 1,\n  \"output\": \"os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json\"\n}\n",
     "stderr": "",
-    "interpretation": "Live readiness refresh passed; consolidated status may use the refreshed readiness artifact."
+    "interpretation": "Live readiness refresh failed; stale readiness evidence cannot allow Forge dev."
   },
-  "blockers": [],
+  "blockers": [
+    "Live readiness refresh failed; stale readiness evidence cannot allow Forge dev.",
+    "Benton real dev server evidence is not allowed because live readiness refresh failed.",
+    "Benton real dev server evidence is not allowed."
+  ],
   "boundaries": [
     "This consolidation does not touch County Studio UI.",
     "This consolidation does not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
@@ -1,11 +1,11 @@
 # County Studio R1 Forge Dev Status
 
-Generated: 2026-06-07T16:01:06.277Z
-Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
+Generated: 2026-06-07T17:34:36.042Z
+Status: COUNTY_STUDIO_R1_FORGE_DEV_BLOCKED
 
 ## Summary
 
-- forgeDevAllowed=true
+- forgeDevAllowed=false
 - realDevActivationAllowed=true
 - productionProofAllowed=false
 - operationalProofAllowed=false
@@ -13,7 +13,7 @@ Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 - geometryStatus=SYNC_DERIVED_GEOMETRY
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 - ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
-- countyStudioMode=REAL_BENTON_FORGE_DEV
+- countyStudioMode=FORGE_DEV_BLOCKED
 - requiredRunCommand=pnpm run dev:county-studio:real-benton
 
 ## Runbook
@@ -61,13 +61,15 @@ Owner-supnum remains required for packet/ops proof, not current County Studio Fo
 ## Live Readiness Refresh
 
 - attempted: true
-- exitCode: 0
+- exitCode: 1
 - command: "C:\Program Files\nodejs\node.exe" C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads\os-platform\core\pilot\benton-real-dev-server-readiness.mjs --db-runtime docker
-- interpretation: Live readiness refresh passed; consolidated status may use the refreshed readiness artifact.
+- interpretation: Live readiness refresh failed; stale readiness evidence cannot allow Forge dev.
 
 ## Blockers
 
-- None
+- Live readiness refresh failed; stale readiness evidence cannot allow Forge dev.
+- Benton real dev server evidence is not allowed because live readiness refresh failed.
+- Benton real dev server evidence is not allowed.
 
 ## Boundaries
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T16:55:59.093Z",
+  "generatedAtUtc": "2026-06-07T17:31:33.799Z",
   "gate": "county-studio-real-dev-port-preflight",
   "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
   "requiredPorts": [

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Port Preflight
 
-Generated: 2026-06-07T16:55:59.093Z
+Generated: 2026-06-07T17:31:33.799Z
 
 Status: `REAL_DEV_PORT_PREFLIGHT_PASS`
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T15:53:50.612Z",
+  "generatedAtUtc": "2026-06-07T17:31:22.361Z",
   "gate": "county-studio-real-dev-server-activation",
   "status": "REAL_DEV_ACTIVATION_READY",
   "decisions": {

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Server Activation
 
-Generated: 2026-06-07T15:53:50.612Z
+Generated: 2026-06-07T17:31:22.361Z
 Status: REAL_DEV_ACTIVATION_READY
 
 ## Decision


### PR DESCRIPTION
## Purpose

Correct County Studio canonical parcel readiness for Forge dev mode.

This PR answers the #916 blocker question: `canonicalParcel=0` was not accepted as proof that Benton canonical parcels were absent. The canonical table is populated, and the gate now avoids treating canonical parcel as the sole Forge-dev parcel identity dependency when real property landing/truth/map/ledger/inspector paths are readable.

## Findings

- `canonical_tf.tf_parcel` direct read returned `3,198,979` rows.
- `legacy_pacs_raw.property` returned `1,190,834` rows.
- `truth_pacs.parcel_spine` returned `83,326` rows.
- `gis_tf.tf_parcel_geom` returned `80,075` rows.
- Canonical parcel remains required for production proof.
- Canonical parcel is not the sole required Forge-dev parcel identity path.

## Current posture

- `canonicalParcelBlocksForgeDev=false`
- `forgeDevRequiresCanonicalParcel=false`
- `productionProofRequiresCanonicalParcel=true`
- `productionProofAllowed=false`
- `operationalProofAllowed=false`

## Important current blocker

The latest consolidated live refresh is still blocked, but not by canonical parcel:

```text
backend health: Backend health is not proven.
localhost:5000 and localhost:5046 are not responding.
```

That is a separate backend/runtime-health issue. This PR does not start backend services, mutate Sync, change DB seeding, or weaken proof gates.

## Verification

- `node --test os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `git diff --check`
- pre-push quality gate passed on push