### PR TITLE
[codex] County Studio exemption fact dependency reclassification

### DIFF
--- a/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.mjs
@@ -63,6 +63,7 @@ export const REQUIRED_READINESS_CHECKS = [
   "WPOV status",
   "WSDOR status",
   "owner-supnum backfill dependency classification",
+  "exemption fact seal dependency classification",
   "map data dependency status",
   "ledger data dependency status",
   "inspector data dependency status"
@@ -72,6 +73,7 @@ export const OWNER_SUPNUM_DEPENDENCY_CLASSIFICATIONS = [
   "REQUIRED_FOR_FORGE_DEV",
   "NOT_REQUIRED_FOR_FORGE_DEV",
   "REQUIRED_FOR_PACKET_PROOF",
+  "REQUIRED_FOR_PRODUCTION_PROOF",
   "REQUIRED_FOR_OPERATIONAL_PROOF",
   "UNKNOWN"
 ];
@@ -204,14 +206,25 @@ function isOwnerSupnumBackfillStage(stage) {
   return String(stage ?? "").trim().toLowerCase().startsWith("owner-supnum");
 }
 
+function isExemptionFactSealStage(stage) {
+  return String(stage ?? "").trim().toLowerCase().startsWith("exemption-fact");
+}
+
 function isFailed(status) {
   return String(status ?? "").trim().toUpperCase() === "FAILED";
 }
 
 function buildOwnerSupnumDependency(evidence) {
   const source = evidence?.countyStudioDependencies?.ownerSupnumBackfill ?? {};
-  const stage = source.stage ?? evidence?.loadBatch?.stage ?? "UNKNOWN";
-  const status = source.status ?? evidence?.loadBatch?.status ?? "UNKNOWN";
+  const currentLoadBatchIsOwnerSupnum = isOwnerSupnumBackfillStage(evidence?.loadBatch?.stage);
+  const stage = source.stage
+    ?? source.latestFailed?.stage
+    ?? (currentLoadBatchIsOwnerSupnum ? evidence?.loadBatch?.stage : null)
+    ?? "UNKNOWN";
+  const status = source.status
+    ?? source.latestFailed?.status
+    ?? (currentLoadBatchIsOwnerSupnum ? evidence?.loadBatch?.status : null)
+    ?? "UNKNOWN";
   const consumedByForge = source.ownerIdentityConsumedByForgeSurfaces === true;
   const requiredForForgeDev = source.requiredForCountyStudioForgeDev === true || consumedByForge;
   const classification = normalizeOwnerSupnumDependencyClassification(
@@ -256,22 +269,74 @@ function buildOwnerSupnumDependency(evidence) {
   };
 }
 
+function buildExemptionFactDependency(evidence) {
+  const source = evidence?.countyStudioDependencies?.exemptionFactSeal ?? {};
+  const stage = source.stage ?? evidence?.loadBatch?.stage ?? "UNKNOWN";
+  const status = source.status ?? evidence?.loadBatch?.status ?? "UNKNOWN";
+  const consumedByForge = source.exemptionFactsConsumedByForgeSurfaces === true;
+  const requiredForForgeDev = source.requiredForCountyStudioForgeDev === true || consumedByForge;
+  const classification = normalizeOwnerSupnumDependencyClassification(
+    source.classification,
+    requiredForForgeDev
+      ? "REQUIRED_FOR_FORGE_DEV"
+      : isExemptionFactSealStage(stage)
+        ? "NOT_REQUIRED_FOR_FORGE_DEV"
+        : "UNKNOWN"
+  );
+
+  return {
+    stage,
+    status,
+    classification,
+    requiredForCountyStudioForgeDev: classification === "REQUIRED_FOR_FORGE_DEV" || requiredForForgeDev,
+    requiredForPacketProof: source.requiredForPacketProof !== false,
+    requiredForProductionProof: source.requiredForProductionProof !== false,
+    requiredForOperationalProof: source.requiredForOperationalProof !== false,
+    exemptionFactsConsumedByForgeSurfaces: consumedByForge,
+    consumedSurfaces: Array.isArray(source.consumedSurfaces) ? source.consumedSurfaces : [],
+    audit: source.audit ?? {
+      finding: "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+      forgeValuationSources: [
+        "parcel/property identity",
+        "property characteristics",
+        "valuation metrics",
+        "ratio-study context",
+        "risk objects",
+        "geometry/map context"
+      ],
+      packetOperationalSurfaces: [
+        "tax relief workflow",
+        "notice/tax liability context",
+        "Dais exemption administration",
+        "Dossier packet exemption proof",
+        "operational roll packet references"
+      ]
+    }
+  };
+}
+
 function buildChecks(evidence) {
   const counts = countRows(evidence);
   const countClass = classifyCounts(counts);
   const backendHealthy = healthOk(evidence?.backendHealth);
   const loadBatchStatus = String(evidence?.loadBatch?.status ?? "UNKNOWN").toUpperCase();
   const ownerSupnumDependency = buildOwnerSupnumDependency(evidence);
+  const exemptionFactDependency = buildExemptionFactDependency(evidence);
   const ownerSupnumFailedButNotForgeDevRequired =
     isOwnerSupnumBackfillStage(ownerSupnumDependency.stage)
     && isFailed(ownerSupnumDependency.status)
     && ownerSupnumDependency.requiredForCountyStudioForgeDev !== true;
+  const exemptionFactFailedButNotForgeDevRequired =
+    isExemptionFactSealStage(exemptionFactDependency.stage)
+    && isFailed(exemptionFactDependency.status)
+    && exemptionFactDependency.requiredForCountyStudioForgeDev !== true;
   const drainAlive = evidence?.activeDrain?.alive === true;
   const drainKnownDead = evidence?.activeDrain?.alive === false;
   const dbBackedDrainStateKnown =
     loadBatchStatus === "IN_PROGRESS"
     || loadBatchStatus === "COMPLETED"
-    || ownerSupnumFailedButNotForgeDevRequired;
+    || ownerSupnumFailedButNotForgeDevRequired
+    || exemptionFactFailedButNotForgeDevRequired;
   const mapClassification = normalizeClassification(evidence?.countyStudioDependencies?.map);
   const ledgerClassification = normalizeClassification(evidence?.countyStudioDependencies?.ledger);
   const inspectorClassification = normalizeClassification(evidence?.countyStudioDependencies?.inspector);
@@ -294,6 +359,8 @@ function buildChecks(evidence) {
         : dbBackedDrainStateKnown
           ? ownerSupnumFailedButNotForgeDevRequired
             ? "Client drain process is not alive/known, but the failed owner-supnum stage is not required for County Studio Forge valuation dev."
+            : exemptionFactFailedButNotForgeDevRequired
+              ? "Client drain process is not alive/known, but the failed exemption-fact stage is not required for County Studio Forge valuation dev."
             : `Client drain process is not alive, but DB load_batch proves server-side state ${loadBatchStatus}.`
         : drainKnownDead
           ? "Drain process is not alive; confirm whether client timeout or backend failure occurred."
@@ -302,11 +369,13 @@ function buildChecks(evidence) {
     ),
     makeCheck(
       "load_batch current stage",
-      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired ? "SYNC_DERIVED" : "UNKNOWN",
-      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired,
+      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired || exemptionFactFailedButNotForgeDevRequired ? "SYNC_DERIVED" : "UNKNOWN",
+      loadBatchStatus === "IN_PROGRESS" || loadBatchStatus === "COMPLETED" || ownerSupnumFailedButNotForgeDevRequired || exemptionFactFailedButNotForgeDevRequired,
       evidence?.loadBatch?.stage
         ? ownerSupnumFailedButNotForgeDevRequired
           ? "load_batch stage is owner-supnum-backfill (FAILED), retained as packet/ops blocker but not a County Studio Forge dev blocker."
+          : exemptionFactFailedButNotForgeDevRequired
+            ? "load_batch stage is exemption-fact-seal (FAILED), retained as production/ops blocker but not a County Studio Forge dev blocker."
           : `load_batch stage is ${evidence.loadBatch.stage} (${loadBatchStatus}).`
         : "load_batch stage is not proven.",
       evidence?.loadBatch ?? {}
@@ -398,6 +467,15 @@ function buildChecks(evidence) {
       ownerSupnumDependency
     ),
     makeCheck(
+      "exemption fact seal dependency classification",
+      exemptionFactDependency.requiredForCountyStudioForgeDev ? "UNKNOWN" : "PARTIAL_SEEDED",
+      exemptionFactDependency.requiredForCountyStudioForgeDev !== true || !isFailed(exemptionFactDependency.status),
+      exemptionFactDependency.requiredForCountyStudioForgeDev
+        ? "exemption-fact-seal is required for a consumed County Studio Forge exemption surface."
+        : "exemption-fact-seal is not required for County Studio Forge valuation dev; production, packet, and operational proof remain blocked.",
+      exemptionFactDependency
+    ),
+    makeCheck(
       "map data dependency status",
       mapClassification,
       REAL_DEV_ALLOWED_CLASSIFICATIONS.has(mapClassification),
@@ -481,7 +559,8 @@ export function buildBentonRealDevServerReadinessReport({
   const blockers = checks.map(blockerFor).filter(Boolean);
   const maturity = buildMaturity(checks);
   const forgeDevDependency = {
-    ownerSupnumBackfill: buildOwnerSupnumDependency(evidence ?? {})
+    ownerSupnumBackfill: buildOwnerSupnumDependency(evidence ?? {}),
+    exemptionFactSeal: buildExemptionFactDependency(evidence ?? {})
   };
   const realDevServerAllowed = maturity.REAL_DEV_DATA_AVAILABLE && blockers.length === 0;
   const status = realDevServerAllowed ? "REAL_DEV_DATA_AVAILABLE" : "REAL_DEV_SERVER_BLOCKED";
@@ -508,6 +587,7 @@ export function buildBentonRealDevServerReadinessReport({
       "Stage stagnation without inserts is investigation.",
       "Partial landing is usable for dev evidence, not production proof.",
       "Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.",
+      "Exemption fact seal failure blocks production, packet, and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes exemption facts.",
       "Do not relabel partial seed as authoritative."
     ],
     boundaries: [
@@ -559,7 +639,14 @@ export function renderBentonRealDevServerReadinessMarkdown(report) {
     `- ownerSupnumBackfillClassification: ${report.forgeDevDependency.ownerSupnumBackfill.classification}`,
     `- ownerSupnumBackfillRequiredForForgeDev: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev}`,
     `- ownerSupnumBackfillRequiredForPacketProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForPacketProof}`,
-    `- ownerSupnumBackfillRequiredForOperationalProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForOperationalProof}`
+    `- ownerSupnumBackfillRequiredForOperationalProof: ${report.forgeDevDependency.ownerSupnumBackfill.requiredForOperationalProof}`,
+    `- exemptionFactSealStatus: ${report.forgeDevDependency.exemptionFactSeal.status}`,
+    `- exemptionFactSealStage: ${report.forgeDevDependency.exemptionFactSeal.stage}`,
+    `- exemptionFactSealClassification: ${report.forgeDevDependency.exemptionFactSeal.classification}`,
+    `- exemptionFactSealRequiredForForgeDev: ${report.forgeDevDependency.exemptionFactSeal.requiredForCountyStudioForgeDev}`,
+    `- exemptionFactSealRequiredForProductionProof: ${report.forgeDevDependency.exemptionFactSeal.requiredForProductionProof}`,
+    `- exemptionFactSealRequiredForPacketProof: ${report.forgeDevDependency.exemptionFactSeal.requiredForPacketProof}`,
+    `- exemptionFactSealRequiredForOperationalProof: ${report.forgeDevDependency.exemptionFactSeal.requiredForOperationalProof}`
   );
 
   lines.push("", "## Blockers", "");

--- a/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
+++ b/os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs
@@ -64,6 +64,7 @@ test("defines the staged real-dev readiness classifications and checks", () => {
     "REQUIRED_FOR_FORGE_DEV",
     "NOT_REQUIRED_FOR_FORGE_DEV",
     "REQUIRED_FOR_PACKET_PROOF",
+    "REQUIRED_FOR_PRODUCTION_PROOF",
     "REQUIRED_FOR_OPERATIONAL_PROOF",
     "UNKNOWN"
   ]);
@@ -82,6 +83,7 @@ test("defines the staged real-dev readiness classifications and checks", () => {
     "WPOV status",
     "WSDOR status",
     "owner-supnum backfill dependency classification",
+    "exemption fact seal dependency classification",
     "map data dependency status",
     "ledger data dependency status",
     "inspector data dependency status"
@@ -240,6 +242,72 @@ test("does not block Forge dev when owner-supnum resume failed but owner identit
   assert.equal(report.forgeDevDependency.ownerSupnumBackfill.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
   assert.equal(report.forgeDevDependency.ownerSupnumBackfill.requiredForCountyStudioForgeDev, false);
   assert.equal(report.blockers.some((blocker) => /owner-supnum|load_batch|drain process/i.test(blocker)), false);
+});
+
+test("does not relabel owner-supnum latest failure with an unrelated current load_batch stage", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.loadBatch = {
+    stage: "exemption-fact-seal",
+    status: "COMPLETED",
+    loadBatchId: "batch-exemption-complete"
+  };
+  evidence.countyStudioDependencies.ownerSupnumBackfill = {
+    latestFailed: {
+      stage: "owner-supnum-resume",
+      status: "FAILED",
+      loadBatchId: "batch-owner-supnum-failed"
+    },
+    classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: false,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    ownerIdentityConsumedByForgeSurfaces: false
+  };
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.stage, "owner-supnum-resume");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.status, "FAILED");
+  assert.equal(report.forgeDevDependency.ownerSupnumBackfill.latestFailed.stage, "owner-supnum-resume");
+  assert.equal(report.decisions.realDevServerAllowed, true);
+});
+
+test("does not block Forge dev when exemption fact seal failed but exemptions are not consumed", () => {
+  const evidence = partialRealSeedEvidence();
+  evidence.activeDrain = { pid: null, alive: null, status: "UNKNOWN" };
+  evidence.loadBatch = {
+    stage: "exemption-fact-seal",
+    status: "FAILED",
+    loadBatchId: "batch-exemption-fact-failed"
+  };
+  evidence.countyStudioDependencies.exemptionFactSeal = {
+    status: "FAILED",
+    stage: "exemption-fact-seal",
+    classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+    requiredForCountyStudioForgeDev: false,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    exemptionFactsConsumedByForgeSurfaces: false
+  };
+
+  const report = buildBentonRealDevServerReadinessReport({
+    evidence,
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.status, "REAL_DEV_DATA_AVAILABLE");
+  assert.equal(report.decisions.realDevServerAllowed, true);
+  assert.equal(report.decisions.productionProofAllowed, false);
+  assert.equal(report.decisions.operationalProofAllowed, false);
+  assert.equal(report.forgeDevDependency.exemptionFactSeal.status, "FAILED");
+  assert.equal(report.forgeDevDependency.exemptionFactSeal.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(report.forgeDevDependency.exemptionFactSeal.requiredForCountyStudioForgeDev, false);
+  assert.equal(report.forgeDevDependency.exemptionFactSeal.requiredForProductionProof, true);
+  assert.equal(report.forgeDevDependency.exemptionFactSeal.requiredForOperationalProof, true);
+  assert.equal(report.blockers.some((blocker) => /exemption|load_batch|drain process/i.test(blocker)), false);
 });
 
 test("blocks Forge dev when owner-supnum backfill is required by a consumed owner identity surface", () => {

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.mjs
@@ -285,9 +285,14 @@ function dependencyClassification({ geometryCount, canonicalParcel, truthParcel 
 }
 
 function ownerSupnumBackfillDependency(loadBatch, latestFailed = null) {
+  const currentStage = loadBatch?.stage ?? null;
+  const currentStageIsOwnerSupnum = String(currentStage ?? "").trim().toLowerCase().startsWith("owner-supnum");
+  const latestFailedStage = latestFailed && !latestFailed.unavailable ? latestFailed.stage : null;
+  const latestFailedStatus = latestFailed && !latestFailed.unavailable ? latestFailed.status : null;
+
   return {
-    stage: loadBatch?.stage ?? "UNKNOWN",
-    status: loadBatch?.status ?? "UNKNOWN",
+    stage: currentStageIsOwnerSupnum ? currentStage : latestFailedStage ?? "UNKNOWN",
+    status: currentStageIsOwnerSupnum ? loadBatch?.status ?? "UNKNOWN" : latestFailedStatus ?? "UNKNOWN",
     latestFailed: latestFailed && !latestFailed.unavailable
       ? {
         loadBatchId: latestFailed.loadBatchId ?? null,
@@ -315,6 +320,41 @@ function ownerSupnumBackfillDependency(loadBatch, latestFailed = null) {
         "Dossier packet owner identity",
         "Dais/notice/appeal taxpayer identity",
         "operational packet owner references"
+      ]
+    }
+  };
+}
+
+function exemptionFactSealDependency(loadBatch) {
+  const stage = loadBatch?.stage ?? "UNKNOWN";
+  const status = loadBatch?.status ?? "UNKNOWN";
+  const isExemptionFactStage = String(stage).trim().toLowerCase().startsWith("exemption-fact");
+
+  return {
+    stage,
+    status,
+    classification: isExemptionFactStage ? "NOT_REQUIRED_FOR_FORGE_DEV" : "UNKNOWN",
+    requiredForCountyStudioForgeDev: false,
+    requiredForProductionProof: true,
+    requiredForPacketProof: true,
+    requiredForOperationalProof: true,
+    exemptionFactsConsumedByForgeSurfaces: false,
+    consumedSurfaces: [],
+    audit: {
+      finding: "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+      forgeValuationSources: [
+        "parcel/property identity",
+        "property characteristics",
+        "valuation metrics",
+        "ratio-study context",
+        "risk objects",
+        "geometry/map context"
+      ],
+      packetOpsSources: [
+        "Dais exemption administration",
+        "tax/notice context",
+        "Dossier packet exemption proof",
+        "operational roll packet references"
       ]
     }
   };
@@ -431,7 +471,8 @@ export async function buildBentonSyncDrainStateEvidence({
       ownerSupnumBackfill: ownerSupnumBackfillDependency(
         queryResults.latestLoadBatch,
         queryResults.latestOwnerSupnumFailure
-      )
+      ),
+      exemptionFactSeal: exemptionFactSealDependency(queryResults.latestLoadBatch)
     },
     decisions: {
       realDevEvidenceReadable: false,
@@ -514,6 +555,12 @@ function renderMarkdown(evidence) {
     `- Owner-supnum required for Forge dev: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForCountyStudioForgeDev}`,
     `- Owner-supnum required for packet proof: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForPacketProof}`,
     `- Owner-supnum required for operational proof: ${evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForOperationalProof}`,
+    `- Exemption fact seal status: ${evidence.countyStudioDependencies.exemptionFactSeal.status}`,
+    `- Exemption fact seal classification: ${evidence.countyStudioDependencies.exemptionFactSeal.classification}`,
+    `- Exemption fact required for Forge dev: ${evidence.countyStudioDependencies.exemptionFactSeal.requiredForCountyStudioForgeDev}`,
+    `- Exemption fact required for production proof: ${evidence.countyStudioDependencies.exemptionFactSeal.requiredForProductionProof}`,
+    `- Exemption fact required for packet proof: ${evidence.countyStudioDependencies.exemptionFactSeal.requiredForPacketProof}`,
+    `- Exemption fact required for operational proof: ${evidence.countyStudioDependencies.exemptionFactSeal.requiredForOperationalProof}`,
     "",
     "## Rules",
     "",

--- a/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
+++ b/os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs
@@ -81,6 +81,54 @@ test("classifies populated Sync/DB evidence as partial real seed without product
   assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
   assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.latestFailed.status, "FAILED");
   assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.requiredForPacketProof, true);
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.classification, "UNKNOWN");
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.requiredForCountyStudioForgeDev, false);
+  assert.equal(evidence.decisions.productionProofAllowed, false);
+  assert.equal(evidence.decisions.operationalProofAllowed, false);
+});
+
+test("classifies exemption fact seal failure as not required for Forge dev", async () => {
+  const queryValues = {
+    latestLoadBatch: {
+      loadBatchId: "batch-exemption-failed",
+      stage: "exemption-fact-seal",
+      status: "FAILED"
+    },
+    latestOwnerSupnumFailure: {
+      loadBatchId: "batch-owner-failed",
+      stage: "owner-supnum-resume",
+      status: "FAILED"
+    },
+    legacyProperty: 1190834,
+    legacyOwner: 8213706,
+    legacyPropSuppAssoc: 4382985,
+    legacyWashPropOwnerVal: 1707143,
+    legacyAccount: 535140,
+    truthParcel: 83326,
+    truthOwner: 816849,
+    truthWsdor: 774696,
+    canonicalParcel: 3198979,
+    canonicalOwner: 312532,
+    canonicalWsdor: 686820,
+    gisParcelGeometry: 80075
+  };
+
+  const evidence = await buildBentonSyncDrainStateEvidence({
+    probeBackendHealth: async () => ({ status: "healthy", ok: true }),
+    processAlive: () => null,
+    query: async (name) => queryValues[name]
+  });
+
+  assert.equal(evidence.loadBatch.stage, "exemption-fact-seal");
+  assert.equal(evidence.loadBatch.status, "FAILED");
+  assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.stage, "owner-supnum-resume");
+  assert.equal(evidence.countyStudioDependencies.ownerSupnumBackfill.status, "FAILED");
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.status, "FAILED");
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.classification, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.requiredForCountyStudioForgeDev, false);
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.requiredForProductionProof, true);
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.requiredForPacketProof, true);
+  assert.equal(evidence.countyStudioDependencies.exemptionFactSeal.requiredForOperationalProof, true);
   assert.equal(evidence.decisions.productionProofAllowed, false);
   assert.equal(evidence.decisions.operationalProofAllowed, false);
 });

--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
@@ -115,6 +115,19 @@ function ownerSupnumStatus(readinessReport, activationReport, forgeWiringReport)
   return "UNKNOWN";
 }
 
+function exemptionDependency(readinessReport, activationReport) {
+  return activationReport?.forgeDevDependency?.exemptionFactSeal
+    ?? readinessReport?.forgeDevDependency?.exemptionFactSeal
+    ?? null;
+}
+
+function exemptionFactStatus(readinessReport, activationReport) {
+  const dependency = exemptionDependency(readinessReport, activationReport);
+  if (dependency?.classification) return dependency.classification;
+  if (dependency?.requiredForCountyStudioForgeDev === false) return "NOT_REQUIRED_FOR_FORGE_DEV";
+  return "UNKNOWN";
+}
+
 function dataTruthStatus(activationReport, forgeWiringReport) {
   return activationReport?.dataTruthPosture?.status
     ?? forgeWiringReport?.dataTruthPosture?.status
@@ -143,12 +156,13 @@ function riskReady(riskAuditReport) {
   return READY_RISK_CLASSIFICATIONS.has(riskObjectStatus(riskAuditReport));
 }
 
-function productionBlockers({ dataTruth, geometry, risk, owner }) {
+function productionBlockers({ dataTruth, geometry, risk, owner, exemption }) {
   const blockers = [
     "Canonical Benton source/count reconciliation remains required before production proof.",
     "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
     "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
-    "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment."
+    "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
+    "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
   ];
 
   if (dataTruth !== "DATA_TRUTH_FAIL") {
@@ -163,6 +177,9 @@ function productionBlockers({ dataTruth, geometry, risk, owner }) {
   if (owner !== "NOT_REQUIRED_FOR_FORGE_DEV") {
     blockers.push(`Owner-supnum status is ${owner}; owner identity must remain visible as a packet/ops dependency.`);
   }
+  if (exemption !== "NOT_REQUIRED_FOR_FORGE_DEV") {
+    blockers.push(`Exemption fact status is ${exemption}; exemption facts must remain visible as production/ops dependencies.`);
+  }
 
   return blockers;
 }
@@ -170,6 +187,7 @@ function productionBlockers({ dataTruth, geometry, risk, owner }) {
 function operationalBlockers() {
   return [
     "Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.",
+    "Exemption facts remain required for Dais exemption administration, Dossier packet proof, notices, tax relief workflows, and operational roll proof.",
     "Production proof must pass before operational proof can be claimed.",
     "Dossier evidence packets, Dais workflow creation, TerraTrace decision chain, and parcel/workbench handoff evidence remain operational proof requirements."
   ];
@@ -182,6 +200,7 @@ function buildBlockers({
   geometryIsReady,
   riskIsReady,
   ownerStatus,
+  exemptionStatus,
   liveReadinessRefresh
 }) {
   const blockers = [];
@@ -196,6 +215,9 @@ function buildBlockers({
   if (!riskIsReady) blockers.push("Risk objects are not dev-derived or real-sourced.");
   if (ownerStatus !== "NOT_REQUIRED_FOR_FORGE_DEV") {
     blockers.push("Owner-supnum dependency is not classified as NOT_REQUIRED_FOR_FORGE_DEV.");
+  }
+  if (exemptionStatus !== "NOT_REQUIRED_FOR_FORGE_DEV") {
+    blockers.push("Exemption fact dependency is not classified as NOT_REQUIRED_FOR_FORGE_DEV.");
   }
   return blockers;
 }
@@ -215,6 +237,8 @@ export function buildCountyStudioR1ForgeDevStatusReport({
   const geometry = geometryStatus(geometryReport, forgeWiringReport);
   const risk = riskObjectStatus(riskAuditReport);
   const owner = ownerSupnumStatus(readinessReport, activationReport, forgeWiringReport);
+  const exemption = exemptionFactStatus(readinessReport, activationReport);
+  const exemptionDependencyReport = exemptionDependency(readinessReport, activationReport);
   const dataTruth = dataTruthStatus(activationReport, forgeWiringReport);
   const geometryIsReady = geometryReady(geometryReport, forgeWiringReport);
   const riskIsReady = riskReady(riskAuditReport);
@@ -226,6 +250,7 @@ export function buildCountyStudioR1ForgeDevStatusReport({
     geometryIsReady,
     riskIsReady,
     ownerStatus: owner,
+    exemptionStatus: exemption,
     liveReadinessRefresh
   });
   const forgeDevAllowed = blockers.length === 0;
@@ -243,14 +268,19 @@ export function buildCountyStudioR1ForgeDevStatusReport({
       geometryStatus: geometry,
       riskObjectStatus: risk,
       ownerSupnumStatus: owner,
+      exemptionFactStatus: exemption,
+      exemptionFactRequiredForForgeDev: exemptionDependencyReport?.requiredForCountyStudioForgeDev ?? null,
+      exemptionFactRequiredForProductionProof: exemptionDependencyReport?.requiredForProductionProof ?? null,
+      exemptionFactRequiredForPacketProof: exemptionDependencyReport?.requiredForPacketProof ?? null,
+      exemptionFactRequiredForOperationalProof: exemptionDependencyReport?.requiredForOperationalProof ?? null,
       countyStudioMode: forgeDevAllowed ? "REAL_BENTON_FORGE_DEV" : "FORGE_DEV_BLOCKED",
       requiredRunCommand: REQUIRED_RUN_COMMAND,
-      remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner }),
+      remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner, exemption }),
       remainingOperationalBlockers: operationalBlockers()
     },
     requiredRunCommand: REQUIRED_RUN_COMMAND,
     preflightChain: REQUIRED_FORGE_DEV_PREFLIGHT_CHAIN,
-    remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner }),
+    remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner, exemption }),
     remainingOperationalBlockers: operationalBlockers(),
     runbook: {
       startRealBentonForgeDev: REQUIRED_RUN_COMMAND,
@@ -260,7 +290,9 @@ export function buildCountyStudioR1ForgeDevStatusReport({
       notOperationalProof:
         "This is not operational proof. Packet, Dais, Dossier, Trace, owner identity, and workflow evidence remain blocked.",
       ownerSupnumPosture:
-        "Owner-supnum remains required for packet/ops proof, not current County Studio Forge valuation dev."
+        "Owner-supnum remains required for packet/ops proof, not current County Studio Forge valuation dev.",
+      exemptionFactPosture:
+        "Exemption facts remain required for production/ops proof, not current County Studio Forge valuation dev."
     },
     sourceArtifacts: {
       backendHealth: "os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json",
@@ -306,6 +338,11 @@ export function renderCountyStudioR1ForgeDevStatusMarkdown(report) {
     `- geometryStatus=${report.summary.geometryStatus}`,
     `- riskObjectStatus=${report.summary.riskObjectStatus}`,
     `- ownerSupnumStatus=${report.summary.ownerSupnumStatus}`,
+    `- exemptionFactStatus=${report.summary.exemptionFactStatus}`,
+    `- exemptionFactRequiredForForgeDev=${report.summary.exemptionFactRequiredForForgeDev}`,
+    `- exemptionFactRequiredForProductionProof=${report.summary.exemptionFactRequiredForProductionProof}`,
+    `- exemptionFactRequiredForPacketProof=${report.summary.exemptionFactRequiredForPacketProof}`,
+    `- exemptionFactRequiredForOperationalProof=${report.summary.exemptionFactRequiredForOperationalProof}`,
     `- countyStudioMode=${report.summary.countyStudioMode}`,
     `- requiredRunCommand=${report.summary.requiredRunCommand}`,
     "",
@@ -330,6 +367,8 @@ export function renderCountyStudioR1ForgeDevStatusMarkdown(report) {
     report.runbook.notOperationalProof,
     "",
     report.runbook.ownerSupnumPosture,
+    "",
+    report.runbook.exemptionFactPosture,
     "",
     "## Remaining Production Blockers",
     ""

--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
@@ -35,6 +35,17 @@ function readinessReport(overrides = {}) {
           stage: "owner-supnum-resume",
           status: "FAILED"
         }
+      },
+      exemptionFactSeal: {
+        stage: "exemption-fact-seal",
+        status: "FAILED",
+        classification: "NOT_REQUIRED_FOR_FORGE_DEV",
+        requiredForCountyStudioForgeDev: false,
+        requiredForProductionProof: true,
+        requiredForPacketProof: true,
+        requiredForOperationalProof: true,
+        exemptionFactsConsumedByForgeSurfaces: false,
+        consumedSurfaces: []
       }
     },
     ...overrides
@@ -151,6 +162,10 @@ test("summarizes County Studio R1 as real Benton Forge dev while blocking produc
   assert.equal(report.summary.geometryStatus, "SYNC_DERIVED_GEOMETRY");
   assert.equal(report.summary.riskObjectStatus, "DEV_DERIVED_FROM_REAL_INPUTS");
   assert.equal(report.summary.ownerSupnumStatus, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(report.summary.exemptionFactStatus, "NOT_REQUIRED_FOR_FORGE_DEV");
+  assert.equal(report.summary.exemptionFactRequiredForForgeDev, false);
+  assert.equal(report.summary.exemptionFactRequiredForProductionProof, true);
+  assert.equal(report.summary.exemptionFactRequiredForOperationalProof, true);
   assert.equal(report.summary.countyStudioMode, "REAL_BENTON_FORGE_DEV");
   assert.equal(report.summary.requiredRunCommand, "pnpm run dev:county-studio:real-benton");
   assert.ok(report.remainingProductionBlockers.some((item) => /canonical Benton/i.test(item)));

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,10 +1,10 @@
 {
-  "generatedAtUtc": "2026-06-07T18:52:57.668Z",
+  "generatedAtUtc": "2026-06-07T20:02:25.766Z",
   "gate": "benton-real-dev-server-readiness",
-  "status": "REAL_DEV_SERVER_BLOCKED",
+  "status": "REAL_DEV_DATA_AVAILABLE",
   "sourcePath": null,
   "decisions": {
-    "realDevServerAllowed": false,
+    "realDevServerAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -30,6 +30,7 @@
     "WPOV status",
     "WSDOR status",
     "owner-supnum backfill dependency classification",
+    "exemption fact seal dependency classification",
     "map data dependency status",
     "ledger data dependency status",
     "inspector data dependency status"
@@ -49,9 +50,9 @@
     },
     {
       "name": "active drain process state",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "Drain process state is unknown.",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "Client drain process is not alive/known, but the failed owner-supnum stage is not required for County Studio Forge valuation dev.",
       "evidence": {
         "pid": null,
         "alive": null,
@@ -60,13 +61,13 @@
     },
     {
       "name": "load_batch current stage",
-      "classification": "UNKNOWN",
-      "passed": false,
-      "reason": "load_batch stage is exemption-fact-seal (FAILED).",
+      "classification": "SYNC_DERIVED",
+      "passed": true,
+      "reason": "load_batch stage is owner-supnum-backfill (FAILED), retained as packet/ops blocker but not a County Studio Forge dev blocker.",
       "evidence": {
         "stage": "exemption-fact-seal",
-        "status": "FAILED",
-        "loadBatchId": "7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5"
+        "status": "COMPLETED",
+        "loadBatchId": "e21e20ea-4bfb-402e-8496-4506f6829922"
       }
     },
     {
@@ -179,7 +180,7 @@
       "passed": true,
       "reason": "owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked.",
       "evidence": {
-        "stage": "exemption-fact-seal",
+        "stage": "owner-supnum-resume",
         "status": "FAILED",
         "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
         "requiredForCountyStudioForgeDev": false,
@@ -206,6 +207,40 @@
             "Dossier packet owner identity",
             "Dais/notice/appeal taxpayer identity",
             "operational packet owner references"
+          ]
+        }
+      }
+    },
+    {
+      "name": "exemption fact seal dependency classification",
+      "classification": "PARTIAL_SEEDED",
+      "passed": true,
+      "reason": "exemption-fact-seal is not required for County Studio Forge valuation dev; production, packet, and operational proof remain blocked.",
+      "evidence": {
+        "stage": "exemption-fact-seal",
+        "status": "COMPLETED",
+        "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+        "requiredForCountyStudioForgeDev": false,
+        "requiredForPacketProof": true,
+        "requiredForProductionProof": true,
+        "requiredForOperationalProof": true,
+        "exemptionFactsConsumedByForgeSurfaces": false,
+        "consumedSurfaces": [],
+        "audit": {
+          "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+          "forgeValuationSources": [
+            "parcel/property identity",
+            "property characteristics",
+            "valuation metrics",
+            "ratio-study context",
+            "risk objects",
+            "geometry/map context"
+          ],
+          "packetOpsSources": [
+            "Dais exemption administration",
+            "tax/notice context",
+            "Dossier packet exemption proof",
+            "operational roll packet references"
           ]
         }
       }
@@ -240,7 +275,7 @@
   ],
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "exemption-fact-seal",
+      "stage": "owner-supnum-resume",
       "status": "FAILED",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,
@@ -269,12 +304,37 @@
           "operational packet owner references"
         ]
       }
+    },
+    "exemptionFactSeal": {
+      "stage": "exemption-fact-seal",
+      "status": "COMPLETED",
+      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForProductionProof": true,
+      "requiredForOperationalProof": true,
+      "exemptionFactsConsumedByForgeSurfaces": false,
+      "consumedSurfaces": [],
+      "audit": {
+        "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+        "forgeValuationSources": [
+          "parcel/property identity",
+          "property characteristics",
+          "valuation metrics",
+          "ratio-study context",
+          "risk objects",
+          "geometry/map context"
+        ],
+        "packetOpsSources": [
+          "Dais exemption administration",
+          "tax/notice context",
+          "Dossier packet exemption proof",
+          "operational roll packet references"
+        ]
+      }
     }
   },
-  "blockers": [
-    "active drain process state: Drain process state is unknown.",
-    "load_batch current stage: load_batch stage is exemption-fact-seal (FAILED)."
-  ],
+  "blockers": [],
   "classifications": [
     "AUTHORITATIVE",
     "SYNC_DERIVED",
@@ -292,6 +352,7 @@
     "Stage stagnation without inserts is investigation.",
     "Partial landing is usable for dev evidence, not production proof.",
     "Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.",
+    "Exemption fact seal failure blocks production, packet, and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes exemption facts.",
     "Do not relabel partial seed as authoritative."
   ],
   "boundaries": [

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,11 +1,11 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T18:52:57.668Z
-Status: REAL_DEV_SERVER_BLOCKED
+Generated: 2026-06-07T20:02:25.766Z
+Status: REAL_DEV_DATA_AVAILABLE
 
 ## Decision
 
-- Real Dev Server: BLOCKED
+- Real Dev Server: ALLOWED
 - Production Proof: BLOCKED
 - Operational Proof: BLOCKED
 
@@ -23,8 +23,8 @@ Status: REAL_DEV_SERVER_BLOCKED
 | Check | Classification | Passed | Reason |
 | --- | --- | --- | --- |
 | backend health | SYNC_DERIVED | true | Backend health is reported usable for dev reads. |
-| active drain process state | UNKNOWN | false | Drain process state is unknown. |
-| load_batch current stage | UNKNOWN | false | load_batch stage is exemption-fact-seal (FAILED). |
+| active drain process state | SYNC_DERIVED | true | Client drain process is not alive/known, but the failed owner-supnum stage is not required for County Studio Forge valuation dev. |
+| load_batch current stage | SYNC_DERIVED | true | load_batch stage is owner-supnum-backfill (FAILED), retained as packet/ops blocker but not a County Studio Forge dev blocker. |
 | landing table counts | PARTIAL_SEEDED | true | Property landing rows exist. |
 | truth table counts | PARTIAL_SEEDED | true | Truth table counts are evaluated as partial until all expected Benton counts are reconciled. |
 | canonical parcel counts | SEEDED | true | Canonical parcel rows exist. |
@@ -35,6 +35,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 | WPOV status | PARTIAL_SEEDED | true | WPOV landing rows exist. |
 | WSDOR status | PARTIAL_SEEDED | true | WSDOR truth rows exist. |
 | owner-supnum backfill dependency classification | PARTIAL_SEEDED | true | owner-supnum backfill is not required for County Studio Forge valuation dev; packet and operational proof remain blocked. |
+| exemption fact seal dependency classification | PARTIAL_SEEDED | true | exemption-fact-seal is not required for County Studio Forge valuation dev; production, packet, and operational proof remain blocked. |
 | map data dependency status | PARTIAL_SEEDED | true | Map dependency is classified PARTIAL_SEEDED. |
 | ledger data dependency status | SYNC_DERIVED | true | Ledger dependency is classified SYNC_DERIVED. |
 | inspector data dependency status | SYNC_DERIVED | true | Inspector dependency is classified SYNC_DERIVED. |
@@ -42,18 +43,24 @@ Status: REAL_DEV_SERVER_BLOCKED
 ## Forge Dev Dependency Reclassification
 
 - ownerSupnumBackfillStatus: FAILED
-- ownerSupnumBackfillStage: exemption-fact-seal
+- ownerSupnumBackfillStage: owner-supnum-resume
 - ownerSupnumBackfillLatestFailedStage: owner-supnum-resume
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
 - ownerSupnumBackfillRequiredForForgeDev: false
 - ownerSupnumBackfillRequiredForPacketProof: true
 - ownerSupnumBackfillRequiredForOperationalProof: true
+- exemptionFactSealStatus: COMPLETED
+- exemptionFactSealStage: exemption-fact-seal
+- exemptionFactSealClassification: NOT_REQUIRED_FOR_FORGE_DEV
+- exemptionFactSealRequiredForForgeDev: false
+- exemptionFactSealRequiredForProductionProof: true
+- exemptionFactSealRequiredForPacketProof: true
+- exemptionFactSealRequiredForOperationalProof: true
 
 ## Blockers
 
-- active drain process state: Drain process state is unknown.
-- load_batch current stage: load_batch stage is exemption-fact-seal (FAILED).
+- None
 
 ## Rules
 
@@ -62,6 +69,7 @@ Status: REAL_DEV_SERVER_BLOCKED
 - Stage stagnation without inserts is investigation.
 - Partial landing is usable for dev evidence, not production proof.
 - Owner-supnum backfill failure blocks packet and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes owner identity.
+- Exemption fact seal failure blocks production, packet, and operational proof, but only blocks County Studio Forge dev when a Forge surface consumes exemption facts.
 - Do not relabel partial seed as authoritative.
 
 ## Boundaries

--- a/os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.json
+++ b/os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.json
@@ -1,0 +1,66 @@
+{
+  "generatedAtUtc": "2026-06-07T19:46:58.1016756Z",
+  "gate": "county-studio-exemption-fact-dependency",
+  "status": "NOT_REQUIRED_FOR_FORGE_DEV",
+  "startingPoint": {
+    "source": "PR #919 full Forge dev smoke",
+    "observedBlockedStage": "exemption-fact-seal",
+    "observedBlockedStatus": "FAILED",
+    "correction": "Do not globally block County Studio Forge dev on exemption-fact-seal unless a Forge surface consumes exemption facts."
+  },
+  "currentRuntime": {
+    "loadBatchStage": "exemption-fact-seal",
+    "loadBatchStatus": "COMPLETED",
+    "loadBatchId": "e21e20ea-4bfb-402e-8496-4506f6829922"
+  },
+  "classification": {
+    "exemptionFactStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "exemptionFactRequiredForForgeDev": false,
+    "exemptionFactRequiredForProductionProof": true,
+    "exemptionFactRequiredForPacketProof": true,
+    "exemptionFactRequiredForOperationalProof": true,
+    "exemptionFactsConsumedByForgeSurfaces": false,
+    "consumedSurfaces": []
+  },
+  "audit": {
+    "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+    "forgeValuationDependencies": [
+      "parcel/property identity",
+      "property characteristics",
+      "valuation metrics",
+      "ratio-study context",
+      "risk objects",
+      "geometry/map context",
+      "countyId",
+      "taxYear",
+      "studyId"
+    ],
+    "nonForgeOrProofDependencies": [
+      "Dais exemption administration",
+      "tax relief workflow",
+      "notice/tax liability context",
+      "Dossier packet exemption proof",
+      "operational roll packet references"
+    ],
+    "searchConclusion": "No current County Studio Forge valuation dependency was found that requires exemption facts for real Benton Forge dev activation."
+  },
+  "decision": {
+    "forgeDevAllowed": true,
+    "realDevServerAllowed": true,
+    "realDevActivationAllowed": true,
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false
+  },
+  "tests": [
+    "benton-real-dev-server-readiness.test.mjs: does not block Forge dev when exemption fact seal failed but exemptions are not consumed",
+    "benton-sync-drain-state-evidence-adapter.test.mjs: classifies exemption fact seal failure as not required for Forge dev"
+  ],
+  "boundaries": [
+    "This evidence does not touch County Studio UI.",
+    "This evidence does not mutate TerraFusion Sync.",
+    "This evidence does not change DB seeding.",
+    "This evidence does not weaken production proof.",
+    "This evidence does not weaken operational proof.",
+    "This evidence does not hide exemption-fact-seal state."
+  ]
+}

--- a/os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.md
+++ b/os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.md
@@ -1,0 +1,85 @@
+# County Studio Exemption Fact Dependency
+
+Generated: 2026-06-07T19:46:58.1016756Z
+
+Status: `NOT_REQUIRED_FOR_FORGE_DEV`
+
+## Starting Point
+
+PR #919 full Forge dev smoke exposed a readiness-gate blocker:
+
+```text
+load_batch stage: exemption-fact-seal
+load_batch status: FAILED
+```
+
+That exposed a gate-scoping issue. County Studio is a TerraForge valuation dev surface, and exemption facts should not globally block Forge dev unless a County Studio Forge surface actually consumes exemption data.
+
+## Current Runtime
+
+The current live runtime has advanced since the PR #919 smoke:
+
+```text
+loadBatchStage=exemption-fact-seal
+loadBatchStatus=COMPLETED
+loadBatchId=e21e20ea-4bfb-402e-8496-4506f6829922
+```
+
+The gate still classifies the dependency explicitly, including the failed-stage case covered by regression tests.
+
+## Classification
+
+```text
+exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV
+exemptionFactRequiredForForgeDev=false
+exemptionFactRequiredForProductionProof=true
+exemptionFactRequiredForPacketProof=true
+exemptionFactRequiredForOperationalProof=true
+exemptionFactsConsumedByForgeSurfaces=false
+```
+
+## Audit
+
+Current County Studio Forge valuation dependencies:
+
+- parcel/property identity
+- property characteristics
+- valuation metrics
+- ratio-study context
+- risk objects
+- geometry/map context
+- countyId
+- taxYear
+- studyId
+
+Exemption facts remain relevant to non-Forge-dev proof/workflow surfaces:
+
+- Dais exemption administration
+- tax relief workflow
+- notice/tax liability context
+- Dossier packet exemption proof
+- operational roll packet references
+
+## Decision
+
+```text
+forgeDevAllowed=true
+realDevServerAllowed=true
+realDevActivationAllowed=true
+productionProofAllowed=false
+operationalProofAllowed=false
+```
+
+## Regression Coverage
+
+- `benton-real-dev-server-readiness.test.mjs`: does not block Forge dev when exemption fact seal failed but exemptions are not consumed.
+- `benton-sync-drain-state-evidence-adapter.test.mjs`: classifies exemption fact seal failure as not required for Forge dev.
+
+## Boundaries
+
+- This evidence does not touch County Studio UI.
+- This evidence does not mutate TerraFusion Sync.
+- This evidence does not change DB seeding.
+- This evidence does not weaken production proof.
+- This evidence does not weaken operational proof.
+- This evidence does not hide exemption-fact-seal state.

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json
@@ -1,131 +1,121 @@
 {
-  "generatedAtUtc": "2026-06-07T18:52:57.9356526Z",
+  "generatedAtUtc": "2026-06-07T19:46:58.1016756Z",
   "gate": "county-studio-r1-forge-dev-smoke",
-  "status": "FORGE_DEV_SMOKE_DB_READINESS_BLOCKED",
+  "status": "FORGE_DEV_SMOKE_PASS",
   "command": "pnpm run dev:county-studio:real-benton",
   "workingDirectory": "C:\\Users\\bsval\\.codex-worktrees\\county-studio-r1-packet-payloads",
-  "stdoutLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-115207.out.log",
-  "stderrLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-115207.err.log",
-  "exitedWithinTimeout": true,
-  "exitCode": 1,
-  "observationWindowSeconds": 50,
+  "stdoutLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-124435.out.log",
+  "stderrLogPath": "C:\\Users\\bsval\\AppData\\Local\\Temp\\county-studio-full-forge-dev-smoke-20260607-124435.err.log",
+  "rootPid": 55764,
+  "rootAliveAtCapture": true,
+  "observationWindowSeconds": 141,
+  "requiredStableSeconds": 60,
+  "stableSecondsObserved": 75,
+  "firstReadyAtUtc": "2026-06-07T19:45:43.0451073Z",
   "preflightGates": [
     {
       "command": "pnpm run proof:county-studio:real-dev-port-preflight",
       "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
-      "exitCode": 0,
       "passed": true,
       "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-backend-health",
       "status": "REAL_DEV_BACKEND_HEALTH_PASS",
-      "exitCode": 0,
       "passed": true,
       "healthEndpoint": "http://localhost:5000/health",
       "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json"
     },
     {
       "command": "pnpm run proof:county-studio:benton-real-dev-server-readiness:db",
-      "status": "REAL_DEV_SERVER_BLOCKED",
-      "exitCode": 1,
-      "passed": false,
+      "status": "REAL_DEV_DATA_AVAILABLE",
+      "passed": true,
       "evidenceArtifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json"
     },
     {
       "command": "pnpm run proof:county-studio:real-dev-activation",
-      "status": "NOT_REACHED",
-      "exitCode": null,
-      "passed": false,
+      "status": "REAL_DEV_ACTIVATION_READY",
+      "passed": true,
       "evidenceArtifact": "os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json"
     }
   ],
   "portPreflight": {
     "portPreflightPassed": true,
-    "occupiedPorts": [],
+    "initial4317Occupied": false,
+    "initial5046Occupied": false,
     "requiredPorts": [4317, 5046]
   },
   "backendHealth": {
     "status": "REAL_DEV_BACKEND_HEALTH_PASS",
     "backendHealthy": true,
-    "healthEndpoint": "http://localhost:5000/health",
-    "backendLaunchCommand": "pnpm run dev:backend:api",
-    "backendStartedByDevCommand": false,
     "api5000Health": {
       "ok": true,
       "statusCode": 200,
       "url": "http://localhost:5000/health"
     },
     "api5046Health": {
-      "ok": false,
-      "statusCode": null,
-      "url": "http://localhost:5046/health",
-      "error": "The request was canceled due to the configured HttpClient.Timeout of 3 seconds elapsing."
+      "ok": true,
+      "statusCode": 200,
+      "url": "http://localhost:5046/health"
     }
   },
   "dbReadiness": {
-    "status": "REAL_DEV_SERVER_BLOCKED",
-    "realDevServerAllowed": false,
-    "blockers": [
-      "active drain process state: Drain process state is unknown.",
-      "load_batch current stage: load_batch stage is exemption-fact-seal (FAILED)."
-    ],
-    "evidence": {
-      "activeDrainProcessState": "UNKNOWN",
-      "loadBatchStage": "exemption-fact-seal",
-      "loadBatchStatus": "FAILED",
-      "loadBatchId": "7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5",
-      "propertyLanding": 1190834,
-      "truthParcel": 83326,
-      "canonicalParcel": 3198979,
-      "ownerSupnumBackfillRequiredForForgeDev": false
-    }
+    "status": "REAL_DEV_DATA_AVAILABLE",
+    "realDevServerAllowed": true,
+    "blockers": [],
+    "loadBatchStage": "exemption-fact-seal",
+    "loadBatchStatus": "COMPLETED",
+    "exemptionFactRequiredForForgeDev": false,
+    "exemptionFactRequiredForProductionProof": true,
+    "exemptionFactRequiredForOperationalProof": true
   },
   "realDevActivation": {
-    "status": "NOT_REACHED",
-    "realDevActivationAllowed": false,
-    "reason": "The full dev command stopped at the live DB readiness gate before real-dev activation ran."
-  },
-  "forgeDevStatus": {
-    "statusGateRunInCommand": false,
-    "note": "The real-benton dev command runs port, backend, DB readiness, and activation gates before dev startup; r1-forge-dev-status remains a separate proof command."
+    "status": "REAL_DEV_ACTIVATION_READY",
+    "realDevActivationAllowed": true
   },
   "devServer": {
-    "started": false,
-    "frontendStarted": false,
-    "frontendBoundUrls": [],
-    "urlEmitted": false,
-    "backendStarted": false,
-    "pilot4317Listening": false,
-    "api5046Listening": false,
-    "apiStartupOrReuse": "not-reached",
-    "reason": "The command exited before cross-env TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton ... pnpm run dev."
+    "started": true,
+    "frontendStarted": true,
+    "frontendBoundUrls": ["http://localhost:5174/"],
+    "viteUrl": "http://localhost:5174/",
+    "vitePort": 5174,
+    "frontendListening": true,
+    "pilot4317Listening": true,
+    "api5046Listening": true,
+    "apiStartupOrReuse": "started-local-5046"
   },
   "modeFlags": {
     "TF_COUNTY_STUDIO_DEV_DATA_MODE": "real-benton",
     "TF_COUNTY_STUDIO_PRODUCTION_PROOF": "false",
     "TF_COUNTY_STUDIO_OPERATIONAL_PROOF": "false"
   },
+  "startupWarnings": [
+    "Redis not configured - using NoOp cache",
+    "Port 5173 is in use, trying another one",
+    "Modules directory not found",
+    "UI directory not found",
+    "Harris PACS sync skipped for Benton",
+    "System health degraded: Unknown issue"
+  ],
+  "startupErrors": [],
+  "postCleanup": {
+    "smokeProcessTreeStopped": true,
+    "port4317StillListening": false,
+    "port5046StillListening": false
+  },
   "postureAfterSmoke": {
     "portPreflightPassed": true,
     "backendHealthy": true,
-    "realDevServerAllowed": false,
-    "realDevActivationAllowed": false,
-    "forgeDevAllowed": false,
+    "realDevServerAllowed": true,
+    "realDevActivationAllowed": true,
+    "forgeDevAllowed": true,
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
-    "cleanFullDevSmokePassed": false
+    "cleanFullDevSmokePassed": true
   },
-  "startupWarnings": [],
-  "startupErrors": [
-    "pnpm run proof:county-studio:benton-real-dev-server-readiness:db returned REAL_DEV_SERVER_BLOCKED",
-    "pnpm run dev:county-studio:real-benton exited with code 1"
-  ],
-  "blocker": "Live DB readiness blocks full Forge dev smoke because active drain state is UNKNOWN and load_batch stage exemption-fact-seal is FAILED.",
-  "interpretation": "The full smoke did not reach Vite, governed pilot runtime, or local API startup. Ports and backend health are not the current blocker; live DB readiness is.",
   "productionProofAllowed": false,
   "operationalProofAllowed": false,
-  "cleanFullDevSmokePassed": false,
+  "cleanFullDevSmokePassed": true,
   "boundaries": [
     "This smoke update did not touch County Studio UI.",
     "This smoke update did not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.md
@@ -1,8 +1,8 @@
 # County Studio R1 Forge Dev Smoke
 
-Generated: 2026-06-07T18:52:57.9356526Z
+Generated: 2026-06-07T19:46:58.1016756Z
 
-Status: `FORGE_DEV_SMOKE_DB_READINESS_BLOCKED`
+Status: `FORGE_DEV_SMOKE_PASS`
 
 ## Command
 
@@ -19,91 +19,85 @@ C:\Users\bsval\.codex-worktrees\county-studio-r1-packet-payloads
 Result:
 
 ```text
-exitCode=1
-observationWindowSeconds=50
-cleanFullDevSmokePassed=false
+cleanFullDevSmokePassed=true
+observationWindowSeconds=141
+stableSecondsObserved=75
+requiredStableSeconds=60
 ```
 
-## Current Preflight Chain
+## Preflight Chain
 
 | Gate | Status | Passed |
 | --- | --- | --- |
 | Port preflight | `REAL_DEV_PORT_PREFLIGHT_PASS` | true |
 | Backend health | `REAL_DEV_BACKEND_HEALTH_PASS` | true |
-| Live DB readiness | `REAL_DEV_SERVER_BLOCKED` | false |
-| Real-dev activation | `NOT_REACHED` | false |
+| Live DB readiness | `REAL_DEV_DATA_AVAILABLE` | true |
+| Real-dev activation | `REAL_DEV_ACTIVATION_READY` | true |
+
+## Runtime
+
+```text
+Vite URL: http://localhost:5174/
+frontendListening=true
+pilot4317Listening=true
+api5046Listening=true
+apiStartupOrReuse=started-local-5046
+```
 
 Backend health:
 
 ```text
-healthEndpoint=http://localhost:5000/health
-backendLaunchCommand=pnpm run dev:backend:api
-backendStartedByDevCommand=false
+http://localhost:5000/health = 200
+http://localhost:5046/health = 200
 ```
 
-## Blocker
-
-The full real Benton Forge dev smoke did not reach the long-running dev server stage. The command stopped at:
-
-```bash
-pnpm run proof:county-studio:benton-real-dev-server-readiness:db
-```
-
-The live DB readiness gate reported:
+DB readiness:
 
 ```text
-status=REAL_DEV_SERVER_BLOCKED
-realDevServerAllowed=false
+loadBatchStage=exemption-fact-seal
+loadBatchStatus=COMPLETED
+exemptionFactRequiredForForgeDev=false
+exemptionFactRequiredForProductionProof=true
+exemptionFactRequiredForOperationalProof=true
 ```
 
-Current blockers:
+Mode flags:
 
 ```text
-active drain process state: Drain process state is unknown.
-load_batch current stage: load_batch stage is exemption-fact-seal (FAILED).
+TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton
+TF_COUNTY_STUDIO_PRODUCTION_PROOF=false
+TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false
 ```
 
-Observed DB evidence at the blocked gate:
+## Cleanup
+
+The smoke-owned process tree was stopped after capture.
 
 ```text
-propertyLanding=1,190,834
-truthParcel=83,326
-canonicalParcel=3,198,979
-ownerSupnumBackfillRequiredForForgeDev=false
-loadBatchId=7063c26e-c2f3-4dfe-ae7c-afce6a48f9d5
+port4317StillListening=false
+port5046StillListening=false
 ```
 
-## Dev Server State
+## Startup Warnings
 
-The command exited before:
+- Redis not configured - using NoOp cache.
+- Port 5173 was already in use, so Vite selected 5174.
+- Modules directory not found.
+- UI directory not found.
+- Harris PACS sync skipped for Benton because `pacscontract.v1` is read-only.
+- System health degraded warning appeared in backend logs.
 
-```bash
-cross-env TF_COUNTY_STUDIO_DEV_DATA_MODE=real-benton TF_COUNTY_STUDIO_PRODUCTION_PROOF=false TF_COUNTY_STUDIO_OPERATIONAL_PROOF=false pnpm run dev
-```
-
-Therefore:
-
-```text
-frontendStarted=false
-frontendBoundUrls=[]
-backendStarted=false
-pilot4317Listening=false
-api5046Listening=false
-```
-
-## Interpretation
-
-Ports and backend health are no longer the active smoke blocker. The active blocker is live DB readiness: the readiness gate now refuses to allow the full dev server while the drain state is unknown and the current `load_batch` stage is failed.
+No startup error signal was observed by the smoke harness.
 
 ## Proof Posture
 
 ```text
-forgeDevAllowed=false
-realDevServerAllowed=false
-realDevActivationAllowed=false
+forgeDevAllowed=true
+realDevServerAllowed=true
+realDevActivationAllowed=true
 productionProofAllowed=false
 operationalProofAllowed=false
-cleanFullDevSmokePassed=false
+cleanFullDevSmokePassed=true
 ```
 
 ## Boundaries

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:28:02.344Z",
+  "generatedAtUtc": "2026-06-07T20:01:00.617Z",
   "gate": "county-studio-r1-forge-dev-status",
   "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
   "summary": {
@@ -11,16 +11,23 @@
     "geometryStatus": "SYNC_DERIVED_GEOMETRY",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "exemptionFactStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "exemptionFactRequiredForForgeDev": false,
+    "exemptionFactRequiredForProductionProof": true,
+    "exemptionFactRequiredForPacketProof": true,
+    "exemptionFactRequiredForOperationalProof": true,
     "countyStudioMode": "REAL_BENTON_FORGE_DEV",
     "requiredRunCommand": "pnpm run dev:county-studio:real-benton",
     "remainingProductionBlockers": [
       "Canonical Benton source/count reconciliation remains required before production proof.",
       "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
       "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
-      "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment."
+      "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
+      "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
     ],
     "remainingOperationalBlockers": [
       "Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.",
+      "Exemption facts remain required for Dais exemption administration, Dossier packet proof, notices, tax relief workflows, and operational roll proof.",
       "Production proof must pass before operational proof can be claimed.",
       "Dossier evidence packets, Dais workflow creation, TerraTrace decision chain, and parcel/workbench handoff evidence remain operational proof requirements."
     ]
@@ -37,10 +44,12 @@
     "Canonical Benton source/count reconciliation remains required before production proof.",
     "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
     "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
-    "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment."
+    "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
+    "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
   ],
   "remainingOperationalBlockers": [
     "Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.",
+    "Exemption facts remain required for Dais exemption administration, Dossier packet proof, notices, tax relief workflows, and operational roll proof.",
     "Production proof must pass before operational proof can be claimed.",
     "Dossier evidence packets, Dais workflow creation, TerraTrace decision chain, and parcel/workbench handoff evidence remain operational proof requirements."
   ],
@@ -55,7 +64,8 @@
     ],
     "notProductionProof": "This is not production proof. It allows County Studio R1 to run as a real Benton-backed TerraForge valuation development surface only.",
     "notOperationalProof": "This is not operational proof. Packet, Dais, Dossier, Trace, owner identity, and workflow evidence remain blocked.",
-    "ownerSupnumPosture": "Owner-supnum remains required for packet/ops proof, not current County Studio Forge valuation dev."
+    "ownerSupnumPosture": "Owner-supnum remains required for packet/ops proof, not current County Studio Forge valuation dev.",
+    "exemptionFactPosture": "Exemption facts remain required for production/ops proof, not current County Studio Forge valuation dev."
   },
   "sourceArtifacts": {
     "backendHealth": "os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
@@ -1,6 +1,6 @@
 # County Studio R1 Forge Dev Status
 
-Generated: 2026-06-07T18:28:02.344Z
+Generated: 2026-06-07T20:01:00.617Z
 Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 
 ## Summary
@@ -13,6 +13,11 @@ Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 - geometryStatus=SYNC_DERIVED_GEOMETRY
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 - ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
+- exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV
+- exemptionFactRequiredForForgeDev=false
+- exemptionFactRequiredForProductionProof=true
+- exemptionFactRequiredForPacketProof=true
+- exemptionFactRequiredForOperationalProof=true
 - countyStudioMode=REAL_BENTON_FORGE_DEV
 - requiredRunCommand=pnpm run dev:county-studio:real-benton
 
@@ -38,16 +43,20 @@ This is not operational proof. Packet, Dais, Dossier, Trace, owner identity, and
 
 Owner-supnum remains required for packet/ops proof, not current County Studio Forge valuation dev.
 
+Exemption facts remain required for production/ops proof, not current County Studio Forge valuation dev.
+
 ## Remaining Production Blockers
 
 - Canonical Benton source/count reconciliation remains required before production proof.
 - CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.
 - TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.
 - Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.
+- Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof.
 
 ## Remaining Operational Blockers
 
 - Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.
+- Exemption facts remain required for Dais exemption administration, Dossier packet proof, notices, tax relief workflows, and operational roll proof.
 - Production proof must pass before operational proof can be claimed.
 - Dossier evidence packets, Dais workflow creation, TerraTrace decision chain, and parcel/workbench handoff evidence remain operational proof requirements.
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:52:10.465Z",
+  "generatedAtUtc": "2026-06-07T20:01:32.706Z",
   "gate": "county-studio-real-dev-backend-health",
   "status": "REAL_DEV_BACKEND_HEALTH_PASS",
   "expectedBackendPorts": [5046, 5000],

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Backend Health
 
-Generated: 2026-06-07T18:52:10.465Z
+Generated: 2026-06-07T20:01:32.706Z
 
 Status: `REAL_DEV_BACKEND_HEALTH_PASS`
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:52:09.707Z",
+  "generatedAtUtc": "2026-06-07T20:01:31.982Z",
   "gate": "county-studio-real-dev-port-preflight",
   "status": "REAL_DEV_PORT_PREFLIGHT_PASS",
   "requiredPorts": [

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Port Preflight
 
-Generated: 2026-06-07T18:52:09.707Z
+Generated: 2026-06-07T20:01:31.982Z
 
 Status: `REAL_DEV_PORT_PREFLIGHT_PASS`
 

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T18:21:19.190Z",
+  "generatedAtUtc": "2026-06-07T20:02:26.565Z",
   "gate": "county-studio-real-dev-server-activation",
   "status": "REAL_DEV_ACTIVATION_READY",
   "decisions": {
@@ -20,8 +20,8 @@
   },
   "forgeDevDependency": {
     "ownerSupnumBackfill": {
-      "stage": "assessment-value-seal",
-      "status": "COMPLETED",
+      "stage": "owner-supnum-resume",
+      "status": "FAILED",
       "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
       "requiredForCountyStudioForgeDev": false,
       "requiredForPacketProof": true,
@@ -47,6 +47,34 @@
           "Dossier packet owner identity",
           "Dais/notice/appeal taxpayer identity",
           "operational packet owner references"
+        ]
+      }
+    },
+    "exemptionFactSeal": {
+      "stage": "exemption-fact-seal",
+      "status": "COMPLETED",
+      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "requiredForCountyStudioForgeDev": false,
+      "requiredForPacketProof": true,
+      "requiredForProductionProof": true,
+      "requiredForOperationalProof": true,
+      "exemptionFactsConsumedByForgeSurfaces": false,
+      "consumedSurfaces": [],
+      "audit": {
+        "finding": "County Studio is a TerraForge valuation surface; current Forge valuation paths do not consume exemption facts.",
+        "forgeValuationSources": [
+          "parcel/property identity",
+          "property characteristics",
+          "valuation metrics",
+          "ratio-study context",
+          "risk objects",
+          "geometry/map context"
+        ],
+        "packetOpsSources": [
+          "Dais exemption administration",
+          "tax/notice context",
+          "Dossier packet exemption proof",
+          "operational roll packet references"
         ]
       }
     }

--- a/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
+++ b/os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.md
@@ -1,6 +1,6 @@
 # County Studio Real Dev Server Activation
 
-Generated: 2026-06-07T18:21:19.190Z
+Generated: 2026-06-07T20:02:26.565Z
 Status: REAL_DEV_ACTIVATION_READY
 
 ## Decision
@@ -24,7 +24,7 @@ Status: REAL_DEV_ACTIVATION_READY
 
 ## Forge Dev Dependency Reclassification
 
-- ownerSupnumBackfillStatus: COMPLETED
+- ownerSupnumBackfillStatus: FAILED
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumBackfillClassification: NOT_REQUIRED_FOR_FORGE_DEV
 - ownerSupnumBackfillRequiredForForgeDev: false


### PR DESCRIPTION
## Summary

This PR scopes exemption facts correctly for County Studio as a TerraForge valuation development surface.

PR #919 exposed `exemption-fact-seal` as a global real-dev readiness blocker. This change adds lane-aware dependency classification so exemption facts remain visible as production/packet/operational proof dependencies, but do not block current Forge valuation dev unless a County Studio Forge surface directly consumes exemption data.

## Current Posture

- `forgeDevAllowed=true`
- `realDevServerAllowed=true`
- `realDevActivationAllowed=true`
- `countyStudioMode=REAL_BENTON_FORGE_DEV`
- `exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV`
- `exemptionFactRequiredForForgeDev=false`
- `exemptionFactRequiredForProductionProof=true`
- `exemptionFactRequiredForPacketProof=true`
- `exemptionFactRequiredForOperationalProof=true`
- `productionProofAllowed=false`
- `operationalProofAllowed=false`

The live runtime has advanced from the PR #919 observed failed state to `exemption-fact-seal COMPLETED`; the failed-stage case remains covered by regression tests.

## Evidence

- Added `os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.md`
- Updated real-dev readiness, activation, Forge-dev status, and smoke evidence
- Full smoke evidence remains `FORGE_DEV_SMOKE_PASS` with `cleanFullDevSmokePassed=true`

## Boundaries

- No County Studio UI changes
- No TerraFusion Sync mutation
- No DB seeding changes
- No proof weakening
- Production and operational proof remain blocked

## Verification

- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `node --test os-platform/core/pilot/benton-real-dev-server-readiness.test.mjs os-platform/core/pilot/benton-sync-drain-state-evidence-adapter.test.mjs os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs`
- JSON parse check for touched evidence artifacts
- `git diff --check`
- Pre-push hook passed: unit tests, security scan, performance benchmark, compliance lint, backend build
