### PR TITLE
fix(forge): remove PACS from runtime valuation path

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CostForgeController.cs
@@ -950,7 +950,7 @@ public class CostForgeController : ControllerBase
 
   /// <summary>
   /// Batch property valuation for county-wide assessments
-  /// Supports Washington State compliance and Harris PACS integration
+  /// Supports Washington State compliance and canonical county data integration
   /// </summary>
   [HttpPost("batch-calculate")]
   public async Task<ActionResult<BatchValuationResultDto>> BatchCalculateValuations([FromBody] BatchValuationRequestDto request)
@@ -1426,7 +1426,7 @@ public class CostForgeController : ControllerBase
     if (countyContext is null)
       return Forbid();
 
-    _logger.LogInformation("Harris PACS sync initiated for county {CountyId} by {UserId}",
+    _logger.LogInformation("Legacy source sync initiated for county {CountyId} by {UserId}",
         countyContext.CountyId, User.FindFirst("sub")?.Value);
 
     var startTime = DateTime.UtcNow;
@@ -1439,7 +1439,7 @@ public class CostForgeController : ControllerBase
 
     await _auditLogger.LogUserActionAsync("CostForge:HarrisPACSSync",
         User.FindFirst("sub")?.Value ?? "anonymous",
-        $"Harris PACS sync status retrieved for county {countyContext.CountyName}. Properties: {propertyCount}");
+        $"Legacy source sync status retrieved for county {countyContext.CountyName}. Properties: {propertyCount}");
 
     return Ok(new HarrisSyncResultDto
     {
@@ -2388,7 +2388,7 @@ public class CostForgeController : ControllerBase
     ];
 
     // Tri-Cities neighborhood statistics (source: Benton County market area analysis)
-    // RevalArea maps to the PACS Cycle field (physical inspection rotation area)
+    // RevalArea maps to the county physical inspection rotation area.
     public static readonly NeighborhoodStat[] NeighborhoodStats =
     [
       new("Kennewick – South", 425_000m, 195m, "Reval 1", "Established neighborhoods, retail center"),
@@ -2612,7 +2612,7 @@ public class CostForgeController : ControllerBase
   /// <summary>
   /// Depreciation model: economic life by building type, physical age-life schedules,
   /// functional and external obsolescence factor definitions.
-  /// Source: Harris PACS CMS tables + IAAO age-life method.
+  /// Source: canonical county cost tables + IAAO age-life method.
   /// </summary>
   [HttpGet("valuation-lineage/depreciation-model")]
   public ActionResult GetDepreciationModel()
@@ -2627,13 +2627,13 @@ public class CostForgeController : ControllerBase
       externalObsolescenceFactors = ValuationLineageData.ExternalObsolescenceFactors,
       depreciationModel = "Multiplicative: remaining = (1 - physical) × (1 - functional) × (1 - external)",
       effectiveDate = "2025-01-01",
-      source = "Harris PACS CMS + IAAO Standard on Mass Appraisal / Benton County FY 2025",
+      source = "Canonical county cost model + IAAO Standard on Mass Appraisal / Benton County FY 2025",
     });
   }
 
   /// <summary>
   /// Land base rates per zone and land use for Benton County.
-  /// Source: Benton County land schedule (slope-intercept method from PACS land_sched_si_detail).
+  /// Source: Benton County land schedule (slope-intercept method from canonical land schedule details).
   /// </summary>
   [HttpGet("valuation-lineage/land-rates/benton")]
   public ActionResult GetLandRates()
@@ -2642,7 +2642,7 @@ public class CostForgeController : ControllerBase
     return Ok(new
     {
       rates = ValuationLineageData.LandRates,
-      method = "Slope-Intercept (PACS land_sched_si_detail)",
+      method = "Slope-Intercept (canonical land schedule detail)",
       effectiveDate = "2025-01-01",
       source = "Benton County Assessor – Land Schedule FY 2025",
     });
@@ -2650,7 +2650,7 @@ public class CostForgeController : ControllerBase
 
   /// <summary>
   /// Site/yard improvement value schedule: garages, pools, outbuildings, fencing, landscaping.
-  /// Source: Benton County residential valuation policy + PACS imprv_detail type codes.
+  /// Source: Benton County residential valuation policy + canonical improvement detail type codes.
   /// </summary>
   [HttpGet("valuation-lineage/site-improvements")]
   public ActionResult GetSiteImprovements()
@@ -2707,7 +2707,7 @@ public class CostForgeController : ControllerBase
     adjustedRate = BankersRound(adjustedRate);
     var rcn = BankersRound(adjustedRate * request.SquareFeet);
 
-    // Step 3: Depreciation (multiplicative age-life model from PACS)
+    // Step 3: Depreciation (multiplicative age-life model from canonical county schedules)
     int effectiveAge = request.EffectiveAge ?? (DateTime.UtcNow.Year - (request.YearBuilt ?? DateTime.UtcNow.Year));
     if (effectiveAge < 0) effectiveAge = 0;
 
@@ -2719,14 +2719,14 @@ public class CostForgeController : ControllerBase
         ? ValuationLineageData.EconomicLifeByType.FirstOrDefault(e => e.Category == "Industrial")?.Years ?? 45
         : ValuationLineageData.EconomicLifeByType.FirstOrDefault(e => e.Category == "Commercial")?.Years ?? 50;
 
-    // Physical depreciation: age-life with 85% cap (per PACS/IAAO)
+    // Physical depreciation: age-life with 85% cap (county schedule / IAAO)
     var physicalDepPct = Math.Min((decimal)effectiveAge / economicLife, 0.85m);
     physicalDepPct = BankersRound(physicalDepPct * 100m) / 100m; // round to 2 decimal pct
 
     var functionalObsPct = request.FunctionalObsolescence ?? 0m;
     var externalObsPct = request.ExternalObsolescence ?? 0m;
 
-    // Multiplicative depreciation (per PACS CMS model)
+    // Multiplicative depreciation (per canonical county cost model)
     var remainingPct = (1m - physicalDepPct) * (1m - functionalObsPct / 100m) * (1m - externalObsPct / 100m);
     var totalDepPct = BankersRound((1m - remainingPct) * 100m);
     var depreciationAmount = BankersRound(rcn * (1m - remainingPct));
@@ -3323,7 +3323,7 @@ public class CostForgeController : ControllerBase
           new { name = "yearBuilt", type = "int", required = true, description = "Year of original construction" },
           new { name = "quality", type = "string", required = false, description = "Construction quality class (1-6)" },
           new { name = "condition", type = "string", required = false, description = "Physical condition rating (Good/Average/Fair/Poor)" },
-          new { name = "revalArea", type = "string", required = false, description = "Reval Area (PACS Cycle 1-6) for local cost multiplier" },
+          new { name = "revalArea", type = "string", required = false, description = "Reval Area (county inspection cycle 1-6) for local cost multiplier" },
         },
         outputs = new[] { "rcn", "depreciation", "rcnld", "landValue", "totalValue" },
         county = ctx.CountyName ?? "Unknown",
@@ -3975,7 +3975,7 @@ public class CostForgeController : ControllerBase
       new("SEVERE",       35m,  "Extreme external impact (contamination, blight)"),
     ];
 
-    // Benton County land rates by zone (from PACS land_sched_si_detail)
+    // Benton County land rates by zone (from canonical land schedule detail)
     public static readonly LandRateEntry[] LandRates =
     [
       new("central-residential",   "Central Benton Residential",    3.50m),
@@ -3992,7 +3992,7 @@ public class CostForgeController : ControllerBase
       new("industrial",            "Industrial Zone",                4.00m),
     ];
 
-    // Site/yard improvement schedule (from PACS imprv_detail type codes + Benton policy)
+    // Site/yard improvement schedule (from canonical improvement detail type codes + Benton policy)
     public static readonly SiteImprovementEntry[] SiteImprovements =
     [
       new("ATTGAR", "Attached Garage",       42.50m, "per sqft"),
@@ -4147,7 +4147,7 @@ public class CostForgeController : ControllerBase
     return Ok(new { buildingTypes = types });
   }
 
-  /// <summary>GET /api/costforge/regions — Benton County Reval Areas (PACS Cycle field) with cost factors.</summary>
+  /// <summary>GET /api/costforge/regions — Benton County Reval Areas with cost factors.</summary>
   [HttpGet("regions")]
   [AllowAnonymous]
   public IActionResult GetRegions()
@@ -4171,9 +4171,9 @@ public class CostForgeController : ControllerBase
   }
 
   /// <summary>
-  /// GET /api/costforge/neighborhoods — Distinct hood_cd values from pacs_valuations with parcel counts.
-  /// hood_cd is the PACS neighborhood code. Reval area is loaded only from explicit Region/Cycle-derived fields.
-  /// Falls back to BentonSalesData if PACS table is empty or unreachable.
+  /// GET /api/costforge/neighborhoods — Distinct canonical neighborhood values with parcel counts.
+  /// Reval area is loaded only from explicit Region/Cycle-derived fields.
+  /// Falls back to BentonSalesData if canonical neighborhood rows are unavailable.
   /// </summary>
   [HttpGet("neighborhoods")]
   [AllowAnonymous]
@@ -4243,7 +4243,7 @@ public class CostForgeController : ControllerBase
 
     var parcelIds = sales.Select(s => s.ParcelId).Where(id => id != null).Distinct().ToHashSet();
 
-    // Assessed values from Properties table (canonical, no PACS naming)
+    // Assessed values from Properties table.
     var avMap = await _db.Properties
       .AsNoTracking()
       .Where(p => p.CountyId == countyContext.CountyId
@@ -4739,7 +4739,7 @@ public class CostForgeController : ControllerBase
       {
         new { step = 1, label = "Base Rate from Cost Matrix",   value = baseRate,        unit = "$/sqft",
               formula = $"Matrix [{buildingType}] × [{revalArea}]",
-              explanation = "Published Benton County cost rate for this building type and Reval Area (PACS Cycle)" },
+              explanation = "Published Benton County cost rate for this building type and Reval Area" },
         new { step = 2, label = "Quality Grade Adjustment",     value = qualityFactor,   unit = "× multiplier",
               formula = $"Quality: {quality} = ×{qualityFactor}",
               explanation = $"Adjusts base rate for construction quality. {quality} grade costs {(qualityFactor >= 1m ? "more" : "less")} than standard." },
@@ -4789,7 +4789,7 @@ public class CostForgeController : ControllerBase
   {
     // 11 building types × 6 Reval Areas = 66 matrix entries
     // Source: Cost Matrix 2025.xlsx, Benton County Assessor's Office
-    // Reval Areas (Cycle field in PACS) = physical inspection rotation areas 1-6
+    // Reval Areas = physical inspection rotation areas 1-6
     internal static readonly CostMatrixEntry[] CostMatrix =
     [
       // ── Reval 1 — Kennewick (Urban Core), Cycle 1, factor 1.00 ──
@@ -4866,7 +4866,7 @@ public class CostForgeController : ControllerBase
       new("S2", "School",                     "Reval 6", 122.44m),
     ];
 
-    // Reval Area (Cycle) adjustment factors — Benton County PACS Cycle field
+    // Reval Area adjustment factors — Benton County inspection cycle
     internal static readonly Dictionary<string, decimal> RegionFactors = new(StringComparer.OrdinalIgnoreCase)
     {
       ["Reval 1"] = 1.00m,  // Kennewick Urban Core
@@ -6987,7 +6987,7 @@ public class CostForgeController : ControllerBase
         category = "Accuracy",
         field = "ImprvVal",
         affectedCount = badImprvVal,
-        description = "Improvement value is negative — invalid; check PACS source.",
+        description = "Improvement value is negative — invalid; check canonical source data.",
         severity = "critical"
       });
     if (effExceedsLife > 0)
@@ -8033,7 +8033,7 @@ public class CostForgeController : ControllerBase
         .OrderBy(e => e.code)
         .ToList();
 
-    // Feature factor codes — real certified-lane improvement detail codes from PACS
+    // Feature factor codes — real certified-lane canonical improvement detail codes
     var featureCodes = new[]
     {
         new { code = "CovPatio",  description = "Covered Patio",          bivPct = 0.03m },

--- a/backend/src/TerraFusion.API/Controllers/ForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/ForgeController.cs
@@ -15,8 +15,8 @@ namespace TerraFusion.API.Controllers;
 /// <summary>
 /// Phase 10 — PropertyForge valuation API.
 /// Four endpoints serving the Forge sub-tabs: cost, sales, income, reconciliation.
-/// Queries PACS tables for real Benton County data; returns structured fallback
-/// where PACS data is incomplete.
+/// Queries canonical TerraFusion runtime tables; returns structured unavailable
+/// states where canonical data is incomplete.
 /// </summary>
 [ApiController]
 [Route("api/forge")]
@@ -35,7 +35,7 @@ public class ForgeController : ControllerBase
 
     /// <summary>
     /// GET /api/forge/{parcelId}/years
-    /// Returns all pacs_valuations year layers for a parcel with program enrollment metadata.
+    /// Returns canonical valuation year layers for a parcel with program enrollment metadata.
     /// Call this on parcel load to populate the year selector. Use DefaultYear as the
     /// starting point — it is the most recent base-roll (SupNum=0) layer.
     ///
@@ -206,7 +206,7 @@ public class ForgeController : ControllerBase
     // Assessor Sale Qualification Override
     // Layer 3: The assessor is the final authority. Their explicit decision
     // always overrides the TerraFusion recommendation (Layer 2).
-    // Raw PACS codes are facts. TF recommendation is a suggestion. Assessor decision is law.
+    // Raw source codes are facts. TF recommendation is a suggestion. Assessor decision is law.
     // ─────────────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -291,7 +291,7 @@ public class ForgeController : ControllerBase
     ///
     /// Re-runs the TF qualification rule engine (Layer 2) for all sales in the
     /// assessor's county. Safe to call any time — does not touch Layer 3 assessor decisions.
-    /// Typically called after a PACS ingest to populate QualificationRecommendation.
+    /// Typically called after canonical sales ingest to populate QualificationRecommendation.
     /// </summary>
     [Authorize]
     [RequiresPermission("access:forge")]

--- a/backend/src/TerraFusion.API/Controllers/TerraForgeController.cs
+++ b/backend/src/TerraFusion.API/Controllers/TerraForgeController.cs
@@ -233,7 +233,7 @@ public class TerraForgeController : ControllerBase
         if (s is null)
             return NotFound(new { error = $"Sale {saleId} not found for active county scope." });
 
-        // Properties join for assessed value (canonical TF table — no PACS read).
+        // Properties join for assessed value (canonical TF table).
         decimal? assessedValue = null;
         if (s.ParcelId != null)
         {
@@ -261,9 +261,8 @@ public class TerraForgeController : ControllerBase
             saleAdjustmentAmount = s.SaleAdjustmentAmount,
             saleExemptionAmount = s.SaleExemptionAmount,
             exciseNumber        = s.ExciseNumber,
-            pacsChgOfOwnerId    = s.PacsChgOfOwnerId,
             salesYear           = s.SalesYear,
-            // Time-of-sale physical characteristics (PACS snapshot — use these for ratio)
+            // Time-of-sale physical characteristics — use these for ratio when available.
             slLivingArea        = s.SlLivingArea,
             slYearBuilt         = s.SlYearBuilt,
             slLandAcres         = s.SlLandAcres,
@@ -276,7 +275,7 @@ public class TerraForgeController : ControllerBase
             bathrooms           = s.Bathrooms,
             condition           = s.Condition,
             qualityGrade        = s.QualityGrade,
-            // Raw PACS codes (Layer 1 — facts, never transformed)
+            // Raw source codes (Layer 1 — facts, never transformed)
             rawSaleQualifier    = s.RawSaleQualifier,
             rawCountyRatioCd    = s.RawCountyRatioCd,
             rawWacCd            = s.RawWacCd,
@@ -585,8 +584,8 @@ public class TerraForgeController : ControllerBase
     }
 
     /// <summary>
-    /// Code audit: breakdown of raw PACS qualification codes in the taxYear sale window.
-    /// Exposes WAC code nulls as a data quality flag (the known PACS seeding gap).
+    /// Code audit: breakdown of raw qualification codes in the taxYear sale window.
+    /// Exposes WAC code nulls as a data quality flag.
     /// </summary>
     [HttpGet("sale-qualification/code-audit")]
     public async Task<IActionResult> GetSaleQualificationCodeAudit(
@@ -624,7 +623,7 @@ public class TerraForgeController : ControllerBase
             .Select(g => new
             {
                 wacCd       = g.Key,
-                description = g.Key == null ? "No WAC code (PACS seeding gap — data quality issue)" : g.Key,
+                description = g.Key == null ? "No WAC code (source data quality issue)" : g.Key,
                 count       = g.Count(),
                 isDataGap   = g.Key == null,
             })
@@ -664,7 +663,7 @@ public class TerraForgeController : ControllerBase
             taxYear,
             totalSales,
             dataQualityAlert = wacNullCount > 0
-                ? $"{wacNullCount:N0} of {totalSales:N0} sales ({wacNullPct}%) have no WAC code — PACS seeding gap"
+                ? $"{wacNullCount:N0} of {totalSales:N0} sales ({wacNullPct}%) have no WAC code — source data quality gap"
                 : null,
             wacCdBreakdown        = wacBreakdown,
             saleQualifierBreakdown,
@@ -688,7 +687,7 @@ public class TerraForgeController : ControllerBase
     ///   Run POST /api/terraforge/compute-qualifications to populate recommendations from county ratio codes.
     /// Sales suppressed from the ratio report or flagged IncludeNoCalc are excluded.
     /// Returns IAAO stats (median ratio, mean ratio, COD, PRD) plus paginated detail.
-    /// Ratio = Properties.AssessedValue / ComparableSales.SalePrice (TF-computed; PACS ratio column unused).
+    /// Ratio = Properties.AssessedValue / ComparableSales.SalePrice (TF-computed from canonical runtime data).
     /// </summary>
     [HttpGet("ratio-study")]
     public async Task<IActionResult> GetRatioStudy(
@@ -741,7 +740,7 @@ public class TerraForgeController : ControllerBase
         var total = await baseQuery.CountAsync(ct);
 
         // TF computes its own sales ratios: AssessedValue / SalePrice.
-        // PACS is the legacy system being replaced — TF never uses PACS-computed ratio values.
+        // TerraFusion computes ratio values from canonical runtime data.
         var salesData = await baseQuery
             .Select(s => new
             {
@@ -1096,7 +1095,7 @@ public class TerraForgeController : ControllerBase
     ///
     /// Model: SalePrice ~ intercept + GLA + LotSizeSqft + YearBuilt
     /// Predictors use sale-time values (sl_living_area, sl_land_sqft, sl_yr_blt)
-    /// falling back to assessment-time values when PACS did not record sale-time data.
+    /// falling back to assessment-time values when sale-time data is unavailable.
     /// Observations missing both GLA sources are excluded from the fit.
     ///
     /// Filters: same effective qualified pool as ratio-study (hood / propertyType optional).
@@ -1134,7 +1133,7 @@ public class TerraForgeController : ControllerBase
         if (!string.IsNullOrWhiteSpace(propertyType))
             baseQuery = baseQuery.Where(s => s.PropertyType == propertyType);
 
-        // Fetch fields needed for regression. Prefer sale-time PACS values; fall back to
+        // Fetch fields needed for regression. Prefer sale-time values; fall back to
         // assessment-time values. YearBuilt of 0 is treated as missing.
         var rows = await baseQuery
             .Select(s => new
@@ -1329,9 +1328,9 @@ public class TerraForgeController : ControllerBase
     /// <summary>
     /// Run the county/state ratio-code qualification engine against all ComparableSales.
     /// Reads only TerraFusion canonical tables (ComparableSales, CountyRatioCodes,
-    /// SaleRatioTypes, ReetWacCodes). No PACS staging read. Safe to call anytime.
+    /// SaleRatioTypes, ReetWacCodes). No legacy staging read. Safe to call anytime.
     /// Sets QualificationRecommendation on every sale using the 4-layer hierarchy:
-    ///   1 - PACS SaleQualifier (already on ComparableSales.RawSaleQualifier)
+    ///   1 - raw source SaleQualifier (already on ComparableSales.RawSaleQualifier)
     ///   2 - County ratio code (sl_county_ratio_cd → TF CountyRatioCodes table)
     ///   3 - Exclude-calc flag (sales_exclude_calc_cd)
     ///   4 - WAC 458-61A      (wac_cd            → TF ReetWacCodes table)
@@ -1379,11 +1378,11 @@ public class TerraForgeController : ControllerBase
     /// TerraFusion canonical raw-code truth only.
     ///
     /// Ownership rule:
-    ///   - SyncController owns PACS/raw-mirror backfill into ComparableSales.Raw* fields.
+    ///   - SyncController owns raw-source backfill into ComparableSales.Raw* fields.
     ///   - TerraForgeController owns recommendation computation and appraiser decisions.
     ///
     /// If canonical raw-code columns are still missing, this endpoint reports that gap but
-    /// does not reach back into PACS staging. Missing raw-code repair must happen in Sync.
+    /// does not reach back into legacy staging. Missing raw-code repair must happen in Sync.
     /// </summary>
     [HttpPost("apply-recommendations")]
     public async Task<IActionResult> ApplyQualificationRecommendations(

--- a/backend/src/TerraFusion.API/Services/ValuationService.cs
+++ b/backend/src/TerraFusion.API/Services/ValuationService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.DTOs;
 using TerraFusion.Core.Entities;
@@ -7,13 +8,12 @@ using CanonicalComparableSale = TerraFusion.Core.Entities.ComparableSale;
 
 namespace TerraFusion.API.Services;
 
-// BOUNDARY REPAIR COMPLETE (CP-3b): All Pacs* reads removed per PACS Sync mandate.
 // Service reads canonical TF entities only: Properties, ValuationRecords,
-// ComparableSales, CamaCharacteristics.
+// ComparableSales, CamaCharacteristics, and optional CamaImprovementDetails.
 // Assessor workflow PARITY gaps are tracked as CP-4/5/6 work — not this service.
 /// <summary>
 /// Phase 10 — PropertyForge valuation service.
-/// Reads canonical TerraFusion entities only. No direct Pacs* mirror reads.
+/// Reads canonical TerraFusion entities only. No legacy source mirror reads.
 /// </summary>
 public class ValuationService : IValuationService
 {
@@ -53,12 +53,10 @@ public class ValuationService : IValuationService
             .Where(c => c.ParcelId == parcelId && c.TaxYear == taxYear)
             .FirstOrDefaultAsync(ct);
 
-        // Phase B: Load per-segment breakdown first — needed for Benton depreciation path.
-        // Note: no OrderBy in EF query — SQLite decimal ORDER BY not supported.
-        var segmentRows = await _db.CamaImprovementDetails
-            .AsNoTracking()
-            .Where(s => s.ParcelId == parcelId && s.TaxYear == taxYear)
-            .ToListAsync(ct);
+        // Phase B: Load per-segment breakdown when the optional canonical projection exists.
+        // Production can run before this projection is promoted; that state must return
+        // honest empty segment details, not a 500.
+        var segmentRows = await LoadSegmentRowsAsync(parcelId, taxYear, ct);
 
         var segments = segmentRows
             .OrderByDescending(s => s.Area ?? 0m)
@@ -77,10 +75,10 @@ public class ValuationService : IValuationService
             }).ToList();
 
         // Benton residential depreciation path:
-        // pacs_improvement_details.DepPct = percent-GOOD from the county age×condition matrix
+        // CamaImprovementDetails.DepPct = percent-GOOD from the county age×condition matrix
         //   (e.g., 86 = 86% good = 14% total depreciation)
-        // The improvement-level DepPct=100 in PACS is a "formula-driven" flag, not the applied rate.
-        // ImprvVal in PACS IS the RCNLD (depreciation already applied). Back-calculate RCN:
+        // The improvement-level DepPct=100 is a "formula-driven" flag, not the applied rate.
+        // ImprvVal is the canonical RCNLD (depreciation already applied). Back-calculate RCN:
         //   RCN = RCNLD / (percentGood / 100)
         var primaryPctGood = segmentRows
             .OrderByDescending(s => s.Area ?? 0m)
@@ -188,22 +186,25 @@ public class ValuationService : IValuationService
             .FirstOrDefaultAsync(ct);
 
         // Find comps by property type and date range.
-        // CP-5: Neighborhood filter uses hood_cd from PacsValuation.
+        // CP-5: Neighborhood filter uses canonical CAMA NeighborhoodCode.
         // Strategy: prefer comps from same neighborhood; fall back to county-wide if < 5 in hood.
         var cutoffStart = new DateTime(taxYear - 2, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var cutoffEnd   = new DateTime(taxYear, 12, 31, 23, 59, 59, DateTimeKind.Utc);
 
-        // Resolve subject neighborhood from PacsValuation (most recent base-roll year)
-        var subjectHood = await _db.PacsValuations
+        // Resolve subject neighborhood from canonical CAMA first; fall back to the
+        // canonical Property neighborhood when CAMA has not projected the field.
+        var subjectHood = await _db.CamaCharacteristics
             .AsNoTracking()
-            .Where(v => v.SupNum == 0 && v.NeighborhoodCode != null &&
-                (v.Parcel.GeoId == parcelId || v.Parcel.SimpleGeoId == parcelId))
-            .OrderByDescending(v => v.PropValYear)
-            .Select(v => v.NeighborhoodCode)
+            .Where(c => c.ParcelId == parcelId && c.NeighborhoodCode != null && c.NeighborhoodCode != "")
+            .OrderByDescending(c => c.TaxYear == taxYear)
+            .ThenByDescending(c => c.TaxYear)
+            .Select(c => c.NeighborhoodCode)
             .FirstOrDefaultAsync(ct);
 
+        subjectHood ??= property.Neighborhood;
+
         // Qualified comps base query.
-        // Qualification priority: Layer 3 (assessor decision) → Layer 2 (TF recommendation) → Layer 1b (PACS legacy sync field).
+        // Qualification priority: Layer 3 (assessor decision) → Layer 2 (TF recommendation) → Layer 1b (canonical raw source field).
         var baseCompsQuery = _db.ComparableSales
             .AsNoTracking()
             .Where(cs =>
@@ -292,7 +293,7 @@ public class ValuationService : IValuationService
             .ToList();
 
         // TF computes its own sales ratio: AssessedValue / SalePrice.
-        // PACS is the legacy system being replaced — TF never trusts PACS calculations.
+        // TerraFusion computes its own ratios from canonical runtime data.
         var compParcelIds = qualifiedComps.Select(c => c.ParcelId).Distinct().ToList();
         Dictionary<string, decimal> compAssessedValues = compParcelIds.Count > 0
             ? await _db.Properties
@@ -301,7 +302,7 @@ public class ValuationService : IValuationService
                 .ToDictionaryAsync(p => p.ParcelId, p => p.AssessedValue, ct)
             : new Dictionary<string, decimal>();
 
-        // Ratio = AssessedValue / SalePrice — IAAO standard; TF-computed, not PACS-sourced.
+        // Ratio = AssessedValue / SalePrice — IAAO standard; TF-computed from canonical data.
         var ratioPoints = qualifiedComps
             .Select(c => {
                 var salePrice = (double)(c.AdjustedSalePrice ?? c.SalePrice);
@@ -350,8 +351,8 @@ public class ValuationService : IValuationService
                 ParcelId      = c.ParcelId,
                 SaleDate      = c.SaleDate,
                 SalePrice     = c.SalePrice,
-                // Use PACS adjusted_sl_price when available — this is the price used for ratio study calculations.
-                // Fall back to raw SalePrice only when the adjusted price hasn't been synced from PACS yet.
+                // Use canonical adjusted sale price when available — this is the price used for ratio study calculations.
+                // Fall back to raw SalePrice only when the adjusted price has not been projected yet.
                 AdjustedPrice = c.AdjustedSalePrice ?? c.SalePrice,
                 // Use living area frozen at time of sale (sl_living_area) for ratio study accuracy.
                 // Fall back to current GLA when freeze data hasn't been synced.
@@ -367,7 +368,7 @@ public class ValuationService : IValuationService
                     subjectQualityGrade:    subjectCama?.QualityGrade,    // imprv_det_class_cd → ECONOMY…EXCELLENT
                     subjectImprvTypeCode:   subjectCama?.BuildingType),   // imprv_type_cd → R1, R2, A1, etc.
                 Notes         = BuildSaleNotes(c),
-                // TF-computed ratio: AssessedValue / SalePrice. Never uses PACS sl_ratio.
+                // TF-computed ratio: AssessedValue / SalePrice. Never uses legacy source ratios.
                 SalesRatio    = ((Func<double>)(() => {
                     var sp = (double)(c.AdjustedSalePrice ?? c.SalePrice);
                     compAssessedValues.TryGetValue(c.ParcelId, out var tav);
@@ -379,7 +380,7 @@ public class ValuationService : IValuationService
                 QualificationDecision     = c.QualificationDecision,
                 DecisionSource            = c.DecisionSource,
                 EffectiveQualification    = c.QualificationDecision ?? c.QualificationRecommendation ?? c.SaleQualification,
-                // Qualification-relevant sale flags (imported from ingested data; not PACS calculations)
+                // Qualification-relevant sale flags imported as canonical source facts.
                 LandOnlySale              = c.LandOnlySale,
                 ContinueCurrentUse        = c.ContinueCurrentUse,
                 SalesYear                 = c.SalesYear,
@@ -585,7 +586,7 @@ public class ValuationService : IValuationService
     /// Returns valuation year layers for a parcel from canonical ValuationRecords.
     ///
     /// PARITY GAP (CP-4): The canonical ValuationRecord does not capture the full
-    /// PACS year-layer model (SupNum, PropState, program enrollment, exemptions, etc.).
+    /// county year-layer model (SupNum, PropState, program enrollment, exemptions, etc.).
     /// Those fields return null/empty/false until the canonical model is extended.
     /// </summary>
     public async Task<ParcelYearLayersResult> GetAvailableYearsAsync(
@@ -689,6 +690,60 @@ public class ValuationService : IValuationService
 
     // ── Helpers ─────────────────────────────────────────────────────────
 
+    private async Task<List<CamaImprovementDetail>> LoadSegmentRowsAsync(
+        string parcelId,
+        int taxYear,
+        CancellationToken ct)
+    {
+        if (!await CanReadTableAsync("cama_improvement_details", ct))
+        {
+            _logger.LogInformation(
+                "Canonical CAMA improvement detail projection is unavailable; returning empty segment details for parcel {ParcelId}, tax year {TaxYear}",
+                parcelId,
+                taxYear);
+            return [];
+        }
+
+        return await _db.CamaImprovementDetails
+            .AsNoTracking()
+            .Where(s => s.ParcelId == parcelId && s.TaxYear == taxYear)
+            .ToListAsync(ct);
+    }
+
+    private async Task<bool> CanReadTableAsync(string tableName, CancellationToken ct)
+    {
+        var provider = _db.Database.ProviderName ?? string.Empty;
+        if (!provider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var connection = _db.Database.GetDbConnection();
+        var shouldClose = connection.State != ConnectionState.Open;
+        if (shouldClose)
+            await connection.OpenAsync(ct);
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = @"
+SELECT 1
+FROM sqlite_master
+WHERE type IN ('table', 'view')
+  AND name = $tableName
+LIMIT 1";
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = "$tableName";
+            parameter.Value = tableName;
+            command.Parameters.Add(parameter);
+
+            return await command.ExecuteScalarAsync(ct) != null;
+        }
+        finally
+        {
+            if (shouldClose)
+                await connection.CloseAsync();
+        }
+    }
+
     private static List<ModelInputEntry> BuildCostInputs(bool hasValuation, bool hasLand, bool hasCama)
     {
         return
@@ -735,10 +790,10 @@ public class ValuationService : IValuationService
     ///
     /// Weighted dimensions:
     ///   GLA (30%)            — largest driver of value, WA assessment rule
-    ///   Quality class (20%)  — PACS imprv_det_class_cd (ECONOMY…EXCELLENT); ordinal distance
+    ///   Quality class (20%)  — canonical quality grade (ECONOMY…EXCELLENT); ordinal distance
     ///   Year Built (20%)     — effective age is core to cost/income approaches
     ///   Same Neighborhood (15%) — location adjustment proxy when lat/lng unavailable
-    ///   Improvement Type (10%)  — PACS imprv_type_cd: R1=SFR, R2=Mobile/MFH, A1=Apt, etc.
+    ///   Improvement Type (10%)  — canonical improvement type code: R1=SFR, R2=Mobile/MFH, A1=Apt, etc.
     ///   Land Size (5%)       — supplementary, noisy for residential
     ///
     /// Quality scoring: ordinal tier distance — ECONOMY=1 through EXCELLENT=6.
@@ -763,7 +818,7 @@ public class ValuationService : IValuationService
         // Neutral score when either side has no data for a dimension
         private const double NeutralDimScore = 0.5;
 
-        // PACS quality tier ordinal map — imprv_det_class_cd normalized values.
+        // Canonical quality tier ordinal map.
         // Source: Benton County 2026 Calibration Technical Report + NormalizeQualityGrade().
         private static readonly IReadOnlyDictionary<string, int> QualityOrdinal =
             new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
@@ -815,7 +870,7 @@ public class ValuationService : IValuationService
                     ? 1.0
                     : 0.0;
 
-            // Improvement type: binary match on PACS imprv_type_cd (R1=SFR, R2=Mobile/MFH, etc.)
+            // Improvement type: binary match on canonical improvement type code (R1=SFR, R2=Mobile/MFH, etc.)
             double typeScore;
             if (comp.ImprvTypeCode == null || subjectImprvTypeCode == null)
                 typeScore = NeutralDimScore;

--- a/backend/src/TerraFusion.Core/DTOs/ForgeValuationDtos.cs
+++ b/backend/src/TerraFusion.Core/DTOs/ForgeValuationDtos.cs
@@ -4,8 +4,8 @@ namespace TerraFusion.Core.DTOs;
 
 /// <summary>
 /// Cost approach result matching the frontend CostApproach / ForgeOverview panels.
-/// Maps to fields from pacs_valuations (CostValue, CostMarket, CostLand*, CostImprv*)
-/// and pacs_improvement_details (RCN, depreciation).
+/// Maps to canonical valuation and improvement-detail fields for cost value,
+/// land value, improvement value, replacement cost, and depreciation.
 /// </summary>
 public record CostApproachResult
 {
@@ -27,19 +27,19 @@ public record CostApproachResult
     /// <summary>RCN minus all depreciation.</summary>
     public decimal DepreciatedCost { get; init; }
 
-    /// <summary>Land value from pacs_land_details sum.</summary>
+    /// <summary>Land value from canonical land valuation data.</summary>
     public decimal LandValue { get; init; }
 
     /// <summary>Final cost approach indicated value (DepreciatedCost + LandValue).</summary>
     public decimal IndicatedValue { get; init; }
 
-    /// <summary>Improvement homestead + non-homestead from pacs_valuations cost columns.</summary>
+    /// <summary>Canonical improvement value.</summary>
     public decimal ImprovementValue { get; init; }
 
     /// <summary>Data source label: "pacs" when real data, "fallback" when synthetic.</summary>
     public string Source { get; init; } = "fallback";
 
-    /// <summary>Confidence 0.0 – 1.0 (higher when sourced from real PACS data).</summary>
+    /// <summary>Confidence 0.0 – 1.0 (higher when sourced from real canonical data).</summary>
     public double Confidence { get; init; }
 
     /// <summary>Cost model input factors for the explain_model_inputs tool.</summary>
@@ -70,7 +70,7 @@ public record CostApproachResult
     public bool IsAgriculturalOrTimber { get; init; }
     public string? WaClassificationNote { get; init; }
 
-    // ── Phase B: Physical building attributes from PACS improvement attributes ──
+    // ── Phase B: Physical building attributes from canonical improvement attributes ──
     /// <summary>Foundation type (e.g., Crawl/Concrete Perimeter Piers, Slab, Post & Pier).</summary>
     public string? Foundation { get; init; }
     /// <summary>Exterior wall material (e.g., Alum siding, Vinyl, Brick Veneer).</summary>
@@ -100,13 +100,13 @@ public record CostApproachResult
 
 /// <summary>
 /// One building segment row from cama_improvement_details.
-/// Preserves PACS cost matrix join keys for CostForge recalculation.
+/// Preserves canonical cost matrix join keys for CostForge recalculation.
 /// </summary>
 public record SegmentEntry
 {
     /// <summary>Segment type code (ImprvDetTypeCd): MA, CovPatio, Patio, Shop, DETGAR, etc.</summary>
     public string? SegmentType { get; init; }
-    /// <summary>Human-readable PACS description.</summary>
+    /// <summary>Human-readable segment description.</summary>
     public string? SegmentDesc { get; init; }
     /// <summary>Method code — matrix join key (e.g., R, EXT-B).</summary>
     public string? MethodCode { get; init; }
@@ -116,9 +116,9 @@ public record SegmentEntry
     public string? SubClassCode { get; init; }
     /// <summary>Floor area in square feet.</summary>
     public decimal? Area { get; init; }
-    /// <summary>PACS unit cost per square foot.</summary>
+    /// <summary>Canonical unit cost per square foot.</summary>
     public decimal? UnitPrice { get; init; }
-    /// <summary>PACS-computed segment value (Area × UnitPrice × adjustments). Null if not loaded.</summary>
+    /// <summary>Canonical segment value (Area × UnitPrice × adjustments). Null if not loaded.</summary>
     public decimal? CalcValue { get; init; }
     /// <summary>Condition code for this segment.</summary>
     public string? ConditionCode { get; init; }
@@ -136,14 +136,14 @@ public record ModelInputEntry
 
 /// <summary>
 /// Sales comparison result matching the frontend SalesComparison panel.
-/// Populated from pacs_sales joined to pacs_valuations.
+/// Populated from canonical comparable sales and canonical valuation/property data.
 /// </summary>
 public record SalesComparisonResult
 {
     public string ParcelId { get; init; } = string.Empty;
     public int TaxYear { get; init; }
 
-    /// <summary>Indicated value from market approach (pacs_valuations.MktapprMarket).</summary>
+    /// <summary>Indicated value from canonical market approach data.</summary>
     public decimal IndicatedValue { get; init; }
 
     /// <summary>Number of comparables found.</summary>
@@ -174,7 +174,7 @@ public record SalesComparisonResult
     /// <summary>
     /// Price-Related Differential (IAAO standard). Arithmetic mean / weighted mean.
     /// IAAO target: 0.98–1.03. >1.03 = assessment regressivity; &lt;0.98 = progressivity.
-    /// 0.0 when fewer than 2 qualified sales with PACS ratios available.
+    /// 0.0 when fewer than 2 qualified sales with canonical ratios available.
     /// </summary>
     public double PriceRelatedDifferential { get; init; }
 
@@ -263,7 +263,7 @@ public record ComparableSaleEntry
 
 /// <summary>
 /// Income approach result matching the frontend IncomeApproach panel.
-/// Sourced from pacs_valuations income columns and pacs_sales income data.
+/// Sourced from canonical income valuation and comparable sales data.
 /// </summary>
 public record IncomeApproachResult
 {
@@ -276,7 +276,7 @@ public record IncomeApproachResult
     public decimal GrossIncomeMultiplier { get; init; }
     public string RiskClassification { get; init; } = "moderate";
 
-    /// <summary>Income approach indicated value from pacs_valuations.</summary>
+    /// <summary>Income approach indicated value from canonical valuation data.</summary>
     public decimal IncomeIndicatedValue { get; init; }
 
     public string Source { get; init; } = "fallback";
@@ -322,10 +322,10 @@ public record ReconciliationResult
     /// <summary>Method used for reconciliation.</summary>
     public string Method { get; init; } = "weighted_average";
 
-    /// <summary>Assessed value from pacs_valuations.AssessedVal.</summary>
+    /// <summary>Assessed value from canonical valuation/property data.</summary>
     public decimal? AssessedValue { get; init; }
 
-    /// <summary>Market value from pacs_valuations.Market.</summary>
+    /// <summary>Market value from canonical valuation/property data.</summary>
     public decimal? MarketValue { get; init; }
 
     public string Source { get; init; } = "fallback";
@@ -344,11 +344,11 @@ public record ApproachSummary
 // ── Available Years (Year-Layer Inventory) ─────────────────────────────
 
 /// <summary>
-/// All pacs_valuations year layers for a parcel, ordered most-recent first.
+/// All canonical valuation year layers for a parcel, ordered most-recent first.
 /// The UI calls this endpoint on parcel load to populate the year selector
 /// and default to the most recent base-roll layer.
 ///
-/// PACS year-layer model: each (PropValYear, SupNum) pair is a discrete,
+/// Canonical year-layer model: each (tax year, supplemental number) pair is a discrete,
 /// sovereign snapshot. Layers are never silently substituted — year selection
 /// is explicit and driven by the caller.
 /// </summary>
@@ -367,7 +367,7 @@ public record ParcelYearLayersResult
 }
 
 /// <summary>
-/// Metadata for a single pacs_valuations row (one year-layer).
+/// Metadata for a single canonical valuation year layer.
 /// </summary>
 public record ParcelYearLayer
 {
@@ -377,7 +377,7 @@ public record ParcelYearLayer
     /// <summary>"base" when SupNum=0 (roll record), "supplemental" when SupNum>0 (mid-year adjustment).</summary>
     public string LayerType { get; init; } = "base";
 
-    /// <summary>Raw PropState from PACS (e.g. "A"=active). Null if not set.</summary>
+    /// <summary>Raw property state from canonical valuation data (e.g. "A"=active). Null if not set.</summary>
     public string? PropState { get; init; }
 
     /// <summary>True when HasLockedValues=true — layer is certified / closed roll.</summary>
@@ -385,13 +385,13 @@ public record ParcelYearLayer
 
     /// <summary>
     /// True if this is the oldest known layer for this parcel (data-driven minimum year).
-    /// For Benton County parcels this will be 2015 — the asend/proval → PACS migration year.
+    /// For Benton County parcels this will be the earliest canonical conversion-era valuation year.
     /// That layer is NOT stale data; it is the active certified value for parcels not
     /// reappraised since migration (e.g. agricultural parcels on the 6-year cycle).
     /// </summary>
     public bool IsEarliestKnownLayer { get; init; }
 
-    /// <summary>Revaluation cycle number from pacs_valuations.Cycle.</summary>
+    /// <summary>Revaluation cycle number from canonical valuation data.</summary>
     public int? RevaluationCycle { get; init; }
 
     /// <summary>Date parcel was last appraised (LastAppraisalDate ?? LastActualAppraisalDate).</summary>
@@ -409,7 +409,7 @@ public record ParcelYearLayer
 
 /// <summary>
 /// Special valuation programs active in a given year layer.
-/// Derived from pacs_valuations value fields and pacs_exemptions codes.
+/// Derived from canonical valuation fields and exemption codes.
 ///
 /// Programs with deferred losses (AgLossDeferred, TimberLossDeferred) are the
 /// BASIS for removal penalty calculations under RCW 84.34 and RCW 84.33.
@@ -440,7 +440,7 @@ public record ProgramEnrollment
     // ── RCW 84.36: Exemptions ─────────────────────────────────────────────
     /// <summary>
     /// Exemption type codes active for this parcel in this year layer.
-    /// From pacs_exemptions.ExemptTypeCode (e.g. HS, OV65, DP, AG, EX).
+    /// From canonical exemption code data (e.g. HS, OV65, DP, AG, EX).
     /// </summary>
     public List<string> ExemptionCodes { get; init; } = [];
 }

--- a/backend/src/TerraFusion.Core/Interfaces/IValuationService.cs
+++ b/backend/src/TerraFusion.Core/Interfaces/IValuationService.cs
@@ -5,8 +5,8 @@ namespace TerraFusion.Core.Interfaces;
 /// <summary>
 /// Phase 10 — PropertyForge valuation API contract.
 /// Four approaches: cost, sales-comparison, income, and reconciliation.
-/// Implementations query PACS tables for real data and return structured fallback
-/// where PACS data is incomplete.
+/// Implementations query canonical TerraFusion runtime tables and return structured
+/// unavailable states where canonical data is incomplete.
 ///
 /// Year-layer model: callers are responsible for year selection. Use GetAvailableYearsAsync
 /// to discover which layers exist for a parcel before requesting approach data.
@@ -15,7 +15,7 @@ namespace TerraFusion.Core.Interfaces;
 public interface IValuationService
 {
     /// <summary>
-    /// Returns all pacs_valuations year layers for a parcel with program enrollment metadata.
+    /// Returns canonical valuation year layers for a parcel with program enrollment metadata.
     /// Call this on parcel load to populate the year selector. DefaultYear is the recommended
     /// starting point (most recent base-roll layer).
     /// </summary>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyForge.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyForge.tsx
@@ -89,7 +89,7 @@ export const PropertyForge: React.FC = () => {
   /* Probe the cost endpoint to determine if the Forge API is reachable */
   const forgeProbe = useCostApproach(parcelId, CURRENT_YEAR);
 
-  /* PACS year layers for this parcel */
+  /* Canonical valuation year layers for this parcel */
   const parcelYears = useParcelYears(parcelId);
 
   /* Shared state */
@@ -117,7 +117,7 @@ export const PropertyForge: React.FC = () => {
 
   return (
     <div className="tf-suite-forge space-y-4" data-testid="property-forge-tab">
-      {/* PACS Year Selector */}
+      {/* Canonical Year Selector */}
       <ForgeYearSelector
         parcelId={parcelId}
         taxYear={taxYear}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/forge/CostApproach.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/forge/CostApproach.tsx
@@ -228,7 +228,7 @@ export const CostApproach: React.FC<ForgeSubTabProps> = ({
                 )}
               </div>
             )}
-            {/* Physical attributes from PACS improvement attributes */}
+            {/* Physical attributes from canonical improvement attributes */}
             {(costAPI.data.foundation || costAPI.data.exteriorWall || costAPI.data.roofType ||
               costAPI.data.hvacType || costAPI.data.bedrooms != null || costAPI.data.fireplaces != null) && (
               <div className="tf-panel p-3">

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/forge/ForgeYearContextPanel.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/forge/ForgeYearContextPanel.tsx
@@ -2,7 +2,7 @@
  * forge/ForgeYearContextPanel.tsx
  *
  * Compact contextual strip displayed below the year selector in
- * PropertyForge. Shows the selected year's PACS layer attributes:
+ * PropertyForge. Shows the selected year's canonical layer attributes:
  *   - Lock state (certified vs open roll)
  *   - PropState code
  *   - Earliest known layer (migration baseline) flag

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/forge/ForgeYearSelector.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/forge/ForgeYearSelector.tsx
@@ -1,11 +1,11 @@
 /**
  * forge/ForgeYearSelector.tsx
  *
- * PACS-aware year selector for the Forge workbench.
+ * Canonical year selector for the Forge workbench.
  *
  * Replaces the static TAX_YEARS <select> in PropertyForge.tsx.
  * Calls GET /api/forge/{parcelId}/years to discover the real year
- * layers that exist for this parcel in PACS.
+ * layers that exist for this parcel in canonical TerraFusion data.
  *
  * Each option shows:
  *   - Tax year (bold)
@@ -120,7 +120,7 @@ export const ForgeYearSelector: React.FC<ForgeYearSelectorProps> = ({
     );
   }
 
-  /* Happy path — render PACS-sourced layer list */
+  /* Happy path — render canonical layer list */
   return (
     <div className="flex items-center gap-4 flex-wrap">
       <label htmlFor="forge-tax-year" className="tf-text-secondary text-sm whitespace-nowrap">

--- a/os-platform/core/tests/forge-runtime-pacs-boundary.test.mjs
+++ b/os-platform/core/tests/forge-runtime-pacs-boundary.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..', '..', '..');
+
+const RUNTIME_TARGETS = [
+  'backend/src/TerraFusion.API/Controllers/ForgeController.cs',
+  'backend/src/TerraFusion.API/Controllers/TerraForgeController.cs',
+  'backend/src/TerraFusion.API/Controllers/CostForgeController.cs',
+  'backend/src/TerraFusion.API/Services/ValuationService.cs',
+  'backend/src/TerraFusion.Core/Interfaces/IValuationService.cs',
+  'backend/src/TerraFusion.Core/DTOs/ForgeValuationDtos.cs',
+  'frontend/apps/os-shell/src/hooks/forge',
+  'frontend/apps/os-shell/src/pages/forge',
+  'frontend/apps/os-shell/src/services/forge',
+  'frontend/apps/os-shell/src/pages/workbench/tabs/forge',
+  'frontend/apps/os-shell/src/pages/workbench/tabs/PropertyForge.tsx',
+];
+
+const SOURCE_EXTENSIONS = new Set(['.cs', '.ts', '.tsx', '.js', '.jsx', '.mjs']);
+const FORBIDDEN_PATTERNS = [
+  /\bPacs\b/,
+  /\bPacs[A-Za-z0-9_]*/,
+  /\bPACS\b/,
+  /pacs_/,
+];
+
+function isRuntimeSource(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  return (
+    SOURCE_EXTENSIONS.has(extname(filePath)) &&
+    !normalized.includes('/__tests__/') &&
+    !normalized.includes('/test/') &&
+    !normalized.includes('/tests/')
+  );
+}
+
+function collectFiles(target) {
+  const absolute = resolve(ROOT, target);
+  if (!existsSync(absolute)) return [];
+
+  const info = statSync(absolute);
+  if (info.isFile()) {
+    return isRuntimeSource(absolute) ? [absolute] : [];
+  }
+
+  const files = [];
+  for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+    const child = join(absolute, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(child));
+    } else if (isRuntimeSource(child)) {
+      files.push(child);
+    }
+  }
+
+  return files;
+}
+
+function findForbiddenRuntimeReferences() {
+  const files = RUNTIME_TARGETS.flatMap(collectFiles);
+  const violations = [];
+
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (FORBIDDEN_PATTERNS.some(pattern => pattern.test(line))) {
+        violations.push({
+          file: file.replace(ROOT + '\\', '').replace(ROOT + '/', ''),
+          line: index + 1,
+          text: line.trim(),
+        });
+      }
+    });
+  }
+
+  return violations;
+}
+
+describe('Forge runtime PACS boundary', () => {
+  it('keeps PACS out of Workbench and TerraForge runtime code paths', () => {
+    const violations = findForbiddenRuntimeReferences();
+    assert.equal(
+      violations.length,
+      0,
+      [
+        'PACS is source/provenance/sync only and must not be a Forge runtime dependency.',
+        'Forbidden runtime references:',
+        ...violations.map(v => `${v.file}:${v.line} ${v.text}`),
+      ].join('\n'),
+    );
+  });
+});


### PR DESCRIPTION
This PR removes the legacy PACS dependency from the Forge runtime path.

Scope:
- Workbench Forge / Forge runtime services no longer reference `Pacs*`, `PACS`, or `pacs_` runtime sources.
- `ValuationService` resolves sales neighborhood from canonical `CamaCharacteristics` instead of legacy PACS valuation mirrors.
- Missing optional canonical CAMA improvement-detail projection returns empty segment details instead of a 500.
- Runtime-facing Forge comments/labels now refer to canonical TerraFusion sources instead of PACS.
- Adds `forge-runtime-pacs-boundary.test.mjs` to prevent PACS references in Forge runtime controllers/services/hooks/UI paths.

This does not:
- add `pacs_valuations`
- create PACS views
- add PACS fallback
- mutate DB data
- touch Home, Counties, Sentinel, Atlas, Dais, auth, or production deployment

Local proof:
- `node --test os-platform/core/tests/forge-runtime-pacs-boundary.test.mjs`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release --no-restore -m:1 -nr:false /p:UseSharedCompilation=false`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`

Status:
- Production is not redeployed by this PR.
- Phase 6 remains blocked until this is merged, redeployed, and authenticated Forge browser smoke proves no 401/500 and honest data/unavailable state.