### PR TITLE
feat(notice): TerraNotice governed civic communications console (GUI)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/notice/terraNoticeConsole.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/notice/terraNoticeConsole.contract.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * TerraNotice Console Contract.
+ *
+ * Verifies the governed civic communications console renders its operator
+ * shell: the honesty ribbon, all twelve navigable areas, and area switching.
+ * TerraNotice must present as a governed control surface, not a mail-merge tool.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TerraNoticeConsole from '../../pages/notice/TerraNoticeConsole';
+import type { ConsoleAreaId } from '../../pages/notice/types';
+
+const AREA_IDS: ConsoleAreaId[] = [
+  'command-center',
+  'county-configuration',
+  'policy-packs',
+  'template-governance',
+  'batch-operations',
+  'freeze-snapshots',
+  'vendor-dispatch',
+  'returned-mail',
+  'citizen-portal',
+  'telemetry',
+  'audit-vault',
+  'release-console',
+];
+
+async function renderConsole() {
+  render(<TerraNoticeConsole />);
+  // Snapshot loads asynchronously; wait for the nav rail to appear.
+  await screen.findByTestId('notice-nav-rail');
+}
+
+describe('TerraNotice Console Contract', () => {
+  it('renders the console shell after loading the snapshot', async () => {
+    await renderConsole();
+    expect(screen.getByTestId('terra-notice-console')).toBeDefined();
+  });
+
+  it('shows the sandbox honesty ribbon (no fabricated-as-live data)', async () => {
+    await renderConsole();
+    const ribbon = screen.getByTestId('notice-sandbox-ribbon');
+    expect(ribbon).toBeDefined();
+    expect(ribbon.textContent).toContain('County Sandbox');
+  });
+
+  it('exposes all twelve governed console areas in the nav rail', async () => {
+    await renderConsole();
+    for (const id of AREA_IDS) {
+      expect(screen.getByTestId(`notice-nav-${id}`)).toBeDefined();
+    }
+  });
+
+  it('opens the Command Center by default', async () => {
+    await renderConsole();
+    expect(screen.getByTestId('notice-area-command-center')).toBeDefined();
+  });
+
+  it('switches areas when a nav item is selected', async () => {
+    await renderConsole();
+
+    fireEvent.click(screen.getByTestId('notice-nav-returned-mail'));
+    await waitFor(() => expect(screen.getByTestId('notice-area-returned-mail')).toBeDefined());
+    expect(screen.getByTestId('exception-queue-table')).toBeDefined();
+
+    fireEvent.click(screen.getByTestId('notice-nav-audit-vault'));
+    await waitFor(() => expect(screen.getByTestId('notice-area-audit-vault')).toBeDefined());
+  });
+});

--- a/frontend/apps/os-shell/src/components/suites/SuiteModuleGrid.tsx
+++ b/frontend/apps/os-shell/src/components/suites/SuiteModuleGrid.tsx
@@ -27,7 +27,6 @@ import type { LucideIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { usePropertyStore } from '../../stores/propertyStore';
-import { activateModule } from '../../orchestration/moduleActivation';
 
 export interface SuiteModuleDef {
   id: string;
@@ -83,12 +82,7 @@ export function SuiteModuleGrid({ modules, accentVar = '--tf-accent' }: SuiteMod
       if (!targetId) {
         return;
       }
-      // Open as a desktop window via the canonical activation path. Previously this
-      // navigated to `/${targetId}`, which has no registered route, so standalone
-      // suite tiles silently no-opped. activateModule resolves the registered module
-      // and opens (or focuses) its window — the same path used by the desktop,
-      // command palette, and start menu.
-      void activateModule(targetId, { source: 'system' });
+      navigate(`/${targetId}`);
     }
   };
 

--- a/frontend/apps/os-shell/src/components/suites/SuiteModuleGrid.tsx
+++ b/frontend/apps/os-shell/src/components/suites/SuiteModuleGrid.tsx
@@ -27,6 +27,7 @@ import type { LucideIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { usePropertyStore } from '../../stores/propertyStore';
+import { activateModule } from '../../orchestration/moduleActivation';
 
 export interface SuiteModuleDef {
   id: string;
@@ -82,7 +83,12 @@ export function SuiteModuleGrid({ modules, accentVar = '--tf-accent' }: SuiteMod
       if (!targetId) {
         return;
       }
-      navigate(`/${targetId}`);
+      // Open as a desktop window via the canonical activation path. Previously this
+      // navigated to `/${targetId}`, which has no registered route, so standalone
+      // suite tiles silently no-opped. activateModule resolves the registered module
+      // and opens (or focuses) its window — the same path used by the desktop,
+      // command palette, and start menu.
+      void activateModule(targetId, { source: 'system' });
     }
   };
 

--- a/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
+++ b/frontend/apps/os-shell/src/config/__tests__/moduleRegistryConsistency.test.ts
@@ -102,9 +102,10 @@ describe('MODULE_REGISTRY -> ModuleRenderer coverage', () => {
     'gpt-builder',
     'gpt-analytics',
     'gpt-rag',
-    // Queued certification / notice modules (QueuedModuleSurface — no MODULE_ENTRY yet)
+    // Queued certification module (QueuedModuleSurface — no MODULE_ENTRY yet)
+    // NOTE: terra-notice graduated to a real MODULE_ENTRY (TerraNoticeConsole),
+    // so it is intentionally NOT listed here.
     'terra-cert',
-    'terra-notice',
     // AppFrame native-app modules — rendered via <AppFrame> iframe (no MODULE_ENTRY)
     'costforge',
     // Phase 36+: inline Suspense+lazy in switch (no MODULE_ENTRY)

--- a/frontend/apps/os-shell/src/config/moduleComponents.tsx
+++ b/frontend/apps/os-shell/src/config/moduleComponents.tsx
@@ -433,6 +433,13 @@ const AtlasLivePage = lazy(() =>
 // CUForge — Current Use Program (RCW 84.33/84.34)
 const CUForge = lazy(() => import('../pages/forge/current-use/CUForge'));
 
+// TerraNotice — Governed Civic Communications Console (TerraDais suite).
+// OS-native operator console: 12 governed areas (command center, policy packs,
+// template governance, batch ops, freeze snapshots, vendor dispatch, exceptions,
+// citizen portal preview, telemetry, audit vault, release console). Runs on
+// clearly-labeled County Sandbox fixtures until a backend is wired.
+const TerraNoticeConsole = lazy(() => import('../pages/notice/TerraNoticeConsole'));
+
 // NOTE: ComparableSalesPanel is used inside Forge → Sales sub-tab (not standalone)
 
 // ============================================================================
@@ -500,6 +507,7 @@ const MODULE_ENTRIES: Record<string, ModuleEntry> = {
   'terra-gama': { Component: TerraGamaPage },
   // Dais standalone modules
   'terra-queue': { Component: TerraQueue },
+  'terra-notice': { Component: TerraNoticeConsole },
   // OS Features (in-shell windows)
   'os-pilot': { Component: PilotHome },
   'os-trace': { Component: TraceHome },
@@ -985,13 +993,12 @@ export const ModuleRenderer: React.FC<ModuleRendererProps> = ({ module, metadata
         />
       );
 
+    // TerraNotice — Governed Civic Communications Console (OS-native operator surface).
     case 'terra-notice':
       return (
-        <QueuedModuleSurface
-          name="TerraNotice"
-          description="Notice templates, batch generation, and mail queue — assessment notice production and delivery tracking."
-          moduleId="terra-notice"
-        />
+        <Suspense fallback={<ModuleLoadingFallback />}>
+          <TerraNoticeConsole />
+        </Suspense>
       );
 
     // Analytics - Real-time Reporting

--- a/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
@@ -71,19 +71,44 @@ const AREAS: AreaDef[] = [
 
 export const TerraNoticeConsole: React.FC = () => {
   const [snapshot, setSnapshot] = useState<NoticeConsoleSnapshot | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [area, setArea] = useState<ConsoleAreaId>('command-center');
 
   useEffect(() => {
     let alive = true;
-    void getNoticeConsoleSnapshot().then((snap) => {
-      if (alive) setSnapshot(snap);
-    });
+    getNoticeConsoleSnapshot()
+      .then((snap) => {
+        if (alive) setSnapshot(snap);
+      })
+      .catch(() => {
+        // A real backend fetch can reject; surface the typed 'unavailable'
+        // state instead of hanging on the loading view forever.
+        if (alive) setLoadFailed(true);
+      });
     return () => {
       alive = false;
     };
   }, []);
 
   const activeArea = useMemo(() => AREAS.find((a) => a.id === area) ?? AREAS[0], [area]);
+
+  if (loadFailed) {
+    return (
+      <div
+        data-testid="terra-notice-console"
+        className="w-full h-full flex flex-col items-center justify-center gap-2 p-8 text-center"
+        style={{ background: 'hsl(var(--tf-bg))', color: 'hsl(var(--tf-fg))' }}
+      >
+        <div data-testid="notice-unavailable" className="text-base font-semibold">
+          TerraNotice is unavailable
+        </div>
+        <p className="text-sm max-w-md" style={{ color: 'hsl(var(--tf-muted))' }}>
+          The console could not load its data, so no notice information is shown. Retry once the
+          TerraNotice service is reachable.
+        </p>
+      </div>
+    );
+  }
 
   if (!snapshot) {
     return (

--- a/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
@@ -10,7 +10,7 @@
  * area reads from a single console snapshot so a real backend can replace the
  * sandbox fixtures without touching the screens.
  *
- * HONESTY: while the snapshot's `source` is 'sandbox', a persistent ribbon
+ * (see ./fixtures/sandboxData). HONESTY: while the snapshot's `source` is 'sandbox', a persistent ribbon
  * makes clear the data is demonstration content, not live county production
  * data, and write-style actions are inert.
  *
@@ -34,7 +34,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { ConsoleAreaId, NoticeConsoleSnapshot } from './types';
-import { getNoticeConsoleSnapshot } from './data/sandboxData';
+import { getNoticeConsoleSnapshot } from './fixtures/sandboxData';
 import { CommandCenter } from './areas/CommandCenter';
 import { CountyConfiguration } from './areas/CountyConfiguration';
 import { PolicyPacks } from './areas/PolicyPacks';

--- a/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/TerraNoticeConsole.tsx
@@ -1,0 +1,203 @@
+/**
+ * TerraNotice — Governed Civic Communications Console.
+ *
+ * TN-GUI-001..010. TerraNotice is NOT a mail-merge tool: it is the governed
+ * control surface for notice legality, delivery, explanation, and proof —
+ * an air-traffic-control system for civic communications.
+ *
+ * This component is the operator shell: a left-rail of the twelve console
+ * areas plus a header carrying county / program / environment context. Every
+ * area reads from a single console snapshot so a real backend can replace the
+ * sandbox fixtures without touching the screens.
+ *
+ * HONESTY: while the snapshot's `source` is 'sandbox', a persistent ribbon
+ * makes clear the data is demonstration content, not live county production
+ * data, and write-style actions are inert.
+ *
+ * @module pages/notice/TerraNoticeConsole
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  Boxes,
+  Building2,
+  FileText,
+  Globe,
+  Inbox,
+  LayoutDashboard,
+  Rocket,
+  ScrollText,
+  ShieldCheck,
+  Snowflake,
+  Truck,
+  type LucideIcon,
+} from 'lucide-react';
+import type { ConsoleAreaId, NoticeConsoleSnapshot } from './types';
+import { getNoticeConsoleSnapshot } from './data/sandboxData';
+import { CommandCenter } from './areas/CommandCenter';
+import { CountyConfiguration } from './areas/CountyConfiguration';
+import { PolicyPacks } from './areas/PolicyPacks';
+import { TemplateGovernance } from './areas/TemplateGovernance';
+import { BatchOperations } from './areas/BatchOperations';
+import { FreezeSnapshots } from './areas/FreezeSnapshots';
+import { VendorDispatch } from './areas/VendorDispatch';
+import { ReturnedMail } from './areas/ReturnedMail';
+import { CitizenPortalPreview } from './areas/CitizenPortalPreview';
+import { Telemetry } from './areas/Telemetry';
+import { AuditVault } from './areas/AuditVault';
+import { ReleaseConsole } from './areas/ReleaseConsole';
+
+interface AreaDef {
+  id: ConsoleAreaId;
+  label: string;
+  icon: LucideIcon;
+}
+
+const AREAS: AreaDef[] = [
+  { id: 'command-center', label: 'Command Center', icon: LayoutDashboard },
+  { id: 'county-configuration', label: 'County Configuration', icon: Building2 },
+  { id: 'policy-packs', label: 'Policy Packs', icon: ScrollText },
+  { id: 'template-governance', label: 'Template Governance', icon: FileText },
+  { id: 'batch-operations', label: 'Batch Operations', icon: Boxes },
+  { id: 'freeze-snapshots', label: 'Freeze Snapshots', icon: Snowflake },
+  { id: 'vendor-dispatch', label: 'Vendor Dispatch', icon: Truck },
+  { id: 'returned-mail', label: 'Returned Mail / Exceptions', icon: Inbox },
+  { id: 'citizen-portal', label: 'Citizen Portal Preview', icon: Globe },
+  { id: 'telemetry', label: 'Telemetry / Risk', icon: Activity },
+  { id: 'audit-vault', label: 'Audit Evidence Vault', icon: ShieldCheck },
+  { id: 'release-console', label: 'Release & Deployment', icon: Rocket },
+];
+
+export const TerraNoticeConsole: React.FC = () => {
+  const [snapshot, setSnapshot] = useState<NoticeConsoleSnapshot | null>(null);
+  const [area, setArea] = useState<ConsoleAreaId>('command-center');
+
+  useEffect(() => {
+    let alive = true;
+    void getNoticeConsoleSnapshot().then((snap) => {
+      if (alive) setSnapshot(snap);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const activeArea = useMemo(() => AREAS.find((a) => a.id === area) ?? AREAS[0], [area]);
+
+  if (!snapshot) {
+    return (
+      <div
+        data-testid="terra-notice-console"
+        className="w-full h-full flex items-center justify-center"
+        style={{ background: 'hsl(var(--tf-bg))', color: 'hsl(var(--tf-muted))' }}
+      >
+        Loading TerraNotice console…
+      </div>
+    );
+  }
+
+  const { county } = snapshot;
+
+  return (
+    <div
+      data-testid="terra-notice-console"
+      className="w-full h-full flex flex-col"
+      style={{ background: 'hsl(var(--tf-bg))', color: 'hsl(var(--tf-fg))' }}
+    >
+      {/* Header */}
+      <header
+        className="px-5 py-3 flex flex-wrap items-center justify-between gap-2"
+        style={{ borderBottom: '1px solid hsl(var(--tf-border) / 0.25)' }}
+      >
+        <div>
+          <h1 className="text-lg font-semibold">TerraNotice</h1>
+          <p className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>
+            Governed Civic Communications Console · {county.countyName} · {county.program} · Tax Year {county.taxYear}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span
+            className="px-2.5 py-1 rounded-full"
+            style={{ background: 'hsl(var(--tf-accent) / 0.12)', color: 'hsl(var(--tf-accent))' }}
+          >
+            Environment: {county.environment}
+          </span>
+          <span
+            className="px-2.5 py-1 rounded-full"
+            style={{ background: 'hsl(var(--tf-accent-2) / 0.12)', color: 'hsl(var(--tf-accent-2))' }}
+          >
+            Policy Pack {snapshot.policyPacks[0]?.packId ?? '—'}
+          </span>
+        </div>
+      </header>
+
+      {/* Sandbox honesty ribbon */}
+      {snapshot.source === 'sandbox' && (
+        <div
+          role="note"
+          data-testid="notice-sandbox-ribbon"
+          className="px-5 py-1.5 text-xs text-center"
+          style={{
+            background: 'hsl(var(--tf-warning) / 0.12)',
+            color: 'hsl(var(--tf-warning))',
+            borderBottom: '1px solid hsl(var(--tf-warning) / 0.25)',
+          }}
+        >
+          County Sandbox — demonstration data. Not connected to live county systems; dispatch, freeze, reissue, and
+          export actions are inert.
+        </div>
+      )}
+
+      {/* Body: nav rail + active area */}
+      <div className="flex-1 flex min-h-0">
+        <nav
+          data-testid="notice-nav-rail"
+          aria-label="TerraNotice console areas"
+          className="w-60 shrink-0 overflow-y-auto py-2"
+          style={{ borderRight: '1px solid hsl(var(--tf-border) / 0.2)' }}
+        >
+          {AREAS.map((a) => {
+            const Icon = a.icon;
+            const isActive = a.id === area;
+            return (
+              <button
+                key={a.id}
+                data-testid={`notice-nav-${a.id}`}
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => setArea(a.id)}
+                className="w-full flex items-center gap-2.5 px-4 py-2.5 text-left text-sm transition-colors"
+                style={{
+                  background: isActive ? 'hsl(var(--tf-accent) / 0.12)' : 'transparent',
+                  color: isActive ? 'hsl(var(--tf-accent))' : 'hsl(var(--tf-fg) / 0.8)',
+                  borderLeft: `2px solid ${isActive ? 'hsl(var(--tf-accent))' : 'transparent'}`,
+                }}
+              >
+                <Icon size={16} />
+                <span className="truncate">{a.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+
+        <main className="flex-1 overflow-y-auto p-5 min-w-0">
+          <h2 className="text-base font-semibold mb-4">{activeArea.label}</h2>
+          {area === 'command-center' && <CommandCenter snapshot={snapshot} onNavigate={setArea} />}
+          {area === 'county-configuration' && <CountyConfiguration snapshot={snapshot} />}
+          {area === 'policy-packs' && <PolicyPacks snapshot={snapshot} />}
+          {area === 'template-governance' && <TemplateGovernance snapshot={snapshot} />}
+          {area === 'batch-operations' && <BatchOperations snapshot={snapshot} />}
+          {area === 'freeze-snapshots' && <FreezeSnapshots snapshot={snapshot} />}
+          {area === 'vendor-dispatch' && <VendorDispatch snapshot={snapshot} />}
+          {area === 'returned-mail' && <ReturnedMail snapshot={snapshot} />}
+          {area === 'citizen-portal' && <CitizenPortalPreview snapshot={snapshot} />}
+          {area === 'telemetry' && <Telemetry snapshot={snapshot} />}
+          {area === 'audit-vault' && <AuditVault snapshot={snapshot} />}
+          {area === 'release-console' && <ReleaseConsole snapshot={snapshot} />}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default TerraNoticeConsole;

--- a/frontend/apps/os-shell/src/pages/notice/areas/AuditVault.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/AuditVault.tsx
@@ -16,6 +16,8 @@ import { EmptyState, SectionCard, StatusPill } from '../components/primitives';
 
 export const AuditVault: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
   const bundles = snapshot.auditBundles;
+  // Vault open/export operate against a live backend; disabled in sandbox.
+  const inert = snapshot.source !== 'live';
   const [selected, setSelected] = useState(bundles[0]?.bundleId ?? '');
   const active = bundles.find((b) => b.bundleId === selected) ?? bundles[0];
 
@@ -68,8 +70,8 @@ export const AuditVault: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snap
             ))}
           </dl>
           <div className="flex flex-wrap gap-2 mt-4">
-            <Button size="sm" variant="outline">Open Evidence Bundle</Button>
-            <Button size="sm" variant="outline">Export Release Manifest</Button>
+            <Button size="sm" variant="outline" disabled={inert}>Open Evidence Bundle</Button>
+            <Button size="sm" variant="outline" disabled={inert}>Export Release Manifest</Button>
           </div>
           <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
             Sandbox: export actions are inert. A sealed bundle binds every notice to its template, policy, config,

--- a/frontend/apps/os-shell/src/pages/notice/areas/AuditVault.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/AuditVault.tsx
@@ -1,0 +1,84 @@
+/**
+ * TN-GUI-010 — Audit Evidence Vault.
+ *
+ * Every issued notice must bind to template version, policy version, county
+ * configuration version, parcel/data snapshot, batch ID, artifact hash,
+ * dispatch receipt, and an immutable approval trace. This screen exposes the
+ * evidence bundle and a release-manifest export.
+ *
+ * @module pages/notice/areas/AuditVault
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { NoticeConsoleSnapshot } from '../types';
+import { EmptyState, SectionCard, StatusPill } from '../components/primitives';
+
+export const AuditVault: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const bundles = snapshot.auditBundles;
+  const [selected, setSelected] = useState(bundles[0]?.bundleId ?? '');
+  const active = bundles.find((b) => b.bundleId === selected) ?? bundles[0];
+
+  if (bundles.length === 0) {
+    return (
+      <div data-testid="notice-area-audit-vault">
+        <SectionCard title="Audit Evidence Vault">
+          <EmptyState message="No evidence bundles sealed yet." />
+        </SectionCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-5" data-testid="notice-area-audit-vault">
+      <SectionCard title="Evidence Bundles">
+        <ul className="space-y-2">
+          {bundles.map((b) => (
+            <li key={b.bundleId}>
+              <button
+                onClick={() => setSelected(b.bundleId)}
+                className="w-full text-left p-3 rounded-lg transition-colors"
+                style={{
+                  background: b.bundleId === selected ? 'hsl(var(--tf-accent) / 0.12)' : 'hsl(var(--tf-card-bg) / 0.4)',
+                  border: `1px solid hsl(var(--tf-border) / ${b.bundleId === selected ? 0.4 : 0.15})`,
+                }}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-xs">{b.bundleId}</span>
+                  <StatusPill label={b.sealed ? 'Sealed' : 'Open'} variant={b.sealed ? 'default' : 'secondary'} />
+                </div>
+                <div className="text-xs mt-1" style={{ color: 'hsl(var(--tf-muted))' }}>{b.batchId}</div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </SectionCard>
+
+      <div className="lg:col-span-2">
+        <SectionCard
+          title={`Evidence Bundle — ${active.bundleId}`}
+          chip={<StatusPill label={active.sealed ? 'Immutable' : 'Assembling'} variant={active.sealed ? 'default' : 'secondary'} />}
+        >
+          <dl className="space-y-2 text-sm">
+            {active.bindings.map((b) => (
+              <div key={b.label} className="flex items-center justify-between gap-3 py-1" style={{ borderBottom: '1px solid hsl(var(--tf-border) / 0.12)' }}>
+                <dt style={{ color: 'hsl(var(--tf-muted))' }}>{b.label}</dt>
+                <dd className="font-medium text-right font-mono text-xs">{b.value}</dd>
+              </div>
+            ))}
+          </dl>
+          <div className="flex flex-wrap gap-2 mt-4">
+            <Button size="sm" variant="outline">Open Evidence Bundle</Button>
+            <Button size="sm" variant="outline">Export Release Manifest</Button>
+          </div>
+          <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
+            Sandbox: export actions are inert. A sealed bundle binds every notice to its template, policy, config,
+            snapshot, artifact hash, dispatch receipt, and approval trace.
+          </p>
+        </SectionCard>
+      </div>
+    </div>
+  );
+};
+
+export default AuditVault;

--- a/frontend/apps/os-shell/src/pages/notice/areas/BatchOperations.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/BatchOperations.tsx
@@ -38,6 +38,9 @@ export const BatchOperations: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({
 
   const allChecked = CHECKLIST.every((c) => checked[c.id]);
   const validationPassed = active?.status !== 'failed' && active?.status !== 'draft';
+  // Release dispatches notices — only valid against a live backend. Freeze stays
+  // interactive in sandbox to demonstrate the checklist→freeze gating locally.
+  const inert = snapshot.source !== 'live';
 
   if (!active) {
     return (
@@ -109,7 +112,7 @@ export const BatchOperations: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({
             >
               Freeze Snapshot
             </Button>
-            <Button size="sm" variant="outline" disabled={!frozen} data-testid="batch-release-action">
+            <Button size="sm" variant="outline" disabled={!frozen || inert} data-testid="batch-release-action">
               Release to Dispatch
             </Button>
             {!validationPassed && (

--- a/frontend/apps/os-shell/src/pages/notice/areas/BatchOperations.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/BatchOperations.tsx
@@ -1,0 +1,139 @@
+/**
+ * TN-GUI-005 — Batch Workspace.
+ *
+ * Draft batch → validation results → approval checklist → freeze → release,
+ * with a status timeline. Actions are gated: Freeze requires validation pass
+ * and a complete approval checklist; Release requires a freeze.
+ *
+ * In sandbox the action buttons advance a local lifecycle marker only and are
+ * clearly labeled as non-dispatching.
+ *
+ * @module pages/notice/areas/BatchOperations
+ */
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { BatchRow, NoticeConsoleSnapshot } from '../types';
+import {
+  EmptyState,
+  GovernanceTimeline,
+  SectionCard,
+  StatusPill,
+  formatInt,
+} from '../components/primitives';
+
+const CHECKLIST = [
+  { id: 'policy', label: 'Policy pack approved' },
+  { id: 'template', label: 'Template version legally approved' },
+  { id: 'parcels', label: 'Parcel snapshot reconciled' },
+  { id: 'legal', label: 'Legal sign-off recorded' },
+];
+
+export const BatchOperations: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const draftable = snapshot.batches;
+  const [activeBatchId, setActiveBatchId] = useState(draftable[0]?.batchId ?? '');
+  const active = draftable.find((b) => b.batchId === activeBatchId) ?? draftable[0];
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [frozen, setFrozen] = useState(false);
+
+  const allChecked = CHECKLIST.every((c) => checked[c.id]);
+  const validationPassed = active?.status !== 'failed' && active?.status !== 'draft';
+
+  if (!active) {
+    return (
+      <div data-testid="notice-area-batch-operations">
+        <SectionCard title="Batch Workspace">
+          <EmptyState message="No batches to work. Create one from a county program." />
+        </SectionCard>
+      </div>
+    );
+  }
+
+  const timeline = [
+    { label: 'Draft assembled', state: 'done' as const, at: `${formatInt(active.notices)} notices` },
+    { label: 'Validation', state: validationPassed ? ('done' as const) : ('active' as const), at: validationPassed ? `${formatPctOf(snapshot)} pass` : 'pending' },
+    { label: 'Approval checklist', state: allChecked ? ('done' as const) : ('active' as const), at: `${CHECKLIST.filter((c) => checked[c.id]).length}/${CHECKLIST.length}` },
+    { label: 'Freeze', state: frozen ? ('done' as const) : ('pending' as const), at: frozen ? 'snapshot sealed' : '—' },
+    { label: 'Release', state: 'pending' as const, at: '—' },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-5" data-testid="notice-area-batch-operations">
+      <SectionCard title="Batches">
+        <ul className="space-y-2">
+          {draftable.map((b: BatchRow) => (
+            <li key={b.batchId}>
+              <button
+                onClick={() => { setActiveBatchId(b.batchId); setFrozen(false); setChecked({}); }}
+                className="w-full text-left p-3 rounded-lg transition-colors"
+                style={{
+                  background: b.batchId === activeBatchId ? 'hsl(var(--tf-accent) / 0.12)' : 'hsl(var(--tf-card-bg) / 0.4)',
+                  border: `1px solid hsl(var(--tf-border) / ${b.batchId === activeBatchId ? 0.4 : 0.15})`,
+                }}
+              >
+                <div className="font-mono text-sm">{b.batchId}</div>
+                <div className="text-xs mt-1" style={{ color: 'hsl(var(--tf-muted))' }}>
+                  {b.program} · {formatInt(b.notices)} notices
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </SectionCard>
+
+      <div className="lg:col-span-2 space-y-5">
+        <SectionCard
+          title={`Approval Checklist — ${active.batchId}`}
+          chip={<StatusPill label={allChecked ? 'Complete' : 'Incomplete'} variant={allChecked ? 'default' : 'secondary'} />}
+        >
+          <div className="space-y-2">
+            {CHECKLIST.map((c) => (
+              <label key={c.id} className="flex items-center gap-3 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!checked[c.id]}
+                  onChange={() => setChecked((prev) => ({ ...prev, [c.id]: !prev[c.id] }))}
+                  aria-label={c.label}
+                />
+                {c.label}
+              </label>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 mt-4">
+            <Button
+              size="sm"
+              disabled={!validationPassed || !allChecked || frozen}
+              onClick={() => setFrozen(true)}
+              data-testid="batch-freeze-action"
+            >
+              Freeze Snapshot
+            </Button>
+            <Button size="sm" variant="outline" disabled={!frozen} data-testid="batch-release-action">
+              Release to Dispatch
+            </Button>
+            {!validationPassed && (
+              <span className="text-xs" style={{ color: 'hsl(var(--tf-warning))' }}>
+                Run validation before freezing.
+              </span>
+            )}
+          </div>
+          <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
+            Sandbox: Freeze / Release advance the local lifecycle marker only — no notices are dispatched and no
+            artifacts are sealed.
+          </p>
+        </SectionCard>
+
+        <SectionCard title="Status Timeline">
+          <GovernanceTimeline steps={timeline} />
+        </SectionCard>
+      </div>
+    </div>
+  );
+};
+
+function formatPctOf(snapshot: NoticeConsoleSnapshot): string {
+  return `${(snapshot.kpis.validationPassRate * 100).toFixed(1)}%`;
+}
+
+export default BatchOperations;

--- a/frontend/apps/os-shell/src/pages/notice/areas/CitizenPortalPreview.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/CitizenPortalPreview.tsx
@@ -1,0 +1,107 @@
+/**
+ * TN-GUI-009 — Citizen Portal Preview.
+ *
+ * The QR landing page a citizen reaches from the printed notice: a plain
+ * explanation, parcel summary, appeal guidance, and a language / accessibility
+ * toggle. This is a preview of citizen-facing content, not the live portal.
+ *
+ * @module pages/notice/areas/CitizenPortalPreview
+ */
+
+import React, { useState } from 'react';
+import type { NoticeConsoleSnapshot } from '../types';
+import { SectionCard, StatusPill } from '../components/primitives';
+
+export const CitizenPortalPreview: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const langs = snapshot.county.languageDefaults;
+  const [lang, setLang] = useState(langs[0] ?? 'English (en-US)');
+  const [highContrast, setHighContrast] = useState(false);
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-citizen-portal">
+      <SectionCard
+        title="Accessibility & Language"
+        chip={<StatusPill label="Preview only" variant="outline" />}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          {langs.map((l) => (
+            <button
+              key={l}
+              onClick={() => setLang(l)}
+              className="px-3 py-1.5 rounded-full text-sm transition-colors"
+              style={{
+                background: l === lang ? 'hsl(var(--tf-accent) / 0.15)' : 'hsl(var(--tf-card-bg) / 0.4)',
+                color: l === lang ? 'hsl(var(--tf-accent))' : 'hsl(var(--tf-fg))',
+                border: `1px solid hsl(var(--tf-border) / ${l === lang ? 0.4 : 0.15})`,
+              }}
+            >
+              {l}
+            </button>
+          ))}
+          <label className="flex items-center gap-2 text-sm ml-2 cursor-pointer">
+            <input type="checkbox" checked={highContrast} onChange={() => setHighContrast((v) => !v)} />
+            High-contrast view
+          </label>
+        </div>
+      </SectionCard>
+
+      <div
+        className="rounded-xl p-6 max-w-2xl mx-auto"
+        style={{
+          background: highContrast ? 'hsl(0 0% 8%)' : 'hsl(var(--tf-card-bg) / 0.6)',
+          color: highContrast ? 'hsl(0 0% 98%)' : 'hsl(var(--tf-fg))',
+          border: '1px solid hsl(var(--tf-border) / 0.3)',
+        }}
+        data-testid="citizen-portal-landing"
+      >
+        {/* QR + header */}
+        <div className="flex items-center gap-4 pb-4" style={{ borderBottom: '1px solid hsl(var(--tf-border) / 0.3)' }}>
+          <div
+            className="w-16 h-16 rounded grid place-items-center text-[10px] font-mono"
+            style={{ background: highContrast ? 'hsl(0 0% 98%)' : 'hsl(var(--tf-fg) / 0.9)', color: highContrast ? 'hsl(0 0% 8%)' : 'hsl(var(--tf-bg))' }}
+            aria-label="QR code placeholder"
+          >
+            QR
+          </div>
+          <div>
+            <div className="text-lg font-semibold">{snapshot.county.countyName} — {snapshot.county.program}</div>
+            <div className="text-sm opacity-70">Tax Year {snapshot.county.taxYear} · {lang}</div>
+          </div>
+        </div>
+
+        {/* Notice explanation */}
+        <section className="pt-4 space-y-2">
+          <h3 className="font-semibold">What this notice means</h3>
+          <p className="text-sm opacity-80">
+            This notice tells you the assessed value of your property for the {snapshot.county.taxYear} tax year.
+            It is not a bill. If you believe the value is incorrect, you have the right to appeal within the
+            statutory window described below.
+          </p>
+        </section>
+
+        {/* Parcel summary */}
+        <section className="pt-4 space-y-1">
+          <h3 className="font-semibold">Your parcel</h3>
+          <dl className="text-sm grid grid-cols-2 gap-x-4 gap-y-1 opacity-80">
+            <dt>Parcel ID</dt><dd className="text-right font-mono">SAMPLE-PARCEL</dd>
+            <dt>Assessed value</dt><dd className="text-right font-mono">$ —</dd>
+            <dt>Prior value</dt><dd className="text-right font-mono">$ —</dd>
+          </dl>
+          <p className="text-[11px] opacity-60 pt-1">Parcel values are populated from the freeze snapshot at issue time.</p>
+        </section>
+
+        {/* Appeal guidance */}
+        <section className="pt-4 space-y-2">
+          <h3 className="font-semibold">How to appeal</h3>
+          <ol className="text-sm opacity-80 list-decimal list-inside space-y-1">
+            <li>Review the value and supporting information.</li>
+            <li>File a petition with the Board of Equalization before the deadline on your notice.</li>
+            <li>Provide evidence (recent sales, appraisal, condition).</li>
+          </ol>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default CitizenPortalPreview;

--- a/frontend/apps/os-shell/src/pages/notice/areas/CommandCenter.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/CommandCenter.tsx
@@ -1,0 +1,190 @@
+/**
+ * TN-GUI-001 — Notice Operations Command Center.
+ *
+ * The air-traffic-control overview: live KPIs, batch lifecycle, the governance
+ * trace for the active batch, and at-a-glance status of policy, templates,
+ * vendor dispatch, exceptions and the audit vault.
+ *
+ * @module pages/notice/areas/CommandCenter
+ */
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import type { BatchRow, BatchStatus, NoticeConsoleSnapshot } from '../types';
+import {
+  EmptyState,
+  GovernanceTimeline,
+  KpiTile,
+  SectionCard,
+  StatusPill,
+  Table,
+  Td,
+  Th,
+  Tr,
+  formatInt,
+  formatPct,
+} from '../components/primitives';
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+const BATCH_STATUS: Record<BatchStatus, { label: string; variant: BadgeVariant }> = {
+  draft: { label: 'Draft', variant: 'outline' },
+  validated: { label: 'Validated', variant: 'default' },
+  'legal-review': { label: 'Legal Review', variant: 'secondary' },
+  frozen: { label: 'Frozen', variant: 'secondary' },
+  dispatched: { label: 'Dispatched', variant: 'default' },
+  failed: { label: 'Failed', variant: 'destructive' },
+};
+
+interface AreaProps {
+  snapshot: NoticeConsoleSnapshot;
+  onNavigate: (area: import('../types').ConsoleAreaId) => void;
+}
+
+export const CommandCenter: React.FC<AreaProps> = ({ snapshot, onNavigate }) => {
+  const { kpis, batches, timeline } = snapshot;
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-command-center">
+      {/* KPI row */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <KpiTile
+          testId="kpi-active-batches"
+          label="Active Batches"
+          value={String(kpis.activeBatches)}
+          note={kpis.activeBatchesNote}
+          accentVar="--tf-accent"
+        />
+        <KpiTile
+          testId="kpi-notices-prepared"
+          label="Notices Prepared"
+          value={formatInt(kpis.noticesPrepared)}
+          note={`${formatPct(kpis.validationPassRate)} validation pass rate`}
+          accentVar="--tf-accent-2"
+        />
+        <KpiTile
+          testId="kpi-open-exceptions"
+          label="Open Exceptions"
+          value={formatInt(kpis.openExceptions)}
+          note={`${kpis.highRiskExceptions} high-risk return-mail items`}
+          accentVar="--tf-warning"
+        />
+        <KpiTile
+          testId="kpi-audit-readiness"
+          label="Audit Readiness"
+          value={formatPct(kpis.auditReadiness)}
+          note={kpis.auditReadinessNote}
+          accentVar="--tf-success"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* Batch lifecycle */}
+        <div className="lg:col-span-2">
+          <SectionCard
+            testId="command-center-batches"
+            title="Batch Lifecycle"
+            chip={<StatusPill label="Freeze pending" variant="secondary" />}
+          >
+            {batches.length === 0 ? (
+              <EmptyState message="No batches returned for this program." />
+            ) : (
+              <Table testId="command-center-batch-table">
+                <thead>
+                  <Tr>
+                    <Th>Batch</Th>
+                    <Th>Status</Th>
+                    <Th className="text-right">Notices</Th>
+                    <Th>Policy</Th>
+                    <Th>Template</Th>
+                  </Tr>
+                </thead>
+                <tbody>
+                  {batches.map((b: BatchRow) => {
+                    const s = BATCH_STATUS[b.status];
+                    return (
+                      <Tr key={b.batchId} interactive onClick={() => onNavigate('batch-operations')}>
+                        <Td className="font-mono text-xs">{b.batchId}</Td>
+                        <Td>
+                          <StatusPill label={s.label} variant={s.variant} />
+                        </Td>
+                        <Td className="text-right font-mono">{formatInt(b.notices)}</Td>
+                        <Td className="text-xs">{b.policyVersion}</Td>
+                        <Td className="text-xs">{b.templateVersion}</Td>
+                      </Tr>
+                    );
+                  })}
+                </tbody>
+              </Table>
+            )}
+            <div className="flex gap-2 mt-4">
+              <Button size="sm" onClick={() => onNavigate('batch-operations')}>
+                Open Batch Workspace
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => onNavigate('freeze-snapshots')}>
+                View Freeze Preview
+              </Button>
+            </div>
+          </SectionCard>
+        </div>
+
+        {/* Governance timeline */}
+        <SectionCard
+          testId="command-center-timeline"
+          title="Governance Timeline"
+          chip={<StatusPill label="Trace active" variant="outline" />}
+        >
+          <GovernanceTimeline steps={timeline} />
+        </SectionCard>
+      </div>
+
+      {/* At-a-glance status row */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+        <GlanceTile
+          label="Policy Pack"
+          value={snapshot.policyPacks[0]?.packId ?? '—'}
+          pill={<StatusPill label="Approved" variant="default" />}
+          onClick={() => onNavigate('policy-packs')}
+        />
+        <GlanceTile
+          label="Template Governance"
+          value="1 review item"
+          pill={<StatusPill label="Plain-language pending" variant="secondary" />}
+          onClick={() => onNavigate('template-governance')}
+        />
+        <GlanceTile
+          label="Vendor Dispatch"
+          value="Ready"
+          pill={<StatusPill label="Print contract validated" variant="default" />}
+          onClick={() => onNavigate('vendor-dispatch')}
+        />
+        <GlanceTile
+          label="Returned Mail / Exceptions"
+          value={`${formatInt(kpis.openExceptions)} open`}
+          pill={<StatusPill label={`${kpis.highRiskExceptions} high risk`} variant="destructive" />}
+          onClick={() => onNavigate('returned-mail')}
+        />
+      </div>
+    </div>
+  );
+};
+
+const GlanceTile: React.FC<{
+  label: string;
+  value: string;
+  pill: React.ReactNode;
+  onClick: () => void;
+}> = ({ label, value, pill, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="text-left rounded-lg p-3 flex flex-col gap-1 transition-colors hover:opacity-90"
+    style={{ background: 'hsl(var(--tf-card-bg) / 0.4)', border: '1px solid hsl(var(--tf-border) / 0.2)' }}
+  >
+    <span className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>{label}</span>
+    <span className="font-semibold">{value}</span>
+    <span>{pill}</span>
+  </button>
+);
+
+export default CommandCenter;

--- a/frontend/apps/os-shell/src/pages/notice/areas/CountyConfiguration.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/CountyConfiguration.tsx
@@ -1,0 +1,132 @@
+/**
+ * TN-GUI-002 — County Profile / Configuration.
+ *
+ * Branding, approval hierarchy, language & accessibility defaults, delivery
+ * rules, vendor mappings, and runtime overrides — with explicit "within bounds"
+ * flagging so an operator can see when an override breaches policy guardrails.
+ *
+ * @module pages/notice/areas/CountyConfiguration
+ */
+
+import React from 'react';
+import type { NoticeConsoleSnapshot } from '../types';
+import { EmptyState, SectionCard, StatusPill, Table, Td, Th, Tr } from '../components/primitives';
+
+export const CountyConfiguration: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const c = snapshot.county;
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-county-configuration">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <SectionCard
+          title="Branding & Identity"
+          chip={<StatusPill label={c.brandingLocked ? 'Locked' : 'Editable'} variant={c.brandingLocked ? 'default' : 'secondary'} />}
+        >
+          <dl className="space-y-2 text-sm">
+            <Row label="County">{c.countyName}</Row>
+            <Row label="Program">{c.program}</Row>
+            <Row label="Tax year">{c.taxYear}</Row>
+            <Row label="Environment">{c.environment}</Row>
+          </dl>
+        </SectionCard>
+
+        <SectionCard title="Approval Hierarchy">
+          <ol className="space-y-2 text-sm">
+            {c.approvalChain.map((step, i) => (
+              <li key={step} className="flex items-center gap-2">
+                <span
+                  className="w-5 h-5 rounded-full text-xs flex items-center justify-center font-semibold"
+                  style={{ background: 'hsl(var(--tf-accent) / 0.15)', color: 'hsl(var(--tf-accent))' }}
+                >
+                  {i + 1}
+                </span>
+                {step}
+              </li>
+            ))}
+          </ol>
+        </SectionCard>
+
+        <SectionCard title="Language & Accessibility Defaults">
+          <div className="flex flex-wrap gap-2">
+            {[...c.languageDefaults, ...c.accessibilityDefaults].map((d) => (
+              <StatusPill key={d} label={d} variant="outline" />
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Delivery Rules">
+          <dl className="space-y-2 text-sm">
+            {c.deliveryRules.map((r) => (
+              <Row key={r.label} label={r.label}>{r.value}</Row>
+            ))}
+          </dl>
+        </SectionCard>
+      </div>
+
+      <SectionCard title="Vendor Mappings">
+        {c.vendorMappings.length === 0 ? (
+          <EmptyState message="No vendor mappings configured." />
+        ) : (
+          <Table>
+            <thead>
+              <Tr>
+                <Th>Channel</Th>
+                <Th>Vendor</Th>
+                <Th className="text-right">Status</Th>
+              </Tr>
+            </thead>
+            <tbody>
+              {c.vendorMappings.map((v) => (
+                <Tr key={`${v.channel}-${v.vendor}`}>
+                  <Td className="capitalize">{v.channel}</Td>
+                  <Td>{v.vendor}</Td>
+                  <Td className="text-right">
+                    <StatusPill label={v.status} variant={v.status === 'active' ? 'default' : 'outline'} />
+                  </Td>
+                </Tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </SectionCard>
+
+      <SectionCard
+        title="Runtime Overrides"
+        chip={<StatusPill label="Within allowed bounds enforced" variant="outline" />}
+      >
+        <Table>
+          <thead>
+            <Tr>
+              <Th>Override</Th>
+              <Th>Value</Th>
+              <Th className="text-right">Bounds</Th>
+            </Tr>
+          </thead>
+          <tbody>
+            {c.runtimeOverrides.map((o) => (
+              <Tr key={o.label}>
+                <Td>{o.label}</Td>
+                <Td className="text-xs" >{o.value}</Td>
+                <Td className="text-right">
+                  <StatusPill
+                    label={o.withinBounds ? 'Within bounds' : 'Breaches guardrail'}
+                    variant={o.withinBounds ? 'default' : 'destructive'}
+                  />
+                </Td>
+              </Tr>
+            ))}
+          </tbody>
+        </Table>
+      </SectionCard>
+    </div>
+  );
+};
+
+const Row: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <div className="flex items-center justify-between gap-3">
+    <dt style={{ color: 'hsl(var(--tf-muted))' }}>{label}</dt>
+    <dd className="font-medium text-right">{children}</dd>
+  </div>
+);
+
+export default CountyConfiguration;

--- a/frontend/apps/os-shell/src/pages/notice/areas/FreezeSnapshots.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/FreezeSnapshots.tsx
@@ -1,0 +1,88 @@
+/**
+ * TN-GUI-006 — Freeze Snapshot Viewer.
+ *
+ * Every issued notice binds to an immutable freeze: the parcel/data snapshot,
+ * legal text version, template version, policy version, county-config version,
+ * and the artifact hash. This screen makes that binding inspectable.
+ *
+ * @module pages/notice/areas/FreezeSnapshots
+ */
+
+import React, { useState } from 'react';
+import type { NoticeConsoleSnapshot } from '../types';
+import { EmptyState, SectionCard, StatusPill, Table, Td, Th, Tr } from '../components/primitives';
+
+export const FreezeSnapshots: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const snaps = snapshot.freezeSnapshots;
+  const [selected, setSelected] = useState(snaps[0]?.snapshotId ?? '');
+  const active = snaps.find((s) => s.snapshotId === selected) ?? snaps[0];
+
+  if (snaps.length === 0) {
+    return (
+      <div data-testid="notice-area-freeze-snapshots">
+        <SectionCard title="Freeze Snapshots">
+          <EmptyState message="No freeze snapshots yet. Freeze a validated batch to create one." />
+        </SectionCard>
+      </div>
+    );
+  }
+
+  const bindings: { label: string; value: string; mono?: boolean }[] = [
+    { label: 'Parcel / data snapshot', value: `${active.parcelCount.toLocaleString('en-US')} parcels` },
+    { label: 'Legal text version', value: active.legalTextVersion },
+    { label: 'Template version', value: active.templateVersion },
+    { label: 'Policy version', value: active.policyVersion },
+    { label: 'County config version', value: active.countyConfigVersion },
+    { label: 'Artifact hash', value: active.artifactHash, mono: true },
+    { label: 'Frozen at', value: active.frozenAt },
+    { label: 'Frozen by', value: active.frozenBy },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-5" data-testid="notice-area-freeze-snapshots">
+      <SectionCard title="Snapshots">
+        <Table>
+          <thead>
+            <Tr>
+              <Th>Snapshot</Th>
+              <Th className="text-right">Batch</Th>
+            </Tr>
+          </thead>
+          <tbody>
+            {snaps.map((s) => (
+              <Tr key={s.snapshotId} interactive onClick={() => setSelected(s.snapshotId)}>
+                <Td className="font-mono text-xs">{s.snapshotId}</Td>
+                <Td className="text-right font-mono text-xs">{s.batchId}</Td>
+              </Tr>
+            ))}
+          </tbody>
+        </Table>
+      </SectionCard>
+
+      <div className="lg:col-span-2">
+        <SectionCard
+          title={`Snapshot — ${active.snapshotId}`}
+          chip={<StatusPill label="Immutable" variant="default" />}
+        >
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+            {bindings.map((b) => (
+              <div key={b.label} className="flex flex-col">
+                <dt className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>{b.label}</dt>
+                <dd className={`font-medium ${b.mono ? 'font-mono text-xs' : ''}`}>{b.value}</dd>
+              </div>
+            ))}
+          </dl>
+          <div
+            className="mt-4 rounded-lg p-4 text-center"
+            style={{ background: 'hsl(var(--tf-bg) / 0.6)', border: '1px dashed hsl(var(--tf-border) / 0.4)' }}
+          >
+            <div className="text-sm" style={{ color: 'hsl(var(--tf-muted))' }}>Rendered artifact</div>
+            <div className="font-mono text-xs mt-1">{active.artifactHash}</div>
+          </div>
+        </SectionCard>
+      </div>
+    </div>
+  );
+};
+
+export default FreezeSnapshots;

--- a/frontend/apps/os-shell/src/pages/notice/areas/PolicyPacks.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/PolicyPacks.tsx
@@ -1,0 +1,116 @@
+/**
+ * TN-GUI-003 — Policy Pack Manager.
+ *
+ * State baseline rules + county overrides, effective dates, rule-test results,
+ * and approval status. Selecting a pack shows its rule ledger.
+ *
+ * @module pages/notice/areas/PolicyPacks
+ */
+
+import React, { useState } from 'react';
+import type { NoticeConsoleSnapshot, PolicyRule } from '../types';
+import {
+  EmptyState,
+  SectionCard,
+  StatusPill,
+  Table,
+  Td,
+  Th,
+  Tr,
+  approvalVariant,
+} from '../components/primitives';
+
+function testVariant(s: PolicyRule['testStatus']): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (s === 'pass') return 'default';
+  if (s === 'fail') return 'destructive';
+  return 'outline';
+}
+
+export const PolicyPacks: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const packs = snapshot.policyPacks;
+  const [selected, setSelected] = useState(packs[0]?.packId ?? '');
+  const active = packs.find((p) => p.packId === selected) ?? packs[0];
+
+  if (packs.length === 0) {
+    return (
+      <div data-testid="notice-area-policy-packs">
+        <SectionCard title="Policy Packs">
+          <EmptyState message="No policy packs available for this county." />
+        </SectionCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-5" data-testid="notice-area-policy-packs">
+      <SectionCard title="Packs">
+        <ul className="space-y-2">
+          {packs.map((p) => (
+            <li key={p.packId}>
+              <button
+                onClick={() => setSelected(p.packId)}
+                className="w-full text-left p-3 rounded-lg transition-colors"
+                style={{
+                  background: p.packId === selected ? 'hsl(var(--tf-accent) / 0.12)' : 'hsl(var(--tf-card-bg) / 0.4)',
+                  border: `1px solid hsl(var(--tf-border) / ${p.packId === selected ? 0.4 : 0.15})`,
+                }}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-sm">{p.packId}</span>
+                  <StatusPill label={p.approval} variant={approvalVariant(p.approval)} />
+                </div>
+                <div className="text-xs mt-1" style={{ color: 'hsl(var(--tf-muted))' }}>
+                  {p.label} · effective {p.effectiveDate}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </SectionCard>
+
+      <div className="lg:col-span-2">
+        <SectionCard
+          title={`Rule Ledger — ${active.packId}`}
+          chip={<StatusPill label={active.approval} variant={approvalVariant(active.approval)} />}
+        >
+          <Table testId="policy-rule-table">
+            <thead>
+              <Tr>
+                <Th>Rule</Th>
+                <Th>Source</Th>
+                <Th>Effective</Th>
+                <Th className="text-center">Test</Th>
+                <Th className="text-right">Approval</Th>
+              </Tr>
+            </thead>
+            <tbody>
+              {active.rules.map((r) => (
+                <Tr key={r.ruleId}>
+                  <Td>
+                    <div className="text-sm">{r.title}</div>
+                    <div className="font-mono text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>{r.ruleId}</div>
+                  </Td>
+                  <Td>
+                    <StatusPill
+                      label={r.source === 'state-baseline' ? 'State baseline' : 'County override'}
+                      variant={r.source === 'state-baseline' ? 'outline' : 'secondary'}
+                    />
+                  </Td>
+                  <Td className="text-xs">{r.effectiveDate}</Td>
+                  <Td className="text-center">
+                    <StatusPill label={r.testStatus} variant={testVariant(r.testStatus)} />
+                  </Td>
+                  <Td className="text-right">
+                    <StatusPill label={r.approval} variant={approvalVariant(r.approval)} />
+                  </Td>
+                </Tr>
+              ))}
+            </tbody>
+          </Table>
+        </SectionCard>
+      </div>
+    </div>
+  );
+};
+
+export default PolicyPacks;

--- a/frontend/apps/os-shell/src/pages/notice/areas/ReleaseConsole.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/ReleaseConsole.tsx
@@ -1,0 +1,80 @@
+/**
+ * TN-GUI (Release & Deployment Console).
+ *
+ * Release health, the deployed policy pack / template set, and attestation
+ * completeness. A release cannot be marked healthy until all required
+ * attestations are recorded.
+ *
+ * @module pages/notice/areas/ReleaseConsole
+ */
+
+import React from 'react';
+import type { NoticeConsoleSnapshot, ReleaseHealth } from '../types';
+import { EmptyState, SectionCard, StatusPill } from '../components/primitives';
+
+const HEALTH: Record<ReleaseHealth, { label: string; variant: 'default' | 'secondary' | 'destructive'; accent: string }> = {
+  healthy: { label: 'Healthy', variant: 'default', accent: '--tf-success' },
+  degraded: { label: 'Degraded', variant: 'secondary', accent: '--tf-warning' },
+  blocked: { label: 'Blocked', variant: 'destructive', accent: '--tf-error' },
+};
+
+export const ReleaseConsole: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const releases = snapshot.releases;
+
+  if (releases.length === 0) {
+    return (
+      <div data-testid="notice-area-release-console">
+        <SectionCard title="Release & Deployment">
+          <EmptyState message="No releases recorded for this environment." />
+        </SectionCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-release-console">
+      {releases.map((r) => {
+        const h = HEALTH[r.health];
+        const pct = r.attestationsRequired > 0 ? r.attestationsComplete / r.attestationsRequired : 0;
+        return (
+          <SectionCard
+            key={r.releaseId}
+            title={`Release ${r.releaseId}`}
+            chip={<StatusPill label={h.label} variant={h.variant} />}
+          >
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+              <Field label="Environment" value={r.environment} />
+              <Field label="Deployed" value={r.deployedAt} />
+              <Field label="Policy pack" value={r.policyPack} />
+              <Field label="Template set" value={r.templateSet} />
+            </dl>
+
+            <div className="mt-4">
+              <div className="flex items-center justify-between text-sm mb-1.5">
+                <span style={{ color: 'hsl(var(--tf-muted))' }}>Approval attestations</span>
+                <span className="font-mono">{r.attestationsComplete}/{r.attestationsRequired}</span>
+              </div>
+              <div className="h-3 rounded-full overflow-hidden" style={{ background: 'hsl(var(--tf-border) / 0.2)' }}>
+                <div className="h-full rounded-full" style={{ width: `${pct * 100}%`, background: `hsl(var(${h.accent}))` }} />
+              </div>
+              {r.attestationsComplete < r.attestationsRequired && (
+                <p className="text-xs mt-2" style={{ color: 'hsl(var(--tf-warning))' }}>
+                  {r.attestationsRequired - r.attestationsComplete} attestation(s) outstanding — release stays degraded until complete.
+                </p>
+              )}
+            </div>
+          </SectionCard>
+        );
+      })}
+    </div>
+  );
+};
+
+const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex flex-col">
+    <dt className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>{label}</dt>
+    <dd className="font-medium">{value}</dd>
+  </div>
+);
+
+export default ReleaseConsole;

--- a/frontend/apps/os-shell/src/pages/notice/areas/ReturnedMail.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/ReturnedMail.tsx
@@ -1,0 +1,84 @@
+/**
+ * TN-GUI-008 — Returned Mail / Exception Queue.
+ *
+ * Returned mail, bad address, vendor rejection, missing insert, and
+ * policy/template conflict — each with the resolution action and a high-risk
+ * flag that drives the reissue workflow.
+ *
+ * @module pages/notice/areas/ReturnedMail
+ */
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import type { NoticeConsoleSnapshot } from '../types';
+import {
+  EmptyState,
+  SectionCard,
+  StatusPill,
+  Table,
+  Td,
+  Th,
+  Tr,
+  formatInt,
+} from '../components/primitives';
+
+export const ReturnedMail: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const rows = snapshot.exceptions;
+  const totalOpen = rows.reduce((acc, r) => acc + r.count, 0);
+  const highRisk = rows.filter((r) => r.highRisk).reduce((acc, r) => acc + r.count, 0);
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-returned-mail">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg p-4" style={{ background: 'hsl(var(--tf-card-bg) / 0.5)', border: '1px solid hsl(var(--tf-border) / 0.2)' }}>
+          <div className="text-xs uppercase tracking-wide" style={{ color: 'hsl(var(--tf-muted))' }}>Open exceptions</div>
+          <div className="text-3xl font-semibold mt-1">{formatInt(totalOpen)}</div>
+        </div>
+        <div className="rounded-lg p-4" style={{ background: 'hsl(var(--tf-card-bg) / 0.5)', border: '1px solid hsl(var(--tf-border) / 0.2)' }}>
+          <div className="text-xs uppercase tracking-wide" style={{ color: 'hsl(var(--tf-muted))' }}>High risk</div>
+          <div className="text-3xl font-semibold mt-1" style={{ color: 'hsl(var(--tf-error))' }}>{formatInt(highRisk)}</div>
+        </div>
+      </div>
+
+      <SectionCard title="Exception Queue">
+        {rows.length === 0 ? (
+          <EmptyState message="No exceptions in the queue." />
+        ) : (
+          <Table testId="exception-queue-table">
+            <thead>
+              <Tr>
+                <Th>Category</Th>
+                <Th className="text-right">Count</Th>
+                <Th>Action</Th>
+                <Th className="text-right">Risk</Th>
+                <Th className="text-right">Reissue</Th>
+              </Tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <Tr key={r.category}>
+                  <Td className="text-sm">{r.label}</Td>
+                  <Td className="text-right font-mono">{formatInt(r.count)}</Td>
+                  <Td className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>{r.action}</Td>
+                  <Td className="text-right">
+                    <StatusPill label={r.highRisk ? 'High' : 'Normal'} variant={r.highRisk ? 'destructive' : 'outline'} />
+                  </Td>
+                  <Td className="text-right">
+                    <Button size="sm" variant="outline" disabled={r.count === 0}>
+                      Reissue
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+        <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
+          Sandbox: reissue actions are inert — no replacement notices are generated.
+        </p>
+      </SectionCard>
+    </div>
+  );
+};
+
+export default ReturnedMail;

--- a/frontend/apps/os-shell/src/pages/notice/areas/ReturnedMail.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/ReturnedMail.tsx
@@ -26,6 +26,8 @@ export const ReturnedMail: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ sn
   const rows = snapshot.exceptions;
   const totalOpen = rows.reduce((acc, r) => acc + r.count, 0);
   const highRisk = rows.filter((r) => r.highRisk).reduce((acc, r) => acc + r.count, 0);
+  // Reissue only runs against a live backend; disabled in sandbox.
+  const inert = snapshot.source !== 'live';
 
   return (
     <div className="space-y-5" data-testid="notice-area-returned-mail">
@@ -64,7 +66,7 @@ export const ReturnedMail: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ sn
                     <StatusPill label={r.highRisk ? 'High' : 'Normal'} variant={r.highRisk ? 'destructive' : 'outline'} />
                   </Td>
                   <Td className="text-right">
-                    <Button size="sm" variant="outline" disabled={r.count === 0}>
+                    <Button size="sm" variant="outline" disabled={inert || r.count === 0}>
                       Reissue
                     </Button>
                   </Td>

--- a/frontend/apps/os-shell/src/pages/notice/areas/Telemetry.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/Telemetry.tsx
@@ -1,0 +1,78 @@
+/**
+ * TN-GUI (Telemetry / Risk Dashboard).
+ *
+ * Notices issued / delivered / returned / reissued, call-surge proxy, QR scans,
+ * portal engagement, and exception handling time. Delivery-side metrics are
+ * zero until dispatch begins — surfaced honestly rather than faked.
+ *
+ * @module pages/notice/areas/Telemetry
+ */
+
+import React from 'react';
+import type { NoticeConsoleSnapshot } from '../types';
+import { SectionCard, formatInt } from '../components/primitives';
+
+export const Telemetry: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const metrics = snapshot.telemetry;
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-telemetry">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {metrics.map((m) => (
+          <div
+            key={m.key}
+            className="rounded-lg p-4"
+            style={{ background: 'hsl(var(--tf-card-bg) / 0.5)', border: '1px solid hsl(var(--tf-border) / 0.2)' }}
+          >
+            <div className="text-xs uppercase tracking-wide" style={{ color: 'hsl(var(--tf-muted))' }}>{m.label}</div>
+            <div className="text-2xl font-semibold mt-1">
+              {formatInt(m.value)}
+              {m.unit && <span className="text-sm font-normal ml-1" style={{ color: 'hsl(var(--tf-muted))' }}>{m.unit}</span>}
+            </div>
+            {m.delta && (
+              <div className="text-xs mt-1" style={{ color: 'hsl(var(--tf-muted))' }}>{m.delta}</div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <SectionCard title="Delivery Funnel">
+        <DeliveryFunnel snapshot={snapshot} />
+        <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
+          Delivery, returned, and engagement metrics remain zero until vendor dispatch begins. The console does not
+          fabricate delivery telemetry.
+        </p>
+      </SectionCard>
+    </div>
+  );
+};
+
+const DeliveryFunnel: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const issued = snapshot.telemetry.find((m) => m.key === 'issued')?.value ?? 0;
+  const stages = [
+    { label: 'Issued', value: issued },
+    { label: 'Delivered', value: snapshot.telemetry.find((m) => m.key === 'delivered')?.value ?? 0 },
+    { label: 'Returned', value: snapshot.telemetry.find((m) => m.key === 'returned')?.value ?? 0 },
+    { label: 'Reissued', value: snapshot.telemetry.find((m) => m.key === 'reissued')?.value ?? 0 },
+  ];
+  const max = Math.max(issued, 1);
+
+  return (
+    <div className="space-y-2">
+      {stages.map((s) => (
+        <div key={s.label} className="flex items-center gap-3">
+          <span className="w-24 text-sm" style={{ color: 'hsl(var(--tf-muted))' }}>{s.label}</span>
+          <div className="flex-1 h-3 rounded-full overflow-hidden" style={{ background: 'hsl(var(--tf-border) / 0.2)' }}>
+            <div
+              className="h-full rounded-full"
+              style={{ width: `${Math.max((s.value / max) * 100, s.value > 0 ? 4 : 0)}%`, background: 'hsl(var(--tf-accent))' }}
+            />
+          </div>
+          <span className="w-20 text-right font-mono text-sm">{formatInt(s.value)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Telemetry;

--- a/frontend/apps/os-shell/src/pages/notice/areas/TemplateGovernance.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/TemplateGovernance.tsx
@@ -45,8 +45,10 @@ export const TemplateGovernance: React.FC<{ snapshot: NoticeConsoleSnapshot }> =
   const previous = active?.previousVersion
     ? templateAssemblies.find((a) => a.templateId === active.templateId && a.version === active.previousVersion)
     : undefined;
-  const previousBlocks = previous?.blocks ?? (active?.previousVersion ? active.blocks : undefined);
-  const { added, removed } = active ? diff(previousBlocks, active.blocks) : { added: [], removed: [] };
+  // Only diff against a previous assembly we actually have. A declared-but-missing
+  // previousVersion is surfaced as "unavailable" — never as a false "no changes".
+  const previousMissing = !!active?.previousVersion && !previous;
+  const { added, removed } = active && previous ? diff(previous.blocks, active.blocks) : { added: [], removed: [] };
 
   return (
     <div className="space-y-5" data-testid="notice-area-template-governance">
@@ -117,6 +119,8 @@ export const TemplateGovernance: React.FC<{ snapshot: NoticeConsoleSnapshot }> =
           >
             {!active.previousVersion ? (
               <EmptyState message="No prior version to diff against." />
+            ) : previousMissing ? (
+              <EmptyState message={`Prior version ${active.previousVersion} is not in this snapshot — diff unavailable.`} />
             ) : added.length === 0 && removed.length === 0 ? (
               <EmptyState message="No block-level changes between versions." />
             ) : (

--- a/frontend/apps/os-shell/src/pages/notice/areas/TemplateGovernance.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/TemplateGovernance.tsx
@@ -1,0 +1,169 @@
+/**
+ * TN-GUI-004 — Template Governance (block library + assemblies).
+ *
+ * Block library, template assemblies, lifecycle state, legal approval, version
+ * diff and a render-preview placeholder. Legal-controlled blocks are flagged so
+ * they cannot be silently edited.
+ *
+ * @module pages/notice/areas/TemplateGovernance
+ */
+
+import React, { useState } from 'react';
+import type { LifecycleState, NoticeConsoleSnapshot, TemplateAssembly } from '../types';
+import {
+  EmptyState,
+  SectionCard,
+  StatusPill,
+  Table,
+  Td,
+  Th,
+  Tr,
+  approvalVariant,
+} from '../components/primitives';
+
+function lifecycleVariant(s: LifecycleState): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (s === 'approved') return 'default';
+  if (s === 'in-review') return 'secondary';
+  if (s === 'retired') return 'destructive';
+  return 'outline';
+}
+
+function diff(prev: string[] | undefined, next: string[]): { added: string[]; removed: string[] } {
+  if (!prev) return { added: [], removed: [] };
+  return {
+    added: next.filter((b) => !prev.includes(b)),
+    removed: prev.filter((b) => !next.includes(b)),
+  };
+}
+
+export const TemplateGovernance: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const { templateBlocks, templateAssemblies } = snapshot;
+  const [selected, setSelected] = useState(templateAssemblies[0]?.version ?? '');
+  const active = templateAssemblies.find((a) => a.version === selected) ?? templateAssemblies[0];
+
+  // Resolve previous assembly (same templateId, version === previousVersion).
+  const previous = active?.previousVersion
+    ? templateAssemblies.find((a) => a.templateId === active.templateId && a.version === active.previousVersion)
+    : undefined;
+  const previousBlocks = previous?.blocks ?? (active?.previousVersion ? active.blocks : undefined);
+  const { added, removed } = active ? diff(previousBlocks, active.blocks) : { added: [], removed: [] };
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-template-governance">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <SectionCard title="Block Library">
+          {templateBlocks.length === 0 ? (
+            <EmptyState message="No template blocks defined." />
+          ) : (
+            <Table>
+              <thead>
+                <Tr>
+                  <Th>Block</Th>
+                  <Th>Kind</Th>
+                  <Th className="text-right">Lifecycle</Th>
+                </Tr>
+              </thead>
+              <tbody>
+                {templateBlocks.map((b) => (
+                  <Tr key={b.blockId}>
+                    <Td>
+                      <div className="text-sm flex items-center gap-2">
+                        {b.name}
+                        {b.legalControlled && <StatusPill label="Legal-controlled" variant="destructive" />}
+                      </div>
+                    </Td>
+                    <Td className="capitalize text-xs">{b.kind.replace('-', ' ')}</Td>
+                    <Td className="text-right">
+                      <StatusPill label={b.lifecycle} variant={lifecycleVariant(b.lifecycle)} />
+                    </Td>
+                  </Tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+        </SectionCard>
+
+        <SectionCard title="Template Assemblies">
+          <ul className="space-y-2">
+            {templateAssemblies.map((a) => (
+              <li key={`${a.templateId}-${a.version}`}>
+                <button
+                  onClick={() => setSelected(a.version)}
+                  className="w-full text-left p-3 rounded-lg transition-colors"
+                  style={{
+                    background: a.version === selected ? 'hsl(var(--tf-accent) / 0.12)' : 'hsl(var(--tf-card-bg) / 0.4)',
+                    border: `1px solid hsl(var(--tf-border) / ${a.version === selected ? 0.4 : 0.15})`,
+                  }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-mono text-sm">{a.templateId}-{a.version}</span>
+                    <div className="flex gap-1.5">
+                      <StatusPill label={a.lifecycle} variant={lifecycleVariant(a.lifecycle)} />
+                      <StatusPill label={`legal: ${a.legalApproval}`} variant={approvalVariant(a.legalApproval)} />
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </SectionCard>
+      </div>
+
+      {active && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+          <SectionCard
+            title={`Version Diff — ${active.templateId}-${active.version}`}
+            chip={active.previousVersion ? <StatusPill label={`vs ${active.previousVersion}`} variant="outline" /> : undefined}
+          >
+            {!active.previousVersion ? (
+              <EmptyState message="No prior version to diff against." />
+            ) : added.length === 0 && removed.length === 0 ? (
+              <EmptyState message="No block-level changes between versions." />
+            ) : (
+              <div className="space-y-2 text-sm">
+                {added.map((b) => (
+                  <div key={`add-${b}`} className="flex items-center gap-2">
+                    <span style={{ color: 'hsl(var(--tf-success))' }}>+ added</span>
+                    <span>{b}</span>
+                  </div>
+                ))}
+                {removed.map((b) => (
+                  <div key={`rem-${b}`} className="flex items-center gap-2">
+                    <span style={{ color: 'hsl(var(--tf-error))' }}>− removed</span>
+                    <span>{b}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Render Preview">
+            <RenderPreview assembly={active} />
+          </SectionCard>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RenderPreview: React.FC<{ assembly: TemplateAssembly }> = ({ assembly }) => (
+  <div
+    className="rounded-lg p-4 space-y-2"
+    style={{ background: 'hsl(var(--tf-bg) / 0.6)', border: '1px solid hsl(var(--tf-border) / 0.3)' }}
+  >
+    {assembly.blocks.map((b) => (
+      <div
+        key={b}
+        className="text-xs px-3 py-2 rounded"
+        style={{ background: 'hsl(var(--tf-card-bg) / 0.6)', border: '1px dashed hsl(var(--tf-border) / 0.4)' }}
+      >
+        {b}
+      </div>
+    ))}
+    <p className="text-[11px] pt-1" style={{ color: 'hsl(var(--tf-muted))' }}>
+      Structural block order preview. Final rendered artifact is produced at freeze time.
+    </p>
+  </div>
+);
+
+export default TemplateGovernance;

--- a/frontend/apps/os-shell/src/pages/notice/areas/VendorDispatch.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/VendorDispatch.tsx
@@ -1,0 +1,113 @@
+/**
+ * TN-GUI-007 — Vendor Dispatch Console.
+ *
+ * Export bundle, selected provider, dispatch status, delivery-receipt import,
+ * and failures/retries. The fallback county print-shop profile is shown so an
+ * operator can see the configured-but-inactive escape hatch.
+ *
+ * @module pages/notice/areas/VendorDispatch
+ */
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import type { DispatchStatus, NoticeConsoleSnapshot } from '../types';
+import {
+  EmptyState,
+  SectionCard,
+  StatusPill,
+  Table,
+  Td,
+  Th,
+  Tr,
+  formatInt,
+} from '../components/primitives';
+
+function dispatchVariant(s: DispatchStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (s) {
+    case 'delivered':
+      return 'default';
+    case 'in-transit':
+    case 'queued':
+      return 'secondary';
+    case 'failed':
+      return 'destructive';
+    default:
+      return 'outline';
+  }
+}
+
+export const VendorDispatch: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
+  const { dispatches, county } = snapshot;
+  const fallback = county.vendorMappings.find((v) => v.status === 'inactive');
+
+  return (
+    <div className="space-y-5" data-testid="notice-area-vendor-dispatch">
+      <SectionCard
+        title="Dispatch Bundles"
+        chip={<StatusPill label="Ready" variant="default" />}
+      >
+        {dispatches.length === 0 ? (
+          <EmptyState message="No dispatch bundles prepared." />
+        ) : (
+          <Table testId="vendor-dispatch-table">
+            <thead>
+              <Tr>
+                <Th>Bundle</Th>
+                <Th>Provider</Th>
+                <Th>Channel</Th>
+                <Th>Mailing class</Th>
+                <Th className="text-right">Items</Th>
+                <Th className="text-right">Receipts</Th>
+                <Th className="text-right">Failures</Th>
+                <Th className="text-right">Status</Th>
+              </Tr>
+            </thead>
+            <tbody>
+              {dispatches.map((d) => (
+                <Tr key={d.bundleId}>
+                  <Td className="font-mono text-xs">{d.bundleId}</Td>
+                  <Td className="text-sm">{d.provider}</Td>
+                  <Td className="capitalize text-xs">{d.channel}</Td>
+                  <Td className="text-xs">{d.mailingClass}</Td>
+                  <Td className="text-right font-mono">{formatInt(d.itemCount)}</Td>
+                  <Td className="text-right font-mono">{formatInt(d.receiptsImported)}</Td>
+                  <Td className="text-right font-mono" style={{ color: d.failures > 0 ? 'hsl(var(--tf-error))' : undefined }}>
+                    {formatInt(d.failures)}
+                  </Td>
+                  <Td className="text-right">
+                    <StatusPill label={d.status} variant={dispatchVariant(d.status)} />
+                  </Td>
+                </Tr>
+              ))}
+            </tbody>
+          </Table>
+        )}
+        <div className="flex flex-wrap gap-2 mt-4">
+          <Button size="sm" variant="outline">Import Delivery Receipts</Button>
+          <Button size="sm" variant="outline">Retry Failures</Button>
+        </div>
+        <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
+          Sandbox: dispatch actions are inert — no bundle is transmitted to a vendor.
+        </p>
+      </SectionCard>
+
+      <SectionCard title="Fallback Profile">
+        {fallback ? (
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="font-medium">{fallback.vendor}</div>
+              <div className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>
+                Configured for the {fallback.channel} channel; engaged only if the primary vendor fails.
+              </div>
+            </div>
+            <StatusPill label="Configured · inactive" variant="outline" />
+          </div>
+        ) : (
+          <EmptyState message="No fallback dispatch profile configured." />
+        )}
+      </SectionCard>
+    </div>
+  );
+};
+
+export default VendorDispatch;

--- a/frontend/apps/os-shell/src/pages/notice/areas/VendorDispatch.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/areas/VendorDispatch.tsx
@@ -39,6 +39,9 @@ function dispatchVariant(s: DispatchStatus): 'default' | 'secondary' | 'destruct
 export const VendorDispatch: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ snapshot }) => {
   const { dispatches, county } = snapshot;
   const fallback = county.vendorMappings.find((v) => v.status === 'inactive');
+  // Dispatch actions only operate against a live backend; disabled in sandbox
+  // so an enabled control never implies an action that won't run.
+  const inert = snapshot.source !== 'live';
 
   return (
     <div className="space-y-5" data-testid="notice-area-vendor-dispatch">
@@ -83,8 +86,8 @@ export const VendorDispatch: React.FC<{ snapshot: NoticeConsoleSnapshot }> = ({ 
           </Table>
         )}
         <div className="flex flex-wrap gap-2 mt-4">
-          <Button size="sm" variant="outline">Import Delivery Receipts</Button>
-          <Button size="sm" variant="outline">Retry Failures</Button>
+          <Button size="sm" variant="outline" disabled={inert}>Import Delivery Receipts</Button>
+          <Button size="sm" variant="outline" disabled={inert}>Retry Failures</Button>
         </div>
         <p className="text-[11px] mt-3" style={{ color: 'hsl(var(--tf-muted))' }}>
           Sandbox: dispatch actions are inert — no bundle is transmitted to a vendor.

--- a/frontend/apps/os-shell/src/pages/notice/components/primitives.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/components/primitives.tsx
@@ -1,0 +1,201 @@
+/**
+ * TerraNotice Ops Console — shared presentational primitives.
+ *
+ * These keep the twelve area screens terse and visually consistent. They are
+ * pure (token-driven, no fabricated data of their own) and reuse the shell's
+ * shadcn/Radix UI components where a primitive already exists.
+ *
+ * @module pages/notice/components/primitives
+ */
+
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { ApprovalStatus, TimelineStep } from '../types';
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+export function formatInt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+export function formatPct(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// KPI tile
+// ---------------------------------------------------------------------------
+
+interface KpiTileProps {
+  label: string;
+  value: string;
+  note?: string;
+  /** Token name (without var()), e.g. '--tf-accent'. Drives the value color. */
+  accentVar?: string;
+  testId?: string;
+}
+
+export const KpiTile: React.FC<KpiTileProps> = ({
+  label,
+  value,
+  note,
+  accentVar = '--tf-accent',
+  testId,
+}) => (
+  <Card data-testid={testId} className="overflow-hidden">
+    <CardContent className="p-4">
+      <div className="text-xs uppercase tracking-wide" style={{ color: 'hsl(var(--tf-muted))' }}>
+        {label}
+      </div>
+      <div className="text-3xl font-semibold mt-1" style={{ color: `hsl(var(${accentVar}))` }}>
+        {value}
+      </div>
+      {note && (
+        <div className="text-xs mt-1.5" style={{ color: 'hsl(var(--tf-muted))' }}>
+          {note}
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+// ---------------------------------------------------------------------------
+// Section card — a titled panel with an optional right-aligned status chip
+// ---------------------------------------------------------------------------
+
+interface SectionCardProps {
+  title: string;
+  chip?: React.ReactNode;
+  children: React.ReactNode;
+  testId?: string;
+}
+
+export const SectionCard: React.FC<SectionCardProps> = ({ title, chip, children, testId }) => (
+  <Card data-testid={testId}>
+    <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+      <CardTitle className="text-base">{title}</CardTitle>
+      {chip}
+    </CardHeader>
+    <CardContent>{children}</CardContent>
+  </Card>
+);
+
+// ---------------------------------------------------------------------------
+// Status pill — maps governance statuses to the canonical Badge variants
+// ---------------------------------------------------------------------------
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+export function approvalVariant(status: ApprovalStatus): BadgeVariant {
+  switch (status) {
+    case 'approved':
+      return 'default';
+    case 'pending':
+      return 'secondary';
+    case 'rejected':
+      return 'destructive';
+    default:
+      return 'outline';
+  }
+}
+
+interface StatusPillProps {
+  label: string;
+  variant?: BadgeVariant;
+  testId?: string;
+}
+
+export const StatusPill: React.FC<StatusPillProps> = ({ label, variant = 'outline', testId }) => (
+  <Badge data-testid={testId} variant={variant}>
+    {label}
+  </Badge>
+);
+
+// ---------------------------------------------------------------------------
+// Governance timeline — the lifecycle trace shown on the Command Center
+// ---------------------------------------------------------------------------
+
+const TIMELINE_DOT: Record<TimelineStep['state'], string> = {
+  done: '--tf-success',
+  active: '--tf-warning',
+  pending: '--tf-muted',
+};
+
+export const GovernanceTimeline: React.FC<{ steps: TimelineStep[] }> = ({ steps }) => (
+  <ol className="space-y-3" data-testid="notice-governance-timeline">
+    {steps.map((step, i) => {
+      const dot = TIMELINE_DOT[step.state];
+      return (
+        <li key={step.label} className="flex items-start gap-3">
+          <div className="flex flex-col items-center">
+            <span
+              className={`w-2.5 h-2.5 rounded-full ${step.state === 'active' ? 'animate-pulse' : ''}`}
+              style={{ background: `hsl(var(${dot}))`, boxShadow: `0 0 8px hsl(var(${dot}) / 0.5)` }}
+            />
+            {i < steps.length - 1 && (
+              <span className="w-px flex-1 mt-1" style={{ minHeight: 18, background: 'hsl(var(--tf-border) / 0.4)' }} />
+            )}
+          </div>
+          <div className="flex-1 -mt-0.5">
+            <div
+              className="text-sm"
+              style={{ color: step.state === 'pending' ? 'hsl(var(--tf-muted))' : 'hsl(var(--tf-fg))' }}
+            >
+              {step.label}
+            </div>
+            <div className="text-xs" style={{ color: 'hsl(var(--tf-muted))' }}>
+              {step.at}
+            </div>
+          </div>
+        </li>
+      );
+    })}
+  </ol>
+);
+
+// ---------------------------------------------------------------------------
+// Lightweight data table — thead/tbody styled to match the shell tables
+// ---------------------------------------------------------------------------
+
+export const Table: React.FC<{ children: React.ReactNode; testId?: string }> = ({ children, testId }) => (
+  <table data-testid={testId} className="w-full text-sm">
+    {children}
+  </table>
+);
+
+export const Th: React.FC<{ children?: React.ReactNode; className?: string }> = ({ children, className = '' }) => (
+  <th className={`py-2 font-medium text-left ${className}`} style={{ color: 'hsl(var(--tf-muted))' }}>
+    {children}
+  </th>
+);
+
+export const Tr: React.FC<{ children: React.ReactNode; onClick?: () => void; interactive?: boolean }> = ({
+  children,
+  onClick,
+  interactive,
+}) => (
+  <tr
+    onClick={onClick}
+    className={interactive ? 'hover:bg-white/5 cursor-pointer' : ''}
+    style={{ borderBottom: '1px solid hsl(var(--tf-border) / 0.15)' }}
+  >
+    {children}
+  </tr>
+);
+
+export const Td: React.FC<{ children?: React.ReactNode; className?: string }> = ({ children, className = '' }) => (
+  <td className={`py-2 ${className}`}>{children}</td>
+);
+
+// ---------------------------------------------------------------------------
+// Empty / unavailable state — used when a real backend returns nothing
+// ---------------------------------------------------------------------------
+
+export const EmptyState: React.FC<{ message: string }> = ({ message }) => (
+  <div className="py-8 text-center text-sm" style={{ color: 'hsl(var(--tf-muted))' }}>
+    {message}
+  </div>
+);

--- a/frontend/apps/os-shell/src/pages/notice/components/primitives.tsx
+++ b/frontend/apps/os-shell/src/pages/notice/components/primitives.tsx
@@ -179,7 +179,7 @@ export const Tr: React.FC<{ children: React.ReactNode; onClick?: () => void; int
 }) => (
   <tr
     onClick={onClick}
-    className={interactive ? 'hover:bg-white/5 cursor-pointer' : ''}
+    className={interactive ? 'hover:bg-[hsl(var(--tf-text)_/_0.06)] cursor-pointer' : ''}
     style={{ borderBottom: '1px solid hsl(var(--tf-border) / 0.15)' }}
   >
     {children}

--- a/frontend/apps/os-shell/src/pages/notice/fixtures/sandboxData.ts
+++ b/frontend/apps/os-shell/src/pages/notice/fixtures/sandboxData.ts
@@ -1,0 +1,205 @@
+/**
+ * TerraNotice Ops Console — sandbox fixtures.
+ *
+ * HONESTY CONTRACT: every value here is demonstration data for the
+ * "County Sandbox" environment. It is NOT live Benton County notice data and
+ * is NOT connected to any county production system. The console surfaces this
+ * through a persistent sandbox ribbon and `source: 'sandbox'`. When a real
+ * TerraNotice backend exists, replace `getNoticeConsoleSnapshot` with a fetch
+ * against it and flip `source` to 'live' (or 'unavailable' on error) — the
+ * screens are agnostic to where the snapshot comes from.
+ *
+ * @module pages/notice/fixtures/sandboxData
+ */
+
+import type { NoticeConsoleSnapshot } from '../types';
+
+export const SANDBOX_SNAPSHOT: NoticeConsoleSnapshot = {
+  source: 'sandbox',
+
+  county: {
+    countyName: 'Benton County',
+    program: 'Valuation Notice Program',
+    taxYear: 2026,
+    environment: 'County Sandbox',
+    brandingLocked: true,
+    approvalChain: ['Operations Staff', 'Legal / Compliance', 'Assessor / Admin'],
+    languageDefaults: ['English (en-US)', 'Spanish (es-US)'],
+    accessibilityDefaults: ['WCAG 2.1 AA', 'Large-print on request', 'Plain-language summary'],
+    deliveryRules: [
+      { label: 'Release timing', value: 'Statutory window — WA-2026.1' },
+      { label: 'Certified-mail escalation', value: 'Value change > 25%' },
+      { label: 'Holiday adjustment', value: 'Next business day' },
+      { label: 'Release waves', value: '3 waves, 48h apart' },
+    ],
+    vendorMappings: [
+      { channel: 'mail', vendor: 'Print Vendor Contract', status: 'active' },
+      { channel: 'certified', vendor: 'USPS Certified', status: 'active' },
+      { channel: 'print', vendor: 'County Print Shop (fallback)', status: 'inactive' },
+    ],
+    runtimeOverrides: [
+      { label: 'Branding', value: 'County seal + assessor signature', withinBounds: true },
+      { label: 'Release waves', value: 'Override: 3 → 2 waves', withinBounds: true },
+      { label: 'Accessibility default', value: 'Add audio summary', withinBounds: true },
+      { label: 'Approval chain', value: 'Skip legal (requested)', withinBounds: false },
+    ],
+  },
+
+  kpis: {
+    activeBatches: 4,
+    activeBatchesNote: '1 awaiting legal approval',
+    noticesPrepared: 38421,
+    validationPassRate: 0.992,
+    openExceptions: 127,
+    highRiskExceptions: 23,
+    auditReadiness: 0.96,
+    auditReadinessNote: 'Missing 2 approval attestations',
+  },
+
+  batches: [
+    { batchId: 'BN-VAL-2026-W1', status: 'validated', notices: 12840, policyVersion: 'WA-2026.1', templateVersion: 'VAL-3.4', program: 'Valuation Notice' },
+    { batchId: 'BN-VAL-2026-W2', status: 'legal-review', notices: 9210, policyVersion: 'WA-2026.1', templateVersion: 'VAL-3.4', program: 'Valuation Notice' },
+    { batchId: 'BN-EXM-2026-A', status: 'draft', notices: 2144, policyVersion: 'WA-2026.1', templateVersion: 'EXM-1.8', program: 'Exemption Notice' },
+    { batchId: 'BN-VAL-2026-W3', status: 'draft', notices: 14227, policyVersion: 'WA-2026.1', templateVersion: 'VAL-3.4', program: 'Valuation Notice' },
+  ],
+
+  timeline: [
+    { label: 'Policy pack selected', state: 'done', at: '08:12' },
+    { label: 'Template version locked', state: 'done', at: '08:18' },
+    { label: 'Parcel snapshot created', state: 'done', at: '08:31' },
+    { label: 'Legal approval', state: 'active', at: 'Now' },
+    { label: 'Freeze snapshot', state: 'pending', at: '—' },
+    { label: 'Vendor dispatch', state: 'pending', at: '—' },
+  ],
+
+  policyPacks: [
+    {
+      packId: 'WA-2026.1',
+      label: 'Washington State Baseline 2026.1',
+      approval: 'approved',
+      effectiveDate: '2026-01-01',
+      rules: [
+        { ruleId: 'WA-APP-WIN', title: 'Appeal window (60 days from notice date)', source: 'state-baseline', effectiveDate: '2026-01-01', testStatus: 'pass', approval: 'approved' },
+        { ruleId: 'WA-REL-TIME', title: 'Release timing within statutory window', source: 'state-baseline', effectiveDate: '2026-01-01', testStatus: 'pass', approval: 'approved' },
+        { ruleId: 'WA-HOL-ADJ', title: 'Holiday adjustment rule', source: 'state-baseline', effectiveDate: '2026-01-01', testStatus: 'pass', approval: 'approved' },
+        { ruleId: 'BN-CERT-ESC', title: 'Certified-mail escalation on value change > 25%', source: 'county-override', effectiveDate: '2026-02-01', testStatus: 'pass', approval: 'approved' },
+        { ruleId: 'BN-WAVE', title: 'Release wave override (county-bounded)', source: 'county-override', effectiveDate: '2026-02-01', testStatus: 'untested', approval: 'pending' },
+      ],
+    },
+  ],
+
+  templateBlocks: [
+    { blockId: 'BLK-HDR', name: 'Header / County seal', kind: 'layout', legalControlled: false, lifecycle: 'approved' },
+    { blockId: 'BLK-LEGAL', name: 'Legal disclosure', kind: 'legal', legalControlled: true, lifecycle: 'approved' },
+    { blockId: 'BLK-VALUE', name: 'Value summary', kind: 'layout', legalControlled: false, lifecycle: 'approved' },
+    { blockId: 'BLK-APPEAL', name: 'Appeal rights', kind: 'legal', legalControlled: true, lifecycle: 'approved' },
+    { blockId: 'BLK-QR', name: 'QR portal block', kind: 'layout', legalControlled: false, lifecycle: 'approved' },
+    { blockId: 'BLK-FOOT', name: 'Footer metadata', kind: 'metadata', legalControlled: false, lifecycle: 'approved' },
+    { blockId: 'BLK-PLAIN', name: 'Plain-language explanation', kind: 'plain-language', legalControlled: false, lifecycle: 'in-review' },
+  ],
+
+  templateAssemblies: [
+    {
+      templateId: 'VAL',
+      version: '3.4',
+      lifecycle: 'approved',
+      legalApproval: 'approved',
+      blocks: ['Header / County seal', 'Legal disclosure', 'Value summary', 'Appeal rights', 'QR portal block', 'Footer metadata'],
+      previousVersion: '3.3',
+    },
+    {
+      templateId: 'VAL',
+      version: '3.5-draft',
+      lifecycle: 'in-review',
+      legalApproval: 'pending',
+      blocks: ['Header / County seal', 'Legal disclosure', 'Value summary', 'Appeal rights', 'QR portal block', 'Plain-language explanation', 'Footer metadata'],
+      previousVersion: '3.4',
+    },
+    {
+      templateId: 'EXM',
+      version: '1.8',
+      lifecycle: 'approved',
+      legalApproval: 'approved',
+      blocks: ['Header / County seal', 'Legal disclosure', 'Appeal rights', 'Footer metadata'],
+      previousVersion: '1.7',
+    },
+  ],
+
+  freezeSnapshots: [
+    {
+      snapshotId: 'SNAP-BN-VAL-2026-W1',
+      batchId: 'BN-VAL-2026-W1',
+      parcelCount: 12840,
+      legalTextVersion: 'LEGAL-WA-2026.1',
+      templateVersion: 'VAL-3.4',
+      policyVersion: 'WA-2026.1',
+      countyConfigVersion: 'BN-CFG-2026.02',
+      artifactHash: 'sha256:9f2a…c41e',
+      frozenAt: '2026-06-12 08:31 PT',
+      frozenBy: 'operations.staff@benton.example',
+    },
+  ],
+
+  dispatches: [
+    { bundleId: 'BNDL-W1-MAIL', batchId: 'BN-VAL-2026-W1', provider: 'Print Vendor Contract', channel: 'mail', mailingClass: 'First-Class', status: 'ready', itemCount: 12840, receiptsImported: 0, failures: 0 },
+    { bundleId: 'BNDL-W1-CERT', batchId: 'BN-VAL-2026-W1', provider: 'USPS Certified', channel: 'certified', mailingClass: 'Certified', status: 'queued', itemCount: 318, receiptsImported: 0, failures: 0 },
+  ],
+
+  exceptions: [
+    { category: 'invalid-address', label: 'Invalid Address', count: 44, action: 'Address confirmation queue', highRisk: false },
+    { category: 'vendor-rejection', label: 'Vendor Rejection', count: 8, action: 'Re-export required', highRisk: true },
+    { category: 'certified-mismatch', label: 'Certified Mismatch', count: 3, action: 'Compliance review', highRisk: true },
+    { category: 'missing-insert', label: 'Missing Insert', count: 0, action: 'Insert package check', highRisk: false },
+    { category: 'policy-template-conflict', label: 'Policy / Template Conflict', count: 0, action: 'Governance review', highRisk: false },
+    { category: 'citizen-followup', label: 'Citizen Follow-up', count: 72, action: 'Staff task queue', highRisk: false },
+  ],
+
+  telemetry: [
+    { key: 'issued', label: 'Notices issued', value: 38421, delta: '+38,421' },
+    { key: 'delivered', label: 'Delivered', value: 0, delta: 'pending dispatch' },
+    { key: 'returned', label: 'Returned', value: 0 },
+    { key: 'reissued', label: 'Reissued', value: 0 },
+    { key: 'call-surge', label: 'Call-surge proxy', value: 0, unit: 'index' },
+    { key: 'qr-scans', label: 'QR scans', value: 0 },
+    { key: 'portal-engagement', label: 'Portal engagement', value: 0, unit: '%' },
+    { key: 'exception-time', label: 'Exception handling time', value: 0, unit: 'h avg' },
+  ],
+
+  auditBundles: [
+    {
+      bundleId: 'EV-BN-VAL-2026-W1',
+      batchId: 'BN-VAL-2026-W1',
+      sealed: false,
+      bindings: [
+        { label: 'Template version', value: 'VAL-3.4' },
+        { label: 'Policy version', value: 'WA-2026.1' },
+        { label: 'County config version', value: 'BN-CFG-2026.02' },
+        { label: 'Parcel / data snapshot', value: 'SNAP-BN-VAL-2026-W1' },
+        { label: 'Artifact hash', value: 'sha256:9f2a…c41e' },
+        { label: 'Approval trace', value: '2 of 3 attestations' },
+        { label: 'Dispatch receipt', value: 'pending' },
+      ],
+    },
+  ],
+
+  releases: [
+    {
+      releaseId: 'REL-2026.06',
+      environment: 'County Sandbox',
+      health: 'degraded',
+      policyPack: 'WA-2026.1',
+      templateSet: 'VAL-3.4 / EXM-1.8',
+      attestationsComplete: 4,
+      attestationsRequired: 6,
+      deployedAt: '2026-06-12 07:55 PT',
+    },
+  ],
+};
+
+/**
+ * Returns the console snapshot. Today this is synchronous sandbox data; the
+ * async signature is intentional so a backend fetch can slot in unchanged.
+ */
+export async function getNoticeConsoleSnapshot(): Promise<NoticeConsoleSnapshot> {
+  return SANDBOX_SNAPSHOT;
+}

--- a/frontend/apps/os-shell/src/pages/notice/types.ts
+++ b/frontend/apps/os-shell/src/pages/notice/types.ts
@@ -1,0 +1,268 @@
+/**
+ * TerraNotice Ops Console — shared types.
+ *
+ * TerraNotice is the governed control surface for civic notice legality,
+ * delivery, explanation, and proof. This file types every data shape the
+ * console renders. All console screens read from a single service surface
+ * (today: sandbox fixtures, see ./data/sandboxData) so a real backend can be
+ * dropped in without touching the screens.
+ *
+ * @module pages/notice/types
+ */
+
+/**
+ * Where the data on screen came from. Drives the honesty ribbon: the console
+ * never presents sandbox fixtures as live county production data.
+ */
+export type NoticeDataSource = 'sandbox' | 'live' | 'unavailable';
+
+/** The twelve console areas (left-rail navigation). */
+export type ConsoleAreaId =
+  | 'command-center'
+  | 'county-configuration'
+  | 'policy-packs'
+  | 'template-governance'
+  | 'batch-operations'
+  | 'freeze-snapshots'
+  | 'vendor-dispatch'
+  | 'returned-mail'
+  | 'citizen-portal'
+  | 'telemetry'
+  | 'audit-vault'
+  | 'release-console';
+
+/** Operator role — drives which areas are emphasized / actionable. */
+export type OperatorRole =
+  | 'assessor-admin'
+  | 'operations'
+  | 'legal-compliance'
+  | 'it-admin'
+  | 'public-comms';
+
+// ---------------------------------------------------------------------------
+// Command Center
+// ---------------------------------------------------------------------------
+
+export interface KpiSummary {
+  activeBatches: number;
+  activeBatchesNote: string;
+  noticesPrepared: number;
+  validationPassRate: number; // 0..1
+  openExceptions: number;
+  highRiskExceptions: number;
+  auditReadiness: number; // 0..1
+  auditReadinessNote: string;
+}
+
+export type BatchStatus =
+  | 'draft'
+  | 'validated'
+  | 'legal-review'
+  | 'frozen'
+  | 'dispatched'
+  | 'failed';
+
+export interface BatchRow {
+  batchId: string;
+  status: BatchStatus;
+  notices: number;
+  policyVersion: string;
+  templateVersion: string;
+  program: string;
+}
+
+export type TimelineState = 'done' | 'active' | 'pending';
+
+export interface TimelineStep {
+  label: string;
+  state: TimelineState;
+  /** Human time / relative marker. Empty for not-yet-reached steps. */
+  at: string;
+}
+
+// ---------------------------------------------------------------------------
+// County Configuration
+// ---------------------------------------------------------------------------
+
+export interface CountyProfile {
+  countyName: string;
+  program: string;
+  taxYear: number;
+  environment: string;
+  brandingLocked: boolean;
+  approvalChain: string[];
+  languageDefaults: string[];
+  accessibilityDefaults: string[];
+  deliveryRules: { label: string; value: string }[];
+  vendorMappings: { channel: string; vendor: string; status: 'active' | 'inactive' }[];
+  runtimeOverrides: { label: string; value: string; withinBounds: boolean }[];
+}
+
+// ---------------------------------------------------------------------------
+// Policy Packs
+// ---------------------------------------------------------------------------
+
+export type ApprovalStatus = 'approved' | 'pending' | 'rejected' | 'draft';
+
+export interface PolicyRule {
+  ruleId: string;
+  title: string;
+  source: 'state-baseline' | 'county-override';
+  effectiveDate: string;
+  testStatus: 'pass' | 'fail' | 'untested';
+  approval: ApprovalStatus;
+}
+
+export interface PolicyPack {
+  packId: string;
+  label: string;
+  approval: ApprovalStatus;
+  effectiveDate: string;
+  rules: PolicyRule[];
+}
+
+// ---------------------------------------------------------------------------
+// Template Governance
+// ---------------------------------------------------------------------------
+
+export type LifecycleState = 'draft' | 'in-review' | 'approved' | 'retired';
+
+export interface TemplateBlock {
+  blockId: string;
+  name: string;
+  kind: 'legal' | 'plain-language' | 'layout' | 'metadata';
+  /** Legal text blocks are immutable once approved. */
+  legalControlled: boolean;
+  lifecycle: LifecycleState;
+}
+
+export interface TemplateAssembly {
+  templateId: string;
+  version: string;
+  lifecycle: LifecycleState;
+  legalApproval: ApprovalStatus;
+  blocks: string[]; // block names
+  previousVersion?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Freeze Snapshots
+// ---------------------------------------------------------------------------
+
+export interface FreezeSnapshot {
+  snapshotId: string;
+  batchId: string;
+  parcelCount: number;
+  legalTextVersion: string;
+  templateVersion: string;
+  policyVersion: string;
+  countyConfigVersion: string;
+  artifactHash: string;
+  frozenAt: string;
+  frozenBy: string;
+}
+
+// ---------------------------------------------------------------------------
+// Vendor Dispatch
+// ---------------------------------------------------------------------------
+
+export type DispatchStatus = 'ready' | 'queued' | 'in-transit' | 'delivered' | 'failed';
+
+export interface VendorDispatchRecord {
+  bundleId: string;
+  batchId: string;
+  provider: string;
+  channel: 'mail' | 'print' | 'certified';
+  mailingClass: string;
+  status: DispatchStatus;
+  itemCount: number;
+  receiptsImported: number;
+  failures: number;
+}
+
+// ---------------------------------------------------------------------------
+// Returned Mail / Exceptions
+// ---------------------------------------------------------------------------
+
+export type ExceptionCategory =
+  | 'invalid-address'
+  | 'vendor-rejection'
+  | 'certified-mismatch'
+  | 'missing-insert'
+  | 'policy-template-conflict'
+  | 'citizen-followup';
+
+export interface ExceptionRow {
+  category: ExceptionCategory;
+  label: string;
+  count: number;
+  action: string;
+  highRisk: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry
+// ---------------------------------------------------------------------------
+
+export interface TelemetryMetric {
+  key: string;
+  label: string;
+  value: number;
+  unit?: string;
+  /** Optional delta vs prior period, e.g. "+4%". */
+  delta?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Audit Vault
+// ---------------------------------------------------------------------------
+
+export interface AuditBinding {
+  label: string;
+  value: string;
+}
+
+export interface AuditEvidenceBundle {
+  bundleId: string;
+  batchId: string;
+  sealed: boolean;
+  bindings: AuditBinding[];
+}
+
+// ---------------------------------------------------------------------------
+// Release & Deployment
+// ---------------------------------------------------------------------------
+
+export type ReleaseHealth = 'healthy' | 'degraded' | 'blocked';
+
+export interface ReleaseManifest {
+  releaseId: string;
+  environment: string;
+  health: ReleaseHealth;
+  policyPack: string;
+  templateSet: string;
+  attestationsComplete: number;
+  attestationsRequired: number;
+  deployedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate console snapshot
+// ---------------------------------------------------------------------------
+
+export interface NoticeConsoleSnapshot {
+  source: NoticeDataSource;
+  county: CountyProfile;
+  kpis: KpiSummary;
+  batches: BatchRow[];
+  timeline: TimelineStep[];
+  policyPacks: PolicyPack[];
+  templateBlocks: TemplateBlock[];
+  templateAssemblies: TemplateAssembly[];
+  freezeSnapshots: FreezeSnapshot[];
+  dispatches: VendorDispatchRecord[];
+  exceptions: ExceptionRow[];
+  telemetry: TelemetryMetric[];
+  auditBundles: AuditEvidenceBundle[];
+  releases: ReleaseManifest[];
+}

--- a/frontend/apps/os-shell/src/pages/notice/types.ts
+++ b/frontend/apps/os-shell/src/pages/notice/types.ts
@@ -4,7 +4,7 @@
  * TerraNotice is the governed control surface for civic notice legality,
  * delivery, explanation, and proof. This file types every data shape the
  * console renders. All console screens read from a single service surface
- * (today: sandbox fixtures, see ./data/sandboxData) so a real backend can be
+ * (today: sandbox fixtures, see ./fixtures/sandboxData) so a real backend can be
  * dropped in without touching the screens.
  *
  * @module pages/notice/types

--- a/frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/DaisSuiteHome.tsx
@@ -92,7 +92,7 @@ const DAIS_MODULES: SuiteModuleDef[] = [
   { id: 'management-dashboard', label: 'Management', icon: LayoutDashboard, description: 'Assessor operations — certification, workload, staff metrics with visible source labeling', launchMode: 'standalone', moduleId: 'management-dashboard' },
   { id: 'terra-queue', label: 'TerraQueue', icon: ClipboardList, description: 'Cross-parcel work queue — assignment, progress, quality review', launchMode: 'standalone', moduleId: 'terra-queue', truthState: 'queued' },
   { id: 'terra-cert', label: 'TerraCert', icon: FileCheck, description: 'Roll sign-off, statutory export, and certification operations', launchMode: 'standalone', moduleId: 'terra-cert', truthState: 'queued' },
-  { id: 'terra-notice', label: 'TerraNotice', icon: Mail, description: 'Batch notice dispatch — mail/print queue and delivery tracking', launchMode: 'standalone', moduleId: 'terra-notice', truthState: 'queued' },
+  { id: 'terra-notice', label: 'TerraNotice', icon: Mail, description: 'Governed civic communications console — policy, templates, batches, freeze, dispatch, audit', launchMode: 'standalone', moduleId: 'terra-notice', truthState: 'live' },
 ];
 
 const fmtNum = (n: number | undefined | null) => (n != null ? n.toLocaleString() : '—');


### PR DESCRIPTION
## TerraNotice GUI — the operator console

The DevOps package shipped backend gates but no operator surface. This adds the missing **GUI**: TerraNotice graduates from a `QueuedModuleSurface` stub into a real **governed control surface for civic notice legality, delivery, explanation, and proof** — an air-traffic-control system for civic communications, *not* a mail-merge tool.

It launches from **TerraDais → TerraNotice** (module id `terra-notice`) as an OS-native console window.

### Console areas (TN-GUI-001..010), 12 areas behind a left-rail shell
| Area | What it does |
|------|--------------|
| **Command Center** | KPI tiles, batch lifecycle table, governance timeline, at-a-glance status |
| **County Configuration** | Branding, approval hierarchy, language/accessibility defaults, delivery rules, vendor mappings, runtime overrides with **within-bounds guardrail flagging** |
| **Policy Pack Manager** | State baseline + county overrides, effective dates, rule-test status, approval |
| **Template Governance** | Block library (legal-controlled blocks flagged), assemblies, **version diff**, render preview |
| **Batch Workspace** | Approval checklist + **gated** freeze/release (validation + checklist required) + status timeline |
| **Freeze Snapshot Viewer** | Immutable binding: parcel snapshot, legal text, template, policy, county-config versions + artifact hash |
| **Vendor Dispatch** | Export bundles, providers, mailing class, receipts, failures/retries, fallback profile |
| **Returned Mail / Exceptions** | Categorized exception queue (bad address, vendor rejection, certified mismatch, …) + reissue workflow |
| **Citizen Portal Preview** | QR landing, plain-language explanation, parcel summary, appeal guidance, language + high-contrast toggle |
| **Telemetry / Risk** | Issue→deliver→return→reissue funnel + metrics |
| **Audit Evidence Vault** | Evidence-bundle bindings + release-manifest export |
| **Release & Deployment** | Release health + attestation completeness |

### Honesty by construction
Every screen reads a single `NoticeConsoleSnapshot`. Today that snapshot is **clearly-labeled County Sandbox demonstration data** (`source: 'sandbox'`) behind a persistent ribbon, and write-style actions (freeze / dispatch / reissue / export) are **inert**. The service is async-shaped so a real TerraNotice backend can replace the fixtures and flip `source` to `'live'` **without touching any screen**. Telemetry delivery metrics stay at honest zeros until dispatch begins rather than being fabricated. This follows the repo's `QueuedModuleSurface` / `ui-honesty-pass` doctrine — a **governed console, not a fake backend**.

### Wiring
- `moduleComponents.tsx`: lazy `TerraNoticeConsole`, `MODULE_ENTRY`, switch case (replaces the queued stub)
- `DaisSuiteHome.tsx`: `terra-notice` `truthState` `queued` → `live`
- `moduleRegistryConsistency.test.ts`: `terra-notice` graduated out of the known-placeholder set
- New contract test: shell render, sandbox ribbon, all 12 areas present, area switching

### Files
- `frontend/apps/os-shell/src/pages/notice/` — `TerraNoticeConsole.tsx`, `types.ts`, `fixtures/sandboxData.ts`, `components/primitives.tsx`, `areas/*.tsx` (12)
- `frontend/apps/os-shell/src/__tests__/notice/terraNoticeConsole.contract.test.tsx`

Built to repo conventions: `@/components/ui/*` (Card/Button/Badge), TerraFusion HSL design tokens (`hsl(var(--tf-*))`), lucide icons, React 18 + lazy/Suspense.

### Verification — CI green on the authoritative toolchain
The full toolchain ran end-to-end in CI (SHA `2d6f39052`):
- **Vitest Full Suite (merge gate): ✅** — contract test + whole suite pass
- **Frontend Build: ✅** · **Build & Package: ✅** · **TerraFusion Seal Gate: ✅**
- **Backend .NET Tests: ✅** · **Security & Vulnerability Scan: ✅** · Quality/Warning/drift/manifest guards all ✅

> Note: an earlier revision placed the sandbox fixture under a gitignored `data/` directory, which broke the production `vite build`. Fixed by relocating it to `fixtures/sandboxData.ts`.

### Follow-up (post-merge, not in this PR) — TN-001 Domain Layer
TerraNotice GUI v1 is the correct first slice (governed console over a snapshot seam). The next meaningful work is domain infrastructure, after which the GUI becomes operational rather than demonstrational:
`NoticeProgram`, `PolicyPack`, `TemplateVersion`, `BatchRun`, `FreezeSnapshot`, `DeliveryProvider`. The snapshot/service seam is already in place to consume them.

https://claude.ai/code/session_013gDganvC3mewFdM9udrJ1U