### PR TITLE
WO-FORGE-002: Align /forge to TerraForge canonical inventory

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx
@@ -8,11 +8,12 @@
  * because a test failed, the zombie is back. Find the wrong component source
  * and kill it again.
  *
- * Locked taxonomy (IAAO three-approaches-to-value + sale qualification):
- *   PRIMARY:   CostForge · CompsForge · IncomeForge · SalesForge
- *   SECONDARY: Batch Cost Runs · Regression Studio ·
- *              TerraGAMA · Coefficient Preview
- *   DEFAULT ANALYTICS: County Studio
+ * Locked taxonomy (June 10 TerraForge canonical inventory):
+ *   PRIMARY:   CostForge · CompsForge · SalesForge · IncomeForge ·
+ *              Reconciliation · Calibration / QC · CAMA Characteristics ·
+ *              Valuation Notes / Defensibility
+ *   SUPPORT:   Batch Cost Runs · Regression Studio · County Studio ·
+ *              Coefficient Preview · Current-use Support
  *   QUEUE:     SaleQualificationQueue (the only panel surface)
  *
  * BANNED from suite home:
@@ -27,6 +28,7 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getTerraForgeCanonicalInventory } from '../../pages/suites/terraforgeCanonicalInventory';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -88,11 +90,11 @@ describe('TerraForge suite home — taxonomy contract', () => {
 
   // ── Primary tier ────────────────────────────────────────────────────────────
 
-  it('renders exactly four primary valuation scenes — three approaches to value plus SalesForge', async () => {
+  it('renders every June 10 primary capability', async () => {
     await renderForgeSuiteHome();
     const primary = screen.getByTestId('forge-primary-applications');
     const cards = within(primary).getAllByRole('button');
-    expect(cards).toHaveLength(4);
+    expect(cards).toHaveLength(8);
   });
 
   it('renders CostForge in the primary tier', async () => {
@@ -119,44 +121,62 @@ describe('TerraForge suite home — taxonomy contract', () => {
     expect(within(primary).getByText('SalesForge')).toBeDefined();
   });
 
-  // ── Secondary tier ──────────────────────────────────────────────────────────
-
-  it('renders exactly four secondary/specialist scenes', async () => {
+  it('renders Reconciliation, Calibration / QC, CAMA Characteristics, and Valuation Notes as primary capability lanes', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    const cards = within(secondary).getAllByRole('button');
-    expect(cards).toHaveLength(4);
+    const primary = screen.getByTestId('forge-primary-applications');
+
+    expect(within(primary).getByText('Reconciliation')).toBeDefined();
+    expect(within(primary).getByText('Calibration / QC')).toBeDefined();
+    expect(within(primary).getByText('CAMA Characteristics')).toBeDefined();
+    expect(within(primary).getByText('Valuation Notes / Defensibility')).toBeDefined();
   });
 
-  it('does not render Statistics Studio in the secondary tier', async () => {
+  // ── Support / deferred tier ────────────────────────────────────────────────
+
+  it('renders exactly five support/deferred tools outside primary proof', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    expect(within(secondary).queryByText('Statistics Studio')).toBeNull();
-    expect(within(secondary).queryByText(/legacy specialist/i)).toBeNull();
+    const support = screen.getByTestId('forge-support-applications');
+    const cards = within(support).getAllByRole('button');
+    expect(cards).toHaveLength(5);
   });
 
-  it('renders Batch Cost Runs in the secondary tier', async () => {
+  it('does not render Statistics Studio or TerraGAMA in support/deferred tools', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    expect(within(secondary).getByText('Batch Cost Runs')).toBeDefined();
+    const support = screen.getByTestId('forge-support-applications');
+    expect(within(support).queryByText('Statistics Studio')).toBeNull();
+    expect(within(support).queryByText('TerraGAMA')).toBeNull();
+    expect(within(support).queryByText(/legacy specialist/i)).toBeNull();
   });
 
-  it('renders Regression Studio in the secondary tier', async () => {
+  it('renders Batch Cost Runs in the support/deferred tier', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    expect(within(secondary).getByText('Regression Studio')).toBeDefined();
+    const support = screen.getByTestId('forge-support-applications');
+    expect(within(support).getByText('Batch Cost Runs')).toBeDefined();
   });
 
-  it('renders TerraGAMA in the secondary tier', async () => {
+  it('renders Regression Studio in the support/deferred tier', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    expect(within(secondary).getByText('TerraGAMA')).toBeDefined();
+    const support = screen.getByTestId('forge-support-applications');
+    expect(within(support).getByText('Regression Studio')).toBeDefined();
   });
 
-  it('renders Coefficient Preview in the secondary tier', async () => {
+  it('renders County Studio, Coefficient Preview, and Current-use Support in the support/deferred tier', async () => {
     await renderForgeSuiteHome();
-    const secondary = screen.getByTestId('forge-secondary-applications');
-    expect(within(secondary).getByText('Coefficient Preview')).toBeDefined();
+    const support = screen.getByTestId('forge-support-applications');
+    expect(within(support).getByText('County Studio')).toBeDefined();
+    expect(within(support).getByText('Coefficient Preview')).toBeDefined();
+    expect(within(support).getByText('Current-use Support')).toBeDefined();
+  });
+
+  it('matches the canonical inventory labels rendered on /forge', async () => {
+    await renderForgeSuiteHome();
+    const primary = screen.getByTestId('forge-primary-applications');
+    const support = screen.getByTestId('forge-support-applications');
+
+    for (const capability of getTerraForgeCanonicalInventory()) {
+      const surface = capability.tier === 'primary' ? primary : support;
+      expect(within(surface).getByText(capability.label)).toBeDefined();
+    }
   });
 
   // ── Queue / panel surface ───────────────────────────────────────────────────
@@ -189,9 +209,11 @@ describe('TerraForge suite home — taxonomy contract', () => {
     expect(screen.queryByText('Comparable Sales')).toBeNull();
   });
 
-  it('BANNED: does not render Reconciliation card', async () => {
+  it('renders Reconciliation only as a primary canonical lane, not as a workbench-opener card', async () => {
     await renderForgeSuiteHome();
-    expect(screen.queryByText('Reconciliation')).toBeNull();
+    const primary = screen.getByTestId('forge-primary-applications');
+    expect(within(primary).getByText('Reconciliation')).toBeDefined();
+    expect(screen.queryByText('Open Property Workbench')).toBeNull();
   });
 
   it('BANNED: does not render Appeals card', async () => {
@@ -216,9 +238,13 @@ describe('TerraForge suite home — taxonomy contract', () => {
     expect(screen.queryByText(/ratio study/i)).toBeNull();
   });
 
-  it('BANNED: does not render CompsPoolBrowser', async () => {
+  it('BANNED: does not render CompsPoolBrowser as a suite proof card', async () => {
     await renderForgeSuiteHome();
-    expect(screen.queryByText(/comps pool/i)).toBeNull();
+    const primary = screen.getByTestId('forge-primary-applications');
+    const support = screen.getByTestId('forge-support-applications');
+
+    expect(within(primary).queryByText(/comps pool/i)).toBeNull();
+    expect(within(support).queryByText(/comps pool/i)).toBeNull();
   });
 
   // ── Wrong-suite items ───────────────────────────────────────────────────────

--- a/frontend/apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx
@@ -1,15 +1,15 @@
 /**
  * forgeSuiteSourceHonesty.contract.test.tsx
  *
- * CONTRACT: ForgeSuiteHome must display sourceDisclosure that matches
- * the actual DataProvider mode — never derive it from an independent
- * network call that can disagree with the provider singleton.
+ * CONTRACT: ForgeSuiteHome must display source posture honestly. During the
+ * June 10 proof freeze, /forge always shows the suite posture disclosure even
+ * when the county stats provider is live, because full TerraForge suite proof
+ * is not established by a live county stats provider alone.
  *
  * These tests verify:
  *   1. When provider is snapshot → disclosure banner appears
- *   2. When provider is live    → no disclosure banner
- *   3. sourceDisclosure originates from useCountyStats (provider-aware),
- *      not from a hardcoded string in the component
+ *   2. When provider is live    → June 10 suite posture banner remains
+ *   3. sourceDisclosure remains provider-aware when proof freeze is lifted
  *   4. Diagnostics pill absent in test env (VITE_SHOW_MODE_DIAGNOSTICS not set)
  */
 
@@ -105,16 +105,20 @@ describe('ForgeSuiteHome — source honesty contract', () => {
     expect(screen.getByTestId('forge-source-disclosure')).toBeDefined();
   });
 
-  it('does NOT show source disclosure when provider mode is live', async () => {
+  it('shows June 10 suite posture disclosure when provider mode is live', async () => {
     await renderWithStats({ source: 'live', sourceDisclosure: null });
 
-    expect(screen.queryByTestId('forge-source-disclosure')).toBeNull();
+    expect(screen.getByTestId('forge-source-disclosure')).toHaveTextContent(
+      'TerraForge is part of the Benton operating model',
+    );
   });
 
-  it('does NOT show source disclosure when source is null (loading)', async () => {
+  it('shows June 10 suite posture disclosure when source is null (loading)', async () => {
     await renderWithStats({ source: null, sourceDisclosure: null });
 
-    expect(screen.queryByTestId('forge-source-disclosure')).toBeNull();
+    expect(screen.getByTestId('forge-source-disclosure')).toHaveTextContent(
+      'unverified standalone Forge modules stay preview-locked',
+    );
   });
 
   it('diagnostics pill absent when VITE_SHOW_MODE_DIAGNOSTICS is not set', async () => {

--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve, sep } from 'path';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TERRAFORGE_CANONICAL_INVENTORY,
+  getTerraForgeCanonicalInventory,
+} from '../../pages/suites/terraforgeCanonicalInventory';
+
+vi.mock('../../hooks/useCountyStats', () => ({
+  useCountyStats: () => ({
+    stats: null,
+    loading: false,
+    error: null,
+    source: null,
+  }),
+}));
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector?: (s: unknown) => unknown) => {
+    const state = { recentParcels: [] as unknown[], activeParcel: null };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: vi.fn(),
+}));
+
+vi.mock('../../pages/suites/SaleQualificationQueue', () => ({
+  SaleQualificationQueue: () => <div data-testid="mock-sale-qualification-queue" />,
+}));
+
+vi.mock('../../pages/suites/CompsPoolBrowser', () => ({
+  CompsPoolBrowser: () => null,
+}));
+
+async function renderForgeSuiteHome() {
+  const { default: ForgeSuiteHome } = await import('../../pages/suites/ForgeSuiteHome');
+  return render(
+    <MemoryRouter>
+      <ForgeSuiteHome />
+    </MemoryRouter>,
+  );
+}
+
+describe('TerraForge canonical inventory contract', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('freezes every June 10 primary capability in testable form', () => {
+    const primaryLabels = getTerraForgeCanonicalInventory()
+      .filter((capability) => capability.tier === 'primary')
+      .map((capability) => capability.label);
+
+    expect(primaryLabels).toEqual([
+      'CostForge',
+      'CompsForge',
+      'SalesForge',
+      'IncomeForge',
+      'Reconciliation',
+      'Calibration / QC',
+      'CAMA Characteristics',
+      'Valuation Notes / Defensibility',
+    ]);
+  });
+
+  it('classifies primary capabilities with honest runtime posture', () => {
+    const primary = getTerraForgeCanonicalInventory().filter((capability) => capability.tier === 'primary');
+
+    expect(primary.every((capability) => capability.proofSurface === 'suite')).toBe(true);
+    expect(primary.every((capability) => ['active', 'honest-unavailable', 'deferred', 'fail'].includes(capability.status))).toBe(true);
+    expect(primary.find((capability) => capability.id === 'incomeforge')?.status).toMatch(/^(active|deferred)$/);
+  });
+
+  it('keeps support and deferred tools outside primary suite proof', () => {
+    const supportLabels = getTerraForgeCanonicalInventory()
+      .filter((capability) => capability.tier === 'support' || capability.tier === 'deferred')
+      .map((capability) => capability.label);
+
+    expect(supportLabels).toEqual([
+      'Batch Cost Runs',
+      'Regression Studio',
+      'County Studio',
+      'Coefficient Preview',
+      'Current-use Support',
+    ]);
+    expect(supportLabels).not.toContain('TerraGAMA');
+  });
+
+  it('does not count Workbench Forge as TerraForge suite proof', () => {
+    expect(TERRAFORGE_CANONICAL_INVENTORY.every((capability) => capability.proofSurface !== 'workbench')).toBe(true);
+    expect(TERRAFORGE_CANONICAL_INVENTORY.every((capability) => !capability.route?.startsWith('/property/'))).toBe(true);
+  });
+});
+
+describe('/forge canonical suite rendering', () => {
+  it('renders every primary capability in the primary suite section', async () => {
+    await renderForgeSuiteHome();
+    const primary = screen.getByTestId('forge-primary-applications');
+
+    for (const capability of getTerraForgeCanonicalInventory().filter((entry) => entry.tier === 'primary')) {
+      expect(within(primary).getByText(capability.label)).toBeDefined();
+    }
+  });
+
+  it('renders support and deferred tools separately from primary suite proof', async () => {
+    await renderForgeSuiteHome();
+    const support = screen.getByTestId('forge-support-applications');
+    const primary = screen.getByTestId('forge-primary-applications');
+
+    for (const capability of getTerraForgeCanonicalInventory().filter((entry) => entry.tier !== 'primary')) {
+      expect(within(support).getByText(capability.label)).toBeDefined();
+      expect(within(primary).queryByText(capability.label)).toBeNull();
+    }
+  });
+
+  it('does not render non-canonical extras as suite proof', async () => {
+    await renderForgeSuiteHome();
+
+    expect(screen.queryByText('TerraGAMA')).toBeNull();
+    expect(screen.queryByText(/recent parcels/i)).toBeNull();
+    expect(screen.queryByText(/generic dashboard/i)).toBeNull();
+    expect(screen.queryByText(/queued card/i)).toBeNull();
+  });
+});
+
+describe('Forge PACS boundary guard', () => {
+  const repoRoot = resolve(import.meta.dirname, '../../../../../..');
+  const scanRoots = [
+    'frontend/apps/os-shell/src/pages/forge',
+    'frontend/apps/os-shell/src/pages/suites',
+    'frontend/apps/os-shell/src/services/forge',
+    'frontend/apps/os-shell/src/services/suites',
+  ];
+  const allowedPathParts = new Set(['sync', 'provenance', 'intake', '__tests__']);
+  const forbidden = /\bPACS\b|\bPacs\b|\bpacs_/;
+
+  function listFiles(root: string): string[] {
+    const absoluteRoot = resolve(repoRoot, root);
+    const entries = readdirSync(absoluteRoot);
+    return entries.flatMap((entry) => {
+      const absolutePath = join(absoluteRoot, entry);
+      const stat = statSync(absolutePath);
+      if (stat.isDirectory()) {
+        return listFiles(relative(repoRoot, absolutePath));
+      }
+      return /\.(ts|tsx)$/.test(entry) ? [absolutePath] : [];
+    });
+  }
+
+  it('does not expose PACS language in Forge runtime UI or runtime service paths', () => {
+    const violations = scanRoots
+      .flatMap(listFiles)
+      .filter((absolutePath) => {
+        const pathParts = relative(repoRoot, absolutePath).split(sep);
+        return !pathParts.some((part) => allowedPathParts.has(part.toLowerCase()));
+      })
+      .flatMap((absolutePath) => {
+        const content = readFileSync(absolutePath, 'utf-8');
+        return content
+          .split(/\r?\n/)
+          .map((line, index) => ({ absolutePath, line, lineNumber: index + 1 }))
+          .filter(({ line }) => forbidden.test(line))
+          .map(({ absolutePath: file, lineNumber, line }) => `${relative(repoRoot, file)}:${lineNumber}: ${line.trim()}`);
+      });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts
@@ -1,27 +1,40 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { getTerraForgeCanonicalInventory } from '../../pages/suites/terraforgeCanonicalInventory';
 
 function read(relPath: string): string {
   return readFileSync(resolve(import.meta.dirname, relPath), 'utf-8');
 }
 
 describe('TerraForge module boundaries contract', () => {
-  it('freezes County Studio as the superset workbench and Statistics Studio as temporary parity source', () => {
-    const suiteHome = read('../../pages/suites/ForgeSuiteHome.tsx');
+  it('freezes /forge as the TerraForge Suite surface instead of County Studio or Statistics Studio', () => {
+    const inventory = getTerraForgeCanonicalInventory();
+    const primaryLabels = inventory
+      .filter((capability) => capability.tier === 'primary')
+      .map((capability) => capability.label);
+    const supportLabels = inventory
+      .filter((capability) => capability.tier !== 'primary')
+      .map((capability) => capability.label);
 
-    expect(suiteHome).toContain('Temporary full-statistics parity source');
-    expect(suiteHome).toContain('The countywide operating workspace for valuation analysis, statistics, embedded spatial review');
-    expect(suiteHome).toContain('County-wide cost approach');
-    expect(suiteHome).toContain('County-wide sales comparison');
-    expect(suiteHome).toContain('Sale qualification & ratio audit');
+    expect(primaryLabels).toContain('CostForge');
+    expect(primaryLabels).toContain('CompsForge');
+    expect(primaryLabels).toContain('SalesForge');
+    expect(primaryLabels).toContain('IncomeForge');
+    expect(primaryLabels).toContain('Reconciliation');
+    expect(primaryLabels).toContain('Calibration / QC');
+    expect(primaryLabels).toContain('CAMA Characteristics');
+    expect(primaryLabels).toContain('Valuation Notes / Defensibility');
+    expect(supportLabels).toContain('County Studio');
+    expect(primaryLabels).not.toContain('County Studio');
+    expect(inventory.map((capability) => capability.label)).not.toContain('Statistics Studio');
   });
 
   it('keeps parcel-level action in the workbench lane instead of suite-home cards', () => {
     const suiteHomeContract = read('./forgeSuiteHome.contract.test.tsx');
 
     expect(suiteHomeContract).toContain('does not render ComparableSales as a standalone card');
-    expect(suiteHomeContract).toContain('does not render Reconciliation card');
+    expect(suiteHomeContract).toContain('Reconciliation only as a primary canonical lane');
     expect(suiteHomeContract).toContain('does not render Value Audit card');
     expect(suiteHomeContract).toContain('does not render RatioStudyPanel');
   });

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -1,43 +1,27 @@
 /**
  * TerraFusion OS — TerraForge Suite Home
  *
- * TerraForge launcher posture is governed by the current Suite layer contract:
- * County Studio is the countywide workbench; Atlas is its embedded/pop-out
- * spatial surface; GeoForge remains internal compatibility infrastructure.
- *
- * The PRIMARY_MODULES and SECONDARY_MODULES arrays below define the v1
- * TerraForge app list. This list was verified correct at commit 8da26658a.
- *
- * IF THIS FILE LOOKS WRONG (wrong apps, wrong labels, wrong grouping):
- *   git checkout 8da26658a -- frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
- *
- * DO NOT rewrite the module list from memory or "fix" it by editing.
- * Restore from git. That is the only correct action.
- *
- * Verified layout (matches screenshot from 2026-04-09):
- *   PRIMARY   : CostForge (cost approach, AppFrame → port 5002)
- *               CompsForge (sales comparison, standalone React module)
- *               IncomeForge (income approach, live)
- *   SPECIALIST: Batch Cost Runs (batch execution)
- *               Regression Studio / TerraGAMA / Coefficient Preview live
- *   DEFAULT ANALYTICS: County Studio (study-anchored Operational Health +
- *                      Statistics Compat + VEI exploration)
+ * TerraForge launcher posture is governed by the June 10 canonical inventory
+ * in terraforgeCanonicalInventory.ts. /forge is the TerraForge Suite surface;
+ * parcel-scoped Workbench Forge views are support only and are not counted as
+ * suite proof here.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getToken, setToken as persistToken } from '../../auth/authStorage';
 import { invokeTool } from '../../api/pilotApi';
 import { getSession } from '../../auth/session';
-import type { WorkbenchTabSlug } from '../../contracts/workbench';
 import { useCountyStats } from '../../hooks/useCountyStats';
 import { apiFetch } from '../../lib/apiBase';
 import { activateModule } from '../../orchestration/moduleActivation';
 import { buildCountyScopedSessionHeaders } from '../../services/countyIsolation';
-import { usePropertyStore } from '../../stores/propertyStore';
 import { SaleQualificationQueue } from './SaleQualificationQueue';
 import { CompsPoolBrowser } from './CompsPoolBrowser';
+import {
+  TERRAFORGE_CANONICAL_INVENTORY,
+  type TerraForgeCanonicalCapability,
+} from './terraforgeCanonicalInventory';
 import './ForgeSuiteHome.css';
 
-type LaunchMode = 'standalone' | 'workbench';
 type TruthState = 'live' | 'queued';
 
 const JUNE_10_PROOF_FREEZE = true;
@@ -48,17 +32,7 @@ const JUNE_10_FORGE_NOTICE =
 const JUNE_10_FORGE_ACTION_LOCK_NOTICE =
   'Unverified TerraForge suite action locked for June 10 proof freeze.';
 
-interface ForgeModuleDef {
-  id: string;
-  label: string;
-  description: string;
-  priority: 'primary' | 'secondary';
-  launchMode: LaunchMode;
-  chipLabel?: string;
-  truthState?: TruthState;
-  workbenchTab?: WorkbenchTabSlug;
-  moduleId?: string;
-}
+type ForgeModuleDef = TerraForgeCanonicalCapability & { truthState?: TruthState };
 
 interface CountyFindingSummary {
   findingType: string;
@@ -141,108 +115,15 @@ interface CountyStatsRuntimeResponse {
   assessmentCompletionPercent?: number;
 }
 
-const PRIMARY_MODULES: readonly ForgeModuleDef[] = [
-  {
-    id: 'costforge',
-    label: 'CostForge',
-    description:
-      'County-wide cost approach — replacement cost schedules, depreciation tables, land schedules, and RCNLD',
-    priority: 'primary',
-    launchMode: 'standalone',
-    moduleId: 'costforge',
-    chipLabel: 'Cost approach',
-  },
-  {
-    id: 'comps-forge',
-    label: 'CompsForge',
-    description:
-      'County-wide sales comparison — adjustment grid studio, paired-sales analysis, and market-derived time trends',
-    priority: 'primary',
-    launchMode: 'standalone',
-    moduleId: 'comps-forge',
-    chipLabel: 'Sales comparison',
-  },
-  {
-    id: 'income-forge',
-    label: 'IncomeForge',
-    description:
-      'County-wide income approach — cap rates, NOI modeling, and rent schedules for commercial properties',
-    priority: 'primary',
-    launchMode: 'standalone',
-    moduleId: 'income-forge',
-    chipLabel: 'Income approach',
-  },
-  {
-    id: 'sales-forge',
-    label: 'SalesForge',
-    description:
-      'Sale qualification & ratio audit — qualify sales, audit WAC codes, review IAAO stats, and export DOR-certified study',
-    priority: 'primary',
-    launchMode: 'standalone',
-    moduleId: 'sales-forge',
-    chipLabel: 'Sale qualification',
-  },
-  {
-    id: 'cuforge',
-    label: 'CUForge',
-    description:
-      'Current Use Program — DFL/CUFA/CUOS/CUTL enrollment, RCW 84.34.108 rollback calculator, DOR interest rates, and removal proceedings',
-    priority: 'primary',
-    launchMode: 'standalone',
-    moduleId: 'cuforge',
-    chipLabel: 'Current use',
-  },
-] as const;
+const PRIMARY_MODULES: readonly ForgeModuleDef[] = TERRAFORGE_CANONICAL_INVENTORY.filter(
+  (capability) => capability.tier === 'primary',
+);
 
-const COUNTY_STUDIO_MODULE: ForgeModuleDef = {
-  id: 'county-studio',
-  label: 'County Studio',
-  description:
-    'Countywide operating workspace for valuation analysis, Operational Health, Statistics Compat, segment review, scenario preview, and evidence defense.',
-  priority: 'primary',
-  launchMode: 'standalone',
-  moduleId: 'county-studio',
-  chipLabel: 'County operations',
-};
+const SUPPORT_MODULES: readonly ForgeModuleDef[] = TERRAFORGE_CANONICAL_INVENTORY.filter(
+  (capability) => capability.tier !== 'primary',
+);
 
-const SECONDARY_MODULES: readonly ForgeModuleDef[] = [
-  {
-    id: 'batch-cost-run',
-    label: 'Batch Cost Runs',
-    description: 'County-wide cost model runs with strata, neighborhood, and class filters',
-    priority: 'secondary',
-    launchMode: 'standalone',
-    moduleId: 'batch-cost-run',
-    chipLabel: 'Batch execution',
-  },
-  {
-    id: 'regression-studio',
-    label: 'Regression Studio',
-    description: 'MRA regression models with R² diagnostics for market modeling',
-    priority: 'secondary',
-    launchMode: 'standalone',
-    moduleId: 'regression-studio',
-    chipLabel: 'Regression preview',
-  },
-  {
-    id: 'terra-gama',
-    label: 'TerraGAMA',
-    description: 'Geospatial automated mass appraisal with spatial lag models',
-    priority: 'secondary',
-    launchMode: 'standalone',
-    moduleId: 'terra-gama',
-    chipLabel: 'Spatial preview',
-  },
-  {
-    id: 'coefficient-preview',
-    label: 'Coefficient Preview',
-    description: 'Preview adjustment coefficients before table publication',
-    priority: 'secondary',
-    launchMode: 'standalone',
-    moduleId: 'coefficient-preview',
-    chipLabel: 'Coefficient preview',
-  },
-] as const;
+const COUNTY_STUDIO_MODULE = SUPPORT_MODULES.find((mod) => mod.id === 'county-studio');
 
 const fmtNum = (n: number | undefined | null) => (n != null ? n.toLocaleString() : '—');
 const fmtCurrency = (n: number | undefined | null) => (n != null ? `$${n.toLocaleString()}` : '—');
@@ -440,11 +321,7 @@ function useRuntimeForgeMetrics(runtimeCountyId: string, taxYear: number): Runti
 }
 
 function isJune10RuntimeForgeModule(mod: ForgeModuleDef): boolean {
-  return mod.id === 'sales-forge'
-    || mod.id === 'costforge'
-    || mod.id === 'comps-forge'
-    || mod.id === 'income-forge'
-    || mod.id === 'county-studio';
+  return mod.status === 'active' && Boolean(mod.moduleId);
 }
 
 function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): string | null {
@@ -461,37 +338,38 @@ function getSourceDisclosure(source: 'snapshot' | 'fixtures' | 'live' | null): s
 }
 
 function getLaunchLabel(mod: ForgeModuleDef): string {
-  if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) {
-    return 'Standalone preview locked';
+  if (mod.status === 'deferred') {
+    return 'Deferred by June 10 canon';
+  }
+  if (mod.status === 'honest-unavailable') {
+    return 'Unavailable in /forge runtime';
+  }
+  if (mod.status === 'fail') {
+    return 'Fails current suite gate';
   }
   if (mod.id === 'costforge') {
     return 'Benton CostForge triage API';
   }
-  if (mod.id === 'comps-forge') {
+  if (mod.id === 'compsforge') {
     return 'Statewide sales comp search';
   }
-  if (mod.id === 'income-forge') {
+  if (mod.id === 'incomeforge') {
     return 'Benton income approach API';
   }
   if (mod.id === 'county-studio') {
-    return 'Benton County Studio studies API';
+    return 'Support: County Studio studies API';
+  }
+  if (mod.id === 'calibration-qc') {
+    return 'Benton CostForge calibration API';
   }
   if (isJune10RuntimeForgeModule(mod)) {
     return 'Benton sale qualification API';
   }
-  if (mod.truthState === 'queued') {
-    return 'Queued surface';
-  }
-  if (mod.launchMode === 'workbench') {
-    return mod.workbenchTab === 'dais' ? 'Opens TerraDais workbench' : 'Opens Property Workbench';
-  }
-  return 'Launches in window';
+  return 'Support tool';
 }
 
 export default function ForgeSuiteHome() {
   const { stats, loading, error, source } = useCountyStats();
-  const activeParcel = usePropertyStore((s) => s.activeParcel);
-  const recentParcels = usePropertyStore((s) => s.recentParcels);
   const runtimeCountyId = getSession()?.countyId ?? 'benton';
   const runtimeTaxYear = 2026;
   const runtimeMetrics = useRuntimeForgeMetrics(runtimeCountyId, runtimeTaxYear);
@@ -560,7 +438,7 @@ export default function ForgeSuiteHome() {
       ] as const;
 
   const handleModuleLaunch = (mod: ForgeModuleDef) => {
-    if (JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) {
+    if (!isJune10RuntimeForgeModule(mod)) {
       return;
     }
 
@@ -568,19 +446,10 @@ export default function ForgeSuiteHome() {
       return;
     }
 
-    if (mod.launchMode === 'workbench') {
-      if (!mod.workbenchTab) {
-        return;
-      }
-      const parcelId = activeParcel?.parcelId;
-      void activateModule('property-workbench', {
-        source: 'system',
-        metadata: { tab: mod.workbenchTab, ...(parcelId ? { parcelId } : {}) },
-      });
+    const targetId = mod.moduleId;
+    if (!targetId) {
       return;
     }
-
-    const targetId = mod.moduleId ?? mod.id;
     const metadata = mod.id === 'costforge'
       ? {
           launchContext: 'terraforge-suite',
@@ -596,7 +465,14 @@ export default function ForgeSuiteHome() {
           countyId: runtimeCountyId,
           taxYear: 2026,
         }
-      : mod.id === 'comps-forge'
+      : mod.id === 'salesforge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'compsforge'
       ? {
           launchContext: 'terraforge-suite',
           dataSource: 'terrafusion-api',
@@ -612,6 +488,22 @@ export default function ForgeSuiteHome() {
           countyId: runtimeCountyId,
           taxYear: 2026,
         }
+      : mod.id === 'incomeforge'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'income-approach',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
+      : mod.id === 'calibration-qc'
+      ? {
+          launchContext: 'terraforge-suite',
+          dataSource: 'terrafusion-api',
+          runtimePath: 'costforge-calibration',
+          countyId: runtimeCountyId,
+          taxYear: 2026,
+        }
       : mod.id === 'county-studio'
       ? {
           launchContext: 'terraforge-suite',
@@ -622,13 +514,6 @@ export default function ForgeSuiteHome() {
         }
       : undefined;
     void activateModule(targetId, { source: 'system', ...(metadata ? { metadata } : {}) });
-  };
-
-  const handleParcelOpen = (parcelId: string) => {
-    void activateModule('property-workbench', {
-      source: 'system',
-      metadata: { parcelId },
-    });
   };
 
   const parseToolOutput = <T,>(output: unknown, fallback: T): T => {
@@ -948,13 +833,15 @@ export default function ForgeSuiteHome() {
                     >
                       Open CostForge
                     </button>
-                    <button
-                      type="button"
-                      className="forge-ops-btn forge-ops-btn--ghost"
-                      onClick={() => handleModuleLaunch(COUNTY_STUDIO_MODULE)}
-                    >
-                      Open County Studio
-                    </button>
+                    {COUNTY_STUDIO_MODULE && (
+                      <button
+                        type="button"
+                        className="forge-ops-btn forge-ops-btn--ghost"
+                        onClick={() => handleModuleLaunch(COUNTY_STUDIO_MODULE)}
+                      >
+                        Open County Studio
+                      </button>
+                    )}
                   </div>
                 </div>
                 {memoState.status === 'success' && memoState.result && (
@@ -990,11 +877,14 @@ export default function ForgeSuiteHome() {
                   type="button"
                   className="forge-card forge-card--primary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={(JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) || mod.truthState === 'queued'}
-                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
+                  disabled={!isJune10RuntimeForgeModule(mod) || mod.truthState === 'queued'}
+                  title={!isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
-                    {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
+                    <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>
+                    <span className={`forge-chip ${mod.status === 'active' ? 'forge-chip--success' : 'forge-chip--warn'}`}>
+                      {mod.status.replace(/-/g, ' ')}
+                    </span>
                     <span className="forge-card__foot">{getLaunchLabel(mod)}</span>
                   </div>
                   <div className="forge-card__title">{mod.label}</div>
@@ -1004,26 +894,28 @@ export default function ForgeSuiteHome() {
             </div>
           </section>
 
-          {/* Secondary / Specialist Applications */}
-          <section className="forge-panel" data-testid="forge-secondary-applications">
+          <section className="forge-panel" data-testid="forge-support-applications">
             <div className="forge-panel__header">
               <div>
-                <p className="forge-panel__eyebrow">Specialist &amp; Legacy Tools</p>
-                <h2 className="forge-panel__title">Temporary shells outside County Studio</h2>
+                <p className="forge-panel__eyebrow">Support &amp; deferred tools</p>
+                <h2 className="forge-panel__title">Outside primary TerraForge proof</h2>
               </div>
             </div>
             <div className="forge-primary-grid">
-              {SECONDARY_MODULES.map((mod) => (
+              {SUPPORT_MODULES.map((mod) => (
                 <button
                   key={mod.id}
                   type="button"
                   className="forge-card forge-card--secondary"
                   onClick={() => handleModuleLaunch(mod)}
-                  disabled={(JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod)) || mod.truthState === 'queued'}
-                  title={JUNE_10_PROOF_FREEZE && mod.launchMode === 'standalone' && !isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
+                  disabled={!isJune10RuntimeForgeModule(mod) || mod.truthState === 'queued'}
+                  title={!isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
                 >
                   <div className="forge-card__rail">
-                    {mod.chipLabel && <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>}
+                    <span className="forge-chip forge-chip--neutral">{mod.chipLabel}</span>
+                    <span className={`forge-chip ${mod.status === 'active' ? 'forge-chip--success' : 'forge-chip--warn'}`}>
+                      {mod.status.replace(/-/g, ' ')}
+                    </span>
                     <span className="forge-card__foot">{getLaunchLabel(mod)}</span>
                   </div>
                   <div className="forge-card__title">{mod.label}</div>
@@ -1031,34 +923,6 @@ export default function ForgeSuiteHome() {
                 </button>
               ))}
             </div>
-          </section>
-
-          {/* County Studio — segment-first countywide valuation workspace */}
-          <section className="forge-panel" data-testid="forge-county-applications">
-            <div className="forge-panel__header">
-              <div>
-                <p className="forge-panel__eyebrow">County Operations</p>
-                <h2 className="forge-panel__title">County Studio · Analysis, Scenario, Defense</h2>
-              </div>
-            </div>
-            <button
-              type="button"
-              className="forge-card forge-card--primary"
-              style={{ width: '100%', textAlign: 'left' }}
-              onClick={() => handleModuleLaunch(COUNTY_STUDIO_MODULE)}
-            >
-              <div className="forge-card__rail">
-                <span className="forge-chip forge-chip--success">Runtime studies path</span>
-                <span className="forge-card__foot">{getLaunchLabel(COUNTY_STUDIO_MODULE)}</span>
-              </div>
-              <div className="forge-card__title">County Studio</div>
-              <p className="forge-card__description">
-                The countywide operating workspace for valuation analysis, Operational Health, Statistics Compat,
-                embedded spatial review, cohort creation, scenario preview, correction routing, and evidence defense.
-                Atlas map review opens inside County Studio or as a pop-out for the same study session; governed
-                approval and publish remain downstream workflow steps.
-              </p>
-            </button>
           </section>
 
           {JUNE_10_RUNTIME_PANELS_ENABLED && (
@@ -1070,39 +934,6 @@ export default function ForgeSuiteHome() {
               <CompsPoolBrowser />
             </>
           )}
-
-
-          <section className="forge-panel" data-testid="forge-queue">
-            <div className="forge-panel__header">
-              <div>
-                <p className="forge-panel__eyebrow">Operational Queue</p>
-                <h2 className="forge-panel__title">Recent parcels</h2>
-              </div>
-            </div>
-
-            {recentParcels.length === 0 ? (
-              <div className="forge-queue forge-queue--empty">No recent parcel activity.</div>
-            ) : (
-              <div className="forge-queue">
-                {recentParcels.slice(0, 8).map((parcel) => (
-                  <button
-                    key={parcel.parcelId}
-                    type="button"
-                    className="forge-queue__row"
-                    onClick={() => handleParcelOpen(parcel.parcelId)}
-                  >
-                    <div className="forge-queue__identity">
-                      <div className="forge-queue__address">{parcel.address}</div>
-                      <div className="forge-queue__meta">
-                        {parcel.parcelId} · {parcel.city}
-                      </div>
-                    </div>
-                    <div className="forge-queue__value">{fmtCurrency(parcel.totalAssessedValue)}</div>
-                  </button>
-                ))}
-              </div>
-            )}
-          </section>
         </div>
       </main>
     </div>

--- a/frontend/apps/os-shell/src/pages/suites/modules/ValueAuditModule.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/modules/ValueAuditModule.tsx
@@ -6,7 +6,7 @@
  * Tracks: cost calculations, income analyses, comp selections,
  * reconciliations, appeal filings/decisions, manual overrides.
  *
- * Source: Harris PACS change_of_value_report + TerraTrace audit spine
+ * Source: TerraFusion valuation change feed + TerraTrace audit spine
  *
  * DATA POSTURE:
  * - `loadAuditEntries()` is the only source for this surface.

--- a/frontend/apps/os-shell/src/pages/suites/terraforgeCanonicalInventory.ts
+++ b/frontend/apps/os-shell/src/pages/suites/terraforgeCanonicalInventory.ts
@@ -1,0 +1,171 @@
+export type TerraForgeCapabilityStatus = 'active' | 'honest-unavailable' | 'deferred' | 'fail';
+export type TerraForgeCapabilityTier = 'primary' | 'support' | 'deferred';
+export type TerraForgeProofSurface = 'suite' | 'support' | 'none';
+
+export interface TerraForgeCanonicalCapability {
+  id: string;
+  label: string;
+  description: string;
+  tier: TerraForgeCapabilityTier;
+  status: TerraForgeCapabilityStatus;
+  proofSurface: TerraForgeProofSurface;
+  moduleId?: string;
+  route?: string;
+  chipLabel: string;
+}
+
+export const TERRAFORGE_CANONICAL_INVENTORY: readonly TerraForgeCanonicalCapability[] = [
+  {
+    id: 'costforge',
+    label: 'CostForge',
+    description:
+      'Cost and land valuation lane for replacement cost schedules, depreciation, land schedules, and RCNLD review.',
+    tier: 'primary',
+    status: 'active',
+    proofSurface: 'suite',
+    moduleId: 'costforge',
+    route: '/forge',
+    chipLabel: 'Cost + land valuation',
+  },
+  {
+    id: 'compsforge',
+    label: 'CompsForge',
+    description:
+      'Sales comparison and comparable selection lane for adjustment grids, paired-sales analysis, and market-derived trends.',
+    tier: 'primary',
+    status: 'active',
+    proofSurface: 'suite',
+    moduleId: 'comps-forge',
+    route: '/forge',
+    chipLabel: 'Sales comparison + comps',
+  },
+  {
+    id: 'salesforge',
+    label: 'SalesForge',
+    description:
+      'Sales qualification and ratio audit lane for sale review, WAC audit posture, IAAO statistics, and study export support.',
+    tier: 'primary',
+    status: 'active',
+    proofSurface: 'suite',
+    moduleId: 'sales-forge',
+    route: '/forge',
+    chipLabel: 'Qualification + ratio audit',
+  },
+  {
+    id: 'incomeforge',
+    label: 'IncomeForge',
+    description:
+      'Income approach lane for cap rates, NOI modeling, and rent schedule review where commercial income data is available.',
+    tier: 'primary',
+    status: 'active',
+    proofSurface: 'suite',
+    moduleId: 'income-forge',
+    route: '/forge',
+    chipLabel: 'Income approach',
+  },
+  {
+    id: 'reconciliation',
+    label: 'Reconciliation',
+    description:
+      'Cross-approach value reconciliation lane. Represented in canon, but not yet exposed as an independent /forge runtime module.',
+    tier: 'primary',
+    status: 'honest-unavailable',
+    proofSurface: 'suite',
+    route: '/forge',
+    chipLabel: 'Unavailable',
+  },
+  {
+    id: 'calibration-qc',
+    label: 'Calibration / QC',
+    description:
+      'Calibration and quality-control lane for COD, PRD, segment review, and governed adjustment posture.',
+    tier: 'primary',
+    status: 'active',
+    proofSurface: 'suite',
+    moduleId: 'costforge',
+    route: '/forge',
+    chipLabel: 'Calibration + QC',
+  },
+  {
+    id: 'cama-characteristics',
+    label: 'CAMA Characteristics',
+    description:
+      'Runtime lane for CAMA characteristics used by valuation workflows. Canonical dependency is TerraFusion data, not a legacy system-facing UI.',
+    tier: 'primary',
+    status: 'honest-unavailable',
+    proofSurface: 'suite',
+    route: '/forge',
+    chipLabel: 'Unavailable',
+  },
+  {
+    id: 'valuation-notes-defensibility',
+    label: 'Valuation Notes / Defensibility',
+    description:
+      'Defensibility support lane for valuation notes, rationale, and evidence packet handoff. Not yet a standalone suite module.',
+    tier: 'primary',
+    status: 'honest-unavailable',
+    proofSurface: 'suite',
+    route: '/forge',
+    chipLabel: 'Unavailable',
+  },
+  {
+    id: 'batch-cost-runs',
+    label: 'Batch Cost Runs',
+    description: 'Batch execution support for county-wide cost model runs with strata, neighborhood, and class filters.',
+    tier: 'deferred',
+    status: 'deferred',
+    proofSurface: 'support',
+    moduleId: 'batch-cost-run',
+    route: '/forge',
+    chipLabel: 'Deferred',
+  },
+  {
+    id: 'regression-studio',
+    label: 'Regression Studio',
+    description: 'Modeling support for MRA regression and coefficient diagnostics. Not primary TerraForge proof.',
+    tier: 'deferred',
+    status: 'deferred',
+    proofSurface: 'support',
+    moduleId: 'regression-studio',
+    route: '/forge',
+    chipLabel: 'Deferred',
+  },
+  {
+    id: 'county-studio',
+    label: 'County Studio',
+    description:
+      'Countywide support workspace for study sessions, scenario review, segment work, and downstream evidence handoff.',
+    tier: 'support',
+    status: 'active',
+    proofSurface: 'support',
+    moduleId: 'county-studio',
+    route: '/forge',
+    chipLabel: 'Support tool',
+  },
+  {
+    id: 'coefficient-preview',
+    label: 'Coefficient Preview',
+    description: 'Preview support for adjustment coefficients before table publication. Not primary TerraForge proof.',
+    tier: 'deferred',
+    status: 'deferred',
+    proofSurface: 'support',
+    moduleId: 'coefficient-preview',
+    route: '/forge',
+    chipLabel: 'Deferred',
+  },
+  {
+    id: 'current-use-support',
+    label: 'Current-use Support',
+    description:
+      'Current-use support for DFL/CUFA/CUOS/CUTL enrollment, rollback calculations, interest rates, and removals.',
+    tier: 'support',
+    status: 'deferred',
+    proofSurface: 'support',
+    route: '/forge',
+    chipLabel: 'Deferred',
+  },
+] as const;
+
+export function getTerraForgeCanonicalInventory(): readonly TerraForgeCanonicalCapability[] {
+  return TERRAFORGE_CANONICAL_INVENTORY;
+}


### PR DESCRIPTION
## Summary
- Adds a testable TerraForge canonical inventory contract for the June 10 primary and support/deferred split.
- Rewires /forge to render primary suite capabilities separately from support/deferred tools.
- Removes Workbench/recent-parcel proof leakage and hides TerraGAMA/non-canonical extras from suite proof.
- Adds PACS boundary guard for Forge runtime UI/service paths and removes a runtime-path PACS wording leak.

## Canonical primary represented
CostForge, CompsForge, SalesForge, IncomeForge, Reconciliation, Calibration / QC, CAMA Characteristics, Valuation Notes / Defensibility.

## Support/deferred
Batch Cost Runs, Regression Studio, County Studio, Coefficient Preview, Current-use Support.

## Validation
- pnpm --dir frontend exec vitest run apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx
- pnpm run type-check
- pnpm --dir frontend run type-check
- dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release
- node --test os-platform/core/tests/phase83-tools.test.mjs
- pre-push hook: root unit tests, security scan, perf benchmark, backend build/publish, frontend build