### PR TITLE
fix(localops): 005 follow-up — parse only the leading verdict label

### DIFF
--- a/os-platform/core/pilot/local-agent/exemptionAdvisor.js
+++ b/os-platform/core/pilot/local-agent/exemptionAdvisor.js
@@ -40,13 +40,20 @@ function factLines(input) {
 }
 /**
  * Map the model's free text to a bounded verdict. Conservative by construction:
- * anything that does not clearly assert eligibility or ineligibility falls back
- * to `needs_review`, so the advisory never over-claims eligibility.
+ * the model is instructed to BEGIN with exactly one label, so we parse ONLY the
+ * leading label of the first line. A whole-text substring scan would let a
+ * conservative opener ("needs_review — not enough evidence to say likely
+ * eligible") be overridden by a later mention of a stronger label and overstate
+ * eligibility. Anything without a recognized leading label falls back to
+ * `needs_review`, so the advisory never over-claims eligibility.
  */
 function parseVerdict(text) {
-    const lowered = text.toLowerCase();
+    const firstLine = text.trim().split(/\r?\n/, 1)[0]?.toLowerCase() ?? '';
+    // Keep letters, underscores and spaces so both `likely_eligible` and
+    // `likely eligible` openers match; collapse leading punctuation/markup.
+    const head = firstLine.replace(/[^a-z_ ]+/g, ' ').trim();
     for (const v of VERDICTS) {
-        if (lowered.includes(v) || lowered.includes(v.replace(/_/g, ' ')))
+        if (head.startsWith(v) || head.startsWith(v.replace(/_/g, ' ')))
             return v;
     }
     return 'needs_review';

--- a/os-platform/core/pilot/local-agent/exemptionAdvisor.js
+++ b/os-platform/core/pilot/local-agent/exemptionAdvisor.js
@@ -49,12 +49,26 @@ function factLines(input) {
  */
 function parseVerdict(text) {
     const firstLine = text.trim().split(/\r?\n/, 1)[0]?.toLowerCase() ?? '';
-    // Keep letters, underscores and spaces so both `likely_eligible` and
-    // `likely eligible` openers match; collapse leading punctuation/markup.
-    const head = firstLine.replace(/[^a-z_ ]+/g, ' ').trim();
+    // Normalize: keep letters and underscores, turn every other run (punctuation,
+    // markup, digits, the em-dash) into a single space, and collapse repeated
+    // whitespace. So `likely-eligible:`, `likely   eligible` and `likely_eligible`
+    // all normalize to a comparable head.
+    const head = firstLine
+        .replace(/[^a-z_]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
     for (const v of VERDICTS) {
-        if (head.startsWith(v) || head.startsWith(v.replace(/_/g, ' ')))
+        const spaced = v.replace(/_/g, ' ');
+        // Require a WORD BOUNDARY after the label (exact match or a following
+        // space) so a longer token that merely prefixes a label — e.g.
+        // `likely_eligibleish`, `needs_reviewed` — is NOT accepted and falls
+        // through to the conservative default.
+        if (head === v ||
+            head === spaced ||
+            head.startsWith(`${v} `) ||
+            head.startsWith(`${spaced} `)) {
             return v;
+        }
     }
     return 'needs_review';
 }

--- a/os-platform/core/pilot/local-agent/exemptionAdvisor.ts
+++ b/os-platform/core/pilot/local-agent/exemptionAdvisor.ts
@@ -87,11 +87,28 @@ function factLines(input: ExemptionReviewInput): string[] {
  */
 function parseVerdict(text: string): ExemptionAdvisoryVerdict {
   const firstLine = text.trim().split(/\r?\n/, 1)[0]?.toLowerCase() ?? '';
-  // Keep letters, underscores and spaces so both `likely_eligible` and
-  // `likely eligible` openers match; collapse leading punctuation/markup.
-  const head = firstLine.replace(/[^a-z_ ]+/g, ' ').trim();
+  // Normalize: keep letters and underscores, turn every other run (punctuation,
+  // markup, digits, the em-dash) into a single space, and collapse repeated
+  // whitespace. So `likely-eligible:`, `likely   eligible` and `likely_eligible`
+  // all normalize to a comparable head.
+  const head = firstLine
+    .replace(/[^a-z_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   for (const v of VERDICTS) {
-    if (head.startsWith(v) || head.startsWith(v.replace(/_/g, ' '))) return v;
+    const spaced = v.replace(/_/g, ' ');
+    // Require a WORD BOUNDARY after the label (exact match or a following
+    // space) so a longer token that merely prefixes a label — e.g.
+    // `likely_eligibleish`, `needs_reviewed` — is NOT accepted and falls
+    // through to the conservative default.
+    if (
+      head === v ||
+      head === spaced ||
+      head.startsWith(`${v} `) ||
+      head.startsWith(`${spaced} `)
+    ) {
+      return v;
+    }
   }
   return 'needs_review';
 }

--- a/os-platform/core/pilot/local-agent/exemptionAdvisor.ts
+++ b/os-platform/core/pilot/local-agent/exemptionAdvisor.ts
@@ -78,13 +78,20 @@ function factLines(input: ExemptionReviewInput): string[] {
 
 /**
  * Map the model's free text to a bounded verdict. Conservative by construction:
- * anything that does not clearly assert eligibility or ineligibility falls back
- * to `needs_review`, so the advisory never over-claims eligibility.
+ * the model is instructed to BEGIN with exactly one label, so we parse ONLY the
+ * leading label of the first line. A whole-text substring scan would let a
+ * conservative opener ("needs_review — not enough evidence to say likely
+ * eligible") be overridden by a later mention of a stronger label and overstate
+ * eligibility. Anything without a recognized leading label falls back to
+ * `needs_review`, so the advisory never over-claims eligibility.
  */
 function parseVerdict(text: string): ExemptionAdvisoryVerdict {
-  const lowered = text.toLowerCase();
+  const firstLine = text.trim().split(/\r?\n/, 1)[0]?.toLowerCase() ?? '';
+  // Keep letters, underscores and spaces so both `likely_eligible` and
+  // `likely eligible` openers match; collapse leading punctuation/markup.
+  const head = firstLine.replace(/[^a-z_ ]+/g, ' ').trim();
   for (const v of VERDICTS) {
-    if (lowered.includes(v) || lowered.includes(v.replace(/_/g, ' '))) return v;
+    if (head.startsWith(v) || head.startsWith(v.replace(/_/g, ' '))) return v;
   }
   return 'needs_review';
 }

--- a/os-platform/core/tests/local-agent-localops-exemption-advisor.test.mjs
+++ b/os-platform/core/tests/local-agent-localops-exemption-advisor.test.mjs
@@ -56,6 +56,18 @@ describe('LocalOps exemption advisor (WO-AI-CONSOLIDATION-005)', () => {
     await advisor.close();
   });
 
+  it('parses only the LEADING label — a conservative opener is not overridden by a later mention', async () => {
+    // The model opens with needs_review but later mentions "likely eligible".
+    // A whole-text scan would overstate eligibility; the leading-label parse must not.
+    const fake = new FakeModelAdapter().setFallback(
+      'needs_review — not enough evidence to say likely eligible; verify income documentation.'
+    );
+    const advisor = createExemptionAdvisor({ env: localopsEnv, adapter: fake });
+    const out = await advisor.review(SAMPLE_INPUT);
+    assert.strictEqual(out.verdict, 'needs_review', 'leading label wins; no eligibility overstatement');
+    await advisor.close();
+  });
+
   it('is unavailable with ZERO egress when AI is disabled (no local model)', async () => {
     const calls = [];
     const realFetch = globalThis.fetch;

--- a/os-platform/core/tests/local-agent-localops-exemption-advisor.test.mjs
+++ b/os-platform/core/tests/local-agent-localops-exemption-advisor.test.mjs
@@ -68,6 +68,23 @@ describe('LocalOps exemption advisor (WO-AI-CONSOLIDATION-005)', () => {
     await advisor.close();
   });
 
+  it('requires a word boundary — a token that merely prefixes a label is not accepted', async () => {
+    // 'likely_eligibleish' must NOT be read as a verdict label.
+    const fake = new FakeModelAdapter().setFallback('likely_eligibleish guess — undocumented.');
+    const advisor = createExemptionAdvisor({ env: localopsEnv, adapter: fake });
+    const out = await advisor.review(SAMPLE_INPUT);
+    assert.strictEqual(out.verdict, 'needs_review', 'prefix garbage must not overstate eligibility');
+    await advisor.close();
+  });
+
+  it('normalizes internal whitespace and punctuation in the leading label', async () => {
+    const fake = new FakeModelAdapter().setFallback('likely   eligible:  owner meets the age and income tests.');
+    const advisor = createExemptionAdvisor({ env: localopsEnv, adapter: fake });
+    const out = await advisor.review(SAMPLE_INPUT);
+    assert.strictEqual(out.verdict, 'likely_eligible', 'spaced/punctuated label still matches');
+    await advisor.close();
+  });
+
   it('is unavailable with ZERO egress when AI is disabled (no local model)', async () => {
     const calls = [];
     const realFetch = globalThis.fetch;


### PR DESCRIPTION
## Follow-up to #969 — the parse fix that missed the merge

#969 (the exemption advisory capability) auto-merged at its **pre-fix** SHA (`c2c6eb379`) before this review fix's checks could re-run, so the fix commit was orphaned when the branch auto-deleted. As a result the Codex P2 — substring `parseVerdict` overstating eligibility — **landed on main**. This PR restores the fix (cherry-pick of the original reviewed commit `dac4a1f56`).

### The bug (currently on main)
`parseVerdict` substring-scanned the whole rationale in `likely_eligible`-first order, so a conservative opener — `needs_review — not enough evidence to say likely eligible` — wrongly returned `likely_eligible`, overstating eligibility in assessor-facing advice.

### The fix
Parse only the **leading label** of the first line (the model is instructed to begin with exactly one label). Unrecognized leading labels still fall back to `needs_review`. Regression test added for exactly the flagged opener-vs-later-mention case.

### Proof
Offline `node --test` (Node 20 / CI parity): **5/5**, including the new leading-label regression. `check:generated` clean; no generated `.js` hand-edited.

Scope: same LocalOps lane as 005 (`os-platform/core/pilot/local-agent/**` + tests). Honesty/correctness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Constrain exemption advisor verdict parsing to only consider the leading label on the first line of the model output, ensuring conservative assessments and preventing later mentions from overriding an initial cautious verdict.

Bug Fixes:
- Fix verdict parsing so that conservative `needs_review` openers are not overridden by later mentions of stronger eligibility labels in the same response.

Tests:
- Add a regression test to verify that only the leading label is used when parsing exemption advisor verdicts, preventing eligibility overstatement.