### PR TITLE
fix(openapi): WO-OPENAPI-001 — ExecuteEmergencyProtocol truthful response contract

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/AIOrchestrationController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AIOrchestrationController.cs
@@ -429,10 +429,10 @@ public class AIOrchestrationController : ControllerBase
     /// <param name="protocol">Emergency protocol to execute</param>
     /// <returns>Emergency protocol execution results</returns>
     [HttpPost("emergency/{protocol}")]
-    [ProducesResponseType(typeof(EmergencyProtocolDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(EmergencyProtocolExecutionResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<EmergencyProtocolDto>> ExecuteEmergencyProtocol(
+    public async Task<ActionResult<EmergencyProtocolExecutionResultDto>> ExecuteEmergencyProtocol(
         [FromRoute][Required] string protocol)
     {
         _logger.LogWarning("🚨 API: Executing emergency protocol: {Protocol}", protocol);
@@ -496,7 +496,7 @@ public class AIOrchestrationController : ControllerBase
 
             var executionTime = DateTime.UtcNow - executionStart;
 
-            return Ok(new
+            return Ok(new EmergencyProtocolExecutionResultDto
             {
                 Protocol = protocol.ToUpperInvariant(),
                 Success = success,

--- a/backend/src/TerraFusion.API/Models/DTOs/AIOrchestrationDtos.cs
+++ b/backend/src/TerraFusion.API/Models/DTOs/AIOrchestrationDtos.cs
@@ -201,4 +201,22 @@ namespace TerraFusion.API.Models.DTOs
         public List<string> ActivationTriggers { get; set; } = new();
         public Dictionary<string, object> ProtocolActions { get; set; } = new();
     }
+
+    /// <summary>
+    /// Emergency Protocol Execution Result DTO — the actual response shape returned by
+    /// <c>AIOrchestrationController.ExecuteEmergencyProtocol</c>. This is distinct from
+    /// <see cref="EmergencyProtocolDto"/> (which describes a protocol *definition*); this
+    /// type describes the *result of executing* a protocol, so the OpenAPI contract matches
+    /// the real payload instead of advertising the wrong shape.
+    /// </summary>
+    public class EmergencyProtocolExecutionResultDto
+    {
+        public string Protocol { get; set; } = string.Empty;
+        public bool Success { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public int AffectedAgents { get; set; }
+        public double ExecutionTimeMs { get; set; }
+        public DateTime ExecutedAt { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
 }


### PR DESCRIPTION
## WO-OPENAPI-001 — `ExecuteEmergencyProtocol` truthful response contract

`AIOrchestrationController.ExecuteEmergencyProtocol` advertised `[ProducesResponseType(typeof(EmergencyProtocolDto), 200)]` / `ActionResult<EmergencyProtocolDto>`, but the actual 200 body was an **anonymous object** with a completely different shape. `EmergencyProtocolDto` describes a protocol **definition**; the endpoint returns an **execution result** — the two share **zero** fields, so the OpenAPI contract was advertising the wrong schema entirely.

### Smallest honest fix (2 files)
- **Add** `EmergencyProtocolExecutionResultDto` — the actual 200 shape: `Protocol`, `Success`, `Message`, `AffectedAgents`, `ExecutionTimeMs`, `ExecutedAt`, `Timestamp`.
- **Point** the `[ProducesResponseType(200)]` attribute, the method return type, and the response construction at that DTO.
- **Leave** `EmergencyProtocolDto` untouched as the protocol-definition shape.

### Acceptance
- ✅ `ExecuteEmergencyProtocol` 200 now declared with a truthful execution-result DTO
- ✅ attribute type == return type == constructed type (`EmergencyProtocolExecutionResultDto`)
- ✅ DTO field shape == the 7 real payload fields
- ✅ `EmergencyProtocolDto` unchanged (still the protocol-definition shape)
- ✅ no route / logic / field change beyond making the contract truthful
- ✅ `dotnet build TerraFusion.API`: **0 warnings, 0 errors**
- ✅ exactly 2 files changed (+21 / −3)

Scope: `AIOrchestrationController.cs` + `Models/DTOs/AIOrchestrationDtos.cs` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)