### PR TITLE
[codex] County Studio TerraAtlas GIS truth correction

### DIFF
--- a/os-platform/core/pilot/county-studio-forge-real-data-wiring.mjs
+++ b/os-platform/core/pilot/county-studio-forge-real-data-wiring.mjs
@@ -82,6 +82,7 @@ const REAL_DEV_CLASSIFICATIONS = new Set([
   "SYNC_DERIVED",
   "SEEDED",
   "PARTIAL_SEEDED",
+  "SYNC_DERIVED_PARCEL_GEOMETRY",
   "SYNC_DERIVED_GEOMETRY",
   "SEEDED_GEOMETRY"
 ]);
@@ -338,7 +339,8 @@ function buildSurfaces({ dataTruthReport, lineageReport, readinessReport, geomet
       surface: "geometry/map context source",
       sourceName: "TerraAtlas geometry/map context consumed by County Studio",
       ownerLane: "Atlas",
-      classification: geometryEvidenceReport?.classification
+      classification: geometryEvidenceReport?.parcelGeometryStatus
+        ?? geometryEvidenceReport?.classification
         ?? geometry?.classification
         ?? findProofArea(dataTruthReport, "Atlas layers")?.classification,
       source: geometry,
@@ -446,7 +448,14 @@ export function buildCountyStudioForgeRealDataWiringReport({
     geometryEvidencePosture: {
       status: geometryEvidenceReport?.status ?? "UNKNOWN",
       classification: geometryEvidenceReport?.classification ?? "UNKNOWN",
+      parcelGeometryStatus: geometryEvidenceReport?.parcelGeometryStatus ?? "UNKNOWN",
+      fullGisLayerTruthStatus: geometryEvidenceReport?.fullGisLayerTruthStatus ?? "UNKNOWN",
+      mapOverlayStatus: geometryEvidenceReport?.mapOverlayStatus ?? "UNKNOWN",
+      attributeOverlayStatus: geometryEvidenceReport?.attributeOverlayStatus ?? "UNKNOWN",
+      riskOverlayAnchoring: geometryEvidenceReport?.riskOverlayAnchoring ?? "UNKNOWN",
       realGeometryExists: geometryEvidenceReport?.decisions?.realGeometryExists === true,
+      countyStudioUsesRealParcelGeometry:
+        geometryEvidenceReport?.decisions?.countyStudioUsesRealParcelGeometry === true,
       countyStudioUsesRealTerraAtlasGeometry:
         geometryEvidenceReport?.decisions?.countyStudioUsesRealTerraAtlasGeometry === true
     },
@@ -496,7 +505,13 @@ export function renderCountyStudioForgeRealDataWiringMarkdown(report) {
     "",
     `- status: ${report.geometryEvidencePosture.status}`,
     `- classification: ${report.geometryEvidencePosture.classification}`,
+    `- parcelGeometryStatus: ${report.geometryEvidencePosture.parcelGeometryStatus}`,
+    `- fullGisLayerTruthStatus: ${report.geometryEvidencePosture.fullGisLayerTruthStatus}`,
+    `- mapOverlayStatus: ${report.geometryEvidencePosture.mapOverlayStatus}`,
+    `- attributeOverlayStatus: ${report.geometryEvidencePosture.attributeOverlayStatus}`,
+    `- riskOverlayAnchoring: ${report.geometryEvidencePosture.riskOverlayAnchoring}`,
     `- realGeometryExists: ${report.geometryEvidencePosture.realGeometryExists}`,
+    `- countyStudioUsesRealParcelGeometry: ${report.geometryEvidencePosture.countyStudioUsesRealParcelGeometry}`,
     `- countyStudioUsesRealTerraAtlasGeometry: ${report.geometryEvidencePosture.countyStudioUsesRealTerraAtlasGeometry}`
   );
 

--- a/os-platform/core/pilot/county-studio-forge-real-data-wiring.test.mjs
+++ b/os-platform/core/pilot/county-studio-forge-real-data-wiring.test.mjs
@@ -246,18 +246,24 @@ test("verifies core Forge valuation wiring while identifying generated and fallb
   assert.equal(report.mockFallbackGeneratedScan.disallowedVisibleHits.length, 1);
 });
 
-test("does not count sync-derived TerraAtlas geometry as a Forge-dev wiring gap", () => {
+test("does not count sync-derived parcel geometry as a Forge-dev gap while full GIS truth remains unproven", () => {
   const report = buildCountyStudioForgeRealDataWiringReport({
     readinessReport: readinessReport(),
     activationReport: activationReport(),
     dataTruthReport: dataTruthReport(),
     lineageReport: lineageReport(),
     geometryEvidenceReport: geometryEvidenceReport({
-      status: "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED",
-      classification: "SYNC_DERIVED_GEOMETRY",
+      status: "TERRAATLAS_GIS_TRUTH_PARTIAL",
+      classification: "PARTIAL_GIS_TRUTH",
+      parcelGeometryStatus: "SYNC_DERIVED_PARCEL_GEOMETRY",
+      fullGisLayerTruthStatus: "GIS_LAYER_TRUTH_NOT_PROVEN",
+      mapOverlayStatus: "FALLBACK_MAP_OVERLAY",
+      riskOverlayAnchoring: "NOT_GIS_ANCHORED",
       decisions: {
         realGeometryExists: true,
-        countyStudioUsesRealTerraAtlasGeometry: true,
+        countyStudioUsesRealParcelGeometry: true,
+        countyStudioUsesRealTerraAtlasGeometry: false,
+        countyStudioUsesFullTerraAtlasGisLayerTruth: false,
         productionProofAllowed: false,
         operationalProofAllowed: false
       },
@@ -267,16 +273,20 @@ test("does not count sync-derived TerraAtlas geometry as a Forge-dev wiring gap"
         dbTableOrView: "gis_tf.tf_parcel_geom",
         joinKey: "countyId + parcelId/APN + layerId"
       },
-      finding: "County Studio geometry/map context is wired to a real TerraAtlas sync-derived geometry path for real dev."
+      finding: "County Studio uses real TerraAtlas sync-derived parcel geometry for Forge dev, but full GIS layer truth is not proven."
     }),
     generatedAtUtc: "2026-06-06T00:00:00.000Z"
   });
 
   const geometry = report.surfaces.find((surface) => surface.surface === "geometry/map context source");
-  assert.equal(geometry.classification, "SYNC_DERIVED_GEOMETRY");
+  assert.equal(geometry.classification, "SYNC_DERIVED_PARCEL_GEOMETRY");
   assert.equal(geometry.status, "REAL_DEV_WIRED_PRODUCTION_BLOCKED");
   assert.match(geometry.apiRoute, /atlas-live\/geometry\/parcels/);
   assert.match(geometry.backendServiceOrController, /AtlasLiveGeometryController/);
+  assert.equal(report.geometryEvidencePosture.classification, "PARTIAL_GIS_TRUTH");
+  assert.equal(report.geometryEvidencePosture.parcelGeometryStatus, "SYNC_DERIVED_PARCEL_GEOMETRY");
+  assert.equal(report.geometryEvidencePosture.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
+  assert.equal(report.geometryEvidencePosture.riskOverlayAnchoring, "NOT_GIS_ANCHORED");
   assert.ok(report.wiringGaps.some((gap) => gap.surface === "risk object source"));
   assert.ok(!report.wiringGaps.some((gap) => gap.surface === "geometry/map context source"));
   assert.equal(report.decisions.productionProofAllowed, false);

--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.mjs
@@ -140,10 +140,36 @@ function geometryStatus(geometryReport, forgeWiringReport) {
     ?? "UNKNOWN";
 }
 
+function parcelGeometryStatus(geometryReport, forgeWiringReport) {
+  return geometryReport?.parcelGeometryStatus
+    ?? forgeWiringReport?.geometryEvidencePosture?.parcelGeometryStatus
+    ?? (geometryStatus(geometryReport, forgeWiringReport) === "SYNC_DERIVED_GEOMETRY" ? "SYNC_DERIVED_PARCEL_GEOMETRY" : "UNKNOWN");
+}
+
+function fullGisLayerTruthStatus(geometryReport, forgeWiringReport) {
+  return geometryReport?.fullGisLayerTruthStatus
+    ?? forgeWiringReport?.geometryEvidencePosture?.fullGisLayerTruthStatus
+    ?? "UNKNOWN";
+}
+
+function mapOverlayStatus(geometryReport, forgeWiringReport) {
+  return geometryReport?.mapOverlayStatus
+    ?? forgeWiringReport?.geometryEvidencePosture?.mapOverlayStatus
+    ?? "UNKNOWN";
+}
+
+function riskOverlayAnchoring(geometryReport, forgeWiringReport) {
+  return geometryReport?.riskOverlayAnchoring
+    ?? forgeWiringReport?.geometryEvidencePosture?.riskOverlayAnchoring
+    ?? "UNKNOWN";
+}
+
 function geometryReady(geometryReport, forgeWiringReport) {
-  return geometryStatus(geometryReport, forgeWiringReport) === "SYNC_DERIVED_GEOMETRY"
+  return parcelGeometryStatus(geometryReport, forgeWiringReport) === "SYNC_DERIVED_PARCEL_GEOMETRY"
     && (
-      geometryReport?.decisions?.countyStudioUsesRealTerraAtlasGeometry === true
+      geometryReport?.decisions?.countyStudioUsesRealParcelGeometry === true
+      || forgeWiringReport?.geometryEvidencePosture?.countyStudioUsesRealParcelGeometry === true
+      || geometryReport?.decisions?.countyStudioUsesRealTerraAtlasGeometry === true
       || forgeWiringReport?.geometryEvidencePosture?.countyStudioUsesRealTerraAtlasGeometry === true
     );
 }
@@ -156,11 +182,11 @@ function riskReady(riskAuditReport) {
   return READY_RISK_CLASSIFICATIONS.has(riskObjectStatus(riskAuditReport));
 }
 
-function productionBlockers({ dataTruth, geometry, risk, owner, exemption }) {
+function productionBlockers({ dataTruth, geometry, parcelGeometry, fullGisTruth, mapOverlay, riskAnchoring, risk, owner, exemption }) {
   const blockers = [
     "Canonical Benton source/count reconciliation remains required before production proof.",
     "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
-    "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
+    "TerraAtlas parcel geometry is wired for real dev, but full GIS layer truth is not proven; production GIS proof still requires canonical TerraAtlas layer registry, boundaries, neighborhoods, segments, reval areas, taxing districts, outlines, attributes, overlays, and symbology lineage.",
     "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
     "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
   ];
@@ -168,8 +194,20 @@ function productionBlockers({ dataTruth, geometry, risk, owner, exemption }) {
   if (dataTruth !== "DATA_TRUTH_FAIL") {
     blockers.push(`Data truth status is ${dataTruth}; this consolidated artifact still does not promote production proof.`);
   }
-  if (geometry !== "SYNC_DERIVED_GEOMETRY") {
-    blockers.push(`Geometry status is ${geometry}; real TerraAtlas geometry must be wired before Forge dev readiness can be claimed.`);
+  if (parcelGeometry !== "SYNC_DERIVED_PARCEL_GEOMETRY") {
+    blockers.push(`Parcel geometry status is ${parcelGeometry}; real TerraAtlas parcel geometry must be wired before Forge dev readiness can be claimed.`);
+  }
+  if (fullGisTruth !== "GIS_LAYER_TRUTH_NOT_PROVEN" && fullGisTruth !== "SYNC_DERIVED_GEOMETRY" && fullGisTruth !== "SEEDED_GEOMETRY") {
+    blockers.push(`Full GIS layer truth status is ${fullGisTruth}; GIS layer evidence remains unresolved.`);
+  }
+  if (fullGisTruth === "GIS_LAYER_TRUTH_NOT_PROVEN") {
+    blockers.push(`Full GIS layer truth status is ${fullGisTruth}; parcel geometry proof does not prove neighborhoods, segments, taxing districts, or layer registry truth.`);
+  }
+  if (mapOverlay === "FALLBACK_MAP_OVERLAY") {
+    blockers.push("Map overlay status is FALLBACK_MAP_OVERLAY; valuation/risk overlays are not production GIS proof.");
+  }
+  if (riskAnchoring === "NOT_GIS_ANCHORED") {
+    blockers.push("Risk overlay anchoring is NOT_GIS_ANCHORED; visible risk labels are UI-positioned, not GIS-anchored production overlays.");
   }
   if (!READY_RISK_CLASSIFICATIONS.has(risk)) {
     blockers.push(`Risk object status is ${risk}; risk objects must be dev-derived or real-sourced for Forge dev readiness.`);
@@ -235,6 +273,10 @@ export function buildCountyStudioR1ForgeDevStatusReport({
   const realDevActivationAllowed = activationReport?.decisions?.realDevActivationAllowed === true;
   const coreForgeValuationWiringReady = forgeWiringReport?.decisions?.coreForgeValuationWiringReady === true;
   const geometry = geometryStatus(geometryReport, forgeWiringReport);
+  const parcelGeometry = parcelGeometryStatus(geometryReport, forgeWiringReport);
+  const fullGisTruth = fullGisLayerTruthStatus(geometryReport, forgeWiringReport);
+  const mapOverlay = mapOverlayStatus(geometryReport, forgeWiringReport);
+  const riskAnchoring = riskOverlayAnchoring(geometryReport, forgeWiringReport);
   const risk = riskObjectStatus(riskAuditReport);
   const owner = ownerSupnumStatus(readinessReport, activationReport, forgeWiringReport);
   const exemption = exemptionFactStatus(readinessReport, activationReport);
@@ -266,6 +308,10 @@ export function buildCountyStudioR1ForgeDevStatusReport({
       operationalProofAllowed: false,
       dataTruthStatus: dataTruth,
       geometryStatus: geometry,
+      parcelGeometryStatus: parcelGeometry,
+      fullGisLayerTruthStatus: fullGisTruth,
+      mapOverlayStatus: mapOverlay,
+      riskOverlayAnchoring: riskAnchoring,
       riskObjectStatus: risk,
       ownerSupnumStatus: owner,
       exemptionFactStatus: exemption,
@@ -275,12 +321,32 @@ export function buildCountyStudioR1ForgeDevStatusReport({
       exemptionFactRequiredForOperationalProof: exemptionDependencyReport?.requiredForOperationalProof ?? null,
       countyStudioMode: forgeDevAllowed ? "REAL_BENTON_FORGE_DEV" : "FORGE_DEV_BLOCKED",
       requiredRunCommand: REQUIRED_RUN_COMMAND,
-      remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner, exemption }),
+      remainingProductionBlockers: productionBlockers({
+        dataTruth,
+        geometry,
+        parcelGeometry,
+        fullGisTruth,
+        mapOverlay,
+        riskAnchoring,
+        risk,
+        owner,
+        exemption
+      }),
       remainingOperationalBlockers: operationalBlockers()
     },
     requiredRunCommand: REQUIRED_RUN_COMMAND,
     preflightChain: REQUIRED_FORGE_DEV_PREFLIGHT_CHAIN,
-    remainingProductionBlockers: productionBlockers({ dataTruth, geometry, risk, owner, exemption }),
+    remainingProductionBlockers: productionBlockers({
+      dataTruth,
+      geometry,
+      parcelGeometry,
+      fullGisTruth,
+      mapOverlay,
+      riskAnchoring,
+      risk,
+      owner,
+      exemption
+    }),
     remainingOperationalBlockers: operationalBlockers(),
     runbook: {
       startRealBentonForgeDev: REQUIRED_RUN_COMMAND,
@@ -336,6 +402,10 @@ export function renderCountyStudioR1ForgeDevStatusMarkdown(report) {
     `- operationalProofAllowed=${report.summary.operationalProofAllowed}`,
     `- dataTruthStatus=${report.summary.dataTruthStatus}`,
     `- geometryStatus=${report.summary.geometryStatus}`,
+    `- parcelGeometryStatus=${report.summary.parcelGeometryStatus}`,
+    `- fullGisLayerTruthStatus=${report.summary.fullGisLayerTruthStatus}`,
+    `- mapOverlayStatus=${report.summary.mapOverlayStatus}`,
+    `- riskOverlayAnchoring=${report.summary.riskOverlayAnchoring}`,
     `- riskObjectStatus=${report.summary.riskObjectStatus}`,
     `- ownerSupnumStatus=${report.summary.ownerSupnumStatus}`,
     `- exemptionFactStatus=${report.summary.exemptionFactStatus}`,

--- a/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
+++ b/os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs
@@ -81,10 +81,15 @@ function forgeWiringReport(overrides = {}) {
       operationalProofAllowed: false
     },
     geometryEvidencePosture: {
-      status: "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED",
-      classification: "SYNC_DERIVED_GEOMETRY",
+      status: "TERRAATLAS_GIS_TRUTH_PARTIAL",
+      classification: "PARTIAL_GIS_TRUTH",
+      parcelGeometryStatus: "SYNC_DERIVED_PARCEL_GEOMETRY",
+      fullGisLayerTruthStatus: "GIS_LAYER_TRUTH_NOT_PROVEN",
+      mapOverlayStatus: "FALLBACK_MAP_OVERLAY",
+      riskOverlayAnchoring: "NOT_GIS_ANCHORED",
       realGeometryExists: true,
-      countyStudioUsesRealTerraAtlasGeometry: true
+      countyStudioUsesRealParcelGeometry: true,
+      countyStudioUsesRealTerraAtlasGeometry: false
     },
     ownerIdentityDependency: {
       classification: "NOT_REQUIRED_FOR_FORGE_DEV",
@@ -106,11 +111,17 @@ function forgeWiringReport(overrides = {}) {
 
 function geometryReport(overrides = {}) {
   return {
-    status: "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED",
-    classification: "SYNC_DERIVED_GEOMETRY",
+    status: "TERRAATLAS_GIS_TRUTH_PARTIAL",
+    classification: "PARTIAL_GIS_TRUTH",
+    parcelGeometryStatus: "SYNC_DERIVED_PARCEL_GEOMETRY",
+    fullGisLayerTruthStatus: "GIS_LAYER_TRUTH_NOT_PROVEN",
+    mapOverlayStatus: "FALLBACK_MAP_OVERLAY",
+    riskOverlayAnchoring: "NOT_GIS_ANCHORED",
     decisions: {
       realGeometryExists: true,
-      countyStudioUsesRealTerraAtlasGeometry: true,
+      countyStudioUsesRealParcelGeometry: true,
+      countyStudioUsesRealTerraAtlasGeometry: false,
+      countyStudioUsesFullTerraAtlasGisLayerTruth: false,
       productionProofAllowed: false,
       operationalProofAllowed: false
     },
@@ -159,7 +170,11 @@ test("summarizes County Studio R1 as real Benton Forge dev while blocking produc
   assert.equal(report.summary.productionProofAllowed, false);
   assert.equal(report.summary.operationalProofAllowed, false);
   assert.equal(report.summary.dataTruthStatus, "DATA_TRUTH_FAIL");
-  assert.equal(report.summary.geometryStatus, "SYNC_DERIVED_GEOMETRY");
+  assert.equal(report.summary.geometryStatus, "PARTIAL_GIS_TRUTH");
+  assert.equal(report.summary.parcelGeometryStatus, "SYNC_DERIVED_PARCEL_GEOMETRY");
+  assert.equal(report.summary.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
+  assert.equal(report.summary.mapOverlayStatus, "FALLBACK_MAP_OVERLAY");
+  assert.equal(report.summary.riskOverlayAnchoring, "NOT_GIS_ANCHORED");
   assert.equal(report.summary.riskObjectStatus, "DEV_DERIVED_FROM_REAL_INPUTS");
   assert.equal(report.summary.ownerSupnumStatus, "NOT_REQUIRED_FOR_FORGE_DEV");
   assert.equal(report.summary.exemptionFactStatus, "NOT_REQUIRED_FOR_FORGE_DEV");

--- a/os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.mjs
+++ b/os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.mjs
@@ -61,6 +61,13 @@ const SOURCE_FILES = {
 };
 
 export const TERRAFUSION_GEOMETRY_CLASSIFICATIONS = [
+  "SYNC_DERIVED_PARCEL_GEOMETRY",
+  "PARTIAL_GIS_TRUTH",
+  "GIS_LAYER_TRUTH_NOT_PROVEN",
+  "FALLBACK_MAP_OVERLAY",
+  "UNPROVEN_ATTRIBUTE_OVERLAY",
+  "UI_ABSOLUTE_RISK_LABELS",
+  "REQUIRED_FOR_PRODUCTION_GIS_PROOF",
   "SYNC_DERIVED_GEOMETRY",
   "SEEDED_GEOMETRY",
   "ATLAS_LAYER_AVAILABLE_NOT_WIRED",
@@ -170,6 +177,29 @@ function buildDefaultSourceScan() {
       || controller.includes("GET /api/parcels/{tfParcelId}/geometry")
       && reader.includes("TfParcelGeoms")
       && config.includes("tf_parcel_geom"),
+    returnsParcelPolygonsOnly:
+      atlasLiveGeometryController.includes("TfParcelGeoms")
+      && atlasLiveGeometryController.includes("outlines = (object?)null"),
+    outlinesReturnedFromEndpoint:
+      !atlasLiveGeometryController.includes("outlines = (object?)null"),
+    hardcodedOrNullAttributeFields: [
+      atlasLiveGeometryController.includes("assessedValue = 0") ? "assessedValue" : null,
+      atlasLiveGeometryController.includes("propertyClass = (string?)null") ? "propertyClass" : null,
+      atlasLiveGeometryController.includes("salePrice = 0") ? "salePrice" : null,
+      atlasLiveGeometryController.includes("ratio = (double?)null") ? "ratio" : null,
+      atlasLiveGeometryController.includes("ratioDeviation = (double?)null") ? "ratioDeviation" : null,
+      atlasLiveGeometryController.includes("nbhdMedianRatio = (double?)null") ? "nbhdMedianRatio" : null
+    ].filter(Boolean),
+    neighborhoodCodeFromQueryScope:
+      atlasLiveGeometryController.includes("[FromQuery] string? neighborhoodCode")
+      && atlasLiveGeometryController.includes("neighborhoodCode,"),
+    riskOverlayUsesFeatureNeighborhoodCode:
+      embedded.includes("feature.properties.neighborhoodCode"),
+    riskLabelsScreenPositioned:
+      embedded.includes("data-testid=\"prometheus-risk-map-label\"")
+      && embedded.includes("position: 'absolute'")
+      && embedded.includes("top:")
+      && embedded.includes("left:"),
     candidateTables: [
       { table: "gis_tf.tf_parcel_geom", exists: config.includes("tf_parcel_geom") },
       { table: "canonical_tf.tf_parcel", exists: reader.includes("TfParcels") },
@@ -178,6 +208,21 @@ function buildDefaultSourceScan() {
     ],
     sourceFiles: SOURCE_FILES
   };
+}
+
+function hasUnprovenFullGisTruth({ sourceScan, geometryInventory, atlasProof }) {
+  const atlasProofFallback = String(atlasProof?.classification ?? "").toUpperCase() === "FALLBACK";
+  const geometryInventoryFallback = String(geometryInventory?.classification ?? "").toUpperCase() === "FALLBACK";
+  const unprovenAttributes = Array.isArray(sourceScan?.hardcodedOrNullAttributeFields)
+    && sourceScan.hardcodedOrNullAttributeFields.length > 0;
+  return atlasProofFallback
+    || geometryInventoryFallback
+    || sourceScan?.returnsParcelPolygonsOnly === true
+    || sourceScan?.outlinesReturnedFromEndpoint === false
+    || unprovenAttributes
+    || sourceScan?.neighborhoodCodeFromQueryScope === true
+    || sourceScan?.riskOverlayUsesFeatureNeighborhoodCode === true
+    || sourceScan?.riskLabelsScreenPositioned === true;
 }
 
 function classifyGeometry({ counts, sourceScan, geometryInventory, atlasProof }) {
@@ -190,7 +235,9 @@ function classifyGeometry({ counts, sourceScan, geometryInventory, atlasProof })
   const lineageClaimsFallback = String(geometryInventory?.classification ?? atlasProof?.classification ?? "").toUpperCase() === "FALLBACK";
 
   if (realGeometryExists && (usesRealEndpoint || usesRealTable)) {
-    return "SYNC_DERIVED_GEOMETRY";
+    return hasUnprovenFullGisTruth({ sourceScan, geometryInventory, atlasProof })
+      ? "PARTIAL_GIS_TRUTH"
+      : "SYNC_DERIVED_GEOMETRY";
   }
   if (realGeometryExists && usesCompatibility) {
     return "ATLAS_LAYER_AVAILABLE_NOT_WIRED";
@@ -206,6 +253,8 @@ function classifyGeometry({ counts, sourceScan, geometryInventory, atlasProof })
 
 function statusFor(classification) {
   switch (classification) {
+    case "PARTIAL_GIS_TRUTH":
+      return "TERRAATLAS_GIS_TRUTH_PARTIAL";
     case "SYNC_DERIVED_GEOMETRY":
     case "SEEDED_GEOMETRY":
       return "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED";
@@ -222,6 +271,8 @@ function statusFor(classification) {
 
 function findingFor(classification) {
   switch (classification) {
+    case "PARTIAL_GIS_TRUTH":
+      return "County Studio uses real TerraAtlas sync-derived parcel geometry for Forge dev, but full GIS layer truth, GIS attributes, outlines, neighborhoods/segments/district layers, and risk overlay anchoring are not proven.";
     case "SYNC_DERIVED_GEOMETRY":
       return "County Studio geometry/map context is wired to a real TerraAtlas sync-derived geometry path for real dev; production GIS proof remains blocked pending canonical reconciliation.";
     case "SEEDED_GEOMETRY":
@@ -257,19 +308,60 @@ export function buildCountyStudioTerraAtlasGeometryEvidenceReport({
   });
   const status = statusFor(classification);
   const realGeometryExists = counts.parcelGeometry > 0;
+  const parcelGeometryStatus = realGeometryExists
+    && (
+      resolvedSourceScan?.usesTerraAtlasParcelGeometryEndpoint === true
+      || resolvedSourceScan?.usesTerraAtlasDbTable === true
+    )
+    ? "SYNC_DERIVED_PARCEL_GEOMETRY"
+    : classification === "FALLBACK_GEOMETRY"
+    ? "FALLBACK_GEOMETRY"
+    : "GEOMETRY_UNKNOWN";
+  const fullGisLayerTruthStatus =
+    classification === "SYNC_DERIVED_GEOMETRY" || classification === "SEEDED_GEOMETRY"
+      ? classification
+      : "GIS_LAYER_TRUTH_NOT_PROVEN";
+  const mapOverlayStatus = classification === "PARTIAL_GIS_TRUTH" || classification === "ATLAS_LAYER_AVAILABLE_NOT_WIRED"
+    ? "FALLBACK_MAP_OVERLAY"
+    : classification === "FALLBACK_GEOMETRY"
+    ? "FALLBACK_MAP_OVERLAY"
+    : "GEOMETRY_UNKNOWN";
+  const attributeOverlayStatus =
+    Array.isArray(resolvedSourceScan?.hardcodedOrNullAttributeFields)
+    && resolvedSourceScan.hardcodedOrNullAttributeFields.length > 0
+      ? "UNPROVEN_ATTRIBUTE_OVERLAY"
+      : "GEOMETRY_UNKNOWN";
+  const riskOverlayAnchoring = resolvedSourceScan?.riskLabelsScreenPositioned === true
+    || resolvedSourceScan?.riskOverlayUsesFeatureNeighborhoodCode === true
+    ? "NOT_GIS_ANCHORED"
+    : "UNKNOWN";
+  const riskOverlayAnchoringClassification = riskOverlayAnchoring === "NOT_GIS_ANCHORED"
+    ? "UI_ABSOLUTE_RISK_LABELS"
+    : "GEOMETRY_UNKNOWN";
   const countyStudioUsesRealTerraAtlasGeometry =
     classification === "SYNC_DERIVED_GEOMETRY" || classification === "SEEDED_GEOMETRY";
-  const preferActiveSourceScan = countyStudioUsesRealTerraAtlasGeometry;
+  const countyStudioUsesRealParcelGeometry = parcelGeometryStatus === "SYNC_DERIVED_PARCEL_GEOMETRY";
+  const preferActiveSourceScan = countyStudioUsesRealTerraAtlasGeometry || countyStudioUsesRealParcelGeometry;
 
   return {
     generatedAtUtc,
     gate: "county-studio-terraatlas-geometry-evidence",
     status,
     classification,
+    parcelGeometryStatus,
+    fullGisLayerTruthStatus,
+    mapOverlayStatus,
+    attributeOverlayStatus,
+    riskOverlayAnchoring,
+    riskOverlayAnchoringClassification,
     finding: findingFor(classification),
     decisions: {
       realGeometryExists,
+      countyStudioUsesRealParcelGeometry,
       countyStudioUsesRealTerraAtlasGeometry,
+      countyStudioUsesFullTerraAtlasGisLayerTruth: countyStudioUsesRealTerraAtlasGeometry,
+      fullGisLayerTruthProven: countyStudioUsesRealTerraAtlasGeometry,
+      riskOverlayGisAnchored: riskOverlayAnchoring !== "NOT_GIS_ANCHORED",
       atlasLayerAvailableNotWired: classification === "ATLAS_LAYER_AVAILABLE_NOT_WIRED",
       geometryMisclassified: classification === "GEOMETRY_MISCLASSIFIED",
       productionProofAllowed: false,
@@ -300,7 +392,9 @@ export function buildCountyStudioTerraAtlasGeometryEvidenceReport({
     atlasProof: atlasProof ?? null,
     lineageGeometryInventory: geometryInventory ?? null,
     requiredProofToUpgrade:
-      classification === "ATLAS_LAYER_AVAILABLE_NOT_WIRED"
+      classification === "PARTIAL_GIS_TRUTH"
+        ? "Prove TerraAtlas-owned Benton neighborhoods, segments, reval areas, taxing districts, layer registry, outlines, per-parcel GIS attributes, and GIS-anchored overlays before full GIS or production proof."
+        : classification === "ATLAS_LAYER_AVAILABLE_NOT_WIRED"
         ? "Wire County Studio embedded map context to TerraAtlas-owned geometry/layer service or prove the compatibility feed is backed by gis_tf.tf_parcel_geom with source-row lineage."
         : "Prove TerraAtlas-owned Benton parcel geometry, neighborhoods, segments, reval areas, taxing districts, layer registry, and map overlays by countyId/taxYear/studyId before production proof.",
     boundaries: [
@@ -321,6 +415,11 @@ export function renderCountyStudioTerraAtlasGeometryEvidenceMarkdown(report) {
     `Generated: ${report.generatedAtUtc}`,
     `Status: ${report.status}`,
     `Classification: ${report.classification}`,
+    `Parcel Geometry Status: ${report.parcelGeometryStatus}`,
+    `Full GIS Layer Truth Status: ${report.fullGisLayerTruthStatus}`,
+    `Map Overlay Status: ${report.mapOverlayStatus}`,
+    `Attribute Overlay Status: ${report.attributeOverlayStatus}`,
+    `Risk Overlay Anchoring: ${report.riskOverlayAnchoring}`,
     "",
     "## Finding",
     "",
@@ -329,7 +428,11 @@ export function renderCountyStudioTerraAtlasGeometryEvidenceMarkdown(report) {
     "## Decisions",
     "",
     `- realGeometryExists=${report.decisions.realGeometryExists}`,
+    `- countyStudioUsesRealParcelGeometry=${report.decisions.countyStudioUsesRealParcelGeometry}`,
     `- countyStudioUsesRealTerraAtlasGeometry=${report.decisions.countyStudioUsesRealTerraAtlasGeometry}`,
+    `- countyStudioUsesFullTerraAtlasGisLayerTruth=${report.decisions.countyStudioUsesFullTerraAtlasGisLayerTruth}`,
+    `- fullGisLayerTruthProven=${report.decisions.fullGisLayerTruthProven}`,
+    `- riskOverlayGisAnchored=${report.decisions.riskOverlayGisAnchored}`,
     `- atlasLayerAvailableNotWired=${report.decisions.atlasLayerAvailableNotWired}`,
     `- geometryMisclassified=${report.decisions.geometryMisclassified}`,
     `- productionProofAllowed=${report.decisions.productionProofAllowed}`,
@@ -421,7 +524,12 @@ export function main(argv = process.argv.slice(2)) {
       {
         status: report.status,
         classification: report.classification,
+        parcelGeometryStatus: report.parcelGeometryStatus,
+        fullGisLayerTruthStatus: report.fullGisLayerTruthStatus,
+        mapOverlayStatus: report.mapOverlayStatus,
+        riskOverlayAnchoring: report.riskOverlayAnchoring,
         realGeometryExists: report.decisions.realGeometryExists,
+        countyStudioUsesRealParcelGeometry: report.decisions.countyStudioUsesRealParcelGeometry,
         countyStudioUsesRealTerraAtlasGeometry: report.decisions.countyStudioUsesRealTerraAtlasGeometry,
         productionProofAllowed: report.decisions.productionProofAllowed,
         operationalProofAllowed: report.decisions.operationalProofAllowed,

--- a/os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.test.mjs
+++ b/os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.test.mjs
@@ -81,6 +81,13 @@ function lineage(overrides = {}) {
 
 test("defines TerraAtlas geometry evidence classifications", () => {
   assert.deepEqual(TERRAFUSION_GEOMETRY_CLASSIFICATIONS, [
+    "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "PARTIAL_GIS_TRUTH",
+    "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "FALLBACK_MAP_OVERLAY",
+    "UNPROVEN_ATTRIBUTE_OVERLAY",
+    "UI_ABSOLUTE_RISK_LABELS",
+    "REQUIRED_FOR_PRODUCTION_GIS_PROOF",
     "SYNC_DERIVED_GEOMETRY",
     "SEEDED_GEOMETRY",
     "ATLAS_LAYER_AVAILABLE_NOT_WIRED",
@@ -120,7 +127,7 @@ test("classifies real TerraAtlas geometry as available but not wired when County
   assert.match(report.finding, /available but County Studio is still wired/i);
 });
 
-test("classifies geometry as sync-derived when County Studio uses the real TerraAtlas parcel geometry endpoint", () => {
+test("classifies real parcel geometry separately from unproven full GIS layer truth", () => {
   const report = buildCountyStudioTerraAtlasGeometryEvidenceReport({
     syncEvidenceReport: syncEvidence(),
     dataTruthReport: dataTruth(),
@@ -142,18 +149,39 @@ test("classifies geometry as sync-derived when County Studio uses the real Terra
     sourceScan: {
       usesCompatibilityMapData: false,
       usesTerraAtlasParcelGeometryEndpoint: true,
-      usesTerraAtlasDbTable: true
+      usesTerraAtlasDbTable: true,
+      returnsParcelPolygonsOnly: true,
+      outlinesReturnedFromEndpoint: false,
+      hardcodedOrNullAttributeFields: [
+        "assessedValue",
+        "propertyClass",
+        "salePrice",
+        "ratio",
+        "ratioDeviation",
+        "nbhdMedianRatio"
+      ],
+      neighborhoodCodeFromQueryScope: true,
+      riskOverlayUsesFeatureNeighborhoodCode: true,
+      riskLabelsScreenPositioned: true
     },
     generatedAtUtc: "2026-06-06T00:00:00.000Z"
   });
 
-  assert.equal(report.status, "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED");
-  assert.equal(report.classification, "SYNC_DERIVED_GEOMETRY");
-  assert.equal(report.decisions.countyStudioUsesRealTerraAtlasGeometry, true);
+  assert.equal(report.status, "TERRAATLAS_GIS_TRUTH_PARTIAL");
+  assert.equal(report.classification, "PARTIAL_GIS_TRUTH");
+  assert.equal(report.parcelGeometryStatus, "SYNC_DERIVED_PARCEL_GEOMETRY");
+  assert.equal(report.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
+  assert.equal(report.mapOverlayStatus, "FALLBACK_MAP_OVERLAY");
+  assert.equal(report.attributeOverlayStatus, "UNPROVEN_ATTRIBUTE_OVERLAY");
+  assert.equal(report.riskOverlayAnchoring, "NOT_GIS_ANCHORED");
+  assert.equal(report.riskOverlayAnchoringClassification, "UI_ABSOLUTE_RISK_LABELS");
+  assert.equal(report.decisions.countyStudioUsesRealParcelGeometry, true);
+  assert.equal(report.decisions.countyStudioUsesFullTerraAtlasGisLayerTruth, false);
+  assert.equal(report.decisions.riskOverlayGisAnchored, false);
   assert.equal(report.decisions.productionProofAllowed, false);
 });
 
-test("prefers the proven active source scan path over stale compatibility lineage when geometry is wired", () => {
+test("does not let the parcel endpoint override stale compatibility lineage into full GIS proof", () => {
   const report = buildCountyStudioTerraAtlasGeometryEvidenceReport({
     syncEvidenceReport: syncEvidence(),
     dataTruthReport: dataTruth(),
@@ -164,6 +192,12 @@ test("prefers the proven active source scan path over stale compatibility lineag
       usesCompatibilityMapData: true,
       usesTerraAtlasParcelGeometryEndpoint: true,
       usesTerraAtlasDbTable: true,
+      returnsParcelPolygonsOnly: true,
+      outlinesReturnedFromEndpoint: false,
+      hardcodedOrNullAttributeFields: ["assessedValue", "ratio", "nbhdMedianRatio"],
+      neighborhoodCodeFromQueryScope: true,
+      riskOverlayUsesFeatureNeighborhoodCode: true,
+      riskLabelsScreenPositioned: true,
       candidateTables: [
         { table: "gis_tf.tf_parcel_geom", count: 80075, exists: true }
       ]
@@ -171,9 +205,36 @@ test("prefers the proven active source scan path over stale compatibility lineag
     generatedAtUtc: "2026-06-06T00:00:00.000Z"
   });
 
-  assert.equal(report.classification, "SYNC_DERIVED_GEOMETRY");
+  assert.equal(report.classification, "PARTIAL_GIS_TRUTH");
+  assert.equal(report.parcelGeometryStatus, "SYNC_DERIVED_PARCEL_GEOMETRY");
+  assert.equal(report.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
   assert.match(report.sourcePath.apiRoute, /atlas-live\/geometry\/parcels/);
   assert.match(report.sourcePath.backendServiceOrController, /AtlasLiveGeometryController/);
+});
+
+test("default source scan detects parcel-only payloads and non-GIS-anchored risk labels", () => {
+  const report = buildCountyStudioTerraAtlasGeometryEvidenceReport({
+    syncEvidenceReport: syncEvidence(),
+    dataTruthReport: dataTruth(),
+    lineageReport: lineage(),
+    generatedAtUtc: "2026-06-06T00:00:00.000Z"
+  });
+
+  assert.equal(report.sourceScan.returnsParcelPolygonsOnly, true);
+  assert.equal(report.sourceScan.outlinesReturnedFromEndpoint, false);
+  assert.deepEqual(report.sourceScan.hardcodedOrNullAttributeFields, [
+    "assessedValue",
+    "propertyClass",
+    "salePrice",
+    "ratio",
+    "ratioDeviation",
+    "nbhdMedianRatio"
+  ]);
+  assert.equal(report.sourceScan.neighborhoodCodeFromQueryScope, true);
+  assert.equal(report.sourceScan.riskOverlayUsesFeatureNeighborhoodCode, true);
+  assert.equal(report.sourceScan.riskLabelsScreenPositioned, true);
+  assert.equal(report.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
+  assert.equal(report.riskOverlayAnchoring, "NOT_GIS_ANCHORED");
 });
 
 test("keeps fallback geometry when no real GIS geometry is readable", () => {
@@ -258,6 +319,7 @@ test("CLI writes TerraAtlas geometry evidence JSON and markdown", () => {
   const report = JSON.parse(fs.readFileSync(outJson, "utf8"));
   const markdown = fs.readFileSync(outMd, "utf8");
   assert.equal(report.classification, "ATLAS_LAYER_AVAILABLE_NOT_WIRED");
+  assert.equal(report.fullGisLayerTruthStatus, "GIS_LAYER_TRUTH_NOT_PROVEN");
   assert.equal(report.decisions.productionProofAllowed, false);
   assert.equal(report.decisions.operationalProofAllowed, false);
   assert.match(markdown, /TerraAtlas Geometry Evidence/);

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T20:02:25.766Z",
+  "generatedAtUtc": "2026-06-08T00:11:15.526Z",
   "gate": "benton-real-dev-server-readiness",
   "status": "REAL_DEV_DATA_AVAILABLE",
   "sourcePath": null,
@@ -65,9 +65,9 @@
       "passed": true,
       "reason": "load_batch stage is owner-supnum-backfill (FAILED), retained as packet/ops blocker but not a County Studio Forge dev blocker.",
       "evidence": {
-        "stage": "exemption-fact-seal",
-        "status": "COMPLETED",
-        "loadBatchId": "e21e20ea-4bfb-402e-8496-4506f6829922"
+        "stage": "jurisdiction-spine-seal",
+        "status": "IN_PROGRESS",
+        "loadBatchId": "4a7b6319-f360-433c-abef-0b9004dc0a37"
       }
     },
     {
@@ -217,9 +217,9 @@
       "passed": true,
       "reason": "exemption-fact-seal is not required for County Studio Forge valuation dev; production, packet, and operational proof remain blocked.",
       "evidence": {
-        "stage": "exemption-fact-seal",
-        "status": "COMPLETED",
-        "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+        "stage": "jurisdiction-spine-seal",
+        "status": "IN_PROGRESS",
+        "classification": "UNKNOWN",
         "requiredForCountyStudioForgeDev": false,
         "requiredForPacketProof": true,
         "requiredForProductionProof": true,
@@ -306,9 +306,9 @@
       }
     },
     "exemptionFactSeal": {
-      "stage": "exemption-fact-seal",
-      "status": "COMPLETED",
-      "classification": "NOT_REQUIRED_FOR_FORGE_DEV",
+      "stage": "jurisdiction-spine-seal",
+      "status": "IN_PROGRESS",
+      "classification": "UNKNOWN",
       "requiredForCountyStudioForgeDev": false,
       "requiredForPacketProof": true,
       "requiredForProductionProof": true,

--- a/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
+++ b/os-platform/core/pilot/evidence/benton-real-dev-server-readiness.md
@@ -1,6 +1,6 @@
 # Benton Real Dev Server Readiness
 
-Generated: 2026-06-07T20:02:25.766Z
+Generated: 2026-06-08T00:11:15.526Z
 Status: REAL_DEV_DATA_AVAILABLE
 
 ## Decision
@@ -50,9 +50,9 @@ Status: REAL_DEV_DATA_AVAILABLE
 - ownerSupnumBackfillRequiredForForgeDev: false
 - ownerSupnumBackfillRequiredForPacketProof: true
 - ownerSupnumBackfillRequiredForOperationalProof: true
-- exemptionFactSealStatus: COMPLETED
-- exemptionFactSealStage: exemption-fact-seal
-- exemptionFactSealClassification: NOT_REQUIRED_FOR_FORGE_DEV
+- exemptionFactSealStatus: IN_PROGRESS
+- exemptionFactSealStage: jurisdiction-spine-seal
+- exemptionFactSealClassification: UNKNOWN
 - exemptionFactSealRequiredForForgeDev: false
 - exemptionFactSealRequiredForProductionProof: true
 - exemptionFactSealRequiredForPacketProof: true

--- a/os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json
+++ b/os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T02:29:37.339Z",
+  "generatedAtUtc": "2026-06-08T00:10:17.103Z",
   "gate": "county-studio-forge-real-data-wiring",
   "status": "FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS",
   "decisions": {
@@ -134,7 +134,7 @@
       "backendServiceOrController": "AtlasLiveGeometryController reads gis_tf.tf_parcel_geom as the County Studio bulk map feed",
       "dbTableOrView": "gis_tf.tf_parcel_geom",
       "ownerLane": "Atlas",
-      "classification": "SYNC_DERIVED_GEOMETRY",
+      "classification": "SYNC_DERIVED_PARCEL_GEOMETRY",
       "observedCount": 80075,
       "joinKey": "countyId + parcelId/APN + layerId",
       "countyId": "19190019-1919-1919-1919-191919191919",
@@ -143,8 +143,8 @@
       "requiredForForgeDev": true,
       "productionProofAllowed": false,
       "operationalProofAllowed": false,
-      "failureReason": "County Studio geometry/map context is wired to a real TerraAtlas sync-derived geometry path for real dev; production GIS proof remains blocked pending canonical reconciliation.",
-      "requiredProofToUpgrade": "Prove TerraAtlas-owned Benton parcel geometry, neighborhoods, segments, reval areas, taxing districts, layer registry, and map overlays by countyId/taxYear/studyId before production proof.",
+      "failureReason": "County Studio uses real TerraAtlas sync-derived parcel geometry for Forge dev, but full GIS layer truth, GIS attributes, outlines, neighborhoods/segments/district layers, and risk overlay anchoring are not proven.",
+      "requiredProofToUpgrade": "Prove TerraAtlas-owned Benton neighborhoods, segments, reval areas, taxing districts, layer registry, outlines, per-parcel GIS attributes, and GIS-anchored overlays before full GIS or production proof.",
       "status": "REAL_DEV_WIRED_PRODUCTION_BLOCKED"
     },
     {
@@ -209,7 +209,7 @@
       "requiredForOperationalProof": true,
       "ownerIdentityConsumedByForgeSurfaces": false,
       "consumedSurfaces": [],
-      "ownerSupnumBackfillStatus": "IN_PROGRESS",
+      "ownerSupnumBackfillStatus": "FAILED",
       "ownerSupnumBackfillLatestFailedStatus": "FAILED",
       "productionProofAllowed": false,
       "operationalProofAllowed": false,
@@ -238,7 +238,7 @@
     "requiredForOperationalProof": true,
     "ownerIdentityConsumedByForgeSurfaces": false,
     "consumedSurfaces": [],
-    "ownerSupnumBackfillStatus": "IN_PROGRESS",
+    "ownerSupnumBackfillStatus": "FAILED",
     "ownerSupnumBackfillLatestFailedStatus": "FAILED",
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
@@ -282,10 +282,16 @@
     "operationalProofAllowed": false
   },
   "geometryEvidencePosture": {
-    "status": "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED",
-    "classification": "SYNC_DERIVED_GEOMETRY",
+    "status": "TERRAATLAS_GIS_TRUTH_PARTIAL",
+    "classification": "PARTIAL_GIS_TRUTH",
+    "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+    "attributeOverlayStatus": "UNPROVEN_ATTRIBUTE_OVERLAY",
+    "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
     "realGeometryExists": true,
-    "countyStudioUsesRealTerraAtlasGeometry": true
+    "countyStudioUsesRealParcelGeometry": true,
+    "countyStudioUsesRealTerraAtlasGeometry": false
   },
   "blockers": [],
   "boundaries": [

--- a/os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.md
+++ b/os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.md
@@ -1,6 +1,6 @@
 # County Studio Forge Real Data Wiring
 
-Generated: 2026-06-07T02:29:37.339Z
+Generated: 2026-06-08T00:10:17.103Z
 Status: FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS
 
 ## Decisions
@@ -20,21 +20,27 @@ Status: FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS
 | valuation metrics source | SYNC_DERIVED | Forge | GET /county-study/studies/{studyId}/statistics-compat + health-summary | CountyStudyHealthService / statistics compatibility API | PACS valuation + comparable sales ratio-study population | countyId + taxYear + studyId + parcelId + saleId | REAL_DEV_WIRED_PRODUCTION_BLOCKED |
 | ratio-study context source | SYNC_DERIVED | Forge | GET /county-study/studies/{studyId}/statistics-compat + health-summary | CountyStudyHealthService / statistics compatibility API | PACS valuation + comparable sales ratio-study population | countyId + taxYear + studyId + parcelId + saleId | REAL_DEV_WIRED_PRODUCTION_BLOCKED |
 | risk object source | GENERATED | Forge | GET /county-study/studies/{studyId}/health-summary | CountyStudyHealthService + risk surface derivation | CountySegments / derived risk metrics | studyId + segmentId + riskObjectId | WIRING_GAP_IDENTIFIED |
-| geometry/map context source | SYNC_DERIVED_GEOMETRY | Atlas | fetchTerraAtlasParcelGeometryMapData -> GET /api/atlas-live/geometry/parcels | AtlasLiveGeometryController reads gis_tf.tf_parcel_geom as the County Studio bulk map feed | gis_tf.tf_parcel_geom | countyId + parcelId/APN + layerId | REAL_DEV_WIRED_PRODUCTION_BLOCKED |
+| geometry/map context source | SYNC_DERIVED_PARCEL_GEOMETRY | Atlas | fetchTerraAtlasParcelGeometryMapData -> GET /api/atlas-live/geometry/parcels | AtlasLiveGeometryController reads gis_tf.tf_parcel_geom as the County Studio bulk map feed | gis_tf.tf_parcel_geom | countyId + parcelId/APN + layerId | REAL_DEV_WIRED_PRODUCTION_BLOCKED |
 | countyId/taxYear/studyId propagation | SYNC_DERIVED | Forge | County Studio route/query params and API payloads | CountyStudyController + CountyStudyHealthService | runtime study context | countyId + taxYear + studyId | REAL_DEV_WIRED_PRODUCTION_BLOCKED |
 | fallback/mock/generated path scan | GENERATED | Forge | evidence scan | county-studio-forge-real-data-wiring gate | n/a | surface classification | WIRING_GAP_IDENTIFIED |
 | owner identity dependency scan | NOT_REQUIRED_FOR_FORGE_DEV | Forge | County Studio Forge valuation read paths | CountyStudyController / CountyStudyHealthService / CountyStudyInspectorService | owner/account/supplement lineage | ownerId/supNum only if a Forge surface consumes owner identity | NOT_REQUIRED_FOR_FORGE_DEV |
 
 ## TerraAtlas Geometry Evidence
 
-- status: TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED
-- classification: SYNC_DERIVED_GEOMETRY
+- status: TERRAATLAS_GIS_TRUTH_PARTIAL
+- classification: PARTIAL_GIS_TRUTH
+- parcelGeometryStatus: SYNC_DERIVED_PARCEL_GEOMETRY
+- fullGisLayerTruthStatus: GIS_LAYER_TRUTH_NOT_PROVEN
+- mapOverlayStatus: FALLBACK_MAP_OVERLAY
+- attributeOverlayStatus: UNPROVEN_ATTRIBUTE_OVERLAY
+- riskOverlayAnchoring: NOT_GIS_ANCHORED
 - realGeometryExists: true
-- countyStudioUsesRealTerraAtlasGeometry: true
+- countyStudioUsesRealParcelGeometry: true
+- countyStudioUsesRealTerraAtlasGeometry: false
 
 ## Owner Identity Dependency Scan
 
-- ownerSupnumBackfillStatus: IN_PROGRESS
+- ownerSupnumBackfillStatus: FAILED
 - ownerSupnumBackfillLatestFailedStatus: FAILED
 - ownerSupnumRequiredForForgeDev: false
 - ownerSupnumRequiredForPacketProof: true

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.json
@@ -8,6 +8,11 @@
     "cleanFullDevSmokePassed": true,
     "countyStudioMode": "REAL_BENTON_FORGE_DEV",
     "dataTruthStatus": "DATA_TRUTH_FAIL",
+    "geometryStatus": "PARTIAL_GIS_TRUTH",
+    "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+    "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
     "productionProofAllowed": false,
     "operationalProofAllowed": false
   },
@@ -39,9 +44,14 @@
       "status": "FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS"
     },
     {
-      "gate": "TerraAtlas geometry wiring",
+      "gate": "TerraAtlas GIS truth correction",
       "artifact": "os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json",
-      "status": "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED"
+      "status": "TERRAATLAS_GIS_TRUTH_PARTIAL"
+    },
+    {
+      "gate": "TerraAtlas GIS truth correction detail",
+      "artifact": "os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.json",
+      "status": "PARTIAL_GIS_TRUTH"
     },
     {
       "gate": "risk object source audit",
@@ -65,12 +75,17 @@
     "real property characteristics path for Forge dev",
     "real valuation metrics path for Forge dev",
     "real ratio-study context path for Forge dev",
-    "real TerraAtlas geometry wired for Forge dev",
+    "real TerraAtlas parcel geometry wired for Forge dev",
+    "full TerraAtlas GIS layer truth is not proven",
+    "map/risk overlays remain fallback or unproven",
     "risk objects dev-derived from real Benton inputs",
     "clean full Forge dev smoke under Forge-dev scope"
   ],
   "notProductionProof": [
     "DATA_TRUTH_FAIL remains the data truth posture",
+    "full TerraAtlas GIS layer truth is not proven",
+    "risk overlay labels are not GIS-anchored production overlays",
+    "neighborhoods, segments, reval areas, taxing districts, outlines, attributes, and symbology lineage remain unproven",
     "owner-supnum remains required for packet/ops proof",
     "exemption facts remain required for production/packet/ops proof",
     "canonical Benton source/count reconciliation is not complete",
@@ -84,7 +99,9 @@
     "owner/taxpayer packet complete",
     "Dais/Dossier/Trace operational proof complete",
     "productionProofAllowed=true",
-    "operationalProofAllowed=true"
+    "operationalProofAllowed=true",
+    "full TerraAtlas GIS proof",
+    "production GIS overlay proof"
   ],
   "nextLanes": [
     "Assessment Value Seal current-year active-supp",
@@ -93,7 +110,11 @@
     "production reconciliation"
   ],
   "dependencyPosture": {
-    "geometryStatus": "SYNC_DERIVED_GEOMETRY",
+    "geometryStatus": "PARTIAL_GIS_TRUTH",
+    "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+    "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
     "exemptionFactStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
@@ -104,6 +125,7 @@
   },
   "boundaries": {
     "uiChanged": false,
+    "gisAttributesInvented": false,
     "syncMutated": false,
     "dbSeedingChanged": false,
     "newProofLogicAdded": false,

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-handoff.md
@@ -13,6 +13,11 @@ realDevActivationAllowed=true
 cleanFullDevSmokePassed=true
 countyStudioMode=REAL_BENTON_FORGE_DEV
 dataTruthStatus=DATA_TRUTH_FAIL
+geometryStatus=PARTIAL_GIS_TRUTH
+parcelGeometryStatus=SYNC_DERIVED_PARCEL_GEOMETRY
+fullGisLayerTruthStatus=GIS_LAYER_TRUTH_NOT_PROVEN
+mapOverlayStatus=FALLBACK_MAP_OVERLAY
+riskOverlayAnchoring=NOT_GIS_ANCHORED
 productionProofAllowed=false
 operationalProofAllowed=false
 ```
@@ -34,7 +39,8 @@ pnpm run dev:county-studio:real-benton
 | DB readiness | `REAL_DEV_DATA_AVAILABLE` | os-platform/core/pilot/evidence/benton-real-dev-server-readiness.json |
 | real dev activation | `REAL_DEV_ACTIVATION_READY` | os-platform/core/pilot/evidence/county-studio-real-dev-server-activation.json |
 | Forge real data wiring | `FORGE_REAL_DATA_WIRING_VERIFIED_WITH_GAPS` | os-platform/core/pilot/evidence/county-studio-forge-real-data-wiring.json |
-| TerraAtlas geometry wiring | `TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED` | os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json |
+| TerraAtlas GIS truth correction | `TERRAATLAS_GIS_TRUTH_PARTIAL` | os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json |
+| TerraAtlas GIS truth correction detail | `PARTIAL_GIS_TRUTH` | os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.json |
 | risk object source audit | `RISK_OBJECT_SOURCE_AUDITED_DEV_DERIVED` | os-platform/core/pilot/evidence/county-studio-risk-object-source-audit.json |
 | dependency reclassification | `NOT_REQUIRED_FOR_FORGE_DEV` | os-platform/core/pilot/evidence/county-studio-exemption-fact-dependency.json |
 | full smoke | `FORGE_DEV_SMOKE_PASS` | os-platform/core/pilot/evidence/county-studio-r1-forge-dev-smoke.json |
@@ -46,13 +52,18 @@ pnpm run dev:county-studio:real-benton
 - real property characteristics path for Forge dev
 - real valuation metrics path for Forge dev
 - real ratio-study context path for Forge dev
-- real TerraAtlas geometry wired for Forge dev
+- real TerraAtlas parcel geometry wired for Forge dev
+- full TerraAtlas GIS layer truth is not proven
+- map/risk overlays remain fallback or unproven
 - risk objects dev-derived from real Benton inputs
 - clean full Forge dev smoke under Forge-dev scope
 
 ## What Is Not Production Proof
 
 - DATA_TRUTH_FAIL remains the data truth posture
+- full TerraAtlas GIS layer truth is not proven
+- risk overlay labels are not GIS-anchored production overlays
+- neighborhoods, segments, reval areas, taxing districts, outlines, attributes, and symbology lineage remain unproven
 - owner-supnum remains required for packet/ops proof
 - exemption facts remain required for production/packet/ops proof
 - canonical Benton source/count reconciliation is not complete
@@ -70,11 +81,17 @@ Do not represent this R1 Forge-dev handoff as any of the following:
 - Dais/Dossier/Trace operational proof complete
 - productionProofAllowed=true
 - operationalProofAllowed=true
+- full TerraAtlas GIS proof
+- production GIS overlay proof
 
 ## Dependency Posture
 
 ```text
-geometryStatus=SYNC_DERIVED_GEOMETRY
+geometryStatus=PARTIAL_GIS_TRUTH
+parcelGeometryStatus=SYNC_DERIVED_PARCEL_GEOMETRY
+fullGisLayerTruthStatus=GIS_LAYER_TRUTH_NOT_PROVEN
+mapOverlayStatus=FALLBACK_MAP_OVERLAY
+riskOverlayAnchoring=NOT_GIS_ANCHORED
 riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
 exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV
@@ -85,6 +102,8 @@ exemptionFactRequiredForOperationalProof=true
 ```
 
 Owner-supnum and exemption facts remain visible as packet/ops or production dependencies. They are not Forge-dev blockers unless a County Studio Forge surface consumes those facts.
+
+Real parcel polygons from `gis_tf.tf_parcel_geom` are available for Forge dev, but that does not prove full TerraAtlas GIS truth. The current map endpoint returns parcel polygons only, `outlines` is null, several map attributes are hardcoded/null/zero, `neighborhoodCode` is query-scoped rather than per-parcel sourced, and visible risk labels are UI-positioned rather than GIS-anchored.
 
 ## Next Lanes
 

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-06-07T20:01:00.617Z",
+  "generatedAtUtc": "2026-06-08T00:11:15.574Z",
   "gate": "county-studio-r1-forge-dev-status",
   "status": "COUNTY_STUDIO_R1_FORGE_DEV_READY",
   "summary": {
@@ -8,7 +8,11 @@
     "productionProofAllowed": false,
     "operationalProofAllowed": false,
     "dataTruthStatus": "DATA_TRUTH_FAIL",
-    "geometryStatus": "SYNC_DERIVED_GEOMETRY",
+    "geometryStatus": "PARTIAL_GIS_TRUTH",
+    "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+    "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
     "riskObjectStatus": "DEV_DERIVED_FROM_REAL_INPUTS",
     "ownerSupnumStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
     "exemptionFactStatus": "NOT_REQUIRED_FOR_FORGE_DEV",
@@ -21,9 +25,12 @@
     "remainingProductionBlockers": [
       "Canonical Benton source/count reconciliation remains required before production proof.",
       "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
-      "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
+      "TerraAtlas parcel geometry is wired for real dev, but full GIS layer truth is not proven; production GIS proof still requires canonical TerraAtlas layer registry, boundaries, neighborhoods, segments, reval areas, taxing districts, outlines, attributes, overlays, and symbology lineage.",
       "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
-      "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
+      "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof.",
+      "Full GIS layer truth status is GIS_LAYER_TRUTH_NOT_PROVEN; parcel geometry proof does not prove neighborhoods, segments, taxing districts, or layer registry truth.",
+      "Map overlay status is FALLBACK_MAP_OVERLAY; valuation/risk overlays are not production GIS proof.",
+      "Risk overlay anchoring is NOT_GIS_ANCHORED; visible risk labels are UI-positioned, not GIS-anchored production overlays."
     ],
     "remainingOperationalBlockers": [
       "Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.",
@@ -43,9 +50,12 @@
   "remainingProductionBlockers": [
     "Canonical Benton source/count reconciliation remains required before production proof.",
     "CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.",
-    "TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.",
+    "TerraAtlas parcel geometry is wired for real dev, but full GIS layer truth is not proven; production GIS proof still requires canonical TerraAtlas layer registry, boundaries, neighborhoods, segments, reval areas, taxing districts, outlines, attributes, overlays, and symbology lineage.",
     "Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.",
-    "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof."
+    "Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof.",
+    "Full GIS layer truth status is GIS_LAYER_TRUTH_NOT_PROVEN; parcel geometry proof does not prove neighborhoods, segments, taxing districts, or layer registry truth.",
+    "Map overlay status is FALLBACK_MAP_OVERLAY; valuation/risk overlays are not production GIS proof.",
+    "Risk overlay anchoring is NOT_GIS_ANCHORED; visible risk labels are UI-positioned, not GIS-anchored production overlays."
   ],
   "remainingOperationalBlockers": [
     "Owner-supnum remains required for packet/ops proof, Dossier packets, Dais/notice/appeal identity, and operational owner references.",

--- a/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
+++ b/os-platform/core/pilot/evidence/county-studio-r1-forge-dev-status.md
@@ -1,6 +1,6 @@
 # County Studio R1 Forge Dev Status
 
-Generated: 2026-06-07T20:01:00.617Z
+Generated: 2026-06-08T00:11:15.574Z
 Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 
 ## Summary
@@ -10,7 +10,11 @@ Status: COUNTY_STUDIO_R1_FORGE_DEV_READY
 - productionProofAllowed=false
 - operationalProofAllowed=false
 - dataTruthStatus=DATA_TRUTH_FAIL
-- geometryStatus=SYNC_DERIVED_GEOMETRY
+- geometryStatus=PARTIAL_GIS_TRUTH
+- parcelGeometryStatus=SYNC_DERIVED_PARCEL_GEOMETRY
+- fullGisLayerTruthStatus=GIS_LAYER_TRUTH_NOT_PROVEN
+- mapOverlayStatus=FALLBACK_MAP_OVERLAY
+- riskOverlayAnchoring=NOT_GIS_ANCHORED
 - riskObjectStatus=DEV_DERIVED_FROM_REAL_INPUTS
 - ownerSupnumStatus=NOT_REQUIRED_FOR_FORGE_DEV
 - exemptionFactStatus=NOT_REQUIRED_FOR_FORGE_DEV
@@ -49,9 +53,12 @@ Exemption facts remain required for production/ops proof, not current County Stu
 
 - Canonical Benton source/count reconciliation remains required before production proof.
 - CountyId, taxYear, studyId, parcel/property, valuation, ratio-study, and same-study map/ledger/inspector lineage must be reconciled against authoritative manifests.
-- TerraAtlas geometry is wired for real dev, but production GIS proof still requires canonical TerraAtlas layer, boundary, neighborhood, segment, reval, taxing-district, and symbology lineage.
+- TerraAtlas parcel geometry is wired for real dev, but full GIS layer truth is not proven; production GIS proof still requires canonical TerraAtlas layer registry, boundaries, neighborhoods, segments, reval areas, taxing districts, outlines, attributes, overlays, and symbology lineage.
 - Risk objects are acceptable for Forge dev only; production proof requires recomputation from canonical Benton source rows and same-study alignment.
 - Exemption facts are not required for Forge dev, but exemption/tax relief lineage remains required before production packet or roll proof.
+- Full GIS layer truth status is GIS_LAYER_TRUTH_NOT_PROVEN; parcel geometry proof does not prove neighborhoods, segments, taxing districts, or layer registry truth.
+- Map overlay status is FALLBACK_MAP_OVERLAY; valuation/risk overlays are not production GIS proof.
+- Risk overlay anchoring is NOT_GIS_ANCHORED; visible risk labels are UI-positioned, not GIS-anchored production overlays.
 
 ## Remaining Operational Blockers
 

--- a/os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json
+++ b/os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.json
@@ -1,12 +1,22 @@
 {
-  "generatedAtUtc": "2026-06-07T02:29:37.085Z",
+  "generatedAtUtc": "2026-06-08T00:10:15.981Z",
   "gate": "county-studio-terraatlas-geometry-evidence",
-  "status": "TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED",
-  "classification": "SYNC_DERIVED_GEOMETRY",
-  "finding": "County Studio geometry/map context is wired to a real TerraAtlas sync-derived geometry path for real dev; production GIS proof remains blocked pending canonical reconciliation.",
+  "status": "TERRAATLAS_GIS_TRUTH_PARTIAL",
+  "classification": "PARTIAL_GIS_TRUTH",
+  "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+  "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+  "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+  "attributeOverlayStatus": "UNPROVEN_ATTRIBUTE_OVERLAY",
+  "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
+  "riskOverlayAnchoringClassification": "UI_ABSOLUTE_RISK_LABELS",
+  "finding": "County Studio uses real TerraAtlas sync-derived parcel geometry for Forge dev, but full GIS layer truth, GIS attributes, outlines, neighborhoods/segments/district layers, and risk overlay anchoring are not proven.",
   "decisions": {
     "realGeometryExists": true,
-    "countyStudioUsesRealTerraAtlasGeometry": true,
+    "countyStudioUsesRealParcelGeometry": true,
+    "countyStudioUsesRealTerraAtlasGeometry": false,
+    "countyStudioUsesFullTerraAtlasGisLayerTruth": false,
+    "fullGisLayerTruthProven": false,
+    "riskOverlayGisAnchored": false,
     "atlasLayerAvailableNotWired": false,
     "geometryMisclassified": false,
     "productionProofAllowed": false,
@@ -14,7 +24,7 @@
   },
   "geometryCounts": {
     "parcelGeometry": 80075,
-    "canonicalParcel": 3199335,
+    "canonicalParcel": 3198979,
     "geometryInventoryObservedCount": 80075,
     "mapInventoryObservedCount": 80075
   },
@@ -60,6 +70,19 @@
     "usesTerraAtlasParcelGeometryEndpoint": true,
     "usesTerraAtlasDbTable": true,
     "availableRealGeometryReadPath": true,
+    "returnsParcelPolygonsOnly": true,
+    "outlinesReturnedFromEndpoint": false,
+    "hardcodedOrNullAttributeFields": [
+      "assessedValue",
+      "propertyClass",
+      "salePrice",
+      "ratio",
+      "ratioDeviation",
+      "nbhdMedianRatio"
+    ],
+    "neighborhoodCodeFromQueryScope": true,
+    "riskOverlayUsesFeatureNeighborhoodCode": true,
+    "riskLabelsScreenPositioned": true,
     "candidateTables": [
       {
         "table": "gis_tf.tf_parcel_geom",
@@ -122,7 +145,7 @@
     "productionProofAllowed": false,
     "status": "PRODUCTION_BLOCKER"
   },
-  "requiredProofToUpgrade": "Prove TerraAtlas-owned Benton parcel geometry, neighborhoods, segments, reval areas, taxing districts, layer registry, and map overlays by countyId/taxYear/studyId before production proof.",
+  "requiredProofToUpgrade": "Prove TerraAtlas-owned Benton neighborhoods, segments, reval areas, taxing districts, layer registry, outlines, per-parcel GIS attributes, and GIS-anchored overlays before full GIS or production proof.",
   "boundaries": [
     "This gate does not touch County Studio UI.",
     "This gate does not mutate TerraFusion Sync.",

--- a/os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.md
+++ b/os-platform/core/pilot/evidence/county-studio-terraatlas-geometry-evidence.md
@@ -1,17 +1,26 @@
 # County Studio TerraAtlas Geometry Evidence
 
-Generated: 2026-06-07T02:29:37.085Z
-Status: TERRAATLAS_GEOMETRY_EVIDENCE_REAL_DEV_WIRED
-Classification: SYNC_DERIVED_GEOMETRY
+Generated: 2026-06-08T00:10:15.981Z
+Status: TERRAATLAS_GIS_TRUTH_PARTIAL
+Classification: PARTIAL_GIS_TRUTH
+Parcel Geometry Status: SYNC_DERIVED_PARCEL_GEOMETRY
+Full GIS Layer Truth Status: GIS_LAYER_TRUTH_NOT_PROVEN
+Map Overlay Status: FALLBACK_MAP_OVERLAY
+Attribute Overlay Status: UNPROVEN_ATTRIBUTE_OVERLAY
+Risk Overlay Anchoring: NOT_GIS_ANCHORED
 
 ## Finding
 
-County Studio geometry/map context is wired to a real TerraAtlas sync-derived geometry path for real dev; production GIS proof remains blocked pending canonical reconciliation.
+County Studio uses real TerraAtlas sync-derived parcel geometry for Forge dev, but full GIS layer truth, GIS attributes, outlines, neighborhoods/segments/district layers, and risk overlay anchoring are not proven.
 
 ## Decisions
 
 - realGeometryExists=true
-- countyStudioUsesRealTerraAtlasGeometry=true
+- countyStudioUsesRealParcelGeometry=true
+- countyStudioUsesRealTerraAtlasGeometry=false
+- countyStudioUsesFullTerraAtlasGisLayerTruth=false
+- fullGisLayerTruthProven=false
+- riskOverlayGisAnchored=false
 - atlasLayerAvailableNotWired=false
 - geometryMisclassified=false
 - productionProofAllowed=false
@@ -20,7 +29,7 @@ County Studio geometry/map context is wired to a real TerraAtlas sync-derived ge
 ## Geometry Counts
 
 - parcelGeometry=80075
-- canonicalParcel=3199335
+- canonicalParcel=3198979
 - geometryInventoryObservedCount=80075
 - mapInventoryObservedCount=80075
 
@@ -45,7 +54,7 @@ County Studio geometry/map context is wired to a real TerraAtlas sync-derived ge
 
 ## Required Proof To Upgrade
 
-Prove TerraAtlas-owned Benton parcel geometry, neighborhoods, segments, reval areas, taxing districts, layer registry, and map overlays by countyId/taxYear/studyId before production proof.
+Prove TerraAtlas-owned Benton neighborhoods, segments, reval areas, taxing districts, layer registry, outlines, per-parcel GIS attributes, and GIS-anchored overlays before full GIS or production proof.
 
 ## Boundaries
 

--- a/os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.json
+++ b/os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.json
@@ -1,0 +1,75 @@
+{
+  "generatedAtUtc": "2026-06-08T00:06:00.000Z",
+  "status": "PARTIAL_GIS_TRUTH",
+  "parcelGeometryStatus": "SYNC_DERIVED_PARCEL_GEOMETRY",
+  "fullGisLayerTruthStatus": "GIS_LAYER_TRUTH_NOT_PROVEN",
+  "mapOverlayStatus": "FALLBACK_MAP_OVERLAY",
+  "attributeOverlayStatus": "UNPROVEN_ATTRIBUTE_OVERLAY",
+  "riskOverlayAnchoring": "NOT_GIS_ANCHORED",
+  "classifications": [
+    "SYNC_DERIVED_PARCEL_GEOMETRY",
+    "PARTIAL_GIS_TRUTH",
+    "GIS_LAYER_TRUTH_NOT_PROVEN",
+    "FALLBACK_MAP_OVERLAY",
+    "UNPROVEN_ATTRIBUTE_OVERLAY",
+    "UI_ABSOLUTE_RISK_LABELS",
+    "ATLAS_LAYER_AVAILABLE_NOT_WIRED",
+    "REQUIRED_FOR_PRODUCTION_GIS_PROOF"
+  ],
+  "proven": {
+    "parcelGeometryTable": "gis_tf.tf_parcel_geom",
+    "activeParcelGeometryCount": 80075,
+    "activeCrosswalkedToTfParcelId": 79105,
+    "countyStudioParcelGeometryEndpoint": "GET /api/atlas-live/geometry/parcels",
+    "countyStudioUsesRealParcelGeometry": true
+  },
+  "notProven": {
+    "fullAtlasLayerRegistryTruth": true,
+    "neighborhoodLayerGeometry": true,
+    "segmentLayerGeometry": true,
+    "revalAreaGeometry": true,
+    "taxingDistrictGeometry": true,
+    "realOutlineLayerSource": true,
+    "perParcelMapAttributes": true,
+    "gisAnchoredRiskOverlayLabels": true,
+    "productionGisSymbologyOrLayerConfiguration": true
+  },
+  "attributeFindings": {
+    "outlines": "null",
+    "assessedValue": "hardcoded_or_zero",
+    "propertyClass": "null",
+    "salePrice": "hardcoded_or_zero",
+    "ratio": "null",
+    "ratioDeviation": "null",
+    "nbhdMedianRatio": "null",
+    "neighborhoodCode": "query_scoped_not_per_parcel_sourced"
+  },
+  "overlayFindings": {
+    "riskOverlayJoin": "feature.properties.neighborhoodCode",
+    "riskOverlayJoinTrustworthy": false,
+    "riskLabels": "UI_ABSOLUTE_RISK_LABELS",
+    "riskOverlayProductionProofAllowed": false
+  },
+  "requiredProofToUpgrade": [
+    "TerraAtlas-owned Benton layer registry lineage",
+    "neighborhood geometry source and join key",
+    "segment geometry source and join key",
+    "reval area geometry source and join key",
+    "taxing district geometry source and join key",
+    "real outline layer source",
+    "per-parcel map attributes sourced from DB rows",
+    "GIS-anchored risk overlays and labels",
+    "countyId/taxYear/study context alignment"
+  ],
+  "forgeDevAllowedInDegradedGisMode": true,
+  "productionProofAllowed": false,
+  "operationalProofAllowed": false,
+  "boundaries": {
+    "uiChanged": false,
+    "gisAttributesInvented": false,
+    "syncMutated": false,
+    "dbSeedingChanged": false,
+    "productionProofWeakened": false,
+    "operationalProofWeakened": false
+  }
+}

--- a/os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.md
+++ b/os-platform/core/pilot/evidence/county-studio-terraatlas-gis-truth-correction.md
@@ -1,0 +1,73 @@
+# County Studio TerraAtlas GIS Truth Correction
+
+Generated: 2026-06-08T00:06:00.000Z
+
+Status: `PARTIAL_GIS_TRUTH`
+
+## Corrected Posture
+
+```text
+parcelGeometryStatus=SYNC_DERIVED_PARCEL_GEOMETRY
+fullGisLayerTruthStatus=GIS_LAYER_TRUTH_NOT_PROVEN
+mapOverlayStatus=FALLBACK_MAP_OVERLAY
+attributeOverlayStatus=UNPROVEN_ATTRIBUTE_OVERLAY
+riskOverlayAnchoring=NOT_GIS_ANCHORED
+productionProofAllowed=false
+operationalProofAllowed=false
+```
+
+County Studio can read real TerraAtlas parcel geometry for Forge dev. That does not prove full TerraAtlas GIS layer truth.
+
+## Proven
+
+- `gis_tf.tf_parcel_geom` is readable.
+- active parcel geometry count is 80,075.
+- 79,105 active parcel geometries are crosswalked to `TfParcelId`.
+- County Studio uses `GET /api/atlas-live/geometry/parcels`.
+- The endpoint reads `gis_tf.tf_parcel_geom`.
+
+## Not Proven
+
+- full Atlas layer registry truth
+- neighborhood layer geometry
+- segment layer geometry
+- reval area geometry
+- taxing district geometry
+- real outline layer source
+- per-parcel valuation/GIS attributes in the map payload
+- GIS-anchored risk overlay labels
+- production GIS symbology or layer configuration
+
+## Attribute Findings
+
+`AtlasLiveGeometryController.cs` returns real parcel polygons but does not prove the map attributes:
+
+| Attribute | Current posture |
+| --- | --- |
+| `outlines` | null |
+| `assessedValue` | hardcoded/zero |
+| `propertyClass` | null |
+| `salePrice` | hardcoded/zero |
+| `ratio` | null |
+| `ratioDeviation` | null |
+| `nbhdMedianRatio` | null |
+| `neighborhoodCode` | query-scoped, not per-parcel sourced |
+
+## Overlay Findings
+
+- Risk overlay joins use `feature.properties.neighborhoodCode`, which is not trustworthy while `neighborhoodCode` is query-scoped.
+- Visible red risk labels are absolutely positioned UI labels, not GIS-anchored geometry labels.
+- Map overlays remain fallback or unproven for production GIS proof.
+
+## Required Proof To Upgrade
+
+To move beyond partial GIS truth, prove TerraAtlas-owned Benton neighborhoods, segments, reval areas, taxing districts, layer registry, outlines, per-parcel attributes, map overlays, and GIS-anchored risk labels by source table/view, join key, countyId, taxYear, and study context.
+
+## Boundaries
+
+- No UI changed.
+- No GIS attributes invented.
+- No Sync mutation.
+- No DB seed mutation.
+- Production proof remains blocked.
+- Operational proof remains blocked.


### PR DESCRIPTION
## Summary

Corrects County Studio GIS evidence so real parcel geometry is not represented as full TerraAtlas GIS layer truth.

Current corrected posture:

```text
parcelGeometryStatus=SYNC_DERIVED_PARCEL_GEOMETRY
geometryStatus=PARTIAL_GIS_TRUTH
fullGisLayerTruthStatus=GIS_LAYER_TRUTH_NOT_PROVEN
mapOverlayStatus=FALLBACK_MAP_OVERLAY
attributeOverlayStatus=UNPROVEN_ATTRIBUTE_OVERLAY
riskOverlayAnchoring=NOT_GIS_ANCHORED
productionProofAllowed=false
operationalProofAllowed=false
```

## What changed

- Splits parcel geometry readiness from full GIS layer proof in `county-studio-terraatlas-geometry-evidence`.
- Carries parcel-vs-full-GIS posture through Forge real-data wiring and R1 Forge-dev status.
- Adds `county-studio-terraatlas-gis-truth-correction` evidence artifacts.
- Updates the R1 Forge-dev handoff so it no longer says full TerraAtlas GIS is proven.
- Keeps Forge dev allowed in degraded GIS mode because parcel geometry is real, while production/operational proof remain blocked.

## Important boundary

This PR does not touch UI, Sync, DB seeding, TerraAtlas source data, or production/operational proof gates. It does not invent GIS attributes, neighborhoods, segments, taxing districts, outlines, or risk overlay anchoring.

## Verification

- `node --test os-platform/core/pilot/county-studio-terraatlas-geometry-evidence.test.mjs os-platform/core/pilot/county-studio-forge-real-data-wiring.test.mjs os-platform/core/pilot/county-studio-r1-forge-dev-status.test.mjs`
- `pnpm run proof:county-studio:terraatlas-geometry-evidence`
- `pnpm run proof:county-studio:forge-real-data-wiring`
- `pnpm run proof:county-studio:r1-forge-dev-status`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- pre-push gate passed: unit tests, security scan, performance benchmark, AI swarm monitor, government compliance lint, backend build