### PR TITLE
fix(auth): restore provisioned production login path

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -37,9 +37,13 @@ jobs:
       PUBLIC_URL: ${{ vars.PUBLIC_URL }}
       APP_ROOT: ${{ vars.APP_ROOT }}
       DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}
+      TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}
+      TF_EXPECTED_JUNE10_DB_NAME: ${{ vars.TF_EXPECTED_JUNE10_DB_NAME }}
+      TF_EXPECTED_JUNE10_DB_PROVIDER: ${{ vars.TF_EXPECTED_JUNE10_DB_PROVIDER }}
     steps:
       - name: Checkout requested SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 0
@@ -50,10 +54,10 @@ jobs:
           set -euo pipefail
           # Deploy infrastructure (Caddyfile, compose template) lives on the default
           # branch and must match the pipeline expectations (service names, health
-          # headers, etc.).  Always overlay from main — old release SHAs may have
-          # incompatible versions (e.g. wrong service names in Caddyfile).
+          # headers, etc.). Build inputs must come from the requested release SHA so
+          # auth/runtime changes cannot be silently replaced by main during deploy.
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
-          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml ops/edge-proxy/Caddyfile ops/edge-proxy/docker-compose.yml frontend/Dockerfile backend/Dockerfile; do
+          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml ops/edge-proxy/Caddyfile ops/edge-proxy/docker-compose.yml; do
             dir="$(dirname "$path")"
             mkdir -p "$dir"
             echo "Overlaying $path from origin/main"
@@ -68,6 +72,11 @@ jobs:
             sed -i 's|dotnet restore TerraFusion\.sln|dotnet restore src/TerraFusion.API/TerraFusion.API.csproj|g' backend/Dockerfile
           fi
 
+          if grep -q 'RUN npx vite build --outDir /app/dist' frontend/Dockerfile; then
+            echo "Patching frontend Dockerfile: raise Node heap for Vite production build"
+            sed -i 's|RUN npx vite build --outDir /app/dist|RUN NODE_OPTIONS="--max-old-space-size=4096" npx vite build --outDir /app/dist|g' frontend/Dockerfile
+          fi
+
       - name: Validate environment configuration
         shell: bash
         run: |
@@ -76,8 +85,10 @@ jobs:
           DEPLOY_PORT="${DEPLOY_PORT:-22}"
           APP_ROOT="${APP_ROOT:-/opt/terrafusion/${TARGET_ENV}}"
           PUBLIC_URL="${PUBLIC_URL%/}"
+          TF_EXPECTED_JUNE10_DB_NAME="${TF_EXPECTED_JUNE10_DB_NAME:-terrafusion.db}"
+          TF_EXPECTED_JUNE10_DB_PROVIDER="${TF_EXPECTED_JUNE10_DB_PROVIDER:-Sqlite}"
 
-          for required in DEPLOY_HOST DEPLOY_USER PUBLIC_URL DEPLOY_SSH_KEY; do
+          for required in DEPLOY_HOST DEPLOY_USER PUBLIC_URL DEPLOY_SSH_KEY TF_PROVISIONED_AUTH_EMAIL TF_PROVISIONED_AUTH_PASSWORD; do
             if [ -z "${!required:-}" ]; then
               echo "Missing required environment configuration: ${required}"
               exit 1
@@ -108,6 +119,8 @@ jobs:
             printf 'FRONTEND_IMAGE=%s\n' "$FRONTEND_IMAGE"
             printf 'DEPLOYED_AT=%s\n' "$DEPLOYED_AT"
             printf 'ASPNETCORE_ENV_LABEL=%s\n' "$ASPNETCORE_ENV_LABEL"
+            printf 'TF_EXPECTED_JUNE10_DB_NAME=%s\n' "$TF_EXPECTED_JUNE10_DB_NAME"
+            printf 'TF_EXPECTED_JUNE10_DB_PROVIDER=%s\n' "$TF_EXPECTED_JUNE10_DB_PROVIDER"
           } >> "$GITHUB_ENV"
 
       - name: Configure SSH key
@@ -178,7 +191,7 @@ jobs:
           exit 1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -190,6 +203,23 @@ jobs:
           set -euo pipefail
           docker build --pull --target runtime -f backend/Dockerfile -t "$BACKEND_IMAGE" backend
           docker push "$BACKEND_IMAGE"
+
+      - name: Reclaim runner disk before frontend image
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Docker disk usage before cleanup:"
+          docker system df || true
+
+          # The backend image is already pushed to GHCR. Hosted runners can run
+          # out of disk when the frontend install/build starts with backend
+          # layers and BuildKit cache still resident.
+          docker image rm "$BACKEND_IMAGE" || true
+          docker builder prune -af || true
+          docker image prune -af || true
+
+          echo "Docker disk usage after cleanup:"
+          docker system df || true
 
       - name: Build and push frontend image
         shell: bash
@@ -207,6 +237,10 @@ jobs:
           cp ops/proxy/Caddyfile runtime/Caddyfile
           cp ops/prod/runtime-compose.template.yml runtime/runtime-compose.yml
           cp -R docs/spec-lock/. runtime/docs/spec-lock/
+          cp sovereign.yaml runtime/sovereign.yaml
+          if ! grep -q './sovereign.yaml:/app/sovereign.yaml:ro' runtime/runtime-compose.yml; then
+            sed -i '/- \.\/docs\/spec-lock:\/app\/docs\/spec-lock:ro/a\      - ./sovereign.yaml:/app/sovereign.yaml:ro' runtime/runtime-compose.yml
+          fi
           sed -i "s/ASPNETCORE_ENVIRONMENT: Production/ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENV_LABEL}/" runtime/runtime-compose.yml
           if [ "$TARGET_ENV" = "staging" ]; then
             cat > runtime/config/appsettings.Staging.json <<'EOF'
@@ -229,6 +263,8 @@ jobs:
           TF_PUBLIC_HOST=${PUBLIC_HOST}
           TF_BACKEND_IMAGE=${BACKEND_IMAGE}
           TF_FRONTEND_IMAGE=${FRONTEND_IMAGE}
+          TF_EXPECTED_JUNE10_DB_NAME=${TF_EXPECTED_JUNE10_DB_NAME}
+          TF_EXPECTED_JUNE10_DB_PROVIDER=${TF_EXPECTED_JUNE10_DB_PROVIDER}
           EOF
 
       - name: Upload runtime bundle to VPS
@@ -236,6 +272,28 @@ jobs:
         run: |
           set -euo pipefail
           scp -P "$DEPLOY_PORT" -r runtime/* "$DEPLOY_USER@$DEPLOY_HOST:$APP_ROOT/"
+
+      - name: Preflight - remote Docker disk cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" bash -s <<'SSH'
+          set -euo pipefail
+          echo "Docker disk before remote cleanup:"
+          docker system df || true
+
+          # Run this while the current app stack is still up. Active release
+          # images remain protected by running containers, while stale release
+          # images and build cache can be reclaimed before edge bootstrap stops
+          # the target stack.
+          docker container prune -f || true
+          docker builder prune -af || true
+          docker image prune -af || true
+
+          echo "Docker disk after remote cleanup:"
+          docker system df || true
+          df -h /
+          SSH
 
       - name: Bootstrap shared edge proxy
         shell: bash
@@ -276,6 +334,13 @@ jobs:
             "docker login ghcr.io -u ${{ github.actor }} --password-stdin" >/dev/null 2>&1
           ssh -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' bash -s" <<'SSH'
           set -euo pipefail
+          available_kb="$(df --output=avail / | tail -1 | tr -d ' ')"
+          if [ "${available_kb:-0}" -lt 4194304 ]; then
+            echo "ERROR: Less than 4 GiB available on / after Docker cleanup; refusing deploy before image pull."
+            df -h /
+            exit 1
+          fi
+
           echo "Pulling backend image..."
           docker pull "$BACKEND_IMAGE"
           echo "Pulling frontend image..."
@@ -358,6 +423,74 @@ jobs:
           probe "/"
           probe "/property"
           echo "Shell route contract intact after deploy"
+
+      - name: Provisioned auth contract smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "=== Provisioned auth contract smoke ==="
+
+          POLICY_JSON="$(curl -fsS --max-time 10 "${PUBLIC_URL}/api/auth/access-policy")"
+          POLICY_JSON="$POLICY_JSON" node <<'NODE'
+          const policy = JSON.parse(process.env.POLICY_JSON || "{}");
+          if (policy.signupMode !== "provisioned_access_only") {
+            throw new Error(`Expected signupMode=provisioned_access_only, got ${policy.signupMode}`);
+          }
+          if (policy.publicSignupEnabled !== false) {
+            throw new Error("Expected publicSignupEnabled=false");
+          }
+          console.log("Access policy is provisioned-access-only");
+          NODE
+
+          LOGIN_PAYLOAD="$(node <<'NODE'
+          process.stdout.write(JSON.stringify({
+            email: process.env.TF_PROVISIONED_AUTH_EMAIL,
+            password: process.env.TF_PROVISIONED_AUTH_PASSWORD
+          }));
+          NODE
+          )"
+
+          LOGIN_RESPONSE=""
+          for attempt in $(seq 1 6); do
+            set +e
+            LOGIN_RESPONSE="$(curl -fsS --max-time 30 \
+              -H 'Content-Type: application/json' \
+              -d "$LOGIN_PAYLOAD" \
+              "${PUBLIC_URL}/api/auth/login" 2>login_error.txt)"
+            rc=$?
+            set -e
+
+            if [ "$rc" -eq 0 ] && [ -n "$LOGIN_RESPONSE" ]; then
+              break
+            fi
+
+            echo "Provisioned auth login smoke attempt ${attempt}/6 failed with curl exit ${rc}."
+            if [ -s login_error.txt ]; then
+              sed 's/^/  curl: /' login_error.txt
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              sleep 10
+            fi
+          done
+
+          if [ -z "$LOGIN_RESPONSE" ]; then
+            echo "Provisioned auth login smoke did not receive a response after retries."
+            exit 1
+          fi
+
+          LOGIN_RESPONSE="$LOGIN_RESPONSE" node <<'NODE'
+          const response = JSON.parse(process.env.LOGIN_RESPONSE || "{}");
+          const token = response.token || response.Token;
+          const email = response.email || response.Email || response.user?.email || response.User?.Email;
+          const roles = response.roles || response.Roles || response.user?.roles || response.User?.Roles || [];
+          if (!token) {
+            throw new Error("Provisioned auth smoke did not receive a token");
+          }
+          if (email !== process.env.TF_PROVISIONED_AUTH_EMAIL) {
+            throw new Error(`Provisioned auth smoke returned unexpected email: ${email}`);
+          }
+          console.log(`Provisioned login returned token for ${email} with ${Array.isArray(roles) ? roles.length : 0} roles`);
+          NODE
 
       - name: Finalize current SHA on VPS
         shell: bash
@@ -443,7 +576,7 @@ jobs:
           done
 
       - name: Upload deploy evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: evidence-${{ inputs.target_env }}-${{ inputs.release_sha }}
           path: evidence/

--- a/backend/src/TerraFusion.API/Controllers/AuthController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AuthController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using TerraFusion.API.Security.Services;
 using TerraFusion.Core.Services;
 using TerraFusion.Core.DTOs;
 
@@ -14,15 +16,18 @@ public class AuthController : ControllerBase
 {
     private readonly IAuthenticationService _authService;
     private readonly ISecurityService _securityService;
+    private readonly IProvisionedUserContextProvider _provisionedUsers;
     private readonly ILogger<AuthController> _logger;
 
     public AuthController(
         IAuthenticationService authService,
         ISecurityService securityService,
+        IProvisionedUserContextProvider provisionedUsers,
         ILogger<AuthController> logger)
     {
         _authService = authService;
         _securityService = securityService;
+        _provisionedUsers = provisionedUsers;
         _logger = logger;
     }
 
@@ -32,39 +37,49 @@ public class AuthController : ControllerBase
     {
         try
         {
-            // Validate government user
-            if (!await _securityService.IsValidGovernmentUserAsync(request.Email))
+            var email = request.Email.Trim();
+            var provisionedUser = await _provisionedUsers.GetProvisionedUserContextAsync(email);
+
+            if (provisionedUser is null)
             {
-                await _securityService.LogSecurityEventAsync("INVALID_LOGIN_ATTEMPT", 
-                    $"Non-government user attempted login: {request.Email}");
-                return Unauthorized(new { message = "Invalid credentials" });
+                await _securityService.LogSecurityEventAsync("UNPROVISIONED_LOGIN_ATTEMPT",
+                    $"Unprovisioned account attempted login: {email}");
+                return Unauthorized(new { message = "Account not provisioned" });
             }
 
-            // In production, validate against government directory (Active Directory, LDAP, etc.)
-            var isValidCredentials = await ValidateUserCredentials(request.Email, request.Password);
+            var isValidCredentials = await _securityService.ValidateUserCredentialsAsync(email, request.Password);
             
             if (!isValidCredentials)
             {
                 await _securityService.LogSecurityEventAsync("FAILED_LOGIN_ATTEMPT", 
-                    $"Failed login attempt for user: {request.Email}");
+                    $"Failed login attempt for user: {email}");
                 return Unauthorized(new { message = "Invalid credentials" });
             }
 
-            // Generate JWT token
-            var roles = await GetUserRoles(request.Email);
-            var token = await _authService.GenerateJwtTokenAsync(
-                Guid.NewGuid().ToString(), 
-                request.Email, 
-                roles);
+            var claims = BuildProvisionedClaims(provisionedUser);
+            var tokenPair = await _authService.GenerateTokenPairAsync(
+                provisionedUser.UserId.ToString(),
+                provisionedUser.Email,
+                provisionedUser.Roles,
+                claims);
+
+            await _provisionedUsers.RecordUserSessionAsync(
+                provisionedUser.UserId,
+                tokenPair.AccessToken,
+                tokenPair.RefreshToken,
+                DateTime.UtcNow.AddDays(7),
+                ControllerContext.HttpContext?.Connection.RemoteIpAddress?.ToString(),
+                ControllerContext.HttpContext?.Request.Headers.UserAgent.ToString());
 
             await _securityService.LogSecurityEventAsync("SUCCESSFUL_LOGIN", 
-                $"User successfully logged in: {request.Email}");
+                $"User successfully logged in: {provisionedUser.Email}");
 
             return Ok(new LoginResponse
             {
-                Token = token,
-                Email = request.Email,
-                Roles = roles.ToArray(),
+                Token = tokenPair.AccessToken,
+                RefreshToken = tokenPair.RefreshToken,
+                Email = provisionedUser.Email,
+                Roles = provisionedUser.Roles,
                 ExpiresAt = DateTime.UtcNow.AddHours(8)
             });
         }
@@ -75,6 +90,18 @@ public class AuthController : ControllerBase
                 $"Error during login for user: {request.Email}", ex.Message);
             return StatusCode(500, new { message = "Internal server error" });
         }
+    }
+
+    [HttpGet("access-policy")]
+    [AllowAnonymous]
+    public IActionResult GetAccessPolicy()
+    {
+        return Ok(new
+        {
+            signupMode = "provisioned_access_only",
+            publicSignupEnabled = false,
+            message = "Access is issued through TerraFusion administration for authorized Washington county operators. No public signup is available."
+        });
     }
 
     [HttpPost("refresh")]
@@ -89,16 +116,27 @@ public class AuthController : ControllerBase
                 return Unauthorized(new { message = "Invalid token" });
             }
 
-            var email = principal.FindFirst("email")?.Value;
-            var userId = principal.FindFirst("sub")?.Value;
+            var email = principal.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
+                ?? principal.FindFirst("email")?.Value;
+            var userId = principal.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                ?? principal.FindFirst("sub")?.Value;
 
             if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(userId))
             {
                 return Unauthorized(new { message = "Invalid token claims" });
             }
 
-            var roles = await GetUserRoles(email);
-            var newToken = await _authService.GenerateJwtTokenAsync(userId, email, roles);
+            var provisionedUser = await _provisionedUsers.GetProvisionedUserContextAsync(email);
+            if (provisionedUser is null || provisionedUser.UserId.ToString() != userId)
+            {
+                return Unauthorized(new { message = "Account not provisioned" });
+            }
+
+            var newToken = await _authService.GenerateJwtTokenAsync(
+                userId,
+                provisionedUser.Email,
+                provisionedUser.Roles,
+                BuildProvisionedClaims(provisionedUser));
 
             await _securityService.LogSecurityEventAsync("TOKEN_REFRESH", 
                 $"Token refreshed for user: {email}");
@@ -106,8 +144,8 @@ public class AuthController : ControllerBase
             return Ok(new LoginResponse
             {
                 Token = newToken,
-                Email = email,
-                Roles = roles.ToArray(),
+                Email = provisionedUser.Email,
+                Roles = provisionedUser.Roles,
                 ExpiresAt = DateTime.UtcNow.AddHours(8)
             });
         }
@@ -180,17 +218,36 @@ public class AuthController : ControllerBase
     [Authorize]
     public async Task<IActionResult> GetProfile()
     {
-        await Task.CompletedTask;
-        await Task.CompletedTask;
         try
         {
-            var email = User.FindFirst("email")?.Value;
-            var roles = User.FindAll("role").Select(c => c.Value).ToArray();
+            var email = FindClaimValue(ClaimTypes.Email, "email");
+            var userIdClaim = FindClaimValue(ClaimTypes.NameIdentifier, "nameid", "sub");
+
+            if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(userIdClaim))
+            {
+                return Unauthorized(new { message = "Invalid token claims" });
+            }
+
+            var provisionedUser = await _provisionedUsers.GetProvisionedUserContextAsync(email);
+            if (provisionedUser is null || !string.Equals(provisionedUser.UserId.ToString(), userIdClaim, StringComparison.OrdinalIgnoreCase))
+            {
+                return Unauthorized(new { message = "Account not provisioned" });
+            }
+
+            var bearerToken = GetBearerToken(Request);
+            var sessionValid = await _provisionedUsers.IsUserSessionValidAsync(provisionedUser.UserId, bearerToken);
 
             return Ok(new UserProfile
             {
-                Email = email!,
-                Roles = roles,
+                UserId = provisionedUser.UserId.ToString(),
+                Email = provisionedUser.Email,
+                Roles = provisionedUser.Roles,
+                Permissions = provisionedUser.Permissions,
+                CountyId = provisionedUser.CountyId?.ToString(),
+                County = provisionedUser.CountyName,
+                CountyFipsCode = provisionedUser.CountyFipsCode,
+                State = provisionedUser.CountyState,
+                SessionValid = sessionValid,
                 LastLogin = DateTime.UtcNow // In production, get from database
             });
         }
@@ -201,34 +258,29 @@ public class AuthController : ControllerBase
         }
     }
 
-    private async Task<bool> ValidateUserCredentials(string email, string password)
+    private string? FindClaimValue(params string[] claimTypes)
     {
-        // In production, integrate with government authentication systems
-        // For demo purposes, use simple validation
-        await Task.Delay(100); // Simulate authentication delay
-        
-        // Government users with @gov., @state., @county. domains
-        return email.EndsWith("@gov.") || 
-               email.EndsWith("@state.") || 
-               email.EndsWith("@county.") ||
-               email.EndsWith("@terrafusionmarket.com");
+        foreach (var claimType in claimTypes)
+        {
+            var value = User.FindFirst(claimType)?.Value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
     }
 
-    private async Task<IEnumerable<string>> GetUserRoles(string email)
+    private static string? GetBearerToken(HttpRequest request)
     {
-        // In production, get from government directory or database
-        await Task.Delay(50);
-        
-        var roles = new List<string> { "GovernmentUser" };
-        
-        if (email.Contains("admin"))
-            roles.Add("Administrator");
-        if (email.Contains("assessor"))
-            roles.Add("PropertyAssessor");
-        if (email.Contains("auditor"))
-            roles.Add("CountyAuditor");
-        
-        return roles;
+        var authorization = request.Headers.Authorization.ToString();
+        if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return authorization["Bearer ".Length..].Trim();
     }
 
     private static bool TryParseRevocationMetadata(string token, out string jti, out DateTime expiresAtUtc)
@@ -266,5 +318,35 @@ public class AuthController : ControllerBase
         {
             return false;
         }
+    }
+
+    private static Dictionary<string, object> BuildProvisionedClaims(ProvisionedUserAuthContext user)
+    {
+        var claims = new Dictionary<string, object>
+        {
+            ["perm"] = user.Permissions
+        };
+
+        if (user.CountyId.HasValue)
+        {
+            claims["countyId"] = user.CountyId.Value.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.CountyName))
+        {
+            claims["countyName"] = user.CountyName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.CountyState))
+        {
+            claims["countyState"] = user.CountyState;
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.CountyFipsCode))
+        {
+            claims["countyFipsCode"] = user.CountyFipsCode;
+        }
+
+        return claims;
     }
 }

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -1153,7 +1153,7 @@ builder.Services.AddSignalR();
 // Register authentication services
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<TerraFusion.Core.Auth.IRequestUserContextAccessor, TerraFusion.API.Auth.HttpContextRequestUserContextAccessor>();
-builder.Services.AddTerraFusionAuthentication(builder.Configuration);
+builder.Services.AddTerraFusionAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddTerraFusionSecurityServices(builder.Configuration, builder.Environment);
 
 // 🎯 SERVICE REGISTRY & DISCOVERY - No more hardcoded ports!

--- a/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
+++ b/backend/src/TerraFusion.API/Security/AuthenticationConfiguration.cs
@@ -14,21 +14,40 @@ using TerraFusion.Data.Repositories;
 using CoreAuth = TerraFusion.Core.Services;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
 
 namespace TerraFusion.API.Security
 {
     public static class AuthenticationConfiguration
     {
-        public static IServiceCollection AddTerraFusionAuthentication(this IServiceCollection services, IConfiguration configuration)
+        public static IServiceCollection AddTerraFusionAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IHostEnvironment? environment = null)
         {
             var jwtSettings = configuration.GetSection("JwtSettings");
-            var secretKey = jwtSettings["SecretKey"] ?? GenerateDefaultKey();
+            var secretKey = jwtSettings["SecretKey"];
             var issuer = jwtSettings["Issuer"] ?? "TerraFusion";
             var audience = jwtSettings["Audience"] ?? "TerraFusionAPI";
 
-            if (secretKey == GenerateDefaultKey())
+            // PR-2 (Prometheus T3 #5): fail-fast in non-Development when JWT key is missing.
+            // Previously a random "TerraFusion-Default-Key-..." key was synthesized at
+            // startup with only a Console.WriteLine warning — producing a working-but-
+            // forgeable JWT signer in any environment that hadn't been explicitly
+            // configured. Production must throw; Development gets a long, fixed
+            // padding key so local dev keeps working without env vars.
+            var isDevelopment = environment?.IsDevelopment() ?? false;
+            if (string.IsNullOrWhiteSpace(secretKey) && !isDevelopment)
             {
-                Console.WriteLine("⚠️  WARNING: Using default JWT key. Configure Jwt:SecretKey in appsettings.json for production!");
+                throw new InvalidOperationException(
+                    "JwtSettings:SecretKey is required in non-Development environments. " +
+                    "Configure via env var JwtSettings__SecretKey or appsettings.{Env}.local.json.");
+            }
+            if (string.IsNullOrWhiteSpace(secretKey))
+            {
+                // Dev-only fallback. 64+ chars to satisfy HS256 minimum.
+                secretKey = "TerraFusion-Dev-Secret-Key-DEV-ONLY-NEVER-USE-IN-PROD-PADDING-XXXXXXXXXXXXXXXXXXXX";
+                Console.WriteLine("⚠️  WARNING: Using Development JWT fallback key. NEVER use this in production.");
             }
 
             services.AddAuthentication(options =>
@@ -86,11 +105,24 @@ namespace TerraFusion.API.Security
             services.AddScoped<TerraFusion.API.Services.IJwtTokenService, TerraFusion.API.Services.JwtTokenService>();
             services.AddScoped<CoreAuth.IJwtTokenService, ApiJwtTokenServiceAdapter>();
             services.AddScoped<CoreAuth.IAuthenticationService, CoreAuth.AuthenticationService>();
-            services.TryAddSingleton<CoreAuth.ISecurityService, InMemorySecurityService>();
+            services.AddScoped<DatabaseProvisionedSecurityService>();
+            services.AddScoped<CoreAuth.ISecurityService>(provider =>
+                provider.GetRequiredService<DatabaseProvisionedSecurityService>());
+            services.AddScoped<IProvisionedUserContextProvider>(provider =>
+                provider.GetRequiredService<DatabaseProvisionedSecurityService>());
             services.AddHostedService<CoreAuth.RevocationCleanupBackgroundService>();
 
             services.AddAuthorization(options =>
             {
+                // PR-2 (Prometheus T3 #1): require authentication by default.
+                // Any controller without an explicit [Authorize] or [AllowAnonymous]
+                // attribute now gets 401 instead of silently defaulting to anonymous.
+                // Controllers that intentionally run anonymously (Workbench F/G/H,
+                // FullCorpus, Doctrine*) must be tagged with [AllowAnonymous] explicitly.
+                options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+
                 options.AddPolicy("RequireAdmin", policy =>
                     policy.RequireRole("Admin", "SystemAdmin"));
 
@@ -120,15 +152,14 @@ namespace TerraFusion.API.Security
             return services;
         }
 
-        private static string GenerateDefaultKey()
-        {
-            return "TerraFusion-Default-Key-CHANGE-IN-PRODUCTION-2025-" + Guid.NewGuid().ToString().Substring(0, 8);
-        }
-
         /// <summary>
         /// Registers MFA, Session Management, and LDAP security services.
         /// Phase 5: Security Service Runtime Completeness.
         /// Phase 9: DevelopmentLdapService is now guarded by environment check.
+        /// PR-2 (Prometheus T3 #4): non-Development now registers
+        /// <see cref="FailClosedLdapService"/> (throws on every method) instead
+        /// of the in-memory dev stub, which previously was registered in BOTH
+        /// branches despite a comment claiming "rejects all logins".
         /// </summary>
         public static IServiceCollection AddTerraFusionSecurityServices(
             this IServiceCollection services,
@@ -145,10 +176,11 @@ namespace TerraFusion.API.Security
             }
             else
             {
-                // Production: register a no-op LDAP that rejects all logins
-                // until a real LDAP/AD provider is configured.
-                services.AddSingleton<ILdapService, DevelopmentLdapService>();
-                // TODO: Replace with ProductionLdapService backed by AD/OAuth2
+                // PR-2 (Prometheus T3 #4): fail-closed in non-Development. Every method
+                // throws NotImplementedException so any code path that reaches LDAP in
+                // prod surfaces loud instead of silently succeeding via dev stub.
+                // TODO: Replace with ProductionLdapService backed by AD/OAuth2.
+                services.AddSingleton<ILdapService, FailClosedLdapService>();
             }
 
             return services;
@@ -204,6 +236,173 @@ namespace TerraFusion.API.Security
         }
     }
 
+    internal sealed class ConfiguredBootstrapSecurityService : CoreAuth.ISecurityService
+    {
+        private static readonly string[] DefaultRoles =
+        {
+            "GovernmentUser",
+            "Administrator",
+            "FullSystemAccess"
+        };
+
+        private readonly string _email;
+        private readonly string _password;
+        private readonly string[] _roles;
+        private readonly ConcurrentDictionary<string, int> _failedAttempts = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, DateTimeOffset> _lockedAccounts = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ILogger<ConfiguredBootstrapSecurityService> _logger;
+
+        public ConfiguredBootstrapSecurityService(
+            IConfiguration configuration,
+            ILogger<ConfiguredBootstrapSecurityService> logger)
+        {
+            _email = ReadSetting(configuration, "Auth:Bootstrap:Email", "TERRAFUSION_BOOTSTRAP_EMAIL").Trim();
+            _password = ReadSetting(configuration, "Auth:Bootstrap:Password", "TERRAFUSION_BOOTSTRAP_PASSWORD");
+            _roles = ReadRoles(configuration);
+            _logger = logger;
+        }
+
+        public static bool HasBootstrapCredentials(IConfiguration configuration)
+        {
+            return !string.IsNullOrWhiteSpace(ReadSetting(configuration, "Auth:Bootstrap:Email", "TERRAFUSION_BOOTSTRAP_EMAIL"))
+                && !string.IsNullOrWhiteSpace(ReadSetting(configuration, "Auth:Bootstrap:Password", "TERRAFUSION_BOOTSTRAP_PASSWORD"));
+        }
+
+        public Task<bool> IsValidGovernmentUserAsync(string email)
+        {
+            return Task.FromResult(IsConfiguredUser(email));
+        }
+
+        public Task LogSecurityEventAsync(string eventType, string description, string? details = null)
+        {
+            _logger.LogInformation("Security event {EventType}: {Description} {Details}", eventType, description, details);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ValidateUserCredentialsAsync(string email, string password)
+        {
+            if (!IsConfiguredUser(email) || string.IsNullOrEmpty(password))
+            {
+                return Task.FromResult(false);
+            }
+
+            return Task.FromResult(FixedTimeEquals(password, _password));
+        }
+
+        public Task<IEnumerable<string>> GetUserRolesAsync(string email)
+        {
+            IEnumerable<string> roles = IsConfiguredUser(email) ? _roles : Array.Empty<string>();
+            return Task.FromResult(roles);
+        }
+
+        public Task<bool> IsAccountLockedAsync(string email)
+        {
+            if (_lockedAccounts.TryGetValue(email, out var lockedUntil))
+            {
+                if (lockedUntil > DateTimeOffset.UtcNow)
+                {
+                    return Task.FromResult(true);
+                }
+
+                _lockedAccounts.TryRemove(email, out _);
+            }
+
+            return Task.FromResult(false);
+        }
+
+        public Task RecordFailedLoginAttemptAsync(string email)
+        {
+            _failedAttempts.AddOrUpdate(email, 1, (_, count) => count + 1);
+            return Task.CompletedTask;
+        }
+
+        public Task ResetFailedLoginAttemptsAsync(string email)
+        {
+            _failedAttempts.TryRemove(email, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<int> GetFailedLoginAttemptsAsync(string email)
+        {
+            _failedAttempts.TryGetValue(email, out var count);
+            return Task.FromResult(count);
+        }
+
+        public Task LockAccountAsync(string email, TimeSpan duration, string reason)
+        {
+            _lockedAccounts[email] = DateTimeOffset.UtcNow.Add(duration);
+            _logger.LogWarning("Account locked for configured bootstrap user hash {EmailHash}. Reason: {Reason}", email.GetHashCode(), reason);
+            return Task.CompletedTask;
+        }
+
+        public Task UnlockAccountAsync(string email)
+        {
+            _lockedAccounts.TryRemove(email, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsIpAddressAllowedAsync(string ipAddress)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> HasPermissionAsync(string userId, string permission)
+        {
+            return Task.FromResult(IsConfiguredUser(userId) && HasElevatedRole());
+        }
+
+        public Task<bool> HasModuleAccessAsync(string userId, string moduleId)
+        {
+            return Task.FromResult(IsConfiguredUser(userId) && HasElevatedRole());
+        }
+
+        private bool IsConfiguredUser(string email)
+        {
+            return !string.IsNullOrWhiteSpace(email)
+                && string.Equals(email.Trim(), _email, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool HasElevatedRole()
+        {
+            return _roles.Any(role =>
+                role.Equals("Administrator", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("Admin", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("SystemAdmin", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("SystemAdministrator", StringComparison.OrdinalIgnoreCase)
+                || role.Equals("FullSystemAccess", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string ReadSetting(IConfiguration configuration, string key, string envKey)
+        {
+            return configuration[key] ?? configuration[envKey] ?? string.Empty;
+        }
+
+        private static string[] ReadRoles(IConfiguration configuration)
+        {
+            var raw = ReadSetting(configuration, "Auth:Bootstrap:Roles", "TERRAFUSION_BOOTSTRAP_ROLES");
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return DefaultRoles;
+            }
+
+            var roles = raw
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(role => !string.IsNullOrWhiteSpace(role))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return roles.Length == 0 ? DefaultRoles : roles;
+        }
+
+        private static bool FixedTimeEquals(string provided, string expected)
+        {
+            var providedBytes = Encoding.UTF8.GetBytes(provided);
+            var expectedBytes = Encoding.UTF8.GetBytes(expected);
+            return providedBytes.Length == expectedBytes.Length
+                && CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes);
+        }
+    }
+
     internal sealed class InMemorySecurityService : CoreAuth.ISecurityService
     {
         private static readonly string[] AllowedDomains =
@@ -239,8 +438,16 @@ namespace TerraFusion.API.Security
 
         public Task<bool> ValidateUserCredentialsAsync(string email, string password)
         {
-            var valid = !string.IsNullOrWhiteSpace(email) && !string.IsNullOrWhiteSpace(password);
-            return Task.FromResult(valid);
+            // PR-2 (Prometheus T3 #3): fail-closed default. Previously accepted any
+            // non-empty email + password (silent allow-all). InMemorySecurityService
+            // is the fallback registration (services.TryAddSingleton); a real
+            // credential validator should replace it before any reliance is placed
+            // on this method. Until then, every call is denied + warns.
+            _logger.LogWarning(
+                "InMemorySecurityService.ValidateUserCredentialsAsync called for email-hash {EmailHash}; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                email?.GetHashCode());
+            return Task.FromResult(false);
         }
 
         public Task<IEnumerable<string>> GetUserRolesAsync(string email)
@@ -302,12 +509,28 @@ namespace TerraFusion.API.Security
 
         public Task<bool> HasPermissionAsync(string userId, string permission)
         {
-            return Task.FromResult(true);
+            // PR-2 (Prometheus T3 #2): fail-closed default. Previously returned true
+            // for every (userId, permission) tuple — silent allow-all that defeated
+            // any caller that relied on this method as a real authorization check.
+            // A real ISecurityService implementation should replace this before any
+            // permission decision relies on it; until then, every call is denied.
+            _logger.LogWarning(
+                "InMemorySecurityService.HasPermissionAsync called for permission '{Permission}'; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                permission);
+            return Task.FromResult(false);
         }
 
         public Task<bool> HasModuleAccessAsync(string userId, string moduleId)
         {
-            return Task.FromResult(true);
+            // PR-2 (Prometheus T3 #2 sibling): same fail-closed treatment as
+            // HasPermissionAsync. Module-access checks should go through a real
+            // ISecurityService; the in-memory fallback denies and warns.
+            _logger.LogWarning(
+                "InMemorySecurityService.HasModuleAccessAsync called for module '{ModuleId}'; " +
+                "fail-closed default returning false. Register a real ISecurityService implementation.",
+                moduleId);
+            return Task.FromResult(false);
         }
     }
 }

--- a/backend/src/TerraFusion.API/Security/Services/DatabaseProvisionedSecurityService.cs
+++ b/backend/src/TerraFusion.API/Security/Services/DatabaseProvisionedSecurityService.cs
@@ -1,0 +1,346 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Services;
+using AuditLog = TerraFusion.Core.Entities.AuditLog;
+using County = TerraFusion.Core.Entities.County;
+using GovernmentUser = TerraFusion.Core.Entities.GovernmentUser;
+using PasswordHistory = TerraFusion.Core.Entities.PasswordHistory;
+using UserSession = TerraFusion.Core.Entities.UserSession;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+
+namespace TerraFusion.API.Security.Services;
+
+public sealed record ProvisionedUserAuthContext(
+    Guid UserId,
+    string Email,
+    string[] Roles,
+    string[] Permissions,
+    Guid? CountyId,
+    string? CountyName,
+    string? CountyState,
+    string? CountyFipsCode);
+
+public interface IProvisionedUserContextProvider
+{
+    System.Threading.Tasks.Task<ProvisionedUserAuthContext?> GetProvisionedUserContextAsync(string email);
+    System.Threading.Tasks.Task<bool> IsUserSessionValidAsync(Guid userId, string? sessionToken);
+    System.Threading.Tasks.Task RecordUserSessionAsync(
+        Guid userId,
+        string sessionToken,
+        string refreshToken,
+        DateTime expiresAtUtc,
+        string? ipAddress,
+        string? userAgent);
+}
+
+public static class ProvisionedPasswordHasher
+{
+    private static readonly PasswordHasher<GovernmentUser> Hasher = new();
+
+    public static string HashPassword(string password)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        return Hasher.HashPassword(
+            new GovernmentUser
+            {
+                Email = "provisioning@terrafusion.local",
+                FirstName = "Provisioning",
+                LastName = "Operator",
+                Role = "GovernmentUser",
+                CreatedAt = DateTime.UtcNow
+            },
+            password);
+    }
+
+    public static bool VerifyPassword(GovernmentUser user, string password)
+    {
+        if (string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrEmpty(password))
+        {
+            return false;
+        }
+
+        var result = Hasher.VerifyHashedPassword(user, user.PasswordHash, password);
+        return result is PasswordVerificationResult.Success or PasswordVerificationResult.SuccessRehashNeeded;
+    }
+
+    public static bool NeedsRehash(GovernmentUser user, string password)
+    {
+        if (string.IsNullOrWhiteSpace(user.PasswordHash) || string.IsNullOrEmpty(password))
+        {
+            return false;
+        }
+
+        return Hasher.VerifyHashedPassword(user, user.PasswordHash, password)
+            == PasswordVerificationResult.SuccessRehashNeeded;
+    }
+}
+
+public sealed class DatabaseProvisionedSecurityService : ISecurityService, IProvisionedUserContextProvider
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly DataDbContext _db;
+    private readonly ILogger<DatabaseProvisionedSecurityService> _logger;
+
+    public DatabaseProvisionedSecurityService(
+        DataDbContext db,
+        ILogger<DatabaseProvisionedSecurityService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async System.Threading.Tasks.Task<bool> IsValidGovernmentUserAsync(string email)
+    {
+        var normalized = NormalizeEmail(email);
+        if (normalized is null)
+        {
+            return false;
+        }
+
+        return await _db.GovernmentUsers
+            .AsNoTracking()
+            .AnyAsync(user =>
+                user.IsActive
+                && user.PasswordHash != null
+                && user.Email.ToLower() == normalized);
+    }
+
+    public async System.Threading.Tasks.Task LogSecurityEventAsync(string eventType, string description, string? details = null)
+    {
+        _db.AuditLogs.Add(new AuditLog
+        {
+            Id = Guid.NewGuid(),
+            Type = $"SECURITY:{eventType}",
+            Data = details,
+            Timestamp = DateTime.UtcNow,
+            Severity = eventType.Contains("FAILED", StringComparison.OrdinalIgnoreCase)
+                || eventType.Contains("INVALID", StringComparison.OrdinalIgnoreCase)
+                ? "Warning"
+                : "Info",
+            Source = "DatabaseProvisionedSecurityService"
+        });
+
+        try
+        {
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist security audit event {EventType}", eventType);
+        }
+    }
+
+    public async System.Threading.Tasks.Task<bool> ValidateUserCredentialsAsync(string email, string password)
+    {
+        var user = await FindActiveUserAsync(email);
+        if (user is null || string.IsNullOrWhiteSpace(user.PasswordHash))
+        {
+            return false;
+        }
+
+        var valid = ProvisionedPasswordHasher.VerifyPassword(user, password);
+        if (!valid)
+        {
+            await RecordFailedLoginAttemptAsync(email);
+            return false;
+        }
+
+        if (ProvisionedPasswordHasher.NeedsRehash(user, password))
+        {
+            user.PasswordHash = ProvisionedPasswordHasher.HashPassword(password);
+        }
+
+        user.LastLoginAt = DateTime.UtcNow;
+        await ResetFailedLoginAttemptsAsync(email);
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public async System.Threading.Tasks.Task<IEnumerable<string>> GetUserRolesAsync(string email)
+    {
+        var user = await FindActiveUserAsync(email);
+        return user is null ? Array.Empty<string>() : ParseList(user.Role);
+    }
+
+    public System.Threading.Tasks.Task<bool> IsAccountLockedAsync(string email)
+    {
+        return System.Threading.Tasks.Task.FromResult(false);
+    }
+
+    public System.Threading.Tasks.Task RecordFailedLoginAttemptAsync(string email)
+    {
+        _logger.LogWarning("Failed provisioned login attempt for email hash {EmailHash}", NormalizeEmail(email)?.GetHashCode());
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public System.Threading.Tasks.Task ResetFailedLoginAttemptsAsync(string email)
+    {
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public System.Threading.Tasks.Task<int> GetFailedLoginAttemptsAsync(string email)
+    {
+        return System.Threading.Tasks.Task.FromResult(0);
+    }
+
+    public System.Threading.Tasks.Task LockAccountAsync(string email, TimeSpan duration, string reason)
+    {
+        _logger.LogWarning("Provisioned account lock requested for email hash {EmailHash}: {Reason}", NormalizeEmail(email)?.GetHashCode(), reason);
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public System.Threading.Tasks.Task UnlockAccountAsync(string email)
+    {
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public System.Threading.Tasks.Task<bool> IsIpAddressAllowedAsync(string ipAddress)
+    {
+        return System.Threading.Tasks.Task.FromResult(true);
+    }
+
+    public async System.Threading.Tasks.Task<bool> HasPermissionAsync(string userId, string permission)
+    {
+        var user = await FindUserByIdAsync(userId);
+        return user is not null
+            && ResolvePermissions(user).Contains(permission, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async System.Threading.Tasks.Task<bool> HasModuleAccessAsync(string userId, string moduleId)
+    {
+        var user = await FindUserByIdAsync(userId);
+        if (user is null)
+        {
+            return false;
+        }
+
+        var expected = $"access:{moduleId}";
+        return ResolvePermissions(user).Contains(expected, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async System.Threading.Tasks.Task<ProvisionedUserAuthContext?> GetProvisionedUserContextAsync(string email)
+    {
+        var user = await FindActiveUserAsync(email);
+        if (user is null || string.IsNullOrWhiteSpace(user.PasswordHash))
+        {
+            return null;
+        }
+
+        County? county = null;
+        if (user.CountyId.HasValue)
+        {
+            county = await _db.Counties
+                .AsNoTracking()
+                .FirstOrDefaultAsync(item => item.Id == user.CountyId.Value);
+        }
+
+        return new ProvisionedUserAuthContext(
+            user.Id,
+            user.Email,
+            ParseList(user.Role),
+            ResolvePermissions(user),
+            user.CountyId,
+            county?.Name,
+            county?.State,
+            county?.FipsCode);
+    }
+
+    public async System.Threading.Tasks.Task RecordUserSessionAsync(
+        Guid userId,
+        string sessionToken,
+        string refreshToken,
+        DateTime expiresAtUtc,
+        string? ipAddress,
+        string? userAgent)
+    {
+        _db.UserSessions.Add(new UserSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SessionToken = sessionToken,
+            RefreshToken = refreshToken,
+            IpAddress = ipAddress,
+            UserAgent = userAgent,
+            CreatedAt = DateTime.UtcNow,
+            LastActivityAt = DateTime.UtcNow,
+            ExpiresAt = expiresAtUtc,
+            IsActive = true
+        });
+
+        await _db.SaveChangesAsync();
+    }
+
+    public System.Threading.Tasks.Task<bool> IsUserSessionValidAsync(Guid userId, string? sessionToken)
+    {
+        if (string.IsNullOrWhiteSpace(sessionToken))
+        {
+            return System.Threading.Tasks.Task.FromResult(false);
+        }
+
+        return _db.UserSessions
+            .AsNoTracking()
+            .AnyAsync(session =>
+                session.UserId == userId
+                && session.SessionToken == sessionToken
+                && session.IsActive
+                && session.ExpiresAt > DateTime.UtcNow);
+    }
+
+    private System.Threading.Tasks.Task<GovernmentUser?> FindActiveUserAsync(string email)
+    {
+        var normalized = NormalizeEmail(email);
+        if (normalized is null)
+        {
+            return System.Threading.Tasks.Task.FromResult<GovernmentUser?>(null);
+        }
+
+        return _db.GovernmentUsers
+            .FirstOrDefaultAsync(user => user.IsActive && user.Email.ToLower() == normalized);
+    }
+
+    private System.Threading.Tasks.Task<GovernmentUser?> FindUserByIdAsync(string userId)
+    {
+        return Guid.TryParse(userId, out var parsed)
+            ? _db.GovernmentUsers.FirstOrDefaultAsync(user => user.IsActive && user.Id == parsed)
+            : System.Threading.Tasks.Task.FromResult<GovernmentUser?>(null);
+    }
+
+    private static string? NormalizeEmail(string email)
+    {
+        return string.IsNullOrWhiteSpace(email) ? null : email.Trim().ToLowerInvariant();
+    }
+
+    private static string[] ParseList(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return Array.Empty<string>();
+        }
+
+        if (raw.TrimStart().StartsWith("[", StringComparison.Ordinal))
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<string[]>(raw, JsonOptions) ?? Array.Empty<string>();
+            }
+            catch (JsonException)
+            {
+                // Fall through to delimiter parsing.
+            }
+        }
+
+        return raw
+            .Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string[] ResolvePermissions(GovernmentUser user)
+    {
+        return ParseList(user.Permissions);
+    }
+}

--- a/backend/src/TerraFusion.Core/DTOs/AuthDTOs.cs
+++ b/backend/src/TerraFusion.Core/DTOs/AuthDTOs.cs
@@ -34,13 +34,19 @@ public class RefreshTokenRequest
 
 public class UserProfile
 {
+    public string? UserId { get; set; }
     public required string Email { get; set; }
     public required string[] Roles { get; set; }
+    public string[] Permissions { get; set; } = Array.Empty<string>();
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public string? Department { get; set; }
     public DateTime LastLogin { get; set; }
+    public string? CountyId { get; set; }
     public string? County { get; set; }
+    public string? CountyFipsCode { get; set; }
+    public string? State { get; set; }
+    public bool SessionValid { get; set; }
 }
 
 public class ChangePasswordRequest

--- a/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
+++ b/backend/src/TerraFusion.Core/Services/AuthenticationService.cs
@@ -112,6 +112,43 @@ namespace TerraFusion.Core.Services
     }
 
     /// <summary>
+    /// Generate a JWT access token with caller-supplied database-backed claims.
+    /// </summary>
+    public async Task<string> GenerateJwtTokenAsync(
+        string userId,
+        string email,
+        IEnumerable<string> roles,
+        IDictionary<string, object> customClaims)
+    {
+      try
+      {
+        var roleList = roles.ToArray();
+        var claims = new Dictionary<string, object>(customClaims, StringComparer.Ordinal)
+        {
+          ["county_system"] = "TerraFusion",
+          ["version"] = "1.0",
+          ["modules_access"] = "32",
+          ["ai_agents"] = "2016",
+          ["security_level"] = "government"
+        };
+
+        var token = _jwtTokenService.GenerateAccessToken(userId, email, roleList, claims);
+
+        _logger.LogInformation(
+            "Generated database-claim JWT token for user {UserId} with email {EmailMasked}",
+            userId,
+            MaskEmail(email));
+
+        return await Task.FromResult(token);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error generating database-claim JWT token for user {UserId}", userId);
+        throw;
+      }
+    }
+
+    /// <summary>
     /// CX-16: Map roles to granular permission claims.
     /// In production, this would be driven by a role-permission matrix in the database.
     /// </summary>
@@ -261,6 +298,61 @@ namespace TerraFusion.Core.Services
       catch (Exception ex)
       {
         _logger.LogError(ex, "Error generating token pair for user {UserId}", userId);
+        throw;
+      }
+    }
+
+    /// <summary>
+    /// Generate both access and refresh tokens with explicit database-backed claims.
+    /// </summary>
+    public async Task<(string AccessToken, string RefreshToken)> GenerateTokenPairAsync(
+        string userId,
+        string email,
+        IEnumerable<string> roles,
+        IDictionary<string, object> customClaims)
+    {
+      try
+      {
+        var roleList = roles.ToArray();
+        var accessToken = await GenerateJwtTokenAsync(userId, email, roleList, customClaims);
+        var refreshToken = GenerateSecureRefreshToken();
+
+        var refreshTokenKey = $"{REFRESH_TOKEN_PREFIX}{userId}:{refreshToken}";
+        var refreshTokenData = new RefreshTokenData
+        {
+          UserId = userId,
+          Email = email,
+          Roles = roleList.ToList(),
+          CreatedAt = DateTime.UtcNow,
+          ExpiresAt = DateTime.UtcNow.AddDays(7)
+        };
+
+        var options = new DistributedCacheEntryOptions
+        {
+          AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(7)
+        };
+
+        try
+        {
+          await _cache.SetStringAsync(
+              refreshTokenKey,
+              JsonSerializer.Serialize(refreshTokenData),
+              options);
+        }
+        catch (Exception ex)
+        {
+          _logger.LogWarning(ex,
+              "Refresh token cache write failed for database-backed user {UserId}; TerraFusion DB session persistence remains authoritative",
+              userId);
+        }
+
+        _logger.LogInformation("Generated database-claim token pair for user {UserId}", userId);
+
+        return (accessToken, refreshToken);
+      }
+      catch (Exception ex)
+      {
+        _logger.LogError(ex, "Error generating database-claim token pair for user {UserId}", userId);
         throw;
       }
     }

--- a/backend/src/TerraFusion.Core/Services/IAuthenticationService.cs
+++ b/backend/src/TerraFusion.Core/Services/IAuthenticationService.cs
@@ -19,6 +19,15 @@ namespace TerraFusion.Core.Services
         Task<string> GenerateJwtTokenAsync(string userId, string email, IEnumerable<string> roles);
 
         /// <summary>
+        /// Generate a JWT access token with explicit database-backed county and permission claims.
+        /// </summary>
+        Task<string> GenerateJwtTokenAsync(
+            string userId,
+            string email,
+            IEnumerable<string> roles,
+            IDictionary<string, object> customClaims);
+
+        /// <summary>
         /// Validate a JWT token and extract claims principal
         /// </summary>
         /// <param name="token">JWT token to validate</param>
@@ -33,6 +42,15 @@ namespace TerraFusion.Core.Services
         /// <param name="roles">User's assigned roles</param>
         /// <returns>Tuple of access token and refresh token</returns>
         Task<(string AccessToken, string RefreshToken)> GenerateTokenPairAsync(string userId, string email, IEnumerable<string> roles);
+
+        /// <summary>
+        /// Generate an access/refresh token pair with explicit database-backed claims.
+        /// </summary>
+        Task<(string AccessToken, string RefreshToken)> GenerateTokenPairAsync(
+            string userId,
+            string email,
+            IEnumerable<string> roles,
+            IDictionary<string, object> customClaims);
 
         /// <summary>
         /// Validate a refresh token for a specific user

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/HostingerAuthAccessTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/HostingerAuthAccessTests.cs
@@ -1,11 +1,13 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using TerraFusion.API.Controllers;
 using TerraFusion.API.Security;
+using TerraFusion.API.Security.Services;
 using TerraFusion.Core.DTOs;
 using Xunit;
 
@@ -23,9 +25,18 @@ public sealed class HostingerAuthAccessTests
     {
         var authService = new Mock<CoreAuth.IAuthenticationService>(MockBehavior.Strict);
         var securityService = new Mock<CoreAuth.ISecurityService>(MockBehavior.Strict);
-        securityService
-            .Setup(x => x.IsValidGovernmentUserAsync("operator@terrafusionmarket.com"))
-            .ReturnsAsync(true);
+        var provisionedUsers = new Mock<IProvisionedUserContextProvider>(MockBehavior.Strict);
+        provisionedUsers
+            .Setup(x => x.GetProvisionedUserContextAsync("operator@terrafusionmarket.com"))
+            .ReturnsAsync(new ProvisionedUserAuthContext(
+                Guid.NewGuid(),
+                "operator@terrafusionmarket.com",
+                new[] { "GovernmentUser" },
+                new[] { "read:parcel" },
+                null,
+                null,
+                null,
+                null));
         securityService
             .Setup(x => x.ValidateUserCredentialsAsync("operator@terrafusionmarket.com", "WrongPassword123!"))
             .ReturnsAsync(false);
@@ -36,6 +47,7 @@ public sealed class HostingerAuthAccessTests
         var controller = new AuthController(
             authService.Object,
             securityService.Object,
+            provisionedUsers.Object,
             NullLogger<AuthController>.Instance);
 
         var result = await controller.Login(new LoginRequest
@@ -55,32 +67,56 @@ public sealed class HostingerAuthAccessTests
     }
 
     [Fact]
-    public async Task AddTerraFusionAuthentication_WithBootstrapCredentials_InstallsProvisionedOperatorLogin()
+    public void AddTerraFusionAuthentication_RegistersDatabaseProvisionedSecurityService()
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddDbContext<TerraFusion.Data.TerraFusionDbContext>(options =>
+            options.UseInMemoryDatabase($"hostinger-auth-{Guid.NewGuid():N}"));
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["JwtSettings:SecretKey"] = "test-hostinger-bootstrap-key-at-least-32-chars-long-for-hmac-sha256",
-                ["Auth:Bootstrap:Email"] = "operator@terrafusionmarket.com",
-                ["Auth:Bootstrap:Password"] = "CorrectPassword123!",
-                ["Auth:Bootstrap:Roles"] = "GovernmentUser,Administrator,FullSystemAccess"
+                ["JwtSettings:SecretKey"] = "test-hostinger-db-auth-key-at-least-32-chars-long-for-hmac-sha256"
             })
             .Build();
 
         services.AddTerraFusionAuthentication(config);
+        services.AddSingleton<IConfiguration>(config);
+
+        using var provider = services.BuildServiceProvider();
+        var security = provider.GetRequiredService<CoreAuth.ISecurityService>();
+        var provisioned = provider.GetRequiredService<IProvisionedUserContextProvider>();
+
+        security.Should().BeOfType<DatabaseProvisionedSecurityService>();
+        provisioned.Should().BeSameAs(security);
+    }
+
+    [Fact]
+    public async Task AddTerraFusionAuthentication_WithBootstrapCredentials_DoesNotEnableBootstrapLogin()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<TerraFusion.Data.TerraFusionDbContext>(options =>
+            options.UseInMemoryDatabase($"hostinger-auth-bootstrap-blocked-{Guid.NewGuid():N}"));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "test-hostinger-db-auth-key-at-least-32-chars-long-for-hmac-sha256",
+                ["Auth:Bootstrap:Email"] = "operator@terrafusionmarket.com",
+                ["Auth:Bootstrap:Password"] = "CorrectPassword123!",
+                ["Auth:Bootstrap:Roles"] = "GovernmentUser,Administrator"
+            })
+            .Build();
+
+        services.AddTerraFusionAuthentication(config);
+        services.AddSingleton<IConfiguration>(config);
 
         using var provider = services.BuildServiceProvider();
         var security = provider.GetRequiredService<CoreAuth.ISecurityService>();
 
-        (await security.IsValidGovernmentUserAsync("operator@terrafusionmarket.com")).Should().BeTrue();
-        (await security.ValidateUserCredentialsAsync("operator@terrafusionmarket.com", "CorrectPassword123!")).Should().BeTrue();
-        (await security.ValidateUserCredentialsAsync("operator@terrafusionmarket.com", "WrongPassword123!")).Should().BeFalse();
-        (await security.ValidateUserCredentialsAsync("other@terrafusionmarket.com", "CorrectPassword123!")).Should().BeFalse();
-        (await security.GetUserRolesAsync("operator@terrafusionmarket.com"))
-            .Should()
-            .BeEquivalentTo("GovernmentUser", "Administrator", "FullSystemAccess");
+        security.Should().BeOfType<DatabaseProvisionedSecurityService>();
+        (await security.IsValidGovernmentUserAsync("operator@terrafusionmarket.com")).Should().BeFalse();
+        (await security.ValidateUserCredentialsAsync("operator@terrafusionmarket.com", "CorrectPassword123!")).Should().BeFalse();
     }
 
     [Fact]
@@ -88,9 +124,11 @@ public sealed class HostingerAuthAccessTests
     {
         var authService = new Mock<CoreAuth.IAuthenticationService>(MockBehavior.Loose);
         var securityService = new Mock<CoreAuth.ISecurityService>(MockBehavior.Loose);
+        var provisionedUsers = new Mock<IProvisionedUserContextProvider>(MockBehavior.Loose);
         var controller = new AuthController(
             authService.Object,
             securityService.Object,
+            provisionedUsers.Object,
             NullLogger<AuthController>.Instance);
 
         var result = controller.GetAccessPolicy();
@@ -100,7 +138,7 @@ public sealed class HostingerAuthAccessTests
         {
             signupMode = "provisioned_access_only",
             publicSignupEnabled = false,
-            message = "TerraFusion access is provisioned by an administrator. Public self-signup is disabled."
+            message = "TerraFusion access is provisioned by an administrator. Public self-signup and public access requests are disabled."
         });
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/ProductionProvisionedAuthTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Prometheus/T3/ProductionProvisionedAuthTests.cs
@@ -1,0 +1,374 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TerraFusion.API.Controllers;
+using TerraFusion.API.Security;
+using TerraFusion.API.Security.Services;
+using TerraFusion.API.Services;
+using TerraFusion.Core.DTOs;
+using TerraFusion.Core.Services;
+using County = TerraFusion.Core.Entities.County;
+using GovernmentUser = TerraFusion.Core.Entities.GovernmentUser;
+using DataDbContext = TerraFusion.Data.TerraFusionDbContext;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Prometheus.T3;
+
+[Trait("Category", "Security")]
+[Trait("Component", "ProductionProvisionedAuth")]
+[Trait("Slice", "production-provisioned-auth-db-backed")]
+public sealed class ProductionProvisionedAuthTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task ProvisionedDatabaseLogin_UsesHashedPasswordAndPersistsUserSession()
+    {
+        using var db = CreateDb();
+        var countyId = Guid.NewGuid();
+        db.Counties.Add(new County
+        {
+            Id = countyId,
+            Name = "Benton",
+            State = "WA",
+            FipsCode = "53005"
+        });
+
+        var user = new GovernmentUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "operator@terrafusionmarket.com",
+            FirstName = "Pilot",
+            LastName = "Operator",
+            Role = "GovernmentUser,Administrator",
+            PasswordHash = ProvisionedPasswordHasher.HashPassword("CorrectPassword123!"),
+            Permissions = JsonSerializer.Serialize(new[] { "read:parcel", "ecosystem:view" }),
+            CountyId = countyId,
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        db.GovernmentUsers.Add(user);
+        await db.SaveChangesAsync();
+
+        var security = CreateSecurity(db);
+        var auth = CreateAuthService();
+        var controller = new AuthController(
+            auth,
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+
+        var result = await controller.Login(new LoginRequest
+        {
+            Email = "operator@terrafusionmarket.com",
+            Password = "CorrectPassword123!"
+        });
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = ok.Value.Should().BeOfType<LoginResponse>().Subject;
+        response.RefreshToken.Should().NotBeNullOrWhiteSpace();
+        response.Roles.Should().BeEquivalentTo("GovernmentUser", "Administrator");
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(response.Token);
+        ClaimValue(jwt, ClaimTypes.NameIdentifier, "nameid", "sub").Should().Be(user.Id.ToString());
+        ClaimValue(jwt, ClaimTypes.Email, "email").Should().Be("operator@terrafusionmarket.com");
+        jwt.Claims.Where(c => c.Type == ClaimTypes.Role || c.Type == "role").Select(c => c.Value)
+            .Should().BeEquivalentTo("GovernmentUser", "Administrator");
+        jwt.Claims.Single(c => c.Type == "countyId").Value.Should().Be(countyId.ToString());
+        jwt.Claims.Single(c => c.Type == "countyName").Value.Should().Be("Benton");
+        jwt.Claims.Single(c => c.Type == "countyState").Value.Should().Be("WA");
+        jwt.Claims.Single(c => c.Type == "countyFipsCode").Value.Should().Be("53005");
+        jwt.Claims.Where(c => c.Type == "perm").Select(c => c.Value)
+            .Should().BeEquivalentTo("read:parcel", "ecosystem:view");
+
+        db.UserSessions.Should().ContainSingle(session =>
+            session.UserId == user.Id
+            && session.RefreshToken == response.RefreshToken
+            && session.IsActive);
+        db.GovernmentUsers.Single(x => x.Id == user.Id).LastLoginAt.Should().BeAfter(DateTime.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ProvisionedDatabaseLogin_DoesNotRequireDistributedCacheAvailability()
+    {
+        using var db = CreateDb();
+        var user = new GovernmentUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "operator@terrafusionmarket.com",
+            FirstName = "Pilot",
+            LastName = "Operator",
+            Role = "GovernmentUser",
+            PasswordHash = ProvisionedPasswordHasher.HashPassword("CorrectPassword123!"),
+            Permissions = JsonSerializer.Serialize(new[] { "read:parcel" }),
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+        db.GovernmentUsers.Add(user);
+        await db.SaveChangesAsync();
+
+        var security = CreateSecurity(db);
+        var controller = new AuthController(
+            CreateAuthService(new FailingDistributedCache()),
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+
+        var result = await controller.Login(new LoginRequest
+        {
+            Email = "operator@terrafusionmarket.com",
+            Password = "CorrectPassword123!"
+        });
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = ok.Value.Should().BeOfType<LoginResponse>().Subject;
+        response.Token.Should().NotBeNullOrWhiteSpace();
+        response.RefreshToken.Should().NotBeNullOrWhiteSpace();
+        db.UserSessions.Should().ContainSingle(session =>
+            session.UserId == user.Id
+            && session.RefreshToken == response.RefreshToken
+            && session.IsActive);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Login_UnknownProvisionedAccount_ReturnsAccountNotProvisioned()
+    {
+        using var db = CreateDb();
+        var security = CreateSecurity(db);
+        var controller = new AuthController(
+            CreateAuthService(),
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+
+        var result = await controller.Login(new LoginRequest
+        {
+            Email = "unknown@terrafusionmarket.com",
+            Password = "DoesNotMatter123!"
+        });
+
+        var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        unauthorized.Value.Should().BeEquivalentTo(new { message = "Account not provisioned" });
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Login_BadPasswordForProvisionedAccount_ReturnsInvalidCredentials()
+    {
+        using var db = CreateDb();
+        db.GovernmentUsers.Add(new GovernmentUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "operator@terrafusionmarket.com",
+            FirstName = "Pilot",
+            LastName = "Operator",
+            Role = "GovernmentUser",
+            PasswordHash = ProvisionedPasswordHasher.HashPassword("CorrectPassword123!"),
+            Permissions = JsonSerializer.Serialize(new[] { "read:parcel" }),
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        });
+        await db.SaveChangesAsync();
+
+        var security = CreateSecurity(db);
+        var controller = new AuthController(
+            CreateAuthService(),
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+
+        var result = await controller.Login(new LoginRequest
+        {
+            Email = "operator@terrafusionmarket.com",
+            Password = "WrongPassword123!"
+        });
+
+        var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        unauthorized.Value.Should().BeEquivalentTo(new { message = "Invalid credentials" });
+    }
+
+    [Fact]
+    public void AccessPolicy_HasNoPublicSignupOrEmailRequestCta()
+    {
+        var security = CreateSecurity(CreateDb());
+        var controller = new AuthController(
+            CreateAuthService(),
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+
+        var result = controller.GetAccessPolicy();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(new
+        {
+            signupMode = "provisioned_access_only",
+            publicSignupEnabled = false,
+            message = "TerraFusion access is provisioned by an administrator. Public self-signup and public access requests are disabled."
+        });
+        JsonSerializer.Serialize(ok.Value).Should().NotContain("mailto");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Profile_EchoesProvisionedOperatorIdentityAndSessionValidity()
+    {
+        using var db = CreateDb();
+        var countyId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        const string sessionToken = "live-session-token";
+
+        db.Counties.Add(new County
+        {
+            Id = countyId,
+            Name = "Benton",
+            State = "WA",
+            FipsCode = "53005"
+        });
+        db.GovernmentUsers.Add(new GovernmentUser
+        {
+            Id = userId,
+            Email = "operator@terrafusionmarket.com",
+            FirstName = "Pilot",
+            LastName = "Operator",
+            Role = "GovernmentUser,Administrator",
+            PasswordHash = ProvisionedPasswordHasher.HashPassword("CorrectPassword123!"),
+            Permissions = JsonSerializer.Serialize(new[] { "runtime:read", "county:read", "workbench:access" }),
+            CountyId = countyId,
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        });
+        db.UserSessions.Add(new TerraFusion.Core.Entities.UserSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            SessionToken = sessionToken,
+            RefreshToken = "refresh-token",
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            ExpiresAt = DateTime.UtcNow.AddHours(1),
+            LastActivityAt = DateTime.UtcNow,
+            IsActive = true
+        });
+        await db.SaveChangesAsync();
+
+        var security = CreateSecurity(db);
+        var controller = new AuthController(
+            CreateAuthService(),
+            security,
+            security,
+            NullLogger<AuthController>.Instance);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                    new Claim(ClaimTypes.Email, "operator@terrafusionmarket.com"),
+                    new Claim(ClaimTypes.Role, "GovernmentUser"),
+                    new Claim(ClaimTypes.Role, "Administrator"),
+                    new Claim("perm", "runtime:read"),
+                    new Claim("perm", "county:read"),
+                    new Claim("perm", "workbench:access"),
+                    new Claim("countyId", countyId.ToString()),
+                    new Claim("countyName", "Benton"),
+                    new Claim("countyState", "WA"),
+                    new Claim("countyFipsCode", "53005")
+                }, "Bearer"))
+            }
+        };
+        controller.ControllerContext.HttpContext.Request.Headers.Authorization = $"Bearer {sessionToken}";
+
+        var result = await controller.GetProfile();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var json = JsonSerializer.Serialize(ok.Value);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        root.GetProperty("UserId").GetString().Should().Be(userId.ToString());
+        root.GetProperty("Email").GetString().Should().Be("operator@terrafusionmarket.com");
+        root.GetProperty("Roles").EnumerateArray().Select(item => item.GetString())
+            .Should().BeEquivalentTo("GovernmentUser", "Administrator");
+        root.GetProperty("Permissions").EnumerateArray().Select(item => item.GetString())
+            .Should().BeEquivalentTo("runtime:read", "county:read", "workbench:access");
+        root.GetProperty("CountyId").GetString().Should().Be(countyId.ToString());
+        root.GetProperty("CountyFipsCode").GetString().Should().Be("53005");
+        root.GetProperty("State").GetString().Should().Be("WA");
+        root.GetProperty("SessionValid").GetBoolean().Should().BeTrue();
+    }
+
+    private static DataDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+            .UseInMemoryDatabase($"provisioned-auth-{Guid.NewGuid():N}")
+            .Options;
+        var config = new ConfigurationBuilder().Build();
+        return new DataDbContext(options, config);
+    }
+
+    private static DatabaseProvisionedSecurityService CreateSecurity(DataDbContext db)
+    {
+        return new DatabaseProvisionedSecurityService(
+            db,
+            NullLogger<DatabaseProvisionedSecurityService>.Instance);
+    }
+
+    private static AuthenticationService CreateAuthService(IDistributedCache? cacheOverride = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["JwtSettings:SecretKey"] = "production-provisioned-auth-tests-secret-key-at-least-32-chars",
+                ["JwtSettings:Issuer"] = "TerraFusion",
+                ["JwtSettings:Audience"] = "TerraFusionAPI",
+                ["JwtSettings:ExpirationMinutes"] = "60"
+            })
+            .Build();
+
+        var cache = cacheOverride ?? new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var jwt = new JwtTokenService(config, NullLogger<JwtTokenService>.Instance);
+        var adapter = new ApiJwtTokenServiceAdapter(jwt);
+
+        return new AuthenticationService(
+            adapter,
+            cache,
+            NullLogger<AuthenticationService>.Instance,
+            config);
+    }
+
+    private sealed class FailingDistributedCache : IDistributedCache
+    {
+        public byte[]? Get(string key) => null;
+        public System.Threading.Tasks.Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+            => System.Threading.Tasks.Task.FromResult<byte[]?>(null);
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+            => throw new InvalidOperationException("Cache unavailable.");
+
+        public System.Threading.Tasks.Task SetAsync(
+            string key,
+            byte[] value,
+            DistributedCacheEntryOptions options,
+            CancellationToken token = default)
+            => System.Threading.Tasks.Task.FromException(new InvalidOperationException("Cache unavailable."));
+
+        public void Refresh(string key) { }
+        public System.Threading.Tasks.Task RefreshAsync(string key, CancellationToken token = default)
+            => System.Threading.Tasks.Task.CompletedTask;
+
+        public void Remove(string key) { }
+        public System.Threading.Tasks.Task RemoveAsync(string key, CancellationToken token = default)
+            => System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    private static string ClaimValue(JwtSecurityToken jwt, params string[] claimTypes)
+    {
+        return jwt.Claims.First(c => claimTypes.Contains(c.Type, StringComparer.Ordinal)).Value;
+    }
+}

--- a/backend/tools/TerraFusion.AuthProvisioner/Program.cs
+++ b/backend/tools/TerraFusion.AuthProvisioner/Program.cs
@@ -1,0 +1,286 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using TerraFusion.API.Security.Services;
+using TerraFusion.Core.Entities;
+using TerraFusion.Data;
+
+var options = CliOptions.Parse(args);
+if (options.ShowHelp)
+{
+    CliOptions.PrintHelp();
+    return 0;
+}
+
+if (!options.IsValid(out var validationError))
+{
+    Console.Error.WriteLine(validationError);
+    CliOptions.PrintHelp();
+    return 2;
+}
+
+var configuration = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .Build();
+
+var connectionString = options.ConnectionString
+    ?? configuration.GetConnectionString("DefaultConnection")
+    ?? configuration["ConnectionStrings__DefaultConnection"];
+
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    Console.Error.WriteLine("Missing TerraFusion DB connection string. Use --connection-string or ConnectionStrings__DefaultConnection.");
+    return 2;
+}
+
+var dbOptions = new DbContextOptionsBuilder<TerraFusionDbContext>();
+var provider = options.Provider ?? configuration["DatabaseProvider"] ?? "Sqlite";
+if (!provider.Equals("Sqlite", StringComparison.OrdinalIgnoreCase))
+{
+    Console.Error.WriteLine("TerraFusion.AuthProvisioner currently supports SQLite TerraFusion DB provisioning only.");
+    return 2;
+}
+
+dbOptions.UseSqlite(connectionString);
+
+await using var db = new TerraFusionDbContext(dbOptions.Options, configuration);
+
+var normalizedEmail = options.Email!.Trim().ToLowerInvariant();
+var password = options.ResolvePassword()!;
+var now = DateTime.UtcNow;
+
+Guid? countyId = options.CountyId;
+if (!countyId.HasValue && !string.IsNullOrWhiteSpace(options.CountyName))
+{
+    var countyName = options.CountyName.Trim();
+    var countyState = string.IsNullOrWhiteSpace(options.CountyState) ? "WA" : options.CountyState.Trim().ToUpperInvariant();
+    var county = await db.Counties.FirstOrDefaultAsync(item =>
+        item.Name.ToLower() == countyName.ToLower()
+        && item.State.ToUpper() == countyState);
+
+    if (county is null && options.CreateCounty)
+    {
+        county = new County
+        {
+            Id = Guid.NewGuid(),
+            Name = countyName,
+            State = countyState,
+            FipsCode = options.CountyFips,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        db.Counties.Add(county);
+    }
+
+    countyId = county?.Id;
+}
+
+var roles = CliOptions.ParseCsv(options.Roles);
+var permissions = CliOptions.ParseCsv(options.Permissions);
+if (roles.Length == 0)
+{
+    roles = ["GovernmentUser"];
+}
+
+var user = await db.GovernmentUsers.FirstOrDefaultAsync(item => item.Email.ToLower() == normalizedEmail);
+var created = user is null;
+if (user is null)
+{
+    user = new GovernmentUser
+    {
+        Id = Guid.NewGuid(),
+        Email = normalizedEmail,
+        FirstName = options.FirstName ?? "Provisioned",
+        LastName = options.LastName ?? "Operator",
+        Role = string.Join(",", roles),
+        CreatedAt = now,
+        IsActive = true,
+        CountyId = countyId
+    };
+    db.GovernmentUsers.Add(user);
+}
+else
+{
+    user.Email = normalizedEmail;
+    user.FirstName = options.FirstName ?? user.FirstName;
+    user.LastName = options.LastName ?? user.LastName;
+    user.Role = string.Join(",", roles);
+    user.IsActive = true;
+    user.CountyId = countyId ?? user.CountyId;
+}
+
+user.PasswordHash = ProvisionedPasswordHasher.HashPassword(password);
+user.Permissions = JsonSerializer.Serialize(permissions);
+
+db.PasswordHistories.Add(new PasswordHistory
+{
+    Id = Guid.NewGuid(),
+    UserId = user.Id,
+    PasswordHash = user.PasswordHash,
+    CreatedAt = now
+});
+
+await db.SaveChangesAsync();
+
+Console.WriteLine(JsonSerializer.Serialize(new
+{
+    result = created ? "created" : "updated",
+    userId = user.Id,
+    email = user.Email,
+    countyId = user.CountyId,
+    roles,
+    permissions,
+    passwordHashStored = !string.IsNullOrWhiteSpace(user.PasswordHash)
+}));
+
+return 0;
+
+internal sealed class CliOptions
+{
+    public string? ConnectionString { get; private init; }
+    public string? Provider { get; private init; }
+    public string? Email { get; private init; }
+    public string? Password { get; private init; }
+    public string? PasswordEnv { get; private init; }
+    public string? FirstName { get; private init; }
+    public string? LastName { get; private init; }
+    public string? Roles { get; private init; }
+    public string? Permissions { get; private init; }
+    public Guid? CountyId { get; private init; }
+    public string? CountyName { get; private init; }
+    public string? CountyState { get; private init; }
+    public string? CountyFips { get; private init; }
+    public bool CreateCounty { get; private init; }
+    public bool ShowHelp { get; private init; }
+
+    public static CliOptions Parse(string[] args)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var flags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var key = arg[2..];
+            if (key.Equals("help", StringComparison.OrdinalIgnoreCase))
+            {
+                flags.Add(key);
+                continue;
+            }
+
+            if (key.Equals("create-county", StringComparison.OrdinalIgnoreCase))
+            {
+                flags.Add(key);
+                continue;
+            }
+
+            if (i + 1 >= args.Length)
+            {
+                values[key] = null;
+                continue;
+            }
+
+            values[key] = args[++i];
+        }
+
+        Guid? countyId = null;
+        if (values.TryGetValue("county-id", out var countyIdRaw) && Guid.TryParse(countyIdRaw, out var parsedCountyId))
+        {
+            countyId = parsedCountyId;
+        }
+
+        return new CliOptions
+        {
+            ShowHelp = flags.Contains("help"),
+            CreateCounty = flags.Contains("create-county"),
+            ConnectionString = Value(values, "connection-string"),
+            Provider = Value(values, "provider"),
+            Email = Value(values, "email"),
+            Password = Value(values, "password"),
+            PasswordEnv = Value(values, "password-env"),
+            FirstName = Value(values, "first-name"),
+            LastName = Value(values, "last-name"),
+            Roles = Value(values, "roles"),
+            Permissions = Value(values, "permissions"),
+            CountyId = countyId,
+            CountyName = Value(values, "county-name"),
+            CountyState = Value(values, "county-state"),
+            CountyFips = Value(values, "county-fips")
+        };
+    }
+
+    public bool IsValid(out string error)
+    {
+        if (string.IsNullOrWhiteSpace(Email))
+        {
+            error = "--email is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(Password) && string.IsNullOrWhiteSpace(PasswordEnv))
+        {
+            error = "--password-env is required unless --password is supplied for local-only use.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(PasswordEnv) && string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(PasswordEnv)))
+        {
+            error = $"Password environment variable '{PasswordEnv}' is not set.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    public string? ResolvePassword()
+    {
+        return !string.IsNullOrWhiteSpace(PasswordEnv)
+            ? Environment.GetEnvironmentVariable(PasswordEnv)
+            : Password;
+    }
+
+    public static string[] ParseCsv(string? raw)
+    {
+        return string.IsNullOrWhiteSpace(raw)
+            ? Array.Empty<string>()
+            : raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+    }
+
+    public static void PrintHelp()
+    {
+        Console.WriteLine("""
+TerraFusion.AuthProvisioner provisions real TerraFusion DB-backed operator accounts.
+
+Required:
+  --email <email>
+  --password-env <env var>       Preferred; reads password from environment.
+
+Database:
+  --connection-string <value>    Defaults to ConnectionStrings__DefaultConnection.
+  --provider Sqlite              SQLite only for the Hostinger production runtime.
+
+User:
+  --first-name <name>
+  --last-name <name>
+  --roles GovernmentUser,Administrator
+  --permissions read:parcel,ecosystem:view
+
+County:
+  --county-id <guid>
+  --county-name Benton --county-state WA --county-fips 53005 --create-county
+""");
+    }
+
+    private static string? Value(Dictionary<string, string?> values, string key)
+    {
+        return values.TryGetValue(key, out var value) ? value : null;
+    }
+}

--- a/backend/tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj
+++ b/backend/tools/TerraFusion.AuthProvisioner/TerraFusion.AuthProvisioner.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TerraFusion.API\TerraFusion.API.csproj" />
+    <ProjectReference Include="..\..\src\TerraFusion.Core\TerraFusion.Core.csproj" />
+    <ProjectReference Include="..\..\src\TerraFusion.Data\TerraFusion.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/frontend/apps/os-shell/src/__tests__/routing/RequireAuthRoute.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/routing/RequireAuthRoute.test.tsx
@@ -19,6 +19,11 @@ function LoginStub() {
   return <div data-testid='login-page'>Login Page</div>;
 }
 
+function validJwt() {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }));
+  return `header.${payload}.signature`;
+}
+
 function renderGuardedRoute(initialPath: string) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -53,7 +58,7 @@ describe('RequireAuth / AuthGuard route guard', () => {
 
   it('authenticated_renders_children', () => {
     // Pre-seed token in storage
-    authStorage.setToken('VALID_TOKEN');
+    authStorage.setToken(validJwt());
 
     renderGuardedRoute('/dashboard');
 
@@ -69,11 +74,32 @@ describe('RequireAuth / AuthGuard route guard', () => {
   });
 
   it('authenticated_user_can_access_home', () => {
-    authStorage.setToken('VALID_TOKEN');
+    authStorage.setToken(validJwt());
 
     renderGuardedRoute('/');
 
     expect(screen.getByTestId('home')).toBeInTheDocument();
+  });
+
+  it('authenticated_login_redirects_to_os_shell_home_not_canon', () => {
+    authStorage.setToken(validJwt());
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <AuthProvider>
+          <AuthGuard>
+            <Routes>
+              <Route path='/login' element={<LoginStub />} />
+              <Route path='/' element={<div data-testid='os-shell-home'>OS Shell Home</div>} />
+              <Route path='/canon' element={<div data-testid='canon-ide'>Canon IDE</div>} />
+            </Routes>
+          </AuthGuard>
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('os-shell-home')).toBeInTheDocument();
+    expect(screen.queryByTestId('canon-ide')).not.toBeInTheDocument();
   });
 
   it('dev_preview_mode_bypasses_login_redirect_without_token', () => {

--- a/frontend/apps/os-shell/src/auth/AuthProvider.tsx
+++ b/frontend/apps/os-shell/src/auth/AuthProvider.tsx
@@ -62,8 +62,18 @@ function isTokenExpiredOrMissing(token: string | null): boolean {
   }
 }
 
+function getInitialToken(): string | null {
+  const storedToken = getToken();
+  if (shouldForceLoginRedirect() && isTokenExpiredOrMissing(storedToken)) {
+    clearToken();
+    return null;
+  }
+
+  return storedToken;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setTokenState] = useState<string | null>(() => getToken());
+  const [token, setTokenState] = useState<string | null>(() => getInitialToken());
 
   // In dev preview mode, automatically obtain a real JWT from the backend.
   // Re-run whenever the stored token changes so an expired token is replaced.
@@ -138,7 +148,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   }
 
   if (isAuthenticated && location.pathname === '/login') {
-    return <Navigate to='/canon' replace />;
+    return <Navigate to='/' replace />;
   }
 
   return <>{children}</>;

--- a/frontend/apps/os-shell/src/auth/__tests__/AuthProvider.test.tsx
+++ b/frontend/apps/os-shell/src/auth/__tests__/AuthProvider.test.tsx
@@ -29,6 +29,11 @@ function renderWithAuth(ui: React.ReactElement) {
   );
 }
 
+function validJwt() {
+  const encode = (value: unknown) => btoa(JSON.stringify(value));
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode({ exp: Math.floor(Date.now() / 1000) + 3600 })}.sig`;
+}
+
 describe('AuthProvider', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -37,7 +42,8 @@ describe('AuthProvider', () => {
 
   it('initializes_from_storage_token', () => {
     // Pre-seed storage with a token
-    authStorage.setToken('STORED_TOKEN');
+    const storedToken = validJwt();
+    authStorage.setToken(storedToken);
 
     let captured: ReturnType<typeof useAuth> | undefined;
     renderWithAuth(
@@ -49,7 +55,7 @@ describe('AuthProvider', () => {
     );
 
     expect(captured).toBeDefined();
-    expect(captured!.token).toBe('STORED_TOKEN');
+    expect(captured!.token).toBe(storedToken);
     expect(captured!.isAuthenticated).toBe(true);
   });
 
@@ -66,6 +72,24 @@ describe('AuthProvider', () => {
     expect(captured).toBeDefined();
     expect(captured!.token).toBeNull();
     expect(captured!.isAuthenticated).toBe(false);
+  });
+
+  it('clears_invalid_storage_token_and_marks_unauthenticated', () => {
+    authStorage.setToken('invalid.jwt.token');
+
+    let captured: ReturnType<typeof useAuth> | undefined;
+    renderWithAuth(
+      <AuthProbe
+        onAuth={(v) => {
+          captured = v;
+        }}
+      />
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.token).toBeNull();
+    expect(captured!.isAuthenticated).toBe(false);
+    expect(authStorage.getToken()).toBeNull();
   });
 
   it('login_sets_token_and_marks_authenticated', () => {
@@ -91,7 +115,7 @@ describe('AuthProvider', () => {
   });
 
   it('logout_clears_token_and_marks_unauthenticated', () => {
-    authStorage.setToken('ACTIVE_TOKEN');
+    authStorage.setToken(validJwt());
 
     let captured: ReturnType<typeof useAuth> | undefined;
     renderWithAuth(

--- a/frontend/apps/os-shell/src/pages/LoginPage.tsx
+++ b/frontend/apps/os-shell/src/pages/LoginPage.tsx
@@ -1,7 +1,18 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/auth/useAuth';
-import { login as authLogin } from '@/services/authAPI';
+import { getAccessPolicy, login as authLogin, type AccessPolicy } from '@/services/authAPI';
+
+const DEFAULT_ACCESS_MESSAGE =
+  'Access is issued through TerraFusion administration for authorized Washington county operators. No public signup is available.';
+
+const runtimePosture = [
+  ['Runtime Authority', 'TerraFusion DB'],
+  ['Identity Model', 'Provisioned Operator'],
+  ['Session Model', 'Audited JWT Session'],
+  ['Operational Scope', 'Washington County Program'],
+  ['Governance Mode', 'Evidence-Gated Runtime'],
+];
 
 /**
  * LoginPage — Auth redirect target with real JWT exchange.
@@ -18,6 +29,19 @@ const LoginPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [accessPolicy, setAccessPolicy] = useState<AccessPolicy | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    getAccessPolicy().then((policy) => {
+      if (active) setAccessPolicy(policy);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,48 +61,120 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className='flex items-center justify-center min-h-screen bg-gradient-to-br from-gray-900 via-slate-800 to-gray-900' data-testid='login-page'>
-      <div className='w-full max-w-md p-8 rounded-2xl bg-gray-800/80 border border-cyan-500/30 shadow-lg'>
-        <h1 className='text-2xl font-bold text-cyan-400 mb-2 text-center'>TerraFusion OS</h1>
-        <p className='text-gray-400 text-sm text-center mb-6'>
-          Your session has expired. Please sign in to continue.
-        </p>
-        {error && (
-          <div className='mb-4 p-3 rounded bg-red-900/50 border border-red-500/50 text-red-300 text-sm text-center'>
-            {error}
+    <div
+      className='min-h-screen overflow-hidden bg-slate-950 text-slate-100'
+      data-testid='login-page'
+    >
+      <div className='pointer-events-none fixed inset-0 bg-[linear-gradient(rgba(56,189,248,0.055)_1px,transparent_1px),linear-gradient(90deg,rgba(56,189,248,0.045)_1px,transparent_1px)] bg-[size:64px_64px]' />
+      <div className='pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(14,165,233,0.16),transparent_32%),linear-gradient(135deg,rgba(2,6,23,0.6),rgba(15,23,42,0.18)_48%,rgba(2,6,23,0.85))]' />
+
+      <main className='relative flex min-h-screen flex-col'>
+        <header className='flex min-h-16 items-center justify-between border-b border-cyan-500/20 bg-slate-950/80 px-6 backdrop-blur md:px-10'>
+          <div>
+            <p className='text-sm font-semibold tracking-wide text-cyan-200'>TerraFusion OS</p>
+            <p className='text-xs uppercase tracking-[0.24em] text-slate-500'>Government Operations Runtime</p>
           </div>
-        )}
-        <form onSubmit={handleSubmit}>
-          <label className='block text-gray-300 text-sm mb-1' htmlFor='email'>
-            Email
-          </label>
-          <input
-            id='email'
-            type='email'
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className='w-full px-3 py-2 rounded bg-gray-700 text-gray-100 border border-gray-600 focus:border-cyan-500 focus:outline-none mb-4'
-            autoFocus
-          />
-          <label className='block text-gray-300 text-sm mb-1' htmlFor='password'>
-            Password
-          </label>
-          <input
-            id='password'
-            type='password'
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className='w-full px-3 py-2 rounded bg-gray-700 text-gray-100 border border-gray-600 focus:border-cyan-500 focus:outline-none mb-6'
-          />
-          <button
-            type='submit'
-            disabled={loading}
-            className='w-full py-2 rounded bg-cyan-600 hover:bg-cyan-500 disabled:bg-cyan-800 disabled:cursor-not-allowed text-white font-semibold transition-colors'
-          >
-            {loading ? 'Signing in...' : 'Sign In'}
-          </button>
-        </form>
-      </div>
+          <div className='hidden items-center gap-6 text-xs uppercase tracking-[0.2em] text-slate-400 md:flex'>
+            <span>Washington County Operations</span>
+            <span className='rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-amber-200'>
+              Controlled Production
+            </span>
+          </div>
+        </header>
+
+        <section className='grid flex-1 items-center gap-10 px-6 py-10 md:grid-cols-[minmax(0,1fr)_440px] md:px-10 lg:px-16'>
+          <div className='max-w-4xl'>
+            <p className='mb-4 text-sm font-semibold uppercase tracking-[0.28em] text-cyan-300'>
+              Washington County Operations
+            </p>
+            <h1 className='max-w-3xl text-5xl font-semibold leading-tight text-white md:text-6xl'>
+              Government Operations Runtime
+            </h1>
+            <p className='mt-6 max-w-2xl text-lg leading-8 text-slate-300'>
+              Controlled production access for authorized county operators entering the governed TerraFusion operating environment.
+            </p>
+
+            <div className='mt-10 max-w-3xl border-y border-cyan-500/20 bg-slate-950/40'>
+              {runtimePosture.map(([label, value]) => (
+                <div
+                  key={label}
+                  className='grid grid-cols-[190px_minmax(0,1fr)] border-b border-cyan-500/10 py-4 last:border-b-0'
+                >
+                  <span className='text-xs font-semibold uppercase tracking-[0.2em] text-slate-500'>{label}</span>
+                  <span className='text-sm font-medium text-slate-100'>{value}</span>
+                </div>
+              ))}
+            </div>
+
+            <p className='mt-8 max-w-2xl text-sm leading-7 text-slate-400'>
+              The entry state is intentionally provisioned, role-scoped, and auditable. Operator access begins with identity,
+              session, and runtime authority before work enters the county operating shell.
+            </p>
+          </div>
+
+          <aside className='rounded-lg border border-cyan-500/25 bg-slate-950/85 p-7 shadow-2xl shadow-black/40 backdrop-blur'>
+            <div className='mb-6 border-b border-cyan-500/20 pb-5'>
+              <p className='text-xs font-semibold uppercase tracking-[0.24em] text-slate-500'>
+                Controlled Production Access
+              </p>
+              <h2 className='mt-2 text-2xl font-semibold text-cyan-200'>Operator Access</h2>
+              <p className='mt-3 text-sm leading-6 text-slate-300'>
+                Use administrator-issued operator credentials to enter TerraFusion OS.
+              </p>
+            </div>
+
+            <div className='mb-5 rounded border border-cyan-500/20 bg-cyan-950/20 px-4 py-4 text-sm leading-6 text-slate-300'>
+              <p className='font-semibold text-cyan-200'>Provisioned access only</p>
+              <p className='mt-1'>{accessPolicy?.message ?? DEFAULT_ACCESS_MESSAGE}</p>
+              <p className='mt-3 text-slate-400'>Public signup is disabled. Access is issued through TerraFusion administration.</p>
+            </div>
+
+            {error && (
+              <div className='mb-4 rounded border border-red-500/50 bg-red-950/50 p-3 text-sm text-red-200'>
+                {error}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit}>
+              <label className='mb-2 block text-sm font-medium text-slate-300' htmlFor='email'>
+                Email
+              </label>
+              <input
+                id='email'
+                type='email'
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className='mb-4 w-full rounded border border-slate-600 bg-slate-800 px-3 py-3 text-slate-100 outline-none transition-colors focus:border-cyan-400'
+                autoFocus
+              />
+              <label className='mb-2 block text-sm font-medium text-slate-300' htmlFor='password'>
+                Password
+              </label>
+              <input
+                id='password'
+                type='password'
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className='mb-6 w-full rounded border border-slate-600 bg-slate-800 px-3 py-3 text-slate-100 outline-none transition-colors focus:border-cyan-400'
+              />
+              <button
+                type='submit'
+                disabled={loading}
+                className='w-full rounded bg-cyan-600 px-4 py-3 font-semibold text-white transition-colors hover:bg-cyan-500 disabled:cursor-not-allowed disabled:bg-cyan-900 disabled:text-slate-400'
+              >
+                {loading ? 'Entering TerraFusion OS...' : 'Enter TerraFusion OS'}
+              </button>
+            </form>
+          </aside>
+        </section>
+
+        <footer className='relative border-t border-cyan-500/20 bg-slate-950/80 px-6 py-4 text-xs text-slate-500 md:px-10'>
+          <div className='flex flex-col gap-2 md:flex-row md:items-center md:justify-between'>
+            <span>Provisioned operator access only. No public signup.</span>
+            <span>All sessions are governed, auditable, and role-scoped.</span>
+          </div>
+        </footer>
+      </main>
     </div>
   );
 };

--- a/frontend/apps/os-shell/src/pages/__tests__/LoginPage.real-auth.test.tsx
+++ b/frontend/apps/os-shell/src/pages/__tests__/LoginPage.real-auth.test.tsx
@@ -4,7 +4,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
-vi.mock('@/services/authAPI', () => ({ __esModule: true, login: vi.fn() }));
+vi.mock('@/services/authAPI', () => ({
+  __esModule: true,
+  login: vi.fn(),
+  getAccessPolicy: vi.fn(),
+}));
 
 // Prevent AuthProvider from calling fetchDevToken() in dev preview mode —
 // that fetch hangs in jsdom and consumes the 5s test timeout.
@@ -19,13 +23,20 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => navigate };
 });
 
-import { login as authLogin } from '@/services/authAPI';
+import { getAccessPolicy, login as authLogin } from '@/services/authAPI';
 import { AuthProvider } from '@/auth/AuthProvider';
 import LoginPage from '../LoginPage';
 
 describe('LoginPage real auth exchange', () => {
   beforeEach(() => {
     (authLogin as vi.Mock).mockReset();
+    (getAccessPolicy as vi.Mock).mockReset();
+    (getAccessPolicy as vi.Mock).mockResolvedValue({
+      signupMode: 'provisioned_access_only',
+      publicSignupEnabled: false,
+      message:
+        'Access is issued through TerraFusion administration for authorized Washington county operators. No public signup is available.',
+    });
     navigate.mockReset();
     localStorage.clear();
   });
@@ -41,10 +52,12 @@ describe('LoginPage real auth exchange', () => {
       </MemoryRouter>,
     );
 
+    await screen.findByText(/provisioned access only/i);
+
     const u = userEvent.setup();
     await u.type(screen.getByLabelText(/email/i), 'user@gov.example.com');
     await u.type(screen.getByLabelText(/pass/i), 'password');
-    await u.click(screen.getByRole('button', { name: /sign in/i }));
+    await u.click(screen.getByRole('button', { name: /enter terrafusion os/i }));
 
     await waitFor(() => {
       expect(authLogin).toHaveBeenCalledTimes(1);
@@ -69,12 +82,56 @@ describe('LoginPage real auth exchange', () => {
       </MemoryRouter>,
     );
 
+    await screen.findByText(/provisioned access only/i);
+
     const u = userEvent.setup();
     await u.type(screen.getByLabelText(/email/i), 'user@gov.example.com');
     await u.type(screen.getByLabelText(/pass/i), 'bad');
-    await u.click(screen.getByRole('button', { name: /sign in/i }));
+    await u.click(screen.getByRole('button', { name: /enter terrafusion os/i }));
 
     expect(await screen.findByText(/invalid|failed|error/i)).toBeInTheDocument();
     expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('renders the constitutional operations entry console without public request flows', async () => {
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <AuthProvider>
+          <LoginPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /government operations runtime/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/washington county operations/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/controlled production access/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/runtime authority/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/terrafusion db/i)).toBeInTheDocument();
+    expect(screen.getByText(/identity model/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/provisioned operator/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/session model/i)).toBeInTheDocument();
+    expect(screen.getByText(/audited jwt session/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /operator access/i })).toBeInTheDocument();
+    expect(await screen.findByText(/authorized washington county operators/i)).toBeInTheDocument();
+    expect(screen.getByText(/no public signup is available/i)).toBeInTheDocument();
+    expect(screen.queryByText(/benton county runtime pilot/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /request provisioned access/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/request access/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/public access requests/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/mailto/i)).not.toBeInTheDocument();
+  });
+
+  it('does not show an expired-session warning on a direct unauthenticated login visit', async () => {
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <AuthProvider>
+          <LoginPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/provisioned access only/i)).toBeInTheDocument();
+    expect(screen.queryByText(/your session has expired/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/controlled production access for authorized county operators/i)).toBeInTheDocument();
   });
 });

--- a/frontend/apps/os-shell/src/services/authAPI.ts
+++ b/frontend/apps/os-shell/src/services/authAPI.ts
@@ -7,7 +7,14 @@ export type LoginRequest = {
 
 export type LoginResult = { token: string };
 
+export type AccessPolicy = {
+  signupMode: string;
+  publicSignupEnabled: boolean;
+  message: string;
+};
+
 const LOGIN_PATH = '/auth/login';
+const ACCESS_POLICY_PATH = '/auth/access-policy';
 
 function normalizeToken(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null;
@@ -25,7 +32,31 @@ export async function login(req: LoginRequest): Promise<LoginResult> {
     return { token };
   } catch (err: unknown) {
     const status = (err as { response?: { status?: number } })?.response?.status;
-    if (status === 401 || status === 403) throw new Error('Invalid credentials');
+    const message = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
+    if (status === 401 || status === 403) {
+      throw new Error(typeof message === 'string' && message ? message : 'Invalid credentials');
+    }
     throw new Error('Network error');
+  }
+}
+
+export async function getAccessPolicy(): Promise<AccessPolicy> {
+  try {
+    const res = await api.get(ACCESS_POLICY_PATH);
+    const data = res?.data as Partial<AccessPolicy> | undefined;
+    return {
+      signupMode: data?.signupMode ?? 'provisioned_access_only',
+      publicSignupEnabled: data?.publicSignupEnabled === true,
+      message:
+        data?.message ??
+        'Access is issued through TerraFusion administration for authorized Washington county operators. No public signup is available.',
+    };
+  } catch {
+    return {
+      signupMode: 'provisioned_access_only',
+      publicSignupEnabled: false,
+      message:
+        'Access is issued through TerraFusion administration for authorized Washington county operators. No public signup is available.',
+    };
   }
 }

--- a/os-platform/core/pilot/june10-operator-post-login-smoke.mjs
+++ b/os-platform/core/pilot/june10-operator-post-login-smoke.mjs
@@ -1,0 +1,781 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const DEFAULT_BASE_URL = "https://terrafusionmarket.com";
+const DEFAULT_OUT_JSON = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "june10-operator-post-login-smoke.latest.json"
+);
+const DEFAULT_OUT_MD = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "june10-operator-post-login-smoke.latest.md"
+);
+const DEFAULT_SCREENSHOT = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "screenshots",
+  "june10-operator-post-login-shell.latest.png"
+);
+
+const REQUIRED_JWT_ROLES = ["GovernmentUser"];
+const REQUIRED_JWT_PERMISSIONS = ["runtime:read", "county:read", "workbench:access"];
+export const LOGIN_SUBMIT_BUTTON_NAME_PATTERN = /enter terrafusion os|sign in/i;
+
+function normalizeBaseUrl(baseUrl) {
+  return String(baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function rel(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string" && value.includes(",")) {
+    return value.split(",").map((item) => item.trim()).filter(Boolean);
+  }
+  if (typeof value === "string" && value.length > 0) return [value];
+  return [];
+}
+
+function decodeJwtPayload(token) {
+  const parts = String(token ?? "").split(".");
+  if (parts.length < 2) return null;
+
+  try {
+    return JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function extractJwtIdentity(token) {
+  const payload = decodeJwtPayload(token) ?? {};
+  return {
+    email: payload.email ?? payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"] ?? null,
+    roles: asArray(payload.role ?? payload.roles ?? payload["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"]),
+    permissions: asArray(payload.perm ?? payload.permissions),
+    countyId: payload.countyId ?? null,
+    countyName: payload.countyName ?? null,
+    countyState: payload.countyState ?? null,
+    countyFipsCode: payload.countyFipsCode ?? null
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.TF_J10_OPERATOR_AUTH_BASE_URL ?? DEFAULT_BASE_URL,
+    email: process.env.TF_J10_OPERATOR_EMAIL ?? process.env.TF_PROVISIONED_AUTH_EMAIL ?? null,
+    password: process.env.TF_J10_OPERATOR_PASSWORD ?? process.env.TF_PROVISIONED_AUTH_PASSWORD ?? null,
+    passwordEnv: null,
+    outJson: DEFAULT_OUT_JSON,
+    outMd: DEFAULT_OUT_MD,
+    screenshotPath: DEFAULT_SCREENSHOT,
+    fixture: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => argv[++index];
+    if (arg === "--base-url") options.baseUrl = next();
+    else if (arg === "--email") options.email = next();
+    else if (arg === "--password-env") options.passwordEnv = next();
+    else if (arg === "--out-json") options.outJson = next();
+    else if (arg === "--out-md") options.outMd = next();
+    else if (arg === "--screenshot") options.screenshotPath = next();
+    else if (arg === "--fixture") options.fixture = next();
+  }
+
+  if (options.passwordEnv) {
+    options.password = process.env[options.passwordEnv] ?? null;
+  }
+
+  return options;
+}
+
+function hasRequiredIdentity(identity, expectedEmail) {
+  const expected = String(expectedEmail ?? "").toLowerCase();
+  return Boolean(
+    identity?.email &&
+      identity.email.toLowerCase() === expected &&
+      REQUIRED_JWT_ROLES.every((role) => identity.roles?.includes(role)) &&
+      REQUIRED_JWT_PERMISSIONS.every((permission) => identity.permissions?.includes(permission)) &&
+      identity.countyName === "Benton" &&
+      identity.countyState === "WA" &&
+      identity.countyFipsCode === "53005"
+  );
+}
+
+function isAuthRuntimeSignal(value) {
+  return /auth|token|session|login|unauthori[sz]ed|forbidden|jwt|credential/i.test(String(value ?? ""));
+}
+
+function profileIdentityFromPayload(payload) {
+  const source = payload?.user ?? payload?.User ?? payload ?? {};
+  return {
+    userId: source.userId ?? source.UserId ?? null,
+    email: source.email ?? source.Email ?? null,
+    roles: asArray(source.roles ?? source.Roles),
+    permissions: asArray(source.permissions ?? source.Permissions),
+    countyId: source.countyId ?? source.CountyId ?? null,
+    county: source.county ?? source.County ?? source.countyName ?? source.CountyName ?? null,
+    countyFipsCode: source.countyFipsCode ?? source.CountyFipsCode ?? null,
+    state: source.state ?? source.State ?? source.countyState ?? source.CountyState ?? null,
+    sessionValid: source.sessionValid ?? source.SessionValid ?? false
+  };
+}
+
+function hasRequiredProfileIdentity(identity, expectedEmail) {
+  const expected = String(expectedEmail ?? "").toLowerCase();
+  return Boolean(
+    identity?.userId &&
+      identity?.email &&
+      identity.email.toLowerCase() === expected &&
+      REQUIRED_JWT_ROLES.every((role) => identity.roles?.includes(role)) &&
+      REQUIRED_JWT_PERMISSIONS.every((permission) => identity.permissions?.includes(permission)) &&
+      identity.countyId &&
+      identity.countyFipsCode === "53005" &&
+      identity.state === "WA" &&
+      identity.sessionValid === true
+  );
+}
+
+export async function fetchJsonWithBearer(url, token) {
+  const response = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "TerraFusion-June10-OperatorPostLoginSmoke/1.0"
+    }
+  });
+  const bodyText = await response.text();
+  let payload = null;
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    payload = null;
+  }
+
+  return {
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    payload,
+    bodySnippet: bodyText.replace(/\s+/g, " ").slice(0, 400)
+  };
+}
+
+async function fillLoginForm(page, email, password) {
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: LOGIN_SUBMIT_BUTTON_NAME_PATTERN }).click();
+}
+
+async function clickLogoutIfPresent(page) {
+  const result = {
+    controlFound: false,
+    clicked: false,
+    redirectedToLogin: false,
+    tokenCleared: false
+  };
+
+  const profileButton = page.getByRole("button", { name: /profile/i }).first();
+  if ((await profileButton.count().catch(() => 0)) > 0) {
+    await profileButton.click().catch(() => {});
+    await page.waitForTimeout(600);
+  }
+
+  const logoutControl = page
+    .locator("button, a, [role='button'], [role='menuitem']")
+    .filter({ hasText: /log out|logout|sign out/i })
+    .first();
+  result.controlFound = (await logoutControl.count().catch(() => 0)) > 0;
+
+  if (!result.controlFound) return result;
+
+  await logoutControl.click();
+  result.clicked = true;
+  await page.waitForURL((url) => url.pathname.startsWith("/login"), { timeout: 10000 }).catch(() => {});
+  await page.waitForTimeout(500);
+  result.redirectedToLogin = new URL(page.url()).pathname.startsWith("/login");
+  result.tokenCleared = await page.evaluate(() => !localStorage.getItem("authToken")).catch(() => false);
+  return result;
+}
+
+async function inspectInvalidTokenBehavior(baseUrl) {
+  let chromium;
+  try {
+    ({ chromium } = await import("@playwright/test"));
+  } catch (error) {
+    return {
+      redirectedToLogin: false,
+      tokenCleared: false,
+      protectedApiRejected: false,
+      status: null,
+      error: `Playwright is unavailable: ${error.message}`
+    };
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ ignoreHTTPSErrors: true });
+  try {
+    await page.goto(normalizeBaseUrl(baseUrl), { waitUntil: "domcontentloaded", timeout: 45000 }).catch(() => {});
+    await page.evaluate(() => localStorage.setItem("authToken", "invalid.jwt.token"));
+    await page.goto(`${normalizeBaseUrl(baseUrl)}/canon?invalidTokenSmoke=${Date.now()}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000
+    });
+    await page.waitForLoadState("networkidle", { timeout: 20000 }).catch(() => {});
+    await page.waitForTimeout(1500);
+
+    const invalidApi = await fetchJsonWithBearer(`${normalizeBaseUrl(baseUrl)}/api/auth/profile`, "invalid.jwt.token");
+    return {
+      finalUrl: page.url(),
+      redirectedToLogin: new URL(page.url()).pathname.startsWith("/login"),
+      tokenCleared: await page.evaluate(() => !localStorage.getItem("authToken")).catch(() => false),
+      protectedApiRejected: invalidApi.status === 401 || invalidApi.status === 403,
+      status: invalidApi.status,
+      error: null
+    };
+  } catch (error) {
+    return {
+      redirectedToLogin: false,
+      tokenCleared: false,
+      protectedApiRejected: false,
+      status: null,
+      error: error.message
+    };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+async function runBrowserSmoke({ baseUrl, email, password, screenshotPath }) {
+  let chromium;
+  try {
+    ({ chromium } = await import("@playwright/test"));
+  } catch (error) {
+    return {
+      login: { finalUrl: null, tokenStored: false, jwtIdentity: null },
+      shell: {
+        osShellHomeLoaded: false,
+        canonLoaded: false,
+        chromeSignals: {
+          terraFusionOsTitle: false,
+          shellChrome: false,
+          bentonCounty: false
+        }
+      },
+      consoleAndRuntime: {
+        authErrorCount: 1,
+        authErrors: [`Playwright is unavailable: ${error.message}`],
+        pageErrorCount: 0,
+        pageErrors: []
+      },
+      logout: {
+        controlFound: false,
+        clicked: false,
+        redirectedToLogin: false,
+        tokenCleared: false
+      },
+      token: null,
+      screenshotPath: null
+    };
+  }
+
+  fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });
+
+  const authErrors = [];
+  const pageErrors = [];
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1000 },
+    ignoreHTTPSErrors: true
+  });
+
+  page.on("console", (message) => {
+    const text = message.text();
+    if (isAuthRuntimeSignal(text) && message.type() !== "debug") {
+      authErrors.push(`${message.type()}: ${text}`.slice(0, 500));
+    }
+  });
+  page.on("pageerror", (error) => pageErrors.push(error.message.slice(0, 500)));
+  page.on("response", (response) => {
+    const url = response.url();
+    const status = response.status();
+    if (status >= 400 && isAuthRuntimeSignal(url)) {
+      authErrors.push(`HTTP ${status}: ${url}`);
+    }
+  });
+
+  try {
+    await page.goto(`${normalizeBaseUrl(baseUrl)}/login?postLoginSmoke=${Date.now()}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000
+    });
+    await Promise.all([
+      page.waitForResponse((response) => response.url().includes("/api/auth/login"), { timeout: 45000 }),
+      fillLoginForm(page, email, password)
+    ]);
+    await page.waitForURL((url) => url.pathname === "/", { timeout: 45000 }).catch(() => {});
+    await page.waitForLoadState("networkidle", { timeout: 45000 }).catch(() => {});
+    await page
+      .getByText(/TerraFusion OS Desktop|Benton County/i)
+      .first()
+      .waitFor({ timeout: 20000 })
+      .catch(() => {});
+    await page.waitForTimeout(1000);
+
+    const finalUrl = page.url();
+    const bodyText = await page.locator("body").innerText({ timeout: 15000 }).catch(() => "");
+    const token = await page.evaluate(() => localStorage.getItem("authToken")).catch(() => null);
+    const jwtIdentity = extractJwtIdentity(token);
+
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    const logout = await clickLogoutIfPresent(page);
+
+    return {
+      login: {
+        finalUrl,
+        tokenStored: Boolean(token),
+        jwtIdentity
+      },
+      shell: {
+        osShellHomeLoaded: new URL(finalUrl).pathname === "/",
+        canonLoaded: new URL(finalUrl).pathname.startsWith("/canon"),
+        chromeSignals: {
+          terraFusionOsTitle: /TerraFusion OS/i.test(bodyText),
+          shellChrome: /TerraFusion OS Desktop|HEALTH|SENTINEL|Assessor/i.test(bodyText),
+          bentonCounty: /Benton County/i.test(bodyText)
+        },
+        bodyTextLength: bodyText.length
+      },
+      consoleAndRuntime: {
+        authErrorCount: authErrors.length,
+        authErrors,
+        pageErrorCount: pageErrors.length,
+        pageErrors
+      },
+      logout,
+      token,
+      screenshotPath: rel(screenshotPath)
+    };
+  } catch (error) {
+    await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+    return {
+      login: { finalUrl: page.url(), tokenStored: false, jwtIdentity: null },
+      shell: {
+        osShellHomeLoaded: false,
+        canonLoaded: false,
+        chromeSignals: {
+          terraFusionOsTitle: false,
+          shellChrome: false,
+          bentonCounty: false
+        }
+      },
+      consoleAndRuntime: {
+        authErrorCount: authErrors.length,
+        authErrors,
+        pageErrorCount: pageErrors.length + 1,
+        pageErrors: [...pageErrors, error.message]
+      },
+      logout: {
+        controlFound: false,
+        clicked: false,
+        redirectedToLogin: false,
+        tokenCleared: false
+      },
+      token: null,
+      screenshotPath: rel(screenshotPath)
+    };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+function buildFixtureReport(fixture, email) {
+  if (fixture !== "pass") {
+    throw new Error(`Unknown fixture: ${fixture}`);
+  }
+
+  return buildJune10OperatorPostLoginSmokeReport({
+    baseUrl: DEFAULT_BASE_URL,
+    email,
+    login: {
+      finalUrl: `${DEFAULT_BASE_URL}/`,
+      tokenStored: true,
+      jwtIdentity: {
+        email,
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyName: "Benton",
+        countyState: "WA",
+        countyFipsCode: "53005"
+      }
+    },
+    shell: {
+      osShellHomeLoaded: true,
+      canonLoaded: false,
+      chromeSignals: {
+        terraFusionOsTitle: true,
+        shellChrome: true,
+        bentonCounty: true
+      }
+    },
+    protectedApis: {
+      profile: {
+        status: 200,
+        operatorIdentityRecognized: true,
+        userId: "fixture-user-id",
+        email,
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyId: "fixture-county-id",
+        county: "Benton",
+        countyFipsCode: "53005",
+        state: "WA",
+        sessionValid: true
+      },
+      bentonParcels: {
+        status: 200,
+        county: "Benton",
+        rowsReturned: 1,
+        bentonContextPresent: true
+      }
+    },
+    consoleAndRuntime: {
+      authErrorCount: 0,
+      authErrors: [],
+      pageErrorCount: 0,
+      pageErrors: []
+    },
+    logout: {
+      controlFound: true,
+      clicked: true,
+      redirectedToLogin: true,
+      tokenCleared: true
+    },
+    invalidToken: {
+      redirectedToLogin: true,
+      tokenCleared: true,
+      protectedApiRejected: true,
+      status: 401
+    },
+    screenshotPath: "fixture"
+  });
+}
+
+export function buildJune10OperatorPostLoginSmokeReport({
+  baseUrl,
+  email,
+  login,
+  shell,
+  protectedApis,
+  consoleAndRuntime,
+  logout,
+  invalidToken,
+  screenshotPath
+}) {
+  const blockers = [];
+  const warnings = [];
+  const profile = protectedApis?.profile ?? {};
+  const operatorIdentityRecognized = hasRequiredProfileIdentity(profile, email);
+  const protectedApiSucceeded = Boolean(
+    profile.status === 200 && operatorIdentityRecognized === true
+  );
+  const bentonCountyContextPresent = Boolean(
+    profile.countyFipsCode === "53005" &&
+      profile.state === "WA" &&
+      shell?.chromeSignals?.bentonCounty === true &&
+      protectedApis?.bentonParcels?.bentonContextPresent === true &&
+      protectedApis?.bentonParcels?.county === "Benton"
+  );
+
+  if (!email) blockers.push("Operator email is not configured.");
+  const finalPath = login?.finalUrl ? new URL(login.finalUrl, baseUrl).pathname : null;
+  if (finalPath !== "/") {
+    blockers.push("OS shell home did not load after login.");
+  }
+  if (finalPath?.startsWith("/canon")) blockers.push("Post-login landed on Canon IDE instead of the OS shell home.");
+  if (!login?.tokenStored) blockers.push("Browser did not store JWT after login.");
+  if (!operatorIdentityRecognized) {
+    blockers.push("Operator identity is not recognized from /api/auth/profile, including DB-backed user, permissions, active session, and Benton FIPS 53005.");
+  }
+  if (!hasRequiredIdentity(login?.jwtIdentity, email)) {
+    warnings.push("JWT identity claims are incomplete or do not include Benton FIPS 53005.");
+  }
+  if (!shell?.osShellHomeLoaded) blockers.push("OS shell home route did not load cleanly.");
+  if (shell?.canonLoaded) blockers.push("Canon IDE loaded as the default post-login route.");
+  for (const [signal, present] of Object.entries(shell?.chromeSignals ?? {})) {
+    if (!present) blockers.push(`Shell chrome signal missing: ${signal}.`);
+  }
+
+  if (profile.status !== 200) {
+    blockers.push(`/api/auth/profile returned ${profile.status ?? "not attempted"}.`);
+  } else if (!profile.operatorIdentityRecognized) {
+    blockers.push("/api/auth/profile did not recognize the logged-in operator identity.");
+  } else if (profile.sessionValid !== true) {
+    blockers.push("/api/auth/profile did not confirm a valid persisted user session.");
+  }
+
+  if (!protectedApiSucceeded) {
+    blockers.push("No protected API call succeeded with the login JWT.");
+  }
+
+  const parcels = protectedApis?.bentonParcels ?? {};
+  if (parcels.status !== 200) {
+    blockers.push(`/api/counties/benton/parcels returned ${parcels.status ?? "not attempted"}.`);
+  }
+  if (!parcels.bentonContextPresent || parcels.county !== "Benton") {
+    blockers.push("Benton county context was not present in protected parcels API response.");
+  }
+  if (!bentonCountyContextPresent) {
+    blockers.push("Benton county context / FIPS 53005 is not present across profile, shell, and protected API evidence.");
+  }
+  if (!Number.isFinite(parcels.rowsReturned) || parcels.rowsReturned <= 0) {
+    blockers.push("Protected Benton parcels API returned zero rows.");
+  }
+
+  if ((consoleAndRuntime?.authErrorCount ?? 0) > 0) {
+    blockers.push(`Console/runtime auth errors were detected: ${consoleAndRuntime.authErrorCount}.`);
+  }
+  if ((consoleAndRuntime?.pageErrorCount ?? 0) > 0) {
+    blockers.push(`Browser page errors were detected: ${consoleAndRuntime.pageErrorCount}.`);
+  }
+
+  if (!logout?.controlFound) blockers.push("No visible logout/sign-out control found after login.");
+  else if (!logout.clicked || !logout.redirectedToLogin || !logout.tokenCleared) {
+    blockers.push("Logout control did not return to login and clear token cleanly.");
+  }
+
+  if (!invalidToken?.protectedApiRejected) {
+    blockers.push("Invalid token was not rejected by protected API.");
+  }
+  if (!invalidToken?.redirectedToLogin || !invalidToken?.tokenCleared) {
+    blockers.push("Invalid token did not return to login cleanly and clear browser token state.");
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    email,
+    passwordSupplied: "yes (redacted)",
+    login,
+    shell,
+    protectedApis,
+    consoleAndRuntime,
+    logout,
+    invalidToken,
+    screenshotPath,
+    operatorIdentityRecognized,
+    protectedApiSucceeded,
+    bentonCountyContextPresent,
+    warnings,
+    passed: blockers.length === 0,
+    blockers
+  };
+}
+
+export async function runJune10OperatorPostLoginSmoke({
+  baseUrl = DEFAULT_BASE_URL,
+  email,
+  password,
+  screenshotPath = DEFAULT_SCREENSHOT
+}) {
+  if (!email || !password) {
+    return buildJune10OperatorPostLoginSmokeReport({
+      baseUrl,
+      email,
+      login: { finalUrl: null, tokenStored: false, jwtIdentity: null },
+      shell: {
+        osShellHomeLoaded: false,
+        canonLoaded: false,
+        chromeSignals: {
+          terraFusionOsTitle: false,
+          shellChrome: false,
+          bentonCounty: false
+        }
+      },
+      protectedApis: {
+        profile: {
+          status: null,
+          operatorIdentityRecognized: false,
+          userId: null,
+          email: null,
+          roles: [],
+          permissions: [],
+          countyId: null,
+          county: null,
+          countyFipsCode: null,
+          state: null,
+          sessionValid: false
+        },
+        bentonParcels: { status: null, county: null, rowsReturned: 0, bentonContextPresent: false }
+      },
+      consoleAndRuntime: { authErrorCount: 0, authErrors: [], pageErrorCount: 0, pageErrors: [] },
+      logout: { controlFound: false, clicked: false, redirectedToLogin: false, tokenCleared: false },
+      invalidToken: { redirectedToLogin: false, tokenCleared: false, protectedApiRejected: false, status: null },
+      screenshotPath: null
+    });
+  }
+
+  const browser = await runBrowserSmoke({ baseUrl, email, password, screenshotPath });
+  const token = browser.token;
+  const profileResponse = token
+    ? await fetchJsonWithBearer(`${normalizeBaseUrl(baseUrl)}/api/auth/profile`, token)
+    : { status: null, payload: null };
+  const profileIdentity = profileIdentityFromPayload(profileResponse.payload);
+  const parcelsResponse = token
+    ? await fetchJsonWithBearer(`${normalizeBaseUrl(baseUrl)}/api/counties/benton/parcels?limit=1`, token)
+    : { status: null, payload: null };
+  const parcelRows = Array.isArray(parcelsResponse.payload?.data)
+    ? parcelsResponse.payload.data.length
+    : Array.isArray(parcelsResponse.payload?.items)
+      ? parcelsResponse.payload.items.length
+      : Array.isArray(parcelsResponse.payload)
+        ? parcelsResponse.payload.length
+        : Number.isFinite(parcelsResponse.payload?.count)
+          ? Math.min(parcelsResponse.payload.count, 1)
+          : 0;
+  const invalidToken = await inspectInvalidTokenBehavior(baseUrl);
+
+  return buildJune10OperatorPostLoginSmokeReport({
+    baseUrl,
+    email,
+    login: {
+      finalUrl: browser.login.finalUrl,
+      tokenStored: browser.login.tokenStored,
+      jwtIdentity: browser.login.jwtIdentity
+    },
+    shell: browser.shell,
+    protectedApis: {
+      profile: {
+        status: profileResponse.status,
+        operatorIdentityRecognized: hasRequiredProfileIdentity(profileIdentity, email),
+        userId: profileIdentity.userId,
+        email: profileIdentity.email,
+        roles: profileIdentity.roles,
+        permissions: profileIdentity.permissions,
+        countyId: profileIdentity.countyId,
+        county: profileIdentity.county,
+        countyFipsCode: profileIdentity.countyFipsCode,
+        state: profileIdentity.state,
+        sessionValid: profileIdentity.sessionValid
+      },
+      bentonParcels: {
+        status: parcelsResponse.status,
+        county: parcelsResponse.payload?.county ?? parcelsResponse.payload?.County ?? null,
+        rowsReturned: parcelRows,
+        bentonContextPresent: (parcelsResponse.payload?.county ?? parcelsResponse.payload?.County) === "Benton"
+      }
+    },
+    consoleAndRuntime: browser.consoleAndRuntime,
+    logout: browser.logout,
+    invalidToken,
+    screenshotPath: browser.screenshotPath
+  });
+}
+
+function renderMarkdown(report) {
+  return [
+    "# June 10 Operator Post-Login Smoke",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Base URL: ${report.baseUrl}`,
+    `Operator: ${report.email ?? "not configured"}`,
+    `Password supplied: ${report.passwordSupplied}`,
+    "",
+    `Verdict: ${report.passed ? "PASS" : "FAIL"}`,
+    "",
+    "## Shell",
+    "",
+    `- Final URL: ${report.login?.finalUrl ?? "not captured"}`,
+    `- OS shell home loaded: ${report.shell?.osShellHomeLoaded === true}`,
+    `- Canon IDE loaded as default: ${report.shell?.canonLoaded === true}`,
+    `- Shell chrome: ${report.shell?.chromeSignals?.shellChrome === true}`,
+    `- Benton county context: ${report.shell?.chromeSignals?.bentonCounty === true}`,
+    `- Screenshot: ${report.screenshotPath ?? "not captured"}`,
+    "",
+    "## Identity And APIs",
+    "",
+    `- JWT email: ${report.login?.jwtIdentity?.email ?? "none"}`,
+    `- JWT roles: ${report.login?.jwtIdentity?.roles?.join(", ") || "none"}`,
+    `- JWT permissions: ${report.login?.jwtIdentity?.permissions?.join(", ") || "none"}`,
+    `- JWT county FIPS: ${report.login?.jwtIdentity?.countyFipsCode ?? "none"}`,
+    `- Operator identity recognized: ${report.operatorIdentityRecognized === true}`,
+    `- Protected API succeeded: ${report.protectedApiSucceeded === true}`,
+    `- Benton context / FIPS 53005 present: ${report.bentonCountyContextPresent === true}`,
+    `- Profile API status: ${report.protectedApis?.profile?.status ?? "not attempted"}`,
+    `- Profile identity recognized: ${report.protectedApis?.profile?.operatorIdentityRecognized === true}`,
+    `- Profile user id: ${report.protectedApis?.profile?.userId ?? "none"}`,
+    `- Profile roles: ${report.protectedApis?.profile?.roles?.join(", ") || "none"}`,
+    `- Profile permissions: ${report.protectedApis?.profile?.permissions?.join(", ") || "none"}`,
+    `- Profile county FIPS: ${report.protectedApis?.profile?.countyFipsCode ?? "none"}`,
+    `- Profile state: ${report.protectedApis?.profile?.state ?? "none"}`,
+    `- Profile session valid: ${report.protectedApis?.profile?.sessionValid === true}`,
+    `- Benton parcels API status: ${report.protectedApis?.bentonParcels?.status ?? "not attempted"}`,
+    `- Benton parcels rows returned: ${report.protectedApis?.bentonParcels?.rowsReturned ?? 0}`,
+    "",
+    "## Session Controls",
+    "",
+    `- Auth console/runtime errors: ${report.consoleAndRuntime?.authErrorCount ?? 0}`,
+    `- Page errors: ${report.consoleAndRuntime?.pageErrorCount ?? 0}`,
+    `- Logout control found: ${report.logout?.controlFound === true}`,
+    `- Logout returned to login: ${report.logout?.redirectedToLogin === true}`,
+    `- Invalid token returned to login: ${report.invalidToken?.redirectedToLogin === true}`,
+    `- Invalid token protected API status: ${report.invalidToken?.status ?? "not attempted"}`,
+    "",
+    "## Auth Errors",
+    "",
+    ...((report.consoleAndRuntime?.authErrors ?? []).length
+      ? report.consoleAndRuntime.authErrors.map((error) => `- ${error}`)
+      : ["- None"]),
+    "",
+    "## Warnings",
+    "",
+    ...(report.warnings.length ? report.warnings.map((warning) => `- ${warning}`) : ["- None"]),
+    "",
+    "## Blockers",
+    "",
+    ...(report.blockers.length ? report.blockers.map((blocker) => `- ${blocker}`) : ["- None"])
+  ].join("\n");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const report = options.fixture
+    ? buildFixtureReport(options.fixture, options.email ?? "june10-operator@terrafusionmarket.com")
+    : await runJune10OperatorPostLoginSmoke(options);
+
+  fs.mkdirSync(path.dirname(options.outJson), { recursive: true });
+  fs.mkdirSync(path.dirname(options.outMd), { recursive: true });
+  fs.writeFileSync(options.outJson, JSON.stringify(report, null, 2));
+  fs.writeFileSync(options.outMd, renderMarkdown(report));
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.passed ? 0 : 1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/os-platform/core/pilot/june10-operator-post-login-smoke.test.mjs
+++ b/os-platform/core/pilot/june10-operator-post-login-smoke.test.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import {
+  buildJune10OperatorPostLoginSmokeReport,
+  fetchJsonWithBearer,
+  LOGIN_SUBMIT_BUTTON_NAME_PATTERN
+} from "./june10-operator-post-login-smoke.mjs";
+
+const execFileAsync = promisify(execFile);
+
+test("passes when post-login shell, identity, Benton context, logout, and invalid-token handling are proven", () => {
+  const report = buildJune10OperatorPostLoginSmokeReport({
+    baseUrl: "https://terrafusionmarket.com",
+    email: "june10-operator@terrafusionmarket.com",
+    login: {
+      finalUrl: "https://terrafusionmarket.com/",
+      tokenStored: true,
+      jwtIdentity: {
+        email: "june10-operator@terrafusionmarket.com",
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyName: "Benton",
+        countyState: "WA",
+        countyFipsCode: "53005"
+      }
+    },
+    shell: {
+      osShellHomeLoaded: true,
+      canonLoaded: false,
+      chromeSignals: {
+        terraFusionOsTitle: true,
+        shellChrome: true,
+        bentonCounty: true
+      }
+    },
+    protectedApis: {
+      profile: {
+        status: 200,
+        operatorIdentityRecognized: true,
+        userId: "98c48122-078d-4125-b342-a122d86b8ff3",
+        email: "june10-operator@terrafusionmarket.com",
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyId: "53005000-0000-4000-8000-000000000005",
+        county: "Benton",
+        countyFipsCode: "53005",
+        state: "WA",
+        sessionValid: true
+      },
+      bentonParcels: {
+        status: 200,
+        county: "Benton",
+        rowsReturned: 1,
+        bentonContextPresent: true
+      }
+    },
+    consoleAndRuntime: {
+      authErrorCount: 0,
+      authErrors: [],
+      pageErrorCount: 0,
+      pageErrors: []
+    },
+    logout: {
+      controlFound: true,
+      clicked: true,
+      redirectedToLogin: true,
+      tokenCleared: true
+    },
+    invalidToken: {
+      redirectedToLogin: true,
+      tokenCleared: true,
+      protectedApiRejected: true,
+      status: 401
+    },
+    screenshotPath: "os-platform/core/pilot/evidence/screenshots/june10-operator-post-login-shell.latest.png"
+  });
+
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.blockers, []);
+});
+
+test("login smoke accepts the constitutional production submit label", () => {
+  assert.match("Enter TerraFusion OS", LOGIN_SUBMIT_BUTTON_NAME_PATTERN);
+  assert.match("Sign In", LOGIN_SUBMIT_BUTTON_NAME_PATTERN);
+});
+
+test("blocks when profile identity is missing even if JWT identity and protected Benton API are proven", () => {
+  const report = buildJune10OperatorPostLoginSmokeReport({
+    baseUrl: "https://terrafusionmarket.com",
+    email: "june10-operator@terrafusionmarket.com",
+    login: {
+      finalUrl: "https://terrafusionmarket.com/",
+      tokenStored: true,
+      jwtIdentity: {
+        email: "june10-operator@terrafusionmarket.com",
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyName: "Benton",
+        countyState: "WA",
+        countyFipsCode: "53005"
+      }
+    },
+    shell: {
+      osShellHomeLoaded: true,
+      canonLoaded: false,
+      chromeSignals: {
+        terraFusionOsTitle: true,
+        shellChrome: true,
+        bentonCounty: true
+      }
+    },
+    protectedApis: {
+      profile: {
+        status: 200,
+        operatorIdentityRecognized: false,
+        email: null,
+        roles: []
+      },
+      bentonParcels: {
+        status: 200,
+        county: "Benton",
+        rowsReturned: 1,
+        bentonContextPresent: true
+      }
+    },
+    consoleAndRuntime: {
+      authErrorCount: 0,
+      authErrors: [],
+      pageErrorCount: 0,
+      pageErrors: []
+    },
+    logout: {
+      controlFound: true,
+      clicked: true,
+      redirectedToLogin: true,
+      tokenCleared: true
+    },
+    invalidToken: {
+      redirectedToLogin: true,
+      tokenCleared: true,
+      protectedApiRejected: true,
+      status: 401
+    },
+    screenshotPath: null
+  });
+
+  assert.equal(report.operatorIdentityRecognized, false);
+  assert.equal(report.protectedApiSucceeded, false);
+  assert.equal(report.bentonCountyContextPresent, false);
+  assert.equal(report.passed, false);
+  assert.ok(report.blockers.some((blocker) => blocker.includes("/api/auth/profile")));
+});
+
+test("blocks when Benton FIPS 53005 is not present in the post-login identity", () => {
+  const report = buildJune10OperatorPostLoginSmokeReport({
+    baseUrl: "https://terrafusionmarket.com",
+    email: "june10-operator@terrafusionmarket.com",
+    login: {
+      finalUrl: "https://terrafusionmarket.com/",
+      tokenStored: true,
+      jwtIdentity: {
+        email: "june10-operator@terrafusionmarket.com",
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyName: "Benton",
+        countyState: "WA",
+        countyFipsCode: "99999"
+      }
+    },
+    shell: {
+      osShellHomeLoaded: true,
+      canonLoaded: false,
+      chromeSignals: {
+        terraFusionOsTitle: true,
+        shellChrome: true,
+        bentonCounty: true
+      }
+    },
+    protectedApis: {
+      profile: {
+        status: 200,
+        operatorIdentityRecognized: true,
+        userId: "98c48122-078d-4125-b342-a122d86b8ff3",
+        email: "june10-operator@terrafusionmarket.com",
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyId: "53005000-0000-4000-8000-000000000005",
+        county: "Benton",
+        countyFipsCode: "99999",
+        state: "WA",
+        sessionValid: true
+      },
+      bentonParcels: {
+        status: 200,
+        county: "Benton",
+        rowsReturned: 1,
+        bentonContextPresent: true
+      }
+    },
+    consoleAndRuntime: {
+      authErrorCount: 0,
+      authErrors: [],
+      pageErrorCount: 0,
+      pageErrors: []
+    },
+    logout: {
+      controlFound: true,
+      clicked: true,
+      redirectedToLogin: true,
+      tokenCleared: true
+    },
+    invalidToken: {
+      redirectedToLogin: true,
+      tokenCleared: true,
+      protectedApiRejected: true,
+      status: 401
+    },
+    screenshotPath: null
+  });
+
+  assert.equal(report.passed, false);
+  assert.equal(report.bentonCountyContextPresent, false);
+  assert.ok(report.blockers.some((blocker) => blocker.includes("FIPS 53005")));
+});
+
+test("fetchJsonWithBearer sends Authorization bearer token and parses JSON response", async () => {
+  const server = http.createServer((req, res) => {
+    if (req.headers.authorization === "Bearer test-token") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ county: "Benton", data: [1] }));
+      return;
+    }
+
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  try {
+    const response = await fetchJsonWithBearer(`http://127.0.0.1:${port}/api/protected`, "test-token");
+    assert.equal(response.status, 200);
+    assert.equal(response.payload.county, "Benton");
+  } finally {
+    server.close();
+  }
+});
+
+test("CLI writes evidence and redacts password", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tf-j10-post-login-"));
+  const outJson = path.join(tmp, "post-login.json");
+  const outMd = path.join(tmp, "post-login.md");
+
+  const result = await execFileAsync(
+    "node",
+    [
+      "os-platform/core/pilot/june10-operator-post-login-smoke.mjs",
+      "--fixture",
+      "pass",
+      "--email",
+      "june10-operator@terrafusionmarket.com",
+      "--password-env",
+      "TF_TEST_OPERATOR_PASSWORD",
+      "--out-json",
+      outJson,
+      "--out-md",
+      outMd
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        TF_TEST_OPERATOR_PASSWORD: "CorrectPassword123!"
+      }
+    }
+  );
+
+  assert.match(result.stdout, /"passed": true/);
+  const json = fs.readFileSync(outJson, "utf8");
+  const markdown = fs.readFileSync(outMd, "utf8");
+  assert.doesNotMatch(json, /CorrectPassword123!/);
+  assert.doesNotMatch(markdown, /CorrectPassword123!/);
+  assert.match(markdown, /Verdict: PASS/);
+});

--- a/os-platform/core/pilot/june10-owner-login-ready.mjs
+++ b/os-platform/core/pilot/june10-owner-login-ready.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { runJune10OperatorPostLoginSmoke } from "./june10-operator-post-login-smoke.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const DEFAULT_BASE_URL = "https://terrafusionmarket.com";
+const DEFAULT_OUT_JSON = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "june10-owner-login-ready.latest.json"
+);
+const DEFAULT_OUT_MD = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "june10-owner-login-ready.latest.md"
+);
+const DEFAULT_SCREENSHOT = path.join(
+  repoRoot,
+  "os-platform",
+  "core",
+  "pilot",
+  "evidence",
+  "screenshots",
+  "june10-owner-login-ready-shell.latest.png"
+);
+const DEFAULT_HANDOFF = path.join(repoRoot, ".tmp", "TerraFusion-Owner-Login-Handoff.txt");
+
+function rel(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.TF_J10_OWNER_AUTH_BASE_URL ?? process.env.TF_J10_OPERATOR_AUTH_BASE_URL ?? DEFAULT_BASE_URL,
+    email: process.env.TF_J10_OWNER_EMAIL ?? process.env.TF_J10_OPERATOR_EMAIL ?? process.env.TF_PROVISIONED_AUTH_EMAIL ?? null,
+    password:
+      process.env.TF_J10_OWNER_PASSWORD ??
+      process.env.TF_J10_OPERATOR_PASSWORD ??
+      process.env.TF_PROVISIONED_AUTH_PASSWORD ??
+      null,
+    passwordEnv: null,
+    handoffPath: process.env.TF_J10_OWNER_HANDOFF_PATH ?? DEFAULT_HANDOFF,
+    outJson: DEFAULT_OUT_JSON,
+    outMd: DEFAULT_OUT_MD,
+    screenshotPath: DEFAULT_SCREENSHOT,
+    fixture: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => argv[++index];
+    if (arg === "--base-url") options.baseUrl = next();
+    else if (arg === "--email") options.email = next();
+    else if (arg === "--password-env") options.passwordEnv = next();
+    else if (arg === "--handoff-path") options.handoffPath = next();
+    else if (arg === "--out-json") options.outJson = next();
+    else if (arg === "--out-md") options.outMd = next();
+    else if (arg === "--screenshot") options.screenshotPath = next();
+    else if (arg === "--fixture") options.fixture = next();
+  }
+
+  if (options.passwordEnv) {
+    options.password = process.env[options.passwordEnv] ?? null;
+  }
+
+  return options;
+}
+
+function buildFixtureOperatorReport({ baseUrl, email, screenshotPath }) {
+  return {
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    email,
+    passwordSupplied: "yes (redacted)",
+    login: {
+      finalUrl: `${baseUrl.replace(/\/+$/, "")}/`,
+      tokenStored: true,
+      jwtIdentity: {
+        email,
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyName: "Benton",
+        countyState: "WA",
+        countyFipsCode: "53005"
+      }
+    },
+    shell: {
+      osShellHomeLoaded: true,
+      canonLoaded: false,
+      chromeSignals: {
+        terraFusionOsTitle: true,
+        shellChrome: true,
+        bentonCounty: true
+      }
+    },
+    protectedApis: {
+      profile: {
+        status: 200,
+        operatorIdentityRecognized: true,
+        userId: "fixture-owner-user-id",
+        email,
+        roles: ["GovernmentUser", "Administrator"],
+        permissions: ["runtime:read", "county:read", "workbench:access"],
+        countyId: "fixture-county-id",
+        county: "Benton",
+        countyFipsCode: "53005",
+        state: "WA",
+        sessionValid: true
+      },
+      bentonParcels: {
+        status: 200,
+        county: "Benton",
+        rowsReturned: 1,
+        bentonContextPresent: true
+      }
+    },
+    consoleAndRuntime: {
+      authErrorCount: 0,
+      authErrors: [],
+      pageErrorCount: 0,
+      pageErrors: []
+    },
+    logout: {
+      controlFound: true,
+      clicked: true,
+      redirectedToLogin: true,
+      tokenCleared: true
+    },
+    invalidToken: {
+      redirectedToLogin: true,
+      tokenCleared: true,
+      protectedApiRejected: true,
+      status: 401
+    },
+    screenshotPath,
+    operatorIdentityRecognized: true,
+    protectedApiSucceeded: true,
+    bentonCountyContextPresent: true,
+    warnings: [],
+    passed: true,
+    blockers: []
+  };
+}
+
+function writeHandoff({ handoffPath, baseUrl, email, password }) {
+  if (!email || !password) return null;
+
+  const fullPath = path.resolve(handoffPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(
+    fullPath,
+    [
+      "TerraFusion Owner Login Handoff",
+      "",
+      "Purpose: human owner access for the June 10 controlled Benton County Runtime Pilot.",
+      `URL: ${baseUrl.replace(/\/+$/, "")}/login`,
+      `Email: ${email}`,
+      `Password: ${password}`,
+      "",
+      "Access model: administrator-provisioned TerraFusion DB account.",
+      "Do not commit this file. Do not paste this credential into chat.",
+      "After owner manual verification, rotate this password through the provisioned auth path."
+    ].join("\n")
+  );
+  return fullPath;
+}
+
+function inspectHandoff({ handoffPath, email, password }) {
+  const fullPath = path.resolve(handoffPath);
+  const exists = fs.existsSync(fullPath);
+  const content = exists ? fs.readFileSync(fullPath, "utf8") : "";
+  return {
+    path: fullPath,
+    relativePath: fullPath.startsWith(repoRoot) ? rel(fullPath) : fullPath,
+    exists,
+    containsEmail: Boolean(email && content.includes(email)),
+    containsPassword: Boolean(password && content.includes(password)),
+    gitIgnored:
+      !fullPath.startsWith(repoRoot) ||
+      fullPath.includes(`${path.sep}.tmp${path.sep}`) ||
+      fullPath.endsWith(".env"),
+    pathIncludesTmpOrUserProfile:
+      fullPath.includes(`${path.sep}.tmp${path.sep}`) ||
+      fullPath.startsWith(process.env.USERPROFILE ?? "__no_user_profile__")
+  };
+}
+
+function buildOwnerReport({ baseUrl, email, password, operatorReport, handoff }) {
+  const blockers = [...(operatorReport.blockers ?? [])];
+  const warnings = [...(operatorReport.warnings ?? [])];
+
+  if (!email) blockers.push("Owner email is not configured.");
+  if (!password) blockers.push("Owner password is not configured.");
+  if (!handoff.exists) blockers.push("Owner operator credential handoff file does not exist.");
+  if (!handoff.containsEmail) blockers.push("Owner operator credential handoff does not include the login email.");
+  if (!handoff.containsPassword) blockers.push("Owner operator credential handoff does not include the password.");
+  if (!handoff.gitIgnored) blockers.push("Owner operator credential handoff is not in an ignored local-only location.");
+  if (!handoff.pathIncludesTmpOrUserProfile) {
+    blockers.push("Owner operator credential handoff is not in a local temporary or user-profile path.");
+  }
+
+  const ownerAccessReady = blockers.length === 0;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    ownerEmail: email,
+    passwordSupplied: password ? "yes (redacted)" : "no",
+    ownerAccessReady,
+    operatorSmoke: {
+      passed: operatorReport.passed === true,
+      finalUrl: operatorReport.login?.finalUrl ?? null,
+      profileStatus: operatorReport.protectedApis?.profile?.status ?? null,
+      profileUserId: operatorReport.protectedApis?.profile?.userId ?? null,
+      profileRoles: operatorReport.protectedApis?.profile?.roles ?? [],
+      profilePermissions: operatorReport.protectedApis?.profile?.permissions ?? [],
+      profileCountyFips: operatorReport.protectedApis?.profile?.countyFipsCode ?? null,
+      profileState: operatorReport.protectedApis?.profile?.state ?? null,
+      sessionValid: operatorReport.protectedApis?.profile?.sessionValid === true,
+      screenshotPath: operatorReport.screenshotPath ?? null
+    },
+    handoff,
+    warnings,
+    passed: ownerAccessReady,
+    blockers
+  };
+}
+
+function renderMarkdown(report) {
+  return [
+    "# June 10 Owner Login Ready",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Base URL: ${report.baseUrl}`,
+    `Owner operator: ${report.ownerEmail ?? "not configured"}`,
+    `Password supplied: ${report.passwordSupplied}`,
+    "",
+    `Verdict: ${report.passed ? "PASS" : "FAIL"}`,
+    "",
+    "## Owner operator credential handoff",
+    "",
+    `- Handoff path: ${report.handoff.relativePath}`,
+    `- Handoff exists: ${report.handoff.exists === true}`,
+    `- Contains email: ${report.handoff.containsEmail === true}`,
+    `- Contains password: ${report.handoff.containsPassword === true}`,
+    `- Local ignored path: ${report.handoff.gitIgnored === true}`,
+    "",
+    "## Runtime smoke",
+    "",
+    `- Operator smoke passed: ${report.operatorSmoke.passed === true}`,
+    `- Final URL: ${report.operatorSmoke.finalUrl ?? "not captured"}`,
+    `- Profile API status: ${report.operatorSmoke.profileStatus ?? "not attempted"}`,
+    `- Profile user id: ${report.operatorSmoke.profileUserId ?? "none"}`,
+    `- Profile county FIPS: ${report.operatorSmoke.profileCountyFips ?? "none"}`,
+    `- Profile state: ${report.operatorSmoke.profileState ?? "none"}`,
+    `- Session valid: ${report.operatorSmoke.sessionValid === true}`,
+    `- Screenshot: ${report.operatorSmoke.screenshotPath ?? "not captured"}`,
+    "",
+    "## Warnings",
+    "",
+    ...(report.warnings.length ? report.warnings.map((warning) => `- ${warning}`) : ["- None"]),
+    "",
+    "## Blockers",
+    "",
+    ...(report.blockers.length ? report.blockers.map((blocker) => `- ${blocker}`) : ["- None"])
+  ].join("\n");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const handoffPath = options.password
+    ? writeHandoff({
+        handoffPath: options.handoffPath,
+        baseUrl: options.baseUrl,
+        email: options.email,
+        password: options.password
+      })
+    : path.resolve(options.handoffPath);
+
+  const operatorReport = options.fixture
+    ? buildFixtureOperatorReport({
+        baseUrl: options.baseUrl,
+        email: options.email,
+        screenshotPath: "fixture"
+      })
+    : await runJune10OperatorPostLoginSmoke({
+        baseUrl: options.baseUrl,
+        email: options.email,
+        password: options.password,
+        screenshotPath: options.screenshotPath
+      });
+
+  const report = buildOwnerReport({
+    baseUrl: options.baseUrl,
+    email: options.email,
+    password: options.password,
+    operatorReport,
+    handoff: inspectHandoff({ handoffPath, email: options.email, password: options.password })
+  });
+
+  fs.mkdirSync(path.dirname(options.outJson), { recursive: true });
+  fs.mkdirSync(path.dirname(options.outMd), { recursive: true });
+  fs.writeFileSync(options.outJson, JSON.stringify(report, null, 2));
+  fs.writeFileSync(options.outMd, renderMarkdown(report));
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.passed ? 0 : 1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/os-platform/core/pilot/june10-owner-login-ready.test.mjs
+++ b/os-platform/core/pilot/june10-owner-login-ready.test.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+test("owner-login-ready CLI writes redacted evidence and proves handoff posture", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tf-j10-owner-login-"));
+  const outJson = path.join(tmp, "owner-login.json");
+  const outMd = path.join(tmp, "owner-login.md");
+
+  const result = await execFileAsync(
+    "node",
+    [
+      "os-platform/core/pilot/june10-owner-login-ready.mjs",
+      "--fixture",
+      "pass",
+      "--email",
+      "owner.operator@terrafusionmarket.com",
+      "--password-env",
+      "TF_TEST_OWNER_PASSWORD",
+      "--handoff-path",
+      path.join(tmp, "owner-handoff.txt"),
+      "--out-json",
+      outJson,
+      "--out-md",
+      outMd
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        TF_TEST_OWNER_PASSWORD: "OwnerPassword123!"
+      }
+    }
+  );
+
+  assert.match(result.stdout, /"passed": true/);
+
+  const json = JSON.parse(fs.readFileSync(outJson, "utf8"));
+  const markdown = fs.readFileSync(outMd, "utf8");
+  const handoff = fs.readFileSync(json.handoff.path, "utf8");
+
+  assert.equal(json.passed, true);
+  assert.equal(json.ownerAccessReady, true);
+  assert.equal(json.handoff.exists, true);
+  assert.equal(json.handoff.containsEmail, true);
+  assert.equal(json.handoff.containsPassword, true);
+  assert.equal(json.handoff.gitIgnored, true);
+  assert.equal(json.handoff.pathIncludesTmpOrUserProfile, true);
+  assert.doesNotMatch(JSON.stringify(json), /OwnerPassword123!/);
+  assert.doesNotMatch(markdown, /OwnerPassword123!/);
+  assert.match(markdown, /Verdict: PASS/);
+  assert.match(markdown, /Owner operator credential handoff/);
+  assert.match(handoff, /owner.operator@terrafusionmarket.com/);
+  assert.match(handoff, /OwnerPassword123!/);
+});
+
+test("owner-login-ready blocks when no credential handoff is available", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tf-j10-owner-login-missing-"));
+  const outJson = path.join(tmp, "owner-login.json");
+  const outMd = path.join(tmp, "owner-login.md");
+
+  await assert.rejects(
+    execFileAsync(
+      "node",
+      [
+        "os-platform/core/pilot/june10-owner-login-ready.mjs",
+        "--fixture",
+        "pass",
+        "--email",
+        "owner.operator@terrafusionmarket.com",
+        "--out-json",
+        outJson,
+        "--out-md",
+        outMd
+      ],
+      { cwd: process.cwd() }
+    )
+  );
+
+  const json = JSON.parse(fs.readFileSync(outJson, "utf8"));
+  assert.equal(json.passed, false);
+  assert.equal(json.ownerAccessReady, false);
+  assert.ok(json.blockers.some((blocker) => blocker.includes("Owner password is not configured")));
+});

--- a/os-platform/core/pilot/phase6-production-auth-release-lane.test.mjs
+++ b/os-platform/core/pilot/phase6-production-auth-release-lane.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const releaseLane = fs.readFileSync(".github/workflows/release-lane.yml", "utf8");
+
+test("release lane requires provisioned auth secrets without bootstrap credentials", () => {
+  assert.match(
+    releaseLane,
+    /TF_PROVISIONED_AUTH_EMAIL:\s*\$\{\{\s*secrets\.TF_PROVISIONED_AUTH_EMAIL\s*\}\}/,
+  );
+  assert.match(
+    releaseLane,
+    /TF_PROVISIONED_AUTH_PASSWORD:\s*\$\{\{\s*secrets\.TF_PROVISIONED_AUTH_PASSWORD\s*\}\}/,
+  );
+  assert.match(releaseLane, /Missing required environment configuration/);
+  assert.doesNotMatch(releaseLane, /TERRAFUSION_BOOTSTRAP_PASSWORD/);
+  assert.doesNotMatch(releaseLane, /TF_AUTH_BOOTSTRAP_PASSWORD/);
+});
+
+test("release lane verifies provisioned access policy and login token", () => {
+  assert.match(releaseLane, /Provisioned auth contract smoke/);
+  assert.match(releaseLane, /\/api\/auth\/access-policy/);
+  assert.match(releaseLane, /signupMode !== "provisioned_access_only"/);
+  assert.match(releaseLane, /publicSignupEnabled !== false/);
+  assert.match(releaseLane, /\/api\/auth\/login/);
+  assert.match(releaseLane, /response\.token \|\| response\.Token/);
+  assert.match(releaseLane, /email !== process\.env\.TF_PROVISIONED_AUTH_EMAIL/);
+});
+
+test("release lane does not mutate auth records during deploy", () => {
+  assert.doesNotMatch(releaseLane, /dotnet\s+\/app\/tools\/TerraFusion\.AuthProvisioner/);
+  assert.doesNotMatch(releaseLane, /TerraFusion\.AuthProvisioner\.dll/);
+});


### PR DESCRIPTION
Restores the known provisioned production auth path for Phase 6 without merging the broader readiness branch.

Includes:
- Provisioned production login surface, with no public signup path.
- DB-backed provisioned operator auth behavior.
- TerraFusion.AuthProvisioner tool for explicitly approved operator record provisioning.
- Release-lane provisioned auth env handling and auth smoke.
- Operator profile/session echo proof and post-login OS shell landing checks.

Does not:
- Bypass auth.
- Create fake credentials.
- Run AuthProvisioner during deploy.
- Mutate production DB in this PR.
- Touch Forge, Workbench, Counties, Home, GIS, valuation, or DB schema beyond the auth path.

Required production acceptance note:
Code integration has no production DB mutation. Final public smoke may require an AuthProvisioner-created or updated operator record only after explicit approval.