### PR TITLE
fix(api): accept published content root in production

### DIFF
--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -64,10 +64,13 @@ static string ResolveApiContentRoot()
     var envOverride = Environment.GetEnvironmentVariable("TERRAFUSION_API_CONTENT_ROOT")
                    ?? Environment.GetEnvironmentVariable("ASPNETCORE_CONTENTROOT");
     if (!string.IsNullOrWhiteSpace(envOverride) &&
-        File.Exists(Path.Combine(envOverride, "TerraFusion.API.csproj")) &&
         File.Exists(Path.Combine(envOverride, "appsettings.json")))
     {
-        return Path.GetFullPath(envOverride);
+        if (File.Exists(Path.Combine(envOverride, "TerraFusion.API.csproj")) ||
+            File.Exists(Path.Combine(envOverride, "TerraFusion.API.dll")))
+        {
+            return Path.GetFullPath(envOverride);
+        }
     }
 
     var candidateStarts = new[]
@@ -84,6 +87,12 @@ static string ResolveApiContentRoot()
         foreach (var probe in EnumerateSelfAndAncestors(candidate))
         {
             if (File.Exists(Path.Combine(probe, "TerraFusion.API.csproj")) &&
+                File.Exists(Path.Combine(probe, "appsettings.json")))
+            {
+                return probe;
+            }
+
+            if (File.Exists(Path.Combine(probe, "TerraFusion.API.dll")) &&
                 File.Exists(Path.Combine(probe, "appsettings.json")))
             {
                 return probe;


### PR DESCRIPTION
Fixes the Phase 6 production startup blocker exposed by the post-#1001 deploy attempt.

Problem:
- Target SHA 59d03f16 built and uploaded successfully.
- VPS deploy failed because the backend container crashed on startup:
  Unable to resolve TerraFusion.API content root from '/app' and '/app/'.

Fix:
- Accept the published API content root when appsettings.json and TerraFusion.API.dll are present.
- Preserve source-tree behavior for local/dev/test runs.

Production safety:
- No DB mutation.
- No AuthProvisioner run.
- No Forge/Workbench/Counties/Home changes.
- Production was rolled back to previous healthy image 9e419fc after the failed deploy.

Verification:
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

## Summary by Sourcery

Update TerraFusion API startup to correctly resolve the content root when running from a published deployment while preserving existing local/source-tree behavior.

Bug Fixes:
- Allow the API to use a published content root by recognizing deployments that contain TerraFusion.API.dll and appsettings.json, preventing startup failures in production.

Enhancements:
- Expand content root resolution logic to accept either source-tree (csproj) or published (dll) layouts based on the presence of appsettings.json and relevant artifacts.