### PR TITLE
feat(os-canon): read-only Canon Gate Runner panel (7th ARIA bottom tab)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonBentoCompliance.test.tsx
@@ -163,18 +163,28 @@ describe('Bottom panel tabs – WAI-ARIA tabs pattern', () => {
     localStorage.clear();
   });
 
-  it('exposes a labelled tablist wrapping all six role=tab buttons', () => {
+  it('exposes a labelled tablist wrapping all seven role=tab buttons', () => {
     render(<CanonHome />);
     const tablist = screen.getByRole('tablist', { name: /bottom panel/i });
     const tabs = within(tablist).getAllByRole('tab');
-    // Gates / Terminal / Problems / Runtime (#924) / Console (#928) / Evidence
-    expect(tabs).toHaveLength(6);
+    // Gates / Terminal / Problems / Runtime (#924) / Console (#928) / Evidence (#930) / Gate Runner
+    expect(tabs).toHaveLength(7);
     expect(within(tablist).getByRole('tab', { name: 'Gates' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Terminal' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Problems' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Runtime' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Console' })).toBeInTheDocument();
     expect(within(tablist).getByRole('tab', { name: 'Evidence' })).toBeInTheDocument();
+    expect(within(tablist).getByRole('tab', { name: 'Gate Runner' })).toBeInTheDocument();
+  });
+
+  it('applies the ARIA tab attributes to the Gate Runner tab too', () => {
+    render(<CanonHome />);
+    const gateRunnerTab = screen.getByRole('tab', { name: 'Gate Runner' });
+    expect(gateRunnerTab).toHaveAttribute('aria-selected', 'false');
+    expect(gateRunnerTab).toHaveAttribute('aria-controls');
+    expect(gateRunnerTab).toHaveAttribute('tabindex', '-1');
+    expect(gateRunnerTab.id).toBeTruthy();
   });
 
   it('applies the ARIA tab attributes to the Evidence tab too', () => {

--- a/frontend/apps/os-shell/src/__tests__/ui-observability/CanonGateRunnerPanel.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/ui-observability/CanonGateRunnerPanel.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * CanonGateRunnerPanel — read-only Canon gate runner panel (os-canon).
+ *
+ * Lists the gates configured in the Canon gate registry and their latest KNOWN
+ * status. HONEST by construction:
+ *   - It does NOT run gates, trigger CI, or mutate anything.
+ *   - Status is "not run here" by default; real statuses (from tf canon gates /
+ *     CI / the trace layer) may be passed in via the `statuses` prop.
+ *   - The current execution rail is the `tf canon gates` CLI.
+ *
+ * Configured gates mirror os-platform/core/canon/gate-registry.json. No invented
+ * values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import { CanonGateRunnerPanel } from '../../canon/CanonGateRunnerPanel';
+
+describe('CanonGateRunnerPanel', () => {
+  it('renders the gate runner landmark', () => {
+    render(<CanonGateRunnerPanel />);
+    expect(screen.getByTestId('terracanon-gate-runner')).toBeInTheDocument();
+  });
+
+  it('lists every configured gate by label (mirrors gate-registry.json)', () => {
+    render(<CanonGateRunnerPanel />);
+    const txt = screen.getByTestId('terracanon-gate-runner').textContent ?? '';
+    expect(txt).toMatch(/TypeScript Type Check/);
+    expect(txt).toMatch(/Launch Surface Contract/);
+    expect(txt).toMatch(/Canon Runtime Query Self-Test/);
+  });
+
+  it('shows the real command for each gate without inventing values', () => {
+    render(<CanonGateRunnerPanel />);
+    const txt = screen.getByTestId('terracanon-gate-runner').textContent ?? '';
+    expect(txt).toMatch(/pnpm run type-check/);
+    expect(txt).toMatch(/launch-surface-contract\.test\.mjs/);
+    expect(txt).toMatch(/canon-query\.test\.mjs/);
+  });
+
+  it('is honest that it does not run gates, trigger CI, or mutate, and points to tf canon', () => {
+    render(<CanonGateRunnerPanel />);
+    const txt = screen.getByTestId('terracanon-gate-runner').textContent ?? '';
+    expect(txt).toMatch(/does not run|not run here|read-only/i);
+    expect(txt).toMatch(/tf canon/);
+  });
+
+  it('shows status as not-run by default (no invented pass/fail)', () => {
+    render(<CanonGateRunnerPanel />);
+    const status = screen.getByTestId('terracanon-gate-status-typecheck');
+    expect(status.textContent ?? '').toMatch(/not run|unknown|—/i);
+  });
+
+  it('renders externally-known statuses when provided', () => {
+    render(
+      <CanonGateRunnerPanel
+        statuses={[
+          { gateId: 'typecheck', status: 'pass' },
+          { gateId: 'canon-query', status: 'fail' },
+        ]}
+      />,
+    );
+    expect(
+      within(screen.getByTestId('terracanon-gate-status-typecheck')).getByText(/pass/i),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('terracanon-gate-status-canon-query')).getByText(/fail/i),
+    ).toBeInTheDocument();
+    // A gate with no supplied status stays not-run (not silently passed).
+    expect(
+      screen.getByTestId('terracanon-gate-status-launch-surface-contract').textContent ?? '',
+    ).toMatch(/not run|unknown|—/i);
+  });
+
+  it('is read-only: no buttons or inputs', () => {
+    const { container } = render(
+      <CanonGateRunnerPanel statuses={[{ gateId: 'typecheck', status: 'pass' }]} />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(0);
+    expect(container.querySelectorAll('input, textarea, select').length).toBe(0);
+  });
+});

--- a/frontend/apps/os-shell/src/canon/CanonGateRunnerPanel.tsx
+++ b/frontend/apps/os-shell/src/canon/CanonGateRunnerPanel.tsx
@@ -1,0 +1,142 @@
+/**
+ * Canon Gate Runner Panel (os-canon) — read-only gate registry view.
+ *
+ * Lists the gates configured in the Canon gate registry and their latest KNOWN
+ * status. HONEST by construction:
+ *   - It does NOT run gates, trigger CI, or mutate anything.
+ *   - Status is "not run here" by default; real statuses (from `tf canon gates`,
+ *     CI, or the trace layer) may be passed in via the `statuses` prop.
+ *   - The current execution rail is the `tf canon gates` CLI.
+ *
+ * Configured gates mirror os-platform/core/canon/gate-registry.json (kept in
+ * sync by hand, like CanonRuntimeStatusPanel mirrors CANON_OWNED_PATTERNS).
+ * No invented values.
+ *
+ * @module canon/CanonGateRunnerPanel
+ */
+
+import React from 'react';
+
+/** A configured gate — mirrors an entry in gate-registry.json. */
+interface ConfiguredGate {
+  gateId: string;
+  label: string;
+  command: string;
+  kind: 'regression' | 'contract';
+}
+
+/** Source of truth: os-platform/core/canon/gate-registry.json (version 0.1.0). */
+const CONFIGURED_GATES: readonly ConfiguredGate[] = [
+  {
+    gateId: 'typecheck',
+    label: 'TypeScript Type Check',
+    command: 'pnpm run type-check',
+    kind: 'regression',
+  },
+  {
+    gateId: 'launch-surface-contract',
+    label: 'Launch Surface Contract',
+    command: 'node os-platform/core/tests/launch-surface-contract.test.mjs',
+    kind: 'contract',
+  },
+  {
+    gateId: 'canon-query',
+    label: 'Canon Runtime Query Self-Test',
+    command: 'node --test os-platform/core/tests/canon-query.test.mjs',
+    kind: 'contract',
+  },
+];
+
+/** Known gate status — `unknown` means "not run in-shell" (the honest default). */
+export type GateRunStatus = 'pass' | 'fail' | 'warning' | 'skipped' | 'unknown';
+
+/** Externally-known status for a configured gate (e.g. from `tf canon gates`). */
+export interface GateStatusEntry {
+  gateId: string;
+  status: GateRunStatus;
+}
+
+const labelClass = 'text-xs font-semibold uppercase tracking-wider text-terra-cyan';
+const mutedClass = 'text-xs tf-text-tertiary';
+const codeClass = 'font-mono text-xs tf-text-secondary';
+
+// Status colors use canonical TerraFusion tokens (see CanonEvidenceViewer):
+// terra-accent maps to --tf-success; fail/warning reuse the established palette.
+const STATUS_CLASS: Record<GateRunStatus, string> = {
+  pass: 'text-terra-accent',
+  fail: 'text-red-400',
+  warning: 'text-amber-300',
+  skipped: 'tf-text-dim',
+  unknown: 'tf-text-dim',
+};
+
+const STATUS_LABEL: Record<GateRunStatus, string> = {
+  pass: 'pass',
+  fail: 'fail',
+  warning: 'warning',
+  skipped: 'skipped',
+  unknown: 'not run here',
+};
+
+/**
+ * Read-only Canon gate runner panel. No side effects, no controls.
+ */
+export function CanonGateRunnerPanel({
+  statuses,
+}: {
+  statuses?: readonly GateStatusEntry[];
+}): React.ReactElement {
+  const statusById = new Map((statuses ?? []).map((s) => [s.gateId, s.status]));
+
+  return (
+    <section
+      className='canon-gate-runner liquid-panel--infrastructure bg-terra-slate flex flex-col gap-3 p-3'
+      data-testid='terracanon-gate-runner'
+      aria-label='Canon gate runner panel'
+    >
+      <header className='flex items-baseline justify-between'>
+        <h3 className={labelClass}>Canon Gate Runner</h3>
+        <span className={mutedClass}>read-only</span>
+      </header>
+
+      <p className={mutedClass}>
+        Gates configured in the Canon gate registry. This panel does not run gates, trigger CI, or
+        mutate anything — statuses come from the <span className={codeClass}>tf canon gates</span>{' '}
+        CLI (or CI / the trace layer). Anything not run there shows as{' '}
+        <span className='tf-text-dim'>not run here</span>.
+      </p>
+
+      <div className='flex flex-col gap-2'>
+        {CONFIGURED_GATES.map((g) => {
+          const status: GateRunStatus = statusById.get(g.gateId) ?? 'unknown';
+          return (
+            <div key={g.gateId} className='flex flex-col gap-0.5'>
+              <div className='flex items-baseline gap-2'>
+                <span className='text-xs tf-text-secondary'>{g.label}</span>
+                <span className={mutedClass}>{g.kind}</span>
+                <span
+                  className={`ml-auto text-xs font-semibold ${STATUS_CLASS[status]}`}
+                  data-testid={`terracanon-gate-status-${g.gateId}`}
+                >
+                  {STATUS_LABEL[status]}
+                </span>
+              </div>
+              <span className={codeClass}>{g.command}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <span className={labelClass}>Current rail</span>
+        <span className={codeClass}>tf canon gates</span>
+      </div>
+
+      <p className='text-xs italic tf-text-dim'>
+        Read-only view. No gates run, no CI is triggered, and nothing is mutated from this panel.
+      </p>
+    </section>
+  );
+}
+
+export default CanonGateRunnerPanel;

--- a/frontend/apps/os-shell/src/pages/CanonHome.tsx
+++ b/frontend/apps/os-shell/src/pages/CanonHome.tsx
@@ -89,6 +89,7 @@ import { CanonStatusBar } from '../canon/CanonStatusBar';
 import { CanonRuntimeStatusPanel } from '../canon/CanonRuntimeStatusPanel';
 import { CanonTaskConsole } from '../canon/CanonTaskConsole';
 import { CanonEvidenceViewer } from '../canon/CanonEvidenceViewer';
+import { CanonGateRunnerPanel } from '../canon/CanonGateRunnerPanel';
 import CanonTerminal from '../canon/CanonTerminal';
 import { GoToLineDialog } from '../canon/GoToLineDialog';
 import { useCanonConnection } from '../canon/useCanonConnection';
@@ -638,7 +639,14 @@ function loadLastClosed(): Workspace | null {
 let workspaceCounter = 0;
 
 // ─── Bottom panel tabs (WAI-ARIA tabs pattern) ───────────────────────────────
-type BottomTabKey = 'gates' | 'terminal' | 'problems' | 'runtime' | 'console' | 'evidence';
+type BottomTabKey =
+  | 'gates'
+  | 'terminal'
+  | 'problems'
+  | 'runtime'
+  | 'console'
+  | 'evidence'
+  | 'gaterunner';
 
 const BOTTOM_TABS: ReadonlyArray<{ key: BottomTabKey; label: string }> = [
   { key: 'gates', label: 'Gates' },
@@ -647,6 +655,7 @@ const BOTTOM_TABS: ReadonlyArray<{ key: BottomTabKey; label: string }> = [
   { key: 'runtime', label: 'Runtime' },
   { key: 'console', label: 'Console' },
   { key: 'evidence', label: 'Evidence' },
+  { key: 'gaterunner', label: 'Gate Runner' },
 ];
 
 const bottomTabId = (key: BottomTabKey): string => `canon-bottom-tab-${key}`;
@@ -2209,6 +2218,15 @@ function CanonContent(): React.ReactElement {
                 aria-labelledby={bottomTabId('evidence')}
               >
                 <CanonEvidenceViewer />
+              </div>
+            )}
+            {bottomTab === 'gaterunner' && (
+              <div
+                role='tabpanel'
+                id={bottomPanelId('gaterunner')}
+                aria-labelledby={bottomTabId('gaterunner')}
+              >
+                <CanonGateRunnerPanel />
               </div>
             )}
             {bottomTab === 'problems' && (


### PR DESCRIPTION
## What

Adds **CanonGateRunnerPanel** — a read-only view of the gates configured in the Canon gate registry, wired as the **7th WAI-ARIA bottom-panel tab** in `CanonHome` (Gates / Terminal / Problems / Runtime / Console / Evidence / **Gate Runner**).

## Honest by construction (read-only first)

- **Does not run gates, trigger CI, or mutate anything.**
- Lists each configured gate's label, kind, and **real command** (mirrors `os-platform/core/canon/gate-registry.json`: `typecheck`, `launch-surface-contract`, `canon-query`) — no invented values.
- Status defaults to **"not run here"**; externally-known statuses (from `tf canon gates` / CI / the trace layer) can be supplied via the optional `statuses` prop — a gate with no supplied status stays not-run, never silently passed.
- Current execution rail pointed at `tf canon gates`.
- Status colors reuse the canonical tokens established in CanonEvidenceViewer (`text-terra-accent` / `text-red-400` / `text-amber-300` / `tf-text-dim`).

## Tests (TDD)

- 7 component tests (`CanonGateRunnerPanel.test.tsx`): landmark, lists configured gates, real commands, honesty (no-run / tf canon), not-run default, externally-supplied statuses, read-only.
- Bento ARIA test updated 6 → 7 tabs + Gate Runner ARIA-attribute assertions.
- **31/31** ui-observability tests green · `tsc --noEmit` clean · token ratchet 1556 ≤ 1580.

Continues the read-only Canon surface series: #924 Runtime → #926 ARIA tabs → #928 Task Console → #930 Evidence → this. Read-only visibility before execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)