### PR TITLE
test(ci): align Atlas suite-only gates and patch shell-quote audit

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/routing/directEntryCanonicalUrl.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/routing/directEntryCanonicalUrl.contract.test.ts
@@ -140,15 +140,16 @@ describe('directEntryCanonicalUrl', () => {
 
   // ── Parcel tools never launch standalone from direct entry ────────────────
 
-  it('never opens a standalone parcel module window from a direct-entry parcel link', () => {
-    // Structural: SuiteModuleGrid.handleLaunch is the only launch path for Atlas.
-    // launchMode='workbench' always navigates to /property/:parcelId/:tab.
-    // Atlas parcel-scoped GIS tools use workbench mode via SuiteModuleGrid.
-    //
+  it('keeps TerraAtlas Suite modules on the standalone /atlas suite surface', () => {
+    // Structural: this WO separates the TerraAtlas Suite (/atlas) from the
+    // parcel-scoped Workbench Atlas tab. AtlasSuiteHome is no longer proof for
+    // /property/:parcelId/atlas and must not route its in-suite apps there.
+
     // NOTE: ForgeSuiteHome is frozen at commit 8da26658a and uses standalone-only
     // launchMode for all modules. Forge's parcel-scoped tab (/property/:id/forge)
     // is accessed through PropertyWorkbench routing, not via ForgeSuiteHome's grid.
-    expect(atlasSuiteSource).toContain("launchMode: 'workbench'");
+    expect(atlasSuiteSource).toContain("launchMode: 'standalone'");
+    expect(atlasSuiteSource).not.toContain("workbenchTab: 'atlas'");
 
     // SuiteModuleGrid navigates to /property/ for workbench mode (not activateModule)
     expect(suiteModuleGridSource).toContain("navigate(`/property/${parcelId}/${mod.workbenchTab}`)");
@@ -188,18 +189,19 @@ describe('directEntryCanonicalUrl', () => {
     expect(forgeSuiteSource).toContain("moduleId: 'cuforge'");
   });
 
-  // ── Source: AtlasSuiteHome parcel modules all use workbench launchMode ────
+  // ── Source: AtlasSuiteHome Suite apps use standalone launchMode ───────────
 
-  it('all AtlasSuiteHome parcel-scoped modules use launchMode workbench', () => {
+  it('all AtlasSuiteHome in-suite modules avoid workbench tab targeting', () => {
     const atlasModulesBlock = atlasSuiteSource.match(
       /const ATLAS_MODULES[^=]*=\s*\[([^\]]+)\]/s,
     )?.[1] ?? '';
 
-    const workbenchEntries = [...atlasModulesBlock.matchAll(/launchMode:\s*'workbench'/g)];
-    expect(workbenchEntries.length).toBeGreaterThan(0);
+    const standaloneEntries = [...atlasModulesBlock.matchAll(/launchMode:\s*'standalone'/g)];
+    expect(standaloneEntries.length).toBeGreaterThan(0);
 
-    // All Atlas workbench modules must use the 'atlas' tab
-    const nonAtlasTabs = [...atlasModulesBlock.matchAll(/workbenchTab:\s*'(?!atlas)\w+'/g)];
-    expect(nonAtlasTabs).toHaveLength(0);
+    const workbenchEntries = [...atlasModulesBlock.matchAll(/launchMode:\s*'workbench'/g)];
+    const atlasTabs = [...atlasModulesBlock.matchAll(/workbenchTab:\s*'atlas'/g)];
+    expect(workbenchEntries).toHaveLength(0);
+    expect(atlasTabs).toHaveLength(0);
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/suites/phase4-suite-honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/suites/phase4-suite-honesty.contract.test.tsx
@@ -153,9 +153,14 @@ describe('Phase 4 — DataProvider boundary: suite homes render provider-supplie
     expect(screen.getByTestId('forge-stats').textContent).toContain('73,419');
   });
 
-  it('AtlasSuiteHome renders totalParcels from provider (73,419), not a hardcoded value', () => {
+  it('AtlasSuiteHome does not present provider totalParcels as verified GIS parcel truth', () => {
     render(<MemoryRouter><AtlasSuiteHome /></MemoryRouter>);
-    expect(screen.getByTestId('atlas-stats').textContent).toContain('73,419');
+    const statsText = screen.getByTestId('atlas-stats').textContent ?? '';
+    expect(statsText).not.toContain('73,419');
+    expect(statsText).toContain('GIS geometry rows');
+    expect(statsText).toContain('80,084');
+    expect(statsText).toContain('Active parcel count');
+    expect(statsText).toContain('Not verified');
   });
 
   it('DaisSuiteHome renders activeAppeals from provider (138) and propagates to panels', () => {
@@ -171,4 +176,3 @@ describe('Phase 4 — DataProvider boundary: suite homes render provider-supplie
     expect(screen.getByTestId('suite-dossier-root').textContent).toContain('73,419');
   });
 });
-

--- a/frontend/apps/os-shell/src/__tests__/workflows/workflowEntryPoints.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workflows/workflowEntryPoints.contract.test.tsx
@@ -270,11 +270,13 @@ describe('Atlas GIS Entry Points', () => {
     expect(screen.getByTestId('atlas-queue')).toBeDefined();
   });
 
-  it('Atlas module grid contains workbench-mode GIS modules targeting atlas tab', () => {
+  it('Atlas module grid contains standalone TerraAtlas Suite app entries', () => {
     render(<MemoryRouter><AtlasSuiteHome /></MemoryRouter>);
     const grid = screen.getByTestId('mock-module-grid');
+    const atlasStandalone = grid.querySelectorAll('[data-launch-mode="standalone"][data-module-id="atlas"]');
     const atlasWorkbench = grid.querySelectorAll('[data-workbench-tab="atlas"]');
-    expect(atlasWorkbench.length).toBeGreaterThan(0);
+    expect(atlasStandalone.length).toBeGreaterThan(0);
+    expect(atlasWorkbench).toHaveLength(0);
   });
 
   it('every Atlas module button is clickable and labeled', () => {
@@ -287,21 +289,19 @@ describe('Atlas GIS Entry Points', () => {
     });
   });
 
-  it('clicking Atlas workbench modules invokes correct activation contract', async () => {
+  it('clicking Atlas Suite modules invokes standalone Atlas activation contract', async () => {
     const user = userEvent.setup();
     render(<MemoryRouter><AtlasSuiteHome /></MemoryRouter>);
     const grid = screen.getByTestId('mock-module-grid');
-    const workbenchButtons = Array.from(grid.querySelectorAll('[data-launch-mode="workbench"]')) as HTMLElement[];
+    const standaloneButtons = Array.from(grid.querySelectorAll('[data-launch-mode="standalone"]')) as HTMLElement[];
+    expect(standaloneButtons.length).toBeGreaterThan(0);
 
-    for (const btn of workbenchButtons) {
+    for (const btn of standaloneButtons) {
       mockActivateModule.mockClear();
       await user.click(btn);
       expect(mockActivateModule).toHaveBeenCalledWith(
-        'property-workbench',
-        expect.objectContaining({
-          source: 'start_menu',
-          metadata: expect.objectContaining({ tabId: 'atlas' }),
-        })
+        'atlas',
+        expect.objectContaining({ source: 'start_menu' })
       );
     }
   });
@@ -335,14 +335,20 @@ describe('Cross-Suite Entry Point Consistency', () => {
     }
   });
 
-  it('Dais and Atlas have workbench-mode entry points; Forge exposes standalone primary modules', () => {
-    // Dais and Atlas use SuiteModuleGrid with workbench-targeted entries
-    for (const Component of [DaisSuiteHome, AtlasSuiteHome]) {
-      const { unmount } = render(<MemoryRouter><Component /></MemoryRouter>);
-      const wb = screen.getByTestId('mock-module-grid').querySelectorAll('[data-launch-mode="workbench"]');
-      expect(wb.length).toBeGreaterThan(0);
-      unmount();
-    }
+  it('Dais has workbench-mode entry points; Atlas and Forge expose standalone Suite entries', () => {
+    // Dais remains workbench-targeted for its parcel workflow.
+    const { unmount: unmountDais } = render(<MemoryRouter><DaisSuiteHome /></MemoryRouter>);
+    const daisWorkbench = screen.getByTestId('mock-module-grid').querySelectorAll('[data-launch-mode="workbench"]');
+    expect(daisWorkbench.length).toBeGreaterThan(0);
+    unmountDais();
+
+    // Atlas is the /atlas Suite surface in this WO, not the Property Workbench Atlas tab.
+    const { unmount: unmountAtlas } = render(<MemoryRouter><AtlasSuiteHome /></MemoryRouter>);
+    const atlasStandalone = screen.getByTestId('mock-module-grid').querySelectorAll('[data-launch-mode="standalone"]');
+    const atlasWorkbench = screen.getByTestId('mock-module-grid').querySelectorAll('[data-launch-mode="workbench"]');
+    expect(atlasStandalone.length).toBeGreaterThan(0);
+    expect(atlasWorkbench).toHaveLength(0);
+    unmountAtlas();
 
     // Forge uses its own inline primary-applications section with standalone modules
     const { container, unmount: unmountForge } = render(<MemoryRouter><ForgeSuiteHome /></MemoryRouter>);

--- a/package.json
+++ b/package.json
@@ -464,6 +464,11 @@
     "wait-on": "9.0.3",
     "yargs": "^17.7.2"
   },
+  "pnpm": {
+    "overrides": {
+      "shell-quote": "1.8.4"
+    }
+  },
   "workspaces": [
     "frontend",
     "frontend/electron"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  shell-quote: 1.8.4
+
 importers:
 
   .:
@@ -13878,8 +13881,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   short-unique-id@5.3.2:
@@ -25484,7 +25487,7 @@ snapshots:
       date-fns: 2.30.0
       lodash: 4.17.21
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       spawn-command: 0.0.2
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -25494,7 +25497,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -27372,7 +27375,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       env-paths: 3.0.0
       semver: 7.7.3
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -31550,7 +31553,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   short-unique-id@5.3.2: {}
 


### PR DESCRIPTION
## WO
Release correction follow-up for PR #942.

## Scope
This PR intentionally contains only release-engineering repair that was split out of the TerraAtlas Suite product proof PR.

Base branch: `feat/terraatlas-full-production`
Head branch: `feat/atlas-suite-ci-contract-repair`

## Changes
- Align stale Atlas contract gates with the Suite-only `/atlas` boundary.
- Stop expecting Atlas Suite modules to launch as Property Workbench Atlas-tab entries.
- Stop treating provider `totalParcels` as verified TerraAtlas GIS parcel truth.
- Add `shell-quote@1.8.4` pnpm override to clear the critical production audit gate.

## Explicitly not product proof
- Does not add TerraAtlas features.
- Does not edit Property Workbench source.
- Does not claim `/property/:parcelId/atlas` readiness.
- Does not change PR #942's `/atlas` product evidence package.

## Verification
Passed locally:
- `pnpm audit --prod --audit-level critical --ignore-registry-errors` exits 0 with no critical findings.

Previously passed before split on identical CI repair content at `4a82ef764`:
- focused Vitest suite for `directEntryCanonicalUrl.contract.test.ts`, `phase4-suite-honesty.contract.test.tsx`, and `workflowEntryPoints.contract.test.tsx`.

Fresh isolated-worktree Vitest rerun was not completed because dependency linking in the new worktree did not expose Vitest or `@vitejs/plugin-react`; GitHub CI should be treated as the authoritative rerun for this stacked repair branch.

## Dependency
This PR is stacked on PR #942 and should be reviewed as CI/audit repair separated from the product proof.