### PR TITLE
fix(ai): WO-AI-CONSOLIDATION-004c-b1 — truthful internal AI status (no fabricated 1008)

### DIFF
--- a/backend/src/TerraFusion.AI/Services/AIOrchestrationService.cs
+++ b/backend/src/TerraFusion.AI/Services/AIOrchestrationService.cs
@@ -567,7 +567,7 @@ namespace TerraFusion.AI.Services
 
         private void ApplyPerformanceOptimization(TerraFusion.Core.DTOs.SwarmOptimizationReport report)
         {
-            report.OptimizationsApplied.Add("performance-tuning: Optimized task routing and agent selection algorithms for 1008 agents");
+            report.OptimizationsApplied.Add("performance-tuning: Optimized task routing and agent selection algorithms");
 
             report.MetricsImprovement["avg-response-time-before"] = 245.6m;
             report.MetricsImprovement["avg-response-time-after"] = 187.3m;
@@ -589,7 +589,7 @@ namespace TerraFusion.AI.Services
             ApplyPerformanceOptimization(report);
             ApplyEfficiencyOptimization(report);
 
-            report.OptimizationsApplied.Add("auto-optimization: Applied comprehensive optimization across all strategies affecting 1008 agents with critical impact");
+            report.OptimizationsApplied.Add("auto-optimization: Applied comprehensive optimization across all strategies with critical impact");
         }
 
         private decimal CalculateImprovementScore(TerraFusion.Core.DTOs.SwarmOptimizationReport report)

--- a/backend/src/TerraFusion.AI/Services/AISwarm369MonitoringService.cs
+++ b/backend/src/TerraFusion.AI/Services/AISwarm369MonitoringService.cs
@@ -26,10 +26,7 @@ namespace TerraFusion.AI.Services
         private const int COORDINATOR_AGENTS = 12;    // Supreme coordination layer
         private const int FIELD_GENERAL_AGENTS = 96;  // Tactical execution layer
         private const int MICRO_AGENTS = 900;         // Rapid response layer
-        // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs.
-        // NOTE: this constant is currently unused; the file's live tier metrics derive
-        // from COORDINATOR/FIELD_GENERAL/MICRO_AGENTS (above), flagged for a follow-up decision.
-        private const int TOTAL_AGENTS = 0;            // Total AI agent count (no swarm running)
+        private const int TOTAL_AGENTS = 1008;        // Total AI agent count
 
         // Performance thresholds
         private const decimal SWARM_COORDINATION_THRESHOLD = 90m;  // 90% minimum coordination

--- a/backend/src/TerraFusion.AI/Services/AISwarm369MonitoringService.cs
+++ b/backend/src/TerraFusion.AI/Services/AISwarm369MonitoringService.cs
@@ -26,7 +26,10 @@ namespace TerraFusion.AI.Services
         private const int COORDINATOR_AGENTS = 12;    // Supreme coordination layer
         private const int FIELD_GENERAL_AGENTS = 96;  // Tactical execution layer
         private const int MICRO_AGENTS = 900;         // Rapid response layer
-        private const int TOTAL_AGENTS = 1008;        // Total AI agent count
+        // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs.
+        // NOTE: this constant is currently unused; the file's live tier metrics derive
+        // from COORDINATOR/FIELD_GENERAL/MICRO_AGENTS (above), flagged for a follow-up decision.
+        private const int TOTAL_AGENTS = 0;            // Total AI agent count (no swarm running)
 
         // Performance thresholds
         private const decimal SWARM_COORDINATION_THRESHOLD = 90m;  // 90% minimum coordination

--- a/backend/src/TerraFusion.AI/Services/AdvancedMonitoringService.cs
+++ b/backend/src/TerraFusion.AI/Services/AdvancedMonitoringService.cs
@@ -143,9 +143,10 @@ namespace TerraFusion.AI.Services
             // AI Agent Performance
             metrics.AIMetrics = new AIPerformanceMetrics
             {
-                ActiveAgents = 1008,
-                TotalAgents = 1008,
-                AgentUtilization = 100.0,
+                // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs.
+                ActiveAgents = 0,
+                TotalAgents = 0,
+                AgentUtilization = 0,
                 AverageProcessingTimeMs = GenerateTimeSeriesData(100, 300),
                 TasksProcessedPerMinute = 4567,
                 SwarmCoordinationLatencyMs = 15
@@ -273,10 +274,10 @@ namespace TerraFusion.AI.Services
                 NetworkOutboundMBps = 56.7,
                 ActiveConnections = 156,
 
-                // AI Swarm
-                AIAgentsActive = 1008,
-                AIAgentsTotal = 1008,
-                AISwarmUtilization = 100.0
+                // AI Swarm — Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed swarm runs.
+                AIAgentsActive = 0,
+                AIAgentsTotal = 0,
+                AISwarmUtilization = 0
             };
         }
 

--- a/backend/src/TerraFusion.AI/Services/AnalyticsReportingService.cs
+++ b/backend/src/TerraFusion.AI/Services/AnalyticsReportingService.cs
@@ -99,8 +99,9 @@ namespace TerraFusion.AI.Services
             // AI Analytics
             summary.AIAnalytics = new AIAnalytics
             {
-                TotalAgents = 1008,
-                ActiveAgents = 1008,
+                // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs.
+                TotalAgents = 0,
+                ActiveAgents = 0,
                 TasksProcessed = 567890,
                 AverageProcessingTime = 156.7,
                 SuccessRate = 98.9,

--- a/backend/src/TerraFusion.AI/Services/Codex369AgentIntegrationService.cs
+++ b/backend/src/TerraFusion.AI/Services/Codex369AgentIntegrationService.cs
@@ -94,8 +94,11 @@ public class Codex369AgentIntegrationService : ICodex369AgentIntegrationService
             });
         }
 
-        // Calculate swarm statistics
-        var avgHealth = agentMetrics.Average(a => a.HealthScore);
+        // Calculate swarm statistics.
+        // Empty-guard: with no swarm running (TOTAL_AGENTS = 0) the list is empty;
+        // Average() throws on an empty sequence, so the truthful "no swarm" state
+        // must report 0 health, not crash the health check.
+        var avgHealth = agentMetrics.Count > 0 ? agentMetrics.Average(a => a.HealthScore) : 0;
         var agentsInDivineBalance = agentMetrics.Count(a => a.InDivineBalance);
         var agentsNeedingAttention = agentMetrics.Count(a => a.HealthScore < 10.0);
 
@@ -264,7 +267,10 @@ public class Codex369AgentIntegrationService : ICodex369AgentIntegrationService
         for (int i = 1; i <= TOTAL_COUNTIES; i++)
         {
             var countyId = $"county-{i:D2}";
-            var currentAgents = random.Next(20, 35); // Simulate current distribution
+            // Honesty: with no swarm running (TOTAL_AGENTS = 0) there are no agents to
+            // distribute — report 0 current agents so the deficit is 0 and we never
+            // emit a fabricated "remove N agents" recommendation for a swarm that isn't there.
+            var currentAgents = TOTAL_AGENTS > 0 ? random.Next(20, 35) : 0;
             var deficit = idealAgentsPerCounty - currentAgents;
 
             var countyStatus = await _codexService.GetRealtimeFrameworkStatusAsync(countyId);

--- a/backend/src/TerraFusion.AI/Services/Codex369AgentIntegrationService.cs
+++ b/backend/src/TerraFusion.AI/Services/Codex369AgentIntegrationService.cs
@@ -48,7 +48,10 @@ public class Codex369AgentIntegrationService : ICodex369AgentIntegrationService
 {
     private readonly ICodex369FrameworkService _codexService;
     private readonly ILogger<Codex369AgentIntegrationService> _logger;
-    private const int TOTAL_AGENTS = 1008;
+    // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs.
+    // static readonly (not const) so the zero divisor below is a runtime guard,
+    // not a CS0020 "division by constant zero" compile error.
+    private static readonly int TOTAL_AGENTS = 0;
     private const int TOTAL_COUNTIES = 39;
 
     public Codex369AgentIntegrationService(
@@ -147,7 +150,8 @@ public class Codex369AgentIntegrationService : ICodex369AgentIntegrationService
             ThroughputOpsPerSec = throughput,
             TasksCompleted = tasksCompleted,
             SuccessRate = successRate,
-            ContributionToUltimatePower = healthScore / TOTAL_AGENTS, // Individual contribution
+            // Zero-guard: TOTAL_AGENTS is 0 (no swarm) — avoid divide-by-zero / Infinity.
+            ContributionToUltimatePower = TOTAL_AGENTS > 0 ? healthScore / TOTAL_AGENTS : 0,
             IsOptimal = healthScore >= 11.5,
             RecommendedActions = GenerateAgentRecommendations(healthScore, responseTime, throughput),
             Timestamp = DateTime.UtcNow
@@ -252,7 +256,7 @@ public class Codex369AgentIntegrationService : ICodex369AgentIntegrationService
 
         var random = new Random();
 
-        // Calculate ideal distribution (1008 agents / 39 counties ≈ 26 agents per county)
+        // Calculate ideal distribution (TOTAL_AGENTS / TOTAL_COUNTIES); TOTAL_AGENTS is 0 (no swarm).
         var idealAgentsPerCounty = TOTAL_AGENTS / TOTAL_COUNTIES;
 
         var countyDistributions = new List<CountyAgentDistribution>();

--- a/backend/src/TerraFusion.AI/Services/EnterpriseAIAgentCoordinator.cs
+++ b/backend/src/TerraFusion.AI/Services/EnterpriseAIAgentCoordinator.cs
@@ -236,7 +236,7 @@ public class EnterpriseAIAgentCoordinator : BackgroundService, IEnterpriseAIAgen
                 TeamId = "terragaia-supreme",
                 TeamName = "TerraGaia Supreme Consciousness",
                 TeamType = AgentTeamType.SupremeOrchestrator,
-                AgentCount = 1008, // Fibonacci sequence for quantum coherence
+                AgentCount = 0, // Honesty (WO-AI-CONSOLIDATION-004c-b1): no governed AI agent swarm runs
                 AssignedCounty = "King", // Primary headquarters
                 Capabilities = new[] { "OmniscientOrchestration", "CrossSystemSynergy", "PredictiveGovernance" },
                 Priority = AgentPriority.Critical,


### PR DESCRIPTION
## WO-AI-CONSOLIDATION-004c-b1 — backend honesty, internal services

Second 004c slice (operator-approved, bounded to **six internal `TerraFusion.AI` services only**). Successor to 004c-a (#971, the live-served controllers). These services hardcoded a **1008-agent swarm that does not run**; now truthful.

### Changes (6 files, all `backend/src/TerraFusion.AI/Services/`)
| Service | Fix |
|---|---|
| `AdvancedMonitoringService` | AIPerformanceMetrics + AISwarm block: Active/Total/AIAgents* 1008→0, *Utilization 100→0 |
| `AnalyticsReportingService` | AIAnalytics Total/ActiveAgents 1008→0 |
| `AISwarm369MonitoringService` | TOTAL_AGENTS const 1008→0 (**unused** — see flag below) |
| `Codex369AgentIntegrationService` | TOTAL_AGENTS `const 1008`→`static readonly 0` + **zero-guard** on `healthScore / TOTAL_AGENTS` (avoids **CS0020** division-by-constant-zero); stale 1008 comment corrected |
| `AIOrchestrationService` | removed "1008 agents" from two optimization-report strings |
| `EnterpriseAIAgentCoordinator` | AgentCount 1008→0; dropped "Fibonacci…quantum coherence" lore comment |

### Proof
`dotnet build TerraFusion.AI` → **Build succeeded, 0 warnings / 0 errors** (confirms the `static readonly` + guard dodge CS0020). `grep` confirms no literal 1008 remains in the six files. CI = constitutional review.

### ⚠️ Flagged for a separate honesty decision (NOT widened into b1)
`AISwarm369MonitoringService`'s `TOTAL_AGENTS` is **unused**; the file's *active* fabrication is the tier constants `COORDINATOR_AGENTS=12` / `FIELD_GENERAL_AGENTS=96` / `MICRO_AGENTS=900` (sum = 1008) feeding `GetActiveAgents()` simulated counts. Left untouched here to honor the tight b1 scope — recommend a follow-on slice to zero the tier model coherently.

### Out of scope (held)
`ValuationOptimizationController`, `CostForgeAIService` config-default → **004c-b2** (separate approval). Port-rules (#9) and OpenAPI (#10) debts from 004c-a remain deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inaccurate AI agent swarm metrics. Agent counts, utilization rates, and performance analytics now correctly report zero across all monitoring services, reflecting that no governed AI swarm is currently running.
  * Updated performance optimization messages to remove outdated agent count references.
  * Improved zero-agent scenario handling to prevent configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->