### PR TITLE
feat(os-canon): read-only Canon Evidence Bundle viewer (6th ARIA bottom tab)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
@@ -163,17 +163,27 @@ describe('Bottom panel tabs – WAI-ARIA tabs pattern', () => {
     localStorage.clear();
   });
 
-  it('exposes a labelled tablist wrapping all five role=tab buttons', () => {
+  it('exposes a labelled tablist wrapping all six role=tab buttons', () => {
     render(<CanonHome />);
     const tablist = screen.getByRole('tablist', { name: /bottom panel/i });
     const tabs = within(tablist).getAllByRole('tab');
-    // Gates / Terminal / Problems / Runtime (#924) / Console (#928)
-    expect(tabs).toHaveLength(5);
+    // Gates / Terminal / Problems / Runtime (#924) / Console (#928) / Evidence
+    expect(tabs).toHaveLength(6);
     expect(within(tablist).getByRole('tab', { name: 'Gates' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Terminal' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Problems' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Runtime' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Console' })).toBeInTheDocument();
+    expect(within(tablist).getByRole('tab', { name: 'Evidence' })).toBeInTheDocument();
+  });
+
+  it('applies the ARIA tab attributes to the Evidence tab too', () => {
+    render(<CanonHome />);
+    const evidenceTab = screen.getByRole('tab', { name: 'Evidence' });
+    expect(evidenceTab).toHaveAttribute('aria-selected', 'false');
+    expect(evidenceTab).toHaveAttribute('aria-controls');
+    expect(evidenceTab).toHaveAttribute('tabindex', '-1');
+    expect(evidenceTab.id).toBeTruthy();
   });
 
   it('applies the ARIA tab attributes to the Console tab too', () => {

--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonEvidenceViewer.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonEvidenceViewer.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * CanonEvidenceViewer — read-only Canon evidence bundle viewer (os-canon).
+ *
+ * A read-only surface that renders a Canon evidence bundle (the proof artifact
+ * for a completed task) and is HONEST about provenance:
+ *   - With no bundle it shows an empty state and names the bundle contract;
+ *     bundles are produced by the `tf canon` CLI + trace layer, not in-shell.
+ *   - With a bundle it renders the real fields (task header, gate results,
+ *     read/changed sets, diff hash, risk score) read-only.
+ *   - The cryptographic seal is shown AS REPORTED by the bundle; verification
+ *     is the trace layer's job, not re-computed in the browser.
+ *
+ * Fields mirror os-platform/core/canon/canon-evidence.mjs (EvidenceBundle) and
+ * the seal fields from canon-trace-seal.mjs. No invented values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import { CanonEvidenceViewer } from '../../canon/CanonEvidenceViewer';
+
+const SEALED_BUNDLE = {
+  taskId: 'TF-CANON-EVID-1',
+  intent: 'Add read-only evidence viewer',
+  surface: 'os-canon',
+  canonRulesLoaded: ['engineering-write-lanes', 'gate-registry'],
+  filesRead: ['os-platform/core/canon/canon-evidence.mjs'],
+  filesChanged: ['frontend/apps/os-shell/src/canon/CanonEvidenceViewer.tsx'],
+  gateResults: [
+    { gateId: 'canon-write-lane', status: 'pass' as const },
+    { gateId: 'ui-token-ratchet', status: 'warning' as const, summary: 'no new violations' },
+  ],
+  diffHash: 'sha256-abc123',
+  riskScore: 2,
+  sealed: true,
+  traceHash: 'sha256-deadbeef',
+  sealedAt: '2026-06-08T19:00:00Z',
+};
+
+describe('CanonEvidenceViewer', () => {
+  it('renders the evidence viewer landmark', () => {
+    render(<CanonEvidenceViewer />);
+    expect(screen.getByTestId('terracanon-evidence-viewer')).toBeInTheDocument();
+  });
+
+  it('shows an honest empty state pointing to tf canon when no bundle is loaded', () => {
+    render(<CanonEvidenceViewer />);
+    const txt = screen.getByTestId('terracanon-evidence-viewer').textContent ?? '';
+    expect(txt).toMatch(/no evidence bundle/i);
+    expect(txt).toMatch(/tf canon/);
+  });
+
+  it('names the bundle contract in the empty state without inventing values', () => {
+    render(<CanonEvidenceViewer />);
+    const txt = screen.getByTestId('terracanon-evidence-viewer').textContent ?? '';
+    expect(txt).toMatch(/gate/i);
+    expect(txt).toMatch(/seal/i);
+    expect(txt).toMatch(/diff/i);
+    expect(txt).toMatch(/risk/i);
+  });
+
+  it('renders the task header from a provided bundle', () => {
+    render(<CanonEvidenceViewer bundle={SEALED_BUNDLE} />);
+    const txt = screen.getByTestId('terracanon-evidence-viewer').textContent ?? '';
+    expect(txt).toMatch(/TF-CANON-EVID-1/);
+    expect(txt).toMatch(/Add read-only evidence viewer/);
+    expect(txt).toMatch(/os-canon/);
+  });
+
+  it('renders each gate result with its status', () => {
+    render(<CanonEvidenceViewer bundle={SEALED_BUNDLE} />);
+    const gates = screen.getByTestId('terracanon-evidence-gates');
+    expect(within(gates).getByText('canon-write-lane')).toBeInTheDocument();
+    expect(within(gates).getByText('ui-token-ratchet')).toBeInTheDocument();
+    expect(within(gates).getByText(/pass/i)).toBeInTheDocument();
+    expect(within(gates).getByText(/warning/i)).toBeInTheDocument();
+  });
+
+  it('shows the seal as reported (sealed + trace hash) without claiming in-browser verification', () => {
+    render(<CanonEvidenceViewer bundle={SEALED_BUNDLE} />);
+    const seal = screen.getByTestId('terracanon-evidence-seal');
+    const txt = seal.textContent ?? '';
+    expect(txt).toMatch(/sealed/i);
+    expect(txt).toMatch(/sha256-deadbeef/);
+    // Honest: the seal is reported by the trace layer, not re-verified here.
+    expect(txt).toMatch(/as reported|trace layer/i);
+    expect(txt).not.toMatch(/verified in browser|cryptographically verified here/i);
+  });
+
+  it('marks an unsealed bundle honestly', () => {
+    const { sealed, traceHash, sealedAt, ...rest } = SEALED_BUNDLE;
+    render(<CanonEvidenceViewer bundle={{ ...rest, sealed: false }} />);
+    const seal = screen.getByTestId('terracanon-evidence-seal');
+    expect(seal.textContent ?? '').toMatch(/not sealed|unsealed/i);
+  });
+
+  it('is read-only: no buttons or inputs', () => {
+    const { container } = render(<CanonEvidenceViewer bundle={SEALED_BUNDLE} />);
+    expect(container.querySelectorAll('button').length).toBe(0);
+    expect(container.querySelectorAll('input, textarea, select').length).toBe(0);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/CanonEvidenceViewer.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonEvidenceViewer.tsx
@@ -1,0 +1,189 @@
+/**
+ * Canon Evidence Bundle Viewer (os-canon) — read-only proof viewer.
+ *
+ * Renders a Canon evidence bundle: the proof artifact for a completed task
+ * (rules loaded, files read/changed, gate results, diff hash, risk score, seal).
+ * HONEST about provenance:
+ *   - With no bundle, shows an empty state and names the bundle contract.
+ *     Bundles are produced by the `tf canon` CLI + the trace layer, not in-shell.
+ *   - With a bundle, renders the real fields read-only.
+ *   - The cryptographic seal is shown AS REPORTED by the bundle; verification is
+ *     the trace layer's job (canon-trace-seal.mjs), not re-computed in-browser.
+ *
+ * Field shape mirrors os-platform/core/canon/canon-evidence.mjs (EvidenceBundle)
+ * and the seal fields from canon-trace-seal.mjs. No invented values.
+ *
+ * @module canon/CanonEvidenceViewer
+ */
+
+import React from 'react';
+
+/** Gate status — mirrors GATE_STATUSES in canon-evidence.mjs. */
+export type EvidenceGateStatus = 'pass' | 'fail' | 'warning' | 'skipped';
+
+/** One gate result inside a bundle. */
+export interface EvidenceGateResult {
+  gateId: string;
+  status: EvidenceGateStatus;
+  summary?: string;
+}
+
+/** Read-only view of a Canon evidence bundle (subset rendered here). */
+export interface EvidenceBundleView {
+  taskId: string;
+  intent: string;
+  surface: string;
+  canonRulesLoaded?: readonly string[];
+  filesRead?: readonly string[];
+  filesChanged?: readonly string[];
+  gateResults?: readonly EvidenceGateResult[];
+  diffHash?: string;
+  riskScore?: number;
+  sealed?: boolean;
+  traceHash?: string;
+  sealedAt?: string;
+}
+
+const labelClass = 'text-xs font-semibold uppercase tracking-wider text-terra-cyan';
+const mutedClass = 'text-xs tf-text-tertiary';
+const codeClass = 'font-mono text-xs tf-text-secondary';
+
+const STATUS_CLASS: Record<EvidenceGateStatus, string> = {
+  pass: 'text-emerald-300',
+  fail: 'text-rose-300',
+  warning: 'text-amber-300',
+  skipped: 'tf-text-dim',
+};
+
+function EmptyState(): React.ReactElement {
+  return (
+    <div className='flex flex-col gap-2'>
+      <p className={mutedClass}>
+        No evidence bundle loaded. Bundles are the proof artifact for a completed Canon task and are
+        produced by the <span className={codeClass}>tf canon</span> CLI and sealed by the trace
+        layer. In-shell authoring/execution is not enabled here yet.
+      </p>
+      <div className='flex flex-col gap-1'>
+        <span className={labelClass}>A bundle carries</span>
+        <span className={mutedClass}>
+          canon rules loaded · files read / changed · gate results · diff hash · risk score · trace
+          seal
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function FileList({
+  title,
+  items,
+}: {
+  title: string;
+  items: readonly string[];
+}): React.ReactElement {
+  return (
+    <div className='flex flex-col gap-1'>
+      <span className={labelClass}>
+        {title} ({items.length})
+      </span>
+      {items.length === 0 ? (
+        <span className={mutedClass}>none</span>
+      ) : (
+        items.map((f) => (
+          <span key={f} className={codeClass}>
+            {f}
+          </span>
+        ))
+      )}
+    </div>
+  );
+}
+
+/**
+ * Read-only Canon evidence bundle viewer. No side effects, no controls.
+ */
+export function CanonEvidenceViewer({
+  bundle,
+}: {
+  bundle?: EvidenceBundleView;
+}): React.ReactElement {
+  return (
+    <section
+      className='canon-evidence-viewer liquid-panel--infrastructure flex flex-col gap-3 p-3'
+      style={{ background: 'hsl(var(--tf-surface))' }}
+      data-testid='terracanon-evidence-viewer'
+      aria-label='Canon evidence bundle viewer'
+    >
+      <header className='flex items-baseline justify-between'>
+        <h3 className={labelClass}>Canon Evidence Bundle</h3>
+        <span className={mutedClass}>read-only</span>
+      </header>
+
+      {!bundle ? (
+        <EmptyState />
+      ) : (
+        <>
+          <div className='flex flex-col gap-1'>
+            <span className={codeClass}>{bundle.taskId}</span>
+            <span className='text-xs tf-text-secondary'>{bundle.intent}</span>
+            <span className={mutedClass}>
+              surface <span className={codeClass}>{bundle.surface}</span>
+            </span>
+          </div>
+
+          <div className='flex flex-col gap-1' data-testid='terracanon-evidence-gates'>
+            <span className={labelClass}>Gate results</span>
+            {(bundle.gateResults ?? []).length === 0 ? (
+              <span className={mutedClass}>no gates recorded</span>
+            ) : (
+              (bundle.gateResults ?? []).map((g) => (
+                <div key={g.gateId} className='flex items-baseline gap-2'>
+                  <span className={`text-xs font-semibold ${STATUS_CLASS[g.status]}`}>
+                    {g.status}
+                  </span>
+                  <span className={codeClass}>{g.gateId}</span>
+                  {g.summary ? <span className={mutedClass}>{g.summary}</span> : null}
+                </div>
+              ))
+            )}
+          </div>
+
+          <FileList title='Files read' items={bundle.filesRead ?? []} />
+          <FileList title='Files changed' items={bundle.filesChanged ?? []} />
+
+          <div className='flex flex-col gap-1'>
+            <span className={labelClass}>Diff &amp; risk</span>
+            <span className={mutedClass}>
+              diff <span className={codeClass}>{bundle.diffHash ?? 'n/a'}</span> · risk{' '}
+              <span className={codeClass}>{bundle.riskScore ?? 'n/a'}</span>
+            </span>
+          </div>
+
+          <div className='flex flex-col gap-1' data-testid='terracanon-evidence-seal'>
+            <span className={labelClass}>Trace seal</span>
+            <span
+              className={`text-xs font-semibold ${bundle.sealed ? 'text-emerald-300' : 'text-amber-300'}`}
+            >
+              {bundle.sealed ? 'Sealed' : 'Not sealed'}
+            </span>
+            {bundle.sealed ? (
+              <span className={codeClass}>{bundle.traceHash ?? '(no trace hash)'}</span>
+            ) : null}
+            {bundle.sealed && bundle.sealedAt ? (
+              <span className={mutedClass}>at {bundle.sealedAt}</span>
+            ) : null}
+            <span className='text-xs italic tf-text-dim'>
+              Seal status as reported by the trace layer (canon-trace-seal). Not re-computed here.
+            </span>
+          </div>
+        </>
+      )}
+
+      <p className='text-xs italic tf-text-dim'>
+        Read-only view. No bundles are created, sealed, or modified from this panel.
+      </p>
+    </section>
+  );
+}
+
+export default CanonEvidenceViewer;

--- a/frontend/apps/os-shell/src/canon/CanonEvidenceViewer.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonEvidenceViewer.tsx
@@ -48,9 +48,12 @@ const labelClass = 'text-xs font-semibold uppercase tracking-wider text-terra-cy
 const mutedClass = 'text-xs tf-text-tertiary';
 const codeClass = 'font-mono text-xs tf-text-secondary';
 
+// Status colors use canonical TerraFusion tokens: `terra-accent` maps to
+// --tf-success (tailwind.config.js); fail/warning reuse the palette already
+// established in sibling canon panels (CanonAgentsPanel, CanonTaskConsole).
 const STATUS_CLASS: Record<EvidenceGateStatus, string> = {
-  pass: 'text-emerald-300',
-  fail: 'text-rose-300',
+  pass: 'text-terra-accent',
+  fail: 'text-red-400',
   warning: 'text-amber-300',
   skipped: 'tf-text-dim',
 };
@@ -109,8 +112,7 @@ export function CanonEvidenceViewer({
 }): React.ReactElement {
   return (
     <section
-      className='canon-evidence-viewer liquid-panel--infrastructure flex flex-col gap-3 p-3'
-      style={{ background: 'hsl(var(--tf-surface))' }}
+      className='canon-evidence-viewer liquid-panel--infrastructure bg-terra-slate flex flex-col gap-3 p-3'
       data-testid='terracanon-evidence-viewer'
       aria-label='Canon evidence bundle viewer'
     >
@@ -162,7 +164,7 @@ export function CanonEvidenceViewer({
           <div className='flex flex-col gap-1' data-testid='terracanon-evidence-seal'>
             <span className={labelClass}>Trace seal</span>
             <span
-              className={`text-xs font-semibold ${bundle.sealed ? 'text-emerald-300' : 'text-amber-300'}`}
+              className={`text-xs font-semibold ${bundle.sealed ? 'text-terra-accent' : 'text-amber-300'}`}
             >
               {bundle.sealed ? 'Sealed' : 'Not sealed'}
             </span>

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -88,6 +88,7 @@ import { CanonSearchPanel } from '../canon/CanonSearchPanel';
 import { CanonStatusBar } from '../canon/CanonStatusBar';
 import { CanonRuntimeStatusPanel } from '../canon/CanonRuntimeStatusPanel';
 import { CanonTaskConsole } from '../canon/CanonTaskConsole';
+import { CanonEvidenceViewer } from '../canon/CanonEvidenceViewer';
 import CanonTerminal from '../canon/CanonTerminal';
 import { GoToLineDialog } from '../canon/GoToLineDialog';
 import { useCanonConnection } from '../canon/useCanonConnection';
@@ -637,7 +638,7 @@ function loadLastClosed(): Workspace | null {
 let workspaceCounter = 0;
 
 // ─── Bottom panel tabs (WAI-ARIA tabs pattern) ───────────────────────────────
-type BottomTabKey = 'gates' | 'terminal' | 'problems' | 'runtime' | 'console';
+type BottomTabKey = 'gates' | 'terminal' | 'problems' | 'runtime' | 'console' | 'evidence';
 
 const BOTTOM_TABS: ReadonlyArray<{ key: BottomTabKey; label: string }> = [
   { key: 'gates', label: 'Gates' },
@@ -645,6 +646,7 @@ const BOTTOM_TABS: ReadonlyArray<{ key: BottomTabKey; label: string }> = [
   { key: 'problems', label: 'Problems' },
   { key: 'runtime', label: 'Runtime' },
   { key: 'console', label: 'Console' },
+  { key: 'evidence', label: 'Evidence' },
 ];
 
 const bottomTabId = (key: BottomTabKey): string => `canon-bottom-tab-${key}`;
@@ -2198,6 +2200,15 @@ function CanonContent(): React.ReactElement {
                 aria-labelledby={bottomTabId('console')}
               >
                 <CanonTaskConsole />
+              </div>
+            )}
+            {bottomTab === 'evidence' && (
+              <div
+                role='tabpanel'
+                id={bottomPanelId('evidence')}
+                aria-labelledby={bottomTabId('evidence')}
+              >
+                <CanonEvidenceViewer />
               </div>
             )}
             {bottomTab === 'problems' && (


### PR DESCRIPTION
## What

Adds **CanonEvidenceViewer** — a read-only surface that renders a Canon **evidence bundle** (the proof artifact for a completed task): task header, gate results, files read/changed, diff hash, risk score, and the trace seal. Wired as the **6th WAI-ARIA bottom-panel tab** in `CanonHome` (Gates / Terminal / Problems / Runtime / Console / **Evidence**), reusing the existing roving-tabindex tablist pattern from #926.

## Honest by construction

- **Empty by default in-shell** — bundles are produced by the `tf canon` CLI + the trace layer, not authored here. Empty state names the bundle contract; no invented values.
- **Seal shown AS REPORTED** — `sealed` / `traceHash` / `sealedAt` are displayed as the bundle reports them. Cryptographic verification stays in `canon-trace-seal.mjs`, **not** re-computed in the browser.
- Field shape mirrors `os-platform/core/canon/canon-evidence.mjs` (`EvidenceBundle`) and the seal fields from `canon-trace-seal.mjs`.
- **Read-only**: no buttons, no inputs, no side effects.

## Tests (TDD)

- 8 new component tests (`CanonEvidenceViewer.test.tsx`): landmark, honest empty state, contract naming, task header, gate results + statuses, seal-as-reported, unsealed marking, read-only.
- Bento ARIA test updated 5 → 6 tabs + Evidence ARIA-attribute assertions.
- **28/28** ui-observability tests green · `tsc --noEmit` clean · `noNewRawColors` green · UI token ratchet **1556 ≤ 1580** (no new violations) · prettier clean.

Continues the read-only Canon surface series: #924 (Runtime Status) → #926 (ARIA tabs infra) → #928 (Task Console) → this (Evidence viewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Evidence viewer to display bundle details: task info, gate results, file lists, diff/risk info, and cryptographic seal status.
  * Added an Evidence tab to the bottom panel to access the viewer.

* **Tests**
  * Updated WAI-ARIA tab tests to include the Evidence tab.
  * Added comprehensive tests covering Evidence viewer empty state, rendering of bundle content, gate results, seal display, and read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->