### PR TITLE
docs(ai): WO-AI-DOCS-001 — .ai truth sweep (README/index/claude align to canon)

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,9 +1,23 @@
-# TerraFusion .ai Suite - Advanced AI Infrastructure
+# TerraFusion .ai Suite — AI Infrastructure (Design / Alpha)
 
-**Status**: Production Operational ✅  
-**Integration**: Claude-Flow v2.0.0 Alpha  
-**AI Agents**: 1,008 Agent Swarm Operational  
-**Government Compliance**: FISMA-Ready Architecture
+> **⚠️ Accuracy & status (WO-AI-DOCS-001).** This document is **design / aspirational alpha**, not a
+> description of a running production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`,
+> `CLAUDE.md`, root `README.md`):
+> - The **1,008-agent swarm (and any larger agent counts cited below) is target architecture, NOT a
+>   running runtime** — there is no operational production swarm. The runtime-proven AI path today is
+>   **LocalOps / local-agent**.
+> - **FISMA-HIGH is a posture target, not a current accreditation.**
+> - **Tyler Technologies is NOT in Benton County's stack** (never was); any Tyler reference below is
+>   illustrative lore, not a live integration.
+> - Performance figures (3.9x ROI, 95% accuracy, 99.9% uptime) are **aspirational and unvalidated**.
+> - Code samples and `npm`/script commands below are **illustrative design**; several are not implemented.
+>
+> Capability labels used below: **[implemented] · [partial] · [planned] · [target architecture]**.
+
+**Status**: Alpha — design/aspirational, not production-accredited  
+**Integration**: Claude-Flow v2.0.0 Alpha — integration scaffolding *([partial])*  
+**AI Agents**: 1,008-agent swarm is **designed/target capacity**, not a running runtime *([target architecture])*  
+**Government Compliance**: FISMA-HIGH **posture target**, not current accreditation
 
 ## Overview
 
@@ -43,7 +57,7 @@ cd .ai/core
 # Start AI agent coordination
 npm run start:agents
 
-# Deploy 1,008 agent swarm
+# Deploy the designed 1,008-agent swarm (target architecture — command illustrative, not implemented)
 npm run deploy:swarm
 
 # Monitor agent performance
@@ -73,11 +87,12 @@ curl http://localhost:\${{TF_ADMIN_PORT:-8080}}/ai/agents/health
 
 ### AI Agent Ecosystem
 
-- **Total Agents**: 50,000+ specialized government AI agents
-- **Distribution**: Property assessors (300), revenue hunters (200), data
-  processors (200)
-- **Coordination**: Real-time task routing and performance optimization
-- **Integration**: Harris PACS, Tyler Technologies, legacy government systems
+- **Designed agent capacity** *([target architecture]; no swarm runs today)*: a 1,008-agent
+  hierarchy is the design target. Larger figures that appeared here previously were aspirational.
+- **Designed distribution**: Property assessors (300), revenue hunters (200), data processors (200)
+- **Coordination**: real-time task routing and performance optimization *([planned])*
+- **Integration**: Harris PACS (the legacy source DB; [partial]); **Tyler is NOT in Benton's stack** —
+  do not treat it as a live integration
 
 ## Government AI Applications
 
@@ -109,7 +124,7 @@ const opportunities = await aiWorkflows.execute('revenue_optimization', {
   historicalTrends: fiveYearTrends,
 });
 
-// Results: 3.9x improvement in revenue identification
+// Target (unvalidated): 3.9x improvement in revenue identification
 // - Underassessed property identification
 // - Tax optimization recommendations
 // - Projected revenue impact analysis
@@ -261,23 +276,26 @@ POST /ai/government/compliance-monitoring  # Regulatory compliance check
 GET  /ai/government/audit-trail/{id}      # Government audit documentation
 ```
 
-## Performance Benchmarks
+## Performance Targets (aspirational — unvalidated)
 
-### AI System Performance
+> The figures below are **design targets**, not measured results, and are **not validated** against a
+> running system. Treat them as goals.
 
-- **Response Time**: <100ms average AI inference
-- **Throughput**: 1,000+ concurrent AI operations
-- **Agent Coordination**: 1,008 agents with <2ms routing
-- **Availability**: 99.9% uptime with automatic recovery
-- **Accuracy**: 95%+ AI decision accuracy rate
+### AI System Performance *(targets)*
 
-### Government Workload Metrics
+- **Response Time**: <100ms average AI inference *(target)*
+- **Throughput**: 1,000+ concurrent AI operations *(target)*
+- **Agent Coordination**: designed 1,008-agent hierarchy with <2ms routing *([target architecture])*
+- **Availability**: 99.9% uptime *(target, unvalidated)*
+- **Accuracy**: 95%+ AI decision accuracy *(target, unvalidated)*
 
-- **Property Assessment**: 500 parcels/hour automated processing
-- **Revenue Discovery**: 3.9x improvement in opportunity identification
-- **Compliance Monitoring**: Real-time regulatory validation
-- **Cost Efficiency**: 60% reduction in manual processing costs
-- **Audit Generation**: 100% automated government audit trails
+### Government Workload Targets *(unvalidated)*
+
+- **Property Assessment**: 500 parcels/hour automated processing *(target)*
+- **Revenue Discovery**: 3.9x improvement in opportunity identification *(target, unvalidated)*
+- **Compliance Monitoring**: real-time regulatory validation *([planned])*
+- **Cost Efficiency**: 60% reduction in manual processing costs *(target, unvalidated)*
+- **Audit Generation**: automated government audit trails *([planned])*
 
 ## Security & Compliance
 
@@ -314,7 +332,7 @@ npm install
 npm run dev:all
 
 # Validate AI agent health
-curl http://localhost:\${{TF_ADMIN_PORT:-8080}}/ai/agents | jq '.totalAgents'  # Should return 50000
+curl http://localhost:\${{TF_ADMIN_PORT:-8080}}/ai/agents | jq '.totalAgents'  # illustrative; no swarm runs (returns 0)
 ```
 
 ### Container Development
@@ -454,24 +472,26 @@ curl http://localhost:\${{TF_ADMIN_PORT:-8080}}/ai/compliance/validate
 
 ---
 
-## Production Status Summary
+## Status Summary (design / alpha)
 
-### Operational Capabilities ✅
+### Capability status
 
-- **Claude-Flow v2.0.0**: AI workflow orchestration operational
-- **1,008 AI Agents**: Swarm coordination and task routing
-- **Government Integration**: Harris PACS v12.4.7, Tyler Technologies
-- **Security Framework**: FISMA-compliant with government audit trails
-- **Performance Validated**: 3.9x improvement in government operations
+- **Claude-Flow v2.0.0**: AI workflow orchestration scaffolding *([partial])*
+- **1,008-agent swarm**: designed/target capacity, **not a running runtime** *([target architecture])*
+- **Government integration**: Harris PACS is the legacy source DB *([partial])*; **Tyler is NOT in
+  Benton's stack**
+- **Security framework**: government audit-trail design *([planned])*; FISMA-HIGH is a **posture target**,
+  not an accreditation
+- **Performance**: targets only — **unvalidated** (no measured production results)
 
-### Government Applications ✅
+### Government applications (designed)
 
-- **Property Assessment**: Automated valuation with AI analysis
-- **Revenue Optimization**: 3.9x improvement in opportunity discovery
-- **Compliance Monitoring**: Real-time regulatory validation
-- **Workflow Automation**: 80% reduction in manual processes
-- **Audit Trail Generation**: 100% government compliance documentation
+- **Property Assessment**: automated valuation with AI analysis *([planned])*
+- **Revenue Optimization**: opportunity discovery *([planned])*; the 3.9x figure is a **target, unvalidated**
+- **Compliance Monitoring**: real-time regulatory validation *([planned])*
+- **Workflow Automation**: manual-process reduction *([planned])*
+- **Audit Trail Generation**: government compliance documentation *([planned])*
 
-**Deployment Status**: Production Ready - Government AI Operations  
-**Last Updated**: August 27, 2025  
+**Deployment Status**: Alpha — design/aspirational, not production-accredited  
+**Canon**: see `AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root `README.md` for current truth  
 **Authority**: TerraFusion AI Platform Division

--- a/.ai/claude.md
+++ b/.ai/claude.md
@@ -1,11 +1,21 @@
 # .ai Directory - Claude Development Guide
 
+> **⚠️ Accuracy & status (WO-AI-DOCS-001).** This guide is **design / aspirational alpha**, not a
+> description of a running production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`,
+> `CLAUDE.md`, root `README.md`): the **1,008-agent swarm (and any larger counts) is target
+> architecture, NOT a running runtime** (the runtime-proven AI path is **LocalOps / local-agent**);
+> **FISMA-HIGH is a posture target, not an accreditation**; **Tyler Technologies is NOT in Benton
+> County's stack**; the **3.9x ROI / 95% / 99.9%** figures are **aspirational and unvalidated**; and the
+> TypeScript/JSON samples below are **illustrative design** — several classes, services, vendor versions,
+> and commands are not implemented. Capability labels:
+> **[implemented] · [partial] · [planned] · [target architecture]**.
+
 ## Overview
 
-The `.ai` directory contains the core AI infrastructure for TerraFusion OS,
-including Claude-Flow v2.0.0 integration, AI agent management, and
-government-specific AI workflows. This represents the most advanced AI
-capabilities within the platform, designed for production government operations.
+The `.ai` directory contains the AI-infrastructure **design** for TerraFusion OS — Claude-Flow v2.0.0
+integration scaffolding, AI agent-management design, and government-specific AI workflow designs. It is
+an aspirational architecture for government operations, **not** a description of a running production
+system.
 
 ## Architecture Deep Dive
 
@@ -111,7 +121,7 @@ export class AIAgentManager {
   private performanceMonitor: PerformanceMonitor;
 
   async deployAgentSwarm(config: SwarmConfig): Promise<SwarmDeployment> {
-    // Deploy 1,008 agents across government operations
+    // Designed deployment of the 1,008-agent hierarchy (target architecture — not implemented)
     const agentDistribution = {
       property_assessor: 300, // Property assessment and valuation
       revenue_hunter: 200, // Tax optimization and revenue discovery
@@ -126,9 +136,9 @@ export class AIAgentManager {
     }
 
     return {
-      totalAgents: 50000,
+      totalAgents: 0, // designed capacity 1,008; no swarm runs
       county: config.county,
-      status: 'operational',
+      status: 'not_running', // target architecture, not operational
     };
   }
 
@@ -394,7 +404,7 @@ export class GovernmentIntegrationBridge {
       { properties, county }
     );
 
-    // 3. Tyler Technologies ERP integration
+    // 3. ERP integration (illustrative only — Tyler is NOT in Benton's stack)
     await this.tylerClient.updateAssessments({
       county,
       properties: enhancedProperties,
@@ -541,7 +551,7 @@ describe('Government AI Workflows', () => {
 ```typescript
 interface AISystemMetrics {
   agentHealth: {
-    totalAgents: 50000;
+    totalAgents: number; // designed capacity 1,008; 0 running today
     activeAgents: number;
     errorAgents: number;
     averagePerformance: number;
@@ -689,6 +699,6 @@ export class AIEthicsFramework {
 
 ---
 
-**Classification**: Government AI Infrastructure - Production Ready  
-**Last Updated**: August 27, 2025  
+**Classification**: Government AI Infrastructure — **design / alpha** (not production-accredited)  
+**Canon**: see `AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root `README.md` for current truth  
 **Version**: Claude-Flow v2.0.0-alpha / TerraFusion OS 1.0

--- a/.ai/index.md
+++ b/.ai/index.md
@@ -1,12 +1,20 @@
 # TerraFusion .ai Directory Index
 
+> **⚠️ Accuracy & status (WO-AI-DOCS-001).** This index describes **design / aspirational alpha**, not a
+> running production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root
+> `README.md`): the **1,008-agent swarm is target architecture, NOT a running runtime** (the
+> runtime-proven AI path is **LocalOps / local-agent**); **FISMA-HIGH is a posture target, not an
+> accreditation**; **Tyler Technologies is NOT in Benton County's stack**; and the **3.9x ROI / 95% /
+> 99.9%** figures are **aspirational and unvalidated**. Capability labels:
+> **[implemented] · [partial] · [planned] · [target architecture]**.
+
 ## Directory Overview
 
 **Location**: `/.ai/`  
-**Purpose**: Advanced AI infrastructure, Claude-Flow integration, and government
-AI orchestration  
-**Classification**: Core AI Platform Infrastructure  
-**Security Level**: Government-Grade AI Operations
+**Purpose**: AI infrastructure design — Claude-Flow integration scaffolding and government AI
+orchestration *(design / alpha)*  
+**Classification**: AI platform design docs — **not** a description of a running system  
+**Status**: Alpha — design/aspirational, not production-accredited
 
 ## Architecture Summary
 
@@ -32,21 +40,21 @@ AI orchestration
 
 ### Key Capabilities
 
-- **AI Suite Architecture**: 1,008 agents across 32 government modules
-- **Claude-Flow Integration**: v2.0.0 AI workflow orchestration
-- **Model Context Protocol**: Advanced AI tool integration
-- **Government AI Training**: Custom model development for public sector
-- **Workflow Automation**: Property assessment, compliance, revenue optimization
+- **AI Suite Architecture**: designed 1,008-agent hierarchy across 32 government modules *([target architecture])*
+- **Claude-Flow Integration**: v2.0.0 AI workflow orchestration scaffolding *([partial])*
+- **Model Context Protocol**: AI tool integration *([partial])*
+- **Government AI Training**: custom model development for public sector *([planned])*
+- **Workflow Automation**: property assessment, compliance, revenue optimization *([planned])*
 
 ## Core AI Infrastructure
 
 ### AI Suite Architecture (11KB Documentation)
 
-- **Swarm Orchestration**: 1,008 AI agents across Tier 1-3 modules
-- **Agent Distribution**: Revenue hunters, assessors, compliance monitors
-- **Government Integration**: Harris PACS, Tyler Technologies, legacy systems
-- **Performance Monitoring**: Real-time agent health and efficiency tracking
-- **ROI Framework**: Realistic 3.9x performance improvements (validated)
+- **Swarm Orchestration**: designed 1,008-agent hierarchy across Tier 1-3 modules *([target architecture]; not running)*
+- **Agent Distribution**: revenue hunters, assessors, compliance monitors *(designed)*
+- **Government Integration**: Harris PACS (legacy source DB; [partial]); **Tyler is NOT in Benton's stack**
+- **Performance Monitoring**: real-time agent health and efficiency tracking *([planned])*
+- **ROI Framework**: 3.9x performance improvement is a **target, unvalidated** (not measured)
 
 ### AI Training Platform (12KB Documentation)
 
@@ -137,7 +145,7 @@ docker build -f claude-flow/Dockerfile.dev -t claude-flow-dev .
 
 - **Workflow Orchestration**: Government process automation
 - **AI Tool Integration**: MCP protocol implementation
-- **Legacy System Bridges**: Harris PACS, Tyler Technologies
+- **Legacy System Bridges**: Harris PACS (legacy source DB; [partial]) — **Tyler is NOT in Benton's stack**
 - **Audit Trail Management**: Complete AI decision tracking
 
 ## Government AI Applications
@@ -251,20 +259,20 @@ interface AIGovernance {
 
 ## Performance Metrics
 
-### AI System Performance
+### AI System Performance *(targets — unvalidated)*
 
-- **Response Time**: <100ms average AI inference
-- **Throughput**: 1,000+ concurrent AI operations
-- **Availability**: 99.9% uptime target
-- **Accuracy**: 95%+ AI decision accuracy rate
-- **Cost Efficiency**: 60% reduction in manual processing costs
+- **Response Time**: <100ms average AI inference *(target)*
+- **Throughput**: 1,000+ concurrent AI operations *(target)*
+- **Availability**: 99.9% uptime *(target, unvalidated)*
+- **Accuracy**: 95%+ AI decision accuracy *(target, unvalidated)*
+- **Cost Efficiency**: 60% reduction in manual processing costs *(target, unvalidated)*
 
-### Government Workload Metrics
+### Government Workload Targets *(unvalidated)*
 
-- **Property Assessment**: 500 parcels/hour automated processing
-- **Compliance Monitoring**: Real-time regulatory validation
-- **Revenue Discovery**: 3.9x improvement in revenue identification
-- **Workflow Automation**: 80% reduction in manual government processes
+- **Property Assessment**: 500 parcels/hour automated processing *(target)*
+- **Compliance Monitoring**: real-time regulatory validation *([planned])*
+- **Revenue Discovery**: 3.9x improvement in revenue identification *(target, unvalidated)*
+- **Workflow Automation**: 80% reduction in manual government processes *(target, unvalidated)*
 
 ## Deployment and Operations
 
@@ -310,7 +318,7 @@ npm run test:compliance
 
 ### AI System Monitoring
 
-- **Agent Health**: Real-time 1,008 agent status monitoring
+- **Agent Health**: real-time agent status monitoring for the designed 1,008-agent hierarchy *([planned]; no swarm runs)*
 - **Model Performance**: AI model accuracy and speed metrics
 - **Resource Usage**: CPU, memory, and GPU utilization tracking
 - **Integration Health**: Legacy system connectivity monitoring


### PR DESCRIPTION
## WO-AI-DOCS-001 — .ai/ truth sweep (docs-only)

The three top-level `.ai` docs described a **running production AI system that does not exist**. Aligned all three to repo canon (`AGENTS.md` / `AGENT_OPERATING_MODEL.md` / `CLAUDE.md` / root `README.md`) with a consistent four-tier vocabulary: **[implemented] · [partial] · [planned] · [target architecture]**.

### Files (3, the approved scope)
`.ai/README.md`, `.ai/index.md`, `.ai/claude.md`

### What changed
- **Truth banner** at the top of each file recontextualizing the whole doc as design/aspirational alpha + pointing to canon.
- **Status badges** `Production Operational/Ready ✅` → **Alpha — design/aspirational, not production-accredited**.
- **1,008 / 50,000 'operational' swarm** → **designed/target capacity, NOT a running runtime** (LocalOps/local-agent is the real proven path). `grep -E '50000|50,000'` now **clean** across all three.
- **'FISMA-Ready/compliant'** → FISMA-HIGH **posture target**, not an accreditation.
- **Tyler Technologies live-integration** claims removed/neutralized (**Tyler is NOT in Benton's stack**) — headlines + the one borderline code comment; remaining vendor tokens live only in illustrative, banner-covered code samples.
- **3.9x ROI / 95% / 99.9%** → marked **target/unvalidated** (or removed).
- **Non-existent commands** (`npm run deploy:swarm`, `--agents=1008`, "Should return 50000") marked illustrative.

### Acceptance (verified)
✓ no `50000` anywhere · ✓ no fabricated operational/production headline badges · ✓ banner on all three · ✓ 1,008 only as designed/target capacity · ✓ Tyler live-integration removed · ✓ metrics marked unvalidated · ✓ docs-only (diff = the 3 files). Pre-commit + pre-push gates passed (security audit green).

### Out of scope
Other `.ai/**` docs (`AI_SUITE_ARCHITECTURE.md`, `AI_TRAINING_PLATFORM.md`, `AI_WORKFLOW_ENGINE.md`, `Cloud Coach.md`, `claude-flow/**`) → candidate **WO-AI-DOCS-002**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)