### PR TITLE
test(honesty): WO-DOCS-TEST-HONESTY-013a — live tests no longer pin fabricated 1008

### DIFF
--- a/backend/TerraFusion.API.Tests/Infrastructure/TestConsciousnessStubs.cs
+++ b/backend/TerraFusion.API.Tests/Infrastructure/TestConsciousnessStubs.cs
@@ -39,12 +39,17 @@ namespace TerraFusion.API.Tests.Infrastructure
 
         public Task<ConsciousnessScalingResultDto> ScaleConsciousnessAsync(ConsciousnessScalingRequestDto request)
         {
+            // WO-DOCS-TEST-HONESTY-013a: no running consciousness swarm (target architecture /
+            // stubbed), so scaling is unavailable. Report a self-consistent no-op result —
+            // failed, 0 current, 0 progress — rather than the prior contradictory "100% complete
+            // to target" with a hardcoded 1008 current count.
             var result = new ConsciousnessScalingResultDto
             {
-                Success = true,
-                CurrentAgentCount = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
+                Success = false,
+                CurrentAgentCount = 0,
                 TargetAgentCount = request.TargetAgentCount,
-                ScalingProgress = 1.0m,
+                ScalingProgress = 0m,
+                ErrorMessage = "Scaling unavailable: no running consciousness swarm (target architecture / stubbed).",
                 EstimatedTimeRemaining = TimeSpan.Zero
             };
             return Task.FromResult(result);

--- a/backend/TerraFusion.API.Tests/Infrastructure/TestConsciousnessStubs.cs
+++ b/backend/TerraFusion.API.Tests/Infrastructure/TestConsciousnessStubs.cs
@@ -13,7 +13,7 @@ namespace TerraFusion.API.Tests.Infrastructure
             {
                 LegacySystem = new LegacyConsciousnessStatusDto
                 {
-                    ActiveAgents = 1008,
+                    ActiveAgents = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                     Status = "Active",
                     PerformanceMetrics = 0.99m,
                     LastSync = DateTime.UtcNow
@@ -31,7 +31,7 @@ namespace TerraFusion.API.Tests.Infrastructure
                 CurrentMode = "Legacy",
                 TransitionProgress = 0.0m,
                 LastUpdated = DateTime.UtcNow,
-                TotalActiveAgents = 1008,
+                TotalActiveAgents = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 SystemMetrics = new Dictionary<string, object>()
             };
             return Task.FromResult(status);
@@ -42,7 +42,7 @@ namespace TerraFusion.API.Tests.Infrastructure
             var result = new ConsciousnessScalingResultDto
             {
                 Success = true,
-                CurrentAgentCount = 1008,
+                CurrentAgentCount = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 TargetAgentCount = request.TargetAgentCount,
                 ScalingProgress = 1.0m,
                 EstimatedTimeRemaining = TimeSpan.Zero
@@ -69,7 +69,7 @@ namespace TerraFusion.API.Tests.Infrastructure
             var metrics = new ConsciousnessMetricsDto
             {
                 Timestamp = DateTime.UtcNow,
-                TotalActiveAgents = 1008,
+                TotalActiveAgents = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 SystemLoad = 0.1m,
                 MemoryUsage = 0.1m,
                 CPUUsage = 0.1m,
@@ -155,7 +155,7 @@ namespace TerraFusion.API.Tests.Infrastructure
             {
                 Success = true,
                 MaintenanceId = Guid.NewGuid().ToString(),
-                AgentsMaintained = 1008,
+                AgentsMaintained = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 OptimalPerformanceAchieved = 1.0m,
                 MaintenanceDuration = TimeSpan.FromMilliseconds(1),
                 MaintenanceTimestamp = DateTime.UtcNow
@@ -236,7 +236,7 @@ namespace TerraFusion.API.Tests.Infrastructure
                 InitializedAt = DateTime.UtcNow,
                 Message = "Test initialization",
                 SystemReady = true,
-                LegacyAgentsActive = 1008,
+                LegacyAgentsActive = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 QuantumAgentsActive = 0
             });
         }
@@ -254,8 +254,8 @@ namespace TerraFusion.API.Tests.Infrastructure
                 LayerData = new Dictionary<string, object>(),
                 DataFormat = "test",
                 ConsciousnessLevel = 1.0m,
-                TotalAgents = 1008,
-                ActiveAgents = 1008,
+                TotalAgents = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
+                ActiveAgents = 0, // WO-DOCS-TEST-HONESTY-013a: no running swarm — truthful zero, not fabricated 1008
                 HiveCoherence = 0.99m,
                 ConsciousnessEmergence = 0.99m,
                 SessionMetrics = new Dictionary<string, object>()

--- a/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
+++ b/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
@@ -164,8 +164,10 @@ namespace TerraFusion.API.Tests
             metrics.SecurityScore.Should().BeGreaterThan(95.0, "Security score should be > 95%");
             metrics.CompliancePercentage.Should().BeGreaterThan(95.0, "Compliance should be > 95%");
 
-            // AI metrics
-            metrics.ActiveAIAgents.Should().Be(1008, "Should have 1,008 active AI agents");
+            // AI metrics — WO-DOCS-TEST-HONESTY-013a: do NOT pin a fabricated 1,008-agent swarm.
+            // No production swarm runs (consciousness is target architecture / stubbed), so assert
+            // the count is reported truthfully (>= 0) rather than a hardcoded fabricated figure.
+            metrics.ActiveAIAgents.Should().BeGreaterThanOrEqualTo(0, "AI agent count is reported truthfully; there is no running 1,008-agent swarm");
             metrics.AITasksCompleted.Should().BeGreaterThan(0);
 
             _output.WriteLine($"Total Requests: {metrics.TotalRequests:N0} (Success: {successRate:F2}%)");
@@ -243,7 +245,7 @@ namespace TerraFusion.API.Tests
                 test.TestName.Should().NotBeNullOrEmpty();
                 test.Score.Should().BeInRange(0, 100);
 
-                _output.WriteLine($"  {(test.Status == "passed" ? "✓" : "�--")} {test.TestName}: {test.Score:F1} ({test.Duration:F1}s)");
+                _output.WriteLine($"  {(test.Status == "passed" ? "✓" : "�--")} {test.TestName}: {test.Score:F1} ({test.Duration:F1}s)");
             }
         }
 

--- a/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
+++ b/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
@@ -165,9 +165,10 @@ namespace TerraFusion.API.Tests
             metrics.CompliancePercentage.Should().BeGreaterThan(95.0, "Compliance should be > 95%");
 
             // AI metrics — WO-DOCS-TEST-HONESTY-013a: do NOT pin a fabricated 1,008-agent swarm.
-            // No production swarm runs (consciousness is target architecture / stubbed), so assert
-            // the count is reported truthfully (>= 0) rather than a hardcoded fabricated figure.
-            metrics.ActiveAIAgents.Should().BeGreaterThanOrEqualTo(0, "AI agent count is reported truthfully; there is no running 1,008-agent swarm");
+            // This assertion verifies only that the count is a sane NON-NEGATIVE value; there is no
+            // running swarm to check an exact count against (consciousness is target architecture /
+            // stubbed). It intentionally does not detect a missing field (default 0).
+            metrics.ActiveAIAgents.Should().BeGreaterThanOrEqualTo(0, "agent count must be a non-negative value, not a fabricated 1,008");
             metrics.AITasksCompleted.Should().BeGreaterThan(0);
 
             _output.WriteLine($"Total Requests: {metrics.TotalRequests:N0} (Success: {successRate:F2}%)");


### PR DESCRIPTION
## WO-DOCS-TEST-HONESTY-013a — live compiled tests no longer pin fabricated 1008

Closes the "tests still pin the lie" problem for the **only CI-compiled tests** that did. Truth-gated rebound of the original #13 (which would've touched 414 files — see note below).

### Changes (2 files, both in `backend/TerraFusion.API.Tests`)
- `SystemIntegrationTests.cs:168`: `ActiveAIAgents.Should().Be(1008)` → `BeGreaterThanOrEqualTo(0)` ("reported truthfully; no running 1,008-agent swarm").
- `Infrastructure/TestConsciousnessStubs.cs`: 8 agent-count fields `= 1008` → `= 0` (truthful no-swarm fixture; consciousness is target architecture / stubbed).

Both changed **together** so assertion + fixture stay consistent. `AgentTelemetryContractTests` (asserts counts `>= 0`) stays green at 0.

### Proof
`dotnet build TerraFusion.API.Tests` → 0 errors. `dotnet test` (affected classes) → **Passed! 7 passed / 0 failed / 26 skipped** (skipped = infra/Testcontainer-gated, run in CI). No production code changed.

### Truth-gate note (why this is 2 files, not 414)
414 test files contain `1008`, but **411 are non-CI-run dead scaffolding** under the stray `backend/tests/TerraFusion.Tests.csproj` (`IsTestProject=false`, **not in `TerraFusion.sln`** — same class as the `TerraFusionSimple.csproj` stray). Those + the orphaned `tests/costforge-ai/*.test.cs` are **out of scope** here → a separate **013b** decision (retire/quarantine vs leave-with-inventory-note). Only these 2 files are in real, sln-included test projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test stubs to return realistic system values instead of hardcoded constants
  * Relaxed test assertions to validate against realistic expectations rather than fixed values
  * Improved test accuracy for system integration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->