### PR TITLE
feat(os-canon): add Canon Task Console shell (read-only)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
@@ -163,16 +163,26 @@ describe('Bottom panel tabs – WAI-ARIA tabs pattern', () => {
     localStorage.clear();
   });
 
-  it('exposes a labelled tablist wrapping all four role=tab buttons', () => {
+  it('exposes a labelled tablist wrapping all five role=tab buttons', () => {
     render(<CanonHome />);
     const tablist = screen.getByRole('tablist', { name: /bottom panel/i });
     const tabs = within(tablist).getAllByRole('tab');
-    // Gates / Terminal / Problems / Runtime (Runtime added in #924)
-    expect(tabs).toHaveLength(4);
+    // Gates / Terminal / Problems / Runtime (#924) / Console (#928)
+    expect(tabs).toHaveLength(5);
     expect(within(tablist).getByRole('tab', { name: 'Gates' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Terminal' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Problems' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Runtime' })).toBeInTheDocument();
+    expect(within(tablist).getByRole('tab', { name: 'Console' })).toBeInTheDocument();
+  });
+
+  it('applies the ARIA tab attributes to the Console tab too', () => {
+    render(<CanonHome />);
+    const consoleTab = screen.getByRole('tab', { name: 'Console' });
+    expect(consoleTab).toHaveAttribute('aria-selected', 'false');
+    expect(consoleTab).toHaveAttribute('aria-controls');
+    expect(consoleTab).toHaveAttribute('tabindex', '-1');
+    expect(consoleTab.id).toBeTruthy();
   });
 
   it('applies the ARIA tab attributes to the Runtime tab too', () => {

--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonTaskConsole.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonTaskConsole.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * CanonTaskConsole — read-only Canon task authoring shell (os-canon).
+ *
+ * First slice: a read-only surface that names the governed task lifecycle and
+ * the fields a Canon task carries, and is HONEST that in-shell authoring/
+ * execution is not enabled yet — the tf canon CLI + gates are the current rail.
+ * No fake placeholder values, no execution, no agents, no commands.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CanonTaskConsole } from '../../canon/CanonTaskConsole';
+
+describe('CanonTaskConsole', () => {
+  it('renders the task console landmark', () => {
+    render(<CanonTaskConsole />);
+    expect(screen.getByTestId('terracanon-task-console')).toBeInTheDocument();
+  });
+
+  it('is honest that in-shell execution is not enabled and points to tf canon', () => {
+    render(<CanonTaskConsole />);
+    const txt = screen.getByTestId('terracanon-task-console').textContent ?? '';
+    expect(txt).toMatch(/not enabled/i);
+    expect(txt).toMatch(/tf canon/);
+  });
+
+  it('shows the governed task lifecycle (real doctrine states)', () => {
+    render(<CanonTaskConsole />);
+    const txt = screen.getByTestId('terracanon-task-console').textContent ?? '';
+    expect(txt).toMatch(/Draft/);
+    expect(txt).toMatch(/TraceSealed/);
+    expect(txt).toMatch(/Closed/);
+  });
+
+  it('names the task fields without inventing values', () => {
+    render(<CanonTaskConsole />);
+    const txt = screen.getByTestId('terracanon-task-console').textContent ?? '';
+    expect(txt).toMatch(/intent/i);
+    expect(txt).toMatch(/scope/i);
+    expect(txt).toMatch(/gates/i);
+    expect(txt).toMatch(/risk/i);
+    expect(txt).toMatch(/evidence/i);
+  });
+
+  it('is read-only: no execution buttons or inputs', () => {
+    const { container } = render(<CanonTaskConsole />);
+    expect(container.querySelectorAll('button').length).toBe(0);
+    expect(container.querySelectorAll('input, textarea, select').length).toBe(0);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/CanonTaskConsole.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonTaskConsole.tsx
@@ -1,0 +1,107 @@
+/**
+ * Canon Task Console (os-canon) — read-only authoring shell.
+ *
+ * First slice of the in-shell Canon task surface. It names the governed task
+ * lifecycle and the fields a Canon task carries, and is HONEST that in-shell
+ * authoring/execution is NOT enabled yet — the `tf canon` CLI + gates are the
+ * current rail. No fake placeholder values, no execution, no agents, no
+ * commands, no inputs.
+ *
+ * Source of truth (kept honest):
+ *   - lifecycle states: os-platform/core/canon/canon-task.mjs (STATES)
+ *   - fields: os-platform/core/canon/canon-task.schema.json
+ *
+ * @module canon/CanonTaskConsole
+ */
+
+import React from 'react';
+
+/** Governed task lifecycle (ADR-005) — mirrors canon-task.mjs STATES. */
+const LIFECYCLE = [
+  'Draft',
+  'CanonContextLoaded',
+  'ScopeProposed',
+  'PlanProposed',
+  'RiskScored',
+  'AwaitingApproval',
+  'WorktreeCreated',
+  'Executing',
+  'DiffReady',
+  'GatesRunning',
+  'ReviewRequired',
+  'CommitReady',
+  'TraceSealed',
+  'PRReady',
+  'Closed',
+] as const;
+
+/** Fields a Canon task carries (canon-task.schema.json). Honest descriptions —
+ *  no invented values; each says where it is computed today. */
+const FIELDS: ReadonlyArray<{ label: string; note: string }> = [
+  { label: 'Intent', note: 'what the task should accomplish — authored via tf canon' },
+  { label: 'Surface', note: 'os-canon · canon-desktop · cli · ci' },
+  { label: 'Scope', note: 'allowed / forbidden paths — resolved by tf canon query' },
+  { label: 'Required gates', note: 'computed by tf canon gates (not surfaced in-shell yet)' },
+  { label: 'Risk', note: 'computed by tf canon risk (not surfaced in-shell yet)' },
+  { label: 'Evidence', note: 'sealed bundle from the trace layer (not surfaced in-shell yet)' },
+];
+
+const labelClass = 'text-xs font-semibold uppercase tracking-wider text-terra-cyan';
+const mutedClass = 'text-xs tf-text-tertiary';
+const codeClass = 'font-mono text-xs tf-text-secondary';
+
+/**
+ * Read-only Canon Task Console. No props, no side effects, no controls.
+ */
+export function CanonTaskConsole(): React.ReactElement {
+  return (
+    <section
+      className='canon-task-console liquid-panel--infrastructure flex flex-col gap-3 p-3'
+      style={{ background: 'hsl(var(--tf-surface))' }}
+      data-testid='terracanon-task-console'
+      aria-label='Canon task console'
+    >
+      <header className='flex items-baseline justify-between'>
+        <h3 className={labelClass}>Canon Task Console</h3>
+        <span className={mutedClass}>read-only</span>
+      </header>
+
+      <p className={mutedClass}>
+        Governed Canon tasks are authored and run through the{' '}
+        <span className={codeClass}>tf canon</span> CLI and gates. In-shell authoring and execution
+        are <span className='text-amber-300'>not enabled</span> here yet — this panel is a read-only
+        view of the task contract.
+      </p>
+
+      <div className='flex flex-col gap-1'>
+        <span className={labelClass}>Task lifecycle</span>
+        <span className={codeClass}>{LIFECYCLE.join(' → ')}</span>
+        <span className={mutedClass}>
+          plus terminal <span className={codeClass}>Failed</span>. Guards: approval before
+          WorktreeCreated; gates pass before ReviewRequired.
+        </span>
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        <span className={labelClass}>Task fields</span>
+        {FIELDS.map((f) => (
+          <div key={f.label} className='flex flex-col'>
+            <span className='text-xs tf-text-secondary'>{f.label}</span>
+            <span className={mutedClass}>{f.note}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <span className={labelClass}>Current rail</span>
+        <span className={codeClass}>tf canon query · risk · rules · gates</span>
+      </div>
+
+      <p className='text-xs italic tf-text-dim'>
+        Read-only view. No tasks are created, no agents run, and no commands execute from this panel.
+      </p>
+    </section>
+  );
+}
+
+export default CanonTaskConsole;

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -87,6 +87,7 @@ import CanonGoToSymbol from '../canon/CanonGoToSymbol';
 import { CanonSearchPanel } from '../canon/CanonSearchPanel';
 import { CanonStatusBar } from '../canon/CanonStatusBar';
 import { CanonRuntimeStatusPanel } from '../canon/CanonRuntimeStatusPanel';
+import { CanonTaskConsole } from '../canon/CanonTaskConsole';
 import CanonTerminal from '../canon/CanonTerminal';
 import { GoToLineDialog } from '../canon/GoToLineDialog';
 import { useCanonConnection } from '../canon/useCanonConnection';
@@ -636,13 +637,14 @@ function loadLastClosed(): Workspace | null {
 let workspaceCounter = 0;
 
 // ─── Bottom panel tabs (WAI-ARIA tabs pattern) ───────────────────────────────
-type BottomTabKey = 'gates' | 'terminal' | 'problems' | 'runtime';
+type BottomTabKey = 'gates' | 'terminal' | 'problems' | 'runtime' | 'console';
 
 const BOTTOM_TABS: ReadonlyArray<{ key: BottomTabKey; label: string }> = [
   { key: 'gates', label: 'Gates' },
   { key: 'terminal', label: 'Terminal' },
   { key: 'problems', label: 'Problems' },
   { key: 'runtime', label: 'Runtime' },
+  { key: 'console', label: 'Console' },
 ];
 
 const bottomTabId = (key: BottomTabKey): string => `canon-bottom-tab-${key}`;
@@ -2187,6 +2189,15 @@ function CanonContent(): React.ReactElement {
                 aria-labelledby={bottomTabId('terminal')}
               >
                 <CanonTerminal />
+              </div>
+            )}
+            {bottomTab === 'console' && (
+              <div
+                role='tabpanel'
+                id={bottomPanelId('console')}
+                aria-labelledby={bottomTabId('console')}
+              >
+                <CanonTaskConsole />
               </div>
             )}
             {bottomTab === 'problems' && (


### PR DESCRIPTION
## Summary

First in-shell **Canon Task Console** — a read-only os-canon surface (new 'Console' bottom tab) that names the governed task lifecycle and the fields a Canon task carries, and is **honest** that in-shell authoring/execution is **not enabled yet** (the `tf canon` CLI + gates are the current rail). No fake placeholder values, no execution, no agents, no commands, no inputs/buttons.

## What it shows (real doctrine, no invented values)
- **Task lifecycle**: Draft → … → TraceSealed → PRReady → Closed (+ Failed) — mirrors `canon-task.mjs` STATES; notes the guards.
- **Task fields**: Intent · Surface · Scope · Required gates · Risk · Evidence — each labeled with where it's computed today (`tf canon`), explicitly *not surfaced in-shell yet* (honest, not fake).
- **Current rail**: `tf canon query · risk · rules · gates`.
- Footer: read-only; no tasks created, no agents run, no commands execute.

## Acceptance (met)
1. os-canon displays the Canon Task Console ✅ (Console bottom tab)
2. read-only / non-executing ✅ (test: 0 buttons, 0 inputs)
3. no agents / no commands ✅
4. makes clear execution is not enabled yet ✅
5. points to tf canon CLI / gates ✅

## Files (3, additive)
- `canon/CanonTaskConsole.tsx` — read-only component (token-clean `tf-text-*`/`terra-cyan`)
- `__tests__/ui-observability/CanonTaskConsole.test.tsx` — +5 tests
- `pages/CanonHome.tsx` — wire as additive 'Console' bottom tab

## Verification
- console 5/5, bento compliance 8/8, status-panel 6/6 (**19/19**); frontend `type-check` clean; pre-commit ratchet OK.

## Note
Touches the bottom-tab region also refactored by **#926** (ARIA) — a minor rebase is expected when #926 lands (same additive-tab interaction as #924).

## Scope
os-canon only. No Workbench, Home, Forge, parcels, backend, or Canon-runtime changes.