### PR TITLE
feat(canon): surface Canon runtime status in os-canon

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusContract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusContract.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * CanonRuntimeStatusPanel — drift-proof contract.
+ *
+ * The panel displays STATIC copy mirroring the Canon runtime's source of truth.
+ * Static copy that silently drifts from Canon law would undermine governance,
+ * so this contract fails the build if the panel's listed canon-owned paths or
+ * gates no longer match the runtime config/scripts on disk.
+ *
+ * Source of truth:
+ *   - canon-owned paths: owners canon-runtime + canon-gates in
+ *     os-platform/core/canon/engineering-write-lanes.json
+ *   - gates: the gate scripts in os-platform/core/gates/
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CANON_OWNED_PATHS, GATES } from '../../canon/CanonRuntimeStatusPanel';
+
+// repo root = six levels up from this test's dir
+// (ui-observability → __tests__ → src → os-shell → apps → frontend → ROOT)
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+describe('CanonRuntimeStatusPanel drift contract', () => {
+  it('listed canon-owned paths match the write-lane source of truth', () => {
+    const lanesPath = path.join(REPO_ROOT, 'os-platform/core/canon/engineering-write-lanes.json');
+    const { lanes } = JSON.parse(fs.readFileSync(lanesPath, 'utf8'));
+    const ownedFromSource = lanes
+      .filter((l: { owner: string }) => l.owner === 'canon-runtime' || l.owner === 'canon-gates')
+      .flatMap((l: { paths: string[] }) => l.paths)
+      .sort();
+    expect([...CANON_OWNED_PATHS].sort()).toEqual(ownedFromSource);
+  });
+
+  it('listed gates map to real gate scripts on disk', () => {
+    const gatesDir = path.join(REPO_ROOT, 'os-platform/core/gates');
+    const files = fs.readdirSync(gatesDir);
+    const scriptForGate: Record<string, string> = {
+      'write-lane': 'canon-write-lane-check.mjs',
+      'protected-paths': 'check-protected-paths.mjs',
+      'hardcoded-ports': 'check-hardcoded-ports.mjs',
+    };
+    for (const gate of GATES) {
+      expect(scriptForGate[gate], `panel lists unknown gate "${gate}"`).toBeDefined();
+      expect(files).toContain(scriptForGate[gate]);
+    }
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusPanel.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusPanel.test.tsx
@@ -49,4 +49,11 @@ describe('CanonRuntimeStatusPanel', () => {
     expect(container.querySelectorAll('button').length).toBe(0);
     expect(container.querySelectorAll('input, textarea, select').length).toBe(0);
   });
+
+  it('states honestly that it shows configured posture, not live CI state', () => {
+    render(<CanonRuntimeStatusPanel />);
+    const txt = screen.getByTestId('terracanon-runtime-status').textContent ?? '';
+    expect(txt).toMatch(/canon-gates/); // points to the real health source
+    expect(txt).toMatch(/not live|configured.*posture|posture.*not live/i);
+  });
 });

--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusPanel.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonRuntimeStatusPanel.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * CanonRuntimeStatusPanel — read-only Canon runtime status surface.
+ *
+ * Acceptance (operator spec):
+ *   1. os-canon can show Canon Runtime status.
+ *   2. Panel does NOT execute commands (no buttons / interactive controls).
+ *   3. Panel does NOT mutate config.
+ *   4. Panel accurately states: strict enforcement is scoped to canon-owned
+ *      paths; advisory mode still applies to everything else.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CanonRuntimeStatusPanel } from '../../canon/CanonRuntimeStatusPanel';
+
+describe('CanonRuntimeStatusPanel', () => {
+  it('renders the runtime status landmark', () => {
+    render(<CanonRuntimeStatusPanel />);
+    expect(screen.getByTestId('terracanon-runtime-status')).toBeInTheDocument();
+  });
+
+  it('states strict enforcement is scoped to canon-owned paths', () => {
+    render(<CanonRuntimeStatusPanel />);
+    const root = screen.getByTestId('terracanon-runtime-status');
+    expect(root.textContent).toMatch(/strict/i);
+    expect(root.textContent).toMatch(/canon-owned/i);
+    expect(root.textContent).toMatch(/os-platform\/core\/canon/);
+  });
+
+  it('states advisory mode still applies to everything else', () => {
+    render(<CanonRuntimeStatusPanel />);
+    const root = screen.getByTestId('terracanon-runtime-status');
+    expect(root.textContent).toMatch(/advisory/i);
+  });
+
+  it('lists the canon gates and tf canon CLI commands', () => {
+    render(<CanonRuntimeStatusPanel />);
+    const txt = screen.getByTestId('terracanon-runtime-status').textContent ?? '';
+    expect(txt).toMatch(/write-lane/);
+    expect(txt).toMatch(/protected-paths/);
+    expect(txt).toMatch(/hardcoded-ports/);
+    expect(txt).toMatch(/tf canon/);
+  });
+
+  it('is read-only: renders no buttons or interactive controls', () => {
+    const { container } = render(<CanonRuntimeStatusPanel />);
+    expect(container.querySelectorAll('button').length).toBe(0);
+    expect(container.querySelectorAll('input, textarea, select').length).toBe(0);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/CanonRuntimeStatusPanel.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonRuntimeStatusPanel.tsx
@@ -22,11 +22,15 @@ import React from 'react';
 /** Canon runtime modules present on main (os-platform/core/canon). */
 const RUNTIME_MODULES = ['query', 'risk', 'loader', 'evidence', 'trace-seal', 'task'] as const;
 
-/** Paths under strict (blocking) enforcement — mirrors CANON_OWNED_PATTERNS. */
-const CANON_OWNED_PATHS = ['os-platform/core/canon/**', 'os-platform/core/gates/**'] as const;
+/**
+ * Paths under strict (blocking) enforcement — mirrors CANON_OWNED_PATTERNS and
+ * the canon-runtime + canon-gates write-lane owners. Exported so a drift
+ * contract test can assert this list stays in sync with the runtime source.
+ */
+export const CANON_OWNED_PATHS = ['os-platform/core/canon/**', 'os-platform/core/gates/**'] as const;
 
-/** Advisory gates (os-platform/core/gates). */
-const GATES = ['write-lane', 'protected-paths', 'hardcoded-ports'] as const;
+/** Advisory gates (os-platform/core/gates). Exported for the drift contract test. */
+export const GATES = ['write-lane', 'protected-paths', 'hardcoded-ports'] as const;
 
 /** Headless CLI commands (tf-canon.mjs). */
 const CLI_COMMANDS = ['query', 'risk', 'rules', 'gates'] as const;
@@ -91,6 +95,12 @@ export function CanonRuntimeStatusPanel(): React.ReactElement {
 
       <Row label='CLI'>
         <span className={codeClass}>{CLI_COMMANDS.map((c) => `tf canon ${c}`).join('  ·  ')}</span>
+      </Row>
+
+      <Row label='Health'>
+        Configured enforcement posture (not live CI). Live gate status comes from the{' '}
+        <span className={codeClass}>canon-gates</span> workflow and{' '}
+        <span className={codeClass}>tf canon gates</span>.
       </Row>
 
       <p className='text-xs italic tf-text-dim'>

--- a/frontend/apps/os-shell/src/canon/CanonRuntimeStatusPanel.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonRuntimeStatusPanel.tsx
@@ -1,0 +1,103 @@
+/**
+ * Canon Runtime Status Panel (os-canon)
+ *
+ * Read-only surface that lets os-canon EXPLAIN the Canon runtime: what exists,
+ * how enforcement is scoped, which gates and CLI commands are available. It
+ * runs nothing and mutates nothing — pure display.
+ *
+ * Source of truth (kept in sync by the runtime's own tests on main):
+ *   - os-platform/core/canon/engineering-write-lanes.json  (owners)
+ *   - os-platform/core/canon/gate-registry.json            (gates)
+ *   - os-platform/core/gates/canon-gates.mjs               (CANON_OWNED_PATTERNS)
+ *   - os-platform/core/canon/tf-canon.mjs                  (CLI commands)
+ *
+ * This panel deliberately shows STABLE governance facts only. It does not claim
+ * a live test count or any value it cannot verify at render time.
+ *
+ * @module canon/CanonRuntimeStatusPanel
+ */
+
+import React from 'react';
+
+/** Canon runtime modules present on main (os-platform/core/canon). */
+const RUNTIME_MODULES = ['query', 'risk', 'loader', 'evidence', 'trace-seal', 'task'] as const;
+
+/** Paths under strict (blocking) enforcement — mirrors CANON_OWNED_PATTERNS. */
+const CANON_OWNED_PATHS = ['os-platform/core/canon/**', 'os-platform/core/gates/**'] as const;
+
+/** Advisory gates (os-platform/core/gates). */
+const GATES = ['write-lane', 'protected-paths', 'hardcoded-ports'] as const;
+
+/** Headless CLI commands (tf-canon.mjs). */
+const CLI_COMMANDS = ['query', 'risk', 'rules', 'gates'] as const;
+
+const labelClass = 'text-xs font-semibold uppercase tracking-wider text-terra-cyan';
+const mutedClass = 'text-xs tf-text-tertiary';
+const codeClass = 'font-mono text-xs tf-text-secondary';
+
+function Row({ label, children }: { label: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <div className='flex flex-col gap-1'>
+      <span className={labelClass}>{label}</span>
+      <div className={mutedClass}>{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Read-only Canon runtime status. No props, no side effects, no controls.
+ */
+export function CanonRuntimeStatusPanel(): React.ReactElement {
+  return (
+    <section
+      className='canon-runtime-status liquid-panel--infrastructure flex flex-col gap-3 p-3'
+      style={{ background: 'hsl(var(--tf-surface))' }}
+      data-testid='terracanon-runtime-status'
+      aria-label='Canon runtime status'
+    >
+      <header className='flex items-baseline justify-between'>
+        <h3 className={labelClass}>Canon Runtime</h3>
+        <span className={mutedClass}>read-only</span>
+      </header>
+
+      <Row label='Runtime'>
+        Active · modules:{' '}
+        <span className={codeClass}>{RUNTIME_MODULES.join(' · ')}</span>
+      </Row>
+
+      <Row label='Enforcement'>
+        <div className='flex flex-col gap-1'>
+          <div>
+            <span className='text-amber-300'>Strict (blocking)</span> — scoped to{' '}
+            <span className='tf-text-secondary'>canon-owned</span> paths:
+            <div className='mt-0.5 flex flex-col'>
+              {CANON_OWNED_PATHS.map((p) => (
+                <span key={p} className={codeClass}>
+                  {p}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div>
+            <span className='text-terra-cyan'>Advisory (non-blocking)</span> — all other paths
+            (reported, never blocked).
+          </div>
+        </div>
+      </Row>
+
+      <Row label='Gates'>
+        <span className={codeClass}>{GATES.join(' · ')}</span>
+      </Row>
+
+      <Row label='CLI'>
+        <span className={codeClass}>{CLI_COMMANDS.map((c) => `tf canon ${c}`).join('  ·  ')}</span>
+      </Row>
+
+      <p className='text-xs italic tf-text-dim'>
+        Read-only view. This panel runs nothing and changes no configuration.
+      </p>
+    </section>
+  );
+}
+
+export default CanonRuntimeStatusPanel;

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -86,6 +86,7 @@ import CanonQuickOpen from '../canon/CanonQuickOpen';
 import CanonGoToSymbol from '../canon/CanonGoToSymbol';
 import { CanonSearchPanel } from '../canon/CanonSearchPanel';
 import { CanonStatusBar } from '../canon/CanonStatusBar';
+import { CanonRuntimeStatusPanel } from '../canon/CanonRuntimeStatusPanel';
 import CanonTerminal from '../canon/CanonTerminal';
 import { GoToLineDialog } from '../canon/GoToLineDialog';
 import { useCanonConnection } from '../canon/useCanonConnection';
@@ -688,7 +689,7 @@ function CanonContent(): React.ReactElement {
   });
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [sidebarTab, setSidebarTab] = useState<'explorer' | 'search' | 'outline' | 'bookmarks' | 'snippets' | 'settings'>('explorer');
-  const [bottomTab, setBottomTab] = useState<'gates' | 'terminal' | 'problems'>('gates');
+  const [bottomTab, setBottomTab] = useState<'gates' | 'terminal' | 'problems' | 'runtime'>('gates');
   const [cursorPos, setCursorPos] = useState<CursorPosition | null>(null);
   const [goToLineOpen, setGoToLineOpen] = useState(false);
   const [newFileOpen, setNewFileOpen] = useState(false);
@@ -2124,8 +2125,15 @@ function CanonContent(): React.ReactElement {
               >
                 Problems
               </button>
+              <button
+                className={`canon-ide__bottom-tab ${bottomTab === 'runtime' ? 'canon-ide__bottom-tab--active' : ''}`}
+                onClick={() => setBottomTab('runtime')}
+              >
+                Runtime
+              </button>
             </div>
             {bottomTab === 'gates' && <GateRunnerPanel ref={gateRunnerRef} />}
+            {bottomTab === 'runtime' && <CanonRuntimeStatusPanel />}
             {bottomTab === 'terminal' && <CanonTerminal />}
             {bottomTab === 'problems' && (
               <CanonProblemsPanel


### PR DESCRIPTION
## Summary

Read-only **Canon Runtime status panel** in os-canon — the 'visibility' step (runtime → proof → enforcement → **visibility**). os-canon can now *explain* the runtime. Added as a new **'Runtime' bottom-panel tab** (additive — no existing testid/contract removed).

## What it shows (stable, verifiable facts only)

- Runtime modules present: query · risk · loader · evidence · trace-seal · task
- **Enforcement:** Strict (blocking) scoped to **canon-owned** paths (`os-platform/core/canon/**`, `os-platform/core/gates/**`); **Advisory (non-blocking)** for all other paths
- Gates: write-lane · protected-paths · hardcoded-ports
- CLI: `tf canon query/risk/rules/gates`
- Footnote: "Read-only view. This panel runs nothing and changes no configuration."

## Acceptance (all met)

1. os-canon shows Canon Runtime status ✅
2. Panel does NOT execute commands — **no buttons** (test-asserted) ✅
3. Panel does NOT mutate config — pure display ✅
4. Accurately states strict=canon-owned / advisory=everything-else ✅
5. Existing shell/launch + bento contracts stay green ✅
6. Canon tests stay green ✅

## What changed (3 files)

- `canon/CanonRuntimeStatusPanel.tsx` — read-only component (token-clean: `tf-text-*`/`terra-cyan`, **0 new TDC violations**)
- `__tests__/ui-observability/CanonRuntimeStatusPanel.test.tsx` — +5 tests
- `pages/CanonHome.tsx` — wire as 4th bottom tab (additive: import + tab-state union + button + render)

## Verification

- Panel 5/5; **CanonBentoCompliance 8/8** (unchanged); frontend `type-check` clean; pre-commit UI token ratchet **1556 ≤ 1580**
- 2 pre-existing Monaco-in-jsdom editor-test failures (InMemoryEditing / WorkspaceMVP) **proven unrelated** via a clean-main stash run

## Scope discipline

Only surfaces runtime status. No full Canon IDE UI, no agents, no execution, no editing. (`visibility fourth, agents last`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Runtime tab in Canon Home that shows active runtime modules, enforcement scope (strict vs advisory), available gates, and related CLI commands in a read-only panel.
* **Tests**
  * Added UI tests verifying the panel’s content and read-only behavior.
  * Added contract tests to keep listed owned paths and gates in sync with source-of-truth artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->