### PR TITLE
feat(mcp): add atlas.parcel.workbench tool

### DIFF
--- a/packages/os-core/src/services/pilot/__tests__/atlasParcelWorkbench.test.ts
+++ b/packages/os-core/src/services/pilot/__tests__/atlasParcelWorkbench.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolRunner, type PilotContext } from '../ToolRunner';
 import { ToolRegistry } from '../ToolRegistry';
 import { registerDefaultTools, defaultTools } from '../registerDefaultTools';
@@ -26,6 +26,10 @@ describe('atlas.parcel.workbench', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ToolRegistry._clear();
+  });
+
+  afterEach(() => {
+
   });
 
   it('is registered by registerDefaultTools', () => {
@@ -61,7 +65,7 @@ describe('atlas.parcel.workbench', () => {
     expect(result).toHaveProperty('wsdorRoll', null);
     expect(result.errors).toEqual([]);
 
-    vi.unstubAllGlobals();
+
   });
 
   it('collects per-facet errors without throwing', async () => {
@@ -82,7 +86,7 @@ describe('atlas.parcel.workbench', () => {
     expect(result.errors[1]).toContain('ownerCurrent');
     expect(result.errors[2]).toContain('wsdorRoll');
 
-    vi.unstubAllGlobals();
+
   });
 
   it('nullable output fields are present as null, never omitted', async () => {
@@ -99,7 +103,7 @@ describe('atlas.parcel.workbench', () => {
     expect(keys).toContain('wsdorRoll');
     expect(keys).toContain('errors');
 
-    vi.unstubAllGlobals();
+
   });
 
   it('composes all three facets when API returns 200', async () => {
@@ -162,7 +166,7 @@ describe('atlas.parcel.workbench', () => {
     expect(result.errors).toEqual([]);
     expect(mockFetch).toHaveBeenCalledTimes(3);
 
-    vi.unstubAllGlobals();
+
   });
 
   it('passes era param through to owner-current and wsdor-roll URLs', async () => {
@@ -178,7 +182,7 @@ describe('atlas.parcel.workbench', () => {
     expect(ownerUrl).toContain('era=ALL');
     expect(wsdorUrl).toContain('era=ALL');
 
-    vi.unstubAllGlobals();
+
   });
 
   it('is denied when parcel:read permission is missing', async () => {
@@ -191,9 +195,36 @@ describe('atlas.parcel.workbench', () => {
     ).rejects.toThrow(/Permission Denied/i);
   });
 
-  // CAUTION: acctId is emitted as a JSON number from int64.
-  // Valid JSON, but can exceed Number.MAX_SAFE_INTEGER in the abstract.
-  it('documents acctId int64 caution in the type contract', () => {
-    expect(Number.MAX_SAFE_INTEGER).toBe(9007199254740991);
+  it('passes acctId through as-is from the API response (int64 caution)', async () => {
+    const ownerPayload = {
+      tfParcelId: 'p1',
+      countyId: 'c1',
+      taxYear: 2026,
+      owners: [
+        {
+          tfOwnerId: 'o1',
+          acctId: 9007199254740992,
+          displayName: 'Large AcctId Owner',
+          pctOwnership: null,
+          isPrimary: true,
+          confidentialFlag: false,
+          webSuppression: false,
+        },
+      ],
+    };
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/owner-current')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(ownerPayload) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    const result = await tool.handler({ parcelId: 'p1', taxYear: 2026 }, makeCtx());
+
+    expect(result.ownerCurrent).not.toBeNull();
+    expect(result.ownerCurrent!.owners[0].acctId).toBe(9007199254740992);
   });
 });

--- a/packages/os-core/src/services/pilot/__tests__/atlasParcelWorkbench.test.ts
+++ b/packages/os-core/src/services/pilot/__tests__/atlasParcelWorkbench.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToolRunner, type PilotContext } from '../ToolRunner';
+import { ToolRegistry } from '../ToolRegistry';
+import { registerDefaultTools, defaultTools } from '../registerDefaultTools';
+
+vi.mock('../../trace/TerraTraceService', () => ({
+  TerraTraceService: {
+    emit: vi.fn(async () => 'trace-wb-1'),
+    emitResult: vi.fn(async () => 'trace-wb-result'),
+  },
+}));
+
+function makeCtx(overrides: Partial<PilotContext> = {}): PilotContext {
+  return {
+    userId: 'u-test',
+    userRole: 'appraiser',
+    permissions: ['parcel:read'],
+    activeMode: 'pilot',
+    countyId: 'benton',
+    parcelId: 'test-parcel',
+    ...overrides,
+  };
+}
+
+describe('atlas.parcel.workbench', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ToolRegistry._clear();
+  });
+
+  it('is registered by registerDefaultTools', () => {
+    registerDefaultTools();
+    expect(ToolRegistry.has('atlas.parcel.workbench')).toBe(true);
+    const meta = ToolRegistry.list().find(t => t.id === 'atlas.parcel.workbench');
+    expect(meta).toBeDefined();
+    expect(meta!.suite).toBe('atlas');
+    expect(meta!.risk).toBe('read_only');
+    expect(meta!.writeLane).toBe('atlas:read');
+  });
+
+  it('is exported in defaultTools', () => {
+    expect(defaultTools.atlasParcelWorkbench).toBeDefined();
+    expect(defaultTools.atlasParcelWorkbench.id).toBe('atlas.parcel.workbench');
+  });
+
+  it('returns null facets (not omitted) when API returns 404', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    const result = await tool.handler(
+      { parcelId: '00000000-0000-0000-0000-000000000001' },
+      makeCtx()
+    );
+
+    expect(result).toHaveProperty('geometry', null);
+    expect(result).toHaveProperty('ownerCurrent', null);
+    expect(result).toHaveProperty('wsdorRoll', null);
+    expect(result.errors).toEqual([]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('collects per-facet errors without throwing', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    const result = await tool.handler(
+      { parcelId: '00000000-0000-0000-0000-000000000001' },
+      makeCtx()
+    );
+
+    expect(result.geometry).toBeNull();
+    expect(result.ownerCurrent).toBeNull();
+    expect(result.wsdorRoll).toBeNull();
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors[0]).toContain('geometry');
+    expect(result.errors[1]).toContain('ownerCurrent');
+    expect(result.errors[2]).toContain('wsdorRoll');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('nullable output fields are present as null, never omitted', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    const result = await tool.handler({ parcelId: 'abc' }, makeCtx());
+    const keys = Object.keys(result);
+
+    expect(keys).toContain('parcelId');
+    expect(keys).toContain('geometry');
+    expect(keys).toContain('ownerCurrent');
+    expect(keys).toContain('wsdorRoll');
+    expect(keys).toContain('errors');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('composes all three facets when API returns 200', async () => {
+    const geomPayload = {
+      tfParcelId: 'p1',
+      countyId: 'c1',
+      geomWkt: 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))',
+      centroidLat: 0.5,
+      centroidLon: 0.5,
+      areaSqFt: 43560,
+      lastSyncedAt: '2026-01-01T00:00:00Z',
+      sourceServiceUrl: 'https://gis.example.com',
+      isActive: true,
+    };
+    const ownerPayload = {
+      tfParcelId: 'p1',
+      countyId: 'c1',
+      taxYear: 2026,
+      owners: [
+        {
+          tfOwnerId: 'o1',
+          acctId: 12345,
+          displayName: 'Test Owner',
+          pctOwnership: null,
+          isPrimary: true,
+          confidentialFlag: false,
+          webSuppression: false,
+        },
+      ],
+    };
+    const wsdorPayload = {
+      tfParcelId: 'p1',
+      countyId: 'c1',
+      assessmentYear: 2026,
+      entries: [],
+      assessedValTotal: null,
+      marketValTotal: null,
+    };
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/geometry')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(geomPayload) });
+      }
+      if (url.includes('/owner-current')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(ownerPayload) });
+      }
+      if (url.includes('/wsdor-roll')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(wsdorPayload) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    const result = await tool.handler({ parcelId: 'p1', taxYear: 2026 }, makeCtx());
+
+    expect(result.geometry).toEqual(geomPayload);
+    expect(result.ownerCurrent).toEqual(ownerPayload);
+    expect(result.wsdorRoll).toEqual(wsdorPayload);
+    expect(result.errors).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('passes era param through to owner-current and wsdor-roll URLs', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const tool = defaultTools.atlasParcelWorkbench;
+    await tool.handler({ parcelId: 'p1', taxYear: 2026, era: 'ALL' }, makeCtx());
+
+    const urls = mockFetch.mock.calls.map((c: any[]) => c[0] as string);
+    const ownerUrl = urls.find((u: string) => u.includes('owner-current'));
+    const wsdorUrl = urls.find((u: string) => u.includes('wsdor-roll'));
+    expect(ownerUrl).toContain('era=ALL');
+    expect(wsdorUrl).toContain('era=ALL');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('is denied when parcel:read permission is missing', async () => {
+    registerDefaultTools();
+    const tool = ToolRegistry.get('atlas.parcel.workbench');
+    const ctx = makeCtx({ permissions: [] });
+
+    await expect(
+      ToolRunner.execute(tool, { parcelId: 'p1' }, ctx)
+    ).rejects.toThrow(/Permission Denied/i);
+  });
+
+  // CAUTION: acctId is emitted as a JSON number from int64.
+  // Valid JSON, but can exceed Number.MAX_SAFE_INTEGER in the abstract.
+  it('documents acctId int64 caution in the type contract', () => {
+    expect(Number.MAX_SAFE_INTEGER).toBe(9007199254740991);
+  });
+});

--- a/packages/os-core/src/services/pilot/registerDefaultTools.ts
+++ b/packages/os-core/src/services/pilot/registerDefaultTools.ts
@@ -34,6 +34,129 @@ const atlasParcelRead: ToolDefinition = {
   },
 };
 
+// API base for the .NET Kernel (port 5000 by default, configurable)
+const API_BASE = process.env.TERRAFUSION_API_BASE ?? 'http://localhost:5000';
+
+interface ParcelWorkbenchParams {
+  parcelId: string;
+  taxYear?: number;
+  era?: string;
+}
+
+// ── Output schema contracts (camelCase wire keys; nullable fields present as null, never omitted) ──
+
+interface GeometryFacet {
+  tfParcelId: string;
+  countyId: string;
+  geomWkt: string;
+  centroidLat: number;
+  centroidLon: number;
+  areaSqFt: number;
+  lastSyncedAt: string;
+  sourceServiceUrl: string;
+  isActive: boolean;
+}
+
+interface OwnerEntry {
+  tfOwnerId: string;
+  // CAUTION: acctId is emitted as a JSON number from int64.
+  // Valid JSON, but can exceed Number.MAX_SAFE_INTEGER (2^53-1).
+  acctId: number;
+  displayName: string;
+  pctOwnership: number | null;
+  isPrimary: boolean;
+  confidentialFlag: boolean;
+  webSuppression: boolean;
+}
+
+interface OwnerCurrentFacet {
+  tfParcelId: string;
+  countyId: string;
+  taxYear: number;
+  owners: OwnerEntry[];
+}
+
+interface WsdorEntry {
+  tfAssessmentWsdorId: string;
+  tfOwnerId: string;
+  ownerDisplayName: string;
+  assessedVal: number | null;
+  marketVal: number | null;
+  appraisedVal: number | null;
+  taxableClassified: number | null;
+  taxableNonClassified: number | null;
+  landTaxableClassified: number | null;
+  landTaxableNonClassified: number | null;
+  imprvTaxableClassified: number | null;
+  imprvTaxableNonClassified: number | null;
+  stateValueClassified: number | null;
+  stateValueNonClassified: number | null;
+  boeStatus: string | null;
+  disasterProrationPct: number | null;
+  snrFrzImprvHs: number | null;
+  snrFrzLandHs: number | null;
+}
+
+interface WsdorRollFacet {
+  tfParcelId: string;
+  countyId: string;
+  assessmentYear: number;
+  entries: WsdorEntry[];
+  assessedValTotal: number | null;
+  marketValTotal: number | null;
+}
+
+interface ParcelWorkbenchResult {
+  parcelId: string;
+  geometry: GeometryFacet | null;
+  ownerCurrent: OwnerCurrentFacet | null;
+  wsdorRoll: WsdorRollFacet | null;
+  errors: string[];
+}
+
+async function fetchFacet<T>(url: string): Promise<{ data: T | null; error: string | null }> {
+  try {
+    const res = await fetch(url);
+    if (res.status === 404) return { data: null, error: null };
+    if (!res.ok) return { data: null, error: `HTTP ${res.status} from ${url}` };
+    return { data: (await res.json()) as T, error: null };
+  } catch (err: any) {
+    return { data: null, error: err?.message ?? String(err) };
+  }
+}
+
+const atlasParcelWorkbench: ToolDefinition = {
+  id: 'atlas.parcel.workbench',
+  suite: 'atlas',
+  writeLane: 'atlas:read',
+  risk: 'read_only',
+  requiredPermissions: ['parcel:read'],
+  handler: async (params: ParcelWorkbenchParams): Promise<ParcelWorkbenchResult> => {
+    const { parcelId, taxYear, era } = params;
+    const year = taxYear ?? new Date().getFullYear();
+    const eraParam = era ? `&era=${encodeURIComponent(era)}` : '';
+
+    const [geom, owner, wsdor] = await Promise.all([
+      fetchFacet<GeometryFacet>(`${API_BASE}/api/parcels/${parcelId}/geometry`),
+      fetchFacet<OwnerCurrentFacet>(`${API_BASE}/api/parcels/${parcelId}/owner-current?taxYear=${year}${eraParam}`),
+      fetchFacet<WsdorRollFacet>(`${API_BASE}/api/parcels/${parcelId}/wsdor-roll?taxYear=${year}${eraParam}`),
+    ]);
+
+    const errors: string[] = [];
+    if (geom.error) errors.push(`geometry: ${geom.error}`);
+    if (owner.error) errors.push(`ownerCurrent: ${owner.error}`);
+    if (wsdor.error) errors.push(`wsdorRoll: ${wsdor.error}`);
+
+    return {
+      parcelId,
+      geometry: geom.data,
+      ownerCurrent: owner.data,
+      wsdorRoll: wsdor.data,
+      errors,
+    };
+  },
+};
+
 const atlasParcelSearch: ToolDefinition = {
   id: 'atlas.parcel.search',
   suite: 'atlas',
@@ -154,6 +277,7 @@ export function registerDefaultTools(): void {
   // Atlas suite
   ToolRegistry.register(atlasParcelRead);
   ToolRegistry.register(atlasParcelSearch);
+  ToolRegistry.register(atlasParcelWorkbench);
 
   // Dais suite
   ToolRegistry.register(daisWorkflowRead);
@@ -171,6 +295,7 @@ export function registerDefaultTools(): void {
 export const defaultTools = {
   atlasParcelRead,
   atlasParcelSearch,
+  atlasParcelWorkbench,
   daisWorkflowRead,
   daisWorkflowAdvance,
   forgeValuationRead,

--- a/packages/os-core/src/services/pilot/registerDefaultTools.ts
+++ b/packages/os-core/src/services/pilot/registerDefaultTools.ts
@@ -114,14 +114,20 @@ interface ParcelWorkbenchResult {
   errors: string[];
 }
 
+const FACET_TIMEOUT_MS = 8_000;
+
 async function fetchFacet<T>(url: string): Promise<{ data: T | null; error: string | null }> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FACET_TIMEOUT_MS);
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: controller.signal });
     if (res.status === 404) return { data: null, error: null };
     if (!res.ok) return { data: null, error: `HTTP ${res.status} from ${url}` };
     return { data: (await res.json()) as T, error: null };
   } catch (err: any) {
     return { data: null, error: err?.message ?? String(err) };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -135,11 +141,12 @@ const atlasParcelWorkbench: ToolDefinition = {
     const { parcelId, taxYear, era } = params;
     const year = taxYear ?? new Date().getFullYear();
     const eraParam = era ? `&era=${encodeURIComponent(era)}` : '';
+    const encodedParcelId = encodeURIComponent(parcelId);
 
     const [geom, owner, wsdor] = await Promise.all([
-      fetchFacet<GeometryFacet>(`${API_BASE}/api/parcels/${parcelId}/geometry`),
-      fetchFacet<OwnerCurrentFacet>(`${API_BASE}/api/parcels/${parcelId}/owner-current?taxYear=${year}${eraParam}`),
-      fetchFacet<WsdorRollFacet>(`${API_BASE}/api/parcels/${parcelId}/wsdor-roll?taxYear=${year}${eraParam}`),
+      fetchFacet<GeometryFacet>(`${API_BASE}/api/parcels/${encodedParcelId}/geometry`),
+      fetchFacet<OwnerCurrentFacet>(`${API_BASE}/api/parcels/${encodedParcelId}/owner-current?taxYear=${year}${eraParam}`),
+      fetchFacet<WsdorRollFacet>(`${API_BASE}/api/parcels/${encodedParcelId}/wsdor-roll?taxYear=${year}${eraParam}`),
     ]);
 
     const errors: string[] = [];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       'os-platform/core/terratrc/**/*.test.ts',
       'frontend/apps/os-shell/src/__tests__/**/*.test.{ts,tsx}',
       'frontend/apps/os-shell/src/**/__tests__/**/*.test.{ts,tsx}',
+      'packages/os-core/src/**/__tests__/**/*.test.ts',
     ],
     exclude: [
       'node_modules/**',


### PR DESCRIPTION
## Summary
- Adds one new MCP tool `atlas.parcel.workbench` that composes three existing REST facets (geometry, owner-current, wsdor-roll) into a single parallel-fetched response
- camelCase wire keys, nullable fields present as `null` never omitted, `acctId` int64 caution documented
- 9 new tests covering registration, 404→null, error collection, full composition, era passthrough, RBAC denial

## Test plan
- [x] 9/9 `atlasParcelWorkbench.test.ts` pass
- [x] 7/7 `ToolRunner.test.ts` pass (no regressions)
- [x] 164/164 pre-push unit tests pass
- [x] Backend build: 0 warnings, 0 errors
- [x] Pre-commit + pre-push quality gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new atlas parcel workbench MCP tool that aggregates multiple parcel facets into a single read-only API, and wire it into the default tool registry and test configuration.

New Features:
- Introduce the atlas.parcel.workbench tool that fetches geometry, current owner, and WSDOR roll parcel facets in parallel and returns a combined payload with explicit nulls and per-facet error reporting.

Tests:
- Add a dedicated atlasParcelWorkbench test suite covering registration, null-on-404 handling, error aggregation, successful facet composition, query parameter passthrough, and permission enforcement.
- Update Vitest configuration to include os-core pilot service tests in the test run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atlas.parcel.workbench to retrieve parcel data (geometry, owner details, property records), returning nullable fields and aggregated facet-level errors while preserving identifiers and numeric values.

* **Tests**
  * Added comprehensive tests for the parcel workbench covering 404s, facet failures, full-success composition, URL parameter propagation, permission enforcement, and numeric passthrough behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->