### PR TITLE
fix(deploy): preserve June 10 runtime compose during release

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -57,7 +57,7 @@ jobs:
           # headers, etc.). Build inputs must come from the requested release SHA so
           # auth/runtime changes cannot be silently replaced by main during deploy.
           git fetch origin main --no-tags --depth=1 2>/dev/null || true
-          for path in ops/proxy/Caddyfile ops/prod/runtime-compose.template.yml ops/edge-proxy/Caddyfile ops/edge-proxy/docker-compose.yml; do
+          for path in ops/proxy/Caddyfile ops/edge-proxy/Caddyfile ops/edge-proxy/docker-compose.yml; do
             dir="$(dirname "$path")"
             mkdir -p "$dir"
             echo "Overlaying $path from origin/main"

--- a/ops/prod/runtime-compose.template.yml
+++ b/ops/prod/runtime-compose.template.yml
@@ -36,6 +36,12 @@ services:
       - ./docs/spec-lock:/app/docs/spec-lock:ro
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:5000/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 180s
 
   frontend:
     image: ${TF_FRONTEND_IMAGE}


### PR DESCRIPTION
This PR fixes the Phase 6 release-lane runtime gate without changing product behavior.

Problem:
- release-lane was overlaying `ops/prod/runtime-compose.template.yml` from `origin/main`.
- `origin/main` does not contain the June 10 SQLite runtime defaults.
- The deploy could therefore build the correct target SHA but upload stale runtime compose configuration.
- The backend also missed the Docker health window during long production startup, failing before public health verification could run.

Changes:
- Keep the target branch runtime compose template instead of replacing it from `origin/main`.
- Add an explicit backend healthcheck override with a longer production startup window.

Does not:
- change product behavior
- mutate production DB
- run AuthProvisioner
- touch Workbench, Forge, Counties, Home, or Hostinger app code

Verification:
- `pnpm run type-check` PASS
- `node --test os-platform/core/tests/phase83-tools.test.mjs` PASS
- runtime compose config renders with SQLite defaults and backend healthcheck override
- pre-push quality gate PASS

## Summary by Sourcery

Preserve the target branch runtime compose configuration during release-lane deploys and extend the backend container healthcheck to tolerate longer production startup times.

Bug Fixes:
- Stop overriding the target branch runtime-compose template in the release-lane workflow to avoid deploying stale runtime configuration.
- Add an explicit backend healthcheck with a longer startup window so the deploy does not fail during slow production startups.