### PR TITLE
docs(brain): WO-BRAIN-0013 — domain knowledge pack scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,46 @@
 ## PRIME DIRECTIVE
 Do not destabilize the Core Governance Surface.
 
+## BRAIN GOVERNANCE & DOMAIN KNOWLEDGE PACKS
+
+> **One TerraFusion Brain. Many packs. No competing brains.**
+
+There is exactly **one** TerraFusion Brain / Cortex. It is the single OS-level authority for:
+**queue, sequencing, work orders, risk classification, proof, review-diff, and commit-plan.**
+Suites do **not** get separate brains and do **not** get a suite-local queue or autonomous
+governance. Suites get **domain knowledge packs** (`brain/packs/**`) that provide local knowledge
+only: what a domain owns, what it must never touch, where work routes, what proof is required, and
+when a human must approve.
+
+### Authority hierarchy (higher wins on conflict)
+
+1. **TerraFusion Constitution** — `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (TF-052)
+2. **Brain / Cortex** — OS-level queue, sequencing, work orders, risk, proof, review-diff, commit-plan
+3. **Domain knowledge packs** — `brain/packs/**`
+4. **Directory-local `AGENTS.md` files** — nearest-scope overrides
+5. **Existing implementation patterns**
+6. **Agent judgment**
+
+### Rules for agents
+
+- **Before modifying files, read the relevant domain pack** in `brain/packs/` (see
+  `brain/packs/README.md` for the domain→path map), then read any nearer `AGENTS.md`.
+- **Preserve one-Brain governance.** Do **not** create a second brain or a suite-local queue.
+- **Do not create separate suite brains** or suite-local autonomous governance.
+- Route work through Brain **work orders, review-diff, proof, and commit-plan**.
+- Respect each pack's **Forbidden Writes** and **Escalation Triggers**; never write across a
+  write-lane boundary you do not own.
+
+### Human approval triggers (always stop and ask)
+
+1. Constitutional decision (changing TF-052 / canon)
+2. Destructive operation (delete, redact, irreversible)
+3. Product behavior change
+4. Branch / merge strategy
+5. Production deployment authorization
+6. Conflicting canon (two sources disagree)
+7. Credentials / secrets
+
 ## CORE GOVERNANCE SURFACE (ALLOWED SCOPE)
 Only modify files under:
 - os-platform/core/pilot/**

--- a/brain/packs/README.md
+++ b/brain/packs/README.md
@@ -1,0 +1,169 @@
+# TerraFusion Brain — Domain Knowledge Packs
+
+> **Work Order:** WO-BRAIN-0013 — Domain Knowledge Pack Scaffold
+> **Type:** Documentation / governance scaffold. No production behavior changes.
+> **Status:** Extraction of existing canon into agent-readable packs. Not a new architecture.
+
+## What this is
+
+This directory turns **existing TerraFusion canon** into **agent-readable knowledge packs** so
+Claude Code and future agents can route work by domain, path, and work-order scope **without asking
+the human owner** for boundaries that are already written down.
+
+These packs **extract and normalize** existing canon. They **do not invent** new rules, new suites,
+or new commands. Where this scaffold and the canon disagree, **the canon wins** — open an issue, do
+not silently fork the rule here.
+
+## Doctrine — One Brain, Many Packs
+
+```
+One TerraFusion Brain.
+Many suite/domain packs.
+No competing brains.
+No distributed queue authority.
+No suite-local autonomous governance.
+```
+
+There is exactly **one** TerraFusion Brain / Cortex. It is the single OS-level authority for:
+
+- queue
+- sequencing
+- work orders
+- risk classification
+- proof
+- review-diff
+- commit-plan
+
+Suites and domains **do not** get their own brains. They get **domain knowledge packs** (the files in
+this directory) that provide **local knowledge only**: what the domain owns, what it must never touch,
+where work routes, what proof is required, and when a human must approve.
+
+## Authority hierarchy
+
+When two sources of guidance conflict, the higher one wins:
+
+1. **TerraFusion Constitution** — `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (TF-052)
+2. **Brain / Cortex** — OS-level queue, sequencing, work orders, risk, proof, review-diff, commit-plan
+3. **Domain knowledge packs** — this directory (`brain/packs/**`)
+4. **Directory-local `AGENTS.md` files** — nearest-scope overrides for a path
+5. **Existing implementation patterns** — match the surrounding code
+6. **Agent judgment** — last resort, and only within the bounds set above
+
+## The packs
+
+Each pack answers five questions: **What does this domain own? What must it never touch? Where should
+work route? What proof is required? When must the human approve?**
+
+| Pack | Domain | Canon identity |
+|------|--------|----------------|
+| [`shell/`](shell/README.md) | OS shell chrome, window manager, routing | Property Workbench + OS Core (OS surface, not a suite) |
+| [`dais/`](dais/README.md) | Assessor administration & workflow state | **TerraDais** (`terradais`) |
+| [`forge/`](forge/README.md) | Valuation engineering | **TerraForge** (`terraforge`) |
+| [`atlas/`](atlas/README.md) | GIS / spatial | **TerraAtlas** (`terraatlas`) |
+| [`dossier/`](dossier/README.md) | Records, evidence, documents, packets | **TerraDossier** (`terradossier`) |
+| [`gpt/`](gpt/README.md) | AI / GPT assistance patterns | **TerraGPT** (`terragpt`) |
+| [`trace/`](trace/README.md) | Append-only activity / evidence trail | **TerraTrace** (OS feature, not a suite) |
+| [`localops/`](localops/README.md) | LocalOps AI operator doctrine | **TerraPilot** inside the shell (OS feature) |
+
+### Pack template
+
+Every pack uses this structure:
+
+1. Mission
+2. Owns
+3. Does Not Own
+4. Allowed Writes
+5. Forbidden Writes
+6. Routing Rules
+7. Required Proof
+8. Common Failure Patterns
+9. Escalation Triggers
+10. Non-Goals
+11. Canon Sources
+
+## Repository path map (real, verified)
+
+The original work order assumed paths like `apps/terrafusion-shell/`, `suites/terradias/`, and
+`services/terrapilot/`. **Those directories do not exist in this repo.** Per the work order's
+"do not invent paths" rule, here are the **real** canonical locations discovered during scaffolding:
+
+| Domain | Canonical repo location(s) | Notes |
+|--------|----------------------------|-------|
+| **Shell** | `frontend/apps/os-shell/` | z-index authority: `src/shell/desktop/zIndex.ts`; suite registry: `src/config/suiteRegistry.ts` |
+| **Suite homes (all)** | `frontend/apps/os-shell/src/pages/suites/` | `ForgeSuiteHome.tsx`, `AtlasSuiteHome.tsx`, `DaisSuiteHome.tsx`, `DossierSuiteHome.tsx`, `GptSuiteHome.tsx` |
+| **Forge** | `packages/terrabuild`, `frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx` | Valuation engineering |
+| **Atlas** | `packages/gis-pro`, `frontend/apps/os-shell/src/pages/suites/AtlasSuiteHome.tsx` | GIS / spatial |
+| **Dais** | `packages/terra-levy`, `packages/terra-pilt`, `packages/terra-permit`, `frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx` | Assessor admin modules (`terra-*`) |
+| **Dossier** | `frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx` | Records / evidence (package home TBD) |
+| **GPT** | `frontend/apps/os-shell/src/pages/suites/GptSuiteHome.tsx` | AI/LLM suite (ADR-005) |
+| **TerraPilot / TerraTrace** | OS features routed through OS Core, not standalone suite dirs | TerraPilot spec: `docs/architecture/specs/terrafusion/02_TERRAPILOT_SPEC_v3.1.md` |
+| **LocalOps** | `os-platform/core/pilot/local-agent/` | CLI: `cli.ts`; governance-controlled local agent |
+| **Brain / work-order orchestration** | `os-platform/core/pilot/june10-*.mjs` | Work-order pack, wave planner, control plane, command queue |
+
+### Candidate paths for future directory-local `AGENTS.md`
+
+Suites currently live as **pages inside `os-shell`** plus **scattered `packages/terra-*` modules**,
+not as one clean directory per suite. Because of that, per-suite `AGENTS.md` files were **not** created
+(no obvious single canonical directory). Candidate locations, should suites later consolidate:
+
+- `frontend/apps/os-shell/src/pages/suites/AGENTS.md` (covers all five suite homes) — *candidate*
+- `packages/terrabuild/AGENTS.md` (Forge) — *candidate*
+- `packages/gis-pro/AGENTS.md` (Atlas) — *candidate*
+- `packages/terra-levy/AGENTS.md`, `packages/terra-pilt/AGENTS.md`, `packages/terra-permit/AGENTS.md` (Dais modules) — *candidate*
+
+`AGENTS.md` files **were** added at the two paths whose ownership is unambiguous:
+
+- `frontend/apps/os-shell/AGENTS.md` → points at `brain/packs/shell/README.md`
+- `os-platform/core/pilot/local-agent/AGENTS.md` → points at `brain/packs/localops/README.md`
+
+## How agents should use these packs
+
+1. Before modifying files, **read the pack for the domain you are touching** (use the path map above
+   to find the domain), then read any nearer `AGENTS.md`.
+2. Preserve **one-Brain governance** — never create a second brain or a suite-local queue.
+3. Route work through Brain **work orders, review-diff, proof, and commit-plan**.
+4. Respect the domain's **Forbidden Writes** and **Escalation Triggers**. When in doubt, escalate to the
+   human — do not guess across a write-lane boundary.
+
+## Verification Notes
+
+The work order's suggested verification commands were:
+
+```
+pnpm brain review-diff --workorder WO-BRAIN-0013
+pnpm brain proof --workorder WO-BRAIN-0013
+pnpm brain commit-plan --workorder WO-BRAIN-0013
+```
+
+**`pnpm brain` does not exist in this repository.** Verified against `package.json` scripts and the
+`tools/bin` CLI surface — there is no `brain` script and no `bin/brain` entrypoint. The Brain concept
+(work-order + wave-planning + control-plane orchestration) is implemented through explicit scripts and
+the LocalOps CLI, **not** a single `pnpm brain` command. The real, canonical command surfaces are:
+
+| Intended Brain verb | Real command(s) in this repo |
+|---------------------|------------------------------|
+| canon / governance check | `pnpm canon`, `pnpm canon:doctor`, `pnpm canon:gatefast`, `pnpm canon:ping` |
+| OS CLI | `pnpm tf` → `tools/bin/tf.mjs` |
+| work-order seeding | `pnpm truth:june10-seed-work-order-pack` |
+| wave planning / sequencing | `pnpm truth:june10-seed-wave-plan`, `pnpm truth:june10-launch-control` |
+| control plane / freshness | `pnpm truth:june10-seed-control-plane`, `pnpm truth:june10-control-plane-freshness` |
+| proof / readiness packet | `pnpm truth:june10-readiness-packet`, `pnpm truth:june10-seed-receipts` |
+| operator command queue | `pnpm truth:june10-operator-command-queue` |
+| trace / evidence lookup | `pnpm run trace:query --correlation <id>` |
+| required core gates | `pnpm run type-check`, `node --test os-platform/core/tests/phase83-tools.test.mjs` |
+
+Because `pnpm brain review-diff / proof / commit-plan` are not available, no such commands were run.
+This scaffold is **documentation only** and changes no production code. The relevant verification is:
+
+- **Canon references resolve.** Every file cited in each pack's *Canon Sources* (and every relative
+  `AGENTS.md` link) was verified to exist on disk.
+- **`prettier --check`** passes on all new/changed markdown.
+- **`pnpm canon:ping`** was run as a governance sanity check on 2026-06-10 — result: `PASS Overall: PASS`
+  (exit 0). This confirms the canon tool surface is healthy; it does not assert anything about these
+  docs beyond "governance plumbing works."
+
+## Next work order (not in scope here)
+
+**WO-BRAIN-0014 — Brain Path Router**: given a changed file path or work order, Brain identifies the
+domain pack, risk class, required proof, forbidden boundaries, and escalation triggers. Do **not** build
+that yet — this work order lands the pack scaffold first.

--- a/brain/packs/atlas/README.md
+++ b/brain/packs/atlas/README.md
@@ -1,0 +1,91 @@
+# Domain Pack: Atlas (TerraAtlas)
+
+> Suite ID: `terraatlas` · Domain: GIS / Spatial · Mission: **see the county**
+> Modules: `terra-parcel` (ParcelLens), `terra-layers` (LayerWorks), and related spatial modules
+
+## Mission
+
+See the county. TerraAtlas owns the GIS / spatial domain — maps, layers, geometry, and the spatial
+tools that let assessors understand parcels in space.
+
+## Owns
+
+- GIS layers and layer symbology.
+- Parcel boundaries (geometry).
+- Spatial annotations.
+- Map bookmarks.
+- Neighborhood definitions.
+- Layer preferences.
+
+## Does Not Own
+
+- Valuation calculations, models, or comps (**TerraForge**).
+- Workflow state — permits, exemptions, appeals, notices, certification (**TerraDais**).
+- Document / evidence custody (**TerraDossier**).
+- Shell routing, window management, or the Workbench frame (**Shell / OS Core**).
+
+## Allowed Writes
+
+- GIS layers, symbology, and layer preferences.
+- Parcel boundary geometry (single spatial writer).
+- Spatial annotations and markup.
+- Map bookmarks and neighborhood definitions — spatial writes emitting an appropriate TerraTrace event.
+
+## Forbidden Writes
+
+- Valuation data of any kind — **TerraForge**.
+- Workflow / admin state — **TerraDais** ("no admin workflow writes" per the write-lane matrix).
+- Documents, narratives, packets, evidence — **TerraDossier**.
+- Shell chrome, routing, or z-index.
+- Any persistence not isolated by `CountyId` for county-scoped data.
+
+## Routing Rules
+
+- Spatial artifacts are written only by Atlas; other suites consume geometry read-only.
+- Need a neighborhood used in valuation? **Forge** reads the Atlas-owned definition; Atlas does not
+  compute value from it.
+- Need a map exported into an evidence packet? **Dossier** assembles the packet; Atlas supplies the
+  spatial render, not the document record.
+- Parcel-scoped spatial work surfaces in the **Property Workbench** Atlas tab, not standalone windows.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast` (write-lane gates green).
+- For geometry changes: spatial regression / integrity evidence (cf. `phase4d.wave1c.atlas-gis.json`
+  style artifacts for the expected shape of spatial proof).
+- TerraTrace event emission for spatial writes.
+- `CountyId` isolation evidence for county-scoped writes.
+
+## Common Failure Patterns
+
+- Computing or storing a value from a spatial layer — crosses into Forge's lane.
+- Editing workflow state from a map tool — Dais's lane.
+- Persisting an exported map as a "document" instead of routing to Dossier.
+- A second writer for parcel geometry — single-writer rule violation.
+- Missing `CountyId` filter on spatial persistence.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Change parcel-geometry semantics or the authoritative boundary source.
+- Alter neighborhood definitions that downstream valuation depends on.
+- Touch another suite's write lane.
+- Affect county-isolation behavior.
+
+## Non-Goals
+
+- No valuation math.
+- No workflow orchestration.
+- No document custody.
+- No shell/routing changes.
+- No suite-local brain or queue authority.
+
+## Canon Sources
+
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§3.2 TerraAtlas; Article VI modules; §8.2 `atlas` reserved meaning)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (write-lane matrix; "no admin workflow writes")
+- `CLAUDE.md` (County data isolation / Sovereign County model)
+- Modules: `packages/gis-pro`
+- Suite home: `frontend/apps/os-shell/src/pages/suites/AtlasSuiteHome.tsx`

--- a/brain/packs/dais/README.md
+++ b/brain/packs/dais/README.md
@@ -1,0 +1,93 @@
+# Domain Pack: Dais (TerraDais)
+
+> Suite ID: `terradais` · Domain: Assessor Admin · Mission: **operate value**
+> Modules: `terra-levy`, `terra-pilt`, `terra-permit`, `terra-exempt`, `terra-appeal`, `terra-cert`, `terra-notice`, `terra-queue`
+
+## Mission
+
+Operate value. TerraDais owns assessor administration and the workflow state behind permits,
+exemptions, appeals, notices, and roll certification.
+
+## Owns
+
+- Permit records, lifecycle, and inspection status.
+- Exemption records, eligibility determinations, renewals, and decisions.
+- Appeal records, deadlines, and BOE workflow state.
+- Notices: drafts, queue, and delivery status.
+- Roll certification checklists and sign-offs (policy-gated, high-risk).
+- Task assignments, work queues, SLA tracking, and workflow states generally.
+
+## Does Not Own
+
+- Valuation math, models, comparable selection, or CAMA characteristics (**TerraForge**).
+- GIS geometry, layers, or spatial annotations (**TerraAtlas**).
+- Document/evidence custody (**TerraDossier** — Dais must use the Dossier service API).
+- Shell routing, window management, or the Workbench frame (**Shell / OS Core**).
+
+## Allowed Writes
+
+- Permit lifecycle + inspection state.
+- Exemption decisions, renewals, and supporting status.
+- Appeal state and BOE deadlines.
+- Notice drafts, queue entries, and delivery status (the *published* notice is a Dossier artifact).
+- Certification checklist items and sign-offs (with policy gate).
+- Task/queue assignments and workflow transitions — each emitting a TerraTrace `workflow` event.
+
+## Forbidden Writes
+
+- Valuation artifacts of any kind (model outputs, comps, breakdowns) — **TerraForge** is the single writer.
+- GIS geometry / spatial artifacts — **TerraAtlas**.
+- Documents, narratives, packets, or evidence directly — must go through the **TerraDossier** service API.
+- Shell chrome, routing, or z-index.
+- Any persistence that is **not** filtered by `CountyId` for county-scoped data.
+
+## Routing Rules
+
+- County-scoped persistence **must** be isolated by `CountyId` (Sovereign County model).
+- Workflow status changes emit TerraTrace events in the `workflow` category.
+- Need a document attached to a workflow outcome? Route to the **Dossier** service, do not write the
+  document store from Dais.
+- Need a valuation number to act on? Read it from **Forge** (read-only); never recompute or rewrite it.
+- Parcel-scoped admin work surfaces in the **Property Workbench** Dais tab, not standalone windows.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast` (write-lane + naming gates green).
+- Evidence that county-scoped writes filter by `CountyId`.
+- TerraTrace `workflow` event emission for state transitions.
+- For certification sign-offs: policy-gate evidence (high-risk path).
+
+## Common Failure Patterns
+
+- Writing a valuation number "because the workflow needed it" — crosses into Forge's lane.
+- Storing an uploaded document directly instead of calling the Dossier service.
+- Missing `CountyId` filter, leaking cross-county workflow state.
+- Using `audit` in a module name (reserved for the future TerraAudit office — use `trace`/`activity`).
+- Using reserved office words (`clerk`, `treasury`, `auditor`, `recorder`) in a Dais module.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Alter roll **certification** logic or sign-off gating (statutory, high-risk).
+- Change statutory deadlines or BOE appeal rules.
+- Touch a write lane owned by another suite.
+- Introduce a new Dais module (suite-owner approval + naming-rule compliance required).
+- Affect county-isolation behavior.
+
+## Non-Goals
+
+- No valuation engineering.
+- No GIS editing.
+- No document custody.
+- No shell/routing changes.
+- No suite-local brain or queue authority — sequencing belongs to the OS Brain.
+
+## Canon Sources
+
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§3.3 TerraDais; Article V modules; §8 blocked words)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (write-lane matrix)
+- `CLAUDE.md` (County data isolation / Sovereign County model)
+- Modules: `packages/terra-levy`, `packages/terra-pilt`, `packages/terra-permit`
+- Suite home: `frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx`

--- a/brain/packs/dossier/README.md
+++ b/brain/packs/dossier/README.md
@@ -1,0 +1,87 @@
+# Domain Pack: Dossier (TerraDossier)
+
+> Suite ID: `terradossier` · Domain: Records / Evidence · Mission: **prove the decision**
+
+## Mission
+
+Prove the decision. TerraDossier owns records, evidence, documents, narratives, case files, and
+packets — and the custody of that evidence.
+
+## Owns
+
+- Documents (uploads and generated).
+- Narratives (including Muse drafts, if saved).
+- Evidence items and evidence custody.
+- Packets (assembled collections).
+- Case files.
+
+## Does Not Own
+
+- Valuation math, models, or comps (**TerraForge**).
+- Workflow state — permits, exemptions, appeals, notices, certification (**TerraDais**).
+- GIS geometry, layers, or spatial annotations (**TerraAtlas**).
+- Shell routing, window management, or the Workbench frame (**Shell / OS Core**).
+
+## Allowed Writes
+
+- Document records (upload + generated), with custody metadata.
+- Narratives and saved Muse drafts.
+- Evidence items and their custody chain.
+- Assembled packets and case files — writes emitting an appropriate TerraTrace event.
+
+## Forbidden Writes
+
+- Valuation data — **TerraForge**.
+- Workflow / admin state — **TerraDais** (Dossier records/assembles outcomes; it does not initiate workflows).
+- GIS geometry / spatial artifacts — **TerraAtlas**.
+- Shell chrome, routing, or z-index.
+- Any persistence not isolated by `CountyId` for county-scoped data.
+
+## Routing Rules
+
+- Dossier is the **single custody owner** for documents and evidence; other suites that need a document
+  attached **call the Dossier service** rather than writing the document store themselves.
+- Dossier **records and assembles outcomes** — it does **not** initiate workflows (that is Dais).
+- A published notice (drafted/queued by Dais) becomes a Dossier artifact once delivered.
+- Parcel-scoped records work surfaces in the **Property Workbench** Dossier tab, not standalone windows.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast` (write-lane gates green).
+- Evidence-custody integrity (cf. `phase4d.wave1d.dossier-documents.json` style artifacts for the
+  expected shape of records proof).
+- TerraTrace event emission for evidence/document writes.
+- `CountyId` isolation evidence for county-scoped writes.
+
+## Common Failure Patterns
+
+- Initiating or mutating a workflow from a records flow — Dais's lane.
+- Recomputing or rewriting a valuation number when assembling a packet — Forge's lane.
+- Editing geometry to "correct" a map in a packet — Atlas's lane.
+- Letting another suite write the document store directly instead of through the Dossier service.
+- Missing `CountyId` filter on evidence persistence.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Alter evidence-custody or chain-of-custody semantics (legal significance).
+- Change document retention or classification behavior.
+- Touch another suite's write lane.
+- Affect county-isolation behavior.
+
+## Non-Goals
+
+- No valuation math.
+- No workflow orchestration.
+- No GIS editing.
+- No shell/routing changes.
+- No suite-local brain or queue authority.
+
+## Canon Sources
+
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§3.4 TerraDossier; §8.2 `dossier` reserved meaning)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (write-lane matrix; "Dossier does not initiate workflows")
+- `CLAUDE.md` (County data isolation / Sovereign County model)
+- Suite home: `frontend/apps/os-shell/src/pages/suites/DossierSuiteHome.tsx`

--- a/brain/packs/forge/README.md
+++ b/brain/packs/forge/README.md
@@ -1,0 +1,92 @@
+# Domain Pack: Forge (TerraForge)
+
+> Suite ID: `terraforge` · Domain: Valuation · Mission: **build value**
+> Modules: `terra-cost`, `terra-comp`, and related valuation modules
+
+## Mission
+
+Build value. TerraForge owns valuation engineering — the models, approaches, comparable analysis, and
+calibration that produce defensible value.
+
+## Owns
+
+- Valuation models and model outputs.
+- Cost approach data.
+- Income approach data.
+- Sales comparison data and comparable grids.
+- Comparable selections.
+- Model calibration.
+- CAMA characteristics (single writer for parcel characteristics).
+- Valuation notes.
+
+## Does Not Own
+
+- Appeal workflow, permit/exemption state, notice queues, or certification (**TerraDais**).
+- Document / evidence custody (**TerraDossier**).
+- GIS geometry, layers, or spatial annotations (**TerraAtlas**).
+- Shell routing, window management, or the Workbench frame (**Shell / OS Core**).
+
+## Allowed Writes
+
+- Valuation models, cost/income/sales-comparison data, comparable grids and selections.
+- Model calibration parameters and runs.
+- CAMA characteristics (Forge is the single CAMA writer per the write-lane matrix).
+- Valuation notes — each value-affecting write emitting a TerraTrace `valuation` event.
+
+## Forbidden Writes
+
+- Workflow state (permits, exemptions, appeals, notices, certification) — **TerraDais**.
+- Documents, narratives, packets, or evidence — **TerraDossier**.
+- GIS geometry / spatial artifacts — **TerraAtlas**.
+- Shell chrome, routing, or z-index.
+- Any persistence not isolated by `CountyId` for county-scoped data.
+
+## Routing Rules
+
+- Value changes emit TerraTrace events in the `valuation` category.
+- Other suites **consume valuation read-only**; Forge never writes into their lanes.
+- Need the valuation reflected in a notice or appeal packet? **Dais** drafts the workflow / **Dossier**
+  assembles the document — Forge supplies the number, nothing more.
+- Parcel-scoped valuation work surfaces in the **Property Workbench** Forge tab, not standalone windows.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast` (write-lane gates green).
+- Valuation regression / calibration evidence where models change (see `phase4d.wave1a.forge-*.json`
+  style regression artifacts for the expected shape of valuation proof).
+- TerraTrace `valuation` event emission for value-affecting writes.
+- `CountyId` isolation evidence for county-scoped writes.
+
+## Common Failure Patterns
+
+- Writing workflow state ("mark this appeal resolved") from within a valuation flow — Dais's lane.
+- Persisting a generated valuation PDF directly instead of routing to Dossier.
+- Editing parcel geometry to "fix" a comp — Atlas's lane.
+- Duplicating the CAMA writer (two code paths writing characteristics) — single-writer rule violation.
+- Value-affecting change with no `valuation` trace event.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Change a valuation **methodology** or calibration approach (product behavior change).
+- Alter CAMA characteristic semantics or the single-writer boundary.
+- Touch another suite's write lane.
+- Affect county-isolation behavior.
+
+## Non-Goals
+
+- No workflow orchestration.
+- No document custody.
+- No GIS editing.
+- No shell/routing changes.
+- No suite-local brain or queue authority.
+
+## Canon Sources
+
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§3.1 TerraForge; §8.2 `forge` reserved meaning)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (write-lane matrix; single CAMA writer)
+- `CLAUDE.md` (County data isolation / Sovereign County model)
+- Modules: `packages/terrabuild`
+- Suite home: `frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx`

--- a/brain/packs/gpt/README.md
+++ b/brain/packs/gpt/README.md
@@ -1,0 +1,93 @@
+# Domain Pack: GPT (TerraGPT)
+
+> Suite ID: `terragpt` · Domain: AI / GPT · Mission: **augment every role**
+> Charter: ADR-005. Sub-modules: Studio, Marketplace, Management, Builder, Analytics, RAG.
+
+## Mission
+
+Augment every role. TerraGPT owns AI/GPT assistance patterns — summarization, drafting, Q&A,
+retrieval, prompt surfaces, and explain behavior — acting **through** TerraPilot tools and approved
+service APIs.
+
+## Owns
+
+- AI/GPT assistance patterns: summarization, drafting, Q&A, retrieval, explain behavior.
+- Prompt surfaces.
+- GPT configurations.
+- RAG datasets (metadata) and RAG embeddings.
+- Usage / cost metrics.
+- Conversation history.
+
+## Does Not Own
+
+- Any other suite's data (valuation, GIS, workflow, documents) — read-only consumer only.
+- Direct write access to suite-owned records — must act through TerraPilot tools.
+- The trace store itself (**TerraTrace**) — GPT emits to it, does not own it.
+- Shell routing, window management, or the Workbench frame (**Shell / OS Core**).
+
+## Allowed Writes
+
+- GPT configurations.
+- RAG dataset metadata and embeddings.
+- Usage / cost metrics.
+- Conversation history.
+- AI actions on other domains **only** via approved TerraPilot tools / service APIs (never direct).
+
+## Forbidden Writes
+
+- **Any other suite's data directly** — Forge / Atlas / Dais / Dossier records must be reached through
+  TerraPilot tools or the owning lane's service.
+- Property records or valuation mutation by the AI itself.
+- Shell chrome, routing, or z-index.
+- Trace records as mutable business state.
+- Any persistence not isolated by `CountyId` for county-scoped data.
+
+## Routing Rules
+
+- GPT **acts through TerraPilot tools and approved service APIs** — it does not reach into suite stores.
+- TerraPilot tool calls carry the risk classification (read_only / write_low / write_high / irreversible);
+  write_high and irreversible actions re-confirm mode + intent and are human-gated.
+- **Source grounding and traceability are required** when appropriate: cite the grounding source and
+  emit a TerraTrace event for AI-initiated actions.
+- Drafts that get saved become **Dossier** narratives (via the Dossier service), not GPT-owned records.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast` (write-lane + tool-allowlist gates green).
+- Evidence that AI actions route through TerraPilot tools (no direct cross-suite writes).
+- Source-grounding / traceability evidence where retrieval or factual claims are involved.
+- PII-sanitization + TerraTrace logging on tool calls (per TerraPilot spec).
+
+## Common Failure Patterns
+
+- AI writing directly into a suite's data store instead of calling a TerraPilot tool.
+- Ungrounded generation presented as fact (no source, no citation) where grounding was required.
+- Mutating property or valuation records via the model.
+- Treating trace as editable AI state.
+- Missing PII sanitization or trace emission on a tool call.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Grant the AI a new write_high / irreversible tool, or expand the tool allowlist.
+- Let GPT mutate suite-owned records by any path other than an approved TerraPilot tool.
+- Change source-grounding or PII-handling behavior.
+- Touch another suite's write lane.
+
+## Non-Goals
+
+- No direct suite-record mutation by AI.
+- No property/valuation mutation by AI.
+- No shell/routing changes.
+- No suite-local brain or queue authority.
+- Not changing TerraPilot UI (out of scope for WO-BRAIN-0013).
+
+## Canon Sources
+
+- `docs/architecture/ADR-005-TERRAGPT-CHARTER.md` (TerraGPT charter)
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§3.5 TerraGPT; Article VII TerraPilot modes)
+- `docs/architecture/specs/terrafusion/02_TERRAPILOT_SPEC_v3.1.md` (tool allowlists, risk classes, PII sanitization)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (write-lane matrix)
+- Suite home: `frontend/apps/os-shell/src/pages/suites/GptSuiteHome.tsx`

--- a/brain/packs/localops/README.md
+++ b/brain/packs/localops/README.md
@@ -1,0 +1,96 @@
+# Domain Pack: LocalOps
+
+> LocalOps is **TerraPilot inside the shell** — an OS feature, **not** a standalone app.
+> Implementation: `os-platform/core/pilot/local-agent/` (CLI: `cli.ts`).
+
+## Mission
+
+Provide a county-boundary-safe AI operator. LocalOps is the local-first embodiment of TerraPilot that
+keeps AI operation possible when external AI is unavailable or prohibited — without ever crossing the
+governance lines that protect citizen data and production systems.
+
+## Owns
+
+- LocalOps AI operator doctrine and the local-agent governance surface.
+- Local-first adapter registry (e.g. Claude / OpenAI / Ollama adapters) and controlled command execution.
+- Read-only diagnostic / doctor-mode behavior (`doctorMode`, `controlCenter`).
+- Source-grounded, trace-emitting operator responses inside the shell.
+
+## Does Not Own
+
+- Property records or valuation data — AI may **never** mutate these.
+- Any suite's write lane (Forge / Atlas / Dais / Dossier).
+- Shell chrome, routing, or window management (**Shell / OS Core**) — LocalOps runs *inside* the shell.
+- The trace store (**TerraTrace**) — it emits to it.
+- Autonomous production repair authority.
+
+## Allowed Writes
+
+- Local diagnostic output, doctor-mode reports, and operator session state (local-first).
+- Trace events for operator actions (append-only, via TerraTrace).
+- Mutations **only** after explicit human approval, and **only** through approved TerraPilot tools /
+  service APIs carrying their risk classification.
+
+## Forbidden Writes
+
+- **Property record or valuation mutation by AI** — categorically forbidden.
+- Any suite-owned record by a path other than an approved, human-approved TerraPilot tool.
+- **Silent cloud fallback** — no quietly routing to external AI when local is unavailable/prohibited.
+- **Unrestricted shell** — no arbitrary command execution outside the controlled command registry.
+- **Autonomous production repair** — no self-directed changes to production.
+- Shell chrome, routing, or z-index.
+
+## Routing Rules
+
+- LocalOps **v1 is local-first, read-only diagnostic, source-grounded, trace-emitting, and
+  human-approved before any mutation.**
+- Mutations route through TerraPilot tools; write_high / irreversible re-confirm mode + intent and are
+  human-gated.
+- When external AI is unavailable or prohibited, LocalOps stays local — it does **not** silently fall
+  back to the cloud. The boundary is explicit and county-safe.
+- Diagnostics emit TerraTrace events; findings cite their grounding source.
+- LocalOps surfaces inside the shell (TerraPilot), never as a separate window/app.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `node --test os-platform/core/tests/phase83-tools.test.mjs` (core tool tests — required gate).
+- `pnpm canon` / `pnpm canon:gatefast`.
+- Local-agent tests under `os-platform/core/pilot/local-agent/*.test.mjs`.
+- Evidence of: no silent cloud fallback, no unrestricted shell, human approval before any mutation,
+  trace emission, and source grounding.
+
+## Common Failure Patterns
+
+- Adding a cloud fallback that triggers without explicit operator/county consent.
+- Widening the command registry into an unrestricted shell.
+- An AI path that mutates a property/valuation record.
+- A "self-heal" routine that changes production without human approval.
+- Diagnostics that act (mutate) instead of reporting in v1.
+- Missing trace emission or missing source grounding.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Add or change any **mutation** capability (v1 is read-only diagnostic).
+- Add or alter a **cloud fallback** path.
+- Expand the controlled command registry's reach.
+- Introduce any autonomous (non-human-approved) action.
+- Touch property/valuation data from an AI path.
+
+## Non-Goals (explicit — these are deferred)
+
+- **Do not implement LocalOps yet** beyond this doctrine pack.
+- Do not change TerraPilot UI.
+- Do not build path-routing commands (WO-BRAIN-0014).
+- No per-suite queues.
+- No autonomous suite agents.
+- No production behavior changes.
+
+## Canon Sources
+
+- `docs/architecture/specs/terrafusion/02_TERRAPILOT_SPEC_v3.1.md` (TerraPilot modes, tool allowlists, risk classes, PII sanitization, trace logging)
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§1.2 TerraPilot/TerraTrace as OS features; Article VII modes)
+- `AGENTS.md` (root — Core Governance Surface; allowed scope `os-platform/core/pilot/**`)
+- Implementation: `os-platform/core/pilot/local-agent/` (`cli.ts`, `adapterRegistry.ts`, `commandRegistry.ts`, `doctorMode.ts`, `controlCenter.ts`)

--- a/brain/packs/shell/README.md
+++ b/brain/packs/shell/README.md
@@ -1,0 +1,97 @@
+# Domain Pack: Shell
+
+> OS shell chrome and routing. **Not a suite.** An OS surface owned by OS Core.
+> Canonical location: `frontend/apps/os-shell/`
+
+## Mission
+
+Provide the department-agnostic operating-system shell: the chrome, window management, and routing
+spine that every suite renders inside. The shell teaches and enforces the OS model; it never contains
+department business logic.
+
+## Owns
+
+- OS shell chrome: Dock, Top Bar, global status, stage framing.
+- Window manager and **z-index authority** (`frontend/apps/os-shell/src/shell/desktop/zIndex.ts`).
+- Module/suite activation and the **suite registry** (`frontend/apps/os-shell/src/config/suiteRegistry.ts`).
+- Command palette and global navigation.
+- The **Property Workbench** OS surface and its canonical tab order:
+  `Summary → Forge → Atlas → Dais → Dossier → Pilot` (Dossier and Pilot always last).
+- Bridge/anti-drift UI (Suite Compass, Context Ribbon) that teaches the OS model.
+- Hosting OS features (TerraPilot, TerraTrace) **inside** the shell.
+
+## Does Not Own
+
+- Any suite business logic (valuation, GIS, workflow, documents, AI).
+- Parcel-scoped domain work — that belongs to the **Property Workbench**, not standalone windows.
+- Write lanes for suite-owned facts (see the suite packs).
+- The audit/trace event store (TerraTrace owns it; the shell only hosts the surface).
+
+## Allowed Writes
+
+- Shell chrome layout, Dock/Top Bar configuration, window state, and z-index constants **within the
+  canonical layer hierarchy**.
+- Suite registry entries (registration metadata only — manually maintained source of truth).
+- Routing tables, command-palette entries, and global navigation state.
+- Bridge UI (Suite Compass, Context Ribbon) presentation — read-only projections only.
+
+## Forbidden Writes
+
+- **Hardcoded z-index values.** All stacking goes through the z-index authority module; no magic
+  numbers in components.
+- **Route escape**: opening parcel-scoped work in a standalone window instead of routing to the
+  Property Workbench (`/property/:parcelId/:tab`).
+- Suite-owned domain data (valuation, GIS geometry, workflow state, documents) — route to the owning
+  suite's service, never write directly from the shell.
+- Department-specific business rules embedded in shell chrome.
+- Reordering the canonical Workbench tab order without Architecture-team approval (constitutional).
+
+## Routing Rules
+
+- Parcel-scoped work **routes to the Property Workbench**, not standalone windows.
+- OS features (TerraPilot, TerraTrace) **open inside the shell**, never as separate apps.
+- Suite activation goes through the suite registry; new surfaces register there rather than
+  hard-wiring navigation.
+- Stacking/overlay decisions route through `zIndex.ts` (Top Bar = 10, Windows = 30, Dock = 1000,
+  command palette = 1200–1300, modals = 1400, a11y skip-nav = 99999).
+- Cross-suite actions initiated from the shell route through the owning lane's service + TerraTrace.
+
+## Required Proof
+
+- `pnpm run type-check` (must pass).
+- `pnpm canon` / `pnpm canon:gatefast` (governance gates green).
+- Shell-contract / Tier-1 UI Harness validation green (the `🧪 Tier-1 UI Harness Validation` required check).
+- For routing/z-index changes: evidence that no hardcoded z-index was introduced and no route-escape
+  path was added.
+
+## Common Failure Patterns
+
+- Opening a parcel detail in a free-floating window instead of the Workbench tab route.
+- Hardcoding `z-index: 9999` (or similar) in a component instead of using `zIndex.ts`.
+- Smuggling suite business logic (valuation math, workflow transitions) into shell components.
+- Reordering or renaming Workbench tabs and breaking the locked canonical order.
+- Registering a suite surface ad hoc instead of through `suiteRegistry.ts`.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Reorder, rename, add, or remove a Workbench tab (constitutional — Architecture team).
+- Restructure the z-index layer hierarchy.
+- Change the global routing model or introduce a new top-level surface.
+- Make the shell department-aware (couple it to a specific office's rules).
+
+## Non-Goals
+
+- No suite business logic in the shell.
+- No standalone parcel windows.
+- No second brain / no suite-local queue inside the shell.
+- Not building the Brain Path Router (WO-BRAIN-0014).
+
+## Canon Sources
+
+- `docs/architecture/specs/terrafusion/01_PROPERTY_WORKBENCH_SPEC_v3.1.md`
+- `docs/files/PROPERTY_WORKBENCH_SPEC_v3.md`
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (Article IV: Workbench tab order; §1.2 OS features)
+- `frontend/apps/os-shell/src/shell/desktop/zIndex.ts` (z-index authority)
+- `frontend/apps/os-shell/src/config/suiteRegistry.ts` (suite registration source of truth)

--- a/brain/packs/trace/README.md
+++ b/brain/packs/trace/README.md
@@ -1,0 +1,84 @@
+# Domain Pack: Trace (TerraTrace)
+
+> Feature ID: `terratrace` · Type: OS feature (audit/trace spine) · **Not a suite.**
+> The bridge for cross-lane accountability.
+
+## Mission
+
+Record what happened. TerraTrace owns the append-only activity / evidence trail and is the bridge for
+cross-lane accountability — it answers *what happened, when, by whom/what, and why* across every suite.
+
+## Owns
+
+- The append-only unified activity trail (OS-core trace spine).
+- Trace event categories (`valuation`, `workflow`, `compliance`, `system`, `navigation`).
+- Trace classification levels and retention (`PUBLIC`, `INTERNAL`, `CONFIDENTIAL`, `RESTRICTED`).
+- Correlation-id chains for causal lookups (`pnpm run trace:query --correlation <id>`).
+
+## Does Not Own
+
+- Any suite's business state — Trace records *about* it, it does not own it.
+- Valuation, GIS, workflow, or document data (the suites own those).
+- Shell routing or window management (**Shell / OS Core**).
+- Financial/compliance **audit** semantics reserved for the future TerraAudit office — Trace uses
+  `trace` / `activity`, never `audit`, for assessor activity.
+
+## Allowed Writes
+
+- Appending new trace events (the only write shape — append-only).
+- Correlation metadata linking causally related events.
+
+## Forbidden Writes
+
+- **Mutating or deleting existing trace records** — the trail is append-only and immutable.
+- Turning trace into mutable business state (it must never become the source of truth for a suite fact).
+- Using the word `audit` for assessor activity logging (reserved for TerraAudit; use `trace`/`activity`).
+- Shell chrome, routing, or z-index.
+
+## Routing Rules
+
+- Every write-lane action in a suite **emits** a TerraTrace event in the correct category; suites do not
+  invent their own parallel logs.
+- Cross-lane accountability flows through Trace — it is the bridge, not a per-suite ledger.
+- Debugging routes through trace lookups: `pnpm run trace:query --correlation <id>`, `--recent`,
+  `--type`, `--error-code`, `--component`.
+- AI-initiated actions (TerraPilot/TerraGPT) must emit trace events with source grounding where applicable.
+
+## Required Proof
+
+- `pnpm run type-check`.
+- `pnpm canon` / `pnpm canon:gatefast`.
+- Evidence that write actions emit trace events (the constitution's "Trace Emission" check; warning-level
+  but expected for write paths).
+- Append-only integrity: no update/delete paths introduced against the trail.
+
+## Common Failure Patterns
+
+- Reading the latest state *from* trace and treating it as authoritative business state.
+- Adding an update/delete path to "fix" a trace record instead of appending a correction event.
+- A suite logging to its own side-channel instead of emitting a TerraTrace event.
+- Mislabeling categories (e.g. a workflow change logged as `system`).
+- Using `audit` terminology for assessor activity.
+
+## Escalation Triggers
+
+Stop and get human approval when a change would:
+
+- Make any part of the trail mutable, or add a delete/redact path.
+- Change retention or classification-level semantics (legal / compliance impact).
+- Add or rename a trace **category** or classification **level** (constitutional).
+- Repurpose trace as a business-state store.
+
+## Non-Goals
+
+- No mutable trace state.
+- No suite business logic in the trace spine.
+- No `audit`-named assessor logging.
+- No shell/routing changes.
+- No suite-local brain or queue authority.
+
+## Canon Sources
+
+- `docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md` (§1.2 OS features; Article IX trace categories & classification; §2.3 / §8 audit-vs-trace disambiguation)
+- `docs/architecture/specs/terrafusion/04_SUITE_BOUNDARIES_WRITE_LANES_v3.1.md` (unified activity trail = TerraTrace, append-only)
+- `AGENTS.md` (root — trace:query debugging workflows, correlationId model)

--- a/frontend/apps/os-shell/AGENTS.md
+++ b/frontend/apps/os-shell/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md — OS Shell
+
+This is the **TerraFusion OS Shell** (department-agnostic chrome, window manager, routing spine).
+
+**Before modifying anything here, read the Shell domain pack:** [`brain/packs/shell/README.md`](../../../brain/packs/shell/README.md).
+
+Key boundaries (full detail in the pack):
+
+- **Owns:** Dock, Top Bar, window manager, **z-index authority** (`src/shell/desktop/zIndex.ts`),
+  module activation + suite registry (`src/config/suiteRegistry.ts`), command palette, global status,
+  stage framing, and the Property Workbench frame.
+- **Stay department-agnostic** — no suite business logic in the shell.
+- **No hardcoded z-index** — all stacking goes through `zIndex.ts`.
+- **No route escape** — parcel-scoped work routes to the Property Workbench, not standalone windows.
+- OS features (TerraPilot, TerraTrace) **open inside the shell**.
+
+Governance: one Brain, many packs. Authority hierarchy and human-approval triggers are in the root
+[`AGENTS.md`](../../../AGENTS.md). Workbench tab order and OS-feature classification are constitutional
+(`docs/architecture/TERRAFUSION_SUITE_CONSTITUTION_v1.md`).

--- a/os-platform/core/pilot/local-agent/AGENTS.md
+++ b/os-platform/core/pilot/local-agent/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md — LocalOps (local-agent)
+
+This is **LocalOps** — TerraPilot **inside the shell**, an OS feature, **not** a standalone app.
+
+**Before modifying anything here, read the LocalOps domain pack:** [`brain/packs/localops/README.md`](../../../../brain/packs/localops/README.md).
+
+Hard limits (full detail in the pack):
+
+- **No property record or valuation mutation by AI** — ever.
+- **No silent cloud fallback** — when local AI is unavailable/prohibited, stay local; do not quietly
+  route to the cloud.
+- **No unrestricted shell** — command execution stays within the controlled command registry.
+- **No autonomous production repair.**
+- **LocalOps v1 is local-first, read-only diagnostic, source-grounded, trace-emitting, and
+  human-approved before any mutation.**
+- Mutations route only through approved TerraPilot tools (risk-classified, human-gated).
+
+This directory is inside the **Core Governance Surface** (`os-platform/core/pilot/**`) — changes here
+require the gates and approvals defined in the root [`AGENTS.md`](../../../../AGENTS.md), including
+`pnpm run type-check` and `node --test os-platform/core/tests/phase83-tools.test.mjs`.


### PR DESCRIPTION
## WO-BRAIN-0013 — Domain Knowledge Pack Scaffold

Turns **existing TerraFusion canon** into **agent-readable Brain packs** so Claude Code and future agents can route work by domain, path, and work-order scope without asking the human owner for boundaries that are already written down.

> **One TerraFusion Brain. Many packs. No competing brains. No distributed queue authority. No suite-local autonomous governance.**

This is an **extraction + normalization** of existing canon — not a new architecture, not a second Brain, not suite-specific command systems.

### What's in this PR

- **`brain/packs/README.md`** — doctrine, authority hierarchy, the real repo path map, candidate `AGENTS.md` locations, and **Verification Notes**.
- **8 domain packs** — `shell`, `dais`, `forge`, `atlas`, `dossier`, `gpt`, `trace`, `localops`. Each uses the 11-section template (Mission / Owns / Does Not Own / Allowed Writes / Forbidden Writes / Routing Rules / Required Proof / Common Failure Patterns / Escalation Triggers / Non-Goals / Canon Sources), grounded in **TF-052 Suite Constitution** and the **Suite Boundaries write-lane matrix**.
- **Root `AGENTS.md`** — augmented (not replaced) with a Brain governance section: authority hierarchy, one-Brain rules, and the seven human-approval triggers.
- **Two directory-local `AGENTS.md` pointers** at the only unambiguous canonical paths: `frontend/apps/os-shell/` and `os-platform/core/pilot/local-agent/`.

### Corrections to the work order's assumptions

The original work order assumed paths that **do not exist** in this repo (`apps/terrafusion-shell/`, `suites/terradias/`, `services/terrapilot/`). Per the "do not invent paths" rule, the real locations were discovered and documented in `brain/packs/README.md`:

- Shell → `frontend/apps/os-shell/`
- Suites → pages under `os-shell/src/pages/suites/` + scattered `packages/terra-*`
- LocalOps → `os-platform/core/pilot/local-agent/`

Per-suite `AGENTS.md` files were **not** created because suites have no single canonical directory; candidate paths are listed instead.

**`pnpm brain review-diff / proof / commit-plan` does not exist** — verified against `package.json` and the `tools/bin` CLI. The README's *Verification Notes* documents the real command surface (`pnpm canon`, `pnpm tf`, `pnpm truth:june10-*`, `pnpm run trace:query`).

### Verification

- ✅ Every canon reference and relative `AGENTS.md` link resolves to a real file on disk.
- ✅ `prettier --check` passes on all new/changed markdown.
- ✅ `pnpm canon:ping` → `PASS Overall: PASS` (exit 0).

### Scope guardrails honored

Documentation/governance scaffold only. No production code or behavior changes, no new queue systems, no separate suite brains, no invented paths, no build-config changes. LocalOps is **not** implemented (doctrine pack only); the Brain Path Router (WO-BRAIN-0014) is **not** built.

### Acceptance criteria

- [x] One-Brain doctrine documented
- [x] No separate suite brains created
- [x] `brain/packs` scaffold exists
- [x] Shell, Dais, Forge, Atlas, Dossier, GPT, Trace, LocalOps packs exist
- [x] Each pack defines owns / forbidden / routing / proof / escalation
- [x] Root `AGENTS.md` updated
- [x] No production code behavior changes
- [x] Brain review/proof/commit-plan run-or-documented (documented: `pnpm brain` n/a; `pnpm canon:ping` PASS)

https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established comprehensive governance framework defining system domains, ownership boundaries, and operational constraints across all core platform components.
  * Added domain knowledge documentation for atlas, dais, dossier, forge, GPT, localops, shell, and trace components.
  * Defined permission models and escalation triggers for system operations and state changes.
  * Added operating guidelines for OS shell and local operations management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->