### PR TITLE
fix(coherence): WO-CF-b2e — GetAIAgentStatusAsync single-snapshot DTO coherence

### DIFF
--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -342,9 +342,21 @@ public class CostForgeAIService : ICostForgeAIService
     // sample matches the same generation. Behavior-neutral apart from that consistency.
     var snapshot = _agents.Values.ToList();
     var totalAgents = snapshot.Count;
-    var activeAgents = snapshot.Count(a => a.Status == "active");
-    var idleAgents = snapshot.Count(a => a.Status == "idle");
-    var busyAgents = snapshot.Count(a => a.Status == "busy");
+
+    // Single pass: read each agent's Status exactly once so an agent is classified into at most
+    // one bucket (no double-counting across passes), and avoid three O(n) enumerations.
+    var activeAgents = 0;
+    var idleAgents = 0;
+    var busyAgents = 0;
+    foreach (var agent in snapshot)
+    {
+      switch (agent.Status)
+      {
+        case "active": activeAgents++; break;
+        case "idle": idleAgents++; break;
+        case "busy": busyAgents++; break;
+      }
+    }
 
     return new AIAgentStatusDto
     {

--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -336,10 +336,15 @@ public class CostForgeAIService : ICostForgeAIService
   {
     await System.Threading.Tasks.Task.Delay(10);
 
-    var totalAgents = _agents.Count;
-    var activeAgents = _agents.Values.Count(a => a.Status == "active");
-    var idleAgents = _agents.Values.Count(a => a.Status == "idle");
-    var busyAgents = _agents.Values.Count(a => a.Status == "busy");
+    // Coherence (WO-CF-b2e): _agents is a ConcurrentDictionary that can change between reads
+    // (e.g. via ScaleAIAgentsAsync). Take ONE snapshot and derive every field from it so the
+    // returned DTO is internally consistent — counts cannot exceed TotalAgents, and the Agents
+    // sample matches the same generation. Behavior-neutral apart from that consistency.
+    var snapshot = _agents.Values.ToList();
+    var totalAgents = snapshot.Count;
+    var activeAgents = snapshot.Count(a => a.Status == "active");
+    var idleAgents = snapshot.Count(a => a.Status == "idle");
+    var busyAgents = snapshot.Count(a => a.Status == "busy");
 
     return new AIAgentStatusDto
     {
@@ -351,7 +356,7 @@ public class CostForgeAIService : ICostForgeAIService
       // fabricated 87.3. The non-empty simulation constant remains deferred to the broader
       // simulation-truth cleanup.
       AverageUtilization = totalAgents == 0 ? 0.0 : (double)87.3m,
-      Agents = _agents.Values.Take(10).Cast<object>().ToList() // Return first 10 for performance
+      Agents = snapshot.Take(10).Cast<object>().ToList() // Return first 10 for performance
     };
   }
 


### PR DESCRIPTION
## WO-CF-b2e — `GetAIAgentStatusAsync` single-snapshot coherence

Closes the deferred Copilot finding from #984 (the `#20` follow-up, **Category ① only**).

`GetAIAgentStatusAsync` snapshotted `TotalAgents` once but read `_agents.Values` **separately** for the active/idle/busy counts and the `Agents` sample. Since `_agents` is a `ConcurrentDictionary` mutable via `ScaleAIAgentsAsync`, those independent reads could return an internally inconsistent DTO (counts exceeding `TotalAgents`, or `Agents` non-empty while `TotalAgents==0`).

### Fix (one method, behavior-neutral apart from consistency)
Take **one** `_agents.Values.ToList()` snapshot and derive `TotalAgents` / active / idle / busy / `Agents` from that same snapshot. The b2d empty-fleet `AverageUtilization` guard is preserved, now keyed off the snapshot count.

### Scope
- **Category ① (coherence) of #20 only** — pure correctness, no fabricated-value judgment.
- Deferred to their own representation-decision cards: **Category ②** (fabricated non-empty metric constants — `87.3`, `847`, `quantum_acceleration=379000000`, etc.) → WO-CF-b2f; **Category ③** (analytics + Harris-sync fabrications) → WO-CF-b2g.

- ✅ `dotnet build TerraFusion.AI`: 0 warnings, 0 errors
- ✅ one file changed (+10 / −5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent internally inconsistent AI agent status responses caused by concurrent modifications to the agent collection during status aggregation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of AI agent status reporting to ensure accurate counts of total, active, idle, and busy agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->