### PR TITLE
fix(honesty): WO-AI-CONSOLIDATION-004c-b2c — CostForge agent-count default 1008→0 + empty-fleet guards

### DIFF
--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -95,13 +95,26 @@ public class CostForgeAIService : ICostForgeAIService
     // Calculate current accuracy based on quantum factor and system performance
     var baseAccuracy = _targetAccuracy * 100;
     var quantumBonus = (_quantumFactor - 900) * 0.01m;
-    var systemLoadPenalty = (_agents.Values.Count(a => a.Status == "busy") / (decimal)_agents.Count) * 0.5m;
+    // Honesty/safety (WO-AI-CONSOLIDATION-004c-b2c): with a default-0 fleet, _agents can be
+    // empty. Decimal division by an empty count throws DivideByZeroException, so an empty
+    // fleet contributes no system-load penalty.
+    var systemLoadPenalty = _agents.IsEmpty
+        ? 0m
+        : (_agents.Values.Count(a => a.Status == "busy") / (decimal)_agents.Count) * 0.5m;
 
     return Math.Min(baseAccuracy + quantumBonus - systemLoadPenalty, 99.9m);
   }
 
   private string DetermineSystemStatus()
   {
+    // Honesty/safety (WO-AI-CONSOLIDATION-004c-b2c): no agents configured/running (default
+    // fleet is 0, not a fabricated 1008). Take an explicit empty-fleet path instead of
+    // dividing by an empty count. "critical" is the safest EXISTING status — it is the only
+    // one that does not falsely imply a healthy or operational fleet (no NoAgentsConfigured
+    // status exists in this contract).
+    if (_agents.IsEmpty)
+      return "critical";
+
     var activePercentage = _agents.Values.Count(a => a.Status == "active") / (decimal)_agents.Count;
     var modelsHealthy = _mlModels.Count == _modelLastUpdated.Count;
 
@@ -476,7 +489,11 @@ public class CostForgeAIService : ICostForgeAIService
 
   private void InitializeQuantumAgents()
   {
-    var targetAgentCount = _configuration.GetValue<int>("costforge:target_agent_count", 1008);
+    // Honesty (WO-AI-CONSOLIDATION-004c-b2c): default to 0, not a fabricated 1008.
+    // There is no running agent fleet; this only seeds an internal simulation when an
+    // operator explicitly configures costforge:target_agent_count. A 0 default means the
+    // surfaced agent metrics reflect the real (empty) state by default.
+    var targetAgentCount = _configuration.GetValue<int>("costforge:target_agent_count", 0);
 
     _logger.LogInformation("Initializing {AgentCount} quantum-enhanced AI agents", targetAgentCount);
 

--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -96,11 +96,13 @@ public class CostForgeAIService : ICostForgeAIService
     var baseAccuracy = _targetAccuracy * 100;
     var quantumBonus = (_quantumFactor - 900) * 0.01m;
     // Honesty/safety (WO-AI-CONSOLIDATION-004c-b2c): with a default-0 fleet, _agents can be
-    // empty. Decimal division by an empty count throws DivideByZeroException, so an empty
-    // fleet contributes no system-load penalty.
-    var systemLoadPenalty = _agents.IsEmpty
+    // empty. Snapshot the count once — _agents is a ConcurrentDictionary, so checking
+    // emptiness and reading Count separately would race (the fleet could empty in between) and
+    // still throw DivideByZeroException. An empty fleet contributes no system-load penalty.
+    var agentCount = _agents.Count;
+    var systemLoadPenalty = agentCount == 0
         ? 0m
-        : (_agents.Values.Count(a => a.Status == "busy") / (decimal)_agents.Count) * 0.5m;
+        : (_agents.Values.Count(a => a.Status == "busy") / (decimal)agentCount) * 0.5m;
 
     return Math.Min(baseAccuracy + quantumBonus - systemLoadPenalty, 99.9m);
   }
@@ -108,14 +110,17 @@ public class CostForgeAIService : ICostForgeAIService
   private string DetermineSystemStatus()
   {
     // Honesty/safety (WO-AI-CONSOLIDATION-004c-b2c): no agents configured/running (default
-    // fleet is 0, not a fabricated 1008). Take an explicit empty-fleet path instead of
-    // dividing by an empty count. "critical" is the safest EXISTING status — it is the only
-    // one that does not falsely imply a healthy or operational fleet (no NoAgentsConfigured
-    // status exists in this contract).
-    if (_agents.IsEmpty)
+    // fleet is 0, not a fabricated 1008). Snapshot the count once — _agents is a
+    // ConcurrentDictionary, so checking emptiness and reading Count separately would race and
+    // still throw DivideByZeroException. Take an explicit empty-fleet path instead of dividing
+    // by an empty count. "critical" is the safest EXISTING status — it is the only one that
+    // does not falsely imply a healthy or operational fleet (no NoAgentsConfigured status
+    // exists in this contract).
+    var agentCount = _agents.Count;
+    if (agentCount == 0)
       return "critical";
 
-    var activePercentage = _agents.Values.Count(a => a.Status == "active") / (decimal)_agents.Count;
+    var activePercentage = _agents.Values.Count(a => a.Status == "active") / (decimal)agentCount;
     var modelsHealthy = _mlModels.Count == _modelLastUpdated.Count;
 
     if (activePercentage >= 0.8m && modelsHealthy)


### PR DESCRIPTION
## WO-AI-CONSOLIDATION-004c-b2c — CostForge `target_agent_count` default + empty-fleet guards

**Verdict: honesty defect.** `costforge:target_agent_count` defaulted to `1008` (the key is in no appsettings, so it always resolved to the literal). That default seeded `InitializeQuantumAgents()` to fabricate **1008 fake agents** into `_agents`, which is surfaced via agent-status counts, `TopPerformingAgents`, `TotalAgents`, and the accuracy/status calculations — a fabricated fleet presented as live truth.

### Bounded remediation (one file)
1. **Default `1008` → `0`.** No running fleet exists; the simulation only seeds when an operator explicitly configures the key. By default the surfaced agent metrics now reflect the real (empty) state.
2. **Empty-fleet guards** on the two decimal `/ _agents.Count` sites (default-0 ⇒ `_agents` empty ⇒ decimal `x/0` **throws** `DivideByZeroException`):
   - `CalculateCurrentAccuracy()` → empty fleet contributes **0** system-load penalty.
   - `DetermineSystemStatus()` → empty fleet returns **`"critical"`** — the safest **existing** status, the only one that doesn't falsely imply a healthy/running fleet (no `NoAgentsConfigured` status exists in this contract).

### Safety audit
All other `_agents` consumers audited and confirmed empty-safe: `Count(predicate)` (→0), `Take`, `OrderByDescending`, `SelectOptimalAgents` (`.Take().ToList()`), and the scale comparison (`targetCount > _agents.Count`). The two division sites were the only empty-crash paths; both now guarded.

### Out of scope (deferred to follow-up card)
Broader simulated-metric surfacing (`TopPerformingAgents` and the other fabricated agent metrics) is left alone for now.

- ✅ `dotnet build TerraFusion.AI`: 0 warnings, 0 errors
- ✅ exactly 1 file changed (+19 / −2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust CostForge agent initialization defaults and guard empty fleets to ensure accurate metrics and safe status evaluation.

Bug Fixes:
- Default CostForge target agent count to 0 instead of fabricating a 1008-agent fleet when no configuration is provided.
- Prevent divide-by-zero errors in accuracy and status calculations when the agent fleet is empty by short-circuiting on an empty collection.
- Return a critical system status when no agents are configured to avoid falsely signaling a healthy or operational fleet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability when operating with an empty agent fleet
  * Fixed potential calculation error in accuracy computation
  * Enhanced system status reporting for edge-case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->