### PR TITLE
test(os): add Phase 5 visible navigation contract

### DIFF
--- a/backend/tests/TerraFusion.Integration.Tests/Phase29/SystemGptAtlasLiveServiceTests.cs
+++ b/backend/tests/TerraFusion.Integration.Tests/Phase29/SystemGptAtlasLiveServiceTests.cs
@@ -101,30 +101,19 @@ public class SystemGptAtlasLiveServiceTests
         // Arrange
         var telemetrySource = CreateMockTelemetrySource(countyCount: 1);
         var service = CreateLiveService(telemetrySource, intervalMs: 50);
-        var cts = new CancellationTokenSource();
-        var eventCount = 0;
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource();
+        await using var enumerator = service.StreamEventsAsync(cts.Token).GetAsyncEnumerator(cts.Token);
 
         // Act
-        cts.CancelAfter(300);
+        Assert.True(await enumerator.MoveNextAsync());
 
-        // Async enumerator may either throw or complete gracefully on cancellation
-        try
-        {
-            await foreach (var evt in service.StreamEventsAsync(cts.Token))
-            {
-                eventCount++;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected - cancellation occurred during enumeration
-        }
-        
-        stopwatch.Stop();
+        cts.Cancel();
+        var cancellationTask = enumerator.MoveNextAsync().AsTask();
+        var completedTask = await Task.WhenAny(cancellationTask, Task.Delay(TimeSpan.FromSeconds(5)));
 
-        // Assert - stream stopped within reasonable time (generous for CI runners under load)
-        Assert.True(stopwatch.ElapsedMilliseconds < 5000, "Stream should stop quickly after cancellation");
+        // Assert - timeout is only a deadlock guard; cancellation is the contract.
+        Assert.Same(cancellationTask, completedTask);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await cancellationTask);
     }
 
     [Fact]

--- a/frontend/apps/os-shell/src/shell/desktop/Window.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/Window.tsx
@@ -60,7 +60,7 @@ export interface WindowProps {
 // ============================================================================
 
 /** Window-chrome z-layering (scoped, not shell-level) */
-const WINDOW_CHROME_Z = { titleControls: 50, titleCenter: 10 } as const;
+const WINDOW_CHROME_Z = { titleControls: 50, titleCenter: 10, resizeHandles: 5 } as const;
 
 const MIN_WIDTH = 400;
 const MIN_HEIGHT = 300;
@@ -87,7 +87,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     left: '16px',
     right: '16px',
     cursor: 's-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   bottomLeft: {
     position: 'absolute',
@@ -96,7 +96,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     bottom: '0',
     left: '0',
     cursor: 'sw-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   bottomRight: {
     position: 'absolute',
@@ -105,7 +105,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     bottom: '0',
     right: '0',
     cursor: 'se-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   left: {
     position: 'absolute',
@@ -114,7 +114,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     top: '40px',
     bottom: '16px',
     cursor: 'w-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   right: {
     position: 'absolute',
@@ -123,7 +123,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     top: '40px',
     bottom: '16px',
     cursor: 'e-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   top: {
     position: 'absolute',
@@ -132,7 +132,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     left: '16px',
     right: '90px',
     cursor: 'n-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   topLeft: {
     position: 'absolute',
@@ -141,7 +141,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     top: '0',
     left: '0',
     cursor: 'nw-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
   topRight: {
     position: 'absolute',
@@ -150,7 +150,7 @@ const RESIZE_HANDLE_STYLES: Record<string, React.CSSProperties> = {
     top: '0',
     right: '0',
     cursor: 'ne-resize',
-    zIndex: 9999,
+    zIndex: WINDOW_CHROME_Z.resizeHandles,
   },
 };
 

--- a/frontend/tests/phase5-os-navigation-visible-contract.spec.ts
+++ b/frontend/tests/phase5-os-navigation-visible-contract.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page, type Response } from '@playwright/test';
+
+const PARCEL_ID = '101040000000000';
+const EXPLICIT_ERROR_TEXT =
+  /HTTP 401|HTTP 403|HTTP 500|401 Unauthorized|403 Forbidden|500 Internal Server Error|Internal Server Error|Unauthorized|Forbidden/i;
+
+function collectRuntimeFailures(page: Page): string[] {
+  const failures: string[] = [];
+
+  page.on('response', (response: Response) => {
+    const url = response.url();
+    const status = response.status();
+
+    if (url.includes('/api/') && [401, 403, 500].includes(status)) {
+      failures.push(`${status} ${url}`);
+    }
+  });
+
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    const errorText = request.failure()?.errorText ?? '';
+
+    if (url.includes('/api/') && errorText !== 'net::ERR_ABORTED') {
+      failures.push(`requestfailed ${url} ${errorText}`.trim());
+    }
+  });
+
+  return failures;
+}
+
+async function expectNoRuntimeFailures(page: Page, failures: string[]) {
+  await page.waitForTimeout(500);
+  expect(failures).toEqual([]);
+  await expect(page.locator('body')).not.toContainText(EXPLICIT_ERROR_TEXT);
+}
+
+test('Phase 5 OS navigation visible contract', async ({ page }) => {
+  const runtimeFailures = collectRuntimeFailures(page);
+
+  await page.goto('/');
+  await expect(page.getByText('TerraFusion OS Desktop')).toBeVisible();
+  await expect(page.getByText('EXECUTIVE COMMAND SURFACE')).toBeVisible();
+  await expect(page.getByText('39 Washington counties registered')).toBeVisible();
+  await expect(page.getByText('canonicalImportAllowed: false for intake counties')).toBeVisible();
+  await expect(page.getByText('Map layer unavailable: Mapbox token not configured')).toBeVisible();
+  await expectNoRuntimeFailures(page, runtimeFailures);
+
+  await page.getByRole('button', { name: 'TerraForge' }).click();
+  await expect(page.getByText('TERRAFORGE RUNTIME STATUS')).toBeVisible();
+  await expect(page.getByText('FULL TERRAFORGE NOT DONE')).toBeVisible();
+  await expect(page.getByText(/Metrics app-backed; county rollup (blocked|resolving)/i)).toBeVisible();
+  await expect(page.locator('body')).not.toContainText(/LIVE METRICS|128,784|\$469,565|95,758|71\.4%/);
+  await expectNoRuntimeFailures(page, runtimeFailures);
+
+  await page.getByTestId('window-controls').getByRole('button', { name: 'Close' }).click();
+  await expect(page.getByText('TERRAFORGE RUNTIME STATUS')).toHaveCount(0);
+
+  await page.getByRole('button', { name: /Open Workbench/i }).click();
+  await expect(page.getByTestId('window')).toBeVisible();
+  await expect(page.getByTestId('window-titlebar')).toContainText('Property Workbench');
+  await expect(page.locator('.window-drag-handle')).toBeVisible();
+  await expect(page.locator('.cursor-se-resize')).toBeVisible();
+  await expect(page.getByText('No Parcel Selected')).toBeVisible();
+  await expect(page.getByPlaceholder('Parcel ID')).toBeVisible();
+
+  await page.getByPlaceholder('Parcel ID').fill(PARCEL_ID);
+  await page.getByRole('button', { name: 'Open Parcel' }).click();
+  await expect(page.getByText('IDENTITY')).toBeVisible({ timeout: 30000 });
+  await expect(page.getByText(PARCEL_ID).first()).toBeVisible();
+  await expect(page.getByText('Benton County').first()).toBeVisible();
+  for (const tabName of ['Summary', 'Forge', 'Atlas', 'Dais', 'Clerk', 'Treasury', 'Audit', 'Dossier', 'Pilot']) {
+    await expect(page.getByText(tabName, { exact: true }).first()).toBeVisible();
+  }
+  await expectNoRuntimeFailures(page, runtimeFailures);
+
+  await page.getByRole('button', { name: /Search \(Ctrl\+K\)/i }).click();
+  await page.getByText('Open Counties Hub').click();
+  await expect(page.getByText('Washington County Integration Hub')).toBeVisible();
+  await expect(page.getByTestId('county-runtime-posture-summary')).toContainText('Washington counties');
+  await expect(page.getByTestId('county-runtime-posture-summary')).toContainText('39');
+  await expect(page.getByTestId('county-runtime-posture-summary')).toContainText('Benton County');
+  await expect(page.getByTestId('county-runtime-posture-summary')).toContainText('Runtime-enabled');
+  await expect(page.getByTestId('county-runtime-posture-boundary')).toContainText('Yakima County');
+  await expect(page.getByTestId('county-runtime-posture-boundary')).toContainText('runtimeActionsAllowed: false');
+  await expect(page.getByTestId('county-runtime-posture-boundary')).toContainText('canonicalImportAllowed: false');
+  await expect(page.getByTestId('county-runtime-posture-boundary')).toContainText('source-provenance-onboarding-intake');
+  await expect(page.getByText(/runtime actions are blocked|runtime actions remain blocked/i)).toBeVisible();
+  await expect(page.locator('body')).not.toContainText(/TEST-PARCEL-001|sample parcel|random parcel/i);
+  await expectNoRuntimeFailures(page, runtimeFailures);
+});


### PR DESCRIPTION
Adds browser-level visible contract proof for the integrated June 10 OS path.

Proves:
- GIS Home Scene
- Dock/taskbar Forge launch
- TerraForge corrected runtime posture
- OS-managed Workbench window
- Benton parcel runtime data
- Counties Hub posture
- non-Benton runtime blocking
- no visible 401/403/500

Also fixes Window resize-handle z-index so window controls remain clickable.

Does not touch DB, production, Hostinger, Workbench data model, Forge data model, or county posture model.

## Summary by Sourcery

Add a Playwright-based Phase 5 OS navigation visible contract test and adjust window resize-handle z-index layering to coexist with title controls.

Enhancements:
- Scope window resize-handle z-index within window chrome layering to keep window controls clickable.

Tests:
- Add browser-level visible navigation contract test for Phase 5 OS path, including TerraForge, Workbench, and Counties Hub flows while asserting absence of runtime errors.