### PR TITLE
fix(honesty): WO-CF-b2g — zero Category ③ fabricated analytics + sync counts

### DIFF
--- a/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
+++ b/backend/src/TerraFusion.AI/Services/CostForgeAIService.cs
@@ -423,16 +423,21 @@ public class CostForgeAIService : ICostForgeAIService
 
   public async System.Threading.Tasks.Task<HarrisSyncResultDto> SyncWithHarrisPACSAsync(HarrisSyncRequestDto request)
   {
-    _logger.LogInformation("Starting Harris PACS sync for county {CountyId}", request.CountyId);
+    // Honesty (WO-CF-b2g): this stub returned fabricated sync counts (89,247
+    // processed, 1247 updated, 23 added, fake harris_version "12.4.7").
+    // No controller calls this method — the real endpoint is
+    // CostForgeController.SyncWithHarrisPACS which queries the actual DB.
+    // Zeroed so these fabrications cannot resurface through a future wiring.
+    _logger.LogInformation("Harris PACS sync stub invoked for county {CountyId} — no live connector", request.CountyId);
 
     var startTime = DateTime.UtcNow;
-    await System.Threading.Tasks.Task.Delay(2000); // Simulate sync operation
+    await System.Threading.Tasks.Task.Delay(10);
 
     return new HarrisSyncResultDto
     {
-      RecordsProcessed = 89_247, // CARD-10: Benton County parcel count stub
-      RecordsUpdated = 1247,
-      RecordsAdded = 23,
+      RecordsProcessed = 0,
+      RecordsUpdated = 0,
+      RecordsAdded = 0,
       RecordsSkipped = 0,
       SyncStartTime = startTime,
       SyncEndTime = DateTime.UtcNow,
@@ -441,9 +446,9 @@ public class CostForgeAIService : ICostForgeAIService
       Errors = new List<string>(),
       SyncMetadata = new Dictionary<string, object>
       {
-        ["harris_version"] = "12.4.7",
         ["sync_type"] = request.FullSync ? "full" : "incremental",
-        ["county"] = request.CountyId
+        ["county"] = request.CountyId,
+        ["note"] = "stub — no live Harris PACS connector"
       }
     };
   }
@@ -489,37 +494,20 @@ public class CostForgeAIService : ICostForgeAIService
     var start = startDate ?? DateTime.UtcNow.AddDays(-30);
     var end = endDate ?? DateTime.UtcNow;
 
+    // Honesty (WO-CF-b2g): fabricated analytics constants (98.7m accuracy,
+    // 2847392000m total value, hardcoded CalculationsByType/PerformanceTrends)
+    // zeroed. TotalCalculations is real (from Interlocked counter during actual
+    // valuations) and preserved. No controller calls this method today.
     return new AnalyticsDto
     {
       StartDate = start,
       EndDate = end,
       TotalCalculations = Interlocked.Read(ref _totalCalculations),
-      AverageAccuracy = 98.7m,
-      TotalValueCalculated = 2847392000m,
-      CalculationsByType = new Dictionary<string, int>
-      {
-        ["residential"] = 1247,
-        ["commercial"] = 423,
-        ["industrial"] = 89,
-        ["agricultural"] = 156
-      },
-      PerformanceTrends = new Dictionary<string, decimal>
-      {
-        ["accuracy_trend"] = 0.3m,
-        ["speed_trend"] = 12.7m,
-        ["efficiency_trend"] = 8.9m
-      },
-      TopPerformingAgents = _agents.Values
-            .OrderByDescending(a => a.PerformanceScore)
-            .Take(5)
-            .Select(a => new TopPerformingAgentDto
-            {
-              AgentId = a.AgentId,
-              TasksCompleted = a.TasksCompleted,
-              AverageAccuracy = 98.7m,
-              PerformanceScore = a.PerformanceScore
-            })
-            .ToList()
+      AverageAccuracy = 0m,
+      TotalValueCalculated = 0m,
+      CalculationsByType = new Dictionary<string, int>(),
+      PerformanceTrends = new Dictionary<string, decimal>(),
+      TopPerformingAgents = new List<TopPerformingAgentDto>()
     };
   }
 

--- a/backend/src/TerraFusion.API/Services/MultiCountyIntegrationService.cs
+++ b/backend/src/TerraFusion.API/Services/MultiCountyIntegrationService.cs
@@ -339,22 +339,17 @@ public class MultiCountyIntegrationService : IMultiCountyIntegrationService
 
             using var httpClient = _httpClientFactory.CreateClient("HarrisPacs");
 
-            // Simulate Harris PACS API integration
-            var pacsEndpoint = countyConfig.HarrisPacsIntegration.ApiEndpoint;
-            var apiKey = countyConfig.HarrisPacsIntegration.ApiKey;
-
-            // In a real implementation, this would connect to the actual Harris PACS system
-            // For now, we'll simulate the integration
-            await Task.Delay(2000); // Simulate API call delay
-
-            result.RecordsSynced = Random.Shared.Next(100, 1000);
-            result.RecordsUpdated = Random.Shared.Next(10, 50);
-            result.RecordsCreated = Random.Shared.Next(5, 25);
+            // Honesty (WO-CF-b2g): no live Harris PACS connector is wired here.
+            // Previously returned Random.Shared.Next() fabricated counts; zeroed so
+            // operator-visible sync results do not imply real record movement.
+            result.RecordsSynced = 0;
+            result.RecordsUpdated = 0;
+            result.RecordsCreated = 0;
             result.SyncEndTime = DateTime.UtcNow;
             result.IsSuccessful = true;
 
             await _auditLogger.LogAsync("HARRIS_PACS_SYNC",
-                $"Harris PACS sync for {countyCode}: {result.RecordsSynced} records processed", true);
+                $"Harris PACS sync stub for {countyCode}: no live connector, 0 records", true);
 
             return result;
         }

--- a/backend/src/TerraFusion.API/Services/MultiCountyIntegrationService.cs
+++ b/backend/src/TerraFusion.API/Services/MultiCountyIntegrationService.cs
@@ -337,8 +337,6 @@ public class MultiCountyIntegrationService : IMultiCountyIntegrationService
                 return result;
             }
 
-            using var httpClient = _httpClientFactory.CreateClient("HarrisPacs");
-
             // Honesty (WO-CF-b2g): no live Harris PACS connector is wired here.
             // Previously returned Random.Shared.Next() fabricated counts; zeroed so
             // operator-visible sync results do not imply real record movement.

--- a/backend/src/TerraFusion.Core/Services/CamaPlusLegacyService.cs
+++ b/backend/src/TerraFusion.Core/Services/CamaPlusLegacyService.cs
@@ -50,12 +50,13 @@ namespace TerraFusion.Core.Services
                 Success = true
             };
 
-            await Task.Delay(1200);
+            // Honesty (WO-CF-b2g): stub — no live CAMA+ connector. Zeroed.
+            await Task.Delay(10);
 
-            result.RecordsProcessed = 75000;
-            result.RecordsUpdated = 1450;
-            result.RecordsAdded = 67;
-            result.RecordsSkipped = 15;
+            result.RecordsProcessed = 0;
+            result.RecordsUpdated = 0;
+            result.RecordsAdded = 0;
+            result.RecordsSkipped = 0;
             result.SyncEndTime = DateTime.UtcNow;
 
             return result;

--- a/backend/src/TerraFusion.Core/Services/GenericLegacyService.cs
+++ b/backend/src/TerraFusion.Core/Services/GenericLegacyService.cs
@@ -50,12 +50,13 @@ namespace TerraFusion.Core.Services
                 Success = true
             };
 
-            await Task.Delay(500);
+            // Honesty (WO-CF-b2g): stub — no live generic legacy connector. Zeroed.
+            await Task.Delay(10);
 
-            result.RecordsProcessed = 25000;
-            result.RecordsUpdated = 450;
-            result.RecordsAdded = 15;
-            result.RecordsSkipped = 3;
+            result.RecordsProcessed = 0;
+            result.RecordsUpdated = 0;
+            result.RecordsAdded = 0;
+            result.RecordsSkipped = 0;
             result.SyncEndTime = DateTime.UtcNow;
 
             return result;

--- a/backend/src/TerraFusion.Core/Services/HarrisPacsLegacyService.cs
+++ b/backend/src/TerraFusion.Core/Services/HarrisPacsLegacyService.cs
@@ -71,25 +71,14 @@ namespace TerraFusion.Core.Services
             {
                 _logger.LogInformation("Starting Harris PACS data sync for {Jurisdiction}", Jurisdiction);
 
-                // Simulate Harris PACS specific sync logic
-                await Task.Delay(1000);
+                // Honesty (WO-CF-b2g): no live Harris PACS connector here.
+                // Previously returned fabricated counts; zeroed. No controller calls this.
+                await Task.Delay(10);
 
-                // For Benton County, we know there are await DynamicPropertyService.GetPropertyCountAsync("benton") parcels
-                if (Jurisdiction.Contains("Benton"))
-                {
-                    result.RecordsProcessed = await _dynamicPropertyService.GetActivePropertyCountAsync("benton");
-                    result.RecordsUpdated = 1250;
-                    result.RecordsAdded = 45;
-                    result.RecordsSkipped = 12;
-                }
-                else
-                {
-                    // Default values for other counties
-                    result.RecordsProcessed = 50000;
-                    result.RecordsUpdated = 500;
-                    result.RecordsAdded = 25;
-                    result.RecordsSkipped = 5;
-                }
+                result.RecordsProcessed = 0;
+                result.RecordsUpdated = 0;
+                result.RecordsAdded = 0;
+                result.RecordsSkipped = 0;
 
                 result.Success = true;
                 result.SyncEndTime = DateTime.UtcNow;

--- a/backend/src/TerraFusion.Core/Services/TylerTechLegacyService.cs
+++ b/backend/src/TerraFusion.Core/Services/TylerTechLegacyService.cs
@@ -52,12 +52,13 @@ namespace TerraFusion.Core.Services
                 Success = true
             };
 
-            await Task.Delay(800);
+            // Honesty (WO-CF-b2g): stub — no live Tyler Tech connector. Zeroed.
+            await Task.Delay(10);
 
-            result.RecordsProcessed = await _dynamicPropertyService.GetActivePropertyCountAsync(Jurisdiction);
-            result.RecordsUpdated = 890;
-            result.RecordsAdded = 23;
-            result.RecordsSkipped = 7;
+            result.RecordsProcessed = 0;
+            result.RecordsUpdated = 0;
+            result.RecordsAdded = 0;
+            result.RecordsSkipped = 0;
             result.SyncEndTime = DateTime.UtcNow;
 
             return result;


### PR DESCRIPTION
## Summary

- **Operator-visible fix**: `MultiCountyIntegrationService.SyncWithHarrisPACS` returned `Random.Shared.Next()` fabricated counts for RecordsSynced/Updated/Created — zeroed so dashboard sync results no longer imply real record movement.
- **Dead-code zeroing (no controller caller)**: `CostForgeAIService.GetAnalyticsAsync` zeroed fabricated 98.7% accuracy, $2.8B total value, hardcoded CalculationsByType/PerformanceTrends/TopPerformingAgents; `TotalCalculations` (real Interlocked counter) preserved. `CostForgeAIService.SyncWithHarrisPACSAsync` zeroed 89247/1247/23 counts and removed fake harris_version.
- **Legacy service stubs (no DI registration)**: HarrisPacsLegacyService, CamaPlusLegacyService, GenericLegacyService, TylerTechLegacyService — all fabricated `SyncPropertyDataAsync` counts zeroed.

## Scope contract

Category ③ only (WO-CF-b2g). No opportunistic cleanup. No unrelated analytics. Perf harness and TestConsciousnessStubs untouched (already return zero).

## Test plan

- [x] `dotnet build TerraFusion.sln` — 0 warnings, 0 errors
- [x] Grep test files for `RecordsSynced|RecordsUpdated|RecordsCreated|RecordsProcessed|RecordsAdded` — no assertions depend on fabricated values
- [x] `TestConsciousnessStubs` already returns 0 — untouched
- [x] Pre-commit quality gate passed (164/164 vitest, lint, security scan)
- [x] Pre-push quality gate passed (Release build, publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Zero out fabricated sync and analytics data returned by legacy Harris PACS and related stubs so dashboards and logs no longer imply real record movement or accuracy where no live connectors exist.

Bug Fixes:
- Remove randomized/fabricated Harris PACS sync counts from MultiCountyIntegrationService so operator-visible results always show zero in the absence of a real connector.
- Zero out hardcoded sync counts and fake metadata in CostForgeAIService Harris PACS and analytics stubs while preserving the real TotalCalculations counter.
- Reset fabricated record counts in HarrisPacsLegacyService, CamaPlusLegacyService, GenericLegacyService, and TylerTechLegacyService to zero to avoid misleading sync statistics from unused legacy stubs.

Enhancements:
- Clarify logging and audit messages to explicitly label Harris PACS-related paths as stubs with no live connector and shorten artificial delays to minimal placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated backend property sync and integration services (Harris PACS, CAMA+, TylerTech, generic legacy, and analytics) to return accurate record counts instead of simulated metrics
  * Eliminated artificial operational delays in sync operations for improved performance
  * Enhanced logging clarity regarding connector availability status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->