### PR TITLE
fix(api): WO-AI-CONSOLIDATION-004c-a — truthful live-served AI status (no fabricated 1008)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/AIOrchestrationController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AIOrchestrationController.cs
@@ -464,7 +464,9 @@ public class AIOrchestrationController : ControllerBase
                     await Task.Delay(500); // Simulate failsafe execution
                     success = true;
                     message = "System failsafe executed successfully";
-                    affectedAgents = 1008;
+                    // Honesty (WO-AI-CONSOLIDATION-004c-a): no real agent fleet to affect;
+                    // do not emit a fabricated 1008 count.
+                    affectedAgents = 0;
                     break;
 
                 case "restart-all":

--- a/backend/src/TerraFusion.API/Controllers/ElitePerformanceMonitoringController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ElitePerformanceMonitoringController.cs
@@ -557,10 +557,13 @@ public class ElitePerformanceMonitoringController : ControllerBase
         await Task.CompletedTask;
         return new Dictionary<string, object>
         {
-            ["active_agents"] = 1008,
-            ["healthy_agents"] = 1008,
-            ["average_response_time"] = 8.5,
-            ["requests_per_second"] = 15000
+            // Honesty (WO-AI-CONSOLIDATION-004c-a): no governed AI agent swarm runs.
+            // Report the real state (zero agents, unavailable) — never a fabricated count.
+            ["active_agents"] = 0,
+            ["healthy_agents"] = 0,
+            ["average_response_time"] = 0,
+            ["requests_per_second"] = 0,
+            ["status"] = "unavailable"
         };
     }
 

--- a/backend/src/TerraFusion.API/Controllers/EnhancementController.cs
+++ b/backend/src/TerraFusion.API/Controllers/EnhancementController.cs
@@ -81,7 +81,8 @@ public class EnhancementController : ControllerBase
             {
                 operation = request.Operation,
                 parameters = request.Parameters ?? new Dictionary<string, object>(),
-                agentCount = request.AgentCount ?? 1008,
+                // Honesty (WO-AI-CONSOLIDATION-004c-a): no fabricated default agent count.
+                agentCount = request.AgentCount ?? 0,
                 priority = request.Priority ?? "normal",
                 timestamp = DateTime.UtcNow
             };

--- a/backend/src/TerraFusion.API/Controllers/ProductionPACSIntegrationController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ProductionPACSIntegrationController.cs
@@ -581,12 +581,14 @@ public class ProductionPACSIntegrationController : ControllerBase
         await Task.CompletedTask;
         await Task.CompletedTask;
         // Implementation for AI agent status
+        // Honesty (WO-AI-CONSOLIDATION-004c-a): no governed AI agent swarm runs.
+        // Report the real state (zero agents) — never a fabricated count.
         return new AIAgentStatus
         {
-            TotalAgents = 1008,
-            ActiveAgents = 1008,
+            TotalAgents = 0,
+            ActiveAgents = 0,
             TrainingAgents = 0,
-            HealthyAgents = 1008
+            HealthyAgents = 0
         };
     }
 


### PR DESCRIPTION
## WO-AI-CONSOLIDATION-004c-a — backend honesty, live-served status surfaces

First 004c slice (operator-approved, bounded to the four live-served controllers). The successor to 004b (#960): those four operator-facing API controllers reported a fabricated **1008-agent swarm that does not run**. Now truthful.

### Changes (4 files, all `backend/src/TerraFusion.API/Controllers/`)
| Controller | Was | Now |
|---|---|---|
| `ElitePerformanceMonitoringController.GetCurrentAIAgentMetricsAsync` | active/healthy=1008, rt=8.5, rps=15000 | 0 / 0 / 0 / 0 + `status=unavailable` |
| `ProductionPACSIntegrationController.GetAIAgentStatusAsync` | Total/Active/Healthy=1008 | 0 / 0 / 0 |
| `AIOrchestrationController` (failsafe) | affectedAgents=1008 | 0 (no real fleet to affect) |
| `EnhancementController` | agentCount default 1008 | 0 (no fabricated default) |

### Proof
`dotnet build TerraFusion.API` → **Build succeeded, 0 warnings / 0 errors**. `grep` confirms no fabricated 1008 remains in the four files. CI = constitutional review for the backend slice (per card).

### Scope
Operator-approved backend lane expansion + product-behavior change, **live-served controllers only**. Out of scope, deferred to a separate **004c-b** approval: the internal services/DTOs feeding these (`AdvancedMonitoringService`, `AISwarm369MonitoringService`, `AnalyticsReportingService`, `Codex369AgentIntegrationService`, `AIOrchestrationService`, `CostForgeAIService`, `EnterpriseAIAgentCoordinator`) and the orphaned `ValuationOptimizationController`. No swarm revival, no cloud, no docs churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align operator-facing AI status controllers with the actual absence of a running agent swarm, removing fabricated swarm metrics and counts.

Bug Fixes:
- Correct AI status and metrics responses in operator-facing controllers to report zero agents and unavailable status instead of a fabricated 1008-agent swarm.

Enhancements:
- Add explicit unavailable status and zeroed metrics in AI performance monitoring responses for non-running agent swarms.
- Ensure emergency protocol responses and enhancement operations no longer default to a non-existent 1008-agent fleet but instead reflect zero affected or default agents.