### PR TITLE
fix(honesty): WO-CF-b2d — CostForge empty-fleet metrics return 0, not fabricated live values

### DIFF
--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -92,17 +92,21 @@ public class CostForgeAIService : ICostForgeAIService
 
   private decimal CalculateCurrentAccuracy()
   {
+    // Snapshot the count once — _agents is a ConcurrentDictionary, so checking emptiness and
+    // reading Count separately would race (the fleet could empty in between) and could throw
+    // DivideByZeroException (WO-AI-CONSOLIDATION-004c-b2c).
+    var agentCount = _agents.Count;
+
+    // Honesty (WO-AI-CONSOLIDATION-004c-b2d): an empty fleet has no live accuracy to report.
+    // Return 0 rather than the quantum-derived ~99.9% so the operator-visible AccuracyRate does
+    // not imply live performance when AgentsActive=0 / SystemStatus=critical.
+    if (agentCount == 0)
+      return 0m;
+
     // Calculate current accuracy based on quantum factor and system performance
     var baseAccuracy = _targetAccuracy * 100;
     var quantumBonus = (_quantumFactor - 900) * 0.01m;
-    // Honesty/safety (WO-AI-CONSOLIDATION-004c-b2c): with a default-0 fleet, _agents can be
-    // empty. Snapshot the count once — _agents is a ConcurrentDictionary, so checking
-    // emptiness and reading Count separately would race (the fleet could empty in between) and
-    // still throw DivideByZeroException. An empty fleet contributes no system-load penalty.
-    var agentCount = _agents.Count;
-    var systemLoadPenalty = agentCount == 0
-        ? 0m
-        : (_agents.Values.Count(a => a.Status == "busy") / (decimal)agentCount) * 0.5m;
+    var systemLoadPenalty = (_agents.Values.Count(a => a.Status == "busy") / (decimal)agentCount) * 0.5m;
 
     return Math.Min(baseAccuracy + quantumBonus - systemLoadPenalty, 99.9m);
   }
@@ -332,17 +336,21 @@ public class CostForgeAIService : ICostForgeAIService
   {
     await System.Threading.Tasks.Task.Delay(10);
 
+    var totalAgents = _agents.Count;
     var activeAgents = _agents.Values.Count(a => a.Status == "active");
     var idleAgents = _agents.Values.Count(a => a.Status == "idle");
     var busyAgents = _agents.Values.Count(a => a.Status == "busy");
 
     return new AIAgentStatusDto
     {
-      TotalAgents = _agents.Count,
+      TotalAgents = totalAgents,
       ActiveAgents = activeAgents,
       IdleAgents = idleAgents,
       BusyAgents = busyAgents,
-      AverageUtilization = (double)87.3m,
+      // Honesty (WO-AI-CONSOLIDATION-004c-b2d): an empty fleet has 0 utilization, not a
+      // fabricated 87.3. The non-empty simulation constant remains deferred to the broader
+      // simulation-truth cleanup.
+      AverageUtilization = totalAgents == 0 ? 0.0 : (double)87.3m,
       Agents = _agents.Values.Take(10).Cast<object>().ToList() // Return first 10 for performance
     };
   }


### PR DESCRIPTION
## WO-CF-b2d — CostForge empty-fleet metric honesty

Follow-up to b2c. With the default-0 fleet, two **operator-visible** metrics still implied live performance for a zero-agent system:

| Field (DTO) | Surfaced by | Empty-fleet value before | After |
|---|---|---|---|
| `AccuracyRate` (`CostForgeStatusDto`) | `GetSystemStatusAsync` → `CalculateCurrentAccuracy` | ~99.9% | **0** |
| `AverageUtilization` (`AIAgentStatusDto`) | `GetAIAgentStatusAsync` | hardcoded 87.3 | **0** |

### Bounded empty-fleet fix (one file)
- `CalculateCurrentAccuracy()`: empty fleet → `return 0m` (no live accuracy to report). Count is still snapshotted once and the early return keeps the penalty divisor guaranteed `> 0`, **preserving the b2c TOCTOU / divide-by-zero safety**.
- `GetAIAgentStatusAsync()`: empty fleet → `AverageUtilization = 0` (count snapshotted once).

Both fields are non-nullable on **out-of-scope** DTOs, so `0` is the truthful in-contract value — coherent with `AgentsActive=0` / `SystemStatus="critical"`.

### Out of scope (deferred — broader simulation-truth cleanup)
Non-empty simulation constants (the `87.3` non-empty path, `GetPerformanceMetricsAsync` constants like `847`/`quantum_acceleration=379000000`, `GetAnalyticsAsync` hardcoded `CalculationsByType`). These lie regardless of fleet — a separate slice.

- ✅ `dotnet build TerraFusion.AI`: 0 warnings, 0 errors
- ✅ one file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure CostForge reports honest metrics for empty AI agent fleets by updating accuracy and utilization calculations.

Bug Fixes:
- Return an accuracy rate of 0 for an empty agent fleet instead of a fabricated high value, while preserving divide-by-zero safety.
- Report average utilization as 0 when there are no agents instead of using a hard-coded nonzero constant.