### PR TITLE
WO-BRANCH-003: Forge Cost Reference extract-forward

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/Forge/CalibrationGate.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CalibrationGate.cs
@@ -1,0 +1,55 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// TF-owned calibration acceptance thresholds (IAAO-style; county-settable). Defaults are common
+/// IAAO guidance: level (median) near 1.0, COD uniformity ceiling, PRD vertical-equity band.
+/// </summary>
+public sealed record CalibrationThresholds(
+    decimal MedianMin = 0.90m,
+    decimal MedianMax = 1.10m,
+    decimal CodMax = 15.0m,
+    decimal PrdMin = 0.98m,
+    decimal PrdMax = 1.03m,
+    int MinSampleSize = 5);
+
+/// <summary>Calibration outcome: pass/fail with human-readable findings.</summary>
+public sealed record CalibrationStatus(bool Passed, IReadOnlyList<string> Findings, string Summary);
+
+/// <summary>
+/// Deterministic TF-native calibration/QC gate (pack criterion 6). Flags out-of-tolerance models on
+/// appraisal level (median), uniformity (COD) and vertical equity (PRD), plus insufficient samples.
+/// Pure function over a ratio study — informational/QC, not an automatic value change.
+/// </summary>
+public static class CalibrationGate
+{
+    /// <summary>Evaluates a ratio study against thresholds (deterministic, explained).</summary>
+    public static CalibrationStatus Evaluate(RatioStudyResult study, CalibrationThresholds thresholds)
+    {
+        var findings = new List<string>();
+
+        if (!study.Found || study.Count == 0)
+        {
+            findings.Add("No qualified sales: ratio study could not be computed (model not calibratable).");
+            return new CalibrationStatus(false, findings, "FAIL: no qualified sales.");
+        }
+
+        if (study.Count < thresholds.MinSampleSize)
+            findings.Add($"Insufficient sample: {study.Count} qualified sales < minimum {thresholds.MinSampleSize}.");
+
+        if (study.MedianRatio < thresholds.MedianMin || study.MedianRatio > thresholds.MedianMax)
+            findings.Add($"Appraisal level (median {study.MedianRatio}) outside [{thresholds.MedianMin}, {thresholds.MedianMax}].");
+
+        if (study.Cod > thresholds.CodMax)
+            findings.Add($"Uniformity (COD {study.Cod}) exceeds maximum {thresholds.CodMax}.");
+
+        if (study.Prd < thresholds.PrdMin || study.Prd > thresholds.PrdMax)
+            findings.Add($"Vertical equity (PRD {study.Prd}) outside [{thresholds.PrdMin}, {thresholds.PrdMax}].");
+
+        var passed = findings.Count == 0;
+        var summary = passed
+            ? $"PASS: median {study.MedianRatio}, COD {study.Cod}, PRD {study.Prd} over {study.Count} sales."
+            : $"FLAGGED ({findings.Count}): " + string.Join(" ", findings);
+
+        return new CalibrationStatus(passed, findings, summary);
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/CapRateSet.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CapRateSet.cs
@@ -1,0 +1,73 @@
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Result of resolving a capitalization rate; a miss/invalid rate is explicit.</summary>
+public readonly record struct CapRateResolution(bool Found, decimal CapitalizationRate, string Explanation);
+
+/// <summary>A TF-owned capitalization rate for an income property class.</summary>
+public sealed class CapRate
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CapRateSetId { get; set; }
+
+    /// <summary>Income property class (e.g. APT, RETAIL, OFFICE).</summary>
+    public required string IncomePropertyClass { get; set; }
+
+    /// <summary>TF-owned capitalization rate (fraction, e.g. 0.08).</summary>
+    public decimal CapitalizationRate { get; set; }
+}
+
+/// <summary>
+/// WS-1 — TF-native, county-scoped, versioned capitalization-rate set (D-VAL-1). Same provenance/
+/// versioning/audit contract as the other reference sets; deterministic class lookup. A non-positive
+/// rate is treated as invalid (explicit miss) — never a divide-by-zero or silent value.
+/// </summary>
+public sealed class CapRateSet : IAuditableEntity, IReferenceDataSet
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CountyId { get; set; }
+    public int EffectiveYear { get; set; }
+    public string? RevalCycle { get; set; }
+    public string Version { get; set; } = string.Empty;
+    public ReferenceDataOrigin Origin { get; set; } = ReferenceDataOrigin.TerraFusionOwned;
+    public string ProvenanceAuthor { get; set; } = string.Empty;
+    public List<CapRate> Rates { get; set; } = new();
+
+    public bool IsVendorDependent => false;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = "system";
+    public string? UpdatedBy { get; set; }
+
+    public void EnsureTfProvenance()
+    {
+        if (string.IsNullOrWhiteSpace(Version))
+            throw new InvalidOperationException("CapRateSet provenance incomplete: Version is required (D-VAL-1).");
+        if (string.IsNullOrWhiteSpace(ProvenanceAuthor))
+            throw new InvalidOperationException("CapRateSet provenance incomplete: ProvenanceAuthor is required (D-VAL-1).");
+        if (EffectiveYear <= 0)
+            throw new InvalidOperationException("CapRateSet provenance incomplete: EffectiveYear is required (D-VAL-1).");
+    }
+
+    /// <summary>Deterministically resolves a positive cap rate for the class; explicit on miss/invalid.</summary>
+    public CapRateResolution ResolveCapRate(string incomePropertyClass)
+    {
+        var match = Rates
+            .Where(r => string.Equals(r.IncomePropertyClass, incomePropertyClass, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(r => r.Id)
+            .FirstOrDefault();
+
+        if (match is null)
+            return new CapRateResolution(false, 0m,
+                $"No TF cap rate for income class '{incomePropertyClass}' in set '{Version}' (county {CountyId}, year {EffectiveYear}).");
+
+        if (match.CapitalizationRate <= 0m)
+            return new CapRateResolution(false, match.CapitalizationRate,
+                $"TF cap rate for income class '{incomePropertyClass}' is non-positive ({match.CapitalizationRate}); invalid for direct capitalization.");
+
+        return new CapRateResolution(true, match.CapitalizationRate,
+            $"TF cap rate {match.CapitalizationRate} for income class '{incomePropertyClass}' (set '{Version}').");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/CostApproach.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CostApproach.cs
@@ -1,0 +1,69 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// Inputs to the deterministic TF cost approach for one improvement. Functional/economic
+/// obsolescence are caller-supplied survivorship fractions (default 0); physical depreciation is
+/// resolved from the TF <see cref="DepreciationSchedule"/> by effective age.
+/// </summary>
+public sealed record CostApproachInput(
+    string ImprovementClassCode,
+    int SizeSqFt,
+    int EffectiveAgeYears,
+    decimal LandContribution,
+    decimal FunctionalObsolescenceFraction = 0m,
+    decimal EconomicObsolescenceFraction = 0m);
+
+/// <summary>
+/// Result of the cost approach with a full, explainable breakdown. A miss (<see cref="Found"/> =
+/// false) carries an <see cref="Explanation"/> and no computed value — never a silent default.
+/// </summary>
+public sealed record CostApproachResult(
+    bool Found,
+    decimal ReplacementCostNew,
+    decimal PhysicalDepreciationFraction,
+    decimal FunctionalObsolescenceFraction,
+    decimal EconomicObsolescenceFraction,
+    decimal DepreciatedImprovementValue,
+    decimal LandContribution,
+    decimal IndicatedValue,
+    string Explanation);
+
+/// <summary>
+/// Deterministic, TF-native cost approach (D-VAL-1): IndicatedValue = RCN × (1−physical) ×
+/// (1−functional) × (1−economic) + land contribution. RCN = TF unit cost × size. Pure function of
+/// its inputs and TF-owned reference data — no vendor table, no nondeterministic path.
+/// The Forge project exposes this via IValuationApproach and owns the value write (write-lane).
+/// </summary>
+public static class CostApproachCalculator
+{
+    /// <summary>Computes the cost-approach indicated value (deterministic, fully explained).</summary>
+    public static CostApproachResult Compute(
+        CostApproachInput input, CostFactorSet costs, DepreciationSchedule depreciation)
+    {
+        var f = input.FunctionalObsolescenceFraction;
+        var e = input.EconomicObsolescenceFraction;
+
+        var unit = costs.ResolveUnitCost(input.ImprovementClassCode, input.SizeSqFt);
+        if (!unit.Found)
+            return new CostApproachResult(false, 0m, 0m, f, e, 0m, input.LandContribution, 0m,
+                $"Cost approach incomplete: {unit.Explanation}");
+
+        var rcn = unit.UnitCostPerSqFt * input.SizeSqFt;
+
+        var dep = depreciation.ResolveDepreciation(input.EffectiveAgeYears);
+        if (!dep.Found)
+            return new CostApproachResult(false, rcn, 0m, f, e, 0m, input.LandContribution, 0m,
+                $"Cost approach incomplete: {dep.Explanation}");
+
+        var p = dep.Fraction;
+        var depreciatedImprovement = rcn * (1m - p) * (1m - f) * (1m - e);
+        var indicated = depreciatedImprovement + input.LandContribution;
+
+        var explanation =
+            $"RCN {rcn} (= {unit.UnitCostPerSqFt}/sqft × {input.SizeSqFt} sqft, class '{input.ImprovementClassCode}') " +
+            $"× (1−physical {p}) × (1−functional {f}) × (1−economic {e}) = improvement {depreciatedImprovement}; " +
+            $"+ land {input.LandContribution} = {indicated}.";
+
+        return new CostApproachResult(true, rcn, p, f, e, depreciatedImprovement, input.LandContribution, indicated, explanation);
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/CostFactor.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CostFactor.cs
@@ -1,0 +1,25 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// A single TF-owned cost factor line item within a <see cref="CostFactorSet"/>. Keyed by
+/// improvement class code (maps to <c>TfImprovement.ImprvClassCd</c>) and an optional size band.
+/// <see cref="UnitCostPerSqFt"/> is a TerraFusion-owned replacement-cost-new input, not a vendor figure.
+/// </summary>
+public sealed class CostFactor
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CostFactorSetId { get; set; }
+
+    /// <summary>Improvement class code this factor applies to.</summary>
+    public required string ImprovementClassCode { get; set; }
+
+    /// <summary>Inclusive lower bound of the size band (sq ft); null = no lower bound.</summary>
+    public int? SizeBandMinSqFt { get; set; }
+
+    /// <summary>Inclusive upper bound of the size band (sq ft); null = no upper bound.</summary>
+    public int? SizeBandMaxSqFt { get; set; }
+
+    /// <summary>TF-owned RCN unit cost ($/sq ft).</summary>
+    public decimal UnitCostPerSqFt { get; set; }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/CostFactorCatalog.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CostFactorCatalog.cs
@@ -1,0 +1,18 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// TF-native selection over cost-factor reference sets. County-scoped and version-pinned:
+/// it returns the set for an exact (county, effective year) — no cross-county fallback and no
+/// nearest-year guessing. A miss returns null (the caller decides; never a silent default set).
+/// </summary>
+public static class CostFactorCatalog
+{
+    /// <summary>Selects the TF cost-factor set for an exact county + effective year. STUB (red phase).</summary>
+    public static CostFactorSet? Select(IEnumerable<CostFactorSet> sets, Guid countyId, int effectiveYear)
+    {
+        return sets
+            .Where(s => s.CountyId == countyId && s.EffectiveYear == effectiveYear)
+            .OrderByDescending(s => s.Version, StringComparer.Ordinal) // deterministic if multiple share a year
+            .FirstOrDefault();
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/CostFactorSet.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/CostFactorSet.cs
@@ -1,0 +1,95 @@
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// Result of resolving a unit cost from a <see cref="CostFactorSet"/>. A miss is explicit
+/// (<see cref="Found"/> = false) with an <see cref="Explanation"/> — never a silent default value.
+/// </summary>
+public readonly record struct CostFactorResolution(
+    bool Found,
+    decimal UnitCostPerSqFt,
+    string? ClassCode,
+    string Explanation);
+
+/// <summary>
+/// WS-1 / 1f — TF-native, county-scoped, versioned cost-factor reference set (D-VAL-1).
+/// Owns its provenance (TerraFusion-owned, never a vendor cost basis) and a deterministic factor
+/// lookup. Implements <see cref="IAuditableEntity"/> so writes inherit WS-3 audit stamping; there
+/// is no separate audit path. Honors county isolation via <see cref="CountyId"/>.
+/// </summary>
+public sealed class CostFactorSet : IAuditableEntity, IReferenceDataSet
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Sovereign-county isolation.</summary>
+    public Guid CountyId { get; set; }
+
+    /// <summary>Assessment/effective year the set applies to.</summary>
+    public int EffectiveYear { get; set; }
+
+    /// <summary>Reval cycle label (e.g. "2025-2030").</summary>
+    public string? RevalCycle { get; set; }
+
+    /// <summary>TF-owned version identifier (part of provenance; enables pinned, repeatable lookups).</summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>TF-owned provenance origin (no vendor origin is representable).</summary>
+    public ReferenceDataOrigin Origin { get; set; } = ReferenceDataOrigin.TerraFusionOwned;
+
+    /// <summary>TF authoring/citation for provenance completeness.</summary>
+    public string ProvenanceAuthor { get; set; } = string.Empty;
+
+    public List<CostFactor> Factors { get; set; } = new();
+
+    /// <summary>D-VAL-1: this reference data is never vendor/third-party dependent.</summary>
+    public bool IsVendorDependent => false;
+
+    // WS-3 audit fields (IAuditableEntity) — stamped automatically by AuditableEntityInterceptor.
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = "system";
+    public string? UpdatedBy { get; set; }
+
+    /// <summary>
+    /// Validates TF provenance completeness (D-VAL-1 / EI-2). Throws when version, author, or
+    /// effective year is missing — incomplete provenance is not runtime-legal.
+    /// </summary>
+    public void EnsureTfProvenance()
+    {
+        if (string.IsNullOrWhiteSpace(Version))
+            throw new InvalidOperationException("CostFactorSet provenance incomplete: Version is required (D-VAL-1).");
+        if (string.IsNullOrWhiteSpace(ProvenanceAuthor))
+            throw new InvalidOperationException("CostFactorSet provenance incomplete: ProvenanceAuthor is required (D-VAL-1).");
+        if (EffectiveYear <= 0)
+            throw new InvalidOperationException("CostFactorSet provenance incomplete: EffectiveYear is required (D-VAL-1).");
+    }
+
+    /// <summary>
+    /// Deterministically resolves the unit cost for an improvement class + size. Prefers the most
+    /// specific (narrowest) size band that contains the size; unbanded factors are the fallback.
+    /// A miss returns an explicit, explained <see cref="CostFactorResolution"/> — never a silent value.
+    /// </summary>
+    public CostFactorResolution ResolveUnitCost(string improvementClassCode, int sizeSqFt)
+    {
+        var candidate = Factors
+            .Where(f => string.Equals(f.ImprovementClassCode, improvementClassCode, StringComparison.OrdinalIgnoreCase))
+            .Where(f => (f.SizeBandMinSqFt is null || sizeSqFt >= f.SizeBandMinSqFt)
+                     && (f.SizeBandMaxSqFt is null || sizeSqFt <= f.SizeBandMaxSqFt))
+            .OrderBy(f => BandWidth(f)) // narrowest band first; unbanded = widest
+            .ThenBy(f => f.Id)          // stable tie-break
+            .FirstOrDefault();
+
+        if (candidate is null)
+            return new CostFactorResolution(false, 0m, null,
+                $"No TF cost factor for class '{improvementClassCode}' size {sizeSqFt} sqft in set '{Version}' (county {CountyId}, year {EffectiveYear}).");
+
+        return new CostFactorResolution(true, candidate.UnitCostPerSqFt, candidate.ImprovementClassCode,
+            $"TF cost factor {candidate.UnitCostPerSqFt}/sqft for class '{candidate.ImprovementClassCode}' (set '{Version}', year {EffectiveYear}).");
+    }
+
+    private static long BandWidth(CostFactor f)
+        => f.SizeBandMinSqFt is int min && f.SizeBandMaxSqFt is int max
+            ? (long)max - min
+            : long.MaxValue;
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/DepreciationSchedule.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/DepreciationSchedule.cs
@@ -1,0 +1,76 @@
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Result of resolving physical depreciation; a miss is explicit (no silent default).</summary>
+public readonly record struct DepreciationResolution(bool Found, decimal Fraction, string Explanation);
+
+/// <summary>A TF-owned physical-depreciation line item: an effective-age band → depreciation fraction (0..1).</summary>
+public sealed class DepreciationFactor
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid DepreciationScheduleId { get; set; }
+
+    /// <summary>Inclusive lower bound of the effective-age band (years).</summary>
+    public int AgeMinYears { get; set; }
+
+    /// <summary>Inclusive upper bound of the effective-age band (years).</summary>
+    public int AgeMaxYears { get; set; }
+
+    /// <summary>Physical depreciation fraction (0..1) for this age band.</summary>
+    public decimal DepreciationFraction { get; set; }
+}
+
+/// <summary>
+/// WS-1 — TF-native, county-scoped, versioned physical-depreciation schedule (D-VAL-1). Same
+/// provenance/versioning/audit contract as <see cref="CostFactorSet"/>; deterministic age→fraction
+/// lookup. No vendor depreciation table.
+/// </summary>
+public sealed class DepreciationSchedule : IAuditableEntity, IReferenceDataSet
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CountyId { get; set; }
+    public int EffectiveYear { get; set; }
+    public string? RevalCycle { get; set; }
+    public string Version { get; set; } = string.Empty;
+    public ReferenceDataOrigin Origin { get; set; } = ReferenceDataOrigin.TerraFusionOwned;
+    public string ProvenanceAuthor { get; set; } = string.Empty;
+    public List<DepreciationFactor> Factors { get; set; } = new();
+
+    public bool IsVendorDependent => false;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = "system";
+    public string? UpdatedBy { get; set; }
+
+    public void EnsureTfProvenance()
+    {
+        if (string.IsNullOrWhiteSpace(Version))
+            throw new InvalidOperationException("DepreciationSchedule provenance incomplete: Version is required (D-VAL-1).");
+        if (string.IsNullOrWhiteSpace(ProvenanceAuthor))
+            throw new InvalidOperationException("DepreciationSchedule provenance incomplete: ProvenanceAuthor is required (D-VAL-1).");
+        if (EffectiveYear <= 0)
+            throw new InvalidOperationException("DepreciationSchedule provenance incomplete: EffectiveYear is required (D-VAL-1).");
+    }
+
+    /// <summary>
+    /// Deterministically resolves physical depreciation for an effective age. Prefers the
+    /// narrowest matching age band; an unmatched age is an explicit, explained miss.
+    /// </summary>
+    public DepreciationResolution ResolveDepreciation(int effectiveAgeYears)
+    {
+        var match = Factors
+            .Where(f => effectiveAgeYears >= f.AgeMinYears && effectiveAgeYears <= f.AgeMaxYears)
+            .OrderBy(f => (long)f.AgeMaxYears - f.AgeMinYears)
+            .ThenBy(f => f.Id)
+            .FirstOrDefault();
+
+        if (match is null)
+            return new DepreciationResolution(false, 0m,
+                $"No TF depreciation band for effective age {effectiveAgeYears} in schedule '{Version}' (county {CountyId}, year {EffectiveYear}).");
+
+        return new DepreciationResolution(true, match.DepreciationFraction,
+            $"TF physical depreciation {match.DepreciationFraction} for effective age {effectiveAgeYears} (band {match.AgeMinYears}-{match.AgeMaxYears}, set '{Version}').");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ForgeEngineMode.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ForgeEngineMode.cs
@@ -1,0 +1,33 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Forge engine selection for shadow-first rollout (Forge:Engine flag).</summary>
+public enum ForgeEngineMode
+{
+    /// <summary>Legacy AI-narrative path remains authoritative.</summary>
+    AiNarrativeLegacy,
+
+    /// <summary>The deterministic TF-native engine is authoritative.</summary>
+    Native,
+
+    /// <summary>Native computes in parallel for parity evidence; legacy stays authoritative (default).</summary>
+    Shadow,
+}
+
+/// <summary>Rollout options for the Forge engine, parsed from the Forge:Engine configuration value.</summary>
+public sealed record ForgeEngineOptions(ForgeEngineMode Mode)
+{
+    /// <summary>Parses the Forge:Engine value; defaults to Shadow (safe shadow-first rollout).</summary>
+    public static ForgeEngineOptions FromConfiguration(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return new ForgeEngineOptions(ForgeEngineMode.Shadow);
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "native" => new ForgeEngineOptions(ForgeEngineMode.Native),
+            "legacy" or "ainarrative" or "ainarrativelegacy" => new ForgeEngineOptions(ForgeEngineMode.AiNarrativeLegacy),
+            "shadow" => new ForgeEngineOptions(ForgeEngineMode.Shadow),
+            _ => new ForgeEngineOptions(ForgeEngineMode.Shadow),
+        };
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ForgeGovernance.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ForgeGovernance.cs
@@ -1,0 +1,35 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Sovereign-county isolation guard for Forge valuation (pack V10).</summary>
+public static class ForgeCountyGuard
+{
+    /// <summary>Throws when a reference/source county does not match the parcel's county.</summary>
+    public static void EnsureSameCounty(Guid parcelCountyId, Guid referenceCountyId)
+    {
+        if (parcelCountyId != referenceCountyId)
+            throw new InvalidOperationException(
+                $"Cross-county reference rejected: parcel county {parcelCountyId} != reference county {referenceCountyId} (sovereign-county isolation).");
+    }
+}
+
+/// <summary>
+/// Forge write-lane discipline (pack V11): Forge writes ONLY valuation columns. Supplement/notice/
+/// appeal columns belong to Dais and must never be written by Forge.
+/// </summary>
+public static class ForgeWriteLane
+{
+    /// <summary>Valuation columns Forge is allowed to write.</summary>
+    public static readonly IReadOnlySet<string> AllowedValuationColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "AssessedValue", "MarketValue", "LandValue", "ImprovementValue", "AssessmentMethod", "AssessorNotes",
+    };
+
+    /// <summary>Throws if any column is outside Forge's valuation write-lane.</summary>
+    public static void EnsureValuationColumnsOnly(IEnumerable<string> columns)
+    {
+        var offending = columns.Where(c => !AllowedValuationColumns.Contains(c)).ToList();
+        if (offending.Count > 0)
+            throw new InvalidOperationException(
+                $"Forge write-lane violation: columns outside the valuation lane (belong to Dais/Dossier): {string.Join(", ", offending)}.");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/IncomeApproach.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/IncomeApproach.cs
@@ -1,0 +1,32 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Inputs to the TF income approach (direct capitalization).</summary>
+public sealed record IncomeApproachInput(string IncomePropertyClass, decimal NetOperatingIncome);
+
+/// <summary>Income-approach result. A miss carries an explanation and no value.</summary>
+public sealed record IncomeApproachResult(
+    bool Found,
+    decimal NetOperatingIncome,
+    decimal CapRate,
+    decimal IndicatedValue,
+    string Explanation);
+
+/// <summary>
+/// Deterministic TF-native income approach (D-VAL-1): IndicatedValue = NOI ÷ cap rate, the cap rate
+/// resolved from the TF CapRateSet by income class. Pure function; invalid/missing rate is explicit.
+/// </summary>
+public static class IncomeApproachCalculator
+{
+    /// <summary>Computes the income indicated value (deterministic, explained).</summary>
+    public static IncomeApproachResult Compute(IncomeApproachInput input, CapRateSet capRates)
+    {
+        var rate = capRates.ResolveCapRate(input.IncomePropertyClass);
+        if (!rate.Found)
+            return new IncomeApproachResult(false, input.NetOperatingIncome, rate.CapitalizationRate, 0m,
+                $"Income approach incomplete: {rate.Explanation}");
+
+        var value = input.NetOperatingIncome / rate.CapitalizationRate;
+        return new IncomeApproachResult(true, input.NetOperatingIncome, rate.CapitalizationRate, value,
+            $"Income value {value} (= NOI {input.NetOperatingIncome} ÷ cap rate {rate.CapitalizationRate}, class '{input.IncomePropertyClass}').");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/LandApproach.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/LandApproach.cs
@@ -1,0 +1,44 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Inputs to the TF land approach for one parcel's land.</summary>
+public sealed record LandApproachInput(string Neighborhood, decimal LandSizeUnits, bool CurrentUse = false);
+
+/// <summary>Land-approach result with breakdown. A miss carries an explanation and no value.</summary>
+public sealed record LandApproachResult(
+    bool Found,
+    decimal MarketValue,
+    decimal? CurrentUseValue,
+    decimal IndicatedValue,
+    string Explanation);
+
+/// <summary>
+/// Deterministic TF-native land approach (D-VAL-1). IndicatedValue = unit value × size; when
+/// current-use/ag is requested it uses the TF current-use unit value (WA reduced assessment) and
+/// fails explicitly if no current-use rate exists. Pure function of inputs + TF-owned schedule.
+/// </summary>
+public static class LandApproachCalculator
+{
+    /// <summary>Computes the land indicated value (deterministic, explained).</summary>
+    public static LandApproachResult Compute(LandApproachInput input, LandScheduleSet schedule)
+    {
+        var rate = schedule.ResolveRate(input.Neighborhood);
+        if (!rate.Found)
+            return new LandApproachResult(false, 0m, null, 0m, $"Land approach incomplete: {rate.Explanation}");
+
+        var marketValue = rate.MarketUnitValue * input.LandSizeUnits;
+
+        if (input.CurrentUse)
+        {
+            if (rate.CurrentUseUnitValue is not decimal cuUnit)
+                return new LandApproachResult(false, marketValue, null, 0m,
+                    $"Land approach incomplete: current-use requested but no TF current-use rate for '{input.Neighborhood}'.");
+
+            var currentUseValue = cuUnit * input.LandSizeUnits;
+            return new LandApproachResult(true, marketValue, currentUseValue, currentUseValue,
+                $"WA current-use land value {currentUseValue} (= {cuUnit}/unit × {input.LandSizeUnits}); market would be {marketValue}.");
+        }
+
+        return new LandApproachResult(true, marketValue, null, marketValue,
+            $"Market land value {marketValue} (= {rate.MarketUnitValue}/unit × {input.LandSizeUnits} units, '{input.Neighborhood}').");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/LandScheduleSet.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/LandScheduleSet.cs
@@ -1,0 +1,72 @@
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Result of resolving a land rate; a miss is explicit (no silent default).</summary>
+public readonly record struct LandRateResolution(bool Found, decimal MarketUnitValue, decimal? CurrentUseUnitValue, string Explanation);
+
+/// <summary>A TF-owned land rate for a neighborhood: market unit value and optional WA current-use unit value.</summary>
+public sealed class LandRate
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid LandScheduleSetId { get; set; }
+
+    /// <summary>Neighborhood code (maps to parcel/land neighborhood).</summary>
+    public required string Neighborhood { get; set; }
+
+    /// <summary>TF-owned market unit value (per land unit, e.g. per sq ft).</summary>
+    public decimal MarketUnitValue { get; set; }
+
+    /// <summary>TF-owned WA current-use/ag reduced unit value; null when current-use is not applicable.</summary>
+    public decimal? CurrentUseUnitValue { get; set; }
+}
+
+/// <summary>
+/// WS-1 — TF-native, county-scoped, versioned land schedule (D-VAL-1). Same provenance/versioning/
+/// audit contract as <see cref="CostFactorSet"/>; deterministic neighborhood lookup. Current-use/ag
+/// (WA RCW 84.34) is an explicit reduced-value path, never a silent fallback.
+/// </summary>
+public sealed class LandScheduleSet : IAuditableEntity, IReferenceDataSet
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CountyId { get; set; }
+    public int EffectiveYear { get; set; }
+    public string? RevalCycle { get; set; }
+    public string Version { get; set; } = string.Empty;
+    public ReferenceDataOrigin Origin { get; set; } = ReferenceDataOrigin.TerraFusionOwned;
+    public string ProvenanceAuthor { get; set; } = string.Empty;
+    public List<LandRate> Rates { get; set; } = new();
+
+    public bool IsVendorDependent => false;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = "system";
+    public string? UpdatedBy { get; set; }
+
+    public void EnsureTfProvenance()
+    {
+        if (string.IsNullOrWhiteSpace(Version))
+            throw new InvalidOperationException("LandScheduleSet provenance incomplete: Version is required (D-VAL-1).");
+        if (string.IsNullOrWhiteSpace(ProvenanceAuthor))
+            throw new InvalidOperationException("LandScheduleSet provenance incomplete: ProvenanceAuthor is required (D-VAL-1).");
+        if (EffectiveYear <= 0)
+            throw new InvalidOperationException("LandScheduleSet provenance incomplete: EffectiveYear is required (D-VAL-1).");
+    }
+
+    /// <summary>Deterministically resolves the land rate for a neighborhood; explicit on miss.</summary>
+    public LandRateResolution ResolveRate(string neighborhood)
+    {
+        var rate = Rates
+            .Where(r => string.Equals(r.Neighborhood, neighborhood, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(r => r.Id)
+            .FirstOrDefault();
+
+        if (rate is null)
+            return new LandRateResolution(false, 0m, null,
+                $"No TF land rate for neighborhood '{neighborhood}' in schedule '{Version}' (county {CountyId}, year {EffectiveYear}).");
+
+        return new LandRateResolution(true, rate.MarketUnitValue, rate.CurrentUseUnitValue,
+            $"TF land rate market {rate.MarketUnitValue}/unit (current-use {(rate.CurrentUseUnitValue?.ToString() ?? "n/a")}) for '{neighborhood}' (set '{Version}').");
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ParcelValuation.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ParcelValuation.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// WS-1 — a persisted Forge valuation for a parcel+year: the reconciled indicated value with its
+/// explanation and approach breakdown (JSON). Audit-stamped via WS-3 (<see cref="IAuditableEntity"/>),
+/// county-scoped, and tagged with the engine version for determinism/provenance. Retrievable by
+/// (CountyId, TfParcelId, Year). This is Forge's explanation store; the authoritative value column
+/// on TfAssessment is written separately through the Forge write-lane.
+/// </summary>
+public sealed class ParcelValuation : IAuditableEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CountyId { get; set; }
+    public Guid TfParcelId { get; set; }
+    public int Year { get; set; }
+    public string PropertyType { get; set; } = string.Empty;
+
+    /// <summary>Whether the engine produced an authoritative value (false = incomplete inputs).</summary>
+    public bool Found { get; set; }
+
+    public decimal IndicatedValue { get; set; }
+
+    /// <summary>JSON-serialized approach breakdown (approach, indicated value, weight, contribution).</summary>
+    public string BreakdownJson { get; set; } = "[]";
+
+    public string Explanation { get; set; } = string.Empty;
+    public string CalibrationStatus { get; set; } = "NotEvaluated";
+
+    /// <summary>Engine version for reproducibility/provenance.</summary>
+    public string EngineVersion { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string CreatedBy { get; set; } = "system";
+    public string? UpdatedBy { get; set; }
+
+    /// <summary>Maps a reconciled <see cref="ValuationResult"/> to a persistable row.</summary>
+    public static ParcelValuation FromResult(ValuationResult result, string engineVersion)
+        => new()
+        {
+            CountyId = result.CountyId,
+            TfParcelId = result.ParcelId,
+            Year = result.Year,
+            PropertyType = result.PropertyType,
+            Found = result.Found,
+            IndicatedValue = result.IndicatedValue,
+            BreakdownJson = JsonSerializer.Serialize(result.Breakdown),
+            Explanation = result.Explanation,
+            CalibrationStatus = result.CalibrationStatus,
+            EngineVersion = engineVersion,
+        };
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ParcelValuationAssembler.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ParcelValuationAssembler.cs
@@ -1,0 +1,125 @@
+using TerraFusion.Core.Entities.CanonicalTf;
+
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// Canonical inputs assembled for one parcel. <see cref="Neighborhood"/> is the post-addition
+/// dependency (supplied from TfParcel.Neighborhood once the Sync-lane slice lands; injected today).
+/// </summary>
+public sealed record AssembledParcel(
+    TfParcel Parcel,
+    string? Neighborhood,
+    IReadOnlyList<TfImprovement> Improvements,
+    IReadOnlyDictionary<Guid, IReadOnlyList<TfImprovementFeature>> FeaturesByImprovement,
+    IReadOnlyList<TfLand> Lands,
+    IReadOnlyList<TfSale> Sales,
+    decimal? NetOperatingIncome = null,
+    string? IncomePropertyClass = null);
+
+/// <summary>
+/// Forge-lane, read-only assembler (WS-1 canonical-extension slice). Maps canonical entities to the
+/// engine's <see cref="ParcelValuationInput"/> without writing canonical data. County-guarded;
+/// shadow-only (produces inputs; the engine + persistence remain non-authoritative). Per-parcel
+/// sales-comparison value is out of scope (ratio study is calibration, not value).
+/// </summary>
+public static class ParcelValuationAssembler
+{
+    /// <summary>Sums improvement size (sq ft) from its feature areas.</summary>
+    public static decimal ImprovementSizeSqFt(
+        Guid improvementId, IReadOnlyDictionary<Guid, IReadOnlyList<TfImprovementFeature>> featuresByImprovement)
+        => featuresByImprovement.TryGetValue(improvementId, out var features)
+            ? features.Sum(f => f.Area ?? 0m)
+            : 0m;
+
+    /// <summary>
+    /// True when the land segment is in WA current-use/ag: it carries a positive ag value and is not
+    /// a homesite. Uses canonical signals only (no PACS use-code guessing).
+    /// </summary>
+    public static bool IsCurrentUse(TfLand land)
+        => !land.IsHomesite && land.LandSegAgValue is decimal ag && ag > 0m;
+
+    /// <summary>Maps canonical sales to ratio-study inputs (qualified = SaleQualified AND DorRatioQualified).</summary>
+    public static IReadOnlyList<RatioSale> MapSales(IEnumerable<TfSale> sales, Func<TfSale, decimal> assessedValue)
+        => sales.Select(s => new RatioSale(
+                SalePrice: s.SlPrice ?? s.AdjSlPrice ?? 0m,
+                AssessedValue: assessedValue(s),
+                SaleDate: s.SlDt ?? default,
+                Qualified: s.SaleQualified && s.DorRatioQualified))
+            .ToList();
+
+    /// <summary>
+    /// Assembles canonical inputs into a ParcelValuationInput. Cost approach total = Σ depreciated
+    /// improvements + land value; vacant parcels use the land approach total; income where applicable.
+    /// Every reference set is county-guarded against the parcel. A missing input drops that approach.
+    /// </summary>
+    public static ParcelValuationInput Assemble(
+        AssembledParcel parcel, int year,
+        CostFactorSet? costSet, DepreciationSchedule? depreciation,
+        LandScheduleSet? landSchedule, CapRateSet? capRateSet)
+    {
+        var countyId = parcel.Parcel.CountyId;
+        var approaches = new List<ApproachValue>();
+
+        // Land value (also the land component of the cost approach).
+        decimal landValue = 0m;
+        var landFound = false;
+        if (landSchedule is not null && !string.IsNullOrWhiteSpace(parcel.Neighborhood))
+        {
+            ForgeCountyGuard.EnsureSameCounty(countyId, landSchedule.CountyId);
+            foreach (var land in parcel.Lands)
+            {
+                var size = land.SizeSquareFeet ?? 0m;
+                if (size <= 0m) continue;
+                var res = LandApproachCalculator.Compute(
+                    new LandApproachInput(parcel.Neighborhood!, size, IsCurrentUse(land)), landSchedule);
+                if (res.Found) { landValue += res.IndicatedValue; landFound = true; }
+            }
+        }
+
+        // Cost approach total = depreciated improvements + land value.
+        if (costSet is not null && depreciation is not null && parcel.Improvements.Count > 0)
+        {
+            ForgeCountyGuard.EnsureSameCounty(countyId, costSet.CountyId);
+            ForgeCountyGuard.EnsureSameCounty(countyId, depreciation.CountyId);
+
+            decimal improvementsValue = 0m;
+            var anyImprovement = false;
+            foreach (var imp in parcel.Improvements)
+            {
+                var size = (int)Math.Round(ImprovementSizeSqFt(imp.TfImprovementId, parcel.FeaturesByImprovement));
+                if (size <= 0 || string.IsNullOrWhiteSpace(imp.ImprvClassCd)) continue;
+
+                var res = CostApproachCalculator.Compute(
+                    new CostApproachInput(imp.ImprvClassCd!, size, EffectiveAge(imp, year), 0m),
+                    costSet, depreciation);
+                if (res.Found) { improvementsValue += res.DepreciatedImprovementValue; anyImprovement = true; }
+            }
+
+            if (anyImprovement)
+                approaches.Add(new ApproachValue("Cost", improvementsValue + landValue));
+        }
+        else if (landFound && parcel.Improvements.Count == 0)
+        {
+            // Vacant parcel: land approach is the total.
+            approaches.Add(new ApproachValue("Land", landValue));
+        }
+
+        // Income approach (income property classes only; NOI supplied externally).
+        if (capRateSet is not null && parcel.NetOperatingIncome is decimal noi && !string.IsNullOrWhiteSpace(parcel.IncomePropertyClass))
+        {
+            ForgeCountyGuard.EnsureSameCounty(countyId, capRateSet.CountyId);
+            var res = IncomeApproachCalculator.Compute(new IncomeApproachInput(parcel.IncomePropertyClass!, noi), capRateSet);
+            if (res.Found) approaches.Add(new ApproachValue("Income", res.IndicatedValue));
+        }
+
+        return new ParcelValuationInput(
+            parcel.Parcel.TfParcelId, year, countyId, parcel.Parcel.PropertyType ?? "Unknown", approaches);
+    }
+
+    private static int EffectiveAge(TfImprovement imp, int year)
+    {
+        if (imp.EffectiveYearBuilt is short eyb && eyb > 0) return Math.Max(0, year - eyb);
+        if (imp.YearBuilt is short yb && yb > 0) return Math.Max(0, year - yb);
+        return 0;
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/Parity.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/Parity.cs
@@ -1,0 +1,44 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Acceptance tolerance for a parity comparison (fraction, e.g. 0.01 = ±1%).</summary>
+public readonly record struct ParityTolerance(decimal Fraction);
+
+/// <summary>
+/// Informational parity report. Parity is a GATE, not a source: the TF value is reported as-is and
+/// is never replaced by the comparison (PACS) value.
+/// </summary>
+public sealed record ParityReport(
+    decimal TfValue,
+    decimal ComparisonValue,
+    decimal Delta,
+    decimal DeltaFraction,
+    bool WithinTolerance,
+    string Explanation);
+
+/// <summary>
+/// Read-only TF-vs-comparison parity check (pack V13/V14). Pure function — it computes a delta and
+/// a within/outside-tolerance flag and never mutates the TF value or adopts the comparison value.
+/// </summary>
+public static class ParityComparer
+{
+    /// <summary>Compares a TF value against a comparison (e.g. PACS) value; read-only.</summary>
+    public static ParityReport Compare(decimal tfValue, decimal comparisonValue, ParityTolerance tolerance)
+    {
+        var delta = tfValue - comparisonValue;
+        var deltaFraction = comparisonValue == 0m
+            ? (tfValue == 0m ? 0m : 1m)
+            : Math.Abs(delta) / Math.Abs(comparisonValue);
+        var within = deltaFraction <= tolerance.Fraction;
+
+        var explanation =
+            $"TF {tfValue} vs comparison {comparisonValue}: delta {delta} ({deltaFraction:P2}), " +
+            $"{(within ? "WITHIN" : "OUTSIDE")} tolerance {tolerance.Fraction:P2}. " +
+            "Comparison is informational only; the TF value is the source of truth and is unchanged.";
+
+        return new ParityReport(tfValue, comparisonValue, delta, deltaFraction, within, explanation);
+    }
+
+    /// <summary>Compares a TF valuation result against a comparison value (result is unchanged).</summary>
+    public static ParityReport Compare(ValuationResult tfResult, decimal comparisonValue, ParityTolerance tolerance)
+        => Compare(tfResult.IndicatedValue, comparisonValue, tolerance);
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ParityEvaluator.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ParityEvaluator.cs
@@ -1,0 +1,120 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>One TF-vs-baseline comparison for the parity run. RP-5 carries an exact-lineage flag.</summary>
+public sealed record ParityComparison(
+    string Rp,
+    string PropertyClass,
+    decimal TfValue,
+    decimal ComparisonValue,
+    bool? Rp5LineageExact = null);
+
+/// <summary>An evidence row (matches evidence/parity/parity_evidence.schema.json). Ungated when WithinTolerance is null.</summary>
+public sealed record ParityEvidenceRow(
+    string Rp,
+    string PropertyClass,
+    decimal TfValue,
+    decimal ComparisonValue,
+    decimal Delta,
+    decimal DeltaFraction,
+    bool? WithinTolerance,
+    decimal? ToleranceUsed,
+    bool? Rp5LineageExact);
+
+/// <summary>Per-RP rollup. GatePass is null when ungated (no tolerance/agreed-rate, or unknown lineage).</summary>
+public sealed record RpSummary(
+    string Rp,
+    int N,
+    int WithinCount,
+    decimal? PassRate,
+    decimal? AgreedRate,
+    bool? GatePass);
+
+/// <summary>Result of a parity evaluation: evidence rows + per-RP summaries.</summary>
+public sealed record ParityEvaluation(
+    IReadOnlyList<ParityEvidenceRow> Rows,
+    IReadOnlyList<RpSummary> Summaries);
+
+/// <summary>
+/// Assessor-supplied gate configuration. Tolerances are fractions (0.01 = ±1%); agreed rates are
+/// minimum sample pass rates. A missing entry (and no "Default") yields null → that RP stays ungated.
+/// Values are county inputs and are NEVER invented in code.
+/// </summary>
+public sealed class ParityGateConfig
+{
+    public Dictionary<(string Rp, string PropertyClass), decimal> Tolerances { get; init; } = new();
+    public Dictionary<string, decimal> AgreedRates { get; init; } = new();
+
+    public decimal? ToleranceFor(string rp, string propertyClass)
+        => Tolerances.TryGetValue((rp, propertyClass), out var t) ? t
+         : Tolerances.TryGetValue((rp, "Default"), out var d) ? d
+         : null;
+
+    public decimal? AgreedRateFor(string rp)
+        => AgreedRates.TryGetValue(rp, out var r) ? r
+         : AgreedRates.TryGetValue("Default", out var d) ? d
+         : null;
+}
+
+/// <summary>
+/// Deterministic parity evaluator (read-only, shadow). Compares TF shadow values to internal
+/// TruthPacs baselines and rolls up per-RP gate status. STRUCTURAL HONESTY: gating is null whenever
+/// a tolerance/agreed-rate is unset (or RP-5 lineage is unknown), so an un-approved run can never
+/// report a G1 pass. RP-5 gates on exact lineage, not tolerance.
+/// </summary>
+public static class ParityEvaluator
+{
+    public static ParityEvaluation Evaluate(IEnumerable<ParityComparison> comparisons, ParityGateConfig config)
+    {
+        var rows = new List<ParityEvidenceRow>();
+        foreach (var c in comparisons)
+        {
+            var delta = c.TfValue - c.ComparisonValue;
+            var fraction = c.ComparisonValue == 0m
+                ? (c.TfValue == 0m ? 0m : 1m)
+                : Math.Abs(delta) / Math.Abs(c.ComparisonValue);
+
+            if (c.Rp == "RP-5")
+            {
+                rows.Add(new ParityEvidenceRow(c.Rp, c.PropertyClass, c.TfValue, c.ComparisonValue,
+                    delta, fraction, c.Rp5LineageExact, null, c.Rp5LineageExact));
+            }
+            else
+            {
+                var tol = config.ToleranceFor(c.Rp, c.PropertyClass);
+                bool? within = tol is decimal t ? fraction <= t : null;
+                rows.Add(new ParityEvidenceRow(c.Rp, c.PropertyClass, c.TfValue, c.ComparisonValue,
+                    delta, fraction, within, tol, null));
+            }
+        }
+
+        var summaries = rows
+            .GroupBy(r => r.Rp)
+            .Select(g => Summarize(g.Key, g.ToList(), config))
+            .OrderBy(s => s.Rp, StringComparer.Ordinal)
+            .ToList();
+
+        return new ParityEvaluation(rows, summaries);
+    }
+
+    private static RpSummary Summarize(string rp, IReadOnlyList<ParityEvidenceRow> rows, ParityGateConfig config)
+    {
+        var n = rows.Count;
+
+        if (rp == "RP-5")
+        {
+            var within = rows.Count(r => r.Rp5LineageExact == true);
+            bool? gate = rows.All(r => r.Rp5LineageExact != null)
+                ? rows.All(r => r.Rp5LineageExact == true)
+                : null; // unknown lineage anywhere → ungated
+            return new RpSummary(rp, n, within, n == 0 ? null : (decimal)within / n, null, gate);
+        }
+
+        var withinCount = rows.Count(r => r.WithinTolerance == true);
+        decimal? passRate = n == 0 ? null : (decimal)withinCount / n;
+        var agreedRate = config.AgreedRateFor(rp);
+        var anyUngated = rows.Any(r => r.WithinTolerance == null);
+        bool? gatePass = (anyUngated || agreedRate is null) ? null : passRate >= agreedRate;
+
+        return new RpSummary(rp, n, withinCount, passRate, agreedRate, gatePass);
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ReferenceCatalog.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ReferenceCatalog.cs
@@ -1,0 +1,22 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>Common shape of a county-scoped, versioned TF reference-data set (selectable by year).</summary>
+public interface IReferenceDataSet
+{
+    Guid CountyId { get; }
+    int EffectiveYear { get; }
+    string Version { get; }
+}
+
+/// <summary>
+/// County-scoped, effective-year-pinned selection over any TF reference-data set. No cross-county
+/// fallback and no nearest-year guessing; a miss returns null.
+/// </summary>
+public static class ReferenceCatalog
+{
+    public static T? Select<T>(IEnumerable<T> sets, Guid countyId, int effectiveYear) where T : class, IReferenceDataSet
+        => sets
+            .Where(s => s.CountyId == countyId && s.EffectiveYear == effectiveYear)
+            .OrderByDescending(s => s.Version, StringComparer.Ordinal)
+            .FirstOrDefault();
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/ReferenceDataOrigin.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/ReferenceDataOrigin.cs
@@ -1,0 +1,16 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// Provenance origin for TF-native valuation reference data (D-VAL-1). Only TerraFusion-owned
+/// origins are representable — there is deliberately NO vendor/third-party value, so a proprietary
+/// cost basis (e.g. a vendor cost manual) cannot be the runtime source of a factor set. Legacy
+/// corpora may inform the derivation, but the runtime origin is always TF-owned.
+/// </summary>
+public enum ReferenceDataOrigin
+{
+    /// <summary>Authored and owned by TerraFusion.</summary>
+    TerraFusionOwned = 1,
+
+    /// <summary>Derived by TerraFusion from a county-published study (the derived output is TF-owned).</summary>
+    TerraFusionDerivedFromCountyStudy = 2,
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/SalesRatio.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/SalesRatio.cs
@@ -1,0 +1,73 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>
+/// One sale for the ratio study. Maps from TfSale (SlPrice/AdjSlPrice, sale date) + its
+/// CanonicalSaleQualification / SaleQualified flag. <see cref="Qualified"/> = false is excluded.
+/// </summary>
+public sealed record RatioSale(decimal SalePrice, decimal AssessedValue, DateTime SaleDate, bool Qualified);
+
+/// <summary>IAAO ratio-study result. A study with no qualified sales is an explicit miss.</summary>
+public sealed record RatioStudyResult(
+    bool Found,
+    int Count,
+    decimal MedianRatio,
+    decimal Cod,
+    decimal Prd,
+    string Explanation);
+
+/// <summary>
+/// Deterministic TF-native sales-ratio study (D-VAL-1, IAAO). Excludes disqualified sales, applies
+/// a TF linear time-trend (annual rate × whole-month fraction) to each sale price, then computes
+/// median ratio, COD (coefficient of dispersion) and PRD (price-related differential).
+/// Pure function — no vendor library.
+/// </summary>
+public static class SalesRatioCalculator
+{
+    /// <summary>Computes the IAAO ratio study over qualified, time-trended sales (deterministic).</summary>
+    public static RatioStudyResult ComputeStudy(IEnumerable<RatioSale> sales, DateTime asOf, decimal annualTrendRate)
+    {
+        var rows = sales
+            .Where(s => s.Qualified)
+            .Select(s =>
+            {
+                var adjPrice = TrendPrice(s.SalePrice, s.SaleDate, asOf, annualTrendRate);
+                return (Assessed: s.AssessedValue, AdjPrice: adjPrice, Ratio: s.AssessedValue / adjPrice);
+            })
+            .OrderBy(r => r.Ratio)
+            .ToList();
+
+        if (rows.Count == 0)
+            return new RatioStudyResult(false, 0, 0m, 0m, 0m, "No qualified sales for the ratio study (all excluded or none provided).");
+
+        var ratios = rows.Select(r => r.Ratio).ToList();
+        var median = Median(ratios);
+
+        var meanAbsDev = ratios.Select(r => Math.Abs(r - median)).Sum() / ratios.Count;
+        var cod = median == 0m ? 0m : 100m * meanAbsDev / median;
+
+        var meanRatio = ratios.Sum() / ratios.Count;
+        var sumAssessed = rows.Sum(r => r.Assessed);
+        var sumAdjPrice = rows.Sum(r => r.AdjPrice);
+        var weightedMean = sumAdjPrice == 0m ? 0m : sumAssessed / sumAdjPrice;
+        var prd = weightedMean == 0m ? 0m : meanRatio / weightedMean;
+
+        return new RatioStudyResult(true, rows.Count, median, cod, prd,
+            $"IAAO ratio study over {rows.Count} qualified sales (as-of {asOf:yyyy-MM-dd}, trend {annualTrendRate:P0}): median {median:0.####}, COD {cod:0.##}, PRD {prd:0.###}.");
+    }
+
+    private static decimal Median(List<decimal> sortedAscending)
+    {
+        var n = sortedAscending.Count;
+        return n % 2 == 1
+            ? sortedAscending[n / 2]
+            : (sortedAscending[(n / 2) - 1] + sortedAscending[n / 2]) / 2m;
+    }
+
+    /// <summary>TF linear time-trend: adjusts a sale price to the as-of date by whole months.</summary>
+    public static decimal TrendPrice(decimal salePrice, DateTime saleDate, DateTime asOf, decimal annualTrendRate)
+    {
+        var months = ((asOf.Year - saleDate.Year) * 12) + (asOf.Month - saleDate.Month);
+        var yearsFraction = months / 12m;
+        return salePrice * (1m + (annualTrendRate * yearsFraction));
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/Forge/Valuation.cs
+++ b/backend/src/TerraFusion.Core/Entities/Forge/Valuation.cs
@@ -1,0 +1,133 @@
+namespace TerraFusion.Core.Entities.Forge;
+
+/// <summary>An approach's indicated value, fed to reconciliation.</summary>
+public sealed record ApproachValue(string Approach, decimal IndicatedValue);
+
+/// <summary>One approach's weighted contribution to the reconciled value.</summary>
+public sealed record ApproachContribution(string Approach, decimal IndicatedValue, decimal Weight, decimal Contribution);
+
+/// <summary>Assembled inputs for valuing one parcel (canonical approach values + context).</summary>
+public sealed record ParcelValuationInput(
+    Guid ParcelId,
+    int Year,
+    Guid CountyId,
+    string PropertyType,
+    IReadOnlyList<ApproachValue> Approaches,
+    string CalibrationStatus = "NotEvaluated");
+
+/// <summary>Explainable valuation result. Serializes to the shape the Workbench/OS Core consumes.</summary>
+public sealed record ValuationResult(
+    bool Found,
+    Guid ParcelId,
+    int Year,
+    Guid CountyId,
+    string PropertyType,
+    decimal IndicatedValue,
+    IReadOnlyList<ApproachContribution> Breakdown,
+    string Explanation,
+    string CalibrationStatus);
+
+/// <summary>
+/// AI assistance is advisory ONLY (comp suggestions). It can never set the authoritative value;
+/// the engine does not consult it in the value path.
+/// </summary>
+public interface IValuationAdvisory
+{
+    IReadOnlyList<decimal> SuggestComparables(ParcelValuationInput input);
+}
+
+/// <summary>TF-owned reconciliation rule: desired approach weights by property type.</summary>
+public static class ReconciliationRule
+{
+    /// <summary>Desired weights by approach for a property type (TF-owned rule).</summary>
+    public static IReadOnlyDictionary<string, decimal> WeightsFor(string propertyType)
+    {
+        var t = (propertyType ?? string.Empty).Trim().ToLowerInvariant();
+        var map = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        switch (t)
+        {
+            case "residential":
+                map["Cost"] = 0.5m; map["Sales"] = 0.5m; break;
+            case "incomeproperty":
+            case "income":
+                map["Income"] = 1m; break;
+            case "vacant":
+            case "land":
+                map["Land"] = 1m; break;
+            // default: empty → reconciler falls back to equal weights over available approaches
+        }
+        return map;
+    }
+}
+
+/// <summary>Deterministic TF-owned reconciler: weights available approaches and sums contributions.</summary>
+public static class ValueReconciler
+{
+    /// <summary>Reconciles available approaches into a value + breakdown (deterministic, explained).</summary>
+    public static (bool Found, decimal Value, IReadOnlyList<ApproachContribution> Breakdown, string Explanation)
+        Reconcile(string propertyType, IReadOnlyList<ApproachValue> approaches)
+    {
+        if (approaches.Count == 0)
+            return (false, 0m, Array.Empty<ApproachContribution>(), "No approaches available to reconcile.");
+
+        var desired = ReconciliationRule.WeightsFor(propertyType);
+        var sumDesired = approaches.Sum(a => desired.TryGetValue(a.Approach, out var w) ? w : 0m);
+
+        List<(ApproachValue Approach, decimal Weight)> weighted;
+        if (sumDesired <= 0m)
+        {
+            // No rule match (or default) → equal weight over every available approach.
+            var equal = 1m / approaches.Count;
+            weighted = approaches.Select(a => (a, equal)).ToList();
+        }
+        else
+        {
+            // Normalize the rule's weights over the approaches actually present.
+            weighted = approaches
+                .Select(a => (Approach: a, Weight: (desired.TryGetValue(a.Approach, out var w) ? w : 0m) / sumDesired))
+                .Where(x => x.Weight > 0m)
+                .ToList();
+        }
+
+        var breakdown = weighted
+            .Select(x => new ApproachContribution(x.Approach.Approach, x.Approach.IndicatedValue, x.Weight, x.Approach.IndicatedValue * x.Weight))
+            .OrderBy(c => c.Approach, StringComparer.Ordinal)
+            .ToList();
+
+        var value = breakdown.Sum(c => c.Contribution);
+        var explanation = "weighted approaches → " +
+            string.Join(" + ", breakdown.Select(c => $"{c.Approach} {c.IndicatedValue}×{c.Weight}={c.Contribution}")) +
+            $" = {value}";
+
+        return (true, value, breakdown, explanation);
+    }
+}
+
+/// <summary>
+/// Deterministic TF-native valuation engine (D-VAL-1). Reconciles approach values into an
+/// explainable authoritative value. The value path is pure — an optional advisory is accepted but
+/// NEVER consulted for the authoritative value.
+/// </summary>
+public static class ValuationEngine
+{
+    /// <summary>
+    /// Produces the reconciled, explained valuation result. The <paramref name="advisory"/> is
+    /// accepted for API symmetry but is intentionally NEVER consulted — the authoritative value is
+    /// computed purely by TF-owned deterministic reconciliation (D-VAL-1, pack V2).
+    /// </summary>
+    public static ValuationResult Value(ParcelValuationInput input, IValuationAdvisory? advisory = null)
+    {
+        _ = advisory; // advisory is not in the value path, by design
+
+        var (found, value, breakdown, expl) = ValueReconciler.Reconcile(input.PropertyType, input.Approaches);
+        if (!found)
+            return new ValuationResult(false, input.ParcelId, input.Year, input.CountyId, input.PropertyType,
+                0m, Array.Empty<ApproachContribution>(), expl, input.CalibrationStatus);
+
+        var explanation =
+            $"Reconciled {input.PropertyType} value {value} for parcel {input.ParcelId} (year {input.Year}, county {input.CountyId}): {expl}.";
+
+        return new ValuationResult(true, input.ParcelId, input.Year, input.CountyId, input.PropertyType,
+            value, breakdown, explanation, input.CalibrationStatus);
+    }
+}

--- a/backend/src/TerraFusion.Core/Entities/IAuditableEntity.cs
+++ b/backend/src/TerraFusion.Core/Entities/IAuditableEntity.cs
@@ -1,0 +1,18 @@
+namespace TerraFusion.Core.Entities;
+
+/// <summary>
+/// Marker contract for entities whose audit provenance is stamped automatically by
+/// the AuditableEntityInterceptor (WS-3 / AU-2). Property signatures match the audit
+/// fields already present on entities such as <see cref="PropertyAssessment"/>:
+/// CreatedBy is required (defaults to "system"), UpdatedBy is nullable until first write.
+///
+/// Apply this interface ONLY to entities that already carry all four fields. Adding it
+/// to a new entity opts that entity into automatic stamping + audit-row emission.
+/// </summary>
+public interface IAuditableEntity
+{
+    DateTime CreatedAt { get; set; }
+    DateTime UpdatedAt { get; set; }
+    string CreatedBy { get; set; }
+    string? UpdatedBy { get; set; }
+}

--- a/backend/src/TerraFusion.Data/Migrations/20260616060820_AddForgeCostReference.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260616060820_AddForgeCostReference.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616060820_AddForgeCostReference")]
+    partial class AddForgeCostReference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260616060820_AddForgeCostReference.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260616060820_AddForgeCostReference.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForgeCostReference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CapRateSets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EffectiveYear = table.Column<int>(type: "integer", nullable: false),
+                    RevalCycle = table.Column<string>(type: "text", nullable: true),
+                    Version = table.Column<string>(type: "text", nullable: false),
+                    Origin = table.Column<int>(type: "integer", nullable: false),
+                    ProvenanceAuthor = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CapRateSets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CostFactorSets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EffectiveYear = table.Column<int>(type: "integer", nullable: false),
+                    RevalCycle = table.Column<string>(type: "text", nullable: true),
+                    Version = table.Column<string>(type: "text", nullable: false),
+                    Origin = table.Column<int>(type: "integer", nullable: false),
+                    ProvenanceAuthor = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CostFactorSets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DepreciationSchedules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EffectiveYear = table.Column<int>(type: "integer", nullable: false),
+                    RevalCycle = table.Column<string>(type: "text", nullable: true),
+                    Version = table.Column<string>(type: "text", nullable: false),
+                    Origin = table.Column<int>(type: "integer", nullable: false),
+                    ProvenanceAuthor = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DepreciationSchedules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LandScheduleSets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    EffectiveYear = table.Column<int>(type: "integer", nullable: false),
+                    RevalCycle = table.Column<string>(type: "text", nullable: true),
+                    Version = table.Column<string>(type: "text", nullable: false),
+                    Origin = table.Column<int>(type: "integer", nullable: false),
+                    ProvenanceAuthor = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LandScheduleSets", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ParcelValuations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CountyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TfParcelId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    PropertyType = table.Column<string>(type: "text", nullable: false),
+                    Found = table.Column<bool>(type: "boolean", nullable: false),
+                    IndicatedValue = table.Column<decimal>(type: "numeric", nullable: false),
+                    BreakdownJson = table.Column<string>(type: "text", nullable: false),
+                    Explanation = table.Column<string>(type: "text", nullable: false),
+                    CalibrationStatus = table.Column<string>(type: "text", nullable: false),
+                    EngineVersion = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ParcelValuations", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CapRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CapRateSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IncomePropertyClass = table.Column<string>(type: "text", nullable: false),
+                    CapitalizationRate = table.Column<decimal>(type: "numeric", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CapRates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CapRates_CapRateSets_CapRateSetId",
+                        column: x => x.CapRateSetId,
+                        principalTable: "CapRateSets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CostFactors",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CostFactorSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ImprovementClassCode = table.Column<string>(type: "text", nullable: false),
+                    SizeBandMinSqFt = table.Column<int>(type: "integer", nullable: true),
+                    SizeBandMaxSqFt = table.Column<int>(type: "integer", nullable: true),
+                    UnitCostPerSqFt = table.Column<decimal>(type: "numeric", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CostFactors", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CostFactors_CostFactorSets_CostFactorSetId",
+                        column: x => x.CostFactorSetId,
+                        principalTable: "CostFactorSets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DepreciationFactors",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    DepreciationScheduleId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AgeMinYears = table.Column<int>(type: "integer", nullable: false),
+                    AgeMaxYears = table.Column<int>(type: "integer", nullable: false),
+                    DepreciationFraction = table.Column<decimal>(type: "numeric", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DepreciationFactors", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DepreciationFactors_DepreciationSchedules_DepreciationSched~",
+                        column: x => x.DepreciationScheduleId,
+                        principalTable: "DepreciationSchedules",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LandRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    LandScheduleSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Neighborhood = table.Column<string>(type: "text", nullable: false),
+                    MarketUnitValue = table.Column<decimal>(type: "numeric", nullable: false),
+                    CurrentUseUnitValue = table.Column<decimal>(type: "numeric", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LandRates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LandRates_LandScheduleSets_LandScheduleSetId",
+                        column: x => x.LandScheduleSetId,
+                        principalTable: "LandScheduleSets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CapRates_CapRateSetId",
+                table: "CapRates",
+                column: "CapRateSetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CostFactors_CostFactorSetId",
+                table: "CostFactors",
+                column: "CostFactorSetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DepreciationFactors_DepreciationScheduleId",
+                table: "DepreciationFactors",
+                column: "DepreciationScheduleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LandRates_LandScheduleSetId",
+                table: "LandRates",
+                column: "LandScheduleSetId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CapRates");
+
+            migrationBuilder.DropTable(
+                name: "CostFactors");
+
+            migrationBuilder.DropTable(
+                name: "DepreciationFactors");
+
+            migrationBuilder.DropTable(
+                name: "LandRates");
+
+            migrationBuilder.DropTable(
+                name: "ParcelValuations");
+
+            migrationBuilder.DropTable(
+                name: "CapRateSets");
+
+            migrationBuilder.DropTable(
+                name: "CostFactorSets");
+
+            migrationBuilder.DropTable(
+                name: "DepreciationSchedules");
+
+            migrationBuilder.DropTable(
+                name: "LandScheduleSets");
+        }
+    }
+}

--- a/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
+++ b/backend/src/TerraFusion.Data/TerraFusionDbContext.cs
@@ -7,6 +7,7 @@ using TerraFusion.Core.Entities.Pacs;
 using TerraFusion.Core.Entities.Sync;
 using TerraFusion.Core.Entities.Sync.Mapping;
 using TerraFusion.Core.Entities.Sync.Profile;
+using TerraFusion.Core.Entities.Forge;
 using TerraFusion.Core.Models;
 using TerraFusion.Core.Interfaces;
 using TerraFusion.Data.Configurations;
@@ -36,6 +37,17 @@ public class TerraFusionDbContext : DbContext, ITerraFusionDbContext
   public DbSet<TaxLevy> TaxLevies { get; set; }
   public DbSet<GovernmentUser> GovernmentUsers { get; set; }
   public DbSet<AuditLog> AuditLogs { get; set; }
+
+  // WS-1 Forge Cost Reference — TF-native valuation reference data (county-scoped, versioned, audit-stamped)
+  public DbSet<CostFactorSet> CostFactorSets { get; set; }
+  public DbSet<CostFactor> CostFactors { get; set; }
+  public DbSet<DepreciationSchedule> DepreciationSchedules { get; set; }
+  public DbSet<DepreciationFactor> DepreciationFactors { get; set; }
+  public DbSet<LandScheduleSet> LandScheduleSets { get; set; }
+  public DbSet<LandRate> LandRates { get; set; }
+  public DbSet<CapRateSet> CapRateSets { get; set; }
+  public DbSet<CapRate> CapRates { get; set; }
+  public DbSet<ParcelValuation> ParcelValuations { get; set; }
 
   // AI System Entities
   public DbSet<AIAgent> AIAgents { get; set; }

--- a/docs/branching/FORGE_COST_REFERENCE_EXTRACT_FORWARD_RESULTS.md
+++ b/docs/branching/FORGE_COST_REFERENCE_EXTRACT_FORWARD_RESULTS.md
@@ -1,0 +1,95 @@
+# WO-BRANCH-003 — Forge Cost Reference Extract-Forward Results
+
+**Date**: 2026-06-16
+**Branch**: `feat/forge-cost-reference-v2` (off `origin/main` @ `2f09c7e7d`)
+**Source (read-only)**: `feat/ws1-forge-cost-reference` @ `372471f94`
+**Decision**: **Option A** — ship the verified Forge schema slice; defer the 12 integration tests to a WS-3 audit-infra work order.
+
+---
+
+## What shipped (final scope)
+
+| Item | Detail |
+|------|--------|
+| Forge cost entities | 20 files under `backend/src/TerraFusion.Core/Entities/Forge/` (copied verbatim from source branch) |
+| Allowlist expansion (approved) | `backend/src/TerraFusion.Core/Entities/IAuditableEntity.cs` — trivial 4-property marker interface, required by 5 entities |
+| DbContext wiring (surgical) | `TerraFusion.Data/TerraFusionDbContext.cs`: `+ using TerraFusion.Core.Entities.Forge;` and 9 cost DbSets after `AuditLogs` |
+| Migration (generated) | `20260616060820_AddForgeCostReference` (.cs + .Designer.cs) + `TerraFusionDbContextModelSnapshot.cs` update |
+| Results doc | this file |
+
+`CostForge.csproj` delta: **not applied** — the full solution builds green without it (delta was unnecessary on current main).
+
+## Tests deferred (Option A)
+
+The 12 Forge integration tests were **removed from this PR** because they import branch-only **WS-3 audit infrastructure** that is out of scope for a schema slice:
+- `TerraFusion.Core.Time` → `IClock`
+- `TerraFusion.Data.Interceptors` → `AuditableEntityInterceptor` (which further pulls `TerraFusion.Core.Auth`)
+
+That is a second architecture slice, not a small test dependency. The tests were never on `main`, so removing the newly-copied files deletes nothing from `main`.
+
+**Exact files deferred** (to WO-BRANCH-004):
+```
+backend/tests/TerraFusion.Integration.Tests/Forge/CalibrationGateTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/CostApproachTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/CostReferenceDataTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ForgeGovernanceTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/IncomeApproachTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/LandApproachTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ParcelValuationAssemblerTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ParcelValuationPersistenceTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ParityAndRolloutTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ParityEvaluatorTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/SalesRatioTests.cs
+backend/tests/TerraFusion.Integration.Tests/Forge/ValuationEngineTests.cs
+```
+
+## Migration scope (verified Forge-only)
+
+`Up()` creates exactly **9 tables**; `Down()` drops exactly those 9. ModelSnapshot diff is **+394 / −0 (additive)**, adding only the 9 `Forge.*` entity types.
+
+```
+CostFactorSets   CostFactors
+DepreciationSchedules  DepreciationFactors
+LandScheduleSets  LandRates
+CapRateSets  CapRates
+ParcelValuations
+```
+
+No `CompSet*`, `Revenue*`, `Jurisdiction*`, `Quarantine*`, `SyncBridge*`. No `AddColumn/AlterColumn/RenameTable/Sql`. No drops/renames of existing objects.
+
+## DB apply status (terrafusion_dev_clean only)
+
+- Baseline before: 88 applied, tip `20260509184340_SyncComplete2V2StageLevelResume` (== main tip).
+- `dotnet ef database update` → **Applied `20260616060820_AddForgeCostReference`. Done.**
+- After: **89 applied, 0 pending.** All 9 Forge tables exist in `terrafusion_dev_clean`.
+- No other database touched (no old `terrafusion`, no PACS, no native PG17).
+
+## Build status
+
+- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj` → **succeeded, 0 errors.**
+- `dotnet build backend/TerraFusion.sln` → **succeeded, 0 errors** (after deferring the WS-3-dependent test files).
+
+## Denylist status
+
+CLEAN. No `.playwright-mcp`, `generated/`, package trees, `.rcgu.o`, branch migrations/ModelSnapshot, CompSet, PACS/data files, and **no WS-3 audit files** (`IClock`, `AuditableEntityInterceptor`, `AuditInterceptorServiceCollectionExtensions`, `Core.Auth`, DI audit wiring).
+
+## Follow-up work order
+
+**WO-BRANCH-004 — WS-3 Audit Infrastructure + Forge Integration Tests**: extract the WS-3 audit subsystem (`Core/Time/IClock`, `Data/Interceptors/AuditableEntityInterceptor` + `AuditInterceptorServiceCollectionExtensions`, `Core.Auth` cascade, DI wiring) and re-introduce the 12 deferred Forge integration tests on top of it.
+
+---
+
+## Final Report
+
+```
+RESULT          : Forge Cost Reference schema slice extracted forward onto fresh main; verified green; migration applied to dev-clean.
+FILES CHANGED   : 26 (20 Forge entities + IAuditableEntity + DbContext.cs + ModelSnapshot.cs + migration .cs/.Designer.cs + this results doc)
+TESTS_DEFERRED  : 12 Forge integration tests (require denied WS-3 audit infra) → WO-BRANCH-004
+MIGRATION       : 20260616060820_AddForgeCostReference
+MIGRATION_SCOPE : Forge-only — 9 CreateTable (Up), 9 DropTable (Down), ModelSnapshot +394/-0 additive
+BUILD_STATUS    : TerraFusion.API green; full TerraFusion.sln green (0 errors)
+DB_APPLY_STATUS : applied to terrafusion_dev_clean only (88 -> 89 applied, 0 pending, 9 tables created)
+DENYLIST_STATUS : clean (no WS-3 infra, no cruft, no branch migrations/snapshot)
+PR              : draft — WO-BRANCH-003: Forge Cost Reference extract-forward
+NEXT_WORK_ORDER : WO-BRANCH-004 — WS-3 Audit Infrastructure + Forge Integration Tests
+```


### PR DESCRIPTION
## What this is

Extract-forward of the real **WS-1 Forge Cost Reference** work from the divergent `feat/ws1-forge-cost-reference` branch (1,337 commits / 5,094 files vs main) onto fresh `origin/main`. Only the genuinely-novel schema/domain core is carried; overlap, package trees, build artifacts, and branch migrations are left behind.

## Scope (Option A — schema slice only)

- **20 Forge cost entities** (`TerraFusion.Core/Entities/Forge/*`)
- **`IAuditableEntity.cs`** — approved +1 dependency (trivial 4-property marker interface; 5 entities implement it)
- **Surgical DbContext wiring** — `+ using TerraFusion.Core.Entities.Forge;` and 9 cost `DbSet<>` after `AuditLogs` (existing `Valuation` DbSet untouched; no `CompSet`)
- **Regenerated migration** `20260616060820_AddForgeCostReference` + ModelSnapshot update

The migration was **regenerated fresh on main** (not copied) — the branch's Forge migrations sat atop ~8 branch-only migrations and a ModelSnapshot diverged +4,198/−2,145.

## Migration scope (verified Forge-only)

`Up()` creates exactly **9 tables**, `Down()` drops them, ModelSnapshot diff is **+394 / −0 additive**:
`CostFactorSets, CostFactors, DepreciationSchedules, DepreciationFactors, LandScheduleSets, LandRates, CapRateSets, CapRates, ParcelValuations`.
No `CompSet/Revenue/Jurisdiction/Quarantine/SyncBridge`, no column/rename/drop of existing objects.

## Verification

- `dotnet build TerraFusion.API` → green; full `TerraFusion.sln` → green (0 errors)
- Migration applied to `terrafusion_dev_clean` only: **88 → 89 applied, 0 pending, 9 tables created**
- `git diff --check` clean; denylist clean (no WS-3 infra, branch migrations, ModelSnapshot, CompSet, or package/artifact cruft)

## Deferred → WO-BRANCH-004

The 12 Forge integration tests are **not** in this PR — they depend on WS-3 audit infrastructure (`IClock` + `AuditableEntityInterceptor` + `Core.Auth` cascade), a separate architecture slice. They will land on top of that infra in **WO-BRANCH-004 — WS-3 Audit Infrastructure + Forge Integration Tests**.

See `docs/branching/FORGE_COST_REFERENCE_EXTRACT_FORWARD_RESULTS.md` for the full record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented parcel valuation engine supporting cost, income, and land valuation approaches
  * Added calibration and quality control gate for sales ratio studies
  * Introduced parity comparison tools for valuation accuracy assessment
  * Added comprehensive reference data systems for cost factors, depreciation, capitalization rates, and land schedules

* **Database**
  * Created schema for valuation reference datasets and parcel valuations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->