### PR TITLE
[codex] County Studio R1 full Forge dev smoke

### DIFF
--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,10 +1,10 @@
 {
-  "generatedAtUtc": "2026-06-07T18:28:02.313Z",
+  "generatedAtUtc": "2026-06-07T18:52:57.668Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_DATA_AVAILABLE",
+  "status": "REAL_DEV_SERVER_BLOCKED",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": true,
+    "realDevServerAllowed": false,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -49,9 +49,9 @@
     },
     {
       "name": "active drain process state",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "Client drain process is not alive, but DB load_batch proves server-side state COMPLETED.",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "Drain process state is unknown.",
       "evidence": {
         "pid": null,
         "alive": null,
@@ -60,13 +60,13 @@
     },
     {
       "name": "load_batch current stage",
-      "classification": "SYNC_DERIVED",
-      "passed": true,
-      "reason": "load_batch stage is assessment-value-seal (COMPLETED).",
+      "classification": "UNKNOWN",
+      "passed": false,
+      "reason": "load_batch stage is exemption-fact-seal (FAILED).",
       "evidence": {
-        "stage": "assessment-value-seal",
-        "status": "COMPLETED",
-        "loadBatchId": "613ab22a-0d42-411b-80f1-886e5df4bd97"
+        "stage": "exemption-fact-seal",
+        "status": "FAILED",
+        "loadBatchId": "7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5"
       }
     },
     {
@@ -179,8 +179,8 @@
       "passed": true,
       "reason": "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
       "evidence": {
-        "stage": "assessment-value-seal",
-        "status": "COMPLETED",
+        "stage": "exemption-fact-seal",
+        "status": "FAILED",
         "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
         "requiredForCountyStudioForgeDev": false,
         "requiredForPacketProof": true,
@@ -240,8 +240,8 @@
   ],
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "assessment-value-seal",
-      "status": "COMPLETED",
+      "stage": "exemption-fact-seal",
+      "status": "FAILED",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,
       "requiredForPacketProof": true,
@@ -271,7 +271,10 @@
       }
     }
   },
-  "blockers": [],
+  "blockers": [
+    "active drain process state: Drain process state is unknown.",
+    "load_batch current stage: load_batch stage is exemption-fact-seal (FAILED)."
+  ],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,11 +1,11 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T18:28:02.313Z
-Status: REAL_DEV_DATA_AVAILABLE
+Generated: 2026-06-07T18:52:57.668Z
+Status: REAL_DEV_SERVER_BLOCKED
 
 ## Decision
 
-- Real Dev Server: ALLOWED
+- Real Dev Server: BLOCKED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
@@ -23,8 +23,8 @@ Status: REAL_DEV_DATA_AVAILABLE
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
 | backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
-| active drain process state | SYNC_DERIVED | true | Client drain process is not alive, but DB load_batch proves server-side state COMPLETED. |
-| load_batch current stage | SYNC_DERIVED | true | load_batch stage is assessment-value-seal (COMPLETED). |
+| active drain process state | UNKNOWN | false | Drain process state is unknown. |
+| load_batch current stage | UNKNOWN | false | load_batch stage is exemption-fact-seal (FAILED). |
 | landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
 | truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
 | canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
@@ -41,8 +41,8 @@ Status: REAL_DEV_DATA_AVAILABLE
 
 ## Forge Dev Dependency Reclassification
 
-- ownerSupnumBackfillStatus: COMPLETED
-- ownerSupnumBackfillStage: assessment-value-seal
+- ownerSupnumBackfillStatus: FAILED
+- ownerSupnumBackfillStage: exemption-fact-seal
 - ownerSupnumBackfillLatestFailedStage: owner-supnum-resume
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
@@ -52,7 +52,8 @@ Status: REAL_DEV_DATA_AVAILABLE
 
 ## Blockers
 
-- None
+- active drain process state: Drain process state is unknown.
+- load_batch current stage: load_batch stage is exemption-fact-seal (FAILED).
 
 ## Rules
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,9 +1,14 @@
 {
-  "generatedAtUtc": "2026-06-07T18:22:05.299Z",
+  "generatedAtUtc": "2026-06-07T18:52:57.9356526Z",
   "gate": "county-studio-r1-forge-dev-smoke",
-  "status": "FORGE_DEV_SMOKE_PREFLIGHT_CHAIN_READY_FULL_DEV_NOT_RERUN",
-  "commandInvokedPreviously": "pnpm run dev:county-studio:real-benton",
+  "status": "FORGE_DEV_SMOKE_DB_READINESS_BLOCKED",
+  "command": "pnpm run dev:county-studio:real-benton",
   "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
+  "stdoutLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-115207.out.log",
+  "stderrLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-115207.err.log",
+  "exitedWithinTimeout": true,
+  "exitCode": 1,
+  "observationWindowSeconds": 50,
   "preflightGates": [
     {
       "command": "pnpm run proof:county-studio:real-dev-port-preflight",
@@ -22,52 +27,105 @@
     },
     {
       "command": "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
-      "status": "REAL_DEV_DATA_AVAILABLE",
-      "exitCode": 0,
-      "passed": true,
-      "blockers": [],
+      "status": "REAL_DEV_SERVER_BLOCKED",
+      "exitCode": 1,
+      "passed": false,
       "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-activation",
-      "status": "REAL_DEV_ACTIVATION_READY",
-      "exitCode": 0,
-      "passed": true,
+      "status": "NOT_REACHED",
+      "exitCode": null,
+      "passed": false,
       "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json"
     }
   ],
-  "devServer": {
-    "started": false,
-    "frontendStarted": false,
-    "frontendBoundUrls": [],
-    "urlEmitted": false,
-    "backendStarted": false,
-    "reason": "The long-running cross-env ... pnpm run dev stage was not rerun in this backend health bootstrap slice. The preflight chain is ready."
+  "portPreflight": {
+    "portPreflightPassed": true,
+    "occupiedPorts": [],
+    "requiredPorts": [4317, 5046]
   },
   "backendHealth": {
     "status": "REAL_DEV_BACKEND_HEALTH_PASS",
     "backendHealthy": true,
     "healthEndpoint": "http://localhost:5000/health",
     "backendLaunchCommand": "pnpm run dev:backend:api",
-    "backendStartedByDevCommand": false
+    "backendStartedByDevCommand": false,
+    "api5000Health": {
+      "ok": true,
+      "statusCode": 200,
+      "url": "http://localhost:5000/health"
+    },
+    "api5046Health": {
+      "ok": false,
+      "statusCode": null,
+      "url": "http://localhost:5046/health",
+      "error": "The request was canceled due to the configured HttpClient.Timeout of 3 seconds elapsing."
+    }
   },
-  "portPreflight": {
-    "portPreflightPassed": true,
-    "occupiedPorts": []
+  "dbReadiness": {
+    "status": "REAL_DEV_SERVER_BLOCKED",
+    "realDevServerAllowed": false,
+    "blockers": [
+      "active drain process state: Drain process state is unknown.",
+      "load_batch current stage: load_batch stage is exemption-fact-seal (FAILED)."
+    ],
+    "evidence": {
+      "activeDrainProcessState": "UNKNOWN",
+      "loadBatchStage": "exemption-fact-seal",
+      "loadBatchStatus": "FAILED",
+      "loadBatchId": "7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5",
+      "propertyLanding": 1190834,
+      "truthParcel": 83326,
+      "canonicalParcel": 3198979,
+      "ownerSupnumBackfillRequiredForForgeDev": false
+    }
   },
-  "readinessBlockers": [],
+  "realDevActivation": {
+    "status": "NOT_REACHED",
+    "realDevActivationAllowed": false,
+    "reason": "The full dev command stopped at the live DB readiness gate before real-dev activation ran."
+  },
+  "forgeDevStatus": {
+    "statusGateRunInCommand": false,
+    "note": "The real-benton dev command runs port, backend, DB readiness, and activation gates before dev startup; r1-forge-dev-status remains a separate proof command."
+  },
+  "devServer": {
+    "started": false,
+    "frontendStarted": false,
+    "frontendBoundUrls": [],
+    "urlEmitted": false,
+    "backendStarted": false,
+    "pilot4317Listening": false,
+    "api5046Listening": false,
+    "apiStartupOrReuse": "not-reached",
+    "reason": "The command exited before cross-env TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton ... pnpm run dev."
+  },
+  "modeFlags": {
+    "TF_COUNTY_STUDIO_DEV_DATA_MODE": "real-benton",
+    "TF_COUNTY_STUDIO_PRODUCTION_PROOF": "false",
+    "TF_COUNTY_STUDIO_OPERATIONAL_PROOF": "false"
+  },
   "postureAfterSmoke": {
     "portPreflightPassed": true,
     "backendHealthy": true,
-    "realDevServerAllowed": true,
-    "realDevActivationAllowed": true,
-    "forgeDevAllowed": true,
+    "realDevServerAllowed": false,
+    "realDevActivationAllowed": false,
+    "forgeDevAllowed": false,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
     "cleanFullDevSmokePassed": false
   },
-  "startupErrors": [],
-  "interpretation": "The backend health bootstrap gate removes the vague backend-health failure from the real Benton dev command. The current preflight chain is ready, but this artifact does not claim a clean full long-running dev-server smoke because that stage was not rerun.",
+  "startupWarnings": [],
+  "startupErrors": [
+    "pnpm run proof:county-studio:benton-real-dev-server-readiness:db returned REAL_DEV_SERVER_BLOCKED",
+    "pnpm run dev:county-studio:real-benton exited with code 1"
+  ],
+  "blocker": "Live DB readiness blocks full Forge dev smoke because active drain state is UNKNOWN and load_batch stage exemption-fact-seal is FAILED.",
+  "interpretation": "The full smoke did not reach Vite, governed pilot runtime, or local API startup. Ports and backend health are not the current blocker; live DB readiness is.",
+  "productionProofAllowed": false,
+  "operationalProofAllowed": false,
+  "cleanFullDevSmokePassed": false,
   "boundaries": [
     "This smoke update did not touch County Studio UI.",
     "This smoke update did not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,8 +1,8 @@
 # County Studio R1 Forge Dev Smoke
 
-Generated: 2026-06-07T18:22:05.299Z
+Generated: 2026-06-07T18:52:57.9356526Z
 
-Status: `FORGE_DEV_SMOKE_PREFLIGHT_CHAIN_READY_FULL_DEV_NOT_RERUN`
+Status: `FORGE_DEV_SMOKE_DB_READINESS_BLOCKED`
 
 ## Command
 
@@ -16,14 +16,22 @@ Working directory:
 C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
 ```
 
+Result:
+
+```text
+exitCode=1
+observationWindowSeconds=50
+cleanFullDevSmokePassed=false
+```
+
 ## Current Preflight Chain
 
 | Gate | Status | Passed |
 | --- | --- | --- |
 | Port preflight | `REAL_DEV_PORT_PREFLIGHT_PASS` | true |
 | Backend health | `REAL_DEV_BACKEND_HEALTH_PASS` | true |
-| Live DB readiness | `REAL_DEV_DATA_AVAILABLE` | true |
-| Real-dev activation | `REAL_DEV_ACTIVATION_READY` | true |
+| Live DB readiness | `REAL_DEV_SERVER_BLOCKED` | false |
+| Real-dev activation | `NOT_REACHED` | false |
 
 Backend health:
 
@@ -33,18 +41,69 @@ backendLaunchCommand=pnpm run dev:backend:api
 backendStartedByDevCommand=false
 ```
 
+## Blocker
+
+The full real Benton Forge dev smoke did not reach the long-running dev server stage. The command stopped at:
+
+```bash
+pnpm run proof:county-studio:benton-real-dev-server-readiness:db
+```
+
+The live DB readiness gate reported:
+
+```text
+status=REAL_DEV_SERVER_BLOCKED
+realDevServerAllowed=false
+```
+
+Current blockers:
+
+```text
+active drain process state: Drain process state is unknown.
+load_batch current stage: load_batch stage is exemption-fact-seal (FAILED).
+```
+
+Observed DB evidence at the blocked gate:
+
+```text
+propertyLanding=1,190,834
+truthParcel=83,326
+canonicalParcel=3,198,979
+ownerSupnumBackfillRequiredForForgeDev=false
+loadBatchId=7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5
+```
+
+## Dev Server State
+
+The command exited before:
+
+```bash
+cross-env TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton TF_COUNTY_STUDIO_PRODUCTION_PROOF=false TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false pnpm run dev
+```
+
+Therefore:
+
+```text
+frontendStarted=false
+frontendBoundUrls=[]
+backendStarted=false
+pilot4317Listening=false
+api5046Listening=false
+```
+
 ## Interpretation
 
-The backend health bootstrap gate removes the vague backend-health failure from the real Benton dev command. The current preflight chain is ready.
-
-The long-running `cross-env ... pnpm run dev` stage was not rerun in this backend health bootstrap slice, so this artifact does not claim `cleanFullDevSmokePassed=true`.
+Ports and backend health are no longer the active smoke blocker. The active blocker is live DB readiness: the readiness gate now refuses to allow the full dev server while the drain state is unknown and the current `load_batch` stage is failed.
 
 ## Proof Posture
 
 ```text
-forgeDevAllowed=true
+forgeDevAllowed=false
+realDevServerAllowed=false
+realDevActivationAllowed=false
 productionProofAllowed=false
 operationalProofAllowed=false
+cleanFullDevSmokePassed=false
 ```
 
 ## Boundaries

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:17:39.805Z",
+  "generatedAtUtc": "2026-06-07T18:52:10.465Z",
   "gate": "county-studio-real-dev-backend-health",
   "status": "REAL_DEV_BACKEND_HEALTH_PASS",
   "expectedBackendPorts": [5046, 5000],

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Backend Health
 
-Generated: 2026-06-07T18:17:39.805Z
+Generated: 2026-06-07T18:52:10.465Z
 
 Status: `REAL_DEV_BACKEND_HEALTH_PASS`
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:18:02.268Z",
+  "generatedAtUtc": "2026-06-07T18:52:09.707Z",
   "gate": "county-studio-real-dev-port-preflight",
   "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
   "requiredPorts": [

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Port Preflight
 
-Generated: 2026-06-07T18:18:02.268Z
+Generated: 2026-06-07T18:52:09.707Z
 
 Status: `REAL_DEV_PORT_PREFLIGHT_PASS`
 


### PR DESCRIPTION
## Summary

Captures the full County Studio real Benton Forge dev smoke by invoking:

```bash
pnpm run dev:county-studio:real-benton
```

The smoke now records the fresh runtime truth instead of carrying forward the prior preflight-ready posture.

## Result

Current full smoke status:

```text
FORGE_DEV_SMOKE_DB_READINESS_BLOCKED
cleanFullDevSmokePassed=false
```

The command reached:

```text
REAL_DEV_PORT_PREFLIGHT_PASS
REAL_DEV_BACKEND_HEALTH_PASS
```

It then stopped at:

```text
pnpm run proof:county-studio:benton-real-dev-server-readiness:db
REAL_DEV_SERVER_BLOCKED
```

Current live DB readiness blockers:

```text
active drain process state: UNKNOWN
load_batch stage: exemption-fact-seal
load_batch status: FAILED
```

The evidence also preserves:

```text
productionProofAllowed=false
operationalProofAllowed=false
```

## Boundaries

- No County Studio UI changes
- No Sync mutation
- No DB seeding changes
- No proof weakening
- No production/operational proof claim

## Verification

```text
pnpm run type-check
node --test os-platform/core/tests/phase83-tools.test.mjs
node -e "JSON.parse(...)" for touched evidence JSON
git diff --check
```

Push hook also ran and passed:

```text
unit tests: 164 passed
security scan runner
performance benchmark
compliance lint
backend build
```
