### PR TITLE
fix(workbench): enforce live/deferred lane scope truth

### DIFF
--- a/frontend/apps/os-shell/src/config/workbenchLiveScope.ts
+++ b/frontend/apps/os-shell/src/config/workbenchLiveScope.ts
@@ -1,0 +1,103 @@
+export type WorkbenchLiveScopeClassification = 'LIVE-NOW' | 'DEFERRED';
+
+export type WorkbenchWeakLane =
+  | 'pilot'
+  | 'dais-permits'
+  | 'forge-income'
+  | 'atlas-enrichment-layers'
+  | 'clerk-title-chain'
+  | 'parcel-specific-audit';
+
+export interface WorkbenchLiveScopeDecision {
+  lane: WorkbenchWeakLane;
+  intendedProductRole: string;
+  intendedBackendContract: string;
+  currentRuntimeStatus: 'partial' | 'unavailable' | 'not-live' | 'thin';
+  uiAheadOfBackend: boolean;
+  blockerType:
+    | 'missing projection'
+    | 'parcel-dependent data gap'
+    | 'stale/stub runtime'
+    | 'wrong product expectation'
+    | 'not in current scope';
+  classification: WorkbenchLiveScopeClassification;
+  rationale: string;
+  smallestSafeAction: string;
+}
+
+export const WORKBENCH_LIVE_SCOPE_DECISIONS: WorkbenchLiveScopeDecision[] = [
+  {
+    lane: 'pilot',
+    intendedProductRole: 'Parcel-scoped governed tool invocation and trace review.',
+    intendedBackendContract: '/pilot/tools, /pilot/invoke, /pilot/traces backed by the dedicated Pilot runtime.',
+    currentRuntimeStatus: 'not-live',
+    uiAheadOfBackend: true,
+    blockerType: 'stale/stub runtime',
+    classification: 'DEFERRED',
+    rationale: 'The dedicated Pilot runtime is offline; the .NET fallback can only disclose not-live status.',
+    smallestSafeAction: 'Keep Pilot visibly not-live until the dedicated runtime is started and verified across the parcel matrix.',
+  },
+  {
+    lane: 'dais-permits',
+    intendedProductRole: 'Parcel permit history and assessment-impact workflow.',
+    intendedBackendContract: '/api/dais/permits?parcelId={parcelId} with governed permit records projected by parcel.',
+    currentRuntimeStatus: 'not-live',
+    uiAheadOfBackend: true,
+    blockerType: 'missing projection',
+    classification: 'DEFERRED',
+    rationale: 'Permit records are not projected into the governed Dais store.',
+    smallestSafeAction: 'Keep permit lane labeled not-live:permit-records-not-projected until a real permit projection exists.',
+  },
+  {
+    lane: 'forge-income',
+    intendedProductRole: 'Income approach valuation for parcels with real income data.',
+    intendedBackendContract: '/api/forge/{parcelId}/income backed by actual parcel income records or an explicit not-applicable result.',
+    currentRuntimeStatus: 'unavailable',
+    uiAheadOfBackend: true,
+    blockerType: 'parcel-dependent data gap',
+    classification: 'DEFERRED',
+    rationale: 'The selected real parcel matrix returned no income records; default cap-rate math is not production income support.',
+    smallestSafeAction: 'Keep income marked deferred/unavailable unless a parcel has real income records.',
+  },
+  {
+    lane: 'atlas-enrichment-layers',
+    intendedProductRole: 'Zoning, flood, tax area, and land-class enrichment over live parcel geometry.',
+    intendedBackendContract: '/api/atlas/gis/parcels/{parcelId}/layers with per-layer source and availability.',
+    currentRuntimeStatus: 'unavailable',
+    uiAheadOfBackend: true,
+    blockerType: 'parcel-dependent data gap',
+    classification: 'DEFERRED',
+    rationale: 'Geometry is live for many parcels, but enrichment layers remain unavailable or partial across the matrix.',
+    smallestSafeAction: 'Keep enrichment overlays visibly deferred/unavailable while preserving live geometry.',
+  },
+  {
+    lane: 'clerk-title-chain',
+    intendedProductRole: 'Parcel title-chain history and current-owner trace.',
+    intendedBackendContract: '/api/clerk/parcels/{parcelId}/title-chain backed by projected title-chain entries.',
+    currentRuntimeStatus: 'thin',
+    uiAheadOfBackend: true,
+    blockerType: 'missing projection',
+    classification: 'DEFERRED',
+    rationale: 'Recording summary is live, but title-chain records are not projected for the sampled parcels.',
+    smallestSafeAction: 'Keep title-chain marked not-live/thin and reject fake parcels until title-chain projection exists.',
+  },
+  {
+    lane: 'parcel-specific-audit',
+    intendedProductRole: 'Parcel-specific audit findings, roll compliance, and cross-office reconciliation.',
+    intendedBackendContract: 'Parcel-aware audit endpoints or tools with parcel-specific findings and evidence.',
+    currentRuntimeStatus: 'partial',
+    uiAheadOfBackend: true,
+    blockerType: 'wrong product expectation',
+    classification: 'DEFERRED',
+    rationale: 'Current audit contracts are county/static controls with parcel context, not true parcel-specific audit proof.',
+    smallestSafeAction: 'Keep Audit labeled as county controls with parcel context until parcel-specific audit backend exists.',
+  },
+];
+
+export function getWorkbenchLiveScopeDecision(lane: WorkbenchWeakLane): WorkbenchLiveScopeDecision {
+  const decision = WORKBENCH_LIVE_SCOPE_DECISIONS.find((item) => item.lane === lane);
+  if (!decision) {
+    throw new Error(`Unknown Workbench live-scope lane: ${lane}`);
+  }
+  return decision;
+}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -32,6 +32,7 @@ import {
   useParcelLayers,
   type AtlasGisSource,
 } from '../../../hooks/useAtlasGis';
+import { getWorkbenchLiveScopeDecision } from '../../../config/workbenchLiveScope';
 import LayerWorksModule from '../../suites/modules/LayerWorksModule';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
@@ -285,6 +286,7 @@ function gisSourceToDisclosure(
 
 export const PropertyAtlas: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
+  const enrichmentScope = getWorkbenchLiveScopeDecision('atlas-enrichment-layers');
   const activeParcel = usePropertyStore((s) => s.activeParcel);
 
   // Live GIS hooks
@@ -749,6 +751,20 @@ export const PropertyAtlas: React.FC = () => {
       {/* ── Source disclosure: Workbench hosts the live Atlas GIS and LayerWorks parcel workflow ── */}
       <div className="text-[11px] tf-text-dim px-2" data-testid="atlas-geometry-disclosure">
         Workbench hosts live Atlas GIS parcel geometry when available. Enrichment layers are shown only when returned by county services.
+      </div>
+
+      <div
+        className="tf-status-warning rounded-xl p-4"
+        data-testid="atlas-enrichment-deferred-disclosure"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="tf-text font-semibold">Atlas enrichment layers are deferred for production scope.</p>
+            <p className="tf-text-secondary text-sm mt-1">{enrichmentScope.rationale}</p>
+            <p className="tf-text-dim text-xs mt-2">{enrichmentScope.smallestSafeAction}</p>
+          </div>
+          <span className="tf-badge tf-badge-warning shrink-0">Deferred</span>
+        </div>
       </div>
 
       {/* ── Live GIS Layer Data ─────────────────────────────── */}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyForge.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyForge.tsx
@@ -129,8 +129,7 @@ export const PropertyForge: React.FC = () => {
 
       <div className="flex items-center justify-between gap-3" data-testid="forge-baseline-disclosure">
         <p className="text-xs tf-text-dim">
-          Cost, comp, and income approaches are requested via governed tooling;
-          values shown are returned from the live workbench API.
+          Cost and comp approaches are requested via governed tooling. Income remains explicitly deferred unless real parcel income records are present.
         </p>
         <WorkbenchSourceBadge source={forgeProbe.source} />
       </div>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx
@@ -17,6 +17,7 @@ import { WorkbenchSourceBadge } from '../../../../components/workbench/Workbench
 import { IncomeValuationPanel } from '../../../../components/workbench/IncomeValuationPanel';
 import { DcfPanel } from '../../income/DcfPanel';
 import { useIncomeApproach as useIncomeApproachAPI } from '../../../../hooks/forge/useForgeValuation';
+import { getWorkbenchLiveScopeDecision } from '../../../../config/workbenchLiveScope';
 import {
   type ForgeSubTabProps,
   type IncomeResult,
@@ -57,6 +58,7 @@ export const IncomeApproach: React.FC<ForgeSubTabProps> = ({
   onValueIndicated,
 }) => {
   const { parcelId } = useWorkbenchTab();
+  const incomeScope = getWorkbenchLiveScopeDecision('forge-income');
 
   /* ── Live API data ──────────────────────────────────────── */
   const incomeAPI = useIncomeApproachAPI(parcelId, taxYear);
@@ -163,6 +165,20 @@ export const IncomeApproach: React.FC<ForgeSubTabProps> = ({
 
   return (
     <div className="space-y-4" style={{ overflow: 'hidden' }}>
+      <div
+        className="tf-status-warning rounded-xl p-4"
+        data-testid="forge-income-deferred-disclosure"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="tf-text font-semibold">Income approach is deferred for production scope.</p>
+            <p className="tf-text-secondary text-sm mt-1">{incomeScope.rationale}</p>
+            <p className="tf-text-dim text-xs mt-2">{incomeScope.smallestSafeAction}</p>
+          </div>
+          <WorkbenchSourceBadge source="unavailable" />
+        </div>
+      </div>
+
       {/* Live Income Approach Data */}
       <BentoCard
         title="&#128176; Income Approach Summary"

--- a/os-platform/core/tests/workbench-live-scope-contract.test.mjs
+++ b/os-platform/core/tests/workbench-live-scope-contract.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..');
+const read = (relativePath) => readFileSync(join(repoRoot, relativePath), 'utf8');
+
+test('weak Workbench lanes have explicit live-scope decisions', () => {
+  const configPath = 'frontend/apps/os-shell/src/config/workbenchLiveScope.ts';
+  assert.equal(existsSync(join(repoRoot, configPath)), true, 'workbenchLiveScope.ts must exist');
+
+  const config = read(configPath);
+  for (const lane of [
+    'pilot',
+    'dais-permits',
+    'forge-income',
+    'atlas-enrichment-layers',
+    'clerk-title-chain',
+    'parcel-specific-audit',
+  ]) {
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'`), `${lane} missing from live-scope config`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*classification:\\s*'DEFERRED'`), `${lane} must be explicitly DEFERRED`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*blockerType:`), `${lane} needs blockerType`);
+    assert.match(config, new RegExp(`lane:\\s*'${lane}'[\\s\\S]*smallestSafeAction:`), `${lane} needs smallestSafeAction`);
+  }
+
+  assert.doesNotMatch(config, /classification:\s*'LIVE-NOW'/);
+});
+
+test('deferred lanes have visible Workbench honesty labels', () => {
+  const pilot = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx');
+  const dais = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDais.tsx');
+  const income = read('frontend/apps/os-shell/src/pages/workbench/tabs/forge/IncomeApproach.tsx');
+  const atlas = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx');
+  const clerk = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx');
+  const audit = read('frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx');
+
+  assert.match(pilot, /pilot-runtime-not-live/);
+  assert.match(dais, /dais-permits-lane-disclosure/);
+  assert.match(income, /forge-income-deferred-disclosure/);
+  assert.match(atlas, /atlas-enrichment-deferred-disclosure/);
+  assert.match(clerk, /Title-chain records are not projected/);
+  assert.match(audit, /audit-parcel-specific-disclosure/);
+});


### PR DESCRIPTION
This PR is the Workbench live/deferred scope layer on top of the already-merged June 10 Workbench foundation.

It does not complete the flagship Property Workbench.
It enforces the truthful boundary for which Workbench lanes are live now and which are deferred.

Scope:
- adds `workbenchLiveScope.ts`
- adds visible deferred-lane disclosures for the weak lanes
- adds the live-scope contract test
- keeps Atlas geometry distinct from Atlas enrichment scope

This PR does not include host/window routing repairs, backend endpoint repairs, county posture work, Forge expansion, or product-runtime completion claims.
