### PR TITLE
fix(workbench): authenticate Forge tab API calls

### DIFF
--- a/frontend/apps/os-shell/src/hooks/forge/__tests__/useForgeValuation.auth.test.tsx
+++ b/frontend/apps/os-shell/src/hooks/forge/__tests__/useForgeValuation.auth.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useCostApproach,
+  useParcelYears,
+  useCommitReconciliation,
+  usePatchSaleQualification,
+} from '../useForgeValuation';
+
+const mockFetch = vi.fn() as vi.MockedFunction<typeof fetch>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function headersFromCall(index = 0): Headers {
+  const init = mockFetch.mock.calls[index]?.[1] as RequestInit | undefined;
+  return new Headers(init?.headers);
+}
+
+describe('useForgeValuation auth headers', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+    localStorage.clear();
+    localStorage.setItem('authToken', 'production-jwt');
+  });
+
+  it('attaches Authorization to parcel-scoped Forge approach requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ parcelId: '101040000000000', taxYear: 2026 }),
+    } as Response);
+
+    renderHook(() => useCostApproach('101040000000000', 2026), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/forge/101040000000000/cost?taxYear=2026');
+    expect(headersFromCall().get('Authorization')).toBe('Bearer production-jwt');
+  });
+
+  it('attaches Authorization to parcel year discovery', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ parcelId: '101040000000000', layers: [], defaultYear: null }),
+    } as Response);
+
+    renderHook(() => useParcelYears('101040000000000'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/forge/101040000000000/years');
+    expect(headersFromCall().get('Authorization')).toBe('Bearer production-jwt');
+  });
+
+  it('attaches Authorization to reconciliation commits', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        flagId: 7,
+        parcelId: '101040000000000',
+        finalValue: 238600,
+        method: 'weighted_average',
+        status: 'RECONCILIATION_PENDING',
+        createdAt: '2026-06-15T00:00:00Z',
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useCommitReconciliation('101040000000000'), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        method: 'weighted_average',
+        finalValue: 238600,
+        taxYear: 2026,
+        approaches: [],
+      });
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/forge/101040000000000/reconciliation/commit');
+    expect(headersFromCall().get('Authorization')).toBe('Bearer production-jwt');
+    expect(headersFromCall().get('Content-Type')).toBe('application/json');
+  });
+
+  it('attaches Authorization to sale qualification overrides', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        saleId: 'sale-1',
+        qualificationDecision: 'qualified',
+        decisionBy: 'operator',
+        decisionAt: '2026-06-15T00:00:00Z',
+        decisionSource: 'AssessorOverride',
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => usePatchSaleQualification('101040000000000', 2026), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ saleId: 'sale-1', decision: 'qualified' });
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/forge/sales/sale-1/qualification');
+    expect(headersFromCall().get('Authorization')).toBe('Bearer production-jwt');
+    expect(headersFromCall().get('Content-Type')).toBe('application/json');
+  });
+});

--- a/frontend/apps/os-shell/src/hooks/forge/useForgeValuation.ts
+++ b/frontend/apps/os-shell/src/hooks/forge/useForgeValuation.ts
@@ -10,6 +10,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getToken } from '@/auth/authStorage';
 
 /* ── Response shapes (mirror backend ForgeValuationDtos.cs) ── */
 
@@ -162,8 +163,20 @@ export interface ForgeHookResult<T> {
 
 /* ── Internal fetcher ──────────────────────────────────────── */
 
+function withAuth(init: RequestInit = {}): RequestInit {
+  const headers = new Headers(init.headers);
+  const token = getToken();
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return { ...init, headers };
+}
+
 async function fetchForge<T>(parcelId: string, approach: string, taxYear: number): Promise<T> {
-  const res = await fetch(`/api/forge/${encodeURIComponent(parcelId)}/${approach}?taxYear=${taxYear}`);
+  const res = await fetch(
+    `/api/forge/${encodeURIComponent(parcelId)}/${approach}?taxYear=${taxYear}`,
+    withAuth()
+  );
   if (!res.ok) {
     throw new Error(`Forge ${approach} fetch failed: ${res.status} ${res.statusText}`);
   }
@@ -322,11 +335,14 @@ export function usePatchSaleQualification(parcelId: string | undefined, taxYear:
   const queryClient = useQueryClient();
   return useMutation<PatchSaleQualificationResult, Error, PatchSaleQualificationVars>({
     mutationFn: async ({ saleId, decision, reason }) => {
-      const res = await fetch(`/api/forge/sales/${encodeURIComponent(saleId)}/qualification`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ decision, reason: reason ?? null }),
-      });
+      const res = await fetch(
+        `/api/forge/sales/${encodeURIComponent(saleId)}/qualification`,
+        withAuth({
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ decision, reason: reason ?? null }),
+        })
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(body?.error ?? `Override failed: ${res.status}`);
@@ -369,11 +385,14 @@ export interface ReconciliationCommitResult {
 export function useCommitReconciliation(parcelId: string | undefined) {
   return useMutation<ReconciliationCommitResult, Error, ReconciliationCommitInput>({
     mutationFn: async (input) => {
-      const res = await fetch(`/api/forge/${encodeURIComponent(parcelId!)}/reconciliation/commit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
-      });
+      const res = await fetch(
+        `/api/forge/${encodeURIComponent(parcelId!)}/reconciliation/commit`,
+        withAuth({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        })
+      );
       if (!res.ok) {
         const body = await res.json().catch(() => ({})) as { error?: string };
         throw new Error(body?.error ?? `Reconciliation commit failed: ${res.status}`);
@@ -392,9 +411,7 @@ export function useRecomputeRecommendations(parcelId: string | undefined, taxYea
   const queryClient = useQueryClient();
   return useMutation<RecomputeRecommendationsResult, Error, void>({
     mutationFn: async () => {
-      const res = await fetch('/api/forge/sales/recompute-recommendations', {
-        method: 'POST',
-      });
+      const res = await fetch('/api/forge/sales/recompute-recommendations', withAuth({ method: 'POST' }));
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(body?.error ?? `Recompute failed: ${res.status}`);
@@ -411,7 +428,7 @@ export function useParcelYears(parcelId: string | undefined): ParcelYearsHookRes
   const query = useQuery<ParcelYearLayersResult>({
     queryKey: ['forge', 'years', parcelId],
     queryFn: async () => {
-      const res = await fetch(`/api/forge/${encodeURIComponent(parcelId!)}/years`);
+      const res = await fetch(`/api/forge/${encodeURIComponent(parcelId!)}/years`, withAuth());
       if (!res.ok) {
         throw new Error(`Forge /years fetch failed: ${res.status} ${res.statusText}`);
       }


### PR DESCRIPTION
Fixes the Phase 6 production Workbench Forge tab auth regression.

Root cause:
- Workbench Forge valuation hooks used bare fetch() for /api/forge/{parcelId}/... calls.
- Authenticated OS session existed, but these parcel-scoped Forge calls did not attach Authorization, causing production 401s.

Scope:
- Attach the current AuthProvider/authStorage JWT to Workbench Forge tab API calls.
- Cover cost/sales/income/reconciliation/year discovery and Forge write mutations from the same hook.
- Add a focused auth-header contract test.

Does not:
- Change Forge data semantics.
- Add mock/fallback Forge data.
- Touch DB, Home GIS, Sentinel, Counties, Atlas, Dais, or auth provisioning.
- Weaken backend authorization globally.

Proof:
- pnpm -C frontend exec vitest run apps/os-shell/src/hooks/forge/__tests__/useForgeValuation.auth.test.tsx --config vitest.config.ts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs