### PR TITLE
fix(shell): restore GIS home scene surface

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/home/countyOpsScene.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/home/countyOpsScene.contract.test.tsx
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { WASHINGTON_COUNTY_RUNTIME_POSTURES } from '../../config/countyRuntimePosture';
 
 // ---------------------------------------------------------------------------
 // Mocks — match patterns from homeScene.contract.test.tsx
@@ -146,12 +147,28 @@ vi.mock('../../hooks/useParcelCount', () => ({
   useParcelCount: () => ({ data: undefined, isLoading: false, error: null }),
 }));
 
+vi.mock('../../shell/desktop/BentonCountyMap', () => ({
+  __esModule: true,
+  default: ({ onParcelSelect, className }: { onParcelSelect?: (parcelId: string) => void; className?: string }) => (
+    <div
+      data-testid="benton-county-map"
+      className={className}
+      aria-label="Benton County GIS map"
+    >
+      <span>Benton County GIS Orientation</span>
+      <span>Parcel layer status: TerraFusion DB/API proof path</span>
+      <button type="button" onClick={() => onParcelSelect?.('10-1234-001')}>
+        Select mapped parcel
+      </button>
+    </div>
+  ),
+}));
+
 // Import the REAL components/stores after mocks
 import { StageZeroState } from '../../shell/desktop/StageZeroState';
 import { useSceneStore, SCENE_LIBRARY } from '../../stores/sceneStore';
 import { activateModule } from '../../orchestration/moduleActivation';
 import { selectRecentParcel } from '../../context/parcelContext';
-import { WASHINGTON_COUNTY_RUNTIME_POSTURES } from '../../config/countyRuntimePosture';
 
 // Get mock references
 const mockActivateModule = activateModule as ReturnType<typeof vi.fn>;
@@ -169,8 +186,8 @@ describe('Phase 24: County Ops Scene — Rendering', () => {
   it('1. county map area renders', () => {
     render(<StageZeroState />);
     expect(screen.getByTestId('county-map-center')).toBeInTheDocument();
-    // The SVG map button has an aria-label
-    expect(screen.getByLabelText('Open TerraAtlas for full county map')).toBeInTheDocument();
+    expect(screen.getByLabelText('Benton County GIS map')).toBeInTheDocument();
+    expect(screen.getByText('Benton County GIS Orientation')).toBeInTheDocument();
   });
 
   it('2. Recent Work panel renders', () => {
@@ -191,7 +208,8 @@ describe('Phase 24: County Ops Scene — Rendering', () => {
   it('4. County status info renders', () => {
     render(<StageZeroState />);
     expect(screen.getByTestId('executive-command-surface')).toBeInTheDocument();
-    expect(screen.getByText('Cross-suite county posture')).toBeInTheDocument();
+    expect(screen.getByText('County operations command surface')).toBeInTheDocument();
+    expect(screen.queryByText('Statewide county operating model')).not.toBeInTheDocument();
   });
 
   it('4b. runtime posture summary exposes the 39-county source/runtime boundary', () => {
@@ -213,11 +231,26 @@ describe('Phase 24: County Ops Scene — Rendering', () => {
   it('5. County status info renders', () => {
     render(<StageZeroState />);
     expect(screen.getByTestId('county-status-strip')).toBeInTheDocument();
-    expect(screen.getByText('Benton County, WA')).toBeInTheDocument();
-    expect(screen.getByText('Parcel count unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Washington County Operating Model')).toBeInTheDocument();
+    expect(screen.getAllByText('Benton Runtime Pilot').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('38 counties Onboarding / Provenance / Intake').length).toBeGreaterThan(0);
+    expect(screen.getByText('Parcel count: proof path only')).toBeInTheDocument();
   });
 
-  it('6. Search is NOT the hero surface — no prominent search bar', () => {
+  it('6. June 10 shell frames Benton runtime proof without statewide runtime overclaim', () => {
+    render(<StageZeroState />);
+    const stageZero = screen.getByTestId('stage-zero-state');
+
+    expect(stageZero).toHaveTextContent('Benton Runtime Pilot');
+    expect(stageZero).toHaveTextContent('Benton County GIS Orientation');
+    expect(stageZero).toHaveTextContent('38 counties Onboarding / Provenance / Intake');
+    expect(stageZero).not.toHaveTextContent('Benton absent by design');
+    expect(stageZero).not.toHaveTextContent('38-county runtime preview');
+    expect(stageZero).not.toHaveTextContent('Washington County Runtime');
+    expect(stageZero).not.toHaveTextContent('128,788 parcels');
+  });
+
+  it('7. Search is NOT the hero surface — no prominent search bar', () => {
     render(<StageZeroState />);
     const stageZero = screen.getByTestId('stage-zero-state');
     // No search input elements on the home surface

--- a/frontend/apps/os-shell/src/__tests__/home/homeScene.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/home/homeScene.contract.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { Suspense, lazy } from 'react';
 import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
@@ -26,6 +26,10 @@ import { vi } from 'vitest';
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+
+const mockUseParcelCount = vi.hoisted(() => vi.fn());
+const mockOpenWorkbenchWindow = vi.hoisted(() => vi.fn());
+const mockSelectRecentParcel = vi.hoisted(() => vi.fn());
 
 // Mock zustand stores used by StageZeroState
 vi.mock('../../stores/commandPaletteStore', () => {
@@ -55,8 +59,8 @@ vi.mock('../../stores/commandPaletteStore', () => {
 vi.mock('../../context/parcelContext', () => ({
   __esModule: true,
   useRecentParcels: () => [],
-  openWorkbenchWindow: vi.fn(),
-  selectRecentParcel: vi.fn(),
+  openWorkbenchWindow: mockOpenWorkbenchWindow,
+  selectRecentParcel: mockSelectRecentParcel,
 }));
 
 // Mock module activation
@@ -135,15 +139,33 @@ vi.mock('../../hooks/useTodaysWork', () => ({
   useTodaysWork: () => ({ tasks: [], loading: false, error: null, readState: 'live' }),
 }));
 
+vi.mock('../../shell/desktop/BentonCountyMap', () => ({
+  __esModule: true,
+  default: ({ onParcelSelect, className }: { onParcelSelect?: (parcelId: string) => void; className?: string }) => (
+    <div
+      data-testid="benton-county-map"
+      className={className}
+      aria-label="Benton County GIS map"
+    >
+      <span>Benton County GIS Orientation</span>
+      <span>Parcel layer status: TerraFusion DB/API proof path</span>
+      <button type="button" onClick={() => onParcelSelect?.('101040000000000')}>
+        Select proof parcel
+      </button>
+    </div>
+  ),
+}));
+
 // Mock useParcelCount — no QueryClientProvider in this test tree
 vi.mock('../../hooks/useParcelCount', () => ({
   __esModule: true,
-  useParcelCount: () => ({ data: undefined, isLoading: false, error: null }),
+  useParcelCount: () => mockUseParcelCount(),
 }));
 
 // Import the REAL StageZeroState (with mocked dependencies above)
 // so we test actual rendered structure
 import { StageZeroState } from '../../shell/desktop/StageZeroState';
+import { invokeTool } from '../../api/pilotApi';
 
 // Mock App (Desktop) to include StageZeroState inside it
 vi.mock('../../App', () => ({
@@ -196,6 +218,13 @@ const Phase7Router: React.FC<{ initialRoute: string }> = ({ initialRoute }) => {
 // ---------------------------------------------------------------------------
 
 describe('Phase 7: Home Scene Contract', () => {
+  beforeEach(() => {
+    mockUseParcelCount.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    mockOpenWorkbenchWindow.mockClear();
+    mockSelectRecentParcel.mockClear();
+    sessionStorage.clear();
+  });
+
   /**
    * Test 1: /home redirects to /
    *
@@ -266,8 +295,8 @@ describe('Phase 7: Home Scene Contract', () => {
     // Quick Actions section header
     expect(screen.getByText('Quick Actions')).toBeInTheDocument();
 
-    // County map SVG — check for the Benton County map elements
-    expect(screen.getByLabelText('Open TerraAtlas for full county map')).toBeInTheDocument();
+    // County GIS map — the default home surface for the active county
+    expect(screen.getByLabelText('Benton County GIS map')).toBeInTheDocument();
     expect(screen.getByTestId('executive-command-surface')).toBeInTheDocument();
   });
 
@@ -322,5 +351,79 @@ describe('Phase 7: Home Scene Contract', () => {
     // Verify the store's open function is accessible
     const { _openFn } = await import('../../stores/commandPaletteStore') as any;
     expect(typeof _openFn).toBe('function');
+  });
+
+  it('renders Benton GIS home scene by default without launch-board or unverified count language', async () => {
+    mockUseParcelCount.mockReturnValue({
+      data: { totalParcels: 128788, dataSource: 'LIVE_DB', stubbed: false },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<Phase7Router initialRoute="/" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stage-zero-state')).toBeInTheDocument();
+    });
+
+    const center = screen.getByTestId('county-map-center');
+    expect(center).toHaveTextContent(/Benton County GIS Orientation/i);
+    expect(center).toHaveTextContent(/Parcel layer status/i);
+    expect(screen.getByTestId('benton-county-map')).toBeInTheDocument();
+    expect(screen.getAllByText(/Benton County/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Runtime Pilot/i).length).toBeGreaterThan(0);
+    expect(center.querySelectorAll('[aria-label="Active county workspace"]')).toHaveLength(0);
+
+    expect(screen.queryByText(/June 10 launch board/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Continue to Desktop/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/June 10 Launch Briefing/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Statewide county operating model/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Benton County Operations/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Washington County Runtime/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/128,788 parcels/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Washington County Operating Model/i)).toBeInTheDocument();
+  });
+
+  it('does not invoke TerraPilot briefing tools from the Home Scene automatically', async () => {
+    render(<Phase7Router initialRoute="/" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stage-zero-state')).toBeInTheDocument();
+    });
+
+    expect(invokeTool).not.toHaveBeenCalled();
+  });
+
+  it('opens the Benton Property Workbench from the default Benton workspace', async () => {
+    render(<Phase7Router initialRoute="/" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stage-zero-state')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Workbench/i }));
+
+    await waitFor(() => {
+      expect(mockOpenWorkbenchWindow).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/June 10 launch board/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Benton County GIS Orientation/i)).toBeInTheDocument();
+  });
+
+  it('selecting a map parcel opens the workbench without replacing the GIS home scene', async () => {
+    render(<Phase7Router initialRoute="/" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stage-zero-state')).toBeInTheDocument();
+    });
+
+    const center = screen.getByTestId('county-map-center');
+    fireEvent.click(screen.getByRole('button', { name: /Select proof parcel/i }));
+
+    await waitFor(() => {
+      expect(mockOpenWorkbenchWindow).toHaveBeenCalledWith('101040000000000');
+    });
+    expect(center).toHaveTextContent(/Benton County GIS Orientation/i);
+    expect(center).not.toHaveTextContent(/Open Benton Property Workbench/i);
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/shell/BentonCountyMapIntegration.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/BentonCountyMapIntegration.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 // Mock mapbox-gl so tests run in jsdom without canvas
 vi.mock('mapbox-gl', () => ({
@@ -59,6 +61,19 @@ describe('BentonCountyMap', () => {
     // At least one of the two root elements must be present
     expect(mapEl ?? errorEl).toBeTruthy();
   });
+
+  it('uses honest unavailable language when the map token is not configured', async () => {
+    const { default: BentonCountyMap } = await import(
+      '../../shell/desktop/BentonCountyMap'
+    );
+    render(<BentonCountyMap />);
+
+    const errorEl = screen.queryByTestId('benton-county-map-error');
+    if (errorEl) {
+      expect(errorEl).toHaveTextContent('Map layer unavailable: Mapbox token not configured');
+    }
+    expect(screen.queryByText(/add it to \.env/i)).not.toBeInTheDocument();
+  });
 });
 
 describe('BentonCountyMap props contract', () => {
@@ -72,5 +87,18 @@ describe('BentonCountyMap props contract', () => {
       expect(typeof id).toBe('string');
     };
     expect(typeof fn).toBe('function');
+  });
+});
+
+describe('BentonCountyMap proof-path honesty', () => {
+  it('does not fabricate parcel geometry when source geometry is absent', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../../shell/desktop/BentonCountyMap.tsx'),
+      'utf8',
+    );
+
+    expect(source).not.toContain('Math.random');
+    expect(source).not.toContain("type: 'Point'");
+    expect(source).toContain('Parcel layer unavailable: source check timed out');
   });
 });

--- a/frontend/apps/os-shell/src/shell/desktop/BentonCountyMap.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/BentonCountyMap.tsx
@@ -50,18 +50,27 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [parcelLayerStatus, setParcelLayerStatus] = useState<string>('Loading parcel layer...');
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN as string | undefined;
 
     if (!token) {
-      setError('Map requires VITE_MAPBOX_ACCESS_TOKEN — add it to .env.development');
+      setError('Map layer unavailable: Mapbox token not configured');
       setLoading(false);
       return;
     }
 
     if (mapRef.current || !containerRef.current) return;
+
+    const parcelLayerTimeout = window.setTimeout(() => {
+      setParcelLayerStatus((current) =>
+        current === 'Loading parcel layer...'
+          ? 'Parcel layer unavailable: source check timed out'
+          : current
+      );
+    }, 5000);
 
     mapboxgl.accessToken = token;
 
@@ -113,32 +122,40 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
         },
       });
 
-      // Parcel layer — load from backend, graceful fallback if offline
+      // Parcel layer — load from backend. Missing geometry is reported, never fabricated.
       fetch('/api/benton-county/parcels?limit=500')
         .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
         .then((parcels: unknown[]) => {
-          if (!Array.isArray(parcels) || parcels.length === 0) return;
+          if (!Array.isArray(parcels) || parcels.length === 0) {
+            setParcelLayerStatus('Parcel layer unavailable: no parcel features returned');
+            return;
+          }
+
+          const features = parcels
+            .filter((p: any) => p?.geometry)
+            .map((p: any) => ({
+              type: 'Feature' as const,
+              properties: {
+                id: p.parcelNumber || String(p.objectId),
+                address: p.situsAddress || p.address || '',
+                owner: p.ownerName || '',
+                value: p.assessedValue || '',
+              },
+              geometry: p.geometry,
+            }));
+
+          if (features.length === 0) {
+            setParcelLayerStatus('Parcel layer unavailable: source returned no geometry');
+            return;
+          }
+
+          setParcelLayerStatus(`Parcel layer loaded: ${features.length} source geometries`);
 
           map.addSource('parcels', {
             type: 'geojson',
             data: {
               type: 'FeatureCollection',
-              features: parcels.map((p: any) => ({
-                type: 'Feature',
-                properties: {
-                  id: p.parcelNumber || String(p.objectId),
-                  address: p.situsAddress || p.address || '',
-                  owner: p.ownerName || '',
-                  value: p.assessedValue || '',
-                },
-                geometry: p.geometry ?? {
-                  type: 'Point',
-                  coordinates: [
-                    -119.2687 + (Math.random() - 0.5) * 0.6,
-                    46.2619 + (Math.random() - 0.5) * 0.4,
-                  ],
-                },
-              })),
+              features,
             },
           });
 
@@ -194,15 +211,17 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
           });
         })
         .catch(() => {
-          // Backend offline — map shows satellite tiles without parcel layer
+          setParcelLayerStatus('Parcel layer unavailable: API request failed');
         });
     });
 
     map.on('error', () => {
+      setParcelLayerStatus('Parcel layer unavailable: map source failed');
       setLoading(false);
     });
 
     return () => {
+      window.clearTimeout(parcelLayerTimeout);
       map.remove();
       mapRef.current = null;
     };
@@ -224,6 +243,18 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
 
   return (
     <div data-testid='benton-county-map' className={`relative w-full h-full ${className ?? ''}`}>
+      <div
+        data-testid='benton-map-status'
+        className='absolute left-3 top-3 z-20 rounded-md px-3 py-2 text-xs'
+        style={{
+          border: '1px solid hsl(var(--tf-border) / 0.65)',
+          background: 'hsl(var(--tf-bg) / 0.84)',
+          color: 'hsl(var(--tf-text))',
+        }}
+      >
+        <div className='font-semibold'>Benton County GIS Orientation</div>
+        <div style={{ color: 'hsl(var(--tf-muted))' }}>{parcelLayerStatus}</div>
+      </div>
       {loading && (
         <div
           className='absolute inset-0 flex items-center justify-center z-10'

--- a/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Desktop.tsx
@@ -23,7 +23,7 @@ import { useSentinelStore } from '../../sentinel/sentinelStore';
 import { useCommandPaletteStore } from '../../stores/commandPaletteStore';
 import { useAltTabStore } from '../../stores/altTabStore';
 import { useControlCenterStore } from '../../stores/controlCenterStore';
-import { useDesktopStore, openCompanionWindow } from '../../stores/desktopStore';
+import { useDesktopStore } from '../../stores/desktopStore';
 import { useCompanionStore } from '../../stores/companionStore';
 import { useDevContext } from '../../hooks/useDevContext';
 import { useShellMode, useShellModeActions, useShellSurfaces } from '../../stores/desktopStore';
@@ -106,9 +106,9 @@ const DesktopTopSystemBar: React.FC<{
         </span>
       </div>
 
-      {/* Zone B: County + Department Context (center) */}
+      {/* Zone B: Active county operating context (center) */}
       <div className='absolute left-1/2 -translate-x-1/2 flex items-center gap-2'>
-        <span style={{ fontSize: '0.75rem', color: 'hsl(var(--tf-muted))', fontWeight: 500 }}>
+        <span style={{ fontSize: '0.75rem', color: 'hsl(var(--tf-text) / 0.7)', fontWeight: 500 }}>
           Benton County
         </span>
         <div
@@ -119,7 +119,17 @@ const DesktopTopSystemBar: React.FC<{
           }}
         />
         <span style={{ fontSize: '0.75rem', color: 'hsl(var(--tf-text) / 0.7)', fontWeight: 500 }}>
-          Assessor&apos;s Office
+          Assessor's Office
+        </span>
+        <div
+          style={{
+            width: 1,
+            height: 12,
+            background: 'hsl(var(--tf-border) / 0.5)',
+          }}
+        />
+        <span style={{ fontSize: '0.75rem', color: 'hsl(var(--tf-muted))', fontWeight: 500 }}>
+          Runtime Pilot
         </span>
       </div>
 
@@ -267,6 +277,11 @@ export function Desktop({ className = '', children }: DesktopProps) {
   const shellMode = useShellMode();
   const surfaces = useShellSurfaces();
   const { enterDesktop: transitionToDesktop } = useShellModeActions();
+  const showHomeScene =
+    surfaces.recentWork === 'visible' ||
+    surfaces.quickActions === 'visible' ||
+    surfaces.countyMap === 'visible';
+  const showDesktopWorkspace = surfaces.desktop !== 'hidden';
 
   // Scene Selector state (Phase 8)
   const [isSceneSelectorOpen, setSceneSelectorOpen] = useState(false);
@@ -311,13 +326,6 @@ export function Desktop({ className = '', children }: DesktopProps) {
     }
     prevStartMenuOpen.current = isStartMenuOpen;
   }, [isStartMenuOpen]);
-
-  // ============================================================================
-  // TerraPilot Companion — auto-spawn on desktop mount as floating window
-  // ============================================================================
-  useEffect(() => {
-    openCompanionWindow();
-  }, []);
 
   // ============================================================================
   // Dev context bus — wire engineering signals (buildStatus, branch, file)
@@ -577,14 +585,12 @@ export function Desktop({ className = '', children }: DesktopProps) {
       {isHome ? (
         <>
           {/* Layer 0.3: Desktop Icons — only interactive when desktop surface is visible */}
-          {surfaces.desktop !== 'hidden' && (
+          {showDesktopWorkspace && (
             <DesktopIconGrid className='absolute top-12 left-4' />
           )}
 
-          {/* Layer 0.5: Stage Zero-State — gated by shell mode surface policy */}
-          {surfaces.recentWork !== 'hidden' && (
-            <StageZeroState id='desktop-main-content' />
-          )}
+          {/* Layer 0.5: Stage Zero-State — visible only while the shell is in Home mode */}
+          {showHomeScene && <StageZeroState id='desktop-main-content' />}
         </>
       ) : (
         <div

--- a/frontend/apps/os-shell/src/shell/desktop/StageZeroState.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/StageZeroState.tsx
@@ -13,7 +13,9 @@
  *
  * DATA POSTURE (proof-sealed 2026-03-29, card 50E):
  * - Recent Work: live parcel browsing history from OS session state.
- * - Parcel count: from useParcelCount() API data; unavailable stays unavailable.
+ * - Parcel count: not rendered on the June 10 shell unless owned by a verified
+ *   Benton runtime proof endpoint. /api/government/stats is intentionally not
+ *   used here because it is not the launch proof contract.
  * - Today's Work: TerraDais queue API data only; unavailable state renders
  *   explicitly and never falls back to seeded sample tasks.
  * - County status strip: Last sync, appeal count, and system status fields render
@@ -23,7 +25,7 @@
  */
 
 import { cn } from '@/lib/utils';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
   Clock,
   ArrowRight,
@@ -43,14 +45,13 @@ import { useCommandPaletteStore } from '../../stores/commandPaletteStore';
 import { useRecentParcels } from '../../context/parcelContext';
 import { activateModule } from '../../orchestration/moduleActivation';
 import { useTodaysWork, type TodaysWorkItem } from '../../hooks/useTodaysWork';
-import { useParcelCount } from '../../hooks/useParcelCount';
 import {
   WASHINGTON_COUNTY_RUNTIME_POSTURES,
   getCountyRuntimePosture,
 } from '../../config/countyRuntimePosture';
 import { LiquidPanel } from '../../ui/materials';
-import { invokeTool } from '../../api/pilotApi';
 import { Z } from './zIndex';
+import BentonCountyMap from './BentonCountyMap';
 
 // ============================================================================
 // Types
@@ -211,39 +212,24 @@ function TodaysWorkPanel({
   );
 }
 
-function parseToolOutput<T>(output: unknown): T | null {
-  try {
-    return typeof output === 'string' ? JSON.parse(output) as T : output as T;
-  } catch {
-    return null;
-  }
-}
-
-// ============================================================================
-// County Map — Mapbox GL satellite map with parcel layer
-// ============================================================================
-import BentonCountyMap from './BentonCountyMap';
-
-/**
- * Real Mapbox GL satellite map of Benton County WA.
- * Parcel click → opens PropertyWorkbench for that parcel.
- */
-const CountyMapOverview: React.FC<{
-  onParcelSelect: (parcelId: string) => void;
-}> = ({ onParcelSelect }) => (
-  <div
-    className='relative w-full h-full rounded-xl overflow-hidden'
-    aria-label='Benton County WA — satellite GIS map'
-  >
-    <span className='sr-only' role='img' aria-label='Open TerraAtlas for full county map' />
-
-    {/* Mapbox GL satellite map */}
-    <BentonCountyMap
-      onParcelSelect={onParcelSelect}
-      className='w-full h-full'
-    />
-  </div>
-);
+const HOME_EXECUTIVE_POSTURE: ExecutivePostureState = {
+  dais: {
+    status: 'error',
+    summary: 'County leadership briefing unavailable.',
+  },
+  forge: {
+    status: 'error',
+    summary: 'Chief appraiser brief unavailable.',
+  },
+  atlas: {
+    status: 'error',
+    summary: 'Spatial audit posture unavailable.',
+  },
+  dossier: {
+    status: 'error',
+    summary: 'Packet readiness unavailable.',
+  },
+};
 
 // ============================================================================
 // Main Component
@@ -253,21 +239,12 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
   const openCommandPalette = useCommandPaletteStore((state) => state.open);
   const recentParcels = useRecentParcels();
   const { tasks: todaysTasks, loading: todaysTasksLoading, error: todaysTasksError } = useTodaysWork();
-  const { data: statsData } = useParcelCount();
+  const executivePosture = HOME_EXECUTIVE_POSTURE;
   const bentonPosture = getCountyRuntimePosture('benton');
   const sourceOnlyCountyCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.filter(
     (posture) => !posture.runtimeActionsAllowed
   ).length;
   const runtimeEnabledCountyCount = WASHINGTON_COUNTY_RUNTIME_POSTURES.length - sourceOnlyCountyCount;
-  const parcelCountLabel = typeof statsData?.totalParcels === 'number'
-    ? `${statsData.totalParcels.toLocaleString()} parcels`
-    : 'Parcel count unavailable';
-  const [executivePosture, setExecutivePosture] = useState<ExecutivePostureState>({
-    dais: { status: 'idle' },
-    forge: { status: 'idle' },
-    atlas: { status: 'idle' },
-    dossier: { status: 'idle' },
-  });
 
   const handleOpenAtlas = useCallback(() => {
     activateModule('suite-atlas', { source: 'desktop' });
@@ -296,106 +273,6 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
 
   const handleOpenDossier = useCallback(() => {
     activateModule('suite-dossier', { source: 'desktop' });
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadExecutivePosture() {
-      const taxYear = new Date().getFullYear();
-
-      setExecutivePosture({
-        dais: { status: 'loading' },
-        forge: { status: 'loading' },
-        atlas: { status: 'loading' },
-        dossier: { status: 'loading' },
-      });
-
-      const [daisResult, forgeResult, atlasResult, dossierResult] = await Promise.allSettled([
-        invokeTool({
-          toolId: 'generate_morning_brief',
-          params: { county: 'benton', role: 'assessor_leadership', taxYear },
-        }),
-        invokeTool({
-          toolId: 'generate_morning_brief',
-          params: { county: 'benton', role: 'chief_appraiser', taxYear },
-        }),
-        invokeTool({
-          toolId: 'explain_spatial_anomaly',
-          params: { county: 'benton', taxYear, metric: 'residual_cluster', geographyId: 'BENTON-COUNTY' },
-        }),
-        invokeTool({
-          toolId: 'open_appeal_packet',
-          params: { county: 'benton', appealId: 'BOE-2026-001' },
-        }),
-      ]);
-
-      if (cancelled) {
-        return;
-      }
-
-      setExecutivePosture({
-        dais: daisResult.status === 'fulfilled' && daisResult.value.success
-          ? (() => {
-              const parsed = parseToolOutput<{ queueType?: string; summary?: string; recommendedTool?: string }>(
-                daisResult.value.result?.output
-              );
-              return {
-                status: 'success',
-                summary: parsed?.summary || 'Summary not returned.',
-                queueType: parsed?.queueType,
-                recommendedTool: parsed?.recommendedTool,
-                correlationId: daisResult.value.correlationId,
-              };
-            })()
-          : { status: 'error', summary: 'County leadership briefing unavailable.' },
-        forge: forgeResult.status === 'fulfilled' && forgeResult.value.success
-          ? (() => {
-              const parsed = parseToolOutput<{ summary?: string; queueType?: string }>(
-                forgeResult.value.result?.output
-              );
-              return {
-                status: 'success',
-                summary: parsed?.summary || 'Summary not returned.',
-                readiness: parsed?.queueType,
-                correlationId: forgeResult.value.correlationId,
-              };
-            })()
-          : { status: 'error', summary: 'Chief appraiser brief unavailable.' },
-        atlas: atlasResult.status === 'fulfilled' && atlasResult.value.success
-          ? (() => {
-              const parsed = parseToolOutput<{ narrative?: string; hotspotCount?: number }>(
-                atlasResult.value.result?.output
-              );
-              return {
-                status: 'success',
-                summary: parsed?.narrative || 'Summary not returned.',
-                hotspots: parsed?.hotspotCount,
-                correlationId: atlasResult.value.correlationId,
-              };
-            })()
-          : { status: 'error', summary: 'Spatial audit posture unavailable.' },
-        dossier: dossierResult.status === 'fulfilled' && dossierResult.value.success
-          ? (() => {
-              const parsed = parseToolOutput<{ packetRef?: string; payloadRef?: string }>(
-                dossierResult.value.result?.output
-              );
-              return {
-                status: 'success',
-                summary: parsed?.payloadRef || 'Summary not returned.',
-                packetRef: parsed?.packetRef,
-                correlationId: dossierResult.value.correlationId,
-              };
-            })()
-          : { status: 'error', summary: 'Packet readiness unavailable.' },
-      });
-    }
-
-    void loadExecutivePosture();
-
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   return (
@@ -444,7 +321,10 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
           {/* ═══ Center: County Overview ═══ */}
           <div data-testid='county-map-center' className='flex-1 min-w-0'>
             <GlassCard className='h-full p-2'>
-              <CountyMapOverview onParcelSelect={handleSelectParcel} />
+              <BentonCountyMap
+                className='rounded-xl overflow-hidden'
+                onParcelSelect={handleSelectParcel}
+              />
             </GlassCard>
           </div>
 
@@ -502,11 +382,11 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
                   Executive Command Surface
                 </div>
                 <div className='text-sm font-semibold mt-1' style={{ color: 'hsl(var(--tf-text))' }}>
-                  Cross-suite county posture
+                  County operations command surface
                 </div>
               </div>
               <div className='text-xs' style={{ color: 'hsl(var(--tf-muted))' }}>
-                Benton County • Governed summaries only
+                Benton Runtime Pilot • 38 counties Onboarding / Provenance / Intake
               </div>
             </div>
 
@@ -617,9 +497,11 @@ export const StageZeroState: React.FC<StageZeroStateProps> = ({ id, className = 
         <LiquidPanel variant='shell' radius='lg' className='px-4 py-2 shrink-0'>
           <div data-testid='county-status-strip' className='flex items-center justify-between text-xs' style={{ color: 'hsl(var(--tf-muted))' }}>
             <span className='font-medium' style={{ color: 'hsl(var(--tf-text))' }}>
-              Benton County, WA
+              Washington County Operating Model
             </span>
-            <span>{parcelCountLabel}</span>
+            <span>Benton Runtime Pilot</span>
+            <span>38 counties Onboarding / Provenance / Intake</span>
+            <span>Parcel count: proof path only</span>
             <span>Last sync: –</span>
             <span>Appeals: –</span>
             <span className='flex items-center gap-1'>


### PR DESCRIPTION
This PR restores the GIS Home scene surface onto the June 10 integration branch.

Scope:
- Cherry-picks the Shell/Home GIS restore slice onto feat/june10-dev39-runtime-truth.
- Keeps the merged County posture summary visible in the restored Stage Zero/Home surface.
- Does not start Phase 5 and does not touch Hostinger.

Verification run locally:
- Focused Home/GIS tests: homeScene, countyOpsScene, BentonCountyMapIntegration
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- pre-push quality gate