### PR TITLE
[codex] County Studio R1 Forge dev handoff

### DIFF
--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.json
@@ -1,0 +1,113 @@
+{
+  "generatedAtUtc": "2026-06-07T23:12:06.358Z",
+  "status": "COUNTY_STUDIO_R1_FORGE_DEV_HANDOFF_READY",
+  "finalR1ForgeDevStatus": {
+    "forgeDevAllowed": true,
+    "realDevServerAllowed": true,
+    "realDevActivationAllowed": true,
+    "cleanFullDevSmokePassed": true,
+    "countyStudioMode": "REAL_BENTON_FORGE_DEV",
+    "dataTruthStatus": "DATA_TRUTH_FAIL",
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false
+  },
+  "runCommand": "pnpm run dev:county-studio:real-benton",
+  "evidenceChain": [
+    {
+      "gate": "port preflight",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json",
+      "status": "REAL_DEV_PORT_PREFLIGHT_PASS"
+    },
+    {
+      "gate": "backend health",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json",
+      "status": "REAL_DEV_BACKEND_HEALTH_PASS"
+    },
+    {
+      "gate": "DB readiness",
+      "artifact": "os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json",
+      "status": "REAL_DEV_DATA_AVAILABLE"
+    },
+    {
+      "gate": "real dev activation",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json",
+      "status": "REAL_DEV_ACTIVATION_READY"
+    },
+    {
+      "gate": "Forge real data wiring",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json",
+      "status": "FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS"
+    },
+    {
+      "gate": "TerraAtlas geometry wiring",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json",
+      "status": "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED"
+    },
+    {
+      "gate": "risk object source audit",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json",
+      "status": "RISK_OBJECT_SOURCE_AUDITED_DEV_DERIVED"
+    },
+    {
+      "gate": "dependency reclassification",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.json",
+      "status": "NOT_REQUIRED_FOR_FORGE_DEV"
+    },
+    {
+      "gate": "full smoke",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json",
+      "status": "FORGE_DEV_SMOKE_PASS"
+    }
+  ],
+  "ready": [
+    "real Benton Forge dev mode",
+    "real parcel/property identity path for Forge dev",
+    "real property characteristics path for Forge dev",
+    "real valuation metrics path for Forge dev",
+    "real ratio-study context path for Forge dev",
+    "real TerraAtlas geometry wired for Forge dev",
+    "risk objects dev-derived from real Benton inputs",
+    "clean full Forge dev smoke under Forge-dev scope"
+  ],
+  "notProductionProof": [
+    "DATA_TRUTH_FAIL remains the data truth posture",
+    "owner-supnum remains required for packet/ops proof",
+    "exemption facts remain required for production/packet/ops proof",
+    "canonical Benton source/count reconciliation is not complete",
+    "Dais/Dossier/Trace packet and workflow proof is not complete",
+    "operational proof remains blocked"
+  ],
+  "forbiddenClaims": [
+    "production ready",
+    "operationally proven",
+    "certified county truth",
+    "owner/taxpayer packet complete",
+    "Dais/Dossier/Trace operational proof complete",
+    "productionProofAllowed=true",
+    "operationalProofAllowed=true"
+  ],
+  "nextLanes": [
+    "Assessment Value Seal current-year active-supp",
+    "owner-supnum recovery for packet/ops proof",
+    "exemption fact seal for Dais/tax/ops proof",
+    "production reconciliation"
+  ],
+  "dependencyPosture": {
+    "geometryStatus": "SYNC_DERIVED_GEOMETRY",
+    "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
+    "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "exemptionFactStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
+    "exemptionFactRequiredForForgeDev": false,
+    "exemptionFactRequiredForProductionProof": true,
+    "exemptionFactRequiredForPacketProof": true,
+    "exemptionFactRequiredForOperationalProof": true
+  },
+  "boundaries": {
+    "uiChanged": false,
+    "syncMutated": false,
+    "dbSeedingChanged": false,
+    "newProofLogicAdded": false,
+    "productionProofAllowed": false,
+    "operationalProofAllowed": false
+  }
+}

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.md
@@ -1,0 +1,103 @@
+# County Studio R1 Forge Dev Handoff
+
+Generated: 2026-06-07T23:12:06.358Z
+
+Status: `COUNTY_STUDIO_R1_FORGE_DEV_HANDOFF_READY`
+
+## Final R1 Forge-dev Status
+
+```text
+forgeDevAllowed=true
+realDevServerAllowed=true
+realDevActivationAllowed=true
+cleanFullDevSmokePassed=true
+countyStudioMode=REAL_BENTON_FORGE_DEV
+dataTruthStatus=DATA_TRUTH_FAIL
+productionProofAllowed=false
+operationalProofAllowed=false
+```
+
+County Studio R1 Forge dev is clean-smoke ready against real Benton valuation data. This is scoped Forge development readiness only. It is not production proof and it is not operational proof.
+
+## Run Command
+
+```bash
+pnpm run dev:county-studio:real-benton
+```
+
+## Evidence Chain
+
+| Gate | Status | Artifact |
+| --- | --- | --- |
+| port preflight | `REAL_DEV_PORT_PREFLIGHT_PASS` | os-platform/core/pilot/evidence/county-studio-real-dev-port-preflight.json |
+| backend health | `REAL_DEV_BACKEND_HEALTH_PASS` | os-platform/core/pilot/evidence/county-studio-real-dev-backend-health.json |
+| DB readiness | `REAL_DEV_DATA_AVAILABLE` | os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json |
+| real dev activation | `REAL_DEV_ACTIVATION_READY` | os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json |
+| Forge real data wiring | `FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS` | os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json |
+| TerraAtlas geometry wiring | `TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED` | os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json |
+| risk object source audit | `RISK_OBJECT_SOURCE_AUDITED_DEV_DERIVED` | os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json |
+| dependency reclassification | `NOT_REQUIRED_FOR_FORGE_DEV` | os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.json |
+| full smoke | `FORGE_DEV_SMOKE_PASS` | os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json |
+
+## What Is Ready
+
+- real Benton Forge dev mode
+- real parcel/property identity path for Forge dev
+- real property characteristics path for Forge dev
+- real valuation metrics path for Forge dev
+- real ratio-study context path for Forge dev
+- real TerraAtlas geometry wired for Forge dev
+- risk objects dev-derived from real Benton inputs
+- clean full Forge dev smoke under Forge-dev scope
+
+## What Is Not Production Proof
+
+- DATA_TRUTH_FAIL remains the data truth posture
+- owner-supnum remains required for packet/ops proof
+- exemption facts remain required for production/packet/ops proof
+- canonical Benton source/count reconciliation is not complete
+- Dais/Dossier/Trace packet and workflow proof is not complete
+- operational proof remains blocked
+
+## Forbidden Claims
+
+Do not represent this R1 Forge-dev handoff as any of the following:
+
+- production ready
+- operationally proven
+- certified county truth
+- owner/taxpayer packet complete
+- Dais/Dossier/Trace operational proof complete
+- productionProofAllowed=true
+- operationalProofAllowed=true
+
+## Dependency Posture
+
+```text
+geometryStatus=SYNC_DERIVED_GEOMETRY
+riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
+ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
+exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV
+exemptionFactRequiredForForgeDev=false
+exemptionFactRequiredForProductionProof=true
+exemptionFactRequiredForPacketProof=true
+exemptionFactRequiredForOperationalProof=true
+```
+
+Owner-supnum and exemption facts remain visible as packet/ops or production dependencies. They are not Forge-dev blockers unless a County Studio Forge surface consumes those facts.
+
+## Next Lanes
+
+- Assessment Value Seal current-year active-supp
+- owner-supnum recovery for packet/ops proof
+- exemption fact seal for Dais/tax/ops proof
+- production reconciliation
+
+## Boundaries
+
+- This handoff does not touch County Studio UI.
+- This handoff does not mutate TerraFusion Sync.
+- This handoff does not change DB seeding.
+- This handoff does not add new proof logic.
+- This handoff does not set `productionProofAllowed=true`.
+- This handoff does not set `operationalProofAllowed=true`.


### PR DESCRIPTION
## Summary

Adds the final County Studio R1 Forge-dev handoff artifact so reviewers/operators do not need to reconstruct the current state from the full stacked PR history.

This is documentation/evidence only. It does not add proof logic, touch UI, mutate Sync, or change DB seeding.

## Handoff Status

- `forgeDevAllowed=true`
- `realDevServerAllowed=true`
- `realDevActivationAllowed=true`
- `cleanFullDevSmokePassed=true`
- `countyStudioMode=REAL_BENTON_FORGE_DEV`
- `dataTruthStatus=DATA_TRUTH_FAIL`
- `productionProofAllowed=false`
- `operationalProofAllowed=false`

## Added Artifacts

- `os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.md`
- `os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.json`

## Explicit Non-Claims

This handoff does not claim:

- production readiness
- operational proof
- certified county truth
- owner/taxpayer packet completion
- Dais/Dossier/Trace operational proof

## Verification

- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- handoff JSON/source consistency check
- `git diff --check`
- pre-push hook passed: unit tests, security scan, performance benchmark, compliance lint, backend build
