### PR TITLE
fix(api): allow anonymous release health probe

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/SimpleHealthController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SimpleHealthController.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TerraFusion.API.Controllers;
 
+[AllowAnonymous]
 [ApiController]
 [Route("health")]
 public class SimpleHealthController : ControllerBase
@@ -23,6 +25,7 @@ public class SimpleHealthController : ControllerBase
             Status = "Healthy",
             Timestamp = DateTime.UtcNow,
             Environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+            GitSha = Environment.GetEnvironmentVariable("TF_GIT_SHA") ?? "unknown",
             Version = "1.0.0",
             Service = "TerraFusion OS API - Basic Mode"
         });


### PR DESCRIPTION
This PR fixes the Phase 6 deployment health regression caused by the production auth fallback policy.

Root cause:
- Production auth reconciliation installed a global fallback policy requiring authenticated users.
- `/health` is the release/Docker/public health endpoint but `SimpleHealthController` was not explicitly `[AllowAnonymous]`.
- The new backend image was alive, but `/health` returned 401, making Docker health and release verification fail.

Fix:
- Mark `SimpleHealthController` `[AllowAnonymous]` explicitly.
- Restore `GitSha` in the `/health` payload from `TF_GIT_SHA`, with `unknown` fallback.

Does not change product behavior, Workbench, Forge, Counties, DB, production data, or auth bypass semantics for governed app endpoints.

Verification:
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release` PASS
- `pnpm run type-check` PASS
- `node --test os-platform/core/tests/phase83-tools.test.mjs` PASS

Note:
- Existing focused unit test project currently has unrelated compile failures in other tests, so the `SimpleHealthControllerGitShaTests` filter cannot execute locally. The existing test file already asserts this controller-level `[AllowAnonymous]` and `GitSha` contract.

## Summary by Sourcery

Allow the API health endpoint to be probed anonymously and include deployment Git SHA metadata in the health response.

Bug Fixes:
- Ensure the /health endpoint remains accessible under stricter auth policies by explicitly allowing anonymous access.

Enhancements:
- Expose the TF_GIT_SHA value in the /health response with a safe fallback when the environment variable is unset.