### PR TITLE
fix(workbench): restore OS-managed runtime window

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/shell/shellAntiDrift.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/shell/shellAntiDrift.contract.test.ts
@@ -28,11 +28,11 @@ describe('Phase 25: Shell Anti-Drift Governance', () => {
       expect(size.maximized).not.toBe(true);
     });
 
-    it('property-workbench: opens standalone, maximized', () => {
+    it('property-workbench: opens standalone, normal/resizable', () => {
       const verdict = evaluateSpawnIntent('property-workbench');
       expect(verdict.decision).toBe('open');
       const size = getModuleWindowSize('property-workbench');
-      expect(size.maximized).toBe(true);
+      expect(size.maximized).not.toBe(true);
     });
 
     it('os-pilot: opens standalone, near-full-stage', () => {
@@ -118,14 +118,14 @@ describe('Phase 25: Shell Anti-Drift Governance', () => {
       expect(wbEntry.objectType).toBe('tier0-workbench');
     });
 
-    it('Path B: Home -> Recent Parcel -> Workbench (maximized with parcel context)', () => {
+    it('Path B: Home -> Recent Parcel -> Workbench (OS-managed window with parcel context)', () => {
       // Recent parcel click -> opens workbench
       const verdict = evaluateSpawnIntent('property-workbench');
       expect(verdict.decision).toBe('open');
 
-      // Verify workbench opens maximized
+      // Verify workbench opens as an adjustable OS window.
       const size = getModuleWindowSize('property-workbench');
-      expect(size.maximized).toBe(true);
+      expect(size.maximized).not.toBe(true);
 
       // Verify default landing tab exists
       expect(VALID_WORKBENCH_TAB_IDS).toContain('summary');

--- a/frontend/apps/os-shell/src/__tests__/shell/shellChrome.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/shell/shellChrome.contract.test.ts
@@ -4,7 +4,7 @@
  * Enforces:
  *   1. Zero hardcoded z-depth Tailwind classes in governed shell files
  *   2. Suite windows open near-full-stage (not maximized)
- *   3. Property Workbench opens maximized
+ *   3. Property Workbench opens as an adjustable OS-managed window
  *   4. OS feature windows open near-full-stage
  */
 import { describe, it, expect } from 'vitest';
@@ -47,11 +47,20 @@ describe('Phase 22: Shell Chrome Contract', () => {
   });
 
   describe('Workbench sizing', () => {
-    it('property-workbench opens maximized', () => {
+    it('property-workbench opens as an adjustable OS-managed window', () => {
       const result = getModuleWindowSize('property-workbench');
-      expect(result.maximized).toBe(true);
+      expect(result.maximized).not.toBe(true);
       expect(result.size.width).toBeGreaterThan(0);
       expect(result.size.height).toBeGreaterThan(0);
+      expect(result.size.width).toBeLessThan(window.innerWidth);
+      expect(result.size.height).toBeLessThan(window.innerHeight);
+    });
+
+    it('property-workbench uses normal window chrome and controls', () => {
+      const src = readShellFile('shell/desktop/Window.tsx');
+      expect(src).not.toContain('Tier-0 surface (property-workbench) — no chrome, no titlebar');
+      expect(src).not.toContain('disableDragging={isMaximized || isTier0}');
+      expect(src).not.toContain('enableResizing={\n          isMaximized || isTier0');
     });
   });
 

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.error.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.error.contract.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PropertyWorkbench } from '../../pages/workbench/PropertyWorkbench';
 import { PropertyWorkbenchSurface } from '../../pages/workbench/PropertyWorkbenchSurface';
+import PropertyWorkbench from '../../pages/workbench/PropertyWorkbench';
+
+const { activateModuleMock } = vi.hoisted(() => ({
+  activateModuleMock: vi.fn(),
+}));
 
 const selectParcel = vi.fn();
 
@@ -41,6 +45,10 @@ vi.mock('../../auth/useAuthContext', () => ({
   }),
 }));
 
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: (...args: unknown[]) => activateModuleMock(...args),
+}));
+
 vi.mock('../../hooks/useWorkbenchRoles', () => ({
   useWorkbenchRoles: () => ({
     visibleTabs: ['summary', 'forge', 'atlas', 'dais', 'dossier', 'pilot'],
@@ -73,24 +81,33 @@ function makeJwt(expSecondsFromNow = 3600): string {
   ].join('.');
 }
 
-function renderWorkbench() {
+function renderWorkbenchSurface(parcelId = '101040000000000') {
   return render(
-    <MemoryRouter initialEntries={['/property/101040000000000']}>
-      <Routes>
-        <Route path="/property/:parcelId/*" element={<PropertyWorkbench />} />
-      </Routes>
-    </MemoryRouter>
+    <PropertyWorkbenchSurface
+      parcelId={parcelId}
+      currentTabId="summary"
+      onBack={vi.fn()}
+      onSearch={vi.fn()}
+      renderNavigation={() => null}
+      renderContent={() => null}
+    />
   );
 }
+
+const RouteProbe: React.FC = () => {
+  const location = useLocation();
+  return <div data-testid="route-probe">{location.pathname}</div>;
+};
 
 describe('PropertyWorkbench auth contract', () => {
   beforeEach(() => {
     authToken = null;
     selectParcel.mockClear();
+    activateModuleMock.mockReset();
   });
 
   it('does not request parcel data before a usable auth token exists', () => {
-    renderWorkbench();
+    renderWorkbenchSurface();
 
     expect(screen.getByTestId('workbench-auth-bootstrap')).toBeInTheDocument();
     expect(selectParcel).not.toHaveBeenCalled();
@@ -99,16 +116,17 @@ describe('PropertyWorkbench auth contract', () => {
   it('requests the route parcel after a usable auth token is available', async () => {
     authToken = makeJwt();
 
-    renderWorkbench();
+    renderWorkbenchSurface();
 
     await waitFor(() => {
       expect(selectParcel).toHaveBeenCalledWith('101040000000000');
     });
   });
 
-  it('no-parcel Workbench state offers parcel search instead of a dead Home-only state', async () => {
+  it('no-parcel Workbench state opens a selected parcel in the same Workbench window', async () => {
     const onSearch = vi.fn();
     const onBack = vi.fn();
+    const onParcelSelected = vi.fn();
 
     render(
       <PropertyWorkbenchSurface
@@ -116,16 +134,73 @@ describe('PropertyWorkbench auth contract', () => {
         currentTabId="summary"
         onBack={onBack}
         onSearch={onSearch}
+        onParcelSelected={onParcelSelected}
         renderNavigation={() => null}
         renderContent={() => null}
       />
     );
 
     expect(screen.getByTestId('workbench-no-parcel')).toBeInTheDocument();
-    const searchButton = screen.getByRole('button', { name: /search parcels/i });
-    expect(searchButton).toBeInTheDocument();
-    searchButton.click();
-    expect(onSearch).toHaveBeenCalledTimes(1);
+    fireEvent.change(screen.getByLabelText(/parcel id/i), {
+      target: { value: '101040000000000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /open parcel/i }));
+
+    expect(onParcelSelected).toHaveBeenCalledWith('101040000000000');
+    expect(onSearch).not.toHaveBeenCalled();
     expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it('keeps the route bridge mounted until Cortex activation finishes', async () => {
+    let resolveActivation: (() => void) | undefined;
+    activateModuleMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveActivation = resolve;
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/property/101040000000000/forge']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <>
+                <RouteProbe />
+                <div data-testid="os-home">TerraFusion OS</div>
+              </>
+            }
+          />
+          <Route
+            path="/property/:parcelId/*"
+            element={
+              <>
+                <RouteProbe />
+                <PropertyWorkbench />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(activateModuleMock).toHaveBeenCalledWith('property-workbench', {
+        source: 'route',
+        metadata: { parcelId: '101040000000000', tabId: 'forge' },
+        showNotification: false,
+      });
+    });
+
+    expect(screen.getByTestId('property-workbench-route-bridge')).toBeInTheDocument();
+    expect(screen.getByTestId('route-probe')).toHaveTextContent('/property/101040000000000/forge');
+    expect(screen.queryByTestId('os-home')).not.toBeInTheDocument();
+
+    resolveActivation?.();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('os-home')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('route-probe')).toHaveTextContent('/');
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.routeActivation.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.routeActivation.contract.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import PropertyWorkbench from '../../pages/workbench/PropertyWorkbench';
+import { useDesktopStore } from '../../stores/desktopStore';
+
+vi.mock('../../stores/moduleLoaderStore', () => ({
+  useModuleLoaderStore: {
+    getState: () => ({
+      loadModule: vi.fn(() => Promise.resolve()),
+    }),
+  },
+}));
+
+vi.mock('../../stores/notificationStore', () => ({
+  useNotificationStore: {
+    getState: () => ({
+      addNotification: vi.fn(),
+    }),
+  },
+}));
+
+describe('PropertyWorkbench route activation contract', () => {
+  beforeEach(() => {
+    useDesktopStore.setState({
+      windows: [],
+      activeWindowId: null,
+      nextZIndex: 1,
+      snapPreview: null,
+      currentDesktopId: 'desktop-1',
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('direct parcel deep-link opens the canonical Workbench window before normalizing home', async () => {
+    render(
+      <MemoryRouter initialEntries={['/property/101040000000000/forge']}>
+        <Routes>
+          <Route path="/" element={<div data-testid="os-home">TerraFusion OS</div>} />
+          <Route path="/property/:parcelId/*" element={<PropertyWorkbench />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('os-home')).toBeInTheDocument();
+    });
+
+    const { windows, activeWindowId } = useDesktopStore.getState();
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      moduleId: 'property-workbench',
+      metadata: { parcelId: '101040000000000', tabId: 'forge' },
+      state: 'normal',
+    });
+    expect(activeWindowId).toBe(windows[0].id);
+  });
+
+  it('direct parcel deep-link keeps the Workbench visible under React StrictMode double effects', async () => {
+    render(
+      <React.StrictMode>
+        <MemoryRouter initialEntries={['/property/101040000000000/forge']}>
+          <Routes>
+            <Route path="/" element={<div data-testid="os-home">TerraFusion OS</div>} />
+            <Route path="/property/:parcelId/*" element={<PropertyWorkbench />} />
+          </Routes>
+        </MemoryRouter>
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('os-home')).toBeInTheDocument();
+    });
+
+    const { windows } = useDesktopStore.getState();
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      moduleId: 'property-workbench',
+      metadata: { parcelId: '101040000000000', tabId: 'forge' },
+      state: 'normal',
+    });
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/workbench/workbenchRealHosting.gate.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/workbenchRealHosting.gate.test.tsx
@@ -544,10 +544,10 @@ describe('Workbench Real Hosting Gate', () => {
       }
     });
 
-    it('getModuleWindowSize("property-workbench") returns maximized: true', async () => {
+    it('getModuleWindowSize("property-workbench") returns adjustable window sizing', async () => {
       const { getModuleWindowSize } = await import('../../stores/desktopStore');
       const result = getModuleWindowSize('property-workbench');
-      expect(result.maximized).toBe(true);
+      expect(result.maximized).not.toBe(true);
     });
   });
 });

--- a/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
+++ b/frontend/apps/os-shell/src/orchestration/moduleActivation.ts
@@ -309,14 +309,24 @@ export async function activateModule(
   const existingWindowId = findExistingWindow(canonicalId);
 
   if (existingWindowId) {
+    const desktopState = useDesktopStore.getState();
+    const existingWindow = desktopState.windows.find((w) => w.id === existingWindowId);
+
     if (metadata) {
       useDesktopStore.getState().updateWindowMetadata(existingWindowId, metadata);
     }
 
     // Window already open
     if (focusIfOpen) {
-      // Focus existing window
-      useDesktopStore.getState().focusWindow(existingWindowId);
+      const alreadyVisibleAndActive =
+        existingWindow?.state !== 'minimized' && desktopState.activeWindowId === existingWindowId;
+
+      if (!alreadyVisibleAndActive) {
+        // Focus existing window. Do not call this for the already-active
+        // window because focusWindow intentionally toggles active taskbar
+        // clicks to minimized.
+        useDesktopStore.getState().focusWindow(existingWindowId);
+      }
       
       // Emit focus telemetry
       telemetry.trackEvent('module.focus', {

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbench.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbench.tsx
@@ -49,17 +49,30 @@ export const PropertyWorkbench: React.FC<PropertyWorkbenchProps> = () => {
   );
 
   useEffect(() => {
+    let cancelled = false;
+
     if (!parcelId) {
       navigate('/property', { replace: true });
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
-    void activateModule('property-workbench', {
-      source: 'route',
-      metadata: { parcelId, tabId: routedTabId },
-      showNotification: false,
-    });
-    navigate('/', { replace: true });
+    void (async () => {
+      await activateModule('property-workbench', {
+        source: 'route',
+        metadata: { parcelId, tabId: routedTabId },
+        showNotification: false,
+      });
+
+      if (!cancelled) {
+        navigate('/', { replace: true });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [navigate, parcelId, routedTabId]);
 
   return (

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchSurface.tsx
@@ -44,6 +44,7 @@ export interface PropertyWorkbenchSurfaceProps {
   buildContextRibbonFacts?: typeof buildContextRibbonFactsBase;
   onBack: () => void;
   onSearch: () => void;
+  onParcelSelected?: (parcelId: string) => void;
   onPopOut?: () => void;
   renderNavigation: (args: PropertyWorkbenchSurfaceNavigationArgs) => React.ReactNode;
   renderContent: (context: WorkbenchTabData) => React.ReactNode;
@@ -123,6 +124,7 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
   buildContextRibbonFacts = buildContextRibbonFactsBase,
   onBack,
   onSearch,
+  onParcelSelected,
   onPopOut,
   renderNavigation,
   renderContent,
@@ -136,6 +138,7 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
   const selectParcel = usePropertyStore((s) => s.selectParcel);
   const hasWorkbenchAuth = hasUsableWorkbenchToken(auth.token);
   const [authWaitExpired, setAuthWaitExpired] = useState(false);
+  const [parcelSearchDraft, setParcelSearchDraft] = useState('');
 
   useEffect(() => {
     if (!parcelId || hasWorkbenchAuth) {
@@ -256,6 +259,23 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
     [auth, parcelId],
   );
 
+  const handleOpenSelectedParcel = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const nextParcelId = parcelSearchDraft.trim();
+      if (!nextParcelId) {
+        onSearch();
+        return;
+      }
+      if (onParcelSelected) {
+        onParcelSelected(nextParcelId);
+        return;
+      }
+      onSearch();
+    },
+    [onParcelSelected, onSearch, parcelSearchDraft],
+  );
+
   if (!parcelId) {
     return (
       <div
@@ -272,6 +292,34 @@ export const PropertyWorkbenchSurface: React.FC<PropertyWorkbenchSurfaceProps> =
         <p className="text-sm text-center max-w-md">
           Search for a parcel to view the Property Workbench.
         </p>
+        <form
+          className="flex w-full max-w-md flex-col gap-2 sm:flex-row"
+          onSubmit={handleOpenSelectedParcel}
+          aria-label="Open parcel in Workbench"
+        >
+          <label className="sr-only" htmlFor="workbench-parcel-id-input">
+            Parcel ID
+          </label>
+          <input
+            id="workbench-parcel-id-input"
+            value={parcelSearchDraft}
+            onChange={(event) => setParcelSearchDraft(event.target.value)}
+            className="min-w-0 flex-1 rounded-lg px-3 py-2 text-sm outline-none"
+            placeholder="Parcel ID"
+            style={{
+              background: 'hsl(var(--tf-surface))',
+              color: 'hsl(var(--tf-text))',
+              border: '1px solid hsl(var(--tf-border) / 0.45)',
+            }}
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            style={{ background: 'hsl(var(--tf-accent))', color: 'hsl(var(--tf-text))' }}
+          >
+            Open Parcel
+          </button>
+        </form>
         <div className="flex flex-wrap items-center justify-center gap-2">
           <button
             onClick={onSearch}

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
@@ -133,16 +133,23 @@ const WorkbenchHostViolationNotice: React.FC<{ violation: WorkbenchHostViolation
 };
 
 const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metadata }) => {
-  const parcelId = readMetadataString(metadata, 'parcelId') ?? null;
+  const metadataParcelId = readMetadataString(metadata, 'parcelId') ?? null;
   const metadataTab = resolveMetadataTab(metadata);
   const segmentHandoff = useMemo(() => buildSegmentHandoffContext(metadata), [metadata]);
+  const [selectedParcelId, setSelectedParcelId] = useState<string | null>(metadataParcelId);
   const [activeTab, setActiveTab] = useState<WorkbenchTabSlug>(metadataTab);
   const previousTabRef = useRef<WorkbenchTabSlug>(metadataTab);
   const setCompanionTab = useCompanionStore((state) => state.setActiveTab);
 
   useEffect(() => {
+    setSelectedParcelId(metadataParcelId);
+  }, [metadataParcelId]);
+
+  useEffect(() => {
     setActiveTab(metadataTab);
   }, [metadataTab]);
+
+  const parcelId = selectedParcelId;
 
   useEffect(() => {
     const previousTab = previousTabRef.current;
@@ -165,6 +172,7 @@ const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metad
       showBreadcrumb={false}
       onBack={() => window.history.pushState({}, '', '/')}
       onSearch={() => window.history.pushState({}, '', '/property')}
+      onParcelSelected={setSelectedParcelId}
       onPopOut={() => {
         if (parcelId) {
           window.open(`/property/${encodeURIComponent(parcelId)}`, '_blank', 'noopener');

--- a/frontend/apps/os-shell/src/shell/desktop/Window.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Window.tsx
@@ -19,7 +19,6 @@ import { Rnd, RndDragCallback, RndResizeCallback } from 'react-rnd';
 import { getLucideIcon } from '../../config/iconMap';
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { DesktopWindow, useDesktopStore } from '../../stores/desktopStore';
-import { getObjectClassification } from '../../contracts/objectPlacement';
 import { TerraSphereIcon } from '../../ui/brand/TerraSphereIcon';
 import { LiquidPanel } from '../../ui/materials';
 import { useWindowSnap } from './useWindowSnap';
@@ -432,10 +431,6 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
   const isMaximized = windowData.state === 'maximized';
   const isMinimized = windowData.state === 'minimized';
 
-  // Tier-0 workbench must stay maximized — no restore, no drag, no resize
-  const classification = getObjectClassification(windowData.moduleId);
-  const isTier0 = classification?.objectType === 'tier0-workbench';
-
   // Animation state tracking
   const [animationState, setAnimationState] = useState<'opening' | 'open' | 'focused'>('opening');
 
@@ -491,14 +486,12 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
   }, [minimizeWindow, windowData.id]);
 
   const handleMaximize = useCallback(() => {
-    // Tier-0 windows must stay maximized — block restore
-    if (isTier0) return;
     if (isMaximized) {
       restoreWindow(windowData.id);
     } else {
       maximizeWindow(windowData.id);
     }
-  }, [isTier0, isMaximized, maximizeWindow, restoreWindow, windowData.id]);
+  }, [isMaximized, maximizeWindow, restoreWindow, windowData.id]);
 
   const handleFocus = useCallback(() => {
     // Only bring to front if this is NOT already the active window.
@@ -624,9 +617,9 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
         bounds='window'
         dragHandleClassName='window-drag-handle'
         cancel='[data-testid="window-controls"], [data-testid="window-controls"] *'
-        disableDragging={isMaximized || isTier0}
+        disableDragging={isMaximized}
         enableResizing={
-          isMaximized || isTier0
+          isMaximized
             ? false
             : {
                 top: true,
@@ -666,19 +659,6 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
           data-testid='tf-window-animation'
           className='w-full h-full'
         >
-        {/* ── Tier-0 surface (property-workbench) — no chrome, no titlebar ── */}
-        {isTier0 ? (
-          <div
-            data-testid='tf-window-chrome'
-            data-tier0='true'
-            className='w-full h-full overflow-hidden'
-            style={{ background: 'hsl(var(--tf-bg))' }}
-          >
-            <WindowInteractionContext.Provider value={{ isInteracting }}>
-              {children}
-            </WindowInteractionContext.Provider>
-          </div>
-        ) : (
         <LiquidPanel
           variant='shell'
           radius='lg'
@@ -714,7 +694,6 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
             icon={windowData.icon}
             isActive={isActive}
             isMaximized={isMaximized}
-            isTier0={isTier0}
             isPersistent={!!windowData.metadata?.persistent}
             onMinimize={handleMinimize}
             onMaximize={handleMaximize}
@@ -740,7 +719,7 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
               userSelect: isInteracting ? 'none' : 'auto',
             }}
             onMouseDownCapture={
-              isMaximized || isTier0
+              isMaximized
                 ? undefined
                 : (e) => {
                     // Guard zone slightly wider than the handle itself so near-miss
@@ -791,7 +770,6 @@ export const Window: React.FC<WindowProps> = ({ window: windowData, children }) 
             </WindowInteractionContext.Provider>
           </div>
         </LiquidPanel>
-        )}
         </motion.div>
       </Rnd>
 

--- a/frontend/apps/os-shell/src/stores/desktopStore.ts
+++ b/frontend/apps/os-shell/src/stores/desktopStore.ts
@@ -196,7 +196,20 @@ export function getModuleWindowSize(moduleId: string): { size: Size; maximized: 
   if (classification) {
     const { objectType } = classification;
 
-    // Tier-0 workbench → MAXIMIZED (fills usable area between top bar and taskbar)
+    // Property Workbench remains the Tier-0 parcel surface, but it must be
+    // managed by the OS window system so users can move, resize, minimize,
+    // and close it like the other work surfaces.
+    if (moduleId === 'property-workbench') {
+      return {
+        size: {
+          width: Math.min(1200, Math.max(MIN_WINDOW_SIZE.width, vw - 200)),
+          height: Math.min(760, Math.max(MIN_WINDOW_SIZE.height, vh - 220)),
+        },
+        maximized: false,
+      };
+    }
+
+    // Other Tier-0 workbenches stay maximized unless explicitly reclassified.
     if (objectType === 'tier0-workbench') {
       return {
         size: { width: vw, height: vh - TOP_BAR_HEIGHT - TASKBAR_HEIGHT },


### PR DESCRIPTION
This PR restores the missing Workbench runtime/window reconciliation on top of the current June 10 integration branch.

It:
- Restores Property Workbench as an OS-managed movable/resizable/minimizable/closable window.
- Preserves the canonical shared Workbench surface from the current Workbench foundation.
- Preserves the direct `/property/:parcelId` route bridge.
- Adds a no-parcel search/select state that loads the selected parcel in the same Workbench window.
- Fixes route activation so the route waits for Cortex activation before normalizing back to `/`.
- Fixes the StrictMode double-activation/minimize bug by avoiding a focus toggle on an already-active visible Workbench window.

Boundaries:
- No DB mutation.
- No production touch.
- No Home, TerraForge, Counties, Hostinger, or package.json changes.
- Not a full Workbench completion claim.

Validation:
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- focused Workbench contract tests
- browser proof for OS-managed Workbench, no-parcel search/select, parcel `101040000000000`, direct route activation, and move/resize behavior

## Summary by Sourcery

Restore the Property Workbench as a normal OS-managed window while tightening its routing, activation, and no-parcel behaviors to align with the current Workbench foundation.

New Features:
- Add a no-parcel Workbench state that lets users input a parcel ID and open it directly in the same Workbench window.

Bug Fixes:
- Ensure route-driven Property Workbench activation waits for module activation before normalizing back to the home route.
- Prevent StrictMode double-activation from minimizing an already-active Workbench window when re-focusing an existing window.

Enhancements:
- Make the Property Workbench use standard movable, resizable window chrome instead of a special maximized Tier-0 surface.
- Adjust the default Property Workbench window sizing so it opens as an adjustable OS-managed window rather than always maximized.
- Preserve and reuse the selected parcel within the Workbench window so parcel changes stay within the same runtime surface.

Tests:
- Update shell chrome, anti-drift, and Workbench hosting contract tests to assert OS-managed Property Workbench sizing and chrome behavior.
- Extend Property Workbench auth and UX contract tests to cover no-parcel parcel selection, route activation behavior, and module activation sequencing.
- Add a dedicated route activation contract test to verify the route bridge stays mounted until Cortex activation finishes.