### PR TITLE
fix(honesty): WO-CF-b2g — zero Category 3 fabricated analytics + Harris-sync metrics

### DIFF
--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -428,11 +428,14 @@ public class CostForgeAIService : ICostForgeAIService
     var startTime = DateTime.UtcNow;
     await System.Threading.Tasks.Task.Delay(2000); // Simulate sync operation
 
+    // Honesty (WO-CF-b2g): this method is a stub — no Harris PACS connection occurs.
+    // RecordsProcessed/Updated/Added were fabricated counts; harris_version was invented.
+    // Zeroed per operator representation rule. sync_type and county are request-derived (real).
     return new HarrisSyncResultDto
     {
-      RecordsProcessed = 89_247, // CARD-10: Benton County parcel count stub
-      RecordsUpdated = 1247,
-      RecordsAdded = 23,
+      RecordsProcessed = 0,
+      RecordsUpdated = 0,
+      RecordsAdded = 0,
       RecordsSkipped = 0,
       SyncStartTime = startTime,
       SyncEndTime = DateTime.UtcNow,
@@ -441,7 +444,7 @@ public class CostForgeAIService : ICostForgeAIService
       Errors = new List<string>(),
       SyncMetadata = new Dictionary<string, object>
       {
-        ["harris_version"] = "12.4.7",
+        ["harris_version"] = "0.0.0",
         ["sync_type"] = request.FullSync ? "full" : "incremental",
         ["county"] = request.CountyId
       }
@@ -489,25 +492,28 @@ public class CostForgeAIService : ICostForgeAIService
     var start = startDate ?? DateTime.UtcNow.AddDays(-30);
     var end = endDate ?? DateTime.UtcNow;
 
+    // Honesty (WO-CF-b2g): AverageAccuracy, TotalValueCalculated, CalculationsByType counts,
+    // and PerformanceTrends were fabricated constants with no real analytics pipeline backing.
+    // Zeroed per operator representation rule. TotalCalculations is real (Interlocked counter).
     return new AnalyticsDto
     {
       StartDate = start,
       EndDate = end,
       TotalCalculations = Interlocked.Read(ref _totalCalculations),
-      AverageAccuracy = 98.7m,
-      TotalValueCalculated = 2847392000m,
+      AverageAccuracy = 0m,
+      TotalValueCalculated = 0m,
       CalculationsByType = new Dictionary<string, int>
       {
-        ["residential"] = 1247,
-        ["commercial"] = 423,
-        ["industrial"] = 89,
-        ["agricultural"] = 156
+        ["residential"] = 0,
+        ["commercial"] = 0,
+        ["industrial"] = 0,
+        ["agricultural"] = 0
       },
       PerformanceTrends = new Dictionary<string, decimal>
       {
-        ["accuracy_trend"] = 0.3m,
-        ["speed_trend"] = 12.7m,
-        ["efficiency_trend"] = 8.9m
+        ["accuracy_trend"] = 0m,
+        ["speed_trend"] = 0m,
+        ["efficiency_trend"] = 0m
       },
       TopPerformingAgents = _agents.Values
             .OrderByDescending(a => a.PerformanceScore)
@@ -516,7 +522,7 @@ public class CostForgeAIService : ICostForgeAIService
             {
               AgentId = a.AgentId,
               TasksCompleted = a.TasksCompleted,
-              AverageAccuracy = 98.7m,
+              AverageAccuracy = 0m,
               PerformanceScore = a.PerformanceScore
             })
             .ToList()

--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -83,7 +83,9 @@ public class CostForgeAIService : ICostForgeAIService
           .ToList();
 
       if (recentData.Count == 0)
-        return 847m; // Default baseline
+        // Honesty (WO-CF-b2f): no recorded throughput → report 0, not a fabricated 847
+        // baseline. The computed branch below derives from real _performanceHistory timings.
+        return 0m;
 
       var avgResponseTime = recentData.Average(d => d.Value);
       return Math.Max(1000m / Math.Max(avgResponseTime, 1m), 100m);
@@ -364,10 +366,10 @@ public class CostForgeAIService : ICostForgeAIService
       ActiveAgents = activeAgents,
       IdleAgents = idleAgents,
       BusyAgents = busyAgents,
-      // Honesty (WO-AI-CONSOLIDATION-004c-b2d): an empty fleet has 0 utilization, not a
-      // fabricated 87.3. The non-empty simulation constant remains deferred to the broader
-      // simulation-truth cleanup.
-      AverageUtilization = totalAgents == 0 ? 0.0 : (double)87.3m,
+      // Honesty (WO-CF-b2f): the agent Status values are Random-assigned simulations, so any
+      // utilization derived from them is fabricated. Report 0 in all states — there is no
+      // trustworthy live utilization to surface (supersedes the b2d empty-only guard).
+      AverageUtilization = 0.0,
       Agents = snapshot.Take(10).Cast<object>().ToList() // Return first 10 for performance
     };
   }
@@ -399,18 +401,21 @@ public class CostForgeAIService : ICostForgeAIService
   {
     await System.Threading.Tasks.Task.Delay(10);
 
+    // Honesty (WO-CF-b2f): these were fabricated constants with no real telemetry backing —
+    // zeroed so the surfaced metrics do not imply live performance. HistoricalData below is
+    // real (written by RecordPerformanceMetrics during actual valuations) and is preserved.
     return new PerformanceMetricsDto
     {
-      AverageResponseTime = 1.2m,
-      ThroughputPerSecond = 847m,
-      ErrorRate = 0.03m,
-      MemoryUsage = 2048m,
-      CpuUsage = 23.5m,
+      AverageResponseTime = 0m,
+      ThroughputPerSecond = 0m,
+      ErrorRate = 0m,
+      MemoryUsage = 0m,
+      CpuUsage = 0m,
       CustomMetrics = new Dictionary<string, decimal>
       {
-        ["quantum_acceleration"] = 379000000m,
-        ["harris_sync_rate"] = 99.7m,
-        ["championship_score"] = 98.7m
+        ["quantum_acceleration"] = 0m,
+        ["harris_sync_rate"] = 0m,
+        ["championship_score"] = 0m
       },
       HistoricalData = _performanceHistory.TakeLast(100).ToList()
     };
@@ -452,8 +457,9 @@ public class CostForgeAIService : ICostForgeAIService
       Status = TerraFusion.Core.Enums.HealthStatus.Healthy,
       LastHealthCheck = DateTime.UtcNow,
       Uptime = DateTime.UtcNow - _startTime,
-      MemoryUsage = 2048,
-      CpuUsage = 23.5,
+      // Honesty (WO-CF-b2f): fabricated telemetry constants with no real backing → 0.
+      MemoryUsage = 0,
+      CpuUsage = 0,
       // Honesty (WO-AI-CONSOLIDATION-004c-b2a): no governed AI agent swarm runs,
       // so there are no live agent connections to report.
       ActiveConnections = 0,


### PR DESCRIPTION
## Summary
- Zeroes fabricated analytics metrics in `GetAnalyticsAsync`: AverageAccuracy (98.7→0), TotalValueCalculated ($2.8B→0), CalculationsByType counts (1247/423/89/156→0), PerformanceTrends (0.3/12.7/8.9→0), per-agent AverageAccuracy (98.7→0)
- Zeroes fabricated Harris PACS sync counts in `SyncWithHarrisPACSAsync`: RecordsProcessed (89247→0), RecordsUpdated (1247→0), RecordsAdded (23→0), harris_version (12.4.7→0.0.0) — method is a stub with no actual PACS connection
- Preserves real values: `TotalCalculations` (Interlocked counter), `sync_type`/`county` (request-derived)
- Per operator representation rule: fabricated metric with no truthful backing → returns 0

## Context
Completes the CostForge honesty sweep (TF-AI-OPS-001):
- Category 1 (coherence) — done in #988
- Category 2 (fabricated constants) — done in #991
- **Category 3 (analytics + Harris-sync fabrications) — this PR**

## Test plan
- [ ] Backend builds clean (`dotnet build`) — verified locally (0 warnings, 0 errors)
- [ ] No DTO shape changes — consumers unaffected
- [ ] Zeroed values confirmed in diff (13 fabricated values → 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Zero out fabricated performance, health, sync, and analytics metrics to avoid implying non-existent telemetry or Harris PACS integrations while preserving real counters and request-derived fields.

Bug Fixes:
- Prevent exposure of hard-coded performance and analytics values by returning zero when no real telemetry exists.
- Remove fake Harris PACS sync counts and version metadata from the stubbed sync endpoint to avoid misrepresenting external integrations.

Enhancements:
- Align throughput and utilization reporting with actual recorded history and honesty policy by eliminating default baseline constants and random-based utilization.
- Standardize module health telemetry to report zero for unverifiable CPU and memory usage metrics.