### PR TITLE
WO-SEC-LOCALOPS-001 — Phone-number redaction in the local-agent redactor

### DIFF
--- a/os-platform/core/pilot/local-agent/redact.js
+++ b/os-platform/core/pilot/local-agent/redact.js
@@ -67,6 +67,16 @@ const PATTERNS = [
         re: /\b\d{3}-\d{2}-\d{4}\b/g,
         transform: () => '[REDACTED:ssn]',
     },
+    // US / NANP phone numbers. Mirrors the canonical AUDIT_PHONE_PATTERN used by
+    // the trace audit redactor (core/trace/TraceService.ts) so the local-agent
+    // telemetry redactor and the trace store agree on what a phone number is.
+    // Runs after SSN so a 3-2-4 SSN is consumed first (it is disjoint from the
+    // 3-3-4 phone shape regardless).
+    {
+        kind: 'phone',
+        re: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g,
+        transform: () => '[REDACTED:phone]',
+    },
     // Windows user paths — preserve directory shape, redact only the user name.
     {
         kind: 'win-userpath',

--- a/os-platform/core/pilot/local-agent/redact.ts
+++ b/os-platform/core/pilot/local-agent/redact.ts
@@ -80,6 +80,16 @@ const PATTERNS: Pattern[] = [
     re: /\b\d{3}-\d{2}-\d{4}\b/g,
     transform: () => '[REDACTED:ssn]',
   },
+  // US / NANP phone numbers. Mirrors the canonical AUDIT_PHONE_PATTERN used by
+  // the trace audit redactor (core/trace/TraceService.ts) so the local-agent
+  // telemetry redactor and the trace store agree on what a phone number is.
+  // Runs after SSN so a 3-2-4 SSN is consumed first (it is disjoint from the
+  // 3-3-4 phone shape regardless).
+  {
+    kind: 'phone',
+    re: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g,
+    transform: () => '[REDACTED:phone]',
+  },
   // Windows user paths — preserve directory shape, redact only the user name.
   {
     kind: 'win-userpath',

--- a/os-platform/core/tests/local-agent-event-redaction.test.mjs
+++ b/os-platform/core/tests/local-agent-event-redaction.test.mjs
@@ -73,6 +73,37 @@ test('redact: SSN-shaped values are scrubbed', () => {
   assert.equal(redactStringValue('ssn 123-45-6789'), 'ssn [REDACTED:ssn]');
 });
 
+// WO-SEC-LOCALOPS-001 — close the phone-number gap so the local-agent redactor
+// (used by LocalOps trace) agrees with the canonical trace audit redactor.
+test('redact: phone numbers are scrubbed (dash/dot/bare formats)', () => {
+  assert.equal(redactStringValue('call 509-555-1234 now'), 'call [REDACTED:phone] now');
+  assert.equal(redactStringValue('call 509.555.1234 now'), 'call [REDACTED:phone] now');
+  assert.equal(redactStringValue('call 5095551234 now'), 'call [REDACTED:phone] now');
+});
+
+test('redact: phone is distinct from SSN and both are scrubbed together', () => {
+  assert.equal(
+    redactStringValue('SSN 123-45-6789 phone 360-555-9999'),
+    'SSN [REDACTED:ssn] phone [REDACTED:phone]',
+  );
+});
+
+test('redact: SSN/phone/email all scrubbed from one string (I4 invariant)', () => {
+  const out = redactStringValue(
+    'owner 111-22-3333, ph 509-555-0000, email owner@county.gov',
+  );
+  for (const pii of ['111-22-3333', '509-555-0000', 'owner@county.gov']) {
+    assert.equal(out.includes(pii), false, `raw PII must not survive: ${pii}`);
+  }
+});
+
+test('redact: phone matcher does not broaden — non-phone numbers survive', () => {
+  // Short numbers, ports, years, and >10-digit runs are not phone-shaped and
+  // must pass through unchanged (no over-redaction).
+  const clean = 'port 11434, year 2026, count 42, id 1700000000000';
+  assert.equal(redactStringValue(clean), clean);
+});
+
 test('redact: Windows user paths preserve directory shape', () => {
   const out = redactStringValue('opening C:\\Users\\bsval\\terrafusion_os_1.0\\file.log');
   assert.match(out, /[Cc]:\\Users\\\[redacted-user\]\\terrafusion_os_1\.0\\file\.log/);


### PR DESCRIPTION
## WO-SEC-LOCALOPS-001 — Phone-number redaction in the local-agent redactor

**Bounded remediation** spun out of WO-LOCALOPS-008's honesty finding: the shared local-agent telemetry redactor (`os-platform/core/pilot/local-agent/redact.ts`, used by LocalOps trace via `redactPayload`/`redactStringValue`) scrubbed **email, SSN, and secret/token** patterns but **not phone numbers** — so acceptance invariant **I4** ("SSN/phone/email never appear in trace payloads") was only *partially* satisfiable in shipped code.

### Change (redactor only)
- Add a `phone` pattern that **mirrors the canonical `AUDIT_PHONE_PATTERN`** already used by the trace audit redactor (`core/trace/TraceService.ts`, relied on by the D2 PII leak-guard) — `\b\d{3}[-.]?\d{3}[-.]?\d{4}\b` → `[REDACTED:phone]`. This aligns the two redactors on what a phone number is rather than inventing a new matcher. Placed **after** the SSN pattern (3-2-4 vs 3-3-4 are disjoint; SSN consumed first).
- Regenerated `redact.js` via `build:core-js` (generated artifact in sync; `check:generated` green).

### Tests (prove, don't broaden)
Added to `local-agent-event-redaction.test.mjs`:
- phone scrubbed in dash / dot / bare formats;
- phone distinct from SSN, both scrubbed together;
- SSN + phone + email all scrubbed from one string (the I4 trio);
- **no broadening** — ports (`11434`), years (`2026`), counts, and >10-digit ids (`1700000000000`) pass through unchanged.

### Verified offline (CI is authoritative)
- `node --test local-agent-event-redaction.test.mjs` → 18/18 pass (4 new).
- Full LocalOps suite (trace/diagnostics/kb/provider) → green, no regression.
- `check:generated` → clean (committed `redact.js` matches a fresh regenerate).
- No impact on `TraceService.ts` / the D2 leak-guard (`[PHONE_REDACTED]` path) — different module, untouched.

### Scope / guardrails
Redactor + its test only. No new deps, no behavior change elsewhere, no D-017. This **unblocks WO-LOCALOPS-008** to mark **I4 fully proven** once this lands — and only then.

🤖 Draft — held for human merge per the WO loop.

https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8)_