### PR TITLE
fix(workbench): publish live-scope truth freeze

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/ClerkController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ClerkController.cs
@@ -149,6 +149,14 @@ public class ClerkController : ControllerBase
         var countyId = await ResolveCountyIdAsync();
         if (countyId is null) return Forbid();
 
+        var parcelExists = await _db.Properties
+            .AsNoTracking()
+            .AnyAsync(p => p.CountyId == countyId.Value &&
+                           (p.ParcelId == parcelId || p.ParcelNumber == parcelId));
+
+        if (!parcelExists)
+            return NotFound(new { error = $"Parcel '{parcelId}' not found." });
+
         var chain = await _db.TitleChainEntries
             .AsNoTracking()
             .Where(t => t.CountyId == countyId.Value && t.ParcelId == parcelId)
@@ -163,7 +171,19 @@ public class ClerkController : ControllerBase
             })
             .ToListAsync();
 
-        return Ok(new { chain });
+        if (chain.Count == 0)
+        {
+            Response.Headers["X-Clerk-Title-Chain-Source"] = "not-live:title-chain-records-not-projected";
+            return Ok(new
+            {
+                chain,
+                source = "not-live:title-chain-records-not-projected",
+                message = "Title-chain records are not projected for this parcel in the governed Clerk store."
+            });
+        }
+
+        Response.Headers["X-Clerk-Title-Chain-Source"] = "live";
+        return Ok(new { chain, source = "live" });
     }
 
     // ── GET api/clerk/fees ──────────────────────────────────────────

--- a/backend/src/TerraFusion.API/Controllers/DaisController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DaisController.cs
@@ -248,6 +248,34 @@ public class DaisController : ControllerBase
   }
 
   /// <summary>
+  /// GET api/dais/permits?parcelId={parcelId} — Workbench permit list lane.
+  /// Building permit records are not yet projected into the governed Dais store,
+  /// so this endpoint returns an explicit empty not-live lane instead of a route miss.
+  /// </summary>
+  [HttpGet("permits")]
+  public async Task<IActionResult> GetPermits([FromQuery] string parcelId)
+  {
+    if (string.IsNullOrWhiteSpace(parcelId))
+      return BadRequest(new { error = "parcelId is required." });
+
+    var countyAccess = await RequireCountyAccessAsync();
+    if (countyAccess.ErrorResult is not null)
+      return countyAccess.ErrorResult;
+
+    var parcelExists = await _db.Properties
+      .AsNoTracking()
+      .AnyAsync(p => p.CountyId == countyAccess.CountyId!.Value &&
+                     (p.ParcelId == parcelId || p.ParcelNumber == parcelId));
+
+    if (!parcelExists)
+      return NotFound(new { error = $"Parcel '{parcelId}' not found." });
+
+    Response.Headers["X-Dais-Permits-Source"] = "not-live:permit-records-not-projected";
+    Response.Headers["X-Dais-Source"] = "governed-dais-permit-lane-classification";
+    return Ok(Array.Empty<object>());
+  }
+
+  /// <summary>
   /// GET api/dais/permits/{parcelId}/assessment-impact — Check permit impact for a parcel.
   /// County-isolated: requires countyId/countyCode claim.
   /// </summary>

--- a/backend/src/TerraFusion.API/Controllers/ForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ForgeController.cs
@@ -50,8 +50,16 @@ public class ForgeController : ControllerBase
         CancellationToken ct)
     {
         _logger.LogInformation("Forge available years requested for {ParcelId}", parcelId);
-        var result = await _valuationService.GetAvailableYearsAsync(parcelId, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _valuationService.GetAvailableYearsAsync(parcelId, ct);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Forge available years rejected for unknown parcel {ParcelId}", parcelId);
+            return NotFound(new { error = ex.Message });
+        }
     }
 
     /// <summary>GET /api/forge/{parcelId}/cost?taxYear=2025</summary>
@@ -66,8 +74,16 @@ public class ForgeController : ControllerBase
         var year = taxYear ?? DateTime.UtcNow.Year;
         _logger.LogInformation("Forge cost approach requested for {ParcelId} year {TaxYear}", parcelId, year);
 
-        var result = await _valuationService.CalculateCostApproachAsync(parcelId, year, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _valuationService.CalculateCostApproachAsync(parcelId, year, ct);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Forge cost approach rejected for unknown parcel {ParcelId}", parcelId);
+            return NotFound(new { error = ex.Message });
+        }
     }
 
     /// <summary>GET /api/forge/{parcelId}/sales?taxYear=2025</summary>
@@ -86,6 +102,11 @@ public class ForgeController : ControllerBase
         {
             var result = await _valuationService.CalculateSalesComparisonAsync(parcelId, year, ct);
             return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Forge sales comparison rejected for unknown parcel {ParcelId}", parcelId);
+            return NotFound(new { error = ex.Message });
         }
         catch (Exception ex)
         {
@@ -106,8 +127,16 @@ public class ForgeController : ControllerBase
         var year = taxYear ?? DateTime.UtcNow.Year;
         _logger.LogInformation("Forge income approach requested for {ParcelId} year {TaxYear}", parcelId, year);
 
-        var result = await _valuationService.CalculateIncomeApproachAsync(parcelId, year, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _valuationService.CalculateIncomeApproachAsync(parcelId, year, ct);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Forge income approach rejected for unknown parcel {ParcelId}", parcelId);
+            return NotFound(new { error = ex.Message });
+        }
     }
 
     /// <summary>GET /api/forge/{parcelId}/reconciliation?taxYear=2025</summary>
@@ -122,8 +151,16 @@ public class ForgeController : ControllerBase
         var year = taxYear ?? DateTime.UtcNow.Year;
         _logger.LogInformation("Forge reconciliation requested for {ParcelId} year {TaxYear}", parcelId, year);
 
-        var result = await _valuationService.ReconcileAsync(parcelId, year, ct);
-        return Ok(result);
+        try
+        {
+            var result = await _valuationService.ReconcileAsync(parcelId, year, ct);
+            return Ok(result);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Forge reconciliation rejected for unknown parcel {ParcelId}", parcelId);
+            return NotFound(new { error = ex.Message });
+        }
     }
 
     /// <summary>

--- a/backend/src/TerraFusion.API/Controllers/PilotController.cs
+++ b/backend/src/TerraFusion.API/Controllers/PilotController.cs
@@ -140,29 +140,38 @@ public sealed class PilotController : ControllerBase
         }
     }
 
-    // ── Graceful-degradation stubs for when the dedicated pilot runtime
+    // ── Explicit non-live responses for when the dedicated pilot runtime
     // (dev-pilot-runtime.mjs, port 4317) is offline. The frontend proxy
-    // is redirected here so the Pilot tab renders rather than showing 500s.
+    // is redirected here so the Pilot tab can disclose the non-live lane.
 
-    /// <summary>Stub: returns empty tool list when pilot runtime is offline.</summary>
+    private void MarkPilotRuntimeOffline()
+    {
+        Response.Headers["X-Pilot-Source"] = "not-live:pilot-runtime-offline";
+    }
+
+    /// <summary>Returns explicit non-live tool list when pilot runtime is offline.</summary>
     [HttpGet("tools")]
     [AllowAnonymous]
     public IActionResult GetTools([FromQuery] string? mode = null)
     {
-        _logger.LogDebug("Pilot tools stub hit (mode={Mode}) — pilot runtime offline", mode);
-        return Ok(new { tools = Array.Empty<object>(), source = "stub", runtimeOnline = false });
+        _logger.LogDebug("Pilot tools fallback hit (mode={Mode}) — pilot runtime offline", mode);
+        MarkPilotRuntimeOffline();
+        return Ok(new { tools = Array.Empty<object>(), source = "not-live:pilot-runtime-offline", runtimeOnline = false });
     }
 
-    /// <summary>Stub: returns graceful error when pilot invoke is hit without runtime.</summary>
+    /// <summary>Returns explicit non-live error when pilot invoke is hit without runtime.</summary>
     [HttpPost("invoke")]
     [AllowAnonymous]
     public IActionResult InvokeTool([FromBody] object? body = null)
     {
-        _logger.LogDebug("Pilot invoke stub hit — pilot runtime offline");
+        _logger.LogDebug("Pilot invoke fallback hit — pilot runtime offline");
+        MarkPilotRuntimeOffline();
         return Ok(new
         {
             success = false,
-            correlationId = $"stub-{Guid.NewGuid():N}",
+            correlationId = $"pilot-offline-{Guid.NewGuid():N}",
+            source = "not-live:pilot-runtime-offline",
+            runtimeOnline = false,
             error = new
             {
                 code = "PILOT_RUNTIME_OFFLINE",
@@ -172,29 +181,32 @@ public sealed class PilotController : ControllerBase
         });
     }
 
-    /// <summary>Stub: returns empty traces when pilot runtime is offline.</summary>
+    /// <summary>Returns explicit non-live traces when pilot runtime is offline.</summary>
     [HttpGet("traces")]
     [AllowAnonymous]
     public IActionResult GetTraces()
     {
-        _logger.LogDebug("Pilot traces stub hit — pilot runtime offline");
-        return Ok(new { events = Array.Empty<object>(), total = 0, source = "stub", runtimeOnline = false });
+        _logger.LogDebug("Pilot traces fallback hit — pilot runtime offline");
+        MarkPilotRuntimeOffline();
+        return Ok(new { events = Array.Empty<object>(), total = 0, source = "not-live:pilot-runtime-offline", runtimeOnline = false });
     }
 
-    /// <summary>Stub: returns health indicating pilot runtime is offline.</summary>
+    /// <summary>Returns health indicating pilot runtime is offline.</summary>
     [HttpGet("health")]
     [AllowAnonymous]
     public IActionResult GetPilotHealth()
     {
-        _logger.LogDebug("Pilot health stub hit — pilot runtime offline");
-        return Ok(new { status = "degraded", runtimeOnline = false, message = "Pilot runtime offline — using .NET fallback stubs" });
+        _logger.LogDebug("Pilot health fallback hit — pilot runtime offline");
+        MarkPilotRuntimeOffline();
+        return Ok(new { status = "degraded", source = "not-live:pilot-runtime-offline", runtimeOnline = false, message = "Pilot runtime is not live. The dedicated Pilot runtime is offline." });
     }
 
-    /// <summary>Stub: returns empty for validate when pilot runtime is offline.</summary>
+    /// <summary>Returns explicit non-live validation when pilot runtime is offline.</summary>
     [HttpPost("validate")]
     [AllowAnonymous]
     public IActionResult ValidateTool([FromBody] object? body = null)
     {
-        return Ok(new { valid = false, runtimeOnline = false });
+        MarkPilotRuntimeOffline();
+        return Ok(new { valid = false, source = "not-live:pilot-runtime-offline", runtimeOnline = false });
     }
 }

--- a/backend/src/TerraFusion.API/Services/ValuationService.cs
+++ b/backend/src/TerraFusion.API/Services/ValuationService.cs
@@ -39,8 +39,8 @@ public class ValuationService : IValuationService
 
         if (property == null)
         {
-            _logger.LogWarning("Parcel {ParcelId} not found in canonical Properties — returning fallback cost approach", parcelId);
-            return BuildFallbackCostApproach(parcelId, taxYear);
+            _logger.LogWarning("Parcel {ParcelId} not found in canonical Properties — rejecting governed cost approach", parcelId);
+            throw new KeyNotFoundException($"Parcel {parcelId} was not found in canonical Properties.");
         }
 
         var valRec = await _db.ValuationRecords
@@ -138,7 +138,7 @@ public class ValuationService : IValuationService
             LandValue                 = landValue,
             IndicatedValue            = indicated,
             ImprovementValue          = imprvValue > 0 ? imprvValue : rcnld,
-            Source                    = hasData ? "canonical" : "stub",
+            Source                    = hasData ? "canonical" : "unavailable",
             Confidence                = hasData ? (rcn > 0 ? 0.85 : 0.60) : 0.40,
             Inputs                    = BuildCostInputs(valRec != null, cama?.LandAreaSqft > 0, cama != null),
             // CP-4 additions
@@ -178,8 +178,8 @@ public class ValuationService : IValuationService
 
         if (property == null)
         {
-            _logger.LogWarning("Parcel {ParcelId} not found — returning fallback sales comparison", parcelId);
-            return BuildFallbackSalesComparison(parcelId, taxYear);
+            _logger.LogWarning("Parcel {ParcelId} not found in canonical Properties — rejecting governed sales comparison", parcelId);
+            throw new KeyNotFoundException($"Parcel {parcelId} was not found in canonical Properties.");
         }
 
         var valRec = await _db.ValuationRecords
@@ -393,7 +393,7 @@ public class ValuationService : IValuationService
                     ? $"{comps.Count} comparable sales within {taxYear - 2}–{taxYear}. Median: ${median:N0}. Neighborhood filter active — comps restricted to hood {subjectHood}."
                     : $"{comps.Count} comparable sales within {taxYear - 2}–{taxYear}. Median: ${median:N0}. Neighborhood filter inactive — fewer than 5 sales in hood {subjectHood ?? "unknown"}; comps span entire county."
                 : "No comparable sales found. Market value from canonical valuation record used where available.",
-            Source                   = hasData ? "canonical" : "stub",
+            Source                   = hasData ? "canonical" : "unavailable",
             Confidence               = hasData ? (comps.Count >= 3 ? 0.90 : 0.70) : 0.35,
             // CP-5 / R2Wave39 additions
             SalesRatioMedian         = ratioMedian,
@@ -421,8 +421,8 @@ public class ValuationService : IValuationService
 
         if (property == null)
         {
-            _logger.LogWarning("Parcel {ParcelId} not found — returning fallback income approach", parcelId);
-            return BuildFallbackIncomeApproach(parcelId, taxYear);
+            _logger.LogWarning("Parcel {ParcelId} not found in canonical Properties — rejecting governed income approach", parcelId);
+            throw new KeyNotFoundException($"Parcel {parcelId} was not found in canonical Properties.");
         }
 
         var valRec = await _db.ValuationRecords
@@ -494,7 +494,7 @@ public class ValuationService : IValuationService
             GrossIncomeMultiplier      = gim,
             RiskClassification         = ClassifyRisk(capRate),
             IncomeIndicatedValue       = incomeValue,
-            Source                     = hasData ? "canonical" : "stub",
+            Source                     = hasData ? "canonical" : "unavailable",
             Confidence                 = hasData ? 0.75 : 0.30,
             // CP-6 additions
             GrossIncome                = grossIncome,
@@ -574,7 +574,7 @@ public class ValuationService : IValuationService
             Method          = "weighted_average",
             AssessedValue   = property?.AssessedValue,
             MarketValue     = property?.MarketValue,
-            Source          = anyReal ? "canonical" : "stub",
+            Source          = anyReal ? "canonical" : "unavailable",
             Confidence      = anyReal ? 0.82 : 0.35,
         };
     }
@@ -596,7 +596,7 @@ public class ValuationService : IValuationService
             .FirstOrDefaultAsync(p => p.ParcelId == parcelId || p.ParcelNumber == parcelId, ct);
 
         if (property == null)
-            return new ParcelYearLayersResult { ParcelId = parcelId };
+            throw new KeyNotFoundException($"Parcel {parcelId} was not found in canonical Properties.");
 
         var valRecs = await _db.ValuationRecords
             .AsNoTracking()
@@ -654,7 +654,7 @@ public class ValuationService : IValuationService
         LandValue              = 0,
         IndicatedValue         = 0,
         ImprovementValue       = 0,
-        Source                 = "stub",
+        Source                 = "unavailable",
         Confidence             = 0.0,
         Inputs                 = BuildCostInputs(false, false, false),
     };
@@ -669,7 +669,7 @@ public class ValuationService : IValuationService
         AdjustmentRange     = 0,
         Comparables         = [],
         Rationale           = "No data available for this parcel. Load parcel data to enable sales comparison analysis.",
-        Source              = "stub",
+        Source              = "unavailable",
         Confidence          = 0.0,
     };
 
@@ -683,7 +683,7 @@ public class ValuationService : IValuationService
         GrossIncomeMultiplier = 0,
         RiskClassification    = "unknown",
         IncomeIndicatedValue  = 0,
-        Source                = "stub",
+        Source                = "unavailable",
         Confidence            = 0.0,
     };
 

--- a/frontend/apps/os-shell/src/api/pilotApi.ts
+++ b/frontend/apps/os-shell/src/api/pilotApi.ts
@@ -96,6 +96,8 @@ export interface PilotToolFull extends PilotTool {
 export interface PilotToolListResponse {
   count: number;
   tools: PilotTool[];
+  source?: string;
+  runtimeOnline?: boolean;
 }
 
 /** Nested confirmation payload (preferred form) */
@@ -254,6 +256,8 @@ export interface PilotTraceListParams {
 /** Trace list response (with pagination metadata) */
 export interface PilotTraceListResponse {
   events: PilotTraceEvent[];
+  source?: string;
+  runtimeOnline?: boolean;
   pagination: {
     offset: number;
     limit: number;

--- a/frontend/apps/os-shell/src/config/workbenchLiveScope.ts
+++ b/frontend/apps/os-shell/src/config/workbenchLiveScope.ts
@@ -1,0 +1,103 @@
+export type WorkbenchLiveScopeClassification = 'LIVE-NOW' | 'DEFERRED';
+
+export type WorkbenchWeakLane =
+  | 'pilot'
+  | 'dais-permits'
+  | 'forge-income'
+  | 'atlas-enrichment-layers'
+  | 'clerk-title-chain'
+  | 'parcel-specific-audit';
+
+export interface WorkbenchLiveScopeDecision {
+  lane: WorkbenchWeakLane;
+  intendedProductRole: string;
+  intendedBackendContract: string;
+  currentRuntimeStatus: 'partial' | 'unavailable' | 'not-live' | 'thin';
+  uiAheadOfBackend: boolean;
+  blockerType:
+    | 'missing projection'
+    | 'parcel-dependent data gap'
+    | 'stale/stub runtime'
+    | 'wrong product expectation'
+    | 'not in current scope';
+  classification: WorkbenchLiveScopeClassification;
+  rationale: string;
+  smallestSafeAction: string;
+}
+
+export const WORKBENCH_LIVE_SCOPE_DECISIONS: WorkbenchLiveScopeDecision[] = [
+  {
+    lane: 'pilot',
+    intendedProductRole: 'Parcel-scoped governed tool invocation and trace review.',
+    intendedBackendContract: '/pilot/tools, /pilot/invoke, /pilot/traces backed by the dedicated Pilot runtime.',
+    currentRuntimeStatus: 'not-live',
+    uiAheadOfBackend: true,
+    blockerType: 'stale/stub runtime',
+    classification: 'DEFERRED',
+    rationale: 'The dedicated Pilot runtime is offline; the .NET fallback can only disclose not-live status.',
+    smallestSafeAction: 'Keep Pilot visibly not-live until the dedicated runtime is started and verified across the parcel matrix.',
+  },
+  {
+    lane: 'dais-permits',
+    intendedProductRole: 'Parcel permit history and assessment-impact workflow.',
+    intendedBackendContract: '/api/dais/permits?parcelId={parcelId} with governed permit records projected by parcel.',
+    currentRuntimeStatus: 'not-live',
+    uiAheadOfBackend: true,
+    blockerType: 'missing projection',
+    classification: 'DEFERRED',
+    rationale: 'Permit records are not projected into the governed Dais store.',
+    smallestSafeAction: 'Keep permit lane labeled not-live:permit-records-not-projected until a real permit projection exists.',
+  },
+  {
+    lane: 'forge-income',
+    intendedProductRole: 'Income approach valuation for parcels with real income data.',
+    intendedBackendContract: '/api/forge/{parcelId}/income backed by actual parcel income records or an explicit not-applicable result.',
+    currentRuntimeStatus: 'unavailable',
+    uiAheadOfBackend: true,
+    blockerType: 'parcel-dependent data gap',
+    classification: 'DEFERRED',
+    rationale: 'The selected real parcel matrix returned no income records; default cap-rate math is not production income support.',
+    smallestSafeAction: 'Keep income marked deferred/unavailable unless a parcel has real income records.',
+  },
+  {
+    lane: 'atlas-enrichment-layers',
+    intendedProductRole: 'Zoning, flood, tax area, and land-class enrichment over live parcel geometry.',
+    intendedBackendContract: '/api/atlas/gis/parcels/{parcelId}/layers with per-layer source and availability.',
+    currentRuntimeStatus: 'unavailable',
+    uiAheadOfBackend: true,
+    blockerType: 'parcel-dependent data gap',
+    classification: 'DEFERRED',
+    rationale: 'Geometry can be live for many parcels, but enrichment layers remain unavailable or partial across the matrix.',
+    smallestSafeAction: 'Keep enrichment overlays visibly deferred/unavailable while preserving live geometry.',
+  },
+  {
+    lane: 'clerk-title-chain',
+    intendedProductRole: 'Parcel title-chain history and current-owner trace.',
+    intendedBackendContract: '/api/clerk/parcels/{parcelId}/title-chain backed by projected title-chain entries.',
+    currentRuntimeStatus: 'thin',
+    uiAheadOfBackend: true,
+    blockerType: 'missing projection',
+    classification: 'DEFERRED',
+    rationale: 'Recording summary is live, but title-chain records are not projected for the sampled parcels.',
+    smallestSafeAction: 'Keep title-chain marked not-live/thin and reject fake parcels until title-chain projection exists.',
+  },
+  {
+    lane: 'parcel-specific-audit',
+    intendedProductRole: 'Parcel-specific audit findings, roll compliance, and cross-office reconciliation.',
+    intendedBackendContract: 'Parcel-aware audit endpoints or tools with parcel-specific findings and evidence.',
+    currentRuntimeStatus: 'partial',
+    uiAheadOfBackend: true,
+    blockerType: 'wrong product expectation',
+    classification: 'DEFERRED',
+    rationale: 'Current audit contracts are county/static controls with parcel context, not true parcel-specific audit proof.',
+    smallestSafeAction: 'Keep Audit labeled as county controls with parcel context until parcel-specific audit backend exists.',
+  },
+];
+
+export function getWorkbenchLiveScopeDecision(lane: WorkbenchWeakLane): WorkbenchLiveScopeDecision {
+  const decision = WORKBENCH_LIVE_SCOPE_DECISIONS.find((item) => item.lane === lane);
+  if (!decision) {
+    throw new Error(`Unknown Workbench live-scope lane: ${lane}`);
+  }
+  return decision;
+}

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
@@ -21,6 +21,7 @@ import { BADGE_PROVIDERS } from '../../services/badges';
 import { executeOsAction } from '../../services/osActions';
 import { QUICK_ACTION_PROVIDERS } from '../../services/quickActions';
 import { usePropertyStore } from '../../stores/propertyStore';
+import { activateModule } from '../../orchestration/moduleActivation';
 
 export interface WorkbenchTab {
   id: WorkbenchTabSlug;
@@ -40,6 +41,7 @@ export interface PropertyWorkbenchSurfaceProps {
   currentTabId: WorkbenchTabSlug;
   className?: string;
   segmentHandoff?: WorkbenchSegmentHandoffContext | null;
+  rolesOverride?: readonly string[];
   showBreadcrumb?: boolean;
   buildContextRibbonFacts?: typeof buildContextRibbonFactsBase;
   onBack: () => void;
@@ -119,6 +121,7 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
   currentTabId,
   className = '',
   segmentHandoff = null,
+  rolesOverride,
   showBreadcrumb = true,
   buildContextRibbonFacts = buildContextRibbonFactsBase,
   onBack,
@@ -177,8 +180,8 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
   const countyId = auth.countyId ?? session.countyId;
   const userId = auth.userId ?? session.userId;
   const roles = useMemo(
-    () => (auth.roles.length > 0 ? [...auth.roles] : session.role ? [session.role] : []),
-    [auth.roles, session.role],
+    () => (rolesOverride ? [...rolesOverride] : auth.roles.length > 0 ? [...auth.roles] : session.role ? [session.role] : []),
+    [auth.roles, rolesOverride, session.role],
   );
   const { visibleTabs } = useWorkbenchRoles(roles);
 
@@ -256,6 +259,25 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
     [auth, parcelId],
   );
 
+  const handleSegmentBackToCountyStudio = useCallback(() => {
+    if (!segmentHandoff) return;
+
+    void activateModule('county-studio', {
+      source: 'system',
+      metadata: {
+        segmentId: segmentHandoff.segmentId,
+        segmentLabel: segmentHandoff.segmentLabel,
+        studyId: segmentHandoff.studyId,
+        countyId: segmentHandoff.countyId,
+        sourceSuite: segmentHandoff.source,
+        countyStudioHandoff: segmentHandoff.handoffTemplate,
+        exceptionSetId: segmentHandoff.exceptionSetId,
+        downstreamReceiptId: segmentHandoff.downstreamReceiptId,
+        downstreamStatus: segmentHandoff.downstreamStatus,
+      },
+    });
+  }, [segmentHandoff]);
+
   if (!parcelId) {
     return (
       <div
@@ -272,6 +294,58 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
         <p className="text-sm text-center max-w-md">
           Search for a parcel to view the Property Workbench.
         </p>
+        {segmentHandoff && (
+          <div
+            className="w-full max-w-lg rounded-lg p-4 text-left"
+            style={{
+              background: 'hsl(var(--tf-surface))',
+              border: '1px solid hsl(var(--tf-border) / 0.45)',
+              color: 'hsl(var(--tf-text) / 0.82)',
+            }}
+            data-testid="workbench-segment-handoff-card"
+          >
+            <div className="text-[11px] uppercase tracking-widest" style={{ color: 'hsl(var(--tf-muted) / 0.88)' }}>
+              County Studio Context
+            </div>
+            <h3 className="mt-1 text-base font-semibold" style={{ color: 'hsl(var(--tf-text))' }}>
+              {segmentHandoff.segmentLabel ?? segmentHandoff.segmentId}
+            </h3>
+            <p className="mt-2 text-sm">
+              Segment handoff is preserved, but no parcel is selected for Workbench runtime.
+            </p>
+            <dl className="mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+              <div>
+                <dt style={{ color: 'hsl(var(--tf-muted))' }}>Handoff</dt>
+                <dd>{segmentHandoff.handoffTemplate ?? 'Not specified'}</dd>
+              </div>
+              <div>
+                <dt style={{ color: 'hsl(var(--tf-muted))' }}>Downstream Status</dt>
+                <dd>{segmentHandoff.downstreamStatus ?? 'Not returned'}</dd>
+              </div>
+              <div>
+                <dt style={{ color: 'hsl(var(--tf-muted))' }}>Receipt</dt>
+                <dd>{segmentHandoff.downstreamReceiptId ?? 'Not returned'}</dd>
+              </div>
+              <div>
+                <dt style={{ color: 'hsl(var(--tf-muted))' }}>Study</dt>
+                <dd>{segmentHandoff.studyId ?? 'Not specified'}</dd>
+              </div>
+            </dl>
+            <button
+              type="button"
+              onClick={handleSegmentBackToCountyStudio}
+              className="mt-4 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
+              style={{
+                background: 'hsl(var(--tf-surface-alt, var(--tf-surface)))',
+                color: 'hsl(var(--tf-text))',
+                border: '1px solid hsl(var(--tf-border) / 0.45)',
+              }}
+              data-testid="workbench-segment-back-county-studio"
+            >
+              Back to County Studio
+            </button>
+          </div>
+        )}
         <div className="flex flex-wrap items-center justify-center gap-2">
           <button
             onClick={onSearch}

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
@@ -1,0 +1,508 @@
+/**
+ * TerraFusion OS — canonical Property Workbench surface.
+ *
+ * This component owns the parcel load/auth/ribbon/activity behavior.
+ * Route and OS-window adapters provide only navigation and tab rendering.
+ */
+
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronRight, Home } from 'lucide-react';
+import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
+import { ActivityFeed } from '../../components/workbench/ActivityFeed';
+import { ContextRibbon } from '../../components/workbench/ContextRibbon';
+import { buildContextRibbonFacts as buildContextRibbonFactsBase } from '../../components/workbench/parcelContextFacts';
+import type { WorkbenchSegmentHandoffContext, WorkbenchTabData } from '../../context/workbenchTabContext';
+import type { Badge, QuickActionDefinition, WorkbenchContext, WorkbenchTabSlug, WorkMode } from '../../contracts/workbench';
+import { useAuthContext, toOsActor } from '../../auth/useAuthContext';
+import { useSession } from '../../auth/useSession';
+import { useWorkbenchRoles } from '../../hooks/useWorkbenchRoles';
+import { useParcelActivity } from '../../services/activityFeed';
+import { BADGE_PROVIDERS } from '../../services/badges';
+import { executeOsAction } from '../../services/osActions';
+import { QUICK_ACTION_PROVIDERS } from '../../services/quickActions';
+import { usePropertyStore } from '../../stores/propertyStore';
+
+export interface WorkbenchTab {
+  id: WorkbenchTabSlug;
+  label: string;
+  path: string;
+  enabled: boolean;
+}
+
+export interface PropertyWorkbenchSurfaceNavigationArgs {
+  tabs: WorkbenchTab[];
+  parcelId: string;
+  currentTabId: WorkbenchTabSlug;
+}
+
+export interface PropertyWorkbenchSurfaceProps {
+  parcelId?: string | null;
+  currentTabId: WorkbenchTabSlug;
+  className?: string;
+  segmentHandoff?: WorkbenchSegmentHandoffContext | null;
+  showBreadcrumb?: boolean;
+  buildContextRibbonFacts?: typeof buildContextRibbonFactsBase;
+  onBack: () => void;
+  onSearch: () => void;
+  onPopOut?: () => void;
+  renderNavigation: (args: PropertyWorkbenchSurfaceNavigationArgs) => React.ReactNode;
+  renderContent: (context: WorkbenchTabData) => React.ReactNode;
+}
+
+export const WORKBENCH_TABS: WorkbenchTab[] = [
+  { id: 'summary', label: 'Summary', path: '', enabled: true },
+  { id: 'forge', label: 'Forge', path: 'forge', enabled: true },
+  { id: 'atlas', label: 'Atlas', path: 'atlas', enabled: true },
+  { id: 'dais', label: 'Dais', path: 'dais', enabled: true },
+  { id: 'clerk', label: 'Clerk', path: 'clerk', enabled: true },
+  { id: 'treasury', label: 'Treasury', path: 'treasury', enabled: true },
+  { id: 'audit', label: 'Audit', path: 'audit', enabled: true },
+  { id: 'dossier', label: 'Dossier', path: 'dossier', enabled: true },
+  { id: 'pilot', label: 'Pilot', path: 'pilot', enabled: true },
+];
+
+export function hashParcelId(parcelId: string): string {
+  let hash = 5381;
+  for (let i = 0; i < parcelId.length; i++) {
+    hash = (hash * 33) ^ parcelId.charCodeAt(i);
+  }
+  return `hash_${(hash >>> 0).toString(16)}`;
+}
+
+export function getCurrentTabFromPath(pathname: string, parcelId: string): WorkbenchTabSlug {
+  const basePath = `/property/${parcelId}`;
+  const pathAfterBase = pathname.replace(basePath, '').replace(/^\//, '');
+
+  if (!pathAfterBase) return 'summary';
+  const tabPathMap: Record<string, WorkbenchTabSlug> = {
+    forge: 'forge',
+    atlas: 'atlas',
+    dais: 'dais',
+    clerk: 'clerk',
+    treasury: 'treasury',
+    audit: 'audit',
+    dossier: 'dossier',
+    pilot: 'pilot',
+  };
+  return tabPathMap[pathAfterBase] ?? 'summary';
+}
+
+export function hasUsableWorkbenchToken(token: string | null): boolean {
+  if (!token || token === 'dev-preview-token') return false;
+  try {
+    const [, payload] = token.split('.');
+    if (!payload) return false;
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = JSON.parse(atob(normalized)) as { exp?: unknown };
+    if (typeof decoded.exp !== 'number') return false;
+    return decoded.exp * 1000 > Date.now() + 10_000;
+  } catch {
+    return false;
+  }
+}
+
+export const TabLoader: React.FC = () => (
+  <div className="flex items-center justify-center h-32" style={{ color: 'hsl(var(--tf-text) / 0.5)' }}>
+    <div
+      className="w-6 h-6 rounded-full animate-spin mr-3"
+      style={{
+        border: '2px solid hsl(var(--tf-accent) / 0.2)',
+        borderTopColor: 'hsl(var(--tf-accent))',
+      }}
+    />
+    Loading...
+  </div>
+);
+
+export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> = ({
+  parcelId,
+  currentTabId,
+  className = '',
+  segmentHandoff = null,
+  showBreadcrumb = true,
+  buildContextRibbonFacts = buildContextRibbonFactsBase,
+  onBack,
+  onSearch,
+  onPopOut,
+  renderNavigation,
+  renderContent,
+}) => {
+  const session = useSession();
+  const auth = useAuthContext();
+
+  const activeParcel = usePropertyStore((s) => s.activeParcel);
+  const propertyLoading = usePropertyStore((s) => s.activeParcelLoading);
+  const activeParcelError = usePropertyStore((s) => s.activeParcelError);
+  const selectParcel = usePropertyStore((s) => s.selectParcel);
+  const hasWorkbenchAuth = hasUsableWorkbenchToken(auth.token);
+  const [authWaitExpired, setAuthWaitExpired] = useState(false);
+
+  useEffect(() => {
+    if (!parcelId || hasWorkbenchAuth) {
+      setAuthWaitExpired(false);
+      return;
+    }
+
+    const timer = window.setTimeout(() => setAuthWaitExpired(true), 8_000);
+    return () => window.clearTimeout(timer);
+  }, [hasWorkbenchAuth, parcelId]);
+
+  useEffect(() => {
+    if (parcelId && hasWorkbenchAuth && activeParcel?.parcelId !== parcelId) {
+      selectParcel(parcelId);
+    }
+  }, [parcelId, hasWorkbenchAuth, activeParcel?.parcelId, selectParcel]);
+
+  const propertyData = useMemo(
+    () => ({
+      parcelId: activeParcel?.parcelId || parcelId || 'Unknown',
+      address: activeParcel?.address || '',
+      owner: activeParcel?.ownerName || '',
+      assessedValue: activeParcel?.totalAssessedValue ?? 0,
+      marketValue: activeParcel?.marketValue ?? 0,
+      landValue: activeParcel?.landValue ?? 0,
+      improvementValue: activeParcel?.improvementValue ?? 0,
+      propertyType: activeParcel?.propertyType || '',
+      legalDescription: activeParcel?.legalDescription || '',
+      source: activeParcel?.dataSource || '',
+    }),
+    [activeParcel, parcelId],
+  );
+
+  const parcelFacts = useMemo(
+    () => buildContextRibbonFacts(activeParcel).slice(0, 6),
+    [activeParcel, buildContextRibbonFacts],
+  );
+
+  const countyId = auth.countyId ?? session.countyId;
+  const userId = auth.userId ?? session.userId;
+  const roles = useMemo(
+    () => (auth.roles.length > 0 ? [...auth.roles] : session.role ? [session.role] : []),
+    [auth.roles, session.role],
+  );
+  const { visibleTabs } = useWorkbenchRoles(roles);
+
+  const filteredTabs = useMemo(
+    () => WORKBENCH_TABS.filter((tab) => visibleTabs.includes(tab.id)),
+    [visibleTabs],
+  );
+
+  const [badges, setBadges] = useState<Badge[]>([]);
+  const [workMode, setWorkMode] = useState<WorkMode>('overview');
+
+  useEffect(() => {
+    if (!parcelId) return;
+    let cancelled = false;
+    const ctx: WorkbenchContext = { countyId, userId, roles, parcelId, workMode };
+
+    Promise.allSettled(BADGE_PROVIDERS.map((p) => p.getBadges(parcelId, ctx))).then((results) => {
+      if (cancelled) return;
+      const allBadges: Badge[] = [];
+      for (const result of results) {
+        if (result.status === 'fulfilled') allBadges.push(...result.value);
+      }
+      setBadges(allBadges);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [countyId, parcelId, roles, userId, workMode]);
+
+  const [quickActions, setQuickActions] = useState<QuickActionDefinition[]>([]);
+
+  useEffect(() => {
+    if (!parcelId) return;
+    let cancelled = false;
+    const ctx: WorkbenchContext = { countyId, userId, roles, parcelId, workMode };
+
+    Promise.allSettled(QUICK_ACTION_PROVIDERS.map((p) => p.getActions(ctx))).then((results) => {
+      if (cancelled) return;
+      const all: QuickActionDefinition[] = [];
+      for (const result of results) {
+        if (result.status === 'fulfilled') all.push(...result.value);
+      }
+      setQuickActions(all);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [countyId, parcelId, roles, userId, workMode]);
+
+  const [activityOpen, setActivityOpen] = useState(false);
+  const { entries: activityEntries, loading: activityLoading } = useParcelActivity(parcelId);
+
+  const handleQuickAction = useCallback(
+    (action: QuickActionDefinition) => {
+      if (!parcelId) return;
+      executeOsAction(
+        {
+          id: action.id,
+          label: action.label,
+          intent: 'pilot-tool',
+          disabled: false,
+        },
+        {
+          navigate: () => undefined,
+          suiteId: 'workbench',
+          surface: 'context-ribbon',
+          moduleId: 'quick-actions',
+          parcelIdHash: hashParcelId(parcelId),
+          actor: toOsActor(auth),
+        },
+      );
+    },
+    [auth, parcelId],
+  );
+
+  if (!parcelId) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full gap-4 p-8"
+        style={{ color: 'hsl(var(--tf-text) / 0.6)', background: 'hsl(var(--tf-bg))' }}
+        data-testid="workbench-no-parcel"
+      >
+        <div className="text-[11px] uppercase tracking-widest" style={{ color: 'hsl(var(--tf-muted) / 0.88)' }}>
+          Property Workbench
+        </div>
+        <h2 className="text-xl font-semibold" style={{ color: 'hsl(var(--tf-text))' }}>
+          No Parcel Selected
+        </h2>
+        <p className="text-sm text-center max-w-md">
+          Search for a parcel to view the Property Workbench.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <button
+            onClick={onSearch}
+            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{ background: 'hsl(var(--tf-accent))', color: 'hsl(var(--tf-text))' }}
+          >
+            Search Parcels
+          </button>
+          <button
+            onClick={onBack}
+            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{
+              background: 'hsl(var(--tf-surface))',
+              color: 'hsl(var(--tf-text))',
+              border: '1px solid hsl(var(--tf-border) / 0.45)',
+            }}
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasWorkbenchAuth) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full gap-4 p-8"
+        style={{ color: 'hsl(var(--tf-text) / 0.72)', background: 'hsl(var(--tf-bg))' }}
+        data-testid={authWaitExpired ? 'workbench-auth-error' : 'workbench-auth-bootstrap'}
+        role={authWaitExpired ? 'alert' : undefined}
+      >
+        <div className="text-[11px] uppercase tracking-widest" style={{ color: 'hsl(var(--tf-muted) / 0.88)' }}>
+          Property Workbench
+        </div>
+        <h2 className="text-xl font-semibold" style={{ color: 'hsl(var(--tf-text))' }}>
+          {authWaitExpired ? 'Workbench authentication unavailable' : 'Preparing authenticated Workbench session'}
+        </h2>
+        <p className="text-sm text-center max-w-lg">
+          {authWaitExpired
+            ? 'A valid Workbench auth token was not available, so parcel data was not requested.'
+            : `Waiting for a valid Benton Workbench token before loading parcel ${parcelId}.`}
+        </p>
+      </div>
+    );
+  }
+
+  const parcelLoadPending = Boolean(parcelId && activeParcel?.parcelId !== parcelId && !activeParcelError);
+
+  if (propertyLoading || parcelLoadPending) {
+    return (
+      <div className="flex items-center justify-center h-full" style={{ background: 'hsl(var(--tf-bg))' }}>
+        <div className="text-center p-8">
+          <div
+            className="animate-spin h-8 w-8 rounded-full mx-auto mb-4"
+            style={{
+              borderWidth: 4,
+              borderStyle: 'solid',
+              borderColor: 'hsl(var(--tf-transcend-cyan-hs) 50%)',
+              borderTopColor: 'transparent',
+            }}
+          />
+          <p style={{ color: 'hsl(var(--tf-muted))' }}>Loading property {parcelId}…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (activeParcelError) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full gap-4 p-8"
+        style={{ color: 'hsl(var(--tf-text) / 0.72)', background: 'hsl(var(--tf-bg))' }}
+        data-testid="workbench-parcel-load-error"
+        role="alert"
+      >
+        <div className="text-[11px] uppercase tracking-widest" style={{ color: 'hsl(var(--tf-muted) / 0.88)' }}>
+          Property Workbench
+        </div>
+        <h2 className="text-xl font-semibold" style={{ color: 'hsl(var(--tf-text))' }}>
+          Parcel data unavailable
+        </h2>
+        <p className="text-sm text-center max-w-lg">{activeParcelError}</p>
+        <div className="flex gap-2">
+          <button
+            onClick={onSearch}
+            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{ background: 'hsl(var(--tf-accent))', color: 'hsl(var(--tf-text))' }}
+          >
+            Search Properties
+          </button>
+          <button
+            onClick={onBack}
+            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{
+              background: 'hsl(var(--tf-surface))',
+              color: 'hsl(var(--tf-text))',
+              border: '1px solid hsl(var(--tf-border) / 0.45)',
+            }}
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const tabContext: WorkbenchTabData = {
+    parcelId,
+    propertyData,
+    workMode,
+    segmentHandoff,
+  };
+
+  return (
+    <div className={`flex flex-col h-full ${className}`} style={{ background: 'hsl(var(--tf-bg))' }} data-testid="property-workbench-root">
+      {showBreadcrumb && (
+        <nav
+          aria-label="Breadcrumb"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            padding: '0.375rem 1rem',
+            background: 'hsl(var(--tf-surface) / 0.9)',
+            borderBottom: '1px solid hsl(var(--tf-border) / 0.4)',
+            fontSize: '0.75rem',
+            color: 'hsl(var(--tf-muted))',
+            flexShrink: 0,
+            zIndex: 10,
+          }}
+        >
+          <button
+            onClick={onBack}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+              color: 'hsl(var(--tf-muted))',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '0.125rem 0.375rem',
+              borderRadius: '0.25rem',
+            }}
+            aria-label="Go to Home"
+          >
+            <Home size={12} />
+            <span>Home</span>
+          </button>
+          <ChevronRight size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
+          <button
+            onClick={onSearch}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              color: 'hsl(var(--tf-muted))',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '0.125rem 0.375rem',
+              borderRadius: '0.25rem',
+            }}
+            aria-label="Go to Property Search"
+          >
+            Property Search
+          </button>
+          <ChevronRight size={10} style={{ opacity: 0.4, flexShrink: 0 }} />
+          <span style={{ color: 'hsl(var(--tf-text) / 0.85)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {parcelId}
+          </span>
+        </nav>
+      )}
+
+      <ContextRibbon
+        parcelId={propertyData.parcelId}
+        address={propertyData.address}
+        owner={propertyData.owner}
+        countyName="Benton County"
+        badges={badges}
+        parcelFacts={parcelFacts}
+        quickActions={quickActions}
+        workMode={workMode}
+        onWorkModeChange={setWorkMode}
+        onQuickAction={handleQuickAction}
+        onPopOut={onPopOut}
+      />
+
+      <div className="flex flex-row flex-1 min-h-0">
+        {renderNavigation({ tabs: filteredTabs, parcelId, currentTabId })}
+        <main className="flex-1 overflow-auto p-2" style={{ minWidth: 0, paddingBottom: '80px' }}>
+          <div className="min-h-full">
+            <ErrorBoundary>
+              <Suspense fallback={<TabLoader />}>{renderContent(tabContext)}</Suspense>
+            </ErrorBoundary>
+          </div>
+        </main>
+      </div>
+
+      <div className="shrink-0" style={{ borderTop: '1px solid hsl(var(--tf-border) / 0.15)' }}>
+        <button
+          onClick={() => setActivityOpen((o) => !o)}
+          className="flex items-center gap-2 w-full px-3 py-1 text-xs font-medium transition-colors"
+          style={{ color: 'hsl(var(--tf-text) / 0.5)', background: 'hsl(var(--tf-surface))' }}
+          aria-expanded={activityOpen}
+          aria-controls="workbench-activity-feed"
+        >
+          <span>{activityOpen ? '▼' : '▶'}</span>
+          <span>Activity ({activityEntries.length})</span>
+        </button>
+        {activityOpen && (
+          <div id="workbench-activity-feed" className="max-h-48 overflow-auto">
+            {activityLoading ? (
+              <div className="flex items-center gap-2 px-4 py-3 text-xs" style={{ color: 'hsl(var(--tf-text) / 0.4)' }}>
+                <div
+                  className="w-3 h-3 rounded-full animate-spin"
+                  style={{
+                    border: '1.5px solid hsl(var(--tf-accent) / 0.2)',
+                    borderTopColor: 'hsl(var(--tf-accent))',
+                  }}
+                />
+                Loading activity...
+              </div>
+            ) : (
+              <ActivityFeed entries={activityEntries} maxEntries={15} />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PropertyWorkbenchSurface;

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
@@ -1,213 +1,93 @@
 /**
- * ═══════════════════════════════════════════════════════════════
- * TERRAFUSION OS — PROPERTY WORKBENCH WINDOW ADAPTER
- * Phase A: Workbench-in-a-Window (Desktop Integration)
+ * TerraFusion OS — Property Workbench OS-window adapter.
  *
- * Renders the Property Workbench inside a desktop window.
- * Receives parcelId via window metadata (not URL params).
- *
- * Uses state-based tab switching + WorkbenchTabCtx so tab components
- * get their context without requiring a nested Router (which crashes
- * React Router v6 with "cannot render a Router inside another Router").
- *
- * The full-screen route (/property/:parcelId) remains untouched.
- * This adapter adds window capability without breaking existing code.
- *
- * @see PropertyWorkbench.tsx — Route-based counterpart
- * @see 01_PROPERTY_WORKBENCH_SPEC_v3.1.md — Tier-0 OS Surface
- * ═══════════════════════════════════════════════════════════════
+ * The OS window is the canonical Workbench host. It reuses the shared
+ * PropertyWorkbenchSurface and supplies window-owned tab state only.
  */
 
-import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
-import { usePropertyStore } from '../../stores/propertyStore';
-import { ContextRibbon } from '../../components/workbench/ContextRibbon';
-import { ActivityFeed } from '../../components/workbench/ActivityFeed';
-import { BADGE_PROVIDERS } from '../../services/badges';
-import { QUICK_ACTION_PROVIDERS } from '../../services/quickActions';
-import { useParcelActivity } from '../../services/activityFeed';
+import React, { lazy, useEffect, useMemo, useRef, useState } from 'react';
+import { WorkbenchRail } from '../../components/workbench/WorkbenchRail';
 import { WorkbenchTabCtx } from '../../context/workbenchTabContext';
 import type { WorkbenchSegmentHandoffContext } from '../../context/workbenchTabContext';
-import { emitTraceEvent } from '../../services/terraTrace';
-import type { WorkbenchTabSlug, WorkMode, Badge, QuickActionDefinition, WorkbenchContext } from '../../contracts/workbench';
-import { useWorkbenchRoles } from '../../hooks/useWorkbenchRoles';
-import { validateWorkbenchHost } from '../../contracts/objectPlacement';
-import type { WorkbenchHostViolation } from '../../contracts/objectPlacement';
-import { useRecentParcels, useRecentParcelMeta, recordRecentParcelMeta, openWorkbenchWindow } from '../../context/parcelContext';
+import { validateWorkbenchHost, type WorkbenchHostViolation } from '../../contracts/objectPlacement';
+import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { useCompanionStore } from '../../stores/companionStore';
-import { useParcelSearch } from '../../shell/command-palette/useParcelSearch';
-import { useCommandPaletteStore } from '../../stores/commandPaletteStore';
-import { useSession } from '../../auth/useSession';
-import { useAuthContext } from '../../auth/useAuthContext';
-import { cn } from '@/lib/utils';
-import { buildContextRibbonFacts } from '../../components/workbench/parcelContextFacts';
-import activateModule from '@/orchestration/moduleActivation';
-
-// ============================================================================
-// Lazy-loaded Tab Components (same as Router.tsx)
-// ============================================================================
+import { emitTraceEvent } from '../../services/terraTrace';
+import {
+  PropertyWorkbenchSurface,
+  type PropertyWorkbenchSurfaceNavigationArgs,
+} from './PropertyWorkbenchSurface';
 
 const PropertySummary = lazy(() =>
-  import('./tabs/PropertySummary').then((m) => ({ default: m.PropertySummary }))
+  import('./tabs/PropertySummary').then((m) => ({ default: m.PropertySummary })),
 );
 const PropertyForge = lazy(() =>
-  import('./tabs/PropertyForge').then((m) => ({ default: m.PropertyForge }))
+  import('./tabs/PropertyForge').then((m) => ({ default: m.PropertyForge })),
 );
 const PropertyAtlas = lazy(() =>
-  import('./tabs/PropertyAtlas').then((m) => ({ default: m.PropertyAtlas }))
+  import('./tabs/PropertyAtlas').then((m) => ({ default: m.PropertyAtlas })),
 );
 const PropertyDais = lazy(() =>
-  import('./tabs/PropertyDais').then((m) => ({ default: m.PropertyDais }))
+  import('./tabs/PropertyDais').then((m) => ({ default: m.PropertyDais })),
+);
+const PropertyClerk = lazy(() =>
+  import('./tabs/PropertyClerk').then((m) => ({ default: m.PropertyClerk })),
+);
+const PropertyTreasury = lazy(() =>
+  import('./tabs/PropertyTreasury').then((m) => ({ default: m.PropertyTreasury })),
+);
+const PropertyAudit = lazy(() =>
+  import('./tabs/PropertyAudit').then((m) => ({ default: m.PropertyAudit })),
 );
 const PropertyDossier = lazy(() =>
-  import('./tabs/PropertyDossier').then((m) => ({ default: m.PropertyDossier }))
+  import('./tabs/PropertyDossier').then((m) => ({ default: m.PropertyDossier })),
 );
 const PropertyPilot = lazy(() =>
-  import('./tabs/PropertyPilot').then((m) => ({ default: m.PropertyPilot }))
+  import('./tabs/PropertyPilot').then((m) => ({ default: m.PropertyPilot })),
 );
-
-// ============================================================================
-// Tab → Component Map
-// ============================================================================
 
 const TAB_COMPONENTS: Record<WorkbenchTabSlug, React.LazyExoticComponent<React.FC>> = {
   summary: PropertySummary,
   forge: PropertyForge,
   atlas: PropertyAtlas,
   dais: PropertyDais,
-  clerk: PropertyDossier,
-  treasury: PropertyDais,
-  audit: PropertyDossier,
+  clerk: PropertyClerk,
+  treasury: PropertyTreasury,
+  audit: PropertyAudit,
   dossier: PropertyDossier,
   pilot: PropertyPilot,
 };
 
-// ============================================================================
-// Types
-// ============================================================================
+const VALID_TABS = new Set<WorkbenchTabSlug>([
+  'summary',
+  'forge',
+  'atlas',
+  'dais',
+  'clerk',
+  'treasury',
+  'audit',
+  'dossier',
+  'pilot',
+]);
 
 export interface PropertyWorkbenchWindowProps {
   metadata?: Record<string, unknown>;
 }
 
-interface TabDef {
-  id: WorkbenchTabSlug;
-  label: string;
-}
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-/** Canonical tab order — locked per spec. */
-const TABS: readonly TabDef[] = [
-  { id: 'summary', label: 'Summary' },
-  { id: 'forge', label: 'Forge' },
-  { id: 'atlas', label: 'Atlas' },
-  { id: 'dais', label: 'Dais' },
-  { id: 'clerk', label: 'Clerk' },
-  { id: 'treasury', label: 'Treasury' },
-  { id: 'audit', label: 'Audit' },
-  { id: 'dossier', label: 'Dossier' },
-  { id: 'pilot', label: 'Pilot' },
-] as const;
-
-// ============================================================================
-// Loading Fallback
-// ============================================================================
-
-const TabLoader: React.FC = () => (
-  <div className="flex items-center justify-center h-32" style={{ color: 'hsl(var(--tf-text) / 0.5)' }}>
-    <div
-      className="w-6 h-6 rounded-full animate-spin mr-3"
-      style={{
-        border: '2px solid hsl(var(--tf-accent) / 0.2)',
-        borderTopColor: 'hsl(var(--tf-accent))',
-      }}
-    />
-    Loading...
-  </div>
-);
-
-// ============================================================================
-// Workbench Start Scene — Parcel Intake Surface
-// ============================================================================
-
-/** Plain panel wrapper (data surface — no glass per Liquid Glass spec) */
-const StartGlassCard: React.FC<React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }> = ({
-  children,
-  className = '',
-  ...props
-}) => (
-  <div
-    {...props}
-    className={cn('p-4 flex flex-col rounded-lg', className)}
-    style={{ border: '1px solid hsl(var(--tf-border) / 0.15)', background: 'hsl(var(--tf-surface))', ...props.style }}
-  >
-    {children}
-  </div>
-);
-
-/** Section header */
-const StartSectionHeader: React.FC<{ icon: React.ReactNode; title: string }> = ({ icon, title }) => (
-  <div className="flex items-center gap-2 mb-3">
-    <span className="opacity-50">{icon}</span>
-    <span
-      className="text-xs font-semibold uppercase tracking-wider"
-      style={{ color: 'hsl(var(--tf-text) / 0.5)' }}
-    >
-      {title}
-    </span>
-  </div>
-);
-
-/** Clickable action row */
-const StartActionRow: React.FC<{
-  icon: React.ReactNode;
-  label: string;
-  sublabel?: string;
-  onClick: () => void;
-  subtle?: boolean;
-  shortcut?: string;
-}> = ({ icon, label, sublabel, onClick, subtle = false, shortcut }) => (
-  <button
-    onClick={onClick}
-    className={cn(
-      'flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-left',
-      'transition-all duration-150',
-      'hover:bg-[hsl(var(--tf-text)_/_0.08)]',
-      'focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--tf-accent))]',
-      subtle ? 'opacity-60 hover:opacity-90' : 'opacity-80 hover:opacity-100',
-    )}
-  >
-    <span className="flex-shrink-0 opacity-60">{icon}</span>
-    <span className="flex-1 min-w-0">
-      <span className="text-sm font-medium truncate block" style={{ color: 'hsl(var(--tf-text) / 0.9)' }}>
-        {label}
-      </span>
-      {sublabel && (
-        <span className="text-xs truncate block" style={{ color: 'hsl(var(--tf-text) / 0.4)' }}>
-          {sublabel}
-        </span>
-      )}
-    </span>
-    {shortcut && (
-      <span
-        className="ml-auto flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded"
-        style={{
-          color: 'hsl(var(--tf-text) / 0.35)',
-          background: 'hsl(var(--tf-text) / 0.06)',
-        }}
-      >
-        {shortcut}
-      </span>
-    )}
-  </button>
-);
-
 function readMetadataString(metadata: Record<string, unknown> | undefined, key: string): string | undefined {
   const value = metadata?.[key];
   return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function normalizeRoutedTab(value: unknown): WorkbenchTabSlug {
+  const normalized = String(value ?? '').trim().toLowerCase().replace(/^suite-/, '').replace(/-tab$/, '');
+  return VALID_TABS.has(normalized as WorkbenchTabSlug) ? (normalized as WorkbenchTabSlug) : 'summary';
+}
+
+function resolveMetadataTab(metadata: Record<string, unknown> | undefined): WorkbenchTabSlug {
+  const routedTab = readMetadataString(metadata, '_routedTab');
+  const tab = readMetadataString(metadata, 'tab');
+  return normalizeRoutedTab(routedTab ?? (metadata?.tabId as WorkbenchTabSlug) ?? tab ?? 'summary');
 }
 
 function buildSegmentHandoffContext(
@@ -229,381 +109,21 @@ function buildSegmentHandoffContext(
   };
 }
 
-const SegmentHandoffDetails: React.FC<{ context: WorkbenchSegmentHandoffContext }> = ({ context }) => {
-  const details = [
-    { label: 'Segment', value: context.segmentLabel ?? context.segmentId },
-    { label: 'Template', value: context.handoffTemplate },
-    { label: 'Receipt', value: context.downstreamReceiptId },
-    { label: 'Exception set', value: context.exceptionSetId },
-    { label: 'Status', value: context.downstreamStatus },
-  ].filter((item): item is { label: string; value: string } => Boolean(item.value));
-
-  return (
-    <dl className="mt-3 grid gap-2">
-      {details.map((item) => (
-        <div key={item.label} className="flex items-start justify-between gap-3">
-          <dt className="text-[10px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'hsl(var(--tf-text) / 0.45)' }}>
-            {item.label}
-          </dt>
-          <dd className="max-w-[150px] truncate text-right text-xs font-medium" style={{ color: 'hsl(var(--tf-text) / 0.78)' }}>
-            {item.value}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  );
-};
-
-const SegmentHandoffBanner: React.FC<{ context: WorkbenchSegmentHandoffContext }> = ({ context }) => {
-  const handleBackToCountyStudio = useCallback(() => {
-    void activateModule('county-studio', {
-      source: 'system',
-      metadata: {
-        segmentId: context.segmentId,
-        studyId: context.studyId,
-        countyId: context.countyId,
-        exceptionSetId: context.exceptionSetId,
-        downstreamReceiptId: context.downstreamReceiptId,
-        downstreamStatus: context.downstreamStatus,
-      },
-    });
-  }, [context]);
-
-  return (
-    <div
-      data-testid="workbench-segment-handoff-banner"
-      className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-2"
-      style={{
-        borderColor: 'hsl(var(--tf-border) / 0.18)',
-        background: 'hsl(var(--tf-accent) / 0.08)',
-        color: 'hsl(var(--tf-text) / 0.8)',
-      }}
-    >
-      <div className="min-w-0">
-        <span className="text-[10px] font-bold uppercase tracking-[0.14em]" style={{ color: 'hsl(var(--tf-accent))' }}>
-          County Studio segment context
-        </span>
-        <p className="truncate text-xs">
-          Segment {context.segmentLabel ?? context.segmentId}
-          {context.downstreamReceiptId ? ` · Receipt ${context.downstreamReceiptId}` : ''}
-          {context.downstreamStatus ? ` · ${context.downstreamStatus}` : ''}
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={handleBackToCountyStudio}
-        className="rounded-md border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.08em]"
-        style={{
-          borderColor: 'hsl(var(--tf-accent) / 0.35)',
-          color: 'hsl(var(--tf-accent))',
-        }}
-      >
-        Back to County Studio
-      </button>
-    </div>
-  );
-};
-
-/** Workbench Start Scene — parcel intake when no parcel is active */
-const WorkbenchStartScene: React.FC<{ segmentHandoff?: WorkbenchSegmentHandoffContext | null }> = ({
-  segmentHandoff,
-}) => {
-  const recentParcels = useRecentParcels();
-  const recentMeta = useRecentParcelMeta();
-  const openPalette = useCommandPaletteStore((s) => s.open);
-  const searchInputRef = useRef<HTMLInputElement>(null);
-
-  // Inline search
-  const [searchQuery, setSearchQuery] = useState('');
-  const { results, totalCount, isLoading } = useParcelSearch(searchQuery, searchQuery.length >= 3);
-  const [showResults, setShowResults] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
-
-  // Autofocus the search input
-  useEffect(() => {
-    const timer = setTimeout(() => searchInputRef.current?.focus(), 100);
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Show results when we have them; reset selection
-  useEffect(() => {
-    setShowResults(results.length > 0);
-    setSelectedIndex(-1);
-  }, [results]);
-
-  const handleSelectParcel = useCallback((parcelId: string, meta?: { address: string; ownerName: string }) => {
-    if (meta) recordRecentParcelMeta(parcelId, meta);
-    openWorkbenchWindow(parcelId);
-  }, []);
-
-  const handleResumeLast = useCallback(() => {
-    if (recentParcels.length > 0) {
-      openWorkbenchWindow(recentParcels[0]);
-    }
-  }, [recentParcels]);
-
-  const handleBackToCountyStudio = useCallback(() => {
-    if (!segmentHandoff) return;
-    void activateModule('county-studio', {
-      source: 'system',
-      metadata: {
-        segmentId: segmentHandoff.segmentId,
-        studyId: segmentHandoff.studyId,
-        countyId: segmentHandoff.countyId,
-        exceptionSetId: segmentHandoff.exceptionSetId,
-        downstreamReceiptId: segmentHandoff.downstreamReceiptId,
-        downstreamStatus: segmentHandoff.downstreamStatus,
-      },
-    });
-  }, [segmentHandoff]);
-
-  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
-      return;
-    }
-    if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setSelectedIndex((i) => Math.max(i - 1, -1));
-      return;
-    }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      const trimmed = searchQuery.trim();
-      const target = selectedIndex >= 0 ? results[selectedIndex] : results[0];
-      if (target) {
-        // Text search: navigate to selected/first result
-        handleSelectParcel(target.parcelNumber, { address: target.address, ownerName: target.ownerName });
-      } else if (/^\d+$/.test(trimmed) && trimmed.length >= 3) {
-        // All-digit input: direct parcel number navigation
-        openWorkbenchWindow(trimmed);
-      }
-    }
-    if (e.key === 'Escape') {
-      setSearchQuery('');
-      setShowResults(false);
-      setSelectedIndex(-1);
-    }
-  }, [results, searchQuery, selectedIndex, handleSelectParcel]);
-
-  return (
-    <div className="h-full flex gap-3 p-6" style={{ background: 'hsl(var(--tf-bg))' }}>
-
-      {/* ═══ Left Panel: Recent Parcels ═══ */}
-      <div className="w-[240px] shrink-0 flex flex-col gap-3">
-        <StartGlassCard className="flex-1">
-          <StartSectionHeader icon={<span className="text-sm">&#128339;</span>} title="Recent Parcels" />
-          <div className="flex flex-col gap-0.5 -mx-2.5 flex-1">
-            {recentParcels.length === 0 ? (
-              <div className="flex flex-col items-center justify-center flex-1 gap-2 opacity-40">
-                <span className="text-2xl">&#127970;</span>
-                <p className="text-xs text-center" style={{ color: 'hsl(var(--tf-text) / 0.5)' }}>
-                  No recent parcels.
-                  <br />
-                  Use Ctrl+K to search.
-                </p>
-              </div>
-            ) : (
-              recentParcels.slice(0, 8).map((parcelId) => {
-                const meta = recentMeta[parcelId];
-                return (
-                  <StartActionRow
-                    key={parcelId}
-                    icon={<span className="text-sm">&#127970;</span>}
-                    label={meta?.address ? meta.address : parcelId}
-                    sublabel={meta?.ownerName ? `${parcelId} — ${meta.ownerName}` : parcelId !== (meta?.address ?? parcelId) ? parcelId : undefined}
-                    onClick={() => handleSelectParcel(parcelId)}
-                  />
-                );
-              })
-            )}
-          </div>
-        </StartGlassCard>
-      </div>
-
-      {/* ═══ Center Panel: Parcel Search ═══ */}
-      <div className="flex-1 flex flex-col gap-3 min-w-0">
-        <StartGlassCard className="flex-1 items-center justify-center">
-          <div className="flex flex-col items-center gap-4 w-full max-w-md">
-            <span className="text-4xl opacity-20">&#127970;</span>
-            <h2 className="text-lg font-medium" style={{ color: 'hsl(var(--tf-text))' }}>
-              Property Workbench
-            </h2>
-            <p className="text-sm text-center" style={{ color: 'hsl(var(--tf-text) / 0.5)' }}>
-              Search or select a parcel to begin
-            </p>
-
-            {/* Search input */}
-            <div className="relative w-full">
-              <input
-                ref={searchInputRef}
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-                onFocus={() => results.length > 0 && setShowResults(true)}
-                onBlur={() => setTimeout(() => setShowResults(false), 200)}
-                placeholder="Search by parcel number, address, or owner..."
-                className={cn(
-                  'w-full px-4 py-3 rounded-lg text-sm',
-                  'transition-all duration-150',
-                  'focus:outline-none focus:ring-2',
-                )}
-                style={{
-                  background: 'hsl(var(--tf-text) / 0.06)',
-                  color: 'hsl(var(--tf-text))',
-                  border: '1px solid hsl(var(--tf-border) / 0.15)',
-                }}
-                aria-label="Search parcels"
-              />
-              {isLoading && (
-                <div
-                  className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 rounded-full animate-spin"
-                  style={{
-                    border: '2px solid hsl(var(--tf-accent) / 0.2)',
-                    borderTopColor: 'hsl(var(--tf-accent))',
-                  }}
-                />
-              )}
-
-              {/* Results dropdown */}
-              {showResults && results.length > 0 && (
-                <div
-                  className="absolute left-0 right-0 top-full mt-1 rounded-lg overflow-hidden z-10"
-                  style={{
-                    background: 'hsl(var(--tf-bg-surface))',
-                    border: '1px solid hsl(var(--tf-border) / 0.2)',
-                    boxShadow: '0 4px 12px hsl(0 0% 0% / 0.3)',
-                  }}
-                >
-                  {results.map((r, idx) => (
-                    <button
-                      key={r.parcelNumber}
-                      onMouseDown={(e) => e.preventDefault()}
-                      onMouseEnter={() => setSelectedIndex(idx)}
-                      onClick={() => handleSelectParcel(r.parcelNumber, { address: r.address, ownerName: r.ownerName })}
-                      className={cn(
-                        'flex flex-col w-full px-4 py-2.5 text-left',
-                        'transition-colors duration-100',
-                        idx === selectedIndex
-                          ? 'bg-[hsl(var(--tf-accent)_/_0.12)]'
-                          : 'hover:bg-[hsl(var(--tf-text)_/_0.06)]',
-                      )}
-                    >
-                      <span className="text-sm font-medium" style={{ color: 'hsl(var(--tf-text) / 0.9)' }}>
-                        {r.parcelNumber}
-                      </span>
-                      <span className="text-xs" style={{ color: 'hsl(var(--tf-text) / 0.5)' }}>
-                        {r.address}{r.ownerName ? ` — ${r.ownerName}` : ''}
-                      </span>
-                    </button>
-                  ))}
-                  {totalCount > results.length && (
-                    <button
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={openPalette}
-                      className="flex w-full items-center justify-center px-4 py-2 text-xs font-medium"
-                      style={{
-                        color: 'hsl(var(--tf-accent))',
-                        borderTop: '1px solid hsl(var(--tf-border) / 0.12)',
-                      }}
-                    >
-                      Show all {totalCount.toLocaleString()} results (Ctrl+K)
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <p className="text-xs" style={{ color: 'hsl(var(--tf-text) / 0.3)' }}>
-              Or{' '}
-              <button
-                onClick={openPalette}
-                className="underline-offset-2 hover:underline"
-                style={{ color: 'hsl(var(--tf-accent) / 0.7)' }}
-              >
-                Advanced Search (Ctrl+K)
-              </button>
-              {' '}for filters
-            </p>
-          </div>
-        </StartGlassCard>
-      </div>
-
-      {/* ═══ Right Panel: Quick Actions ═══ */}
-      <div className="w-[240px] shrink-0 flex flex-col gap-3">
-        {segmentHandoff && (
-          <StartGlassCard data-testid="workbench-segment-handoff-card">
-            <StartSectionHeader icon={<span className="text-sm">&#128203;</span>} title="County Studio Context" />
-            <p className="text-sm font-semibold" style={{ color: 'hsl(var(--tf-text) / 0.9)' }}>
-              Segment handoff retained
-            </p>
-            <p className="mt-1 text-xs" style={{ color: 'hsl(var(--tf-text) / 0.48)' }}>
-              Select or search a parcel to continue parcel-level review without losing the originating segment.
-            </p>
-            <SegmentHandoffDetails context={segmentHandoff} />
-            <button
-              type="button"
-              data-testid="workbench-segment-back-county-studio"
-              onClick={handleBackToCountyStudio}
-              className="mt-4 rounded-md border px-3 py-2 text-xs font-semibold uppercase tracking-[0.08em]"
-              style={{
-                borderColor: 'hsl(var(--tf-accent) / 0.35)',
-                background: 'hsl(var(--tf-accent) / 0.1)',
-                color: 'hsl(var(--tf-accent))',
-              }}
-            >
-              Back to County Studio
-            </button>
-          </StartGlassCard>
-        )}
-        <StartGlassCard className="flex-1">
-          <StartSectionHeader icon={<span className="text-sm">&#9889;</span>} title="Quick Actions" />
-          <div className="flex flex-col gap-0.5 -mx-2.5">
-            <StartActionRow
-              icon={<span className="text-sm">&#128269;</span>}
-              label="Search Parcels"
-              onClick={openPalette}
-              shortcut="⌘K"
-            />
-            {recentParcels.length > 0 && (
-              <StartActionRow
-                icon={<span className="text-sm">&#9654;</span>}
-                label="Resume Last Parcel"
-                sublabel={recentMeta[recentParcels[0]]?.address ?? recentParcels[0]}
-                onClick={handleResumeLast}
-              />
-            )}
-          </div>
-        </StartGlassCard>
-      </div>
-
-    </div>
-  );
-};
-
-// ============================================================================
-// Phase 7: Workbench Host Violation Notice
-// ============================================================================
-
 const WorkbenchHostViolationNotice: React.FC<{ violation: WorkbenchHostViolation }> = ({ violation }) => {
-  // Log the violation to console for governance traceability
-  if (typeof console !== 'undefined') {
-  }
+  console.warn('[Codex] Workbench host violation', {
+    tabId: violation.tabId,
+    objectType: violation.objectType,
+    reason: violation.reason,
+  });
 
   return (
-    <div
-      className="flex flex-col items-center justify-center h-full gap-4 p-8"
-      style={{ color: 'hsl(var(--tf-text) / 0.6)' }}
-    >
-      <span className="text-4xl">⛔</span>
+    <div className="flex flex-col items-center justify-center h-full gap-4 p-8" style={{ color: 'hsl(var(--tf-text) / 0.6)' }}>
+      <span className="text-4xl">!</span>
       <h2 className="text-lg font-medium" style={{ color: 'hsl(var(--tf-text))' }}>
-        Codex Violation — Host Boundary
+        Host Boundary Violation
       </h2>
       <p className="text-sm text-center max-w-md">
-        Tab &quot;{violation.tabId}&quot; (type: {violation.objectType}) is not
-        authorized to render inside the Property Workbench.
+        Tab &quot;{violation.tabId}&quot; ({violation.objectType}) is not authorized to render inside the Property Workbench.
       </p>
       <p className="text-xs text-center max-w-md" style={{ color: 'hsl(var(--tf-text) / 0.4)' }}>
         {violation.reason}
@@ -612,405 +132,53 @@ const WorkbenchHostViolationNotice: React.FC<{ violation: WorkbenchHostViolation
   );
 };
 
-// ============================================================================
-// Tab Navigation Bar (state-based, no Router dependency)
-// ============================================================================
-
-interface TabBarProps {
-  activeTab: WorkbenchTabSlug;
-  onTabChange: (tab: WorkbenchTabSlug) => void;
-  /** Filtered tabs to display (Phase 2 role visibility) */
-  tabs?: readonly TabDef[];
-  /** Number of hidden tabs (for toggle badge) */
-  hiddenCount?: number;
-  /** Whether showing all tabs */
-  showAll?: boolean;
-  /** Toggle show-all override */
-  onToggleShowAll?: () => void;
-}
-
-const TabBar: React.FC<TabBarProps> = ({
-  activeTab,
-  onTabChange,
-  tabs = TABS,
-  hiddenCount = 0,
-  showAll = false,
-  onToggleShowAll,
-}) => (
-  <div className="flex items-center">
-    <nav
-      className="flex-1 min-w-0 border-b px-4 flex gap-1 overflow-x-auto"
-      style={{
-        borderColor: 'hsl(var(--tf-border) / 0.4)',
-        background: 'hsl(var(--tf-surface) / 0.92)',
-      }}
-    >
-      {tabs.map((tab) => {
-        const isActive = tab.id === activeTab;
-        return (
-          <button
-            key={tab.id}
-            onClick={() => onTabChange(tab.id)}
-            className="flex items-center px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap"
-            style={{
-              color: isActive ? 'hsl(var(--tf-accent))' : 'hsl(var(--tf-text) / 0.6)',
-              borderBottom: isActive ? '2px solid hsl(var(--tf-accent))' : '2px solid transparent',
-              background: isActive ? 'hsl(var(--tf-accent) / 0.08)' : 'transparent',
-            }}
-            aria-selected={isActive}
-            role="tab"
-          >
-            <span>{tab.label}</span>
-          </button>
-        );
-      })}
-    </nav>
-    {hiddenCount > 0 && onToggleShowAll && (
-      <button
-        onClick={onToggleShowAll}
-        className="shrink-0 px-3 py-1 mr-2 text-xs rounded transition-colors"
-        style={{
-          color: showAll ? 'hsl(var(--tf-accent))' : 'hsl(var(--tf-text) / 0.4)',
-          background: showAll ? 'hsl(var(--tf-accent) / 0.1)' : 'transparent',
-        }}
-        title={showAll ? 'Show role-default tabs' : `Show all tabs (+${hiddenCount} hidden)`}
-      >
-        {showAll ? 'Role view' : `+${hiddenCount} more`}
-      </button>
-    )}
-  </div>
-);
-
-// ============================================================================
-// Inner Layout Types
-// ============================================================================
-
-interface PropertyData {
-  parcelId: string;
-  address: string;
-  owner: string;
-  assessedValue: number;
-  marketValue: number;
-  landValue: number;
-  improvementValue: number;
-  propertyType: string;
-  legalDescription: string;
-  source: string;
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
-
-/**
- * PropertyWorkbenchWindow — Desktop window adapter for the Property Workbench.
- *
- * Opens as a floating desktop window via desktopStore.openWindow().
- * Receives parcelId from window metadata.
- * Full-screen route (/property/:parcelId) remains untouched.
- *
- * Architecture:
- * - State-based tab switching (no Router needed)
- * - WorkbenchTabCtx.Provider gives tab components { parcelId, propertyData }
- * - Tab components use useWorkbenchTab() which reads from this context
- */
 const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metadata }) => {
-  const parcelId = (metadata?.parcelId as string) ?? null;
-  const initialTab = (metadata?.tabId as WorkbenchTabSlug) ?? 'summary';
-  const segmentHandoff = useMemo(
-    () => buildSegmentHandoffContext(metadata),
-    [metadata],
-  );
-  const session = useSession();
-  const auth = useAuthContext();
-
-  // Resolve initial tab from metadata slug
-  const resolvedInitialTab = useMemo<WorkbenchTabSlug>(() => {
-    if (!initialTab || initialTab === '/' as string) return 'summary';
-    if (initialTab === 'clerk' || initialTab === 'audit') return 'dossier';
-    if (initialTab === 'treasury') return 'dais';
-    const valid = TABS.find((t) => t.id === initialTab);
-    return valid?.id ?? 'summary';
-  }, [initialTab]);
-
-  // Active tab state
-  const [activeTab, setActiveTab] = useState<WorkbenchTabSlug>(resolvedInitialTab);
-
-  // Sync initial tab to companion context bus on mount
-  const setCompanionTabOnMount = useCompanionStore((state) => state.setActiveTab);
-  useEffect(() => {
-    setCompanionTabOnMount(resolvedInitialTab);
-    return () => { setCompanionTabOnMount(null); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Property data from store (backed by DataProvider → snapshot/live/fixtures)
-  const activeParcel = usePropertyStore((s) => s.activeParcel);
-  const loading = usePropertyStore((s) => s.activeParcelLoading);
-  const selectParcel = usePropertyStore((s) => s.selectParcel);
-
-  // Load parcel via store when parcelId changes (if not already loaded)
-  useEffect(() => {
-    if (parcelId && activeParcel?.parcelId !== parcelId) {
-      selectParcel(parcelId);
-    }
-  }, [parcelId, activeParcel?.parcelId, selectParcel]);
-
-  const propertyData = useMemo<PropertyData>(
-    () => ({
-      parcelId: activeParcel?.parcelId || parcelId || 'Unknown',
-      address: activeParcel?.address || '',
-      owner: activeParcel?.ownerName || '',
-      assessedValue: activeParcel?.totalAssessedValue ?? 0,
-      marketValue: activeParcel?.marketValue ?? 0,
-      landValue: activeParcel?.landValue ?? 0,
-      improvementValue: activeParcel?.improvementValue ?? 0,
-      propertyType: activeParcel?.propertyType || '',
-      legalDescription: activeParcel?.legalDescription || '',
-      source: activeParcel?.dataSource || '',
-    }),
-    [activeParcel, parcelId]
-  );
-
-  const parcelFacts = useMemo(
-    () => buildContextRibbonFacts(activeParcel).slice(0, 6),
-    [activeParcel]
-  );
-
-  // Work Mode state
-  const [workMode, setWorkMode] = useState<WorkMode>('overview');
-
-  // ── Role-based tab visibility (auth claims first, session fallback) ──
-  const countyId = auth.countyId ?? session.countyId;
-  const userId = auth.userId ?? session.userId;
-  const roles = useMemo(
-    () => (auth.roles.length > 0 ? [...auth.roles] : session.role ? [session.role] : []),
-    [auth.roles, session.role]
-  );
-  const { visibleTabs, hiddenCount, showAll, toggleShowAll } = useWorkbenchRoles(roles);
-
-  /** Tabs filtered by role visibility — order preserved */
-  const filteredTabs = useMemo(
-    () => TABS.filter((tab) => visibleTabs.includes(tab.id)),
-    [visibleTabs]
-  );
-
-  // Context value for tab components (via WorkbenchTabCtx)
-  const tabContextValue = useMemo(
-    () => ({ parcelId: parcelId || 'Unknown', propertyData, workMode, segmentHandoff, launchMetadata: metadata }),
-    [metadata, parcelId, propertyData, segmentHandoff, workMode]
-  );
-
-  // Badge state — collected from all providers
-  const [badges, setBadges] = useState<Badge[]>([]);
-
-  // Fetch badges when parcelId changes
-  useEffect(() => {
-    if (!parcelId) return;
-    let cancelled = false;
-
-    const ctx: WorkbenchContext = {
-      countyId,
-      userId,
-      roles,
-      parcelId,
-      workMode,
-    };
-
-    Promise.allSettled(
-      BADGE_PROVIDERS.map((p) => p.getBadges(parcelId, ctx))
-    ).then((results) => {
-      if (cancelled) return;
-      const allBadges: Badge[] = [];
-      for (const r of results) {
-        if (r.status === 'fulfilled') allBadges.push(...r.value);
-      }
-      setBadges(allBadges);
-    });
-
-    return () => { cancelled = true; };
-  }, [countyId, parcelId, roles, userId, workMode]);
-
-  // Quick Actions — mode-aware, collected from providers
-  const [quickActions, setQuickActions] = useState<QuickActionDefinition[]>([]);
-
-  useEffect(() => {
-    if (!parcelId) return;
-    let cancelled = false;
-
-    const ctx: WorkbenchContext = {
-      countyId,
-      userId,
-      roles,
-      parcelId,
-      workMode,
-    };
-
-    Promise.allSettled(
-      QUICK_ACTION_PROVIDERS.map((p) => p.getActions(ctx))
-    ).then((results) => {
-      if (cancelled) return;
-      const all: QuickActionDefinition[] = [];
-      for (const r of results) {
-        if (r.status === 'fulfilled') all.push(...r.value);
-      }
-      setQuickActions(all);
-    });
-
-    return () => { cancelled = true; };
-  }, [countyId, parcelId, roles, userId, workMode]);
-
-  // Pop out to full-screen route
-  const handlePopOut = useCallback(() => {
-    if (parcelId) {
-      window.open(`/property/${encodeURIComponent(parcelId)}`, '_self');
-    }
-  }, [parcelId]);
-
-  // Tab change handler
+  const parcelId = readMetadataString(metadata, 'parcelId') ?? null;
+  const metadataTab = resolveMetadataTab(metadata);
+  const segmentHandoff = useMemo(() => buildSegmentHandoffContext(metadata), [metadata]);
+  const [activeTab, setActiveTab] = useState<WorkbenchTabSlug>(metadataTab);
+  const previousTabRef = useRef<WorkbenchTabSlug>(metadataTab);
   const setCompanionTab = useCompanionStore((state) => state.setActiveTab);
-  const handleTabChange = useCallback((slug: WorkbenchTabSlug) => {
-    const previousTab = activeTab;
-    setActiveTab(slug);
-    setCompanionTab(slug);
-    emitTraceEvent('tab_switched', 'workbench', parcelId ?? 'unknown', { tab: previousTab }, { tab: slug });
+
+  useEffect(() => {
+    setActiveTab(metadataTab);
+  }, [metadataTab]);
+
+  useEffect(() => {
+    const previousTab = previousTabRef.current;
+    setCompanionTab(activeTab);
+    if (previousTab !== activeTab) {
+      emitTraceEvent('tab_switched', 'workbench', parcelId ?? 'unknown', { tab: previousTab }, { tab: activeTab });
+      previousTabRef.current = activeTab;
+    }
+    return () => setCompanionTab(null);
   }, [activeTab, parcelId, setCompanionTab]);
 
-  // Activity Feed state — collapsible bottom panel
-  const [activityOpen, setActivityOpen] = useState(false);
-  const { entries: activityEntries, loading: activityLoading } = useParcelActivity(parcelId);
-
-  // Phase 7: Workbench Host Boundary Check
-  // Validates that the active tab is lawfully hosted inside the workbench.
-  const hostViolation: WorkbenchHostViolation | null = useMemo(
-    () => validateWorkbenchHost(activeTab),
-    [activeTab],
-  );
-
-  useEffect(() => {
-    if (hostViolation) {
-      console.warn('[Codex] Workbench host violation', hostViolation);
-    }
-  }, [hostViolation]);
-
-  // No parcel selected — show parcel intake scene
-  if (!parcelId) {
-    return <WorkbenchStartScene segmentHandoff={segmentHandoff} />;
-  }
+  const hostViolation = useMemo(() => validateWorkbenchHost(activeTab), [activeTab]);
+  const ActiveTabComponent = TAB_COMPONENTS[activeTab] ?? PropertySummary;
 
   return (
-    <div className="flex flex-col h-full w-full" style={{ background: 'hsl(var(--tf-bg))' }}>
-      {/* Context Ribbon replaces old ParcelHeader */}
-      <ContextRibbon
-        parcelId={parcelId}
-        address={propertyData.address}
-        owner={propertyData.owner}
-        countyName="Benton County"
-        badges={badges}
-        parcelFacts={parcelFacts}
-        quickActions={quickActions}
-        workMode={workMode}
-        onWorkModeChange={setWorkMode}
-        onPopOut={handlePopOut}
-      />
-      {segmentHandoff && <SegmentHandoffBanner context={segmentHandoff} />}
-
-      {/* Workbench content — state-based tabs, no Router needed */}
-      <WorkbenchTabCtx.Provider value={tabContextValue}>
-        <div className="flex flex-1 min-h-0">
-          {/* Main content area */}
-          <div className="flex flex-col flex-1 min-w-0">
-            <TabBar
-              activeTab={activeTab}
-              onTabChange={handleTabChange}
-              tabs={filteredTabs}
-              hiddenCount={hiddenCount}
-              showAll={showAll}
-              onToggleShowAll={toggleShowAll}
-            />
-            {/*
-              Stable tabpanel containers — one per top tab entry.
-              Inactive panels use the HTML `hidden` attribute (display:none),
-              meaning AT skips them and they cost nothing in layout.
-              Content is only mounted when the tab is active (lazy).
-            */}
-            <main className="flex-1 overflow-auto">
-              {filteredTabs.map((tab) => {
-                const isActive = activeTab === tab.id;
-                const ActiveTabComponent = TAB_COMPONENTS[tab.id];
-                return (
-                  <section
-                    key={tab.id}
-                    id={`panel-${tab.id}`}
-                    role="tabpanel"
-                    aria-label={tab.label}
-                    hidden={!isActive}
-                  >
-                    {isActive && (
-                      hostViolation ? (
-                        <WorkbenchHostViolationNotice violation={hostViolation} />
-                      ) : loading ? (
-                        <TabLoader />
-                      ) : (
-                        <ErrorBoundary>
-                          <Suspense fallback={<TabLoader />}>
-                            <ActiveTabComponent />
-                          </Suspense>
-                        </ErrorBoundary>
-                      )
-                    )}
-                  </section>
-                );
-              })}
-            </main>
-          </div>
-        </div>
-      </WorkbenchTabCtx.Provider>
-
-      {/* Collapsible Activity Feed — bottom drawer */}
-      <div
-        className="shrink-0"
-        style={{ borderTop: '1px solid hsl(var(--tf-border) / 0.15)' }}
-      >
-        <button
-          onClick={() => setActivityOpen((o) => !o)}
-          className="flex items-center gap-2 w-full px-4 py-1.5 text-xs font-medium transition-colors"
-          style={{
-            color: 'hsl(var(--tf-text) / 0.5)',
-            background: 'hsl(var(--tf-bg-surface))',
-          }}
-          aria-expanded={activityOpen}
-          aria-controls="workbench-activity-feed"
-        >
-          <span>{activityOpen ? '▼' : '▶'}</span>
-          <span>Activity ({activityEntries.length})</span>
-        </button>
-        {activityOpen && (
-          <div
-            id="workbench-activity-feed"
-            className="max-h-48 overflow-auto"
-          >
-            {activityLoading ? (
-              <div
-                className="flex items-center gap-2 px-4 py-3 text-xs"
-                style={{ color: 'hsl(var(--tf-text) / 0.4)' }}
-              >
-                <div
-                  className="w-3 h-3 rounded-full animate-spin"
-                  style={{
-                    border: '1.5px solid hsl(var(--tf-accent) / 0.2)',
-                    borderTopColor: 'hsl(var(--tf-accent))',
-                  }}
-                />
-                Loading activity...
-              </div>
-            ) : (
-              <ActivityFeed entries={activityEntries} maxEntries={15} />
-            )}
-          </div>
-        )}
-      </div>
-    </div>
+    <PropertyWorkbenchSurface
+      parcelId={parcelId}
+      currentTabId={activeTab}
+      segmentHandoff={segmentHandoff}
+      showBreadcrumb={false}
+      onBack={() => window.history.pushState({}, '', '/')}
+      onSearch={() => window.history.pushState({}, '', '/property')}
+      onPopOut={() => {
+        if (parcelId) {
+          window.open(`/property/${encodeURIComponent(parcelId)}`, '_blank', 'noopener');
+        }
+      }}
+      renderNavigation={({ tabs, parcelId: surfaceParcelId, currentTabId }: PropertyWorkbenchSurfaceNavigationArgs) => (
+        <WorkbenchRail tabs={tabs} parcelId={surfaceParcelId} currentTabId={currentTabId} />
+      )}
+      renderContent={(context) => (
+        <WorkbenchTabCtx.Provider value={context}>
+          {hostViolation ? <WorkbenchHostViolationNotice violation={hostViolation} /> : <ActiveTabComponent />}
+        </WorkbenchTabCtx.Provider>
+      )}
+    />
   );
 };
 

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
@@ -11,6 +11,8 @@ import { WorkbenchTabCtx } from '../../context/workbenchTabContext';
 import type { WorkbenchSegmentHandoffContext } from '../../context/workbenchTabContext';
 import { validateWorkbenchHost, type WorkbenchHostViolation } from '../../contracts/objectPlacement';
 import type { WorkbenchTabSlug } from '../../contracts/workbench';
+import { useAuthContext } from '../../auth/useAuthContext';
+import { useSession } from '../../auth/useSession';
 import { useCompanionStore } from '../../stores/companionStore';
 import { emitTraceEvent } from '../../services/terraTrace';
 import {
@@ -133,12 +135,18 @@ const WorkbenchHostViolationNotice: React.FC<{ violation: WorkbenchHostViolation
 };
 
 const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metadata }) => {
+  const session = useSession();
+  const auth = useAuthContext();
   const parcelId = readMetadataString(metadata, 'parcelId') ?? null;
   const metadataTab = resolveMetadataTab(metadata);
   const segmentHandoff = useMemo(() => buildSegmentHandoffContext(metadata), [metadata]);
   const [activeTab, setActiveTab] = useState<WorkbenchTabSlug>(metadataTab);
   const previousTabRef = useRef<WorkbenchTabSlug>(metadataTab);
   const setCompanionTab = useCompanionStore((state) => state.setActiveTab);
+  const roles = useMemo(
+    () => (auth.roles.length > 0 ? [...auth.roles] : session.role ? [session.role] : []),
+    [auth.roles, session.role],
+  );
 
   useEffect(() => {
     setActiveTab(metadataTab);
@@ -162,6 +170,7 @@ const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metad
       parcelId={parcelId}
       currentTabId={activeTab}
       segmentHandoff={segmentHandoff}
+      rolesOverride={roles}
       showBreadcrumb={false}
       onBack={() => window.history.pushState({}, '', '/')}
       onSearch={() => window.history.pushState({}, '', '/property')}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
@@ -19,6 +19,7 @@ import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
 import {
     InvocationHistory,
     ParcelContextHeader,
+    WorkbenchSourceBadge,
     type InvocationRecord,
 } from '../../../components/workbench';
 import type { ErrorInfo } from '../../../hooks/useErrorHandler';
@@ -229,7 +230,19 @@ export const PropertyAudit: React.FC = () => {
 
   return (
     <div className='tf-suite-audit space-y-4'>
-      <ParcelContextHeader icon='🔍' title='TerraAudit' parcelId={parcelId} subtitle={`Financial compliance & audit for ${parcelId}`} />
+      <ParcelContextHeader icon='🔍' title='TerraAudit' parcelId={parcelId} subtitle={`County audit controls with parcel context for ${parcelId}`} />
+
+      <div className='tf-status-warning rounded-xl p-4' data-testid='audit-parcel-specific-disclosure'>
+        <div className='flex items-start justify-between gap-3'>
+          <div>
+            <p className='tf-text font-semibold'>The parcel-specific audit backend is not live.</p>
+            <p className='tf-text-secondary text-sm mt-1'>
+              Current roll, levy, reconciliation, and compliance report actions use county/static audit contracts with the parcel carried as context.
+            </p>
+          </div>
+          <WorkbenchSourceBadge source='partial' />
+        </div>
+      </div>
 
       {/* Audit History from Store */}
       {auditTrail.length > 0 && (

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -301,7 +301,9 @@ export const PropertyClerk: React.FC = () => {
 
         {/* Title Chain (read_only) */}
         <BentoCard title='🔗 Title Chain' actions={<span className='text-xs tf-badge px-2 py-0.5 rounded'>read_only</span>}>
-          <p className='tf-text-tertiary text-sm mb-3'>Returned title-chain owner and preview entries for parcel {parcelId}</p>
+          <p className='tf-text-tertiary text-sm mb-3'>
+            Title-chain records are not projected for every parcel. Empty results are treated as a thin/non-live chain, not as proof of complete ownership history.
+          </p>
           <button onClick={handleGetTitleChain} disabled={titleChainState.status === 'loading'} className='w-full py-2 px-4 rounded-lg font-semibold transition-all tf-suite-dais-cta mb-4'>
             {titleChainState.status === 'loading' ? 'Loading...' : 'Get Title Chain'}
           </button>
@@ -309,13 +311,22 @@ export const PropertyClerk: React.FC = () => {
           {titleChainState.status === 'success' && titleChainState.result && (
             <div className='space-y-2'>
               <div className='tf-panel p-4'>
-                <span className='font-semibold tf-text'>Returned Title-Chain Owner: {titleChainState.result.currentOwner}</span>
-                <p className='text-xs tf-text-dim mt-1'>Owner shown from the returned title chain. This preview shows up to five returned chain entries.</p>
-                {titleChainState.result.chain.slice(0, 5).map(c => (
-                  <div key={c.documentId} className='text-sm tf-text-secondary mt-1'>
-                    {c.type}: {c.grantor} → {c.grantee} ({formatDate(c.date)})
-                  </div>
-                ))}
+                {titleChainState.result.chain.length > 0 ? (
+                  <>
+                    <span className='font-semibold tf-text'>Returned Title-Chain Owner: {titleChainState.result.currentOwner}</span>
+                    <p className='text-xs tf-text-dim mt-1'>Owner shown from the returned title chain. This preview shows up to five returned chain entries.</p>
+                    {titleChainState.result.chain.slice(0, 5).map(c => (
+                      <div key={c.documentId} className='text-sm tf-text-secondary mt-1'>
+                        {c.type}: {c.grantor} → {c.grantee} ({formatDate(c.date)})
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <>
+                    <span className='font-semibold tf-text'>Title-chain records are not projected for this parcel.</span>
+                    <p className='text-xs tf-text-dim mt-1'>The Clerk lane is truthful but thin here; recording summary may be available while title-chain depth remains unavailable.</p>
+                  </>
+                )}
               </div>
               {titleChainState.correlationId && <div className='text-xs tf-text-dim'>Ref: <code className='tf-suite-accent-text font-mono'>{titleChainState.correlationId.slice(0, 16)}...</code></div>}
             </div>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -302,7 +302,7 @@ export const PropertyClerk: React.FC = () => {
         {/* Title Chain (read_only) */}
         <BentoCard title='🔗 Title Chain' actions={<span className='text-xs tf-badge px-2 py-0.5 rounded'>read_only</span>}>
           <p className='tf-text-tertiary text-sm mb-3'>
-            Title-chain records are not projected for every parcel. Empty results are treated as a thin/non-live chain, not as proof of complete ownership history.
+            Returned title-chain owner and preview entries for parcel {parcelId} when Clerk data is available. Title-chain records are not projected for every parcel. Empty results are treated as a thin/non-live chain, not as proof of complete ownership history.
           </p>
           <button onClick={handleGetTitleChain} disabled={titleChainState.status === 'loading'} className='w-full py-2 px-4 rounded-lg font-semibold transition-all tf-suite-dais-cta mb-4'>
             {titleChainState.status === 'loading' ? 'Loading...' : 'Get Title Chain'}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx
@@ -28,7 +28,7 @@
  * Architecture: UI → select params → governed tool → correlationId UX
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useWorkbenchTab } from '../../../context/workbenchTabContext';
 import { invokeTool } from '../../../api/pilotApi';
 import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
@@ -48,6 +48,7 @@ import AppealDeadlinePanel from '../../../components/dais/AppealDeadlinePanel';
 import AppealHearingPanel from '../../../components/dais/AppealHearingPanel';
 import AppealNoticePanel from '../../../components/dais/AppealNoticePanel';
 import AppealCertificationPanel from '../../../components/dais/AppealCertificationPanel';
+import { getPermitsLane, type PermitsLaneResult } from '../../../services/suites/daisService';
 
 interface WorkflowStep {
   name: string;
@@ -204,6 +205,8 @@ const MORNING_BRIEF_ROLES = [
 export const PropertyDais: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const appeals = usePropertyStore((s) => s.appeals);
+  const [permitsLane, setPermitsLane] = useState<PermitsLaneResult | null>(null);
+  const [permitsLaneError, setPermitsLaneError] = useState<string | null>(null);
 
   const [exemptionState, setExemptionState] = useState<ExemptionState>({ status: 'idle' });
   const [levyState, setLevyState] = useState<DaisToolState<LevyResult>>({ status: 'idle' });
@@ -246,6 +249,20 @@ export const PropertyDais: React.FC = () => {
   const [morningBriefState, setMorningBriefState] = useState<DaisToolState<MorningBriefResult>>({ status: 'idle' });
   const [morningBriefRole, setMorningBriefRole] = useState<(typeof MORNING_BRIEF_ROLES)[number]['value']>('chief_appraiser');
   const [morningBriefTaxYear, setMorningBriefTaxYear] = useState<number>(new Date().getFullYear());
+
+  useEffect(() => {
+    let cancelled = false;
+    setPermitsLane(null);
+    setPermitsLaneError(null);
+    getPermitsLane(parcelId)
+      .then((result) => {
+        if (!cancelled) setPermitsLane(result);
+      })
+      .catch((error) => {
+        if (!cancelled) setPermitsLaneError(error instanceof Error ? error.message : 'Permit lane status unavailable');
+      });
+    return () => { cancelled = true; };
+  }, [parcelId]);
   /** explain_senior_exemption_impact — senior exemption impact summary */
   const handleExemptionImpact = useCallback(async () => {
     setExemptionState({ status: 'loading' });
@@ -613,6 +630,15 @@ export const PropertyDais: React.FC = () => {
           for this parcel and tax year.
         </p>
         <WorkbenchSourceBadge source="unavailable" />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 px-2" data-testid="dais-permits-lane-disclosure">
+        <p className="text-xs tf-text-dim">
+          Permit records are not projected into the governed Workbench permit lane
+          {permitsLane?.source ? ` (${permitsLane.source})` : ' (not-live:permit-records-not-projected)'}.
+          {permitsLaneError ? ` Status check failed: ${permitsLaneError}` : ''}
+        </p>
+        <WorkbenchSourceBadge source={permitsLane?.isLive ? 'live' : 'unavailable'} />
       </div>
 
       {/* Active Appeals from Store */}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
@@ -21,6 +21,7 @@ import {
 import {
   InvocationHistory,
   ParcelContextHeader,
+  WorkbenchSourceBadge,
   type InvocationRecord,
 } from '../../../components/workbench';
 import { ExecutionConsole } from '../../../components/pilot/ExecutionConsole';
@@ -68,6 +69,8 @@ export const PropertyPilot: React.FC = () => {
   const [tools, setTools] = useState<PilotTool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(true);
   const [toolsError, setToolsError] = useState<string | null>(null);
+  const [runtimeOnline, setRuntimeOnline] = useState<boolean | null>(null);
+  const [runtimeSource, setRuntimeSource] = useState<string | null>(null);
 
   // Invocation history (accumulated across tool runs)
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
@@ -80,17 +83,23 @@ export const PropertyPilot: React.FC = () => {
     let cancelled = false;
     setToolsLoading(true);
     setToolsError(null);
+    setRuntimeOnline(null);
+    setRuntimeSource(null);
 
     listPilotTools('muse')
       .then((response) => {
         if (!cancelled) {
           setTools(filterMuseReadOnlyTools(response.tools));
+          setRuntimeOnline(response.runtimeOnline ?? true);
+          setRuntimeSource(response.source ?? 'live');
           setToolsLoading(false);
         }
       })
       .catch((err) => {
         if (!cancelled) {
           setToolsError(err instanceof Error ? err.message : 'Failed to load tools');
+          setRuntimeOnline(null);
+          setRuntimeSource(null);
           setToolsLoading(false);
         }
       });
@@ -159,9 +168,24 @@ export const PropertyPilot: React.FC = () => {
         }
       />
 
-      {!toolsLoading && !toolsError && (
+      {!toolsLoading && !toolsError && runtimeOnline !== false && (
         <div className='tf-status-info rounded-xl p-4' data-testid='pilot-muse-scope'>
           <p className='tf-text'>This panel provides only read-only reasoning and explanation tools for this parcel.</p>
+        </div>
+      )}
+
+      {!toolsLoading && !toolsError && runtimeOnline === false && (
+        <div className='tf-status-warning rounded-xl p-4' data-testid='pilot-runtime-not-live'>
+          <div className='flex items-start justify-between gap-3'>
+            <div>
+              <p className='tf-text font-semibold'>Pilot runtime is not live.</p>
+              <p className='tf-text-secondary text-sm mt-1'>
+                The dedicated Pilot runtime is offline, so read-only analysis tools and traces are intentionally unavailable for this parcel.
+              </p>
+              {runtimeSource && <p className='tf-text-dim text-xs mt-2'>Source: {runtimeSource}</p>}
+            </div>
+            <WorkbenchSourceBadge source='unavailable' />
+          </div>
         </div>
       )}
 
@@ -216,8 +240,18 @@ export const PropertyPilot: React.FC = () => {
               setToolsLoading(true);
               setToolsError(null);
               listPilotTools('muse')
-                .then((r) => { setTools(filterMuseReadOnlyTools(r.tools)); setToolsLoading(false); })
-                .catch((e) => { setToolsError(e instanceof Error ? e.message : 'Retry failed'); setToolsLoading(false); });
+                .then((r) => {
+                  setTools(filterMuseReadOnlyTools(r.tools));
+                  setRuntimeOnline(r.runtimeOnline ?? true);
+                  setRuntimeSource(r.source ?? 'live');
+                  setToolsLoading(false);
+                })
+                .catch((e) => {
+                  setToolsError(e instanceof Error ? e.message : 'Retry failed');
+                  setRuntimeOnline(null);
+                  setRuntimeSource(null);
+                  setToolsLoading(false);
+                });
             }}
             className='mt-2 px-3 py-1 text-sm tf-hover-surface rounded'
           >
@@ -268,7 +302,7 @@ export const PropertyPilot: React.FC = () => {
         </div>
       )}
 
-      {!toolsLoading && !toolsError && tools.length === 0 && (
+      {!toolsLoading && !toolsError && tools.length === 0 && runtimeOnline !== false && (
         <div className='tf-status-info rounded-xl p-4'>
           <p className='tf-text-muted text-center'>No analysis tools are currently available.</p>
         </div>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx
@@ -17,6 +17,7 @@ import { WorkbenchSourceBadge } from '../../../../components/workbench/Workbench
 import { IncomeValuationPanel } from '../../../../components/workbench/IncomeValuationPanel';
 import { DcfPanel } from '../../income/DcfPanel';
 import { useIncomeApproach as useIncomeApproachAPI } from '../../../../hooks/forge/useForgeValuation';
+import { getWorkbenchLiveScopeDecision } from '../../../../config/workbenchLiveScope';
 import {
   type ForgeSubTabProps,
   type IncomeResult,
@@ -57,6 +58,7 @@ export const IncomeApproach: React.FC<ForgeSubTabProps> = ({
   onValueIndicated,
 }) => {
   const { parcelId } = useWorkbenchTab();
+  const incomeScope = getWorkbenchLiveScopeDecision('forge-income');
 
   /* ── Live API data ──────────────────────────────────────── */
   const incomeAPI = useIncomeApproachAPI(parcelId, taxYear);
@@ -163,6 +165,20 @@ export const IncomeApproach: React.FC<ForgeSubTabProps> = ({
 
   return (
     <div className="space-y-4" style={{ overflow: 'hidden' }}>
+      <div
+        className="tf-status-warning rounded-xl p-4"
+        data-testid="forge-income-deferred-disclosure"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="tf-text font-semibold">Income approach is deferred for production scope.</p>
+            <p className="tf-text-secondary text-sm mt-1">{incomeScope.rationale}</p>
+            <p className="tf-text-dim text-xs mt-2">{incomeScope.smallestSafeAction}</p>
+          </div>
+          <WorkbenchSourceBadge source="unavailable" />
+        </div>
+      </div>
+
       {/* Live Income Approach Data */}
       <BentoCard
         title="&#128176; Income Approach Summary"

--- a/frontend/apps/os-shell/src/services/suites/daisService.ts
+++ b/frontend/apps/os-shell/src/services/suites/daisService.ts
@@ -57,6 +57,12 @@ export interface Permit {
   applicant?: string;
 }
 
+export interface PermitsLaneResult {
+  permits: Permit[];
+  source: string;
+  isLive: boolean;
+}
+
 export interface Exemption {
   exemptionId: string;
   parcelId: string;
@@ -132,10 +138,23 @@ export async function createAppeal(
 // Permit Operations
 // ============================================================================
 
-export async function getPermits(parcelId: string): Promise<Permit[]> {
+export async function getPermitsLane(parcelId: string): Promise<PermitsLaneResult> {
   const res = await fetch(`${API}/permits?parcelId=${encodeURIComponent(parcelId)}`, { headers: authHeadersReadOnly() });
   if (!res.ok) throw new Error(`Failed to fetch permits: ${res.statusText}`);
-  return res.json();
+  const permits = await res.json() as Permit[];
+  const source = res.headers.get('x-dais-permits-source')
+    ?? res.headers.get('x-dais-source')
+    ?? 'not-live:permit-records-not-projected';
+  return {
+    permits,
+    source,
+    isLive: !source.startsWith('not-live:'),
+  };
+}
+
+export async function getPermits(parcelId: string): Promise<Permit[]> {
+  const result = await getPermitsLane(parcelId);
+  return result.permits;
 }
 
 export async function updatePermitStatus(

--- a/os-platform/core/tests/workbench-lane-completeness-contract.test.mjs
+++ b/os-platform/core/tests/workbench-lane-completeness-contract.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+const read = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8');
+
+test('Pilot fallback is explicitly non-live, not exposed as an operational stub', () => {
+  const controller = read('backend/src/TerraFusion.API/Controllers/PilotController.cs');
+  const pilotTab = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx');
+
+  assert.doesNotMatch(controller, /source\s*=\s*"stub"/);
+  assert.match(controller, /source\s*=\s*"not-live:pilot-runtime-offline"/);
+  assert.match(controller, /X-Pilot-Source/);
+  assert.match(pilotTab, /runtimeOnline/);
+  assert.match(pilotTab, /Pilot runtime is not live/);
+});
+
+test('Dais permits preserves the backend not-live source through the frontend service', () => {
+  const service = read('frontend/apps/os-shell/src/services/suites/daisService.ts');
+  const daisTab = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx');
+
+  assert.match(service, /PermitsLaneResult/);
+  assert.match(service, /x-dais-permits-source/i);
+  assert.match(service, /not-live:permit-records-not-projected/);
+  assert.match(daisTab, /permit-records-not-projected/);
+});
+
+test('Clerk title-chain empty results are explicitly classified as unavailable/thin', () => {
+  const controller = read('backend/src/TerraFusion.API/Controllers/ClerkController.cs');
+  const clerkTab = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx');
+
+  assert.match(controller, /Parcel '\{parcelId\}' not found/);
+  assert.match(controller, /X-Clerk-Title-Chain-Source/);
+  assert.match(controller, /not-live:title-chain-records-not-projected|partial:title-chain-empty/);
+  assert.match(clerkTab, /Title-chain records are not projected/);
+});
+
+test('Audit tab does not present county/static audit contracts as parcel-specific proof', () => {
+  const auditTab = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx');
+
+  assert.doesNotMatch(auditTab, /Financial compliance & audit for \$\{parcelId\}/);
+  assert.match(auditTab, /County audit controls with parcel context/);
+  assert.match(auditTab, /parcel-specific audit backend is not live/);
+});

--- a/os-platform/core/tests/workbench-live-scope-contract.test.mjs
+++ b/os-platform/core/tests/workbench-live-scope-contract.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+const read = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8');
+
+test('weak Workbench lanes have explicit live-scope decisions', () => {
+  const configPath = 'frontend/apps/os-shell/src/config/workbenchLiveScope.ts';
+  assert.equal(existsSync(join(repoRoot, configPath)), true, 'workbenchLiveScope.ts must exist');
+
+  const config = read(configPath);
+  for (const lane of [
+    'pilot',
+    'dais-permits',
+    'forge-income',
+    'atlas-enrichment-layers',
+    'clerk-title-chain',
+    'parcel-specific-audit',
+  ]) {
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'`), `${lane} missing from live-scope config`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*classification:\\s*'DEFERRED'`), `${lane} must be explicitly DEFERRED`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*blockerType:`), `${lane} needs blockerType`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*smallestSafeAction:`), `${lane} needs smallestSafeAction`);
+  }
+
+  assert.doesNotMatch(config, /classification:\s*'LIVE-NOW'/);
+});
+
+test('deferred lanes have visible Workbench honesty labels outside Atlas-tab implementation', () => {
+  const pilot = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx');
+  const dais = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx');
+  const income = read('frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx');
+  const clerk = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx');
+  const audit = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx');
+
+  assert.match(pilot, /pilot-runtime-not-live/);
+  assert.match(dais, /dais-permits-lane-disclosure/);
+  assert.match(income, /forge-income-deferred-disclosure/);
+  assert.match(clerk, /Title-chain records are not projected/);
+  assert.match(audit, /audit-parcel-specific-disclosure/);
+});

--- a/os-platform/core/tests/workbench-tab-embedding.test.mjs
+++ b/os-platform/core/tests/workbench-tab-embedding.test.mjs
@@ -137,15 +137,32 @@ describe('PropertyWorkbenchWindow Tab Embedding', () => {
     }
   });
 
-  it('TABS array has all 9 canonical tab entries in correct order', () => {
-    const ids = extractTabArrayIds(source, 'TABS');
+  it('delegates rendered tab navigation to PropertyWorkbenchSurface', () => {
+    assert.match(
+      source,
+      /PropertyWorkbenchSurface/,
+      'window adapter must use PropertyWorkbenchSurface for canonical tab navigation',
+    );
+  });
+});
+
+// ============================================================================
+// PropertyWorkbenchSurface.tsx — Shared Workbench Surface
+// ============================================================================
+
+describe('PropertyWorkbenchSurface Tab Embedding', () => {
+  const surfacePath = resolve(SHELL, 'pages/workbench/PropertyWorkbenchSurface.tsx');
+  const source = readFileSync(surfacePath, 'utf-8');
+
+  it('WORKBENCH_TABS has all 9 canonical tab entries in correct order', () => {
+    const ids = extractTabArrayIds(source, 'WORKBENCH_TABS');
 
     assert.equal(ids.length, 9,
-      `TABS array has ${ids.length} entries, expected 9.\nFound: [${ids.join(', ')}]`
+      `WORKBENCH_TABS has ${ids.length} entries, expected 9.\nFound: [${ids.join(', ')}]`
     );
 
     assert.deepEqual(ids, CANONICAL_TAB_IDS,
-      `TABS array order does not match canonical order.\n` +
+      `WORKBENCH_TABS order does not match canonical order.\n` +
       `Expected: [${CANONICAL_TAB_IDS.join(', ')}]\n` +
       `Got:      [${ids.join(', ')}]`
     );

--- a/os-platform/core/tests/workbench-window-rail-contract.test.mjs
+++ b/os-platform/core/tests/workbench-window-rail-contract.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../../..');
+const WINDOW_PATH = resolve(
+  ROOT,
+  'frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx',
+);
+const WINDOW_SRC = readFileSync(WINDOW_PATH, 'utf8');
+
+describe('Property Workbench window chrome contract', () => {
+  it('window host renders the shared Workbench surface with the left rail', () => {
+    assert.match(
+      WINDOW_SRC,
+      /PropertyWorkbenchSurface/,
+      'canonical window host must reuse PropertyWorkbenchSurface instead of a divergent layout',
+    );
+    assert.match(
+      WINDOW_SRC,
+      /<\s*WorkbenchRail\b/,
+      'canonical window host must preserve the left-side WorkbenchRail navigation',
+    );
+  });
+
+  it('window host does not render a duplicate horizontal tab bar', () => {
+    assert.doesNotMatch(
+      WINDOW_SRC,
+      /const\s+TabBar\b/,
+      'canonical window host must not own a competing horizontal TabBar implementation',
+    );
+    assert.doesNotMatch(
+      WINDOW_SRC,
+      /<\s*TabBar\b/,
+      'canonical window host must not render the duplicate horizontal TabBar',
+    );
+  });
+});


### PR DESCRIPTION
## WO
WO-PROPERTY-WORKBENCH-LIVE-SCOPE-TRUTH-FREEZE

## Final status
PROPERTY WORKBENCH LIVE SCOPE TRUTH FREEZE — PASS

## Scope
This PR publishes Workbench live/deferred truth without making deferred lanes live.

In scope:
- Workbench live-scope decision matrix
- visible deferred disclosures for Pilot, Dais permits, Forge income, Clerk title-chain, and parcel-specific Audit
- backend/source-status honesty for non-live Pilot, Dais permit lane, Clerk title-chain, and Forge valuation fallbacks
- shared Workbench surface/window dependency repair so the OS window uses the canonical rail host
- focused Workbench/core contracts

Out of scope:
- Property Workbench Atlas tab integration
- Atlas tab LayerWorks embedding
- Atlas enrichment implementation
- TerraAtlas Suite /atlas work
- PACS reconciliation
- new projections or fake runtime data
- making Pilot, Dais permits, Forge income, Clerk title-chain, or parcel-specific Audit live

## Excluded WO-02 files
The following files were intentionally not changed and remain for WO-PROPERTY-WORKBENCH-ATLAS-TAB-INTEGRATION:
- frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
- frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.honesty.contract.test.tsx
- frontend/apps/os-shell/src/pages/suites/modules/LayerWorksModule.tsx
- backend/src/TerraFusion.API/Controllers/AtlasGisController.cs
- backend/src/TerraFusion.API/Services/GisDataService.cs

## Proof wall
- pnpm run type-check: PASS
- node --test os-platform/core/tests/workbench-live-scope-contract.test.mjs os-platform/core/tests/workbench-lane-completeness-contract.test.mjs os-platform/core/tests/workbench-window-rail-contract.test.mjs os-platform/core/tests/workbench-tab-embedding.test.mjs os-platform/core/tests/phase83-tools.test.mjs: PASS, 79/79
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj --no-restore -p:OutDir=.tmp/api-build-check/: PASS, 0 warnings, 0 errors
- pre-push strict gate: PASS, including unit tests 164/164, security scan completed with existing findings, backend release build, and frontend build

## Notes
First push attempt timed out; stale git push process was stopped and the retry completed successfully.
Fresh worktree setup required pnpm install --frozen-lockfile --ignore-scripts and dotnet restore before no-restore verification could run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data source status indicators across workbench pages showing whether information is live or projected
  * New permit records search and availability display

* **Bug Fixes**
  * Improved error handling with clearer responses for missing parcels
  * Better messaging for offline or unavailable services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->