### PR TITLE
test(ci): stabilize OpenTelemetry null tracer timing

### DIFF
--- a/backend/tests/TerraFusion.Integration.Tests/Phase36/OpenTelemetryDistributedTracingTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/Phase36/OpenTelemetryDistributedTracingTests.cs
@@ -746,19 +746,28 @@ public class OpenTelemetryDistributedTracingTests : IDisposable
         // Arrange
         var nullTracer = NullTerraFusionTracer.Instance;
         Activity? span = null;
+        var exception = new Exception("test");
+        const int iterations = 1000;
+        const int operationsPerIteration = 6;
 
-        // Act - these should all be no-ops
+        // Act - these should all be no-ops. Use many iterations so CI scheduler
+        // jitter does not turn a single tiny measurement window into a false failure.
         var stopwatch = Stopwatch.StartNew();
-        nullTracer.SetAttribute(span, TracingConstants.Attributes.CountyId, "test");
-        nullTracer.SetAttribute(span, TracingConstants.Attributes.DocumentCount, 5);
-        nullTracer.SetAttribute(span, TracingConstants.Attributes.UsesRag, true);
-        nullTracer.SetStatus(span, ActivityStatusCode.Ok);
-        nullTracer.RecordException(span, new Exception("test"));
-        nullTracer.AddEvent(span, "test-event");
+        for (int i = 0; i < iterations; i++)
+        {
+            nullTracer.SetAttribute(span, TracingConstants.Attributes.CountyId, "test");
+            nullTracer.SetAttribute(span, TracingConstants.Attributes.DocumentCount, 5);
+            nullTracer.SetAttribute(span, TracingConstants.Attributes.UsesRag, true);
+            nullTracer.SetStatus(span, ActivityStatusCode.Ok);
+            nullTracer.RecordException(span, exception);
+            nullTracer.AddEvent(span, "test-event");
+        }
         stopwatch.Stop();
 
-        // Assert - operations should complete nearly instantly
-        Assert.True(stopwatch.ElapsedMilliseconds < 10, "Null tracer operations should be near-instant");
+        // Assert - no-op tracer calls should remain comfortably sub-millisecond on average.
+        var averageOperationMs = stopwatch.Elapsed.TotalMilliseconds / (iterations * operationsPerIteration);
+        Assert.True(averageOperationMs < 1.0,
+            $"Null tracer operations averaged {averageOperationMs:F4}ms, expected < 1ms");
     }
 
     #endregion

--- a/backend/tests/TerraFusion.Integration.Tests/Phase36/OpenTelemetryDistributedTracingTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/Phase36/OpenTelemetryDistributedTracingTests.cs
@@ -749,25 +749,39 @@ public class OpenTelemetryDistributedTracingTests : IDisposable
         var exception = new Exception("test");
         const int iterations = 1000;
         const int operationsPerIteration = 6;
+        const double maxBatchMsThreshold = 250.0;
 
         // Act - these should all be no-ops. Use many iterations so CI scheduler
         // jitter does not turn a single tiny measurement window into a false failure.
         var stopwatch = Stopwatch.StartNew();
+        long maxBatchTicks = 0;
         for (int i = 0; i < iterations; i++)
         {
+            var batchStart = Stopwatch.GetTimestamp();
+
             nullTracer.SetAttribute(span, TracingConstants.Attributes.CountyId, "test");
             nullTracer.SetAttribute(span, TracingConstants.Attributes.DocumentCount, 5);
             nullTracer.SetAttribute(span, TracingConstants.Attributes.UsesRag, true);
             nullTracer.SetStatus(span, ActivityStatusCode.Ok);
             nullTracer.RecordException(span, exception);
             nullTracer.AddEvent(span, "test-event");
+
+            var batchTicks = Stopwatch.GetTimestamp() - batchStart;
+            if (batchTicks > maxBatchTicks)
+            {
+                maxBatchTicks = batchTicks;
+            }
         }
         stopwatch.Stop();
 
-        // Assert - no-op tracer calls should remain comfortably sub-millisecond on average.
+        // Assert - no-op tracer calls should remain comfortably sub-millisecond on average,
+        // while a single blocking batch cannot be hidden by the average.
         var averageOperationMs = stopwatch.Elapsed.TotalMilliseconds / (iterations * operationsPerIteration);
+        var maxBatchMs = maxBatchTicks * 1000.0 / Stopwatch.Frequency;
         Assert.True(averageOperationMs < 1.0,
             $"Null tracer operations averaged {averageOperationMs:F4}ms, expected < 1ms");
+        Assert.True(maxBatchMs < maxBatchMsThreshold,
+            $"Null tracer batch took {maxBatchMs:F4}ms, expected < {maxBatchMsThreshold}ms");
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Stabilizes the Phase36 OpenTelemetry null-tracer timing assertion that has been flaking CI.
- Keeps the null tracer behavior unchanged; the test now averages many no-op calls instead of asserting a single six-call wall-clock window under 10ms.
- Separate CI repair PR, not TerraAtlas product work.

## Root cause
The failed gate was a single-shot timing assertion in `Performance_BatchExport_DoesNotBlockMainThread`. CI observed a 17ms elapsed time for six no-op calls, consistent with scheduler jitter rather than a blocking tracer implementation.

## Verification
- Focused failing test: 5 consecutive passes
- Phase36 tracing tests: 52 passed
- Backend canonical gate shape: build succeeded, canonical `dotnet test TerraFusion.sln ...` passed with `1463 passed, 1 skipped, 0 failed` for integration tests
- `pnpm run type-check`: passed
- `node --test os-platform/core/tests/phase83-tools.test.mjs`: passed
- Pre-push hook: unit tests 164/164, backend build 0 warnings/0 errors

## Scope
- One backend test file only
- No TerraAtlas product changes
- No Workbench changes
- No dependency changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved a performance test for distributed tracing: now benchmarks no-op tracer operations over a larger workload, measures per-operation average and worst batch duration, and enforces both average and maximum-duration thresholds for more reliable, granular performance validation (replacing the previous coarse total-time assertion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->