### PR TITLE
fix(release): restore production deploy startup

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -68,6 +68,14 @@ jobs:
             sed -i 's|dotnet restore TerraFusion\.sln|dotnet restore src/TerraFusion.API/TerraFusion.API.csproj|g' backend/Dockerfile
           fi
 
+          if grep -q 'TerraFusion.AuthProvisioner' backend/Dockerfile && [ ! -d backend/tools/TerraFusion.AuthProvisioner ]; then
+            echo "Patching Dockerfile: target SHA has no AuthProvisioner tool"
+            sed -i '/COPY tools\/TerraFusion\.AuthProvisioner/d' backend/Dockerfile
+            sed -i '/RUN dotnet restore tools\/TerraFusion\.AuthProvisioner/d' backend/Dockerfile
+            sed -i '/RUN dotnet publish tools\/TerraFusion\.AuthProvisioner/,/--verbosity minimal/d' backend/Dockerfile
+            sed -i '/COPY --from=build \/app\/auth-provisioner/d' backend/Dockerfile
+          fi
+
       - name: Validate environment configuration
         shell: bash
         run: |

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -64,10 +64,13 @@ static string ResolveApiContentRoot()
     var envOverride = Environment.GetEnvironmentVariable("TERRAFUSION_API_CONTENT_ROOT")
                    ?? Environment.GetEnvironmentVariable("ASPNETCORE_CONTENTROOT");
     if (!string.IsNullOrWhiteSpace(envOverride) &&
-        File.Exists(Path.Combine(envOverride, "TerraFusion.API.csproj")) &&
         File.Exists(Path.Combine(envOverride, "appsettings.json")))
     {
-        return Path.GetFullPath(envOverride);
+        if (File.Exists(Path.Combine(envOverride, "TerraFusion.API.csproj")) ||
+            File.Exists(Path.Combine(envOverride, "TerraFusion.API.dll")))
+        {
+            return Path.GetFullPath(envOverride);
+        }
     }
 
     var candidateStarts = new[]
@@ -84,6 +87,12 @@ static string ResolveApiContentRoot()
         foreach (var probe in EnumerateSelfAndAncestors(candidate))
         {
             if (File.Exists(Path.Combine(probe, "TerraFusion.API.csproj")) &&
+                File.Exists(Path.Combine(probe, "appsettings.json")))
+            {
+                return probe;
+            }
+
+            if (File.Exists(Path.Combine(probe, "TerraFusion.API.dll")) &&
                 File.Exists(Path.Combine(probe, "appsettings.json")))
             {
                 return probe;


### PR DESCRIPTION
Phase 6 production deploy exposed two release blockers after #990 landed:

- release-lane overlays backend/Dockerfile from main, which expects backend/tools/TerraFusion.AuthProvisioner on SHAs that do not contain it
- published production containers run from /app and need Program.cs to accept the published content root layout

This PR:
- keeps the product target unchanged except for the published content-root startup fix
- patches release-lane only when the target SHA lacks AuthProvisioner
- does not mutate DB
- does not change Hostinger secrets
- does not change Workbench, Forge, Counties, or Home behavior

Verification run locally:
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

Production deploy evidence:
- release-lane run succeeded for 9e419fc2360a2ee244c4b816ff8b0c7c107869c5
- https://terrafusionmarket.com/health returns X-Release-Sha: 9e419fc2360a2ee244c4b816ff8b0c7c107869c5

Remaining Phase 6 blocker:
- public browser smoke requires production login access; browser currently lands on /login with session expired.