### PR TITLE
fix(counties): expose 39-county runtime and intake posture

### DIFF
--- a/frontend/apps/os-shell/src/Router.tsx
+++ b/frontend/apps/os-shell/src/Router.tsx
@@ -143,6 +143,7 @@ const Monitoring = lazy(() => import('./pages/Monitoring'));
 const TerraFusionMarketplace = lazy(
   () => import('./components/marketplace/TerraFusionMarketplace')
 );
+const CountiesHub = lazy(() => import('./components/CountiesHub'));
 const ResearchPortal = lazy(() => import('./components/research/ResearchPortal'));
 const ResearchProviders = lazy(() => import('./context/ResearchContext'));
 const ExperimentsList = lazy(() => import('./pages/experiments/ExperimentsList'));
@@ -336,6 +337,7 @@ const Router: React.FC = () => {
 
                   <Route path='monitoring' element={<Monitoring />} />
                   <Route path='marketplace' element={<TerraFusionMarketplace />} />
+                  <Route path='counties' element={<CountiesHub />} />
                   <Route
                     path='elite-research'
                     element={

--- a/frontend/apps/os-shell/src/__tests__/home/countyOpsScene.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/home/countyOpsScene.contract.test.tsx
@@ -151,6 +151,7 @@ import { StageZeroState } from '../../shell/desktop/StageZeroState';
 import { useSceneStore, SCENE_LIBRARY } from '../../stores/sceneStore';
 import { activateModule } from '../../orchestration/moduleActivation';
 import { selectRecentParcel } from '../../context/parcelContext';
+import { WASHINGTON_COUNTY_RUNTIME_POSTURES } from '../../config/countyRuntimePosture';
 
 // Get mock references
 const mockActivateModule = activateModule as ReturnType<typeof vi.fn>;
@@ -191,6 +192,22 @@ describe('Phase 24: County Ops Scene — Rendering', () => {
     render(<StageZeroState />);
     expect(screen.getByTestId('executive-command-surface')).toBeInTheDocument();
     expect(screen.getByText('Cross-suite county posture')).toBeInTheDocument();
+  });
+
+  it('4b. runtime posture summary exposes the 39-county source/runtime boundary', () => {
+    render(<StageZeroState />);
+
+    const summary = screen.getByTestId('county-runtime-posture-summary');
+    expect(summary).toHaveAttribute('data-total-counties', '39');
+    expect(summary).toHaveAttribute('data-runtime-enabled-count', '1');
+    expect(summary).toHaveAttribute('data-source-intake-count', '38');
+    expect(summary).toHaveAttribute('data-benton-runtime-mode', 'runtime-enabled');
+    expect(summary).toHaveAttribute('data-intake-canonical-import-allowed', 'false');
+    expect(WASHINGTON_COUNTY_RUNTIME_POSTURES).toHaveLength(39);
+    expect(screen.getByText(/39 Washington counties registered/i)).toBeInTheDocument();
+    expect(screen.getByText(/38 County Data Intake only/i)).toBeInTheDocument();
+    expect(screen.getByText(/canonicalImportAllowed: false for intake counties/i)).toBeInTheDocument();
+    expect(screen.getByText(/Non-Benton runtime actions remain blocked/i)).toBeInTheDocument();
   });
 
   it('5. County status info renders', () => {

--- a/frontend/apps/os-shell/src/__tests__/shell/countyEmployeeWorkspaceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/countyEmployeeWorkspaceHonesty.contract.test.tsx
@@ -230,6 +230,8 @@ describe('CountyEmployeeWorkspace honesty contract', () => {
 
     expect(benton.runtimeMode).toBe('runtime-enabled');
     expect(benton.runtimeActionsAllowed).toBe(true);
+    expect(benton.canonicalImportAllowed).toBe('not_applicable');
+    expect(benton.sourcePosture).toMatch(/already runtime-enabled/i);
     expect(nonBenton).toHaveLength(38);
     expect(nonBenton.every((posture) => posture.runtimeMode === 'source-provenance-onboarding-intake')).toBe(true);
     expect(nonBenton.every((posture) => posture.runtimeActionsAllowed === false)).toBe(true);

--- a/frontend/apps/os-shell/src/__tests__/shell/countyEmployeeWorkspaceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/countyEmployeeWorkspaceHonesty.contract.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import { CountyEmployeeWorkspace } from '../../pages/CountyEmployeeWorkspace';
+import {
+  WASHINGTON_COUNTY_RUNTIME_POSTURES,
+  getCountyRuntimePosture,
+} from '../../config/countyRuntimePosture';
 
 const invokeToolMock = vi.fn();
 const activateModuleMock = vi.fn();
@@ -214,5 +218,49 @@ describe('CountyEmployeeWorkspace honesty contract', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Open TerraAtlas/i }));
     expect(activateModuleMock).toHaveBeenCalledWith('suite-atlas', { source: 'desktop' });
+  });
+
+  it('keeps the 39-county posture model explicit with only Benton runtime-enabled', () => {
+    expect(WASHINGTON_COUNTY_RUNTIME_POSTURES).toHaveLength(39);
+
+    const benton = getCountyRuntimePosture('benton');
+    const nonBenton = WASHINGTON_COUNTY_RUNTIME_POSTURES.filter(
+      (posture) => posture.countySlug !== 'benton'
+    );
+
+    expect(benton.runtimeMode).toBe('runtime-enabled');
+    expect(benton.runtimeActionsAllowed).toBe(true);
+    expect(nonBenton).toHaveLength(38);
+    expect(nonBenton.every((posture) => posture.runtimeMode === 'source-provenance-onboarding-intake')).toBe(true);
+    expect(nonBenton.every((posture) => posture.runtimeActionsAllowed === false)).toBe(true);
+    expect(nonBenton.every((posture) => posture.canonicalImportAllowed === false)).toBe(true);
+  });
+
+  it('shows County Data Intake boundary and blocks non-Benton runtime actions', async () => {
+    render(
+      <CountyEmployeeWorkspace
+        countyId='yakima'
+        employeeName='Casey Operator'
+        employeeRole='assessor'
+        department='Assessor'
+      />
+    );
+
+    const boundary = screen.getByTestId('county-runtime-posture-boundary');
+    expect(boundary).toHaveAttribute('data-county-slug', 'yakima');
+    expect(boundary).toHaveAttribute('data-runtime-mode', 'source-provenance-onboarding-intake');
+    expect(boundary).toHaveAttribute('data-runtime-actions-allowed', 'false');
+    expect(boundary).toHaveAttribute('data-canonical-import-allowed', 'false');
+    expect(within(boundary).getByText(/County Data Intake/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Runtime actions are blocked for this county/i).length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(invokeToolMock).not.toHaveBeenCalled();
+    });
+
+    const atlasButton = screen.getByRole('button', { name: /Open TerraAtlas/i });
+    expect(atlasButton).toBeDisabled();
+    fireEvent.click(atlasButton);
+    expect(activateModuleMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/shell/legacyDashboardHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/legacyDashboardHonesty.contract.test.tsx
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import CountiesHub from '../../components/CountiesHub';
 import ABTestingFramework from '../../components/ABTestingFramework';
@@ -94,7 +94,10 @@ describe('Legacy dashboard rendered honesty behavior', () => {
     expect(boundary).toHaveAttribute('data-county-slug', 'benton');
     expect(boundary).toHaveAttribute('data-runtime-mode', 'runtime-enabled');
     expect(boundary).toHaveAttribute('data-runtime-actions-allowed', 'true');
-    expect(boundary).toHaveAttribute('data-canonical-import-allowed', 'true');
+    expect(boundary).toHaveAttribute('data-canonical-import-allowed', 'not_applicable');
+    expect(within(boundary).getByText(/Canonical import: not applicable/i)).toBeInTheDocument();
+    expect(within(boundary).getAllByText(/Benton is already runtime-enabled/i).length).toBeGreaterThan(0);
+    expect(within(boundary).queryByText(/canonicalImportAllowed: true/i)).not.toBeInTheDocument();
   });
 
   it('renders ABTestingFramework as a governed guardrail', () => {

--- a/frontend/apps/os-shell/src/__tests__/shell/legacyDashboardHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/legacyDashboardHonesty.contract.test.tsx
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import CountiesHub from '../../components/CountiesHub';
 import ABTestingFramework from '../../components/ABTestingFramework';
@@ -24,11 +24,16 @@ function readSrc(relPath: string): string {
 describe('Legacy dashboard static honesty contract', () => {
   it('CountiesHub removes seeded county readiness claims', () => {
     const src = readSrc('components/CountiesHub.tsx');
+    const routerSrc = readSrc('Router.tsx');
     expect(src).not.toContain('12 Washington counties');
     expect(src).not.toContain('92%');
     expect(src).not.toContain('Pierce County');
     expect(src).toContain('counties-hub-unavailable');
     expect(src).toContain('Counties Hub does not display seeded county readiness counts');
+    expect(src).toContain('county-runtime-posture-summary');
+    expect(src).toContain('county-runtime-posture-boundary');
+    expect(routerSrc).toContain("path='counties'");
+    expect(routerSrc).toContain('<CountiesHub />');
   });
 
   it('ABTestingFramework removes seeded county persuasion metrics', () => {
@@ -55,10 +60,41 @@ describe('Legacy dashboard rendered honesty behavior', () => {
     render(<CountiesHub />);
 
     expect(screen.getByTestId('counties-hub-unavailable')).toBeInTheDocument();
-    expect(screen.getByText(/County registry not connected/i)).toBeInTheDocument();
+    expect(screen.getByText(/Phase 4 runtime\/source posture/i)).toBeInTheDocument();
+    expect(screen.getByText(/Runtime posture governed/i)).toBeInTheDocument();
     expect(screen.getByText(/Readiness metrics withheld/i)).toBeInTheDocument();
     expect(screen.getByText(/Migration actions blocked/i)).toBeInTheDocument();
     expect(screen.queryByText(/Pierce County/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the Phase 4 county posture summary and non-Benton intake boundary', () => {
+    render(<CountiesHub />);
+
+    const summary = screen.getByTestId('county-runtime-posture-summary');
+    expect(summary).toHaveAttribute('data-total-counties', '39');
+    expect(summary).toHaveAttribute('data-runtime-enabled-count', '1');
+    expect(summary).toHaveAttribute('data-source-intake-count', '38');
+    expect(summary).toHaveAttribute('data-benton-runtime-mode', 'runtime-enabled');
+    expect(summary).toHaveAttribute('data-intake-canonical-import-allowed', 'false');
+
+    const boundary = screen.getByTestId('county-runtime-posture-boundary');
+    expect(boundary).toHaveAttribute('data-county-slug', 'yakima');
+    expect(boundary).toHaveAttribute('data-runtime-mode', 'source-provenance-onboarding-intake');
+    expect(boundary).toHaveAttribute('data-runtime-actions-allowed', 'false');
+    expect(boundary).toHaveAttribute('data-canonical-import-allowed', 'false');
+    expect(screen.getAllByText(/County Data Intake/i).length).toBeGreaterThan(0);
+  });
+
+  it('allows Benton runtime posture to be selected without making non-Benton counties live', () => {
+    render(<CountiesHub />);
+
+    fireEvent.click(screen.getByTestId('county-posture-option-benton'));
+
+    const boundary = screen.getByTestId('county-runtime-posture-boundary');
+    expect(boundary).toHaveAttribute('data-county-slug', 'benton');
+    expect(boundary).toHaveAttribute('data-runtime-mode', 'runtime-enabled');
+    expect(boundary).toHaveAttribute('data-runtime-actions-allowed', 'true');
+    expect(boundary).toHaveAttribute('data-canonical-import-allowed', 'true');
   });
 
   it('renders ABTestingFramework as a governed guardrail', () => {

--- a/frontend/apps/os-shell/src/components/CountiesHub.tsx
+++ b/frontend/apps/os-shell/src/components/CountiesHub.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
-import { Alert, Box, Card, CardContent, Chip, Grid, Typography } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+import { Alert, Box, Button, Card, CardContent, Chip, Grid, Typography } from '@mui/material';
 import {
   CloudOff as CloudOffIcon,
   Hub as HubIcon,
   Lan as LanIcon,
   Map as MapIcon,
 } from '@mui/icons-material';
+import {
+  WASHINGTON_COUNTY_RUNTIME_POSTURES,
+  getCountyRuntimePosture,
+} from '../config/countyRuntimePosture';
 
 const UNAVAILABLE_SECTIONS = [
   {
@@ -29,6 +33,14 @@ const UNAVAILABLE_SECTIONS = [
 ];
 
 const CountiesHub: React.FC = () => {
+  const [selectedCountySlug, setSelectedCountySlug] = useState('yakima');
+  const selectedPosture = getCountyRuntimePosture(selectedCountySlug);
+  const runtimeEnabledCount = useMemo(
+    () => WASHINGTON_COUNTY_RUNTIME_POSTURES.filter((posture) => posture.runtimeActionsAllowed).length,
+    []
+  );
+  const intakeCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.length - runtimeEnabledCount;
+
   return (
     <Box sx={{ p: 4 }} data-testid='counties-hub-unavailable'>
       <Typography variant='h4' gutterBottom sx={{ mb: 2 }}>
@@ -36,19 +48,108 @@ const CountiesHub: React.FC = () => {
       </Typography>
 
       <Typography variant='body1' color='text.secondary' sx={{ mb: 3 }}>
-        This surface is retained as a county-control-plane guardrail until the live Washington
-        county registry is bound into the operator shell.
+        This surface is the governed Phase 4 county posture host. It exposes which Washington
+        counties are runtime-enabled now and which remain source/provenance/onboarding/intake only.
       </Typography>
 
       <Alert severity='warning' icon={<CloudOffIcon fontSize='inherit' />} sx={{ mb: 3 }}>
         Counties Hub does not display seeded county readiness counts, seeded parcel totals, or
-        seeded migration claims. The governed county registry is not connected to this module.
+        seeded migration claims. It only displays the governed runtime/intake posture boundary.
       </Alert>
 
       <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 3 }}>
-        <Chip label='Registry unavailable' color='warning' variant='outlined' />
+        <Chip label='Runtime posture governed' color='primary' variant='outlined' />
         <Chip label='Readiness scores withheld' color='warning' variant='outlined' />
-        <Chip label='Governed execution required' color='primary' variant='outlined' />
+        <Chip label='Non-Benton runtime blocked' color='warning' variant='outlined' />
+      </Box>
+
+      <Card
+        variant='outlined'
+        sx={{ mb: 3 }}
+        data-testid='county-runtime-posture-summary'
+        data-total-counties={String(WASHINGTON_COUNTY_RUNTIME_POSTURES.length)}
+        data-runtime-enabled-count={String(runtimeEnabledCount)}
+        data-source-intake-count={String(intakeCount)}
+        data-benton-runtime-mode={getCountyRuntimePosture('benton').runtimeMode}
+        data-intake-canonical-import-allowed='false'
+      >
+        <CardContent>
+          <Typography variant='h6' gutterBottom>
+            Phase 4 runtime/source posture
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={3}>
+              <Typography variant='overline' color='text.secondary'>Washington counties</Typography>
+              <Typography variant='h5'>39</Typography>
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <Typography variant='overline' color='text.secondary'>Runtime-enabled</Typography>
+              <Typography variant='h5'>{runtimeEnabledCount}</Typography>
+              <Typography variant='body2' color='text.secondary'>Benton County</Typography>
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <Typography variant='overline' color='text.secondary'>County Data Intake</Typography>
+              <Typography variant='h5'>{intakeCount}</Typography>
+              <Typography variant='body2' color='text.secondary'>Source/provenance/onboarding/intake</Typography>
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <Typography variant='overline' color='text.secondary'>Intake import boundary</Typography>
+              <Typography variant='h5'>false</Typography>
+              <Typography variant='body2' color='text.secondary'>canonicalImportAllowed for non-Benton counties</Typography>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      <Card
+        variant='outlined'
+        sx={{ mb: 3 }}
+        data-testid='county-runtime-posture-boundary'
+        data-county-slug={selectedPosture.countySlug}
+        data-runtime-mode={selectedPosture.runtimeMode}
+        data-runtime-actions-allowed={String(selectedPosture.runtimeActionsAllowed)}
+        data-canonical-import-allowed={String(selectedPosture.canonicalImportAllowed)}
+      >
+        <CardContent>
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+            <Box>
+              <Typography variant='overline' color='text.secondary'>
+                {selectedPosture.boundaryLabel}
+              </Typography>
+              <Typography variant='h6'>
+                {selectedPosture.countyName} County
+              </Typography>
+              <Typography variant='body2' color='text.secondary' sx={{ maxWidth: 720 }}>
+                {selectedPosture.sourcePosture}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              <Chip label={`runtimeActionsAllowed: ${String(selectedPosture.runtimeActionsAllowed)}`} />
+              <Chip label={`canonicalImportAllowed: ${String(selectedPosture.canonicalImportAllowed)}`} />
+              <Chip label={selectedPosture.runtimeMode} color={selectedPosture.runtimeActionsAllowed ? 'success' : 'warning'} />
+            </Box>
+          </Box>
+          <Typography variant='body2' sx={{ mt: 2 }}>
+            {selectedPosture.nextAction}
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 3 }} aria-label='County posture selector'>
+        {WASHINGTON_COUNTY_RUNTIME_POSTURES.map((posture) => (
+          <Button
+            key={posture.countySlug}
+            type='button'
+            data-testid={`county-posture-option-${posture.countySlug}`}
+            onClick={() => setSelectedCountySlug(posture.countySlug)}
+            size='small'
+            variant={posture.countySlug === selectedPosture.countySlug ? 'contained' : 'outlined'}
+            color={posture.runtimeActionsAllowed ? 'success' : 'warning'}
+            sx={{ textTransform: 'none' }}
+          >
+            {posture.countyName}
+          </Button>
+        ))}
       </Box>
 
       <Grid container spacing={3}>

--- a/frontend/apps/os-shell/src/components/CountiesHub.tsx
+++ b/frontend/apps/os-shell/src/components/CountiesHub.tsx
@@ -40,6 +40,10 @@ const CountiesHub: React.FC = () => {
     []
   );
   const intakeCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.length - runtimeEnabledCount;
+  const canonicalImportLabel =
+    selectedPosture.canonicalImportAllowed === 'not_applicable'
+      ? 'Canonical import: not applicable - Benton is already runtime-enabled'
+      : `canonicalImportAllowed: ${String(selectedPosture.canonicalImportAllowed)}`;
 
   return (
     <Box sx={{ p: 4 }} data-testid='counties-hub-unavailable'>
@@ -125,7 +129,7 @@ const CountiesHub: React.FC = () => {
             </Box>
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
               <Chip label={`runtimeActionsAllowed: ${String(selectedPosture.runtimeActionsAllowed)}`} />
-              <Chip label={`canonicalImportAllowed: ${String(selectedPosture.canonicalImportAllowed)}`} />
+              <Chip label={canonicalImportLabel} />
               <Chip label={selectedPosture.runtimeMode} color={selectedPosture.runtimeActionsAllowed ? 'success' : 'warning'} />
             </Box>
           </Box>

--- a/frontend/apps/os-shell/src/config/countyRuntimePosture.ts
+++ b/frontend/apps/os-shell/src/config/countyRuntimePosture.ts
@@ -1,4 +1,5 @@
 export type CountyRuntimeMode = 'runtime-enabled' | 'source-provenance-onboarding-intake';
+export type CanonicalImportBoundary = false | 'not_applicable';
 
 export interface CountyRuntimePosture {
   countyName: string;
@@ -6,7 +7,7 @@ export interface CountyRuntimePosture {
   state: 'WA';
   runtimeMode: CountyRuntimeMode;
   runtimeActionsAllowed: boolean;
-  canonicalImportAllowed: boolean;
+  canonicalImportAllowed: CanonicalImportBoundary;
   sourcePosture: string;
   boundaryLabel: string;
   nextAction: string;
@@ -79,8 +80,9 @@ function buildPosture(countyName: string): CountyRuntimePosture {
       state: 'WA',
       runtimeMode: 'runtime-enabled',
       runtimeActionsAllowed: true,
-      canonicalImportAllowed: true,
-      sourcePosture: 'Benton runtime-enabled: governed parcel runtime actions are allowed for the June 10 lane.',
+      canonicalImportAllowed: 'not_applicable',
+      sourcePosture:
+        'Benton is already runtime-enabled: governed parcel runtime actions are allowed for the June 10 lane, and County Data Intake canonical import is not applicable.',
       boundaryLabel: 'Runtime-enabled county',
       nextAction: 'Use governed suite actions and keep runtime proof current.',
     };

--- a/frontend/apps/os-shell/src/config/countyRuntimePosture.ts
+++ b/frontend/apps/os-shell/src/config/countyRuntimePosture.ts
@@ -1,0 +1,112 @@
+export type CountyRuntimeMode = 'runtime-enabled' | 'source-provenance-onboarding-intake';
+
+export interface CountyRuntimePosture {
+  countyName: string;
+  countySlug: string;
+  state: 'WA';
+  runtimeMode: CountyRuntimeMode;
+  runtimeActionsAllowed: boolean;
+  canonicalImportAllowed: boolean;
+  sourcePosture: string;
+  boundaryLabel: string;
+  nextAction: string;
+}
+
+export const WASHINGTON_COUNTY_NAMES = [
+  'Adams',
+  'Asotin',
+  'Benton',
+  'Chelan',
+  'Clallam',
+  'Clark',
+  'Columbia',
+  'Cowlitz',
+  'Douglas',
+  'Ferry',
+  'Franklin',
+  'Garfield',
+  'Grant',
+  'Grays Harbor',
+  'Island',
+  'Jefferson',
+  'King',
+  'Kitsap',
+  'Kittitas',
+  'Klickitat',
+  'Lewis',
+  'Lincoln',
+  'Mason',
+  'Okanogan',
+  'Pacific',
+  'Pend Oreille',
+  'Pierce',
+  'San Juan',
+  'Skagit',
+  'Skamania',
+  'Snohomish',
+  'Spokane',
+  'Stevens',
+  'Thurston',
+  'Wahkiakum',
+  'Walla Walla',
+  'Whatcom',
+  'Whitman',
+  'Yakima',
+] as const;
+
+function toCountySlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+county$/i, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function toCountyName(value: string): string {
+  const slug = toCountySlug(value);
+  return WASHINGTON_COUNTY_NAMES.find((county) => toCountySlug(county) === slug) ?? value;
+}
+
+function buildPosture(countyName: string): CountyRuntimePosture {
+  const countySlug = toCountySlug(countyName);
+  const isBenton = countySlug === 'benton';
+
+  if (isBenton) {
+    return {
+      countyName,
+      countySlug,
+      state: 'WA',
+      runtimeMode: 'runtime-enabled',
+      runtimeActionsAllowed: true,
+      canonicalImportAllowed: true,
+      sourcePosture: 'Benton runtime-enabled: governed parcel runtime actions are allowed for the June 10 lane.',
+      boundaryLabel: 'Runtime-enabled county',
+      nextAction: 'Use governed suite actions and keep runtime proof current.',
+    };
+  }
+
+  return {
+    countyName,
+    countySlug,
+    state: 'WA',
+    runtimeMode: 'source-provenance-onboarding-intake',
+    runtimeActionsAllowed: false,
+    canonicalImportAllowed: false,
+    sourcePosture:
+      'Source/provenance/onboarding/intake only: runtime actions are blocked until county-specific ingestion and lineage proof are promoted.',
+    boundaryLabel: 'County Data Intake',
+    nextAction: 'Complete source provenance, onboarding, and intake proof before canonical import or runtime actions.',
+  };
+}
+
+export const WASHINGTON_COUNTY_RUNTIME_POSTURES: readonly CountyRuntimePosture[] =
+  WASHINGTON_COUNTY_NAMES.map(buildPosture);
+
+export function getCountyRuntimePosture(countyId: string): CountyRuntimePosture {
+  const countyName = toCountyName(countyId);
+  return (
+    WASHINGTON_COUNTY_RUNTIME_POSTURES.find((posture) => posture.countySlug === toCountySlug(countyName)) ??
+    buildPosture(countyName)
+  );
+}

--- a/frontend/apps/os-shell/src/pages/CountyEmployeeWorkspace.tsx
+++ b/frontend/apps/os-shell/src/pages/CountyEmployeeWorkspace.tsx
@@ -150,6 +150,10 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
     error?: string;
   }>({ status: 'idle' });
   const countyPosture = getCountyRuntimePosture(countyId);
+  const canonicalImportLabel =
+    countyPosture.canonicalImportAllowed === 'not_applicable'
+      ? 'Canonical import: not applicable - Benton is already runtime-enabled'
+      : `canonicalImportAllowed: ${String(countyPosture.canonicalImportAllowed)}`;
 
   // Initialize AI Assistant hook
   const {
@@ -349,7 +353,7 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
                         {countyPosture.runtimeMode}
                       </Badge>
                       <span>runtimeActionsAllowed: {String(countyPosture.runtimeActionsAllowed)}</span>
-                      <span>canonicalImportAllowed: {String(countyPosture.canonicalImportAllowed)}</span>
+                      <span>{canonicalImportLabel}</span>
                     </div>
                   </div>
                   <p className='mt-3 text-xs text-slate-400'>{countyPosture.nextAction}</p>

--- a/frontend/apps/os-shell/src/pages/CountyEmployeeWorkspace.tsx
+++ b/frontend/apps/os-shell/src/pages/CountyEmployeeWorkspace.tsx
@@ -11,6 +11,7 @@ import { CountyEmployeeDashboard } from '@/components/dashboards/CountyEmployeeD
 import { Badge, Button, Card, CardContent } from '@/components/terrafusion-design-system';
 import { ExecutiveKpiCards } from '@/components/workbench/ExecutiveKpiCards';
 import { SwarmActivityBar } from '@/components/workbench/SwarmActivityBar';
+import { getCountyRuntimePosture } from '@/config/countyRuntimePosture';
 import { useAIAssistant } from '@/hooks/useAIAssistant';
 import { usePropertyAnalysis } from '@/hooks/usePropertyAnalysis';
 import { invokeTool } from '@/api/pilotApi';
@@ -148,6 +149,7 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
     correlationId?: string;
     error?: string;
   }>({ status: 'idle' });
+  const countyPosture = getCountyRuntimePosture(countyId);
 
   // Initialize AI Assistant hook
   const {
@@ -193,6 +195,15 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
     let cancelled = false;
 
     const loadStaffPosture = async () => {
+      if (!countyPosture.runtimeActionsAllowed) {
+        const blockedMessage =
+          'Runtime actions are blocked for this county. Use County Data Intake until source provenance and lineage proof are promoted.';
+        setBriefState({ status: 'error', error: blockedMessage });
+        setSpatialState({ status: 'error', error: blockedMessage });
+        setPacketState({ status: 'error', error: blockedMessage });
+        return;
+      }
+
       setBriefState({ status: 'loading' });
       setSpatialState({ status: 'loading' });
       setPacketState({ status: 'loading' });
@@ -292,9 +303,12 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
     return () => {
       cancelled = true;
     };
-  }, [countyId, selectedRole]);
+  }, [countyId, countyPosture.runtimeActionsAllowed, selectedRole]);
 
   const handleOpenSuite = (suiteId: 'suite-dais' | 'suite-forge' | 'suite-atlas' | 'suite-dossier') => {
+    if (!countyPosture.runtimeActionsAllowed) {
+      return;
+    }
     activateModule(suiteId, { source: 'desktop' });
   };
 
@@ -305,6 +319,42 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
           <div className='space-y-6'>
             <Card className='terra-glass border border-white/10' data-testid='workspace-command-surface'>
               <CardContent className='p-6 space-y-4'>
+                <div
+                  className={cn(
+                    'rounded-xl border p-4',
+                    countyPosture.runtimeActionsAllowed
+                      ? 'border-emerald-400/20 bg-emerald-400/5'
+                      : 'border-amber-400/25 bg-amber-400/5'
+                  )}
+                  data-testid='county-runtime-posture-boundary'
+                  data-county-slug={countyPosture.countySlug}
+                  data-runtime-mode={countyPosture.runtimeMode}
+                  data-runtime-actions-allowed={String(countyPosture.runtimeActionsAllowed)}
+                  data-canonical-import-allowed={String(countyPosture.canonicalImportAllowed)}
+                >
+                  <div className='flex flex-wrap items-start justify-between gap-3'>
+                    <div>
+                      <p className='text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400'>
+                        {countyPosture.boundaryLabel}
+                      </p>
+                      <h4 className='mt-2 text-lg font-semibold text-white'>
+                        {countyPosture.countyName} County posture
+                      </h4>
+                      <p className='mt-2 max-w-3xl text-sm text-slate-300'>
+                        {countyPosture.sourcePosture}
+                      </p>
+                    </div>
+                    <div className='flex flex-col items-start gap-2 text-xs text-slate-300 sm:items-end'>
+                      <Badge variant='outline' className='text-xs'>
+                        {countyPosture.runtimeMode}
+                      </Badge>
+                      <span>runtimeActionsAllowed: {String(countyPosture.runtimeActionsAllowed)}</span>
+                      <span>canonicalImportAllowed: {String(countyPosture.canonicalImportAllowed)}</span>
+                    </div>
+                  </div>
+                  <p className='mt-3 text-xs text-slate-400'>{countyPosture.nextAction}</p>
+                </div>
+
                 <div className='flex flex-wrap items-start justify-between gap-4'>
                   <div>
                     <p className='text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400'>
@@ -366,7 +416,12 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
                       <span className='text-[11px] text-slate-500'>
                         {briefState.correlationId ? `corr ${briefState.correlationId}` : 'corr pending'}
                       </span>
-                      <Button variant='outline' size='sm' onClick={() => handleOpenSuite('suite-dais')}>
+                      <Button
+                        variant='outline'
+                        size='sm'
+                        disabled={!countyPosture.runtimeActionsAllowed}
+                        onClick={() => handleOpenSuite('suite-dais')}
+                      >
                         Open TerraDais
                       </Button>
                     </div>
@@ -395,7 +450,12 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
                       <span className='text-[11px] text-slate-500'>
                         {spatialState.correlationId ? `corr ${spatialState.correlationId}` : 'corr pending'}
                       </span>
-                      <Button variant='outline' size='sm' onClick={() => handleOpenSuite('suite-atlas')}>
+                      <Button
+                        variant='outline'
+                        size='sm'
+                        disabled={!countyPosture.runtimeActionsAllowed}
+                        onClick={() => handleOpenSuite('suite-atlas')}
+                      >
                         Open TerraAtlas
                       </Button>
                     </div>
@@ -425,11 +485,21 @@ export const CountyEmployeeWorkspace: React.FC<CountyEmployeeWorkspaceProps> = (
                         {packetState.correlationId ? `corr ${packetState.correlationId}` : 'corr pending'}
                       </span>
                       <div className='flex gap-2'>
-                        <Button variant='outline' size='sm' onClick={() => handleOpenSuite('suite-forge')}>
+                        <Button
+                          variant='outline'
+                          size='sm'
+                          disabled={!countyPosture.runtimeActionsAllowed}
+                          onClick={() => handleOpenSuite('suite-forge')}
+                        >
                           <Shield className='mr-2 h-4 w-4' />
                           Open Forge
                         </Button>
-                        <Button variant='outline' size='sm' onClick={() => handleOpenSuite('suite-dossier')}>
+                        <Button
+                          variant='outline'
+                          size='sm'
+                          disabled={!countyPosture.runtimeActionsAllowed}
+                          onClick={() => handleOpenSuite('suite-dossier')}
+                        >
                           Open Dossier
                         </Button>
                       </div>

--- a/frontend/apps/os-shell/src/shell/desktop/StageZeroState.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/StageZeroState.tsx
@@ -44,6 +44,10 @@ import { useRecentParcels } from '../../context/parcelContext';
 import { activateModule } from '../../orchestration/moduleActivation';
 import { useTodaysWork, type TodaysWorkItem } from '../../hooks/useTodaysWork';
 import { useParcelCount } from '../../hooks/useParcelCount';
+import {
+  WASHINGTON_COUNTY_RUNTIME_POSTURES,
+  getCountyRuntimePosture,
+} from '../../config/countyRuntimePosture';
 import { LiquidPanel } from '../../ui/materials';
 import { invokeTool } from '../../api/pilotApi';
 import { Z } from './zIndex';
@@ -250,6 +254,11 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
   const recentParcels = useRecentParcels();
   const { tasks: todaysTasks, loading: todaysTasksLoading, error: todaysTasksError } = useTodaysWork();
   const { data: statsData } = useParcelCount();
+  const bentonPosture = getCountyRuntimePosture('benton');
+  const sourceOnlyCountyCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.filter(
+    (posture) => !posture.runtimeActionsAllowed
+  ).length;
+  const runtimeEnabledCountyCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.length - sourceOnlyCountyCount;
   const parcelCountLabel = typeof statsData?.totalParcels === 'number'
     ? `${statsData.totalParcels.toLocaleString()} parcels`
     : 'Parcel count unavailable';
@@ -498,6 +507,33 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
               </div>
               <div className='text-xs' style={{ color: 'hsl(var(--tf-muted))' }}>
                 Benton County • Governed summaries only
+              </div>
+            </div>
+
+            <div
+              data-testid='county-runtime-posture-summary'
+              data-total-counties={String(WASHINGTON_COUNTY_RUNTIME_POSTURES.length)}
+              data-runtime-enabled-count={String(runtimeEnabledCountyCount)}
+              data-source-intake-count={String(sourceOnlyCountyCount)}
+              data-benton-runtime-mode={bentonPosture.runtimeMode}
+              data-intake-canonical-import-allowed='false'
+              className='rounded-xl p-3 text-xs leading-5'
+              style={{
+                border: '1px solid hsl(var(--tf-border) / 0.7)',
+                background: 'hsl(var(--tf-surface) / 0.36)',
+                color: 'hsl(var(--tf-muted))',
+              }}
+            >
+              <div className='flex flex-wrap items-center gap-x-3 gap-y-1'>
+                <span className='font-semibold' style={{ color: 'hsl(var(--tf-text))' }}>
+                  39 Washington counties registered
+                </span>
+                <span>{runtimeEnabledCountyCount} runtime-enabled: Benton</span>
+                <span>{sourceOnlyCountyCount} County Data Intake only</span>
+                <span>canonicalImportAllowed: false for intake counties</span>
+              </div>
+              <div className='mt-1'>
+                Non-Benton runtime actions remain blocked until source provenance, onboarding, and lineage proof are promoted.
               </div>
             </div>
 


### PR DESCRIPTION
This PR exposes the governed Phase 4 county runtime/source posture surface for the June 10 integration line.

It adds governed runtime/source posture for all 39 Washington counties:
- Benton is runtime-enabled.
- The other 38 counties are source/provenance/onboarding/intake.
- Non-Benton runtime actions are blocked.
- County Data Intake boundary is visible.
- canonicalImportAllowed=false for non-Benton counties.
- Benton intake boundary is not_applicable, not true.

This is not a 39-county runtime claim.
This is not Hostinger proof.
This does not mutate production DB state.

Validation performed in the isolated worktree:
- Browser proof on /counties from the Phase 4 worktree runtime.
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- focused Phase 4 frontend contracts
- UI token ratchet / pre-commit gate

## Summary by Sourcery

Expose a governed 39-county runtime/intake posture model for Washington counties and wire it into the Counties Hub, county employee workspace, and Stage Zero dashboard.

New Features:
- Introduce a shared configuration describing runtime and intake postures for all 39 Washington counties, with Benton as the only runtime-enabled county.
- Render a Phase 4 county posture summary and per-county boundary selector in the Counties Hub to display runtime vs intake status and canonical import boundaries.
- Surface county runtime posture and intake boundaries within the County Employee Workspace, including a guardrail banner explaining whether runtime actions are allowed.
- Show a concise runtime/intake posture summary strip in the Stage Zero (County Ops) desktop scene highlighting 39 registered counties and intake-only status for non-Benton counties.

Enhancements:
- Block workspace runtime tool activation and disable suite launch buttons for counties that are intake-only rather than runtime-enabled.
- Extend routing so the legacy /counties path loads the new governed Counties Hub, maintaining the honesty contract for the legacy dashboard.

Tests:
- Add honesty contract tests to assert the 39-county posture model, non-Benton runtime blocking, and the presence of runtime/intake boundary UI in Counties Hub, CountyEmployeeWorkspace, and StageZeroState.