### PR TITLE
feat(canon): enable strict Canon gates for canon-owned paths

### DIFF
--- a/.github/workflows/canon-gates.yml
+++ b/.github/workflows/canon-gates.yml
@@ -1,13 +1,13 @@
 name: canon-gates
 
-# Advisory enforcement rail for the read-only Canon runtime.
-# Runs the Canon gate aggregator over a PR's changed files and reports findings
-# to the job summary. ADVISORY by default (never blocks) — this is the
-# "advisory-in-CI first" step of the Canon doctrine.
+# Enforcement rail for the read-only Canon runtime.
+#  - ADVISORY (non-blocking) for ALL changed files: full report to job summary.
+#  - STRICT (blocking) but SCOPED to canon-owned paths only
+#    (os-platform/core/canon/**, os-platform/core/gates/**): a violation in the
+#    Canon runtime itself fails this job. Non-canon paths NEVER block here.
 #
-# To FLIP TO ENFORCEMENT later: add `--strict` to the node invocation below
-# (optionally scoped to Canon-owned paths first). Do not make this a required
-# status check until signal quality is confirmed on real PRs.
+# Deliberately NOT global. To widen enforcement later, drop --canon-owned-only
+# (and only then consider making this a required status check).
 #
 # Push-triggered (not pull_request): platform.json forbids pull_request on
 # non-constitutional workflows (PR_TRIGGER_LEAK). Runs per feature-branch push
@@ -23,8 +23,8 @@ permissions:
   contents: read
 
 jobs:
-  advisory:
-    name: Canon Gates (advisory)
+  canon-gates:
+    name: Canon Gates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run Canon gates (advisory, non-blocking)
+      - name: Advisory report (all changed files, non-blocking)
         shell: bash
         run: |
           set -euo pipefail
@@ -47,6 +47,24 @@ jobs:
             echo "## Canon Gates (advisory)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          # Advisory: aggregator exits 0 without --strict, so the job never blocks.
+          # Advisory: aggregator exits 0 without --strict, so this step never blocks.
           node os-platform/core/gates/canon-gates.mjs "${FILES[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Strict enforcement (canon-owned paths only, BLOCKING)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          mapfile -t FILES < <(git diff --name-only origin/main...HEAD)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No changed files." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Canon Gates (strict — canon-owned paths)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Strict + scoped: exits 1 only if a CANON-OWNED path has a blocking finding.
+          node os-platform/core/gates/canon-gates.mjs --strict --canon-owned-only "${FILES[@]}" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/os-platform/core/canon/engineering-write-lanes.json
+++ b/os-platform/core/canon/engineering-write-lanes.json
@@ -33,6 +33,13 @@
       "manualReviewRequired": true
     },
     {
+      "owner": "canon-gates",
+      "paths": ["os-platform/core/gates/**"],
+      "risk": "high",
+      "requiredGates": ["canon-query", "typecheck"],
+      "manualReviewRequired": false
+    },
+    {
       "owner": "canon-docs",
       "paths": ["docs/TerraCanon/**"],
       "risk": "low",

--- a/os-platform/core/gates/canon-gates.mjs
+++ b/os-platform/core/gates/canon-gates.mjs
@@ -20,6 +20,7 @@
 import { checkProtectedPaths } from './check-protected-paths.mjs';
 import { checkHardcodedPorts } from './check-hardcoded-ports.mjs';
 import { checkWriteLanes } from './canon-write-lane-check.mjs';
+import { pathMatchesPattern } from '../canon/canon-query.mjs';
 import { printReport, runMain } from './gate-runtime.mjs';
 
 /**
@@ -30,13 +31,47 @@ import { printReport, runMain } from './gate-runtime.mjs';
 const CODE_LIKE = /\.(ts|tsx|js|jsx|mjs|cjs|cs|json|ya?ml)$/i;
 
 /**
- * Run all Canon gates over the given paths and classify findings. Never throws.
+ * Canon-owned / runtime-governance path globs. Strict (blocking) enforcement is
+ * scoped to these; everything else stays advisory. Deliberately NOT global.
+ * @type {ReadonlyArray<string>}
+ */
+export const CANON_OWNED_PATTERNS = Object.freeze([
+  'os-platform/core/canon/**',
+  'os-platform/core/gates/**',
+]);
+
+/** @param {unknown} path @returns {boolean} */
+export function isCanonOwnedPath(path) {
+  if (typeof path !== 'string' || path.length === 0) return false;
+  return CANON_OWNED_PATTERNS.some((p) => pathMatchesPattern(path, p));
+}
+
+/**
+ * Split paths into canon-owned vs the rest. Never throws.
  * @param {ReadonlyArray<string>} paths
- * @param {{ strict?: boolean }} [opts]
+ * @returns {Readonly<{ owned: ReadonlyArray<string>, rest: ReadonlyArray<string> }>}
+ */
+export function partitionByCanonOwnership(paths) {
+  const owned = [];
+  const rest = [];
+  for (const p of Array.isArray(paths) ? paths : []) {
+    if (typeof p !== 'string' || p.length === 0) continue;
+    (isCanonOwnedPath(p) ? owned : rest).push(p);
+  }
+  return Object.freeze({ owned: Object.freeze(owned), rest: Object.freeze(rest) });
+}
+
+/**
+ * Run all Canon gates over the given paths and classify findings. Never throws.
+ * When `canonOwnedOnly` is set, only canon-owned paths are scanned — this is how
+ * strict enforcement stays scoped to the Canon runtime instead of going global.
+ * @param {ReadonlyArray<string>} paths
+ * @param {{ strict?: boolean, canonOwnedOnly?: boolean }} [opts]
  * @returns {CanonGatesResult}
  */
 export function runCanonGates(paths, opts) {
-  const list = Array.isArray(paths) ? paths.filter((p) => typeof p === 'string' && p.length > 0) : [];
+  const all = Array.isArray(paths) ? paths.filter((p) => typeof p === 'string' && p.length > 0) : [];
+  const list = opts && opts.canonOwnedOnly ? all.filter(isCanonOwnedPath) : all;
   const strict = !!(opts && opts.strict);
 
   /** @type {GateFinding[]} */
@@ -77,7 +112,7 @@ export function runCanonGates(paths, opts) {
 }
 
 runMain(import.meta.url, (o) => {
-  const res = runCanonGates(o.paths, { strict: o.strict });
+  const res = runCanonGates(o.paths, { strict: o.strict, canonOwnedOnly: o.flags.has('canon-owned-only') });
   // Surface blocking findings as the report's "findings" (so --strict fails on them);
   // advisory findings are appended to the message but never affect exit code.
   const result = printReport({

--- a/os-platform/core/gates/gate-runtime.mjs
+++ b/os-platform/core/gates/gate-runtime.mjs
@@ -11,20 +11,24 @@
 import { fileURLToPath } from 'node:url';
 
 /**
- * @typedef {Readonly<{ strict: boolean, json: boolean, paths: ReadonlyArray<string> }>} GateArgs
+ * @typedef {Readonly<{ strict: boolean, json: boolean, flags: ReadonlySet<string>, paths: ReadonlyArray<string> }>} GateArgs
  * @typedef {Readonly<{ path?: string, detail: string }>} Finding
  */
 
 /**
- * Parse gate CLI args: flags --strict/--json, everything else is a path.
+ * Parse gate CLI args: any `--x` token becomes a flag; everything else a path.
+ * `strict`/`json` are surfaced directly; `flags` exposes the rest (e.g.
+ * `--canon-owned-only`).
  * @param {ReadonlyArray<string>} argv
  * @returns {GateArgs}
  */
 export function parseArgs(argv) {
   const a = Array.isArray(argv) ? argv : [];
+  const flags = new Set(a.filter((x) => typeof x === 'string' && x.startsWith('--')).map((x) => x.slice(2)));
   return Object.freeze({
-    strict: a.includes('--strict'),
-    json: a.includes('--json'),
+    strict: flags.has('strict'),
+    json: flags.has('json'),
+    flags,
     paths: Object.freeze(a.filter((x) => typeof x === 'string' && !x.startsWith('--'))),
   });
 }

--- a/os-platform/core/tests/canon-strict-gates.test.mjs
+++ b/os-platform/core/tests/canon-strict-gates.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Scoped strict enforcement — self-test.
+ *
+ * Canon gates run in STRICT (blocking) mode for canon-owned/runtime-governance
+ * paths only; everything else stays advisory (non-blocking). This proves the
+ * scoping so global enforcement is NOT turned on.
+ * Run: node --test os-platform/core/tests/canon-strict-gates.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync } from 'node:fs';
+
+import {
+  runCanonGates,
+  isCanonOwnedPath,
+  partitionByCanonOwnership,
+  CANON_OWNED_PATTERNS,
+} from '../gates/canon-gates.mjs';
+
+test('SC.1 canon runtime + gate paths are canon-owned; others are not', () => {
+  assert.ok(Array.isArray(CANON_OWNED_PATTERNS) && CANON_OWNED_PATTERNS.length > 0);
+  assert.equal(isCanonOwnedPath('os-platform/core/canon/canon-query.mjs'), true);
+  assert.equal(isCanonOwnedPath('os-platform/core/canon/tf-canon.mjs'), true);
+  assert.equal(isCanonOwnedPath('os-platform/core/gates/canon-gates.mjs'), true);
+  assert.equal(isCanonOwnedPath('frontend/apps/os-shell/src/canon/CanonEditor.tsx'), false);
+  assert.equal(isCanonOwnedPath('ARCHIVE/old.ts'), false);
+});
+
+test('SC.2 partitionByCanonOwnership splits owned vs rest', () => {
+  const { owned, rest } = partitionByCanonOwnership([
+    'os-platform/core/canon/canon-risk.mjs',
+    'frontend/apps/os-shell/src/x.tsx',
+    'ARCHIVE/y.ts',
+  ]);
+  assert.deepEqual(owned, ['os-platform/core/canon/canon-risk.mjs']);
+  assert.equal(rest.length, 2);
+});
+
+test('SC.3 strict + canonOwnedOnly does NOT block a non-canon violation (scoping holds)', () => {
+  // ARCHIVE is a hard violation, but it is NOT canon-owned -> filtered out -> no block.
+  const r = runCanonGates(['ARCHIVE/old.ts'], { strict: true, canonOwnedOnly: true });
+  assert.equal(r.exitCode, 0);
+  assert.equal(r.blocking.length, 0);
+});
+
+test('SC.4 strict + canonOwnedOnly BLOCKS a violation on a canon-owned path', () => {
+  // A hardcoded port introduced into the canon runtime must block.
+  const p = 'os-platform/core/canon/_tmp_strict_port.mjs';
+  writeFileSync(p, "export const u = 'http://localhost:3000/x';\n", 'utf8');
+  try {
+    const r = runCanonGates([p], { strict: true, canonOwnedOnly: true });
+    assert.equal(r.blocking.length >= 1, true);
+    assert.equal(r.exitCode, 1);
+  } finally {
+    unlinkSync(p);
+  }
+});
+
+test('SC.5 global advisory behavior is unchanged (non-canon still reported, exit 0)', () => {
+  const r = runCanonGates(['ARCHIVE/old.ts'], { strict: false });
+  assert.ok(r.blocking.some((f) => /protected/i.test(f.detail)));
+  assert.equal(r.exitCode, 0);
+});
+
+test('SC.6 canonOwnedOnly defaults off (scans all paths)', () => {
+  const r = runCanonGates(['ARCHIVE/old.ts'], { strict: true });
+  assert.equal(r.exitCode, 1); // not filtered -> blocks
+});
+
+test('SC.7 a clean canon-owned gate file does NOT self-block under strict', () => {
+  // gates/** must have a write-lane owner, else it reads as "unowned" (blocking)
+  // and strict enforcement would block its own gate scripts.
+  const r = runCanonGates(['os-platform/core/gates/gate-runtime.mjs'], { strict: true, canonOwnedOnly: true });
+  assert.equal(r.blocking.length, 0);
+  assert.equal(r.exitCode, 0);
+});


### PR DESCRIPTION
## Summary

Flips `canon-gates` from advisory-only to **scoped strict enforcement**: **blocking** for canon-owned paths only (`os-platform/core/canon/**`, `os-platform/core/gates/**`), **advisory** for everything else. **Deliberately NOT global** — non-canon work is never blocked here.

## What changed (5 files)

- `os-platform/core/gates/canon-gates.mjs` — `CANON_OWNED_PATTERNS`, `isCanonOwnedPath`, `partitionByCanonOwnership`; `runCanonGates` gains `canonOwnedOnly` (filters to canon-owned before scanning). CLI flag `--canon-owned-only` (reuses existing aggregator/CLI — not duplicated).
- `os-platform/core/gates/gate-runtime.mjs` — `parseArgs` exposes a generic `flags` set (back-compat).
- `os-platform/core/canon/engineering-write-lanes.json` — adds `canon-gates` owner for `os-platform/core/gates/**` (without it, gate files read as *unowned* and strict would self-block — caught by SC.7 / pre-push self-check before CI).
- `.github/workflows/canon-gates.yml` — keeps the advisory report (all files) **and** adds a BLOCKING step `--strict --canon-owned-only` (canon paths only). Still push-triggered (platform.json `PR_TRIGGER_LEAK`); **not** a required check.

## Acceptance (all proven)

1. Canon-owned violation → strict gate **blocks** (SC.4: hardcoded port in canon path → exit 1).
2. Non-canon path → **never blocks** under strict scope (SC.3: `ARCHIVE/` filtered out → exit 0).
3. Advisory output preserved (SC.5).
4. CLI strict reused, not duplicated (`--canon-owned-only` flag).
5. Self-check: `--strict --canon-owned-only` on this PR's own files → exit 0.

## Verification

- `canon-strict-gates.test.mjs` → 7/7; full Canon sweep → **102/102**
- `node scripts/platform-lint.mjs` → 0 violations; `pnpm run type-check` → clean; `git diff --check` → clean

## Scope discipline

No UI, no Canon Desktop, no agent executor, no global branch-protection change, no non-canon enforcement. One bounded enforcement upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict enforcement mode for canon-owned code paths; violations now only block workflow on canonical locations while advisory reporting runs on all changes without blocking.

* **Tests**
  * Added comprehensive test coverage for strict enforcement scoping behavior.

* **Chores**
  * Updated CI/CD validation workflow to separate advisory and blocking enforcement steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->