### PR TITLE
WO-DATA-004B-FIX1: PACS Current Source Attach/Restore Plan

### DIFF
--- a/docs/data/PACS_ATTACH_RESTORE_SAFETY_CHECKLIST.md
+++ b/docs/data/PACS_ATTACH_RESTORE_SAFETY_CHECKLIST.md
@@ -1,0 +1,69 @@
+# WO-DATA-004B-FIX1 — PACS Attach/Restore Safety Checklist
+
+**Date**: 2026-06-16 · Companion to `PACS_CURRENT_SOURCE_ATTACH_PLAN.md`. This checklist governs FIX2 execution. Every box must be true; any "no" = STOP.
+
+---
+
+## Absolute prohibitions (never, in any FIX2 step)
+
+- [ ] Do **not** attach the original `tf_mssql_data` / `pacs_oltp.mdf`. Only an isolated COPY.
+- [ ] Do **not** write to the `tf_mssql_data` volume — mount it `:ro` only.
+- [ ] Do **not** delete, truncate, or drop any source file, volume, or DB.
+- [ ] Do **not** restore the Dec-2015 `pacs_benton_122915` (historical) as a current source.
+- [ ] Do **not** run any drain / import / promote / project / writeback.
+- [ ] Do **not** change pipeline filters (`owner_tax_yr >= 2018` stays).
+- [ ] Do **not** mutate TerraFusion DB (`terrafusion_dev_clean` or any other).
+- [ ] Do **not** touch native PG17, Docker PG16 data dirs, or the quarantined shared checkout.
+- [ ] Do **not** use a non-2019 SQL Server engine for the attach (avoids irreversible compat upgrade).
+
+---
+
+## Pre-flight (before any byte is copied)
+
+- [ ] **≥ 600 GB free** secured on the chosen target (external disk, or freed D:/E:). Verified with `df -h`. *(Currently NONE — C:28 / D:233 / E:163 GB free → this gate is OPEN and blocks everything.)*
+- [ ] Target path confirmed **outside** `tf_mssql_data` and not overwriting the original.
+- [ ] No port conflict for `21433` (wo004 used 11433; intended config uses 1433).
+- [ ] Operator approval recorded for **Gate 1 (space)** and **Gate 2 (copy)**.
+
+## Copy phase
+
+- [ ] Source mounted `:ro`; copy is one-directional source→target.
+- [ ] `sha256sum` of `pacs_oltp.mdf` and `pacs_oltp_log.ldf` match between source and copy.
+- [ ] On any mismatch/abort: delete the partial copy, never the source; retry.
+
+## Attach phase
+
+- [ ] Operator approval recorded for **Gate 3 (container start)** and **Gate 4 (attach)**.
+- [ ] `tf-pacs-current-verify` container created fresh; data mount points at the **COPY**.
+- [ ] Attach via `FOR ATTACH` against the copied mdf+ldf only.
+- [ ] Recovery completes against the copy; original volume confirmed untouched (`:ro`, mtimes unchanged).
+
+## Vintage phase
+
+- [ ] Only the read-only `SELECT`s from `PACS_CURRENT_SOURCE_VINTAGE_QUERY_PLAN.md` are run.
+- [ ] Raw output captured verbatim.
+- [ ] Decision A/B/C recorded.
+
+## Post / teardown
+
+- [ ] No TerraFusion drain triggered (Decision A still needs **Gate 5** approval in a later WO).
+- [ ] Isolated container may be stopped; the COPY is retained as evidence (do not delete without approval).
+- [ ] Original `tf_mssql_data`, `pacs_baks`, host backups: unchanged.
+
+---
+
+## Stop points requiring explicit operator approval
+
+| Gate | Before | Why |
+|------|--------|-----|
+| 1 | securing ≥600 GB space | currently impossible on existing drives; needs operator decision (external disk vs free-up) |
+| 2 | copying the 533 GB MDF | large time + space commitment |
+| 3 | starting the SQL container | spinning a new MSSQL engine |
+| 4 | attaching the copied DB | recovery writes (to the copy) |
+| 5 | first drain after vintage proof | only if Decision A; separate WO |
+
+---
+
+## Next work order
+
+**WO-DATA-004B-FIX2 — PACS Current Source Attach/Restore Execution.** Blocked until Gate 1 (space) is resolved and approved.

--- a/docs/data/PACS_CURRENT_SOURCE_ATTACH_PLAN.md
+++ b/docs/data/PACS_CURRENT_SOURCE_ATTACH_PLAN.md
@@ -1,0 +1,128 @@
+# WO-DATA-004B-FIX1 — PACS Current Source Attach/Restore Plan
+
+**Date**: 2026-06-16
+**Branch**: `claude/wo-data-004b-fix1-attach-plan` (off `origin/main` @ `a0cd60c0b`)
+**Mode**: PLANNING ONLY. No MDF attach, no BAK restore, no MSSQL container start, no 533 GB copy, no PACS/TerraFusion mutation, no drain/import/promote/project, no code edits. All inputs gathered via `--rm` alpine `:ro` mounts and read-only host inspection.
+
+**Controlling rule**: *No Sync movement until PACS source vintage is proven. The original 533 GB source must never be attached directly.*
+
+---
+
+## 1. Exact source files (the current-source candidate)
+
+In Docker volume `tf_mssql_data` (physically on `E:\DockerData` via the Docker WSL data-disk symlink), path `/var/opt/mssql/data/`:
+
+| File | Size (actual) | Last modified | Notes |
+|------|---------------|---------------|-------|
+| `pacs_oltp.mdf` | **533.6 GB** | 2026-06-08 | primary data file |
+| `pacs_oltp_log.ldf` | **~1.0 GB** (1023.9 MB) | 2026-06-09 | transaction log |
+| secondary `.ndf` / FILESTREAM | **none** | — | confirmed: only mdf+ldf for pacs_oltp |
+
+ERRORLOG: `pacs_oltp` was online and recovered cleanly **2026-06-09 21:00** under SQL Server **2019**. The DB-engine version for the copy MUST be SQL Server 2019 (matching) to avoid an irreversible on-attach upgrade.
+
+**Total to copy: ~535 GB (mdf + ldf).**
+
+---
+
+## 2. Safe target location — ⚠️ BLOCKED: no drive has enough free space
+
+This is the **#1 prerequisite and approval gate**. A 535 GB copy needs ≥ ~600 GB free (copy + working headroom). Current free space:
+
+| Drive | Size | Free | Enough for 535 GB copy? |
+|-------|------|------|--------------------------|
+| C: | 953 GB | **28 GB** | No |
+| D: | 932 GB | **233 GB** | No |
+| E: | 4.6 TB | **163 GB** | No (and source already lives here, in `E:\DockerData`) |
+| Docker volumes total | — | 603.7 GB used | copying to a new volume grows `E:\DockerData` — E: lacks the space |
+
+**No current target can hold the copy.** Execution (FIX2) cannot start until one of:
+1. **Add a dedicated external/secondary disk** with ≥ 600 GB free (recommended — isolates the copy entirely).
+2. **Free ≥ ~400 GB on E:** (so a new Docker volume or `E:\` path can hold it), or **≥ ~310 GB on D:** then target a `D:\` path.
+
+The target MUST NOT be inside `tf_mssql_data` and MUST NOT overwrite the original.
+
+---
+
+## 3. Copy strategy (source is a Docker volume, not a host path)
+
+`robocopy` cannot read a Docker named volume directly. The copy runs through a read-only container mount:
+
+```
+# READ-ONLY source mount; TARGET is a fresh location with >=600 GB free
+docker run --rm \
+  -v tf_mssql_data:/src:ro \
+  -v <TARGET_PATH_OR_NEW_VOLUME>:/dst \
+  alpine sh -c '
+    cp -av /src/data/pacs_oltp.mdf     /dst/pacs_oltp.mdf
+    cp -av /src/data/pacs_oltp_log.ldf /dst/pacs_oltp_log.ldf
+  '
+```
+
+- **Integrity**: after copy, `sha256sum` both files at source (`:ro`) and target; compare. (533 GB hash ≈ 30–60 min each side.)
+- **Throughput**: ~535 GB at ~100–200 MB/s ≈ **45–90 min** copy + hashing.
+- **Failure handling**: if copy/hash mismatches or aborts, delete the partial target copy and retry; never touch the source.
+- **Source stays `:ro`** the entire time — the original `tf_mssql_data` volume is never written.
+
+(Windows `robocopy /Z /J` is the alternative only if the volume is first surfaced to a host path; the container-mount `cp` above avoids that extra step.)
+
+---
+
+## 4. Isolated SQL Server attach strategy (against the COPY only)
+
+| Item | Value |
+|------|-------|
+| Container name | `tf-pacs-current-verify` (new, dedicated) |
+| Image | `mcr.microsoft.com/mssql/server:2019-latest` (match source engine) |
+| Data mount | the **COPY** location from §3 (new volume or host bind) → `/var/opt/mssql/data` |
+| Port | **21433** → 1433 (avoids 1433 intended-config + 11433 wo004) |
+| Attach | `CREATE DATABASE pacs_oltp ON (FILENAME=.../pacs_oltp.mdf), (FILENAME=.../pacs_oltp_log.ldf) FOR ATTACH;` |
+
+- On-attach recovery writes hit the **COPY only** — the original is untouched.
+- READ_ONLY attach is not assumed: an unclean log forces recovery first. Attach normal, then optionally `ALTER DATABASE pacs_oltp SET READ_ONLY` once recovered. Either way it is the copy.
+- Engine MUST be 2019 — a newer engine performs an irreversible compat upgrade on attach.
+
+---
+
+## 5. Fallback restore strategy — ⚠️ NOT AVAILABLE for pacs_oltp
+
+- `pacs_baks` contains **only satellite** `.bak` (Jan-2026: `Benton_spatial_data`, `pacs_spatial`, `pacs_lists`, `TAAppSvr`) — **no `pacs_oltp.bak`**.
+- `pacs_golive_manual-backup` (Apr-2023) is the sales/go-live DB, **not** the current OLTP, and is older.
+- The Dec-2015 `pacs_benton_122915` is the historical wo004 source — **must not be used**.
+
+**Conclusion: there is no current `pacs_oltp` backup to restore. The MDF copy (§3) is the only path to the current OLTP.** A restore fallback does not exist for OLTP; it would only apply to satellite DBs, which are not what the vintage gate needs.
+
+---
+
+## 6. Vintage queries after attach
+
+See `PACS_CURRENT_SOURCE_VINTAGE_QUERY_PLAN.md` (read-only SQL: DB list, owner min/max + qualifying `>=2018`, property date range, sale date range).
+
+---
+
+## 7. Success / fail decision (post-vintage)
+
+- **A — current/post-2018 proven** (qualifying owner rows > 0): proceed to a controlled parcel drain rerun (separate WO; still bounded TopN).
+- **B — historical only** (no post-2018 rows): STOP. Do **not** adjust pipeline filters. Source is not current.
+- **C — attach/restore fails**: STOP, preserve logs, do not retry against the original.
+
+---
+
+## 8. Safety controls
+
+No drain · no writeback · no source mutation · no original-volume attach · no delete/drop of source · no filter change · no import/promote/project · engine-version match (2019) · source mounted `:ro` only.
+
+---
+
+## 9. Approval gates (each requires explicit operator go)
+
+1. **Before securing ≥600 GB space** (external disk vs free-up D:/E:) — required first; nothing proceeds without it.
+2. **Before copying the 533 GB MDF** (time + space committed).
+3. **Before starting the `tf-pacs-current-verify` SQL container.**
+4. **Before attaching the copied DB.**
+5. **Before the first drain** after vintage is proven (only if Decision A).
+
+---
+
+## Next work order
+
+**WO-DATA-004B-FIX2 — PACS Current Source Attach/Restore Execution** (executes §3–§6 after gate 1–4 approvals; produces the vintage result and Decision A/B/C).

--- a/docs/data/PACS_CURRENT_SOURCE_VINTAGE_QUERY_PLAN.md
+++ b/docs/data/PACS_CURRENT_SOURCE_VINTAGE_QUERY_PLAN.md
@@ -1,0 +1,74 @@
+# WO-DATA-004B-FIX1 — PACS Current Source Vintage Query Plan
+
+**Date**: 2026-06-16 · Companion to `PACS_CURRENT_SOURCE_ATTACH_PLAN.md` · Read-only queries, run only against the **attached COPY** on the isolated `tf-pacs-current-verify` instance (port 21433). Never against the original volume.
+
+**Purpose**: prove whether `tf_mssql_data` / `pacs_oltp` is the current (post-2018) PACS source, using the exact same predicates the Sync pipeline uses.
+
+---
+
+## Queries (all read-only `SELECT`)
+
+```sql
+-- 0. Confirm which DB we are in
+SELECT DB_NAME() AS database_name;
+
+-- 0b. List databases on the isolated instance
+SELECT name FROM sys.databases ORDER BY name;
+
+-- 1. OWNER vintage — THE gate predicate (pipeline filters sup_num=0 AND owner_tax_yr >= 2018)
+SELECT
+  COUNT(*)                                                              AS owner_rows,
+  MIN(owner_tax_yr)                                                     AS min_owner_tax_yr,
+  MAX(owner_tax_yr)                                                     AS max_owner_tax_yr,
+  SUM(CASE WHEN sup_num = 0 AND owner_tax_yr >= 2018 THEN 1 ELSE 0 END) AS qualifying_owner_rows
+FROM owner;
+
+-- 2. PROPERTY date range
+SELECT
+  COUNT(*)            AS property_rows,
+  MIN(prop_create_dt) AS min_prop_create_dt,
+  MAX(prop_create_dt) AS max_prop_create_dt
+FROM property;
+
+-- 3. SALE date range (only if a sale table exists)
+SELECT
+  COUNT(*)     AS sale_rows,
+  MIN(sale_dt) AS min_sale_dt,
+  MAX(sale_dt) AS max_sale_dt
+FROM sale;
+```
+
+If table/column names differ on this instance, inspect read-only first and adapt:
+
+```sql
+SELECT TOP 50 t.name AS table_name
+FROM sys.tables t WHERE t.name IN ('owner','property','sale','property_val')
+ORDER BY t.name;
+
+SELECT c.name AS column_name, ty.name AS type_name
+FROM sys.columns c
+JOIN sys.types ty ON ty.user_type_id = c.user_type_id
+WHERE c.object_id = OBJECT_ID('dbo.owner')
+  AND c.name IN ('owner_tax_yr','sup_num');
+```
+
+---
+
+## Interpretation → Decision
+
+| Result | Decision |
+|--------|----------|
+| `qualifying_owner_rows > 0` AND `max_owner_tax_yr >= 2018` | **A** — current source proven. Proceed to a controlled parcel drain rerun (bounded TopN, separate WO). |
+| `qualifying_owner_rows = 0` (e.g. `max_owner_tax_yr <= 2017`) | **B** — historical only. STOP. Do **not** change pipeline filters. This is not the current source. |
+| queries cannot run (attach failed / schema mismatch unresolved) | **C** — STOP, preserve logs, do not touch the original. |
+
+**Benchmark for context**: the historical wo004 source returns `min=1980, max=2016, qualifying=0`. The current source must return `max >= 2018` with `qualifying > 0` to pass.
+
+---
+
+## Constraints
+
+- Read-only `SELECT` only. No `INSERT/UPDATE/DELETE/DROP`, no `CREATE` except the one-time `FOR ATTACH` (which targets the COPY, per the attach plan).
+- Run on the isolated `tf-pacs-current-verify` instance only.
+- Record raw query output verbatim into the FIX2 results doc.
+- Do not proceed to any TerraFusion drain on Decision B or C.


### PR DESCRIPTION
## What this is

Planning-only attach/restore plan to **prove the vintage** of the likely-current PACS source (`tf_mssql_data` / `pacs_oltp.mdf`, 533.6 GB, last online 2026-06-09) **without risking the original**. No attach, restore, container start, copy, or mutation performed.

## How (the safe path)

1. Copy `pacs_oltp.mdf` (533.6 GB) + `pacs_oltp_log.ldf` (~1 GB) **read-only** (`:ro` source mount) to an isolated target.
2. Attach the **COPY** to a fresh SQL Server **2019** container (`tf-pacs-current-verify`, port `21433`) — recovery writes hit the copy only.
3. Run read-only vintage `SELECT`s (`MIN/MAX(owner_tax_yr)`, qualifying `>=2018`, property/sale date ranges).
4. Decide: **A** post-2018 proven → controlled drain rerun · **B** historical only → stop, no filter change · **C** attach fails → stop, preserve logs.

## Key blocker surfaced

- **No drive has ~600 GB free** for the copy: C: 28 GB, D: 233 GB, E: 163 GB (Docker volumes already use 603 GB on `E:\DockerData`).
- **No `pacs_oltp.bak` exists** (`pacs_baks` = Jan-2026 satellites only; `pacs_golive_manual-backup` = Apr-2023 sales). So an **MDF copy is mandatory** — no restore fallback for OLTP.
- Therefore **"secure ≥600 GB free" is approval gate #1** and blocks execution until resolved (external disk, or free up D:/E:).

## Approval gates (each needs explicit go)
1. secure ≥600 GB space · 2. copy the 533 GB MDF · 3. start the SQL container · 4. attach the copied DB · 5. first drain (only on Decision A, separate WO).

## Safety
No original-volume attach · source mounted `:ro` · SQL 2019 engine match · no drain/import/promote/project · no filter change · no source delete/drop.

Docs: `PACS_CURRENT_SOURCE_ATTACH_PLAN.md`, `PACS_CURRENT_SOURCE_VINTAGE_QUERY_PLAN.md`, `PACS_ATTACH_RESTORE_SAFETY_CHECKLIST.md`.
Next: **WO-DATA-004B-FIX2 — PACS Current Source Attach/Restore Execution** (blocked on gate 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)