### PR TITLE
WO-LOCALOPS-006.1 — Mount + register in-shell LocalOps

### DIFF
--- a/docs/localops/README.md
+++ b/docs/localops/README.md
@@ -55,11 +55,26 @@ It holds only local UI state, performs **no** API calls, mutation, shell executi
 actions, uses design tokens only (`hsl(var(--tf-*))`, leak-guard tested) and the shell z-index
 authority (`Z.companionPanel`, never hardcoded).
 
-**Deferred to WO-LOCALOPS-006.1 (approval-gated):** registering LocalOps as an OS feature
-(`OS_FEATURES`/module registry) and **mounting** the panel in the live `Desktop.tsx`. That step changes
-what the shell renders (a product-behavior change) and touches shell-contract surfaces, so it is a
-separate, explicitly-approved slice. The live engine→view-model adapter (mapping WO-001…005 outputs
-onto `LocalOpsViewModel`) also lands there.
+## Mount + registration (WO-LOCALOPS-006.1)
+
+LocalOps is now **mounted** in the live shell and **registered** as a governed OS feature:
+
+- `frontend/apps/os-shell/src/components/localops/LocalOpsSurface.tsx` is the shell-chrome container
+  that mounts `LocalOpsPanel` into `Desktop.tsx` and renders a right-edge pull-tab. Visibility and the
+  view model live in `frontend/apps/os-shell/src/stores/localOpsStore.ts` (open/close/toggle/setData),
+  mirroring the companion store. It is fixed shell chrome — **not** a routable window.
+- `localops` is registered in `OS_FEATURES` (`suiteRegistry.ts`) **without a `route` or `homeMeta`**, so
+  it stays out of the launcher, desktop icons, standalone-home derivation, and the React Router — there
+  is **no Router / full-page escape**. `os-localops` is registered in the module registry, object-placement
+  contract, and module-activation maps so the shell anti-drift contract sees a consistent feature.
+- The os-localops window home (`pages/LocalOpsHome.tsx`) is a truthful redirect to the side panel, not a
+  duplicate full-page surface.
+
+**Still deferred (separately approvable):** the live engine→view-model adapter (mapping WO-001…005 node
+outputs onto `LocalOpsViewModel`). The store ships the honest `disabled`-profile default and a `setData`
+seam; until an adapter is wired, the panel renders that default and performs **no** API calls, mutation,
+or shell execution. Wiring a live adapter crosses the node/browser boundary (needs a backend surface) and
+is intentionally left to a future slice to keep 006.1 dependency-free.
 
 ## LocalOps trace events (WO-LOCALOPS-003)
 

--- a/frontend/apps/os-shell/src/components/localops/LocalOpsSurface.tsx
+++ b/frontend/apps/os-shell/src/components/localops/LocalOpsSurface.tsx
@@ -1,0 +1,84 @@
+/**
+ * TerraFusion OS — LocalOps Surface (WO-LOCALOPS-006.1)
+ *
+ * The shell-chrome container that mounts the presentational `LocalOpsPanel`
+ * into the live Desktop. It owns no LocalOps logic — it wires the panel's
+ * controlled visibility and view model to `useLocalOpsStore`, and renders a
+ * right-edge pull-tab so an operator can open the panel without a desktop icon,
+ * launcher entry, or route (honoring the in-shell-only / no-Router-escape
+ * guardrail).
+ *
+ * Like `CompanionPanel`, this is fixed shell chrome, not a routable window.
+ * Z-index comes from the shell z-index authority (`Z.companionPanel`), never a
+ * hardcoded value. Colors use design tokens only (`hsl(var(--tf-*))`).
+ *
+ * @module components/localops/LocalOpsSurface
+ */
+
+import React from 'react';
+import { Z } from '../../shell/desktop/zIndex';
+import { useLocalOpsStore } from '../../stores/localOpsStore';
+import { LocalOpsPanel } from './LocalOpsPanel';
+
+const TEXT = 'hsl(var(--tf-text))';
+const SURFACE = 'hsl(var(--tf-surface-dark-hs, 226 30%) 9%)';
+const BORDER = 'hsl(var(--tf-border) / 0.2)';
+
+/**
+ * Right-edge pull-tab. Hidden (aria + pointer) while the panel is open so it
+ * never overlaps the panel's own close affordance.
+ */
+const PullTab: React.FC<{ open: boolean; onOpen: () => void }> = ({ open, onOpen }) => (
+  <button
+    type='button'
+    data-testid='localops-pull-tab'
+    aria-label='Open TerraPilot LocalOps'
+    aria-hidden={open}
+    onClick={onOpen}
+    style={{
+      position: 'fixed',
+      right: 0,
+      top: '50%',
+      transform: open ? 'translate(100%, -50%)' : 'translate(0, -50%)',
+      transition: 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+      zIndex: Z.companionPanel,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 6,
+      padding: '8px 6px',
+      writingMode: 'vertical-rl',
+      background: SURFACE,
+      color: TEXT,
+      border: `1px solid ${BORDER}`,
+      borderRight: 'none',
+      borderRadius: '6px 0 0 6px',
+      cursor: 'pointer',
+      fontSize: 10,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
+      pointerEvents: open ? 'none' : 'auto',
+    }}
+  >
+    LocalOps
+  </button>
+);
+
+/**
+ * Mounts the LocalOps panel as persistent shell chrome. Reads visibility and
+ * the view model from the LocalOps store; renders the pull-tab when closed.
+ */
+export const LocalOpsSurface: React.FC = () => {
+  const isOpen = useLocalOpsStore((s) => s.isOpen);
+  const data = useLocalOpsStore((s) => s.data);
+  const open = useLocalOpsStore((s) => s.open);
+  const close = useLocalOpsStore((s) => s.close);
+
+  return (
+    <div data-testid='localops-surface'>
+      <PullTab open={isOpen} onOpen={open} />
+      <LocalOpsPanel data={data} open={isOpen} onClose={close} />
+    </div>
+  );
+};
+
+export default LocalOpsSurface;

--- a/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
+++ b/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
@@ -238,6 +238,7 @@ describe('moduleActivation displayNames/icons coverage', () => {
       'os-pilot': 'TerraFusion Pilot',
       'os-trace': 'TerraFusion Trace',
       'os-canon': 'TerraCanon',
+      'os-localops': 'TerraFusion LocalOps',
       // Levy (legacy canonical kept for backward compat)
       'terra-levy': 'Levy Calculator',
       // Forge standalone modules (Phase 35 + Phase 36)

--- a/frontend/apps/os-shell/src/config/moduleComponents.tsx
+++ b/frontend/apps/os-shell/src/config/moduleComponents.tsx
@@ -122,9 +122,11 @@ export const MODULE_ALIASES: Record<string, string> = {
   pilot: 'os-pilot',
   trace: 'os-trace',
   canon: 'os-canon',
+  localops: 'os-localops',
   terrapilot: 'os-pilot',
   terratrace: 'os-trace',
   terracanon: 'os-canon',
+  terralocalops: 'os-localops',
 
   // Constitutional Suite Home aliases (desktop icons use these)
   forge: 'suite-forge',
@@ -218,6 +220,9 @@ export const MODULE_REGISTRY = new Set<string>([
   'os-pilot',
   'os-trace',
   'os-canon',
+  // LocalOps — registered OS feature whose ONLY operator surface is the shell
+  // side panel (LocalOpsSurface). The window home is a truthful redirect to it.
+  'os-localops',
   // Atlas & Forge standalone modules (Phase 36)
   'geo-equity-dashboard',
   'mass-appraisal-gis',
@@ -443,6 +448,7 @@ const PropertyWorkbenchWindow = lazy(
 const PilotHome = lazy(() => import('../pages/PilotHome'));
 const TraceHome = lazy(() => import('../pages/TraceHome'));
 const CanonHome = lazy(() => import('../pages/CanonHome'));
+const LocalOpsHome = lazy(() => import('../pages/LocalOpsHome'));
 
 // ============================================================================
 // Constitutional Suite Home Pages (render inside Desktop windows)
@@ -498,6 +504,8 @@ const MODULE_ENTRIES: Record<string, ModuleEntry> = {
   'os-pilot': { Component: PilotHome },
   'os-trace': { Component: TraceHome },
   'os-canon': { Component: CanonHome },
+  // LocalOps window home is a thin in-window redirect to the shell side panel.
+  'os-localops': { Component: LocalOpsHome },
   // Atlas & Forge standalone modules (Phase 36)
   'geo-equity-dashboard': { Component: GeoEquityDashboard },
   'mass-appraisal-gis': { Component: MassAppraisalGIS },
@@ -1157,6 +1165,13 @@ export const ModuleRenderer: React.FC<ModuleRendererProps> = ({ module, metadata
       return (
         <Suspense fallback={<ModuleLoadingFallback />}>
           <CanonHome />
+        </Suspense>
+      );
+
+    case 'os-localops':
+      return (
+        <Suspense fallback={<ModuleLoadingFallback />}>
+          <LocalOpsHome />
         </Suspense>
       );
 

--- a/frontend/apps/os-shell/src/config/suiteRegistry.ts
+++ b/frontend/apps/os-shell/src/config/suiteRegistry.ts
@@ -24,7 +24,8 @@ export type SuiteId =
 export type OsFeatureId =
   | 'pilot' // TerraPilot - Agentic Task Orchestration
   | 'trace' // TerraTrace - Observability & Audit Trail
-  | 'canon'; // TerraCanon - Integrated Development Environment
+  | 'canon' // TerraCanon - Integrated Development Environment
+  | 'localops'; // TerraPilot LocalOps - In-shell, county-boundary-safe local operator (side panel only)
 
 export type OsSurfaceId = 'workbench'; // Property Workbench - Primary parcel-context UX
 
@@ -359,6 +360,24 @@ export const OS_FEATURES: readonly OsFeatureDefinition[] = [
       ],
       showWorkbenchCta: false,
     },
+    objectType: 'os-feature-window',
+    layer: 'layer-5-application',
+  },
+  {
+    id: 'localops',
+    displayName: 'TerraFusion LocalOps',
+    shortName: 'LocalOps',
+    description: 'In-shell, county-boundary-safe local AI operator (read-only, source-grounded)',
+    iconName: 'LifeBuoy',
+    // Intentionally NO `route` and NO `homeMeta`: LocalOps is shell chrome (a fixed
+    // side panel mounted in Desktop), never a routable full-page surface. Omitting
+    // `route` keeps it out of the launcher, desktop icons, standalone-home derivation,
+    // and the React Router — honoring the WO-LOCALOPS-006.1 guardrail
+    // (in-shell only, no Router / full-page escape). It is still registered as a
+    // governed OS feature so the anti-drift contract sees it.
+    status: 'live',
+    label: 'LocalOps',
+    icon: 'life-buoy',
     objectType: 'os-feature-window',
     layer: 'layer-5-application',
   },

--- a/frontend/apps/os-shell/src/contracts/objectPlacement.ts
+++ b/frontend/apps/os-shell/src/contracts/objectPlacement.ts
@@ -303,6 +303,8 @@ export const MODULE_OBJECT_TYPES: Record<string, ObjectClassification> = {
   'os-pilot':             { objectType: 'os-feature-window', entryPath: 'desktop-icon:pilot', hasActionableUI: true },
   'os-trace':             { objectType: 'os-feature-window', entryPath: 'desktop-icon:trace', hasActionableUI: true },
   'os-canon':             { objectType: 'os-feature-window', entryPath: 'desktop-icon:canon', hasActionableUI: true },
+  // LocalOps reaches the operator through the shell side panel, not a desktop icon.
+  'os-localops':          { objectType: 'os-feature-window', entryPath: 'shell-chrome:localops', hasActionableUI: true },
 
   // ── Cross-parcel operational apps (layer 5) ───────────────────────────
   'federation-dashboard': { objectType: 'cross-parcel-operational-app', entryPath: 'desktop-icon:federation-dashboard', hasActionableUI: true },

--- a/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
+++ b/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
@@ -122,6 +122,7 @@ function getModuleDisplayName(moduleId: string): string {
     'os-pilot': 'TerraPilot',
     'os-trace': 'TerraTrace',
     'os-canon': 'TerraCanon',
+    'os-localops': 'TerraFusion LocalOps',
     // Application Constellation (Gen2 catalog)
     'income-valuation': 'Income Valuation',
     'income-forge': 'IncomeForge',
@@ -202,6 +203,7 @@ function getModuleIcon(moduleId: string): string {
     'os-pilot': '🧭',
     'os-trace': '📡',
     'os-canon': '⚙️',
+    'os-localops': '🛟',
     // Application Constellation (Gen2 catalog)
     'income-valuation': '💰',
     'income-forge': '💰',

--- a/frontend/apps/os-shell/src/pages/LocalOpsHome.tsx
+++ b/frontend/apps/os-shell/src/pages/LocalOpsHome.tsx
@@ -1,0 +1,87 @@
+/**
+ * TerraFusion LocalOps — Window Home
+ *
+ * LocalOps is registered as a governed OS feature, but its real operator
+ * surface is the shell side panel (`LocalOpsSurface` / `LocalOpsPanel`), not a
+ * full-page window — by design it never escapes the shell. If the os-localops
+ * window is ever opened, this home tells the truth and offers a button that
+ * opens the side panel instead of duplicating the panel as a routable page.
+ *
+ * Token-only colors (`hsl(var(--tf-*))`); no raw color values.
+ *
+ * @module pages/LocalOpsHome
+ */
+
+import React from 'react';
+import { useLocalOpsStore } from '../stores/localOpsStore';
+
+const TEXT = 'hsl(var(--tf-text))';
+const TEXT_MUTED = 'hsl(var(--tf-text) / 0.6)';
+const BORDER = 'hsl(var(--tf-border) / 0.2)';
+const PILOT = 'hsl(var(--tf-suite-pilot-hs, 226 58%) 60%)';
+
+export function LocalOpsHome(): React.ReactElement {
+  const open = useLocalOpsStore((s) => s.open);
+
+  return (
+    <div
+      data-testid='localops-home-content'
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 14,
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: TEXT,
+        }}
+      >
+        TerraPilot · LocalOps
+      </span>
+      <p style={{ maxWidth: 440, fontSize: 12, lineHeight: 1.6, color: TEXT_MUTED, margin: 0 }}>
+        LocalOps runs as a side panel in the shell, not a full-page window. It is a
+        local-first, source-grounded, read-only operator that observes and explains — it
+        never mutates records and never leaves the county boundary.
+      </p>
+      <button
+        type='button'
+        data-testid='localops-home-open-panel'
+        onClick={open}
+        style={{
+          padding: '8px 16px',
+          fontSize: 12,
+          color: TEXT,
+          background: 'none',
+          border: `1px solid ${PILOT}`,
+          borderRadius: 6,
+          cursor: 'pointer',
+        }}
+      >
+        Open LocalOps panel
+      </button>
+      <span
+        style={{
+          fontSize: 10,
+          color: TEXT_MUTED,
+          borderTop: `1px solid ${BORDER}`,
+          paddingTop: 10,
+        }}
+      >
+        Runbooks: docs/localops/BENTON_SERVER_RUNBOOK.md
+      </span>
+    </div>
+  );
+}
+
+export default LocalOpsHome;

--- a/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
@@ -14,6 +14,7 @@ import { Outlet, useLocation, UNSAFE_NavigationContext } from 'react-router-dom'
 import { Layers, Moon, Search, Settings2, Sun, User } from 'lucide-react';
 import { useTheme } from '../../hooks/useTheme';
 import { Launcher } from '../../components/launcher';
+import { LocalOpsSurface } from '../../components/localops/LocalOpsSurface';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useIpcBridge } from '../../ipc/useIpcBridge';
@@ -633,6 +634,10 @@ export function Desktop({ className = '', children }: DesktopProps) {
       <WindowPeek />
 
       <SentinelPanel open={panelOpen} onClose={() => setPanelOpen(false)} />
+
+      {/* Layer 1050: TerraPilot LocalOps — shell-chrome side panel (in-shell only,
+          no route / no desktop icon). Visibility owned by useLocalOpsStore. */}
+      <LocalOpsSurface />
 
       {/* Layer 9997: Control Center Drawer */}
       <ControlCenter />

--- a/frontend/apps/os-shell/src/stores/localOpsStore.ts
+++ b/frontend/apps/os-shell/src/stores/localOpsStore.ts
@@ -1,0 +1,79 @@
+/**
+ * TerraFusion OS — LocalOps Store (WO-LOCALOPS-006.1)
+ *
+ * Holds the open/closed state of the in-shell TerraPilot LocalOps side panel
+ * and the typed `LocalOpsViewModel` it renders. Like the companion store, the
+ * LocalOps surface is shell chrome — a persistent panel, not a window — so its
+ * visibility lives here rather than in the window/desktop store.
+ *
+ * Scope note (006.1): this slice mounts and registers the panel. The default
+ * view model is the honest `disabled`-profile shape — the live engine→view-model
+ * adapter (mapping WO-001..005 outputs onto `LocalOpsViewModel`) is intentionally
+ * NOT wired here. A future, separately-approved slice supplies real data through
+ * `setData`. The panel performs no API calls, mutation, or shell execution.
+ *
+ * @module stores/localOpsStore
+ */
+
+import { create } from 'zustand';
+import type { LocalOpsViewModel } from '../components/localops/LocalOpsPanel';
+
+// ============================================================================
+// Default view model — honest "disabled" posture (no live adapter yet)
+// ============================================================================
+
+/**
+ * The default LocalOps view model. Profile is `disabled` and every boundary
+ * flag is off, matching LocalOps doctrine defaults: no external calls, no web,
+ * no shell, no mutation; trace + sources required. This is what the panel shows
+ * until a live adapter calls `setData`.
+ */
+export const DEFAULT_LOCALOPS_VIEW_MODEL: LocalOpsViewModel = {
+  profile: 'disabled',
+  provider: '(none)',
+  flags: {
+    externalCalls: false,
+    allowWeb: false,
+    allowShell: false,
+    allowMutation: false,
+    requireTrace: true,
+    requireSources: true,
+  },
+  providerStatus: { ok: false, status: 'disabled' },
+  diagnostics: [],
+  grounded: false,
+  sources: [],
+  traceEvents: [],
+};
+
+// ============================================================================
+// Store
+// ============================================================================
+
+interface LocalOpsState {
+  /** Whether the LocalOps side panel is slid open. Starts closed. */
+  isOpen: boolean;
+  /** The view model rendered by the panel. `null` => engine unavailable. */
+  data: LocalOpsViewModel | null;
+
+  // Panel controls
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+
+  // View-model writer (future live adapter calls this)
+  setData: (data: LocalOpsViewModel | null) => void;
+}
+
+export const useLocalOpsStore = create<LocalOpsState>((set) => ({
+  isOpen: false,
+  data: DEFAULT_LOCALOPS_VIEW_MODEL,
+
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+
+  setData: (data) => set({ data }),
+}));
+
+export default useLocalOpsStore;


### PR DESCRIPTION
## WO-LOCALOPS-006.1 — Mount + register in-shell LocalOps

Mounts the presentational `LocalOpsPanel` (WO-006, merged in #944) into the live shell and registers LocalOps as a governed OS feature. **In-shell only, no Router / full-page escape, no new dependencies.**

### Mount (shell chrome)
- **`stores/localOpsStore.ts`** (new) — zustand `open/close/toggle/setData` + an honest `disabled`-profile default `LocalOpsViewModel`, mirroring `companionStore`.
- **`components/localops/LocalOpsSurface.tsx`** (new) — fixed shell-chrome container that renders `LocalOpsPanel` plus a right-edge pull-tab, wired to the store. Uses the shell z-index authority (`Z.companionPanel`) and design tokens only.
- **`Desktop.tsx`** — renders `<LocalOpsSurface/>` beside `SentinelPanel` (one import + one tag). No z-depth class, no second `shell-routed-content`, `<Outlet/>` preserved — the static shell-chrome/anti-drift/routed-content contracts are untouched.

### Register (governance, route-less)
- **`suiteRegistry.ts`** — `localops` added to `OsFeatureId` and `OS_FEATURES` **with no `route` and no `homeMeta`**, so it never enters the launcher, desktop icons, standalone-home derivation, or the React Router.
- **`moduleComponents.tsx`** — `os-localops` registered (registry + alias + `MODULE_ENTRY` + `ModuleRenderer` case) rendering **`pages/LocalOpsHome.tsx`** (new): a truthful in-window redirect to the side panel, not a duplicate full-page surface.
- **`objectPlacement.ts`** / **`orchestration/moduleActivation.ts`** — classify (`os-feature-window`) and name `os-localops` so the registry-consistency + anti-drift contracts stay green.
- **`config/__tests__/moduleRegistryConsistency.test.ts`** — expected display name for `os-localops` (the designed extension point for new modules).

### Why the full registry chain
The Phase-25 anti-drift contract iterates `OS_FEATURES` and asserts every `os-<id>` is in `MODULE_REGISTRY`, which in turn requires a `MODULE_ENTRY`/placeholder, an expected display name, and loader-store registration (the loader store delegates to the canonical registry, so no separate edit). Registering an OS feature inherently pulls in this chain; all edits are kept route-less so no full-page/Router surface is created.

### Deferred (separately approvable)
The live engine→view-model adapter (mapping WO-001…005 node outputs onto `LocalOpsViewModel`) is **not** wired here — it crosses the node/browser boundary (needs a backend surface) and would add dependencies/surface. The store ships the `disabled` default + a `setData` seam; the panel performs **no** API calls, mutation, or shell execution.

### Verification note
The frontend/shell-contract test runner (vitest/@testing-library) cannot be installed in this environment (the sheetjs-blocked `pnpm install`), so the shell-contract suite — `shellAntiDrift`, `shellChrome`, `shellRoutedContent`, `shellTruthAudit`, `moduleRegistryConsistency`, `codexNavigation`, `standaloneHomes.*` — is verified by **CI** here, not locally. Edits were made against a static reading of each contract; CI is authoritative.

### Doctrine alignment
LocalOps remains in-shell only (Acceptance I8 / S6): no standalone window, no route escape, no hardcoded z-index. Read-only, source-grounded, human-approved posture is unchanged — this slice ships the surface mount + registration, nothing operational.

🤖 Draft — held for human merge per the WO loop.

https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LocalOps side panel to the shell interface with an easy-access pull-tab for opening and closing the panel.
  * Integrated LocalOps feature registration and state management for seamless in-shell access.

* **Documentation**
  * Expanded documentation with shell integration details for the LocalOps side panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->