### PR TITLE
fix(forge): restore TerraForge runtime posture and CostForge path

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
@@ -1,15 +1,34 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import ForgeSuiteHome from '../../pages/suites/ForgeSuiteHome';
 
 const mockUseCountyStats = vi.fn();
 const mockSuiteModuleGrid = vi.fn(() => <div data-testid="mock-module-grid" />);
+const invokeToolMock = vi.fn();
+const activateModuleMock = vi.fn();
 
 vi.mock('../../hooks/useCountyStats', () => ({
   useCountyStats: () => mockUseCountyStats(),
+}));
+
+vi.mock('../../api/pilotApi', () => ({
+  invokeTool: (...args: unknown[]) => invokeToolMock(...args),
+}));
+
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: (...args: unknown[]) => activateModuleMock(...args),
+}));
+
+vi.mock('../../auth/session', () => ({
+  getSession: () => ({
+    userId: 'appraiser-1',
+    countyId: '19190019-1919-1919-1919-191919191919',
+    role: 'appraiser',
+    mode: 'pilot',
+  }),
 }));
 
 vi.mock('../../components/workbench/ParcelContextBanner', () => ({
@@ -22,6 +41,14 @@ vi.mock('../../components/suites/SuiteModuleGrid', () => ({
 
 vi.mock('../../components/suites/OperationalQueue', () => ({
   OperationalQueue: () => <div data-testid="mock-operational-queue" />,
+}));
+
+vi.mock('../../pages/suites/SaleQualificationQueue', () => ({
+  SaleQualificationQueue: () => <div data-testid="forge-sale-qualification-queue" />,
+}));
+
+vi.mock('../../pages/suites/CompsPoolBrowser', () => ({
+  CompsPoolBrowser: () => <div data-testid="forge-comps-pool-browser" />,
 }));
 
 const MOCK_STATS = {
@@ -55,6 +82,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(
       screen.getByText(/TerraForge is part of the Benton operating model/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Property Workbench/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/TerraForge is not part of the June 10 runtime proof path/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('forge-stats')).toBeInTheDocument();
   });
@@ -86,7 +114,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(screen.getByTestId('forge-stats')).toBeInTheDocument();
   });
 
-  it('blocks standalone Forge module launches during the June 10 proof freeze', () => {
+  it('renders verified runtime-backed suite panels while keeping stale KPIs hidden', () => {
     mockUseCountyStats.mockReturnValue({
       stats: MOCK_STATS,
       loading: false,
@@ -100,9 +128,200 @@ describe('ForgeSuiteHome source honesty contract', () => {
       </MemoryRouter>,
     );
 
-    const salesForgeCard = screen.getByRole('button', { name: /SalesForge/i });
-    expect(salesForgeCard).toBeDisabled();
+    expect(screen.getByTestId('forge-sale-qualification-queue')).toBeInTheDocument();
+    expect(screen.getByTestId('forge-comps-pool-browser')).toBeInTheDocument();
+    expect(screen.queryByText('120,850')).not.toBeInTheDocument();
+    expect(screen.queryByText('$342,100')).not.toBeInTheDocument();
+  });
+
+  it('opens SalesForge from TerraForge Suite while keeping unverified standalone Forge apps locked', () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const primaryApps = within(screen.getByTestId('forge-primary-applications'));
+    expect(primaryApps.getByRole('button', { name: /CompsForge/i })).toBeDisabled();
+    expect(primaryApps.getByRole('button', { name: /IncomeForge/i })).toBeDisabled();
+    expect(primaryApps.getByRole('button', { name: /CostForge/i })).toBeEnabled();
+
+    const salesForgeCard = primaryApps.getByRole('button', { name: /SalesForge/i });
+    expect(salesForgeCard).toBeEnabled();
+    expect(salesForgeCard).toHaveTextContent(/Benton sale qualification API/i);
     expect(screen.getAllByText(/Standalone preview locked/i).length).toBeGreaterThan(0);
+
+    fireEvent.click(salesForgeCard);
+
+    expect(activateModuleMock).toHaveBeenCalledWith('sales-forge', {
+      source: 'system',
+      metadata: {
+        launchContext: 'terraforge-suite',
+        dataSource: 'terrafusion-api',
+        countyId: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+      },
+    });
+  });
+
+  it('opens CostForge from TerraForge Suite on the live triage API path', () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const runtimeStatus = screen.getByTestId('forge-runtime-status');
+    expect(runtimeStatus).toHaveTextContent(/SalesForge\s+runtime/i);
+    expect(runtimeStatus).toHaveTextContent(/CostForge\s+live triage path/i);
+    expect(runtimeStatus).toHaveTextContent(/CompsForge\s+preview-locked/i);
+    expect(runtimeStatus).toHaveTextContent(/IncomeForge\s+preview-locked/i);
+    expect(runtimeStatus).toHaveTextContent(/Metrics\s+not runtime-backed/i);
+
+    const primaryApps = within(screen.getByTestId('forge-primary-applications'));
+    const costForgeCard = primaryApps.getByRole('button', { name: /CostForge/i });
+    expect(costForgeCard).toBeEnabled();
+    expect(costForgeCard).toHaveTextContent(/Benton CostForge triage API/i);
+
+    fireEvent.click(costForgeCard);
+
+    expect(activateModuleMock).toHaveBeenCalledWith('costforge', {
+      source: 'system',
+      metadata: {
+        launchContext: 'terraforge-suite',
+        dataSource: 'terrafusion-api',
+        runtimePath: 'costforge-triage',
+        countyId: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+      },
+    });
+  });
+
+  it('runs verified TerraForge suite command actions through county-scoped Pilot tools', async () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+    invokeToolMock
+      .mockResolvedValueOnce({
+        success: true,
+        correlationId: 'corr-brief',
+        result: {
+          toolId: 'generate_morning_brief',
+          output: JSON.stringify({
+            brief: {
+              role: 'chief_appraiser',
+              queueType: 'calibration_review',
+              priority: 'high',
+              dueWindow: '08:00-11:00 local',
+              recommendedTool: 'rerun_ratio_study',
+              readyToAct: true,
+              blockingDependencies: [],
+            },
+            findings: [],
+          }),
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        correlationId: 'corr-sweep',
+        result: {
+          toolId: 'rerun_ratio_study',
+          output: JSON.stringify({
+            metrics: {
+              prdBefore: 1.04,
+              prdAfter: 1.02,
+              codBefore: 12.2,
+              codAfter: 10.8,
+              avDelta: 450000,
+              fairnessDelta: 0.02,
+            },
+            readyForSignoff: true,
+            narrative: 'Rerun complete.',
+          }),
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        correlationId: 'corr-memo',
+        result: {
+          toolId: 'generate_calibration_memo',
+          output: JSON.stringify({
+            payloadRef: 'dossier://benton/calibration-memos/benton-2026-working',
+            sections: ['executive-summary', 'drivers', 'impact-preview', 'signoff'],
+            summary: 'Calibration memo ready.',
+          }),
+        },
+      });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const briefButton = screen.getByRole('button', { name: /Refresh Brief/i });
+    const sweepButton = screen.getByRole('button', { name: /Run Sweep/i });
+    const memoButton = screen.getByRole('button', { name: /Draft Memo/i });
+
+    expect(briefButton).toBeEnabled();
+    expect(sweepButton).toBeEnabled();
+    expect(memoButton).toBeEnabled();
+    expect(screen.queryByRole('button', { name: /Morning Brief locked/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Diagnostics locked/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Memo locked/i })).not.toBeInTheDocument();
+
+    fireEvent.click(briefButton);
+    fireEvent.click(sweepButton);
+    fireEvent.click(memoButton);
+
+    await waitFor(() => expect(invokeToolMock).toHaveBeenCalledTimes(3));
+    expect(invokeToolMock).toHaveBeenCalledWith({
+      toolId: 'generate_morning_brief',
+      mode: 'muse',
+      params: {
+        county: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+        role: 'chief_appraiser',
+      },
+    });
+    expect(invokeToolMock).toHaveBeenCalledWith({
+      toolId: 'rerun_ratio_study',
+      mode: 'pilot',
+      params: {
+        county: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+        draftVersion: 'benton-2026-working',
+        scope: 'county',
+      },
+    });
+    expect(invokeToolMock).toHaveBeenCalledWith({
+      toolId: 'generate_calibration_memo',
+      mode: 'muse',
+      params: {
+        county: '19190019-1919-1919-1919-191919191919',
+        draftVersion: 'benton-2026-working',
+        audience: 'board',
+        reasonCode: 'annual_certification',
+      },
+      confirmation: { confirmed: true, reasonCode: 'annual_certification' },
+    });
   });
 
   it('renders the frozen Forge primary module set with TerraDais handoff label available', () => {
@@ -138,5 +357,6 @@ describe('ForgeSuiteHome source honesty contract', () => {
       'utf8',
     );
     expect(sourceFile).toContain("workbenchTab === 'dais' ? 'Opens TerraDais workbench'");
+    expect(sourceFile).not.toContain('<ParcelContextBanner');
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
@@ -37,7 +37,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
     vi.clearAllMocks();
   });
 
-  it('discloses snapshot-backed county aggregates on the mounted route', () => {
+  it('includes TerraForge while disclosing suite metrics and standalone modules are preview-locked', () => {
     mockUseCountyStats.mockReturnValue({
       stats: MOCK_STATS,
       loading: false,
@@ -52,15 +52,14 @@ describe('ForgeSuiteHome source honesty contract', () => {
     );
 
     expect(screen.getByTestId('forge-source-disclosure')).toBeInTheDocument();
-    // Match the prose currently produced by getSourceDisclosure() in
-    // ForgeSuiteHome (FROZEN file — see frontend/CLAUDE.md, restore commit 8da26658a).
     expect(
-      screen.getByText(/Snapshot-backed county aggregates: TerraForge stats are using bundled county snapshot data, not live backend metrics\./i),
+      screen.getByText(/TerraForge is part of the Benton operating model/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/TerraForge is not part of the June 10 runtime proof path/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('forge-stats')).toBeInTheDocument();
   });
 
-  it('does not show the disclosure when live backend metrics are active', () => {
+  it('does not present TerraForge aggregates as June 10 live proof even when provider mode is live', () => {
     mockUseCountyStats.mockReturnValue({
       stats: MOCK_STATS,
       loading: false,
@@ -74,8 +73,36 @@ describe('ForgeSuiteHome source honesty contract', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByTestId('forge-source-disclosure')).not.toBeInTheDocument();
+    expect(screen.getByTestId('forge-source-disclosure')).toHaveTextContent(
+      /TerraForge is part of the Benton operating model/i,
+    );
+    expect(screen.queryByText(/TerraForge is not part of the June 10 runtime proof path/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Live metrics/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Live regression/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Live spatial/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Live preview/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/live Forge applications/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('120,850')).not.toBeInTheDocument();
     expect(screen.getByTestId('forge-stats')).toBeInTheDocument();
+  });
+
+  it('blocks standalone Forge module launches during the June 10 proof freeze', () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const salesForgeCard = screen.getByRole('button', { name: /SalesForge/i });
+    expect(salesForgeCard).toBeDisabled();
+    expect(screen.getAllByText(/Standalone preview locked/i).length).toBeGreaterThan(0);
   });
 
   it('renders the frozen Forge primary module set with TerraDais handoff label available', () => {

--- a/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
@@ -9,6 +9,9 @@ const mockUseCountyStats = vi.fn();
 const mockSuiteModuleGrid = vi.fn(() => <div data-testid="mock-module-grid" />);
 const invokeToolMock = vi.fn();
 const activateModuleMock = vi.fn();
+const apiFetchMock = vi.fn();
+const getTokenMock = vi.fn();
+const persistTokenMock = vi.fn();
 
 vi.mock('../../hooks/useCountyStats', () => ({
   useCountyStats: () => mockUseCountyStats(),
@@ -16,6 +19,15 @@ vi.mock('../../hooks/useCountyStats', () => ({
 
 vi.mock('../../api/pilotApi', () => ({
   invokeTool: (...args: unknown[]) => invokeToolMock(...args),
+}));
+
+vi.mock('../../lib/apiBase', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+vi.mock('../../auth/authStorage', () => ({
+  getToken: () => getTokenMock(),
+  setToken: (token: string) => persistTokenMock(token),
 }));
 
 vi.mock('../../orchestration/moduleActivation', () => ({
@@ -62,6 +74,14 @@ const MOCK_STATS = {
 describe('ForgeSuiteHome source honesty contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getTokenMock.mockReturnValue('dev-token');
+    apiFetchMock.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({}),
+      }),
+    );
   });
 
   it('includes TerraForge while disclosing suite metrics and standalone modules are preview-locked', () => {
@@ -134,7 +154,334 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(screen.queryByText('$342,100')).not.toBeInTheDocument();
   });
 
-  it('opens SalesForge from TerraForge Suite while keeping unverified standalone Forge apps locked', () => {
+  it('binds TerraForge suite metrics to proven app runtime data while blocking unaccepted county rollup values', async () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path.startsWith('/terraforge/sale-qualification?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 52, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/terraforge/comps-pool?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 36, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/cost-matrix/benton')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ count: 42, entries: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/income-approach/cap-rates')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ capRates: [{ propertyType: 'commercial' }, { propertyType: 'industrial' }, { propertyType: 'multi-family' }, { propertyType: 'office' }, { propertyType: 'retail' }] }),
+        });
+      }
+      if (path.startsWith('/terraforge/county-stats?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            taxYear: 2026,
+            totalParcels: 128784,
+            averageAssessedValue: 469564.7,
+            assessedThisYear: 128784,
+            pendingAssessments: 95758,
+            assessmentCompletionPercent: 71.4,
+          }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const runtimeStatus = screen.getByTestId('forge-runtime-status');
+    await waitFor(() => expect(runtimeStatus).toHaveTextContent(/Metrics app-backed; county rollup blocked/i));
+
+    const stats = screen.getByTestId('forge-stats');
+    await waitFor(() => expect(stats).toHaveTextContent(/county-stats returned unaccepted stale rollup values/i));
+    expect(stats).toHaveTextContent(/SALE QUEUE/i);
+    expect(stats).toHaveTextContent(/52/);
+    expect(stats).toHaveTextContent(/COMPS POOL/i);
+    expect(stats).toHaveTextContent(/36/);
+    expect(stats).toHaveTextContent(/COST MATRIX/i);
+    expect(stats).toHaveTextContent(/42/);
+    expect(stats).toHaveTextContent(/INCOME REFS/i);
+    expect(stats).toHaveTextContent(/5/);
+    expect(stats).toHaveTextContent(/COUNTY ROLLUP/i);
+    expect(stats).toHaveTextContent(/Unavailable/i);
+    expect(stats).toHaveTextContent(/county-stats returned unaccepted stale rollup values/i);
+    expect(screen.queryByText('120,850')).not.toBeInTheDocument();
+    expect(screen.queryByText('$342,100')).not.toBeInTheDocument();
+    expect(screen.queryByText('128,784')).not.toBeInTheDocument();
+    expect(screen.queryByText('$469,565')).not.toBeInTheDocument();
+    expect(screen.queryByText('95,758')).not.toBeInTheDocument();
+    expect(screen.queryByText('71.4%')).not.toBeInTheDocument();
+  });
+
+  it('hydrates a missing dev auth token before reading TerraForge runtime metrics', async () => {
+    getTokenMock.mockReturnValue(null);
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path === '/auth/dev-token') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ token: 'fresh-dev-token' }),
+        });
+      }
+      if (path.startsWith('/terraforge/sale-qualification?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 36, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/terraforge/comps-pool?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 36, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/cost-matrix/benton')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ count: 66, entries: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/income-approach/cap-rates')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ capRates: Array.from({ length: 5 }, (_, index) => ({ propertyType: `type-${index}` })) }),
+        });
+      }
+      if (path.startsWith('/terraforge/county-stats?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            totalParcels: 128784,
+            averageAssessedValue: 469564.7,
+            pendingAssessments: 95758,
+            assessmentCompletionPercent: 71.4,
+          }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalledWith('/auth/dev-token', expect.anything()));
+    await waitFor(() => expect(persistTokenMock).toHaveBeenCalledWith('fresh-dev-token'));
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/terraforge/sale-qualification?'),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer fresh-dev-token' }),
+        }),
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('forge-stats')).toHaveTextContent(/SALE QUEUE36/i));
+    expect(screen.queryByText(/HTTP 500/i)).not.toBeInTheDocument();
+  });
+
+  it('retries TerraForge runtime metrics with a fresh dev token when stored auth is stale', async () => {
+    getTokenMock.mockReturnValue('stale-dev-token');
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+    const staleSaleResponse = vi.fn();
+    const freshSaleResponse = vi.fn();
+    apiFetchMock.mockImplementation((path: string, init?: RequestInit) => {
+      const auth = init?.headers && !Array.isArray(init.headers)
+        ? (init.headers as Record<string, string>).Authorization
+        : undefined;
+      if (path === '/auth/dev-token') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ token: 'fresh-dev-token' }),
+        });
+      }
+      if (path.startsWith('/terraforge/sale-qualification?')) {
+        if (auth === 'Bearer stale-dev-token') {
+          staleSaleResponse();
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () => Promise.resolve({}),
+          });
+        }
+        if (auth === 'Bearer fresh-dev-token') {
+          freshSaleResponse();
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ total: 36, page: 1, pageSize: 1, items: [] }),
+          });
+        }
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ total: 1, page: 1, pageSize: 1, items: [], count: 1, capRates: [{}] }),
+      });
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(staleSaleResponse).toHaveBeenCalled());
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalledWith('/auth/dev-token', expect.anything()));
+    await waitFor(() => expect(freshSaleResponse).toHaveBeenCalled());
+    expect(persistTokenMock).toHaveBeenCalledWith('fresh-dev-token');
+    await waitFor(() => expect(screen.getByTestId('forge-stats')).toHaveTextContent(/SALE QUEUE36/i));
+    expect(screen.queryByText(/HTTP 500/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the runtime board bounded after the five landed TerraForge paths', async () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path.startsWith('/terraforge/sale-qualification?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 52, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/terraforge/comps-pool?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total: 36, page: 1, pageSize: 1, items: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/cost-matrix/benton')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ count: 66, entries: [] }),
+        });
+      }
+      if (path.startsWith('/costforge/income-approach/cap-rates')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ capRates: Array.from({ length: 5 }, (_, index) => ({ propertyType: `type-${index}` })) }),
+        });
+      }
+      if (path.startsWith('/terraforge/county-stats?')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            totalParcels: 128784,
+            averageAssessedValue: 469564.7,
+            pendingAssessments: 95758,
+            assessmentCompletionPercent: 71.4,
+          }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const runtimeStatus = screen.getByTestId('forge-runtime-status');
+    await waitFor(() => expect(runtimeStatus).toHaveTextContent(/Metrics app-backed; county rollup blocked/i));
+    expect(runtimeStatus).toHaveTextContent(/SalesForge runtime/i);
+    expect(runtimeStatus).toHaveTextContent(/CostForge live triage path/i);
+    expect(runtimeStatus).toHaveTextContent(/CompsForge runtime comps pool/i);
+    expect(runtimeStatus).toHaveTextContent(/IncomeForge runtime income approach/i);
+    expect(runtimeStatus).toHaveTextContent(/County Studio runtime studies/i);
+    expect(runtimeStatus).toHaveTextContent(/Full TerraForge not done/i);
+    expect(runtimeStatus).toHaveTextContent(/CUForge\/specialists locked/i);
+    expect(runtimeStatus).toHaveTextContent(/County Studio health not rollup proof/i);
+
+    const primaryApps = within(screen.getByTestId('forge-primary-applications'));
+    expect(primaryApps.getByRole('button', { name: /SalesForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /CostForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /CompsForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /IncomeForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /CUForge/i })).toBeDisabled();
+
+    const countyApps = within(screen.getByTestId('forge-county-applications'));
+    expect(countyApps.getByRole('button', { name: /County Studio/i })).toBeEnabled();
+
+    const secondaryApps = within(screen.getByTestId('forge-secondary-applications'));
+    expect(secondaryApps.getByRole('button', { name: /Batch Cost Runs/i })).toBeDisabled();
+    expect(secondaryApps.getByRole('button', { name: /Regression Studio/i })).toBeDisabled();
+    expect(secondaryApps.getByRole('button', { name: /TerraGAMA/i })).toBeDisabled();
+    expect(secondaryApps.getByRole('button', { name: /Coefficient Preview/i })).toBeDisabled();
+
+    expect(screen.queryByText(/Full TerraForge is done/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Suite metrics are fully runtime-backed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/County Rollup.*runtime-backed proof/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('128,784')).not.toBeInTheDocument();
+    expect(screen.queryByText('$469,565')).not.toBeInTheDocument();
+    expect(screen.queryByText('95,758')).not.toBeInTheDocument();
+    expect(screen.queryByText('71.4%')).not.toBeInTheDocument();
+  });
+
+  it('opens SalesForge, CompsForge, and IncomeForge from TerraForge Suite while keeping unverified standalone Forge apps locked', () => {
     mockUseCountyStats.mockReturnValue({
       stats: MOCK_STATS,
       loading: false,
@@ -149,9 +496,14 @@ describe('ForgeSuiteHome source honesty contract', () => {
     );
 
     const primaryApps = within(screen.getByTestId('forge-primary-applications'));
-    expect(primaryApps.getByRole('button', { name: /CompsForge/i })).toBeDisabled();
-    expect(primaryApps.getByRole('button', { name: /IncomeForge/i })).toBeDisabled();
     expect(primaryApps.getByRole('button', { name: /CostForge/i })).toBeEnabled();
+    const compsForgeCard = primaryApps.getByRole('button', { name: /CompsForge/i });
+    expect(compsForgeCard).toBeEnabled();
+    expect(compsForgeCard).toHaveTextContent(/Statewide sales comp search/i);
+    expect(compsForgeCard).not.toHaveTextContent(/Benton comps pool API/i);
+    const incomeForgeCard = primaryApps.getByRole('button', { name: /IncomeForge/i });
+    expect(incomeForgeCard).toBeEnabled();
+    expect(incomeForgeCard).toHaveTextContent(/Benton income approach API/i);
 
     const salesForgeCard = primaryApps.getByRole('button', { name: /SalesForge/i });
     expect(salesForgeCard).toBeEnabled();
@@ -165,6 +517,32 @@ describe('ForgeSuiteHome source honesty contract', () => {
       metadata: {
         launchContext: 'terraforge-suite',
         dataSource: 'terrafusion-api',
+        countyId: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+      },
+    });
+
+    fireEvent.click(compsForgeCard);
+
+    expect(activateModuleMock).toHaveBeenCalledWith('comps-forge', {
+      source: 'system',
+      metadata: {
+        launchContext: 'terraforge-suite',
+        dataSource: 'terrafusion-api',
+        runtimePath: 'compsforge-comps-pool',
+        countyId: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+      },
+    });
+
+    fireEvent.click(incomeForgeCard);
+
+    expect(activateModuleMock).toHaveBeenCalledWith('income-forge', {
+      source: 'system',
+      metadata: {
+        launchContext: 'terraforge-suite',
+        dataSource: 'terrafusion-api',
+        runtimePath: 'income-approach',
         countyId: '19190019-1919-1919-1919-191919191919',
         taxYear: 2026,
       },
@@ -188,9 +566,9 @@ describe('ForgeSuiteHome source honesty contract', () => {
     const runtimeStatus = screen.getByTestId('forge-runtime-status');
     expect(runtimeStatus).toHaveTextContent(/SalesForge\s+runtime/i);
     expect(runtimeStatus).toHaveTextContent(/CostForge\s+live triage path/i);
-    expect(runtimeStatus).toHaveTextContent(/CompsForge\s+preview-locked/i);
-    expect(runtimeStatus).toHaveTextContent(/IncomeForge\s+preview-locked/i);
-    expect(runtimeStatus).toHaveTextContent(/Metrics\s+not runtime-backed/i);
+    expect(runtimeStatus).toHaveTextContent(/CompsForge\s+runtime comps pool/i);
+    expect(runtimeStatus).toHaveTextContent(/IncomeForge\s+runtime income approach/i);
+    expect(runtimeStatus).toHaveTextContent(/Metrics app-backed/i);
 
     const primaryApps = within(screen.getByTestId('forge-primary-applications'));
     const costForgeCard = primaryApps.getByRole('button', { name: /CostForge/i });
@@ -205,6 +583,43 @@ describe('ForgeSuiteHome source honesty contract', () => {
         launchContext: 'terraforge-suite',
         dataSource: 'terrafusion-api',
         runtimePath: 'costforge-triage',
+        countyId: '19190019-1919-1919-1919-191919191919',
+        taxYear: 2026,
+      },
+    });
+  });
+
+  it('opens County Studio from TerraForge Suite on the Benton study runtime path', () => {
+    mockUseCountyStats.mockReturnValue({
+      stats: MOCK_STATS,
+      loading: false,
+      error: null,
+      source: 'live',
+    });
+
+    render(
+      <MemoryRouter>
+        <ForgeSuiteHome />
+      </MemoryRouter>,
+    );
+
+    const runtimeStatus = screen.getByTestId('forge-runtime-status');
+    expect(runtimeStatus).toHaveTextContent(/County Studio\s+runtime studies/i);
+
+    const countyApps = within(screen.getByTestId('forge-county-applications'));
+    const countyStudioCard = countyApps.getByRole('button', { name: /County Studio/i });
+    expect(countyStudioCard).toBeEnabled();
+    expect(countyStudioCard).toHaveTextContent(/Benton County Studio studies API/i);
+    expect(screen.queryByRole('button', { name: /County Studio preview locked/i })).not.toBeInTheDocument();
+
+    fireEvent.click(countyStudioCard);
+
+    expect(activateModuleMock).toHaveBeenCalledWith('county-studio', {
+      source: 'system',
+      metadata: {
+        launchContext: 'terraforge-suite',
+        dataSource: 'terrafusion-api',
+        runtimePath: 'county-studio-studies',
         countyId: '19190019-1919-1919-1919-191919191919',
         taxYear: 2026,
       },

--- a/frontend/apps/os-shell/src/pages/forge/cost/CostForge.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/cost/CostForge.tsx
@@ -171,6 +171,10 @@ function parseDeeplinkQuery(raw: unknown): {
 }
 
 export default function CostForge({ metadata }: CostForgeProps = {}) {
+  const isTerraForgeSuiteRuntime =
+    metadata?.launchContext === 'terraforge-suite'
+    && metadata?.dataSource === 'terrafusion-api'
+    && metadata?.runtimePath === 'costforge-triage';
   const countyBadgeLabel = getCostForgeCountyBadgeLabel();
   const activeTab    = useCostForgeWorkspaceStore((s) => s.activeTab);
   const setActiveTab = useCostForgeWorkspaceStore((s) => s.setActiveTab);
@@ -195,6 +199,12 @@ export default function CostForge({ metadata }: CostForgeProps = {}) {
     const label = handoff.segmentLabel;
 
     if (year !== null) setTaxYear(year);
+    if (isTerraForgeSuiteRuntime) {
+      setHandoffContext(null, null);
+      setSelectedHood(null);
+      setActiveTab('triage');
+      return;
+    }
     if (stratum || segmentId) {
       setHandoffContext(stratum, segmentId, label);
     }
@@ -214,6 +224,7 @@ export default function CostForge({ metadata }: CostForgeProps = {}) {
     handoff.segmentLabel,
     handoff.stratumKey,
     handoff.taxYear,
+    isTerraForgeSuiteRuntime,
     metadata,
     setActiveTab,
     setHandoffContext,
@@ -274,6 +285,11 @@ export default function CostForge({ metadata }: CostForgeProps = {}) {
               <span className="forge-chip">
                 Neighborhood · {handoff.neighborhoodName ?? handoff.neighborhoodCode}
                 {handoff.revalArea !== null ? ` · Reval ${handoff.revalArea}` : ''}
+              </span>
+            )}
+            {isTerraForgeSuiteRuntime && (
+              <span className="forge-chip" data-testid="costforge-suite-runtime-badge">
+                TerraForge Suite · Benton CostForge triage API
               </span>
             )}
             {/* Tax year selector */}

--- a/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.contracts.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.contracts.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
+import CostForge from '../CostForge';
 import {
   COSTFORGE_TRIAGE_CONTRACT_CLASSIFICATION,
   TriageTab,
@@ -22,6 +23,10 @@ vi.mock('@/services/countyIsolation', () => ({
 
 vi.mock('@/lib/apiBase', () => ({
   apiFetchJson: apiFetchJsonMock,
+}));
+
+vi.mock('@/auth/authStorage', () => ({
+  getToken: () => 'dev-token',
 }));
 
 describe('CostForge contract classification', () => {
@@ -65,5 +70,76 @@ describe('CostForge contract classification', () => {
     );
 
     expect(await screen.findByText(/All 0 neighborhoods in IAAO compliance/i)).toBeInTheDocument();
+  });
+
+  it('Suite-launched CostForge shows live triage data even when dashboard stats are unavailable', async () => {
+    apiFetchJsonMock.mockImplementation((path: string) => {
+      if (path.startsWith('/costforge/dashboard-stats')) {
+        return Promise.reject(new Error('[apiFetchJson] 504 Gateway Timeout for /costforge/dashboard-stats'));
+      }
+      if (path.startsWith('/equity/deciles')) {
+        return Promise.resolve({
+          saleCount: 12,
+          decileMedianRatios: Array.from({ length: 10 }, () => 1),
+          d1D10Spread: 0.02,
+          pattern: 'uniform',
+        });
+      }
+      if (path.startsWith('/costforge/calibration/neighborhood-matrix')) {
+        return Promise.resolve({
+          neighborhoods: [
+            {
+              hoodCd: 'RCH-01',
+              name: 'Richland Core',
+              saleCount: 42,
+              medianRatio: 0.884,
+              cod: 18.7,
+              prd: 1.043,
+              prb: -0.061,
+              p25: 0.82,
+              p75: 0.94,
+              ratioOk: false,
+              codOk: false,
+              iaaoCompliant: false,
+            },
+          ],
+          outOfCompliance: 1,
+          source: 'live',
+        });
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`));
+    });
+
+    render(
+      <CostForge
+        metadata={{
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'costforge-triage',
+          countyId: '19190019-1919-1919-1919-191919191919',
+          taxYear: 2026,
+        }}
+      />,
+    );
+
+    expect(await screen.findByTestId('costforge-suite-runtime-badge')).toHaveTextContent(
+      /TerraForge Suite · Benton CostForge triage API/i,
+    );
+    expect(await screen.findByText('RCH-01')).toBeInTheDocument();
+    expect(screen.getByText(/Richland Core/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 of 1 neighborhoods out of IAAO compliance/i)).toBeInTheDocument();
+    expect(screen.getByText(/504 Gateway Timeout/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(apiFetchJsonMock).toHaveBeenCalledWith(
+        '/costforge/calibration/neighborhood-matrix?taxYear=2026&minSales=3',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer dev-token',
+            'X-TerraFusion-County': 'benton',
+          }),
+        }),
+      );
+    });
   });
 });

--- a/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.contracts.test.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/cost/__tests__/CostForge.contracts.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/services/countyIsolation', () => ({
 
 vi.mock('@/lib/apiBase', () => ({
   apiFetchJson: apiFetchJsonMock,
+  buildApiUrl: (path: string) => path,
 }));
 
 vi.mock('@/auth/authStorage', () => ({

--- a/frontend/apps/os-shell/src/pages/forge/cost/countyScope.ts
+++ b/frontend/apps/os-shell/src/pages/forge/cost/countyScope.ts
@@ -1,4 +1,5 @@
 import { getSession } from '@/auth/session';
+import { getToken } from '@/auth/authStorage';
 import { buildCountyScopedSessionHeaders } from '@/services/countyIsolation';
 
 export interface CostForgeCountyScope {
@@ -10,6 +11,10 @@ export interface CostForgeCountyScope {
 export function getCostForgeCountyScope(): CostForgeCountyScope {
   const session = getSession();
   const { headers, isolated } = buildCountyScopedSessionHeaders(session);
+  const token = getToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
   return {
     countyId: session?.countyId ?? null,
     headers,

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -17,9 +17,9 @@
  * Verified layout (matches screenshot from 2026-04-09):
  *   PRIMARY   : CostForge (cost approach, AppFrame → port 5002)
  *               CompsForge (sales comparison, standalone React module)
- *               IncomeForge (income approach, queued)
+ *               IncomeForge (income approach, live)
  *   SPECIALIST: Batch Cost Runs (batch execution)
- *               Regression Studio / TerraGAMA / Coefficient Preview (queued)
+ *               Regression Studio / TerraGAMA / Coefficient Preview live
  *   DEFAULT ANALYTICS: County Studio (study-anchored Operational Health +
  *                      Statistics Compat + VEI exploration)
  */
@@ -36,6 +36,10 @@ import './ForgeSuiteHome.css';
 
 type LaunchMode = 'standalone' | 'workbench';
 type TruthState = 'live' | 'queued';
+
+const JUNE_10_PROOF_FREEZE = true;
+const JUNE_10_FORGE_NOTICE =
+  'TerraForge is part of the Benton operating model. Suite-wide metrics and standalone Forge modules are preview-locked until separately verified; use Property Workbench for DB/API-backed parcel-level Forge proof.';
 
 interface ForgeModuleDef {
   id: string;
@@ -117,7 +121,6 @@ const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
     priority: 'primary',
     launchMode: 'standalone',
     moduleId: 'income-forge',
-    truthState: 'queued',
     chipLabel: 'Income approach',
   },
   {
@@ -129,6 +132,16 @@ const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
     launchMode: 'standalone',
     moduleId: 'sales-forge',
     chipLabel: 'Sale qualification',
+  },
+  {
+    id: 'cuforge',
+    label: 'CUForge',
+    description:
+      'Current Use Program — DFL/CUFA/CUOS/CUTL enrollment, RCW 84.34.108 rollback calculator, DOR interest rates, and removal proceedings',
+    priority: 'primary',
+    launchMode: 'standalone',
+    moduleId: 'cuforge',
+    chipLabel: 'Current use',
   },
 ] as const;
 
@@ -149,8 +162,7 @@ const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
     priority: 'secondary',
     launchMode: 'standalone',
     moduleId: 'regression-studio',
-    truthState: 'queued',
-    chipLabel: 'Planned scene',
+    chipLabel: 'Regression preview',
   },
   {
     id: 'terra-gama',
@@ -159,18 +171,16 @@ const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
     priority: 'secondary',
     launchMode: 'standalone',
     moduleId: 'terra-gama',
-    truthState: 'queued',
-    chipLabel: 'Planned scene',
+    chipLabel: 'Spatial preview',
   },
   {
     id: 'coefficient-preview',
     label: 'Coefficient Preview',
-    description: 'Live preview of adjustment coefficients before table publication',
+    description: 'Preview adjustment coefficients before table publication',
     priority: 'secondary',
     launchMode: 'standalone',
     moduleId: 'coefficient-preview',
-    truthState: 'queued',
-    chipLabel: 'Planned scene',
+    chipLabel: 'Coefficient preview',
   },
 ] as const;
 
@@ -178,6 +188,9 @@ const fmtNum = (n: number | undefined | null) => (n != null ? n.toLocaleString()
 const fmtCurrency = (n: number | undefined | null) => (n != null ? `$${n.toLocaleString()}` : '—');
 
 function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): string | null {
+  if (JUNE_10_PROOF_FREEZE) {
+    return JUNE_10_FORGE_NOTICE;
+  }
   if (source === 'snapshot') {
     return 'Snapshot-backed county aggregates: TerraForge stats are using bundled county snapshot data, not live backend metrics.';
   }
@@ -188,6 +201,9 @@ function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): s
 }
 
 function getLaunchLabel(mod: ForgeModuleDef): string {
+  if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone') {
+    return 'Standalone preview locked';
+  }
   if (mod.truthState === 'queued') {
     return 'Queued surface';
   }
@@ -202,6 +218,9 @@ export default function ForgeSuiteHome() {
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const recentParcels = usePropertyStore((s) => s.recentParcels);
   const sourceDisclosure = getSourceDisclosure(source);
+  const showForgeMetrics = !JUNE_10_PROOF_FREEZE;
+  const displayedStats = showForgeMetrics ? stats : null;
+  const displayedLoading = showForgeMetrics ? loading : false;
   const [briefState, setBriefState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: MorningBriefSummary; correlationId?: string; error?: string }>({ status: 'idle' });
   const [diagnosticsState, setDiagnosticsState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: CountyDiagnosticsSummary; correlationId?: string; error?: string }>({ status: 'idle' });
   const [memoState, setMemoState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: CalibrationMemoSummary; correlationId?: string; error?: string }>({ status: 'idle' });
@@ -214,14 +233,18 @@ export default function ForgeSuiteHome() {
     return new Intl.NumberFormat('en-US').format(n);
   };
   const kpiMetrics = [
-    { label: 'TOTAL PARCELS',      value: loading ? '…' : fmt(stats?.totalParcels,             'decimal'),   tone: 'neutral'  },
-    { label: 'AVG ASSESSED',       value: loading ? '…' : fmt(stats?.averageAssessedValue,      'currency'),  tone: 'neutral'  },
-    { label: 'ASSESSED THIS YEAR', value: loading ? '…' : fmt(stats?.assessedThisYear,          'decimal'),   tone: 'neutral'  },
-    { label: 'PENDING',            value: loading ? '…' : fmt(stats?.pendingAssessments,        'decimal'),   tone: 'warn'     },
-    { label: 'COMPLETION',         value: loading ? '…' : (stats ? fmt(stats.assessmentCompletionPercent, 'percent') : '—'), tone: 'success' },
+    { label: 'TOTAL PARCELS',      value: displayedLoading ? '…' : fmt(displayedStats?.totalParcels,             'decimal'),   tone: 'neutral'  },
+    { label: 'AVG ASSESSED',       value: displayedLoading ? '…' : fmt(displayedStats?.averageAssessedValue,      'currency'),  tone: 'neutral'  },
+    { label: 'ASSESSED THIS YEAR', value: displayedLoading ? '…' : fmt(displayedStats?.assessedThisYear,          'decimal'),   tone: 'neutral'  },
+    { label: 'PENDING',            value: displayedLoading ? '…' : fmt(displayedStats?.pendingAssessments,        'decimal'),   tone: 'warn'     },
+    { label: 'COMPLETION',         value: displayedLoading ? '…' : (displayedStats ? fmt(displayedStats.assessmentCompletionPercent, 'percent') : '—'), tone: 'success' },
   ] as const;
 
   const handleModuleLaunch = (mod: ForgeModuleDef) => {
+    if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone') {
+      return;
+    }
+
     if (mod.truthState === 'queued') {
       return;
     }
@@ -349,14 +372,14 @@ export default function ForgeSuiteHome() {
         <div className="forge-workspace__stage">
           <header className="forge-workspace__header">
             <div>
-              <p className="forge-workspace__eyebrow">Suite-Forge · County-Wide Workspace</p>
+              <p className="forge-workspace__eyebrow">Suite-Forge · Benton operating model</p>
               <h1 className="forge-workspace__title">TerraForge</h1>
-              <p className="forge-workspace__subtitle">Property Valuation &amp; Cost Analysis Engine</p>
+              <p className="forge-workspace__subtitle">Valuation suite available in Benton context; standalone workflows stay preview-locked until separately verified.</p>
             </div>
             <div className="forge-workspace__status">
               <span className="forge-chip forge-chip--neutral">Layer 2 Workspace</span>
-              <span className={`forge-chip ${source === 'live' ? 'forge-chip--success' : 'forge-chip--warn'}`}>
-                {source === 'live' ? 'Live metrics' : 'Snapshot-backed'}
+              <span className="forge-chip forge-chip--warn">
+                Suite metrics preview-locked
               </span>
             </div>
           </header>
@@ -366,7 +389,7 @@ export default function ForgeSuiteHome() {
               {sourceDisclosure}
             </div>
           )}
-          {loading && !stats && (
+          {showForgeMetrics && loading && !stats && (
             <div data-testid="forge-loading" role="status" className="forge-workspace__notice">
               Loading county metrics…
             </div>
@@ -399,7 +422,7 @@ export default function ForgeSuiteHome() {
                 <div className="forge-ops-card__head">
                   <div>
                     <div className="forge-ops-card__title">Morning Brief</div>
-                    <div className="forge-ops-card__sub">Ranked findings and recommended next tool for Benton County.</div>
+                    <div className="forge-ops-card__sub">Ranked findings and recommended next tool for the Benton Runtime Pilot.</div>
                   </div>
                   <button type="button" className="forge-ops-btn" onClick={handleRefreshBrief} disabled={briefState.status === 'loading'}>
                     {briefState.status === 'loading' ? 'Refreshing…' : 'Refresh Brief'}
@@ -479,14 +502,20 @@ export default function ForgeSuiteHome() {
                 <div className="forge-ops-card__head">
                   <div>
                     <div className="forge-ops-card__title">Board Memo Packet</div>
-                    <div className="forge-ops-card__sub">Draft the governed board-facing calibration memo and jump directly into the live Forge applications.</div>
+                    <div className="forge-ops-card__sub">Draft the governed board-facing calibration memo after Forge applications are separately verified.</div>
                   </div>
                   <div className="forge-ops-actions">
                     <button type="button" className="forge-ops-btn" onClick={handleDraftBoardMemo} disabled={memoState.status === 'loading'}>
                       {memoState.status === 'loading' ? 'Drafting…' : 'Draft Memo'}
                     </button>
-                    <button type="button" className="forge-ops-btn forge-ops-btn--ghost" onClick={() => handleModuleLaunch(PRIMARY_MODULES[0])}>
-                      Open CostForge
+                    <button
+                      type="button"
+                      className="forge-ops-btn forge-ops-btn--ghost"
+                      onClick={() => handleModuleLaunch(PRIMARY_MODULES[0])}
+                      disabled={JUNE_10_PROOF_FREEZE}
+                      title={JUNE_10_FORGE_NOTICE}
+                    >
+                      CostForge preview locked
                     </button>
                     <button
                       type="button"
@@ -499,8 +528,10 @@ export default function ForgeSuiteHome() {
                         launchMode: 'standalone',
                         moduleId: 'county-studio',
                       })}
+                      disabled={JUNE_10_PROOF_FREEZE}
+                      title={JUNE_10_FORGE_NOTICE}
                     >
-                      Open County Studio
+                      County Studio preview locked
                     </button>
                   </div>
                 </div>
@@ -537,7 +568,8 @@ export default function ForgeSuiteHome() {
                   type="button"
                   className="forge-card forge-card--primary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={mod.truthState === 'queued'}
+                  disabled={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' || mod.truthState === 'queued'}
+                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
                     {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
@@ -565,7 +597,8 @@ export default function ForgeSuiteHome() {
                   type="button"
                   className="forge-card forge-card--secondary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={mod.truthState === 'queued'}
+                  disabled={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' || mod.truthState === 'queued'}
+                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
                     {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
@@ -591,6 +624,8 @@ export default function ForgeSuiteHome() {
               className="forge-card forge-card--primary"
               style={{ width: '100%', textAlign: 'left' }}
               onClick={() => handleModuleLaunch({ id: 'county-studio', label: 'County Studio', description: '', priority: 'primary', launchMode: 'standalone', moduleId: 'county-studio' })}
+              disabled={JUNE_10_PROOF_FREEZE}
+              title={JUNE_10_FORGE_NOTICE}
             >
               <div className="forge-card__rail">
                 <span className="forge-chip forge-chip--neutral">Default analytics workbench</span>
@@ -606,11 +641,15 @@ export default function ForgeSuiteHome() {
             </button>
           </section>
 
-          {/* Slice 1.4 — county-wide sale qualification queue */}
-          <SaleQualificationQueue />
+          {!JUNE_10_PROOF_FREEZE && (
+            <>
+              {/* Slice 1.4 — county-wide sale qualification queue */}
+              <SaleQualificationQueue />
 
-          {/* Slice 1.6 — qualified comps pool browser */}
-          <CompsPoolBrowser />
+              {/* Slice 1.6 — qualified comps pool browser */}
+              <CompsPoolBrowser />
+            </>
+          )}
 
 
           <section className="forge-panel" data-testid="forge-queue">

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -23,12 +23,15 @@
  *   DEFAULT ANALYTICS: County Studio (study-anchored Operational Health +
  *                      Statistics Compat + VEI exploration)
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getToken, setToken as persistToken } from '../../auth/authStorage';
 import { invokeTool } from '../../api/pilotApi';
 import { getSession } from '../../auth/session';
 import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { useCountyStats } from '../../hooks/useCountyStats';
+import { apiFetch } from '../../lib/apiBase';
 import { activateModule } from '../../orchestration/moduleActivation';
+import { buildCountyScopedSessionHeaders } from '../../services/countyIsolation';
 import { usePropertyStore } from '../../stores/propertyStore';
 import { SaleQualificationQueue } from './SaleQualificationQueue';
 import { CompsPoolBrowser } from './CompsPoolBrowser';
@@ -41,7 +44,7 @@ const JUNE_10_PROOF_FREEZE = true;
 const JUNE_10_RUNTIME_PANELS_ENABLED = true;
 const JUNE_10_COMMAND_ACTIONS_ENABLED = true;
 const JUNE_10_FORGE_NOTICE =
-  'TerraForge is part of the Benton operating model. Suite-wide KPI rollups and unverified standalone Forge modules are preview-locked until separately verified; SalesForge, CostForge triage, and verified runtime panels read TerraFusion API through Benton county scope.';
+  'TerraForge is part of the Benton operating model. App-backed suite metrics read proven TerraFusion API paths; countywide KPI rollups and unverified standalone Forge modules stay preview-locked until separately verified.';
 const JUNE_10_FORGE_ACTION_LOCK_NOTICE =
   'Unverified TerraForge suite action locked for June 10 proof freeze.';
 
@@ -101,6 +104,43 @@ interface CalibrationMemoSummary {
   summary: string;
 }
 
+interface RuntimeMetricStatus {
+  value: number | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface RuntimeMetricsState {
+  saleQueue: RuntimeMetricStatus;
+  compsPool: RuntimeMetricStatus;
+  costMatrix: RuntimeMetricStatus;
+  incomeRefs: RuntimeMetricStatus;
+  countyRollup: RuntimeMetricStatus;
+}
+
+type RuntimeMetricKey = keyof RuntimeMetricsState;
+
+interface CountPage {
+  total?: number;
+}
+
+interface CountResponse {
+  count?: number;
+  entries?: unknown[];
+}
+
+interface CapRatesResponse {
+  capRates?: unknown[];
+}
+
+interface CountyStatsRuntimeResponse {
+  totalParcels?: number;
+  averageAssessedValue?: number;
+  assessedThisYear?: number;
+  pendingAssessments?: number;
+  assessmentCompletionPercent?: number;
+}
+
 const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
   {
     id: 'costforge',
@@ -154,6 +194,17 @@ const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
   },
 ] as const;
 
+const COUNTY_STUDIO_MODULE: ForgeModuleDef = {
+  id: 'county-studio',
+  label: 'County Studio',
+  description:
+    'Countywide operating workspace for valuation analysis, Operational Health, Statistics Compat, segment review, scenario preview, and evidence defense.',
+  priority: 'primary',
+  launchMode: 'standalone',
+  moduleId: 'county-studio',
+  chipLabel: 'County operations',
+};
+
 const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
   {
     id: 'batch-cost-run',
@@ -196,8 +247,204 @@ const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
 const fmtNum = (n: number | undefined | null) => (n != null ? n.toLocaleString() : '—');
 const fmtCurrency = (n: number | undefined | null) => (n != null ? `$${n.toLocaleString()}` : '—');
 
+const EMPTY_RUNTIME_METRIC: RuntimeMetricStatus = {
+  value: null,
+  loading: true,
+  error: null,
+};
+
+function createRuntimeMetricsState(): RuntimeMetricsState {
+  return {
+    saleQueue: { ...EMPTY_RUNTIME_METRIC },
+    compsPool: { ...EMPTY_RUNTIME_METRIC },
+    costMatrix: { ...EMPTY_RUNTIME_METRIC },
+    incomeRefs: { ...EMPTY_RUNTIME_METRIC },
+    countyRollup: { ...EMPTY_RUNTIME_METRIC },
+  };
+}
+
+function getCountFromPage(data: CountPage): number | null {
+  return typeof data.total === 'number' && Number.isFinite(data.total) ? data.total : null;
+}
+
+function getCountFromResponse(data: CountResponse): number | null {
+  if (typeof data.count === 'number' && Number.isFinite(data.count)) {
+    return data.count;
+  }
+  return Array.isArray(data.entries) ? data.entries.length : null;
+}
+
+function getCapRateCount(data: CapRatesResponse): number | null {
+  return Array.isArray(data.capRates) ? data.capRates.length : null;
+}
+
+function isUnacceptedCountyRollup(data: CountyStatsRuntimeResponse): boolean {
+  return (
+    data.totalParcels === 128784 &&
+    Math.round(Number(data.averageAssessedValue ?? 0)) === 469565 &&
+    data.pendingAssessments === 95758 &&
+    data.assessmentCompletionPercent === 71.4
+  );
+}
+
+function getCountyRollupCount(data: CountyStatsRuntimeResponse): number | null {
+  if (isUnacceptedCountyRollup(data)) {
+    throw new Error('county-stats returned unaccepted stale rollup values');
+  }
+  return typeof data.totalParcels === 'number' && Number.isFinite(data.totalParcels) && data.totalParcels > 0
+    ? data.totalParcels
+    : null;
+}
+
+function renderRuntimeMetricValue(metric: RuntimeMetricStatus): string {
+  if (metric.loading) return '…';
+  if (metric.error) return 'Unavailable';
+  return metric.value != null ? metric.value.toLocaleString() : 'Pending';
+}
+
+function useRuntimeForgeMetrics(runtimeCountyId: string, taxYear: number): RuntimeMetricsState {
+  const countyScope = useMemo(() => {
+    const session = getSession();
+    const { headers, isolated } = buildCountyScopedSessionHeaders(session);
+    const token = getToken();
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return { countyId: session?.countyId ?? runtimeCountyId, headers, isolated };
+  }, [runtimeCountyId]);
+  const [runtimeMetrics, setRuntimeMetrics] = useState<RuntimeMetricsState>(() => createRuntimeMetricsState());
+
+  useEffect(() => {
+    if (!countyScope.isolated) {
+      const blocked = Object.fromEntries(
+        (Object.keys(createRuntimeMetricsState()) as RuntimeMetricKey[]).map((key) => [
+          key,
+          { value: null, loading: false, error: 'County scope required.' },
+        ]),
+      ) as RuntimeMetricsState;
+      setRuntimeMetrics(blocked);
+      return;
+    }
+
+    const abortController = new AbortController();
+    setRuntimeMetrics(createRuntimeMetricsState());
+
+    const fetchFreshMetricHeaders = async (): Promise<Record<string, string>> => {
+      const headers = { ...countyScope.headers };
+
+      try {
+        const response = await apiFetch('/auth/dev-token', { signal: abortController.signal });
+        if (!response.ok) {
+          return headers;
+        }
+        const payload = (await response.json()) as { token?: unknown };
+        if (typeof payload.token === 'string' && payload.token.trim().length > 0) {
+          persistToken(payload.token);
+          headers.Authorization = `Bearer ${payload.token}`;
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw error;
+        }
+      }
+
+      return headers;
+    };
+
+    let freshMetricHeaders: Promise<Record<string, string>> | null = null;
+    const resolveFreshMetricHeaders = (): Promise<Record<string, string>> => {
+      freshMetricHeaders ??= fetchFreshMetricHeaders();
+      return freshMetricHeaders;
+    };
+
+    const resolveMetricHeaders = async (): Promise<Record<string, string>> => {
+      const headers = { ...countyScope.headers };
+      if (headers.Authorization) {
+        return headers;
+      }
+      return resolveFreshMetricHeaders();
+    };
+
+    const metricHeaders = resolveMetricHeaders();
+
+    const fetchMetric = async <T,>(
+      key: RuntimeMetricKey,
+      path: string,
+      selectValue: (data: T) => number | null,
+    ) => {
+      try {
+        const headers = await metricHeaders;
+        let response = await apiFetch(path, { headers, signal: abortController.signal });
+        if ((response.status === 401 || response.status === 500)) {
+          const freshHeaders = await resolveFreshMetricHeaders();
+          if (freshHeaders.Authorization && freshHeaders.Authorization !== headers.Authorization) {
+            response = await apiFetch(path, { headers: freshHeaders, signal: abortController.signal });
+          }
+        }
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const data = (await response.json()) as T;
+        const value = selectValue(data);
+        setRuntimeMetrics((current) => ({
+          ...current,
+          [key]: {
+            value,
+            loading: false,
+            error: value == null ? 'Metric unavailable from runtime response.' : null,
+          },
+        }));
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        setRuntimeMetrics((current) => ({
+          ...current,
+          [key]: {
+            value: null,
+            loading: false,
+            error: error instanceof Error ? error.message : 'Metric unavailable.',
+          },
+        }));
+      }
+    };
+
+    const saleParams = new URLSearchParams({
+      taxYear: String(taxYear),
+      status: 'pending',
+      page: '1',
+      pageSize: '1',
+      countyId: countyScope.countyId,
+    });
+    const compsParams = new URLSearchParams({
+      taxYear: String(taxYear),
+      page: '1',
+      pageSize: '1',
+      countyId: countyScope.countyId,
+    });
+
+    void fetchMetric<CountPage>('saleQueue', `/terraforge/sale-qualification?${saleParams}`, getCountFromPage);
+    void fetchMetric<CountPage>('compsPool', `/terraforge/comps-pool?${compsParams}`, getCountFromPage);
+    void fetchMetric<CountResponse>('costMatrix', '/costforge/cost-matrix/benton', getCountFromResponse);
+    void fetchMetric<CapRatesResponse>('incomeRefs', '/costforge/income-approach/cap-rates', getCapRateCount);
+    void fetchMetric<CountyStatsRuntimeResponse>(
+      'countyRollup',
+      `/terraforge/county-stats?taxYear=${taxYear}&countyId=${encodeURIComponent(countyScope.countyId)}`,
+      getCountyRollupCount,
+    );
+
+    return () => abortController.abort();
+  }, [countyScope, taxYear]);
+
+  return runtimeMetrics;
+}
+
 function isJune10RuntimeForgeModule(mod: ForgeModuleDef): boolean {
-  return mod.id === 'sales-forge' || mod.id === 'costforge';
+  return mod.id === 'sales-forge'
+    || mod.id === 'costforge'
+    || mod.id === 'comps-forge'
+    || mod.id === 'income-forge'
+    || mod.id === 'county-studio';
 }
 
 function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): string | null {
@@ -220,6 +467,15 @@ function getLaunchLabel(mod: ForgeModuleDef): string {
   if (mod.id === 'costforge') {
     return 'Benton CostForge triage API';
   }
+  if (mod.id === 'comps-forge') {
+    return 'Statewide sales comp search';
+  }
+  if (mod.id === 'income-forge') {
+    return 'Benton income approach API';
+  }
+  if (mod.id === 'county-studio') {
+    return 'Benton County Studio studies API';
+  }
   if (isJune10RuntimeForgeModule(mod)) {
     return 'Benton sale qualification API';
   }
@@ -237,10 +493,20 @@ export default function ForgeSuiteHome() {
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const recentParcels = usePropertyStore((s) => s.recentParcels);
   const runtimeCountyId = getSession()?.countyId ?? 'benton';
+  const runtimeTaxYear = 2026;
+  const runtimeMetrics = useRuntimeForgeMetrics(runtimeCountyId, runtimeTaxYear);
   const sourceDisclosure = getSourceDisclosure(source);
   const showForgeMetrics = !JUNE_10_PROOF_FREEZE;
   const displayedStats = showForgeMetrics ? stats : null;
   const displayedLoading = showForgeMetrics ? loading : false;
+  const countyRollupStatus = runtimeMetrics.countyRollup.loading
+    ? 'Metrics app-backed; county rollup resolving'
+    : runtimeMetrics.countyRollup.error
+      ? 'Metrics app-backed; county rollup blocked'
+      : 'Metrics runtime-backed';
+  const countyRollupChipClass = runtimeMetrics.countyRollup.loading || runtimeMetrics.countyRollup.error
+    ? 'forge-chip--warn'
+    : 'forge-chip--success';
   const [briefState, setBriefState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: MorningBriefSummary; correlationId?: string; error?: string }>({ status: 'idle' });
   const [diagnosticsState, setDiagnosticsState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: CountyDiagnosticsSummary; correlationId?: string; error?: string }>({ status: 'idle' });
   const [memoState, setMemoState] = useState<{ status: 'idle' | 'loading' | 'success' | 'error'; result?: CalibrationMemoSummary; correlationId?: string; error?: string }>({ status: 'idle' });
@@ -252,13 +518,46 @@ export default function ForgeSuiteHome() {
     if (style === 'percent') return `${n.toFixed(1)}%`;
     return new Intl.NumberFormat('en-US').format(n);
   };
-  const kpiMetrics = [
-    { label: 'TOTAL PARCELS',      value: displayedLoading ? '…' : fmt(displayedStats?.totalParcels,             'decimal'),   tone: 'neutral'  },
-    { label: 'AVG ASSESSED',       value: displayedLoading ? '…' : fmt(displayedStats?.averageAssessedValue,      'currency'),  tone: 'neutral'  },
-    { label: 'ASSESSED THIS YEAR', value: displayedLoading ? '…' : fmt(displayedStats?.assessedThisYear,          'decimal'),   tone: 'neutral'  },
-    { label: 'PENDING',            value: displayedLoading ? '…' : fmt(displayedStats?.pendingAssessments,        'decimal'),   tone: 'warn'     },
-    { label: 'COMPLETION',         value: displayedLoading ? '…' : (displayedStats ? fmt(displayedStats.assessmentCompletionPercent, 'percent') : '—'), tone: 'success' },
-  ] as const;
+  const kpiMetrics = JUNE_10_PROOF_FREEZE
+    ? [
+        {
+          label: 'SALE QUEUE',
+          value: renderRuntimeMetricValue(runtimeMetrics.saleQueue),
+          tone: runtimeMetrics.saleQueue.error ? 'warn' : 'success',
+          source: runtimeMetrics.saleQueue.error ?? 'SaleQualification API',
+        },
+        {
+          label: 'COMPS POOL',
+          value: renderRuntimeMetricValue(runtimeMetrics.compsPool),
+          tone: runtimeMetrics.compsPool.error ? 'warn' : 'success',
+          source: runtimeMetrics.compsPool.error ?? 'CompsForge comps-pool API',
+        },
+        {
+          label: 'COST MATRIX',
+          value: renderRuntimeMetricValue(runtimeMetrics.costMatrix),
+          tone: runtimeMetrics.costMatrix.error ? 'warn' : 'success',
+          source: runtimeMetrics.costMatrix.error ?? 'CostForge cost-matrix API',
+        },
+        {
+          label: 'INCOME REFS',
+          value: renderRuntimeMetricValue(runtimeMetrics.incomeRefs),
+          tone: runtimeMetrics.incomeRefs.error ? 'warn' : 'success',
+          source: runtimeMetrics.incomeRefs.error ?? 'IncomeForge cap-rate API',
+        },
+        {
+          label: 'COUNTY ROLLUP',
+          value: renderRuntimeMetricValue(runtimeMetrics.countyRollup),
+          tone: runtimeMetrics.countyRollup.error ? 'warn' : 'success',
+          source: runtimeMetrics.countyRollup.error ?? 'TerraForge county-stats API',
+        },
+      ] as const
+    : [
+        { label: 'TOTAL PARCELS',      value: displayedLoading ? '…' : fmt(displayedStats?.totalParcels,             'decimal'),   tone: 'neutral', source: 'County stats API'  },
+        { label: 'AVG ASSESSED',       value: displayedLoading ? '…' : fmt(displayedStats?.averageAssessedValue,      'currency'),  tone: 'neutral', source: 'County stats API'  },
+        { label: 'ASSESSED THIS YEAR', value: displayedLoading ? '…' : fmt(displayedStats?.assessedThisYear,          'decimal'),   tone: 'neutral', source: 'County stats API'  },
+        { label: 'PENDING',            value: displayedLoading ? '…' : fmt(displayedStats?.pendingAssessments,        'decimal'),   tone: 'warn', source: 'County stats API'     },
+        { label: 'COMPLETION',         value: displayedLoading ? '…' : (displayedStats ? fmt(displayedStats.assessmentCompletionPercent, 'percent') : '—'), tone: 'success', source: 'County stats API' },
+      ] as const;
 
   const handleModuleLaunch = (mod: ForgeModuleDef) => {
     if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) {
@@ -294,6 +593,30 @@ export default function ForgeSuiteHome() {
       ? {
           launchContext: 'terraforge-suite',
           dataSource: 'terrafusion-api',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'comps-forge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'compsforge-comps-pool',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'income-forge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'income-approach',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'county-studio'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'county-studio-studies',
           countyId: runtimeCountyId,
           taxYear: 2026,
         }
@@ -449,7 +772,7 @@ export default function ForgeSuiteHome() {
             <div className="forge-workspace__status">
               <span className="forge-chip forge-chip--neutral">Layer 2 Workspace</span>
               <span className="forge-chip forge-chip--warn">
-                Suite metrics preview-locked
+                Suite metrics app-backed partial
               </span>
             </div>
           </header>
@@ -469,9 +792,15 @@ export default function ForgeSuiteHome() {
             <div className="forge-ops-tags">
               <span className="forge-chip forge-chip--success">SalesForge runtime</span>
               <span className="forge-chip forge-chip--success">CostForge live triage path</span>
-              <span className="forge-chip forge-chip--neutral">CompsForge preview-locked</span>
-              <span className="forge-chip forge-chip--neutral">IncomeForge preview-locked</span>
-              <span className="forge-chip forge-chip--warn">Metrics not runtime-backed</span>
+              <span className="forge-chip forge-chip--success">CompsForge runtime comps pool</span>
+              <span className="forge-chip forge-chip--success">IncomeForge runtime income approach</span>
+              <span className="forge-chip forge-chip--success">County Studio runtime studies</span>
+              <span className={`forge-chip ${countyRollupChipClass}`}>
+                {countyRollupStatus}
+              </span>
+              <span className="forge-chip forge-chip--warn">Full TerraForge not done</span>
+              <span className="forge-chip forge-chip--warn">CUForge/specialists locked</span>
+              <span className="forge-chip forge-chip--warn">County Studio health not rollup proof</span>
             </div>
           </section>
           {showForgeMetrics && loading && !stats && (
@@ -486,10 +815,11 @@ export default function ForgeSuiteHome() {
           )}
 
           <section data-testid="forge-stats" className="forge-kpi-grid">
-            {kpiMetrics.map(({ label, value, tone }) => (
+            {kpiMetrics.map(({ label, value, tone, source: metricSource }) => (
               <div key={label} className="forge-kpi-cell">
                 <div className="forge-kpi-cell__label">{label}</div>
                 <div className={`forge-kpi-cell__value forge-kpi-cell__value--${tone}`}>{value}</div>
+                <div className="forge-kpi-cell__source">{metricSource}</div>
               </div>
             ))}
           </section>
@@ -621,18 +951,9 @@ export default function ForgeSuiteHome() {
                     <button
                       type="button"
                       className="forge-ops-btn forge-ops-btn--ghost"
-                      onClick={() => handleModuleLaunch({
-                        id: 'county-studio',
-                        label: 'County Studio',
-                        description: '',
-                        priority: 'primary',
-                        launchMode: 'standalone',
-                        moduleId: 'county-studio',
-                      })}
-                      disabled={JUNE_10_PROOF_FREEZE}
-                      title={JUNE_10_FORGE_NOTICE}
+                      onClick={() => handleModuleLaunch(COUNTY_STUDIO_MODULE)}
                     >
-                      County Studio preview locked
+                      Open County Studio
                     </button>
                   </div>
                 </div>
@@ -724,13 +1045,11 @@ export default function ForgeSuiteHome() {
               type="button"
               className="forge-card forge-card--primary"
               style={{ width: '100%', textAlign: 'left' }}
-              onClick={() => handleModuleLaunch({ id: 'county-studio', label: 'County Studio', description: '', priority: 'primary', launchMode: 'standalone', moduleId: 'county-studio' })}
-              disabled={JUNE_10_PROOF_FREEZE}
-              title={JUNE_10_FORGE_NOTICE}
+              onClick={() => handleModuleLaunch(COUNTY_STUDIO_MODULE)}
             >
               <div className="forge-card__rail">
-                <span className="forge-chip forge-chip--neutral">Default analytics workbench</span>
-                <span className="forge-card__foot">County → Reval Area → Neighborhood → Segment</span>
+                <span className="forge-chip forge-chip--success">Runtime studies path</span>
+                <span className="forge-card__foot">{getLaunchLabel(COUNTY_STUDIO_MODULE)}</span>
               </div>
               <div className="forge-card__title">County Studio</div>
               <p className="forge-card__description">

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -25,7 +25,7 @@
  */
 import { useCallback, useState } from 'react';
 import { invokeTool } from '../../api/pilotApi';
-import { ParcelContextBanner } from '../../components/workbench/ParcelContextBanner';
+import { getSession } from '../../auth/session';
 import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { useCountyStats } from '../../hooks/useCountyStats';
 import { activateModule } from '../../orchestration/moduleActivation';
@@ -38,8 +38,12 @@ type LaunchMode = 'standalone' | 'workbench';
 type TruthState = 'live' | 'queued';
 
 const JUNE_10_PROOF_FREEZE = true;
+const JUNE_10_RUNTIME_PANELS_ENABLED = true;
+const JUNE_10_COMMAND_ACTIONS_ENABLED = true;
 const JUNE_10_FORGE_NOTICE =
-  'TerraForge is part of the Benton operating model. Suite-wide metrics and standalone Forge modules are preview-locked until separately verified; use Property Workbench for DB/API-backed parcel-level Forge proof.';
+  'TerraForge is part of the Benton operating model. Suite-wide KPI rollups and unverified standalone Forge modules are preview-locked until separately verified; SalesForge, CostForge triage, and verified runtime panels read TerraFusion API through Benton county scope.';
+const JUNE_10_FORGE_ACTION_LOCK_NOTICE =
+  'Unverified TerraForge suite action locked for June 10 proof freeze.';
 
 interface ForgeModuleDef {
   id: string;
@@ -69,6 +73,11 @@ interface MorningBriefSummary {
   readyToAct: boolean;
   blockingDependencies: string[];
   findings: CountyFindingSummary[];
+}
+
+interface MorningBriefToolOutput extends Partial<MorningBriefSummary> {
+  brief?: Omit<MorningBriefSummary, 'findings'>;
+  findings?: CountyFindingSummary[];
 }
 
 interface CountyImpactPreview {
@@ -187,6 +196,10 @@ const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
 const fmtNum = (n: number | undefined | null) => (n != null ? n.toLocaleString() : '—');
 const fmtCurrency = (n: number | undefined | null) => (n != null ? `$${n.toLocaleString()}` : '—');
 
+function isJune10RuntimeForgeModule(mod: ForgeModuleDef): boolean {
+  return mod.id === 'sales-forge' || mod.id === 'costforge';
+}
+
 function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): string | null {
   if (JUNE_10_PROOF_FREEZE) {
     return JUNE_10_FORGE_NOTICE;
@@ -201,8 +214,14 @@ function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): s
 }
 
 function getLaunchLabel(mod: ForgeModuleDef): string {
-  if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone') {
+  if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) {
     return 'Standalone preview locked';
+  }
+  if (mod.id === 'costforge') {
+    return 'Benton CostForge triage API';
+  }
+  if (isJune10RuntimeForgeModule(mod)) {
+    return 'Benton sale qualification API';
   }
   if (mod.truthState === 'queued') {
     return 'Queued surface';
@@ -217,6 +236,7 @@ export default function ForgeSuiteHome() {
   const { stats, loading, error, source } = useCountyStats();
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const recentParcels = usePropertyStore((s) => s.recentParcels);
+  const runtimeCountyId = getSession()?.countyId ?? 'benton';
   const sourceDisclosure = getSourceDisclosure(source);
   const showForgeMetrics = !JUNE_10_PROOF_FREEZE;
   const displayedStats = showForgeMetrics ? stats : null;
@@ -241,7 +261,7 @@ export default function ForgeSuiteHome() {
   ] as const;
 
   const handleModuleLaunch = (mod: ForgeModuleDef) => {
-    if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone') {
+    if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) {
       return;
     }
 
@@ -262,7 +282,23 @@ export default function ForgeSuiteHome() {
     }
 
     const targetId = mod.moduleId ?? mod.id;
-    void activateModule(targetId, { source: 'system' });
+    const metadata = mod.id === 'costforge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'costforge-triage',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'sales-forge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : undefined;
+    void activateModule(targetId, { source: 'system', ...(metadata ? { metadata } : {}) });
   };
 
   const handleParcelOpen = (parcelId: string) => {
@@ -280,25 +316,51 @@ export default function ForgeSuiteHome() {
     }
   };
 
+  const normalizeMorningBrief = (output: unknown): MorningBriefSummary => {
+    const parsed = parseToolOutput<MorningBriefToolOutput>(output, {
+      role: 'chief_appraiser',
+      queueType: 'calibration_review',
+      priority: 'medium',
+      dueWindow: 'next business day',
+      recommendedTool: 'rerun_ratio_study',
+      readyToAct: false,
+      blockingDependencies: [],
+      findings: [],
+    });
+
+    if (parsed.brief) {
+      return {
+        ...parsed.brief,
+        findings: parsed.findings ?? [],
+      };
+    }
+
+    return {
+      role: parsed.role ?? 'chief_appraiser',
+      queueType: parsed.queueType ?? 'calibration_review',
+      priority: parsed.priority ?? 'medium',
+      dueWindow: parsed.dueWindow ?? 'next business day',
+      recommendedTool: parsed.recommendedTool ?? 'rerun_ratio_study',
+      readyToAct: parsed.readyToAct ?? false,
+      blockingDependencies: parsed.blockingDependencies ?? [],
+      findings: parsed.findings ?? [],
+    };
+  };
+
   const handleRefreshBrief = useCallback(async () => {
+    if (!JUNE_10_COMMAND_ACTIONS_ENABLED) {
+      return;
+    }
+
     setBriefState({ status: 'loading' });
     try {
       const response = await invokeTool({
         toolId: 'generate_morning_brief',
-        params: { county: 'benton', taxYear: 2026, role: 'chief_appraiser' },
+        mode: 'muse',
+        params: { county: runtimeCountyId, taxYear: 2026, role: 'chief_appraiser' },
       });
       if (response.success && response.result) {
-        const parsed = parseToolOutput<MorningBriefSummary>(response.result.output, {
-          role: 'chief_appraiser',
-          queueType: 'calibration_review',
-          priority: 'medium',
-          dueWindow: 'next business day',
-          recommendedTool: 'propose_rate_adjustment',
-          readyToAct: false,
-          blockingDependencies: [],
-          findings: [],
-        });
-        setBriefState({ status: 'success', result: parsed, correlationId: response.correlationId });
+        setBriefState({ status: 'success', result: normalizeMorningBrief(response.result.output), correlationId: response.correlationId });
       } else {
         setBriefState({ status: 'error', correlationId: response.correlationId, error: response.error?.message || 'Failed to load county briefing.' });
       }
@@ -309,14 +371,19 @@ export default function ForgeSuiteHome() {
         error: toolError instanceof Error ? toolError.message : 'Failed to load county briefing.',
       });
     }
-  }, []);
+  }, [runtimeCountyId]);
 
   const handleRunDiagnostics = useCallback(async () => {
+    if (!JUNE_10_COMMAND_ACTIONS_ENABLED) {
+      return;
+    }
+
     setDiagnosticsState({ status: 'loading' });
     try {
       const response = await invokeTool({
         toolId: 'rerun_ratio_study',
-        params: { county: 'benton', taxYear: 2026, draftVersion: 'benton-2026-working', scope: 'county' },
+        mode: 'pilot',
+        params: { county: runtimeCountyId, taxYear: 2026, draftVersion: 'benton-2026-working', scope: 'county' },
       });
       if (response.success && response.result) {
         const parsed = parseToolOutput<CountyDiagnosticsSummary>(response.result.output, {
@@ -335,14 +402,19 @@ export default function ForgeSuiteHome() {
         error: toolError instanceof Error ? toolError.message : 'Failed to run county diagnostics.',
       });
     }
-  }, []);
+  }, [runtimeCountyId]);
 
   const handleDraftBoardMemo = useCallback(async () => {
+    if (!JUNE_10_COMMAND_ACTIONS_ENABLED) {
+      return;
+    }
+
     setMemoState({ status: 'loading' });
     try {
       const response = await invokeTool({
         toolId: 'generate_calibration_memo',
-        params: { county: 'benton', draftVersion: 'benton-2026-working', audience: 'board', reasonCode: 'annual_certification' },
+        mode: 'muse',
+        params: { county: runtimeCountyId, draftVersion: 'benton-2026-working', audience: 'board', reasonCode: 'annual_certification' },
         confirmation: { confirmed: true, reasonCode: 'annual_certification' },
       });
       if (response.success && response.result) {
@@ -362,19 +434,17 @@ export default function ForgeSuiteHome() {
         error: toolError instanceof Error ? toolError.message : 'Failed to draft board memo.',
       });
     }
-  }, []);
+  }, [runtimeCountyId]);
 
   return (
     <div data-testid="suite-forge-root" className="forge-workspace h-full flex flex-col">
-      <ParcelContextBanner suiteTabId="forge" />
-
       <main className="forge-workspace__viewport">
         <div className="forge-workspace__stage">
           <header className="forge-workspace__header">
             <div>
               <p className="forge-workspace__eyebrow">Suite-Forge · Benton operating model</p>
               <h1 className="forge-workspace__title">TerraForge</h1>
-              <p className="forge-workspace__subtitle">Valuation suite available in Benton context; standalone workflows stay preview-locked until separately verified.</p>
+              <p className="forge-workspace__subtitle">Valuation suite available in Benton context; unverified standalone workflows stay preview-locked until separately verified.</p>
             </div>
             <div className="forge-workspace__status">
               <span className="forge-chip forge-chip--neutral">Layer 2 Workspace</span>
@@ -389,6 +459,21 @@ export default function ForgeSuiteHome() {
               {sourceDisclosure}
             </div>
           )}
+          <section className="forge-panel forge-runtime-status" data-testid="forge-runtime-status">
+            <div className="forge-panel__header">
+              <div>
+                <p className="forge-panel__eyebrow">TerraForge Runtime Status</p>
+                <h2 className="forge-panel__title">One verified app at a time</h2>
+              </div>
+            </div>
+            <div className="forge-ops-tags">
+              <span className="forge-chip forge-chip--success">SalesForge runtime</span>
+              <span className="forge-chip forge-chip--success">CostForge live triage path</span>
+              <span className="forge-chip forge-chip--neutral">CompsForge preview-locked</span>
+              <span className="forge-chip forge-chip--neutral">IncomeForge preview-locked</span>
+              <span className="forge-chip forge-chip--warn">Metrics not runtime-backed</span>
+            </div>
+          </section>
           {showForgeMetrics && loading && !stats && (
             <div data-testid="forge-loading" role="status" className="forge-workspace__notice">
               Loading county metrics…
@@ -424,7 +509,13 @@ export default function ForgeSuiteHome() {
                     <div className="forge-ops-card__title">Morning Brief</div>
                     <div className="forge-ops-card__sub">Ranked findings and recommended next tool for the Benton Runtime Pilot.</div>
                   </div>
-                  <button type="button" className="forge-ops-btn" onClick={handleRefreshBrief} disabled={briefState.status === 'loading'}>
+                  <button
+                    type="button"
+                    className="forge-ops-btn"
+                    onClick={handleRefreshBrief}
+                    disabled={!JUNE_10_COMMAND_ACTIONS_ENABLED || briefState.status === 'loading'}
+                    title={!JUNE_10_COMMAND_ACTIONS_ENABLED ? JUNE_10_FORGE_ACTION_LOCK_NOTICE : undefined}
+                  >
                     {briefState.status === 'loading' ? 'Refreshing…' : 'Refresh Brief'}
                   </button>
                 </div>
@@ -468,7 +559,13 @@ export default function ForgeSuiteHome() {
                     <div className="forge-ops-card__title">County Diagnostics Sweep</div>
                     <div className="forge-ops-card__sub">Refresh PRD, COD, AV delta, and signoff posture for the working draft.</div>
                   </div>
-                  <button type="button" className="forge-ops-btn" onClick={handleRunDiagnostics} disabled={diagnosticsState.status === 'loading'}>
+                  <button
+                    type="button"
+                    className="forge-ops-btn"
+                    onClick={handleRunDiagnostics}
+                    disabled={!JUNE_10_COMMAND_ACTIONS_ENABLED || diagnosticsState.status === 'loading'}
+                    title={!JUNE_10_COMMAND_ACTIONS_ENABLED ? JUNE_10_FORGE_ACTION_LOCK_NOTICE : undefined}
+                  >
                     {diagnosticsState.status === 'loading' ? 'Running…' : 'Run Sweep'}
                   </button>
                 </div>
@@ -505,17 +602,21 @@ export default function ForgeSuiteHome() {
                     <div className="forge-ops-card__sub">Draft the governed board-facing calibration memo after Forge applications are separately verified.</div>
                   </div>
                   <div className="forge-ops-actions">
-                    <button type="button" className="forge-ops-btn" onClick={handleDraftBoardMemo} disabled={memoState.status === 'loading'}>
+                    <button
+                      type="button"
+                      className="forge-ops-btn"
+                      onClick={handleDraftBoardMemo}
+                      disabled={!JUNE_10_COMMAND_ACTIONS_ENABLED || memoState.status === 'loading'}
+                      title={!JUNE_10_COMMAND_ACTIONS_ENABLED ? JUNE_10_FORGE_ACTION_LOCK_NOTICE : undefined}
+                    >
                       {memoState.status === 'loading' ? 'Drafting…' : 'Draft Memo'}
                     </button>
                     <button
                       type="button"
                       className="forge-ops-btn forge-ops-btn--ghost"
                       onClick={() => handleModuleLaunch(PRIMARY_MODULES[0])}
-                      disabled={JUNE_10_PROOF_FREEZE}
-                      title={JUNE_10_FORGE_NOTICE}
                     >
-                      CostForge preview locked
+                      Open CostForge
                     </button>
                     <button
                       type="button"
@@ -568,8 +669,8 @@ export default function ForgeSuiteHome() {
                   type="button"
                   className="forge-card forge-card--primary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' || mod.truthState === 'queued'}
-                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' ? JUNE_10_FORGE_NOTICE : undefined}
+                  disabled={(JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) || mod.truthState === 'queued'}
+                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
                     {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
@@ -597,8 +698,8 @@ export default function ForgeSuiteHome() {
                   type="button"
                   className="forge-card forge-card--secondary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' || mod.truthState === 'queued'}
-                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' ? JUNE_10_FORGE_NOTICE : undefined}
+                  disabled={(JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) || mod.truthState === 'queued'}
+                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
                     {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
@@ -641,7 +742,7 @@ export default function ForgeSuiteHome() {
             </button>
           </section>
 
-          {!JUNE_10_PROOF_FREEZE && (
+          {JUNE_10_RUNTIME_PANELS_ENABLED && (
             <>
               {/* Slice 1.4 — county-wide sale qualification queue */}
               <SaleQualificationQueue />


### PR DESCRIPTION
This PR restores the TerraForge runtime posture and CostForge path onto the June 10 integration branch.

Scope:
- Cherry-picks the TerraForge inclusion correction, CostForge runtime path, and Forge truth gate slices.
- Keeps stale suite/county KPI rollups preview-locked instead of presenting them as live proof.
- Adds a one-line test-harness mock alignment so the CostForge contract test works with the current shared apiBase exports.
- Does not touch Workbench, County posture, Home Scene, Phase 5, Hostinger, DB, or package metadata.

Verification run locally:
- Focused Forge tests: forgeSuiteSourceHonesty, CostForge.contracts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs
- pre-push quality gate