### PR TITLE
WO-AI-CONSOLIDATION-003 — SystemGPT read-only health onto the LocalOps diagnostics path

### DIFF
--- a/docs/ai-consolidation/AI_ESTATE_INVENTORY.md
+++ b/docs/ai-consolidation/AI_ESTATE_INVENTORY.md
@@ -66,7 +66,10 @@ statement (see the plan's honest-status sweep).
 2. **Trace unification.** Emit AICommandService / Muse / Pilot-explain activity to **TerraTrace** (one
    append-only spine, not AuditLogs-vs-TerraTrace), and gate any mutation behind the LocalOps approval gate.
 3. **SystemGPT read-only health/forecast → LocalOps diagnostics** (read-only only; leave the dead swarm
-   bridge out).
+   bridge out). **Realized by WO-AI-CONSOLIDATION-003:** the `health.summary` LocalOps diagnostic brings
+   SystemGPT's read-only Herald health-roll-up pattern onto the Node diagnostics path over local truthful
+   signals; the swarm-dependent forecast is shown unavailable, never inferred. (The .NET
+   `SystemGptHealthEvaluator` is not called — the diagnostics seam is no-network by invariant.)
 
 ## Quarantine list (label non-operational; do **not** wire)
 

--- a/docs/localops/BENTON_SERVER_RUNBOOK.md
+++ b/docs/localops/BENTON_SERVER_RUNBOOK.md
@@ -16,8 +16,8 @@ Each entry has the same shape:
 - **Symptom** — what the operator observes.
 - **Diagnostic source** — one of:
   - _LocalOps read-only diagnostic (shipped)_ — a fixed-allowlist diagnostic from WO-005
-    (`ai.profile`, `config.summary`, `provider.status`, `kb.status`). LocalOps runs it, emits a
-    trace event, and cites the result.
+    (`ai.profile`, `config.summary`, `provider.status`, `kb.status`, `health.summary`). LocalOps runs
+    it, emits a trace event, and cites the result.
   - _Operator-performed read-only check (no LocalOps seam in v1)_ — the operator runs the read-only
     inspection (port/process/log/status). LocalOps surfaces the proposed step but cannot run the
     check itself yet.
@@ -167,7 +167,7 @@ work order may add them; until then these entries are operator-performed and Loc
 ## Grounding and trace (where the entries route)
 
 - Read-only diagnostics: `os-platform/core/pilot/local-agent/localOpsDiagnostics.ts`
-  (`READONLY_DIAGNOSTICS` = `ai.profile`, `config.summary`, `provider.status`, `kb.status`).
+  (`READONLY_DIAGNOSTICS` = `ai.profile`, `config.summary`, `provider.status`, `kb.status`, `health.summary`).
 - Source grounding: `os-platform/core/pilot/local-agent/localOpsKb.ts` (docs/ allowlist only).
 - Trace events: `os-platform/core/pilot/local-agent/localOpsTrace.ts`
   (`localops.tool.diagnostic.started` / `.completed`, `localops.policy.refused`).

--- a/docs/localops/README.md
+++ b/docs/localops/README.md
@@ -121,6 +121,11 @@ contract only.
 - `config.summary` — redacted AI profile configuration
 - `provider.status` — provider readiness (a non-ready provider is `warn`, not `error`)
 - `kb.status` — local KB health (roots, excluded roots, file count)
+- `health.summary` — **(WO-AI-CONSOLIDATION-003)** SystemGPT-style read-only health roll-up: applies
+  Herald threshold rules to the local signals above to produce an overall `ok`/`warn`/`error` + warnings.
+  Local-only (no network, no .NET call, no swarm); swarm-dependent advisory (`systemgpt.forecast`,
+  `swarm.health`) is shown **unavailable**, never inferred — see
+  [`../ai-consolidation/AI_ESTATE_INVENTORY.md`](../ai-consolidation/AI_ESTATE_INVENTORY.md).
 
 Every result is `readonly: true` — diagnostics **observe only**: no mutation, no shell, no service
 restart, no DB write, no migration, no network I/O. `request(name)` is the gated entry point: any name

--- a/os-platform/core/pilot/local-agent/localOpsDiagnostics.js
+++ b/os-platform/core/pilot/local-agent/localOpsDiagnostics.js
@@ -29,6 +29,7 @@ exports.READONLY_DIAGNOSTICS = [
     'config.summary',
     'provider.status',
     'kb.status',
+    'health.summary',
 ];
 function isDiagnosticRefusal(value) {
     return (typeof value === 'object' &&
@@ -161,6 +162,74 @@ class LocalOpsDiagnostics {
                     rootsExcluded: kb.rootsExcluded,
                     fileCount: kb.fileCount,
                     requireSources: kb.requireSources,
+                });
+            }
+            case 'health.summary': {
+                // WO-AI-CONSOLIDATION-003: bring SystemGPT's read-only health-evaluation
+                // pattern (Herald threshold rules -> overall status + warnings) onto the
+                // LocalOps diagnostics path, but ONLY over local, truthful signals — the
+                // sibling read-only diagnostics. No network, no .NET call, no swarm, no
+                // control plane. Swarm/forecast advisory is shown unavailable, never
+                // inferred (see docs/ai-consolidation/AI_ESTATE_INVENTORY.md).
+                const provider = this.compute('provider.status');
+                const kb = this.compute('kb.status');
+                const warnings = [];
+                let overall = 'ok';
+                const escalate = (s) => {
+                    if (s === 'error')
+                        overall = 'error';
+                    else if (s === 'warn' && overall !== 'error')
+                        overall = 'warn';
+                };
+                if (this.config.profile === 'disabled') {
+                    warnings.push({
+                        level: 'warn',
+                        source: 'ai.profile',
+                        message: 'AI profile is disabled; LocalOps will not answer.',
+                    });
+                    escalate('warn');
+                }
+                if (this.config.externalCalls) {
+                    warnings.push({
+                        level: 'warn',
+                        source: 'ai.profile',
+                        message: 'External calls are enabled — unexpected for a county-boundary profile.',
+                    });
+                    escalate('warn');
+                }
+                escalate(provider.status);
+                if (provider.status !== 'ok') {
+                    warnings.push({ level: provider.status, source: 'provider.status', message: provider.summary });
+                }
+                escalate(kb.status);
+                if (kb.status !== 'ok') {
+                    warnings.push({ level: kb.status, source: 'kb.status', message: kb.summary });
+                }
+                if (this.config.requireSources && Number(kb.data.fileCount) === 0) {
+                    warnings.push({
+                        level: 'warn',
+                        source: 'kb.status',
+                        message: 'Sources are required but the local KB is empty — answers will be refused.',
+                    });
+                    escalate('warn');
+                }
+                // Honest unavailability: advisory outputs that depend on swarm state are
+                // NOT inferred from mocked/missing bridge state.
+                const unavailable = [
+                    {
+                        advisory: 'systemgpt.forecast',
+                        reason: 'depends on swarm state via a control plane not present in v1 — not inferred',
+                    },
+                    {
+                        advisory: 'swarm.health',
+                        reason: 'no running swarm — the swarm/consciousness services report "lane unavailable"',
+                    },
+                ];
+                return this.finalize('health.summary', overall, `overall LocalOps health: ${overall} (${warnings.length} warning(s); swarm/forecast advisory unavailable)`, {
+                    overall,
+                    evaluated: ['ai.profile', 'provider.status', 'kb.status'],
+                    warnings,
+                    unavailable,
                 });
             }
         }

--- a/os-platform/core/pilot/local-agent/localOpsDiagnostics.ts
+++ b/os-platform/core/pilot/local-agent/localOpsDiagnostics.ts
@@ -25,6 +25,7 @@ export const READONLY_DIAGNOSTICS = [
   'config.summary',
   'provider.status',
   'kb.status',
+  'health.summary',
 ] as const;
 
 export type DiagnosticName = (typeof READONLY_DIAGNOSTICS)[number];
@@ -230,6 +231,82 @@ export class LocalOpsDiagnostics {
             rootsExcluded: kb.rootsExcluded,
             fileCount: kb.fileCount,
             requireSources: kb.requireSources,
+          }
+        );
+      }
+
+      case 'health.summary': {
+        // WO-AI-CONSOLIDATION-003: bring SystemGPT's read-only health-evaluation
+        // pattern (Herald threshold rules -> overall status + warnings) onto the
+        // LocalOps diagnostics path, but ONLY over local, truthful signals — the
+        // sibling read-only diagnostics. No network, no .NET call, no swarm, no
+        // control plane. Swarm/forecast advisory is shown unavailable, never
+        // inferred (see docs/ai-consolidation/AI_ESTATE_INVENTORY.md).
+        const provider = this.compute('provider.status');
+        const kb = this.compute('kb.status');
+
+        const warnings: Array<{ level: DiagnosticStatus; source: string; message: string }> = [];
+        let overall: DiagnosticStatus = 'ok';
+        const escalate = (s: DiagnosticStatus): void => {
+          if (s === 'error') overall = 'error';
+          else if (s === 'warn' && overall !== 'error') overall = 'warn';
+        };
+
+        if (this.config.profile === 'disabled') {
+          warnings.push({
+            level: 'warn',
+            source: 'ai.profile',
+            message: 'AI profile is disabled; LocalOps will not answer.',
+          });
+          escalate('warn');
+        }
+        if (this.config.externalCalls) {
+          warnings.push({
+            level: 'warn',
+            source: 'ai.profile',
+            message: 'External calls are enabled — unexpected for a county-boundary profile.',
+          });
+          escalate('warn');
+        }
+        escalate(provider.status);
+        if (provider.status !== 'ok') {
+          warnings.push({ level: provider.status, source: 'provider.status', message: provider.summary });
+        }
+        escalate(kb.status);
+        if (kb.status !== 'ok') {
+          warnings.push({ level: kb.status, source: 'kb.status', message: kb.summary });
+        }
+        if (this.config.requireSources && Number(kb.data.fileCount) === 0) {
+          warnings.push({
+            level: 'warn',
+            source: 'kb.status',
+            message: 'Sources are required but the local KB is empty — answers will be refused.',
+          });
+          escalate('warn');
+        }
+
+        // Honest unavailability: advisory outputs that depend on swarm state are
+        // NOT inferred from mocked/missing bridge state.
+        const unavailable = [
+          {
+            advisory: 'systemgpt.forecast',
+            reason: 'depends on swarm state via a control plane not present in v1 — not inferred',
+          },
+          {
+            advisory: 'swarm.health',
+            reason: 'no running swarm — the swarm/consciousness services report "lane unavailable"',
+          },
+        ];
+
+        return this.finalize(
+          'health.summary',
+          overall,
+          `overall LocalOps health: ${overall} (${warnings.length} warning(s); swarm/forecast advisory unavailable)`,
+          {
+            overall,
+            evaluated: ['ai.profile', 'provider.status', 'kb.status'],
+            warnings,
+            unavailable,
           }
         );
       }

--- a/os-platform/core/tests/local-agent-localops-diagnostics.test.mjs
+++ b/os-platform/core/tests/local-agent-localops-diagnostics.test.mjs
@@ -15,13 +15,14 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const localopsEnv = { AI_PROFILE: 'localops', AI_PROVIDER: 'ollama', AI_MODEL: 'm' };
 
 describe('LocalOps read-only diagnostics (WO-LOCALOPS-005)', () => {
-  it('exposes the four read-only diagnostics', () => {
+  it('exposes the read-only diagnostics allowlist', () => {
     const diag = createLocalOpsDiagnostics({ repoRoot: REPO_ROOT, env: localopsEnv });
     assert.deepStrictEqual(diag.list(), [
       'ai.profile',
       'config.summary',
       'provider.status',
       'kb.status',
+      'health.summary',
     ]);
     assert.deepStrictEqual([...READONLY_DIAGNOSTICS], diag.list());
   });
@@ -85,6 +86,29 @@ describe('LocalOps read-only diagnostics (WO-LOCALOPS-005)', () => {
     assert.ok(!isDiagnosticRefusal(r));
     assert.strictEqual(r.status, 'ok');
     assert.ok(Number(r.data.fileCount) >= 1);
+  });
+
+  it('health.summary rolls up local signals (read-only) and marks swarm/forecast unavailable', () => {
+    const diag = createLocalOpsDiagnostics({ repoRoot: REPO_ROOT, env: localopsEnv });
+    const r = diag.request('health.summary');
+    assert.ok(!isDiagnosticRefusal(r));
+    assert.strictEqual(r.readonly, true);
+    assert.ok(['ok', 'warn', 'error'].includes(r.status));
+    assert.strictEqual(r.data.overall, r.status);
+    assert.deepStrictEqual(r.data.evaluated, ['ai.profile', 'provider.status', 'kb.status']);
+    assert.ok(Array.isArray(r.data.warnings));
+    // Swarm-dependent advisory is shown unavailable, never inferred.
+    const advisories = r.data.unavailable.map(u => u.advisory);
+    assert.ok(advisories.includes('systemgpt.forecast'));
+    assert.ok(advisories.includes('swarm.health'));
+  });
+
+  it('health.summary does not report healthy for a disabled profile / unready provider', () => {
+    const diag = createLocalOpsDiagnostics({ repoRoot: REPO_ROOT, env: { AI_PROFILE: 'disabled' } });
+    const r = diag.request('health.summary');
+    assert.ok(!isDiagnosticRefusal(r));
+    assert.notStrictEqual(r.status, 'ok', 'a disabled profile must not report healthy');
+    assert.ok(r.data.warnings.length >= 1);
   });
 
   it('refuses unsafe (mutating/operational) diagnostic requests', () => {


### PR DESCRIPTION
## WO-AI-CONSOLIDATION-003 — SystemGPT read-only health onto the LocalOps diagnostics path

Brings SystemGPT's **read-only health-evaluation pattern** (Herald threshold rules → overall status + warnings) onto the LocalOps diagnostics path **where the operator actually looks** — the Diagnose tab, fed by the WO-001 engine's `viewModel().diagnostics`.

### The boundary call (please sanity-check this)
`SystemGptHealthEvaluator` is a real, **local** rules engine (no swarm bridge, no `localhost:9000`). But it's **.NET**, and the LocalOps diagnostics seam is **Node with a hard no-network-I/O invariant** (WO-005) — so it cannot call the .NET evaluator. I therefore **realized its read-only value** as a new Node diagnostic over local truthful signals, rather than reaching across the boundary. The swarm-dependent **forecast** is the part your guardrail flagged — it's shown **unavailable, never inferred**.

### Changes
- **`localOpsDiagnostics.ts`** (+ generated `.js`) — new **`health.summary`** read-only diagnostic. Rolls up the local signals (`ai.profile`, `provider.status`, `kb.status` + profile flags) into an overall `ok`/`warn`/`error` with warnings. **No network, no .NET call, no swarm, no control plane.** `systemgpt.forecast` / `swarm.health` are listed as **unavailable** (with reasons), never inferred from mocked/missing bridge state.
- **tests** — extend the WO-005 diagnostics contract (allowlist 4 → 5) + add `health.summary` coverage: read-only roll-up, honest unavailability, and "not healthy" for a disabled profile.
- **docs** — `docs/localops` runbook + README list the new diagnostic; `AI_ESTATE_INVENTORY.md` records consolidation shortlist #3 as realized.

### Proof (offline, CI authoritative)
- `health.summary`: read-only, rolls up the three local signals, marks `systemgpt.forecast`/`swarm.health` unavailable; disabled profile ⇒ not `ok`.
- Diagnostics 13/13 · engine 4/4 · **WO-008 proof 13/13** · full LocalOps suite green · `check:generated` clean.

### Guardrails
Read-only only · no swarm revival · no `localhost:9000`/dead bridge · no cloud · no new deps · no D-017 · the .NET tier is untouched (no-network invariant preserved).

### Operator gain
The Diagnose tab now shows an **overall health verdict + warnings** rolled up from the local signals (provider readiness, KB, profile) — actionable where the operator looks — while being honest that swarm/forecast advisory isn't locally available.

Per your order: after this, **002** (trace unification), then **004b** (status surfaces), then CI hardening only if elevated.

🤖 Draft — held for human merge per the WO loop.

https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jcp3XLpsC5Wfn54XWArWH8)_