### PR TITLE
docs(ai): WO-AI-DOCS-002 — broader .ai truth sweep (4 docs align to canon)

### DIFF
--- a/.ai/AI_SUITE_ARCHITECTURE.md
+++ b/.ai/AI_SUITE_ARCHITECTURE.md
@@ -1,18 +1,25 @@
-# TerraFusion OS 1.0/2.0 - Comprehensive .ai Suite Architecture
+# TerraFusion OS 1.0/2.0 - .ai Suite Architecture (Design / Alpha)
+
+> **⚠️ Accuracy & status (WO-AI-DOCS-002).** This is a **design / aspirational alpha** architecture, not
+> a running production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root
+> `README.md`): the **agent swarm (1,008 designed; larger figures are aspirational) is target
+> architecture, NOT a running runtime** (the runtime-proven AI path is **LocalOps / local-agent**);
+> **FISMA-HIGH is a posture target, not an accreditation**; **Tyler / Tyler Vision is NOT in Benton
+> County's stack**; and **3.9x ROI / 95% / 99.9%** figures are **aspirational and unvalidated**.
+> Capability labels: **[implemented] · [partial] · [planned] · [target architecture]**.
 
 ## Overview
 
-The TerraFusion .ai Suite is a comprehensive artificial intelligence platform
-designed specifically for government operations, providing advanced AI
-capabilities for revenue discovery, property assessment, compliance monitoring,
-and operational optimization.
+The TerraFusion .ai Suite is an artificial-intelligence platform **design** for government operations —
+covering revenue discovery, property assessment, compliance monitoring, and operational optimization. It
+is aspirational architecture, **not** a description of a running production system.
 
 ## Core Architecture
 
 ### 1. AI Agent Management System
 
-- **Swarm Orchestration Engine**: Manages 50,000+ AI agents across 32 government
-  modules
+- **Swarm Orchestration Engine**: designed to manage the 1,008-agent hierarchy across 32 government
+  modules *([target architecture]; no swarm runs today — larger counts here were aspirational)*
 - **Agent Lifecycle Management**: Deployment, monitoring, scaling, and
   retirement
 - **Task Distribution**: Intelligent workload balancing across agent pools
@@ -45,11 +52,11 @@ and operational optimization.
 - **Revenue Discovery Analytics**: Track discovered opportunities and collection
   rates
 - **Predictive Insights**: Forecasting and trend analysis
-- **ROI Tracking**: Realistic 3.9x performance improvements (not 379x quantum
-  claims)
+- **ROI Tracking**: a 3.9x performance-improvement **target** *(unvalidated; not a measured result)*
 - **Module Performance**: Individual module AI performance tracking across all
   32 modules
-- **Legacy System Integration**: Harris PACS, Tyler, Aumentum, Vision system AI
+- **Legacy System Integration**: Harris PACS (the legacy source DB; [partial]) and Aumentum where
+  applicable. **Tyler / Tyler Vision is NOT in Benton's stack** — not a live integration.
   analytics
 
 ### 5. AI Training Platform
@@ -254,18 +261,20 @@ metadata:
 
 ## Success Metrics
 
-### Business Impact
+### Business Impact (targets — unvalidated)
 
-- **Revenue Discovery**: $50M+ additional revenue identified annually
-- **Cost Savings**: 60% reduction in manual processing costs
-- **Efficiency Gains**: 10x improvement in processing speed
-- **Accuracy Improvement**: 95%+ accuracy in AI-powered assessments
+> The figures below are **design goals**, not measured results.
 
-### Technical Performance
+- **Revenue Discovery**: $50M+ additional revenue identified annually *(target, unvalidated)*
+- **Cost Savings**: 60% reduction in manual processing costs *(target, unvalidated)*
+- **Efficiency Gains**: 10x improvement in processing speed *(target, unvalidated)*
+- **Accuracy Improvement**: 95%+ accuracy in AI-powered assessments *(target, unvalidated)*
 
-- **Uptime**: 99.9% system availability
-- **Response Time**: <100ms for critical operations
-- **Throughput**: 1M+ transactions per hour
+### Technical Performance (targets — unvalidated)
+
+- **Uptime**: 99.9% system availability *(target, unvalidated)*
+- **Response Time**: <100ms for critical operations *(target)*
+- **Throughput**: 1M+ transactions per hour *(target)*
 - **Scalability**: Linear scaling to 10x current capacity
 
 ### User Satisfaction

--- a/.ai/AI_TRAINING_PLATFORM.md
+++ b/.ai/AI_TRAINING_PLATFORM.md
@@ -1,11 +1,17 @@
-# TerraFusion AI Training Platform
+# TerraFusion AI Training Platform (Design / Alpha)
+
+> **⚠️ Accuracy & status (WO-AI-DOCS-002).** This is a **design / aspirational alpha**, not a running
+> production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root
+> `README.md`): **FISMA-HIGH is a posture target, not an accreditation**, and accuracy/reliability
+> figures (**95% / 99.9%**) are **aspirational and unvalidated**. The runtime-proven AI path today is
+> **LocalOps / local-agent**. Capability labels:
+> **[implemented] · [partial] · [planned] · [target architecture]**.
 
 ## Overview
 
-The AI Training Platform enables government agencies to develop, train, and
-deploy custom AI models tailored to their specific needs and data. It provides
-comprehensive tools for data preparation, model training, validation, and
-deployment with government-grade security and compliance.
+The AI Training Platform is a **design** for government agencies to develop, train, and deploy custom AI
+models — data preparation, model training, validation, and deployment. It is aspirational architecture,
+**not** a description of a running production system.
 
 ## Core Capabilities
 
@@ -358,23 +364,25 @@ class FederatedTraining:
 
 ## Success Metrics
 
-### Technical Performance
+### Technical Performance (targets — unvalidated)
 
-- **Training Efficiency**: 50% reduction in training time through optimization
-- **Model Accuracy**: 95%+ accuracy for government-specific models
-- **Deployment Speed**: Deploy new models in under 24 hours
-- **Resource Utilization**: 80%+ GPU utilization during training
+> Design goals, not measured results.
 
-### Business Impact
+- **Training Efficiency**: 50% reduction in training time through optimization *(target)*
+- **Model Accuracy**: 95%+ accuracy for government-specific models *(target, unvalidated)*
+- **Deployment Speed**: Deploy new models in under 24 hours *(target)*
+- **Resource Utilization**: 80%+ GPU utilization during training *(target)*
 
-- **Custom Model Development**: 20+ jurisdiction-specific models deployed
-- **Performance Improvement**: 25% improvement over generic models
-- **Cost Savings**: 60% reduction in external AI service costs
-- **Time to Value**: 90% reduction in time from data to deployed model
+### Business Impact (targets — unvalidated)
 
-### Operational Excellence
+- **Custom Model Development**: 20+ jurisdiction-specific models *(target)*
+- **Performance Improvement**: 25% improvement over generic models *(target, unvalidated)*
+- **Cost Savings**: 60% reduction in external AI service costs *(target, unvalidated)*
+- **Time to Value**: 90% reduction in time from data to deployed model *(target)*
 
-- **System Reliability**: 99.9% uptime for training infrastructure
-- **Security Incidents**: Zero security breaches or data leaks
-- **Compliance Rate**: 100% compliance with government regulations
+### Operational Excellence (targets — unvalidated)
+
+- **System Reliability**: 99.9% uptime for training infrastructure *(target, unvalidated)*
+- **Security Incidents**: zero breaches *(target — FISMA-HIGH is a posture target, not accredited)*
+- **Compliance Rate**: government-regulation compliance *(target; no measured rate)*
 - **User Satisfaction**: 4.5+ star rating from government data scientists

--- a/.ai/AI_WORKFLOW_ENGINE.md
+++ b/.ai/AI_WORKFLOW_ENGINE.md
@@ -1,11 +1,18 @@
-# TerraFusion AI Workflow Engine
+# TerraFusion AI Workflow Engine (Design / Alpha)
+
+> **⚠️ Accuracy & status (WO-AI-DOCS-002).** This is a **design / aspirational alpha**, not a running
+> production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root
+> `README.md`): the AI agent swarm is **target architecture, NOT a running runtime** (the runtime-proven
+> AI path is **LocalOps / local-agent**); **FISMA-HIGH is a posture target, not an accreditation**;
+> **Tyler is NOT in Benton County's stack**; and reliability/accuracy figures (**99.9% / 95%**) are
+> **aspirational and unvalidated**. Capability labels:
+> **[implemented] · [partial] · [planned] · [target architecture]**.
 
 ## Overview
 
-The AI Workflow Engine automates complex government processes through
-intelligent orchestration of AI agents, human approvals, and system
-integrations. It provides visual workflow design, automated execution, and
-comprehensive monitoring for government operations.
+The AI Workflow Engine is a **design** for automating government processes through orchestration of AI
+agents, human approvals, and system integrations — visual workflow design, automated execution, and
+monitoring. It is aspirational architecture, **not** a description of a running production system.
 
 ## Core Components
 
@@ -237,10 +244,10 @@ workflow:
 
 ### Performance Specifications
 
-- **Throughput**: Process 10,000+ workflows per hour
-- **Latency**: Sub-second workflow step execution
-- **Scalability**: Linear scaling to 100x current capacity
-- **Reliability**: 99.9% uptime with automatic failover
+- **Throughput**: Process 10,000+ workflows per hour *(target)*
+- **Latency**: Sub-second workflow step execution *(target)*
+- **Scalability**: Linear scaling to 100x current capacity *(target)*
+- **Reliability**: 99.9% uptime with automatic failover *(target, unvalidated)*
 
 ### Disaster Recovery
 
@@ -249,14 +256,16 @@ workflow:
 - **Failover Mechanisms**: Automatic switching to backup systems
 - **Business Continuity**: Maintain operations during system failures
 
-## Success Metrics
+## Success Metrics (targets — unvalidated)
 
-### Operational Efficiency
+> The figures in this section are **design goals**, not measured results.
 
-- **Process Automation**: 80% reduction in manual processing time
-- **Error Reduction**: 95% decrease in human errors
-- **Throughput Increase**: 10x improvement in process capacity
-- **Cost Savings**: 60% reduction in operational costs
+### Operational Efficiency *(targets)*
+
+- **Process Automation**: 80% reduction in manual processing time *(target, unvalidated)*
+- **Error Reduction**: 95% decrease in human errors *(target, unvalidated)*
+- **Throughput Increase**: 10x improvement in process capacity *(target, unvalidated)*
+- **Cost Savings**: 60% reduction in operational costs *(target, unvalidated)*
 
 ### Government Impact
 
@@ -265,9 +274,9 @@ workflow:
 - **Compliance Improvement**: Enhanced regulatory compliance rates
 - **Transparency**: Improved visibility into government processes
 
-### Technical Performance
+### Technical Performance *(targets — unvalidated)*
 
-- **System Reliability**: 99.9% uptime and availability
-- **Response Time**: <100ms for critical workflow operations
-- **Scalability**: Support for 1000+ concurrent workflows
-- **Integration Success**: 95% successful integration with external systems
+- **System Reliability**: 99.9% uptime and availability *(target, unvalidated)*
+- **Response Time**: <100ms for critical workflow operations *(target)*
+- **Scalability**: Support for 1000+ concurrent workflows *(target)*
+- **Integration Success**: 95% successful integration with external systems *(target, unvalidated)*

--- a/.ai/claude-flow/README.md
+++ b/.ai/claude-flow/README.md
@@ -1,10 +1,18 @@
-# 🌊 Claude-Flow v2.0.0 Alpha Integration
+# 🌊 Claude-Flow v2.0.0 Alpha Integration (Design / Alpha)
 
-## TerraFusion OS - Government. Transcended.
+> **⚠️ Accuracy & status (WO-AI-DOCS-002).** This is **design / aspirational alpha**, not a running
+> production system. Per repo canon (`AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root
+> `README.md`): the AI agent swarm (**1,008 designed; larger counts are aspirational**) is **target
+> architecture, NOT a running runtime** (the runtime-proven AI path is **LocalOps / local-agent**);
+> **FISMA-HIGH is a posture target, not an accreditation** (no measured compliance rate); **Tyler is NOT
+> in Benton County's stack**. Capability labels:
+> **[implemented] · [partial] · [planned] · [target architecture]**.
 
-This directory contains the complete Claude-Flow v2.0.0 Alpha integration with
-TerraFusion OS, providing revolutionary AI orchestration capabilities for
-government operations.
+## TerraFusion OS — Claude-Flow integration (design)
+
+This directory contains the Claude-Flow v2.0.0 Alpha integration **design** for TerraFusion OS — AI
+orchestration scaffolding for government operations. It is aspirational architecture, **not** a running
+production system.
 
 ## 📁 Directory Structure
 
@@ -107,32 +115,34 @@ npx claude-flow@alpha hive-mind wizard
 - `harris_pacs_sync`, `revenue_discovery`, `property_assessment`
 - `compliance_check`, `jurisdiction_isolate`, `audit_trail_create`
 
-## 📊 Performance Metrics
+## 📊 Performance Targets (aspirational — unvalidated)
 
-- **Total AI Agents**: 50,240+ (50,000 TerraFusion + 240 Claude-Flow)
-- **Neural Models**: 27+ cognitive models with government specialization
-- **Memory Tables**: 12 specialized government data tables
-- **Processing Speed**: 2.8-4.4x improvement through hive-mind coordination
-- **Cost Reduction**: 32.3% token reduction through intelligent task
-  distribution
+> Design goals, not measured results.
 
-## 🛡️ Government Compliance
+- **AI Agents**: 1,008-agent hierarchy is the design target *([target architecture]; no swarm runs —
+  larger counts here were aspirational)*
+- **Neural Models**: 27+ cognitive models *(planned)*
+- **Memory Tables**: 12 specialized government data tables *(design)*
+- **Processing Speed**: 2.8-4.4x improvement target *(unvalidated)*
+- **Cost Reduction**: 32.3% token-reduction target *(unvalidated)*
 
-- ✅ County-level data isolation and sovereignty
-- ✅ FISMA compliance (95%+ compliance rate)
-- ✅ Comprehensive audit trails for all AI decisions
-- ✅ Neural pattern security with encryption
-- ✅ Role-based access control with government-grade security
+## 🛡️ Government Compliance (design targets)
+
+- **County-level data isolation and sovereignty** *([planned])*
+- **FISMA** — posture **target**, not an accreditation; there is **no measured compliance rate**
+- **Audit trails for AI decisions** *([planned])*
+- **Security with encryption** *([planned])*
+- **Role-based access control** *([planned])*
 
 ## 🎯 Benton County Deployment
 
-**Status**: ✅ **PRODUCTION READY**
+**Status**: Alpha — design/aspirational, **not** production-accredited
 
-- **Parcel Count**: 89,247 parcels supported
-- **Harris PACS**: v12.4.7 integration certified
-- **Revenue Target**: $10.1M annual increase identified
-- **ROI**: 2,700%+ in Year 1
-- **Performance**: 379M× quantum speedup validated
+- **Parcel Count**: 89,247 real Benton County parcels *([implemented] data)*
+- **Harris PACS**: legacy source DB; integration is *([partial])* — not "certified"
+- **Revenue Target**: $10.1M annual increase *(target, unvalidated)*
+- **ROI**: Year-1 ROI figure is a **target, unvalidated**
+- **Performance**: "quantum speedup" claims are **not real** — removed as fabricated
 
 ## 📞 Support
 
@@ -153,4 +163,5 @@ npx claude-flow@alpha update --government-mode
 
 ---
 
-**Government. Transcended.**
+**Status**: design / aspirational alpha — not production-accredited.  
+**Canon**: `AGENTS.md`, `AGENT_OPERATING_MODEL.md`, `CLAUDE.md`, root `README.md`.


### PR DESCRIPTION
## WO-AI-DOCS-002 — broader .ai/** truth sweep (docs-only)

Continues DOCS-001 (#976). The four remaining stale-claim `.ai` docs now align to repo canon (`AGENTS.md` / `AGENT_OPERATING_MODEL.md` / `CLAUDE.md` / root `README.md`) with the same four-tier vocabulary: **[implemented] · [partial] · [planned] · [target architecture]**.

### Files (4, the approved scope)
`AI_SUITE_ARCHITECTURE.md`, `AI_WORKFLOW_ENGINE.md`, `claude-flow/README.md`, `AI_TRAINING_PLATFORM.md`

### What changed
- **Truth banner** at the top of each of the four files.
- Status badges `PRODUCTION READY` / `Government. Transcended.` → **Alpha — design/aspirational, not production-accredited**.
- **50,000 / 50,240 'operational' swarm** → designed **1,008-agent target capacity**, NOT a running runtime.
- **'FISMA compliance (95%+ rate)'** → FISMA-HIGH **posture target**, no measured compliance rate.
- **Tyler / Tyler Vision** live-integration → removed (**NOT in Benton's stack**).
- **3.9x / 95% / 99.9% / $50M / 2,700% ROI** → marked **target/unvalidated**; the fabricated **"379M× quantum speedup validated"** claim **removed outright**.

### Acceptance (verified)
✓ banner in all 4 · ✓ no production/operational badges · ✓ 1,008 only as designed/target capacity · ✓ Tyler removed · ✓ metrics marked unvalidated · ✓ docs-only (diff = the 4 files). **`grep -E '50000|50,000'` now matches ONLY the legitimate `estimated_value > 500000` (00k property-value threshold in a workflow condition — a dollar amount, not an agent count; documented benign).**

### Out of scope
`.ai/Cloud Coach.md` (already clean, untouched); all `claude-flow` **code** (`.ts`/`.json`/`.sh`/Dockerfile); the DOCS-001 trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)