### PR TITLE
WO-FORGE-003: Add TerraForge app-by-app runtime audit

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
@@ -73,7 +73,7 @@ describe('TerraForge canonical inventory contract', () => {
 
     expect(primary.every((capability) => capability.proofSurface === 'suite')).toBe(true);
     expect(primary.every((capability) => ['active', 'honest-unavailable', 'deferred', 'fail'].includes(capability.status))).toBe(true);
-    expect(primary.find((capability) => capability.id === 'incomeforge')?.status).toMatch(/^(active|deferred)$/);
+    expect(primary.find((capability) => capability.id === 'incomeforge')?.status).toMatch(/^(active|deferred|fail)$/);
   });
 
   it('keeps support and deferred tools outside primary suite proof', () => {

--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeRuntimeAudit.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeRuntimeAudit.contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { isModuleRegistered } from '../../config/moduleComponents';
+import { getTerraForgeCanonicalInventory } from '../../pages/suites/terraforgeCanonicalInventory';
+import {
+  getTerraForgeRuntimeAudit,
+  type TerraForgeRuntimeAuditEntry,
+} from '../../pages/suites/terraforgeRuntimeAudit';
+
+const byId = (entries: readonly TerraForgeRuntimeAuditEntry[], id: string) => {
+  const entry = entries.find((candidate) => candidate.id === id);
+  if (!entry) {
+    throw new Error(`Missing TerraForge runtime audit entry: ${id}`);
+  }
+  return entry;
+};
+
+describe('TerraForge app-by-app runtime audit contract', () => {
+  it('covers every canonical TerraForge capability and no non-canonical extras', () => {
+    const canonicalIds = getTerraForgeCanonicalInventory().map((capability) => capability.id);
+    const auditIds = getTerraForgeRuntimeAudit().map((entry) => entry.id);
+
+    expect(auditIds).toEqual(canonicalIds);
+    expect(auditIds).not.toContain('terra-gama');
+    expect(auditIds).not.toContain('workbench-forge');
+  });
+
+  it('requires every launchable suite app to resolve through the module registry', () => {
+    const launchable = getTerraForgeRuntimeAudit().filter((entry) => entry.launchableFromSuite);
+
+    expect(launchable.map((entry) => entry.id)).toEqual([
+      'costforge',
+      'compsforge',
+      'salesforge',
+      'calibration-qc',
+      'county-studio',
+    ]);
+
+    for (const entry of launchable) {
+      expect(entry.moduleId, `${entry.id} must declare a moduleId`).toBeTruthy();
+      expect(isModuleRegistered(entry.moduleId!), `${entry.id} module is not registered`).toBe(true);
+    }
+  });
+
+  it('records IncomeForge as the current suite launch gap instead of silently claiming runtime proof', () => {
+    const incomeForge = byId(getTerraForgeRuntimeAudit(), 'incomeforge');
+
+    expect(incomeForge.auditStatus).toBe('fail');
+    expect(incomeForge.launchableFromSuite).toBe(false);
+    expect(incomeForge.moduleId).toBe('income-forge');
+    expect(isModuleRegistered(incomeForge.moduleId)).toBe(false);
+    expect(incomeForge.blocker).toMatch(/module registry/i);
+    expect(incomeForge.runtimePaths).toContain('/costforge/income-approach/cap-rates');
+  });
+
+  it('keeps Workbench and parcel-scoped support out of suite runtime proof', () => {
+    for (const entry of getTerraForgeRuntimeAudit()) {
+      expect(entry.proofSurface).not.toBe('workbench');
+      expect(entry.route).not.toMatch(/^\/property\//);
+      expect(entry.runtimePaths.every((path) => !path.startsWith('/property/'))).toBe(true);
+    }
+  });
+
+  it('marks not-yet-exposed primary lanes as honest unavailable, not active proof', () => {
+    const audit = getTerraForgeRuntimeAudit();
+
+    for (const id of ['reconciliation', 'cama-characteristics', 'valuation-notes-defensibility']) {
+      const entry = byId(audit, id);
+      expect(entry.auditStatus).toBe('not-exposed');
+      expect(entry.launchableFromSuite).toBe(false);
+      expect(entry.runtimeSurface).toBe('suite-card-only');
+    }
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx
@@ -450,7 +450,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(runtimeStatus).toHaveTextContent(/SalesForge runtime/i);
     expect(runtimeStatus).toHaveTextContent(/CostForge live triage path/i);
     expect(runtimeStatus).toHaveTextContent(/CompsForge runtime comps pool/i);
-    expect(runtimeStatus).toHaveTextContent(/IncomeForge runtime income approach/i);
+    expect(runtimeStatus).toHaveTextContent(/IncomeForge launch gap/i);
     expect(runtimeStatus).toHaveTextContent(/County Studio runtime studies/i);
     expect(runtimeStatus).toHaveTextContent(/Full TerraForge not done/i);
     expect(runtimeStatus).toHaveTextContent(/CUForge\/specialists locked/i);
@@ -458,18 +458,18 @@ describe('ForgeSuiteHome source honesty contract', () => {
 
     const primaryApps = within(screen.getByTestId('forge-primary-applications'));
     expect(primaryApps.getByRole('button', { name: /SalesForge/i })).toBeEnabled();
-    expect(primaryApps.getByRole('button', { name: /CostForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /Cost \+ land valuation/i })).toBeEnabled();
     expect(primaryApps.getByRole('button', { name: /CompsForge/i })).toBeEnabled();
-    expect(primaryApps.getByRole('button', { name: /IncomeForge/i })).toBeEnabled();
-    expect(primaryApps.getByRole('button', { name: /CUForge/i })).toBeDisabled();
+    expect(primaryApps.getByRole('button', { name: /IncomeForge/i })).toBeDisabled();
+    expect(primaryApps.getByRole('button', { name: /CAMA Characteristics/i })).toBeDisabled();
 
-    const countyApps = within(screen.getByTestId('forge-county-applications'));
+    const countyApps = within(screen.getByTestId('forge-support-applications'));
     expect(countyApps.getByRole('button', { name: /County Studio/i })).toBeEnabled();
 
-    const secondaryApps = within(screen.getByTestId('forge-secondary-applications'));
+    const secondaryApps = within(screen.getByTestId('forge-support-applications'));
     expect(secondaryApps.getByRole('button', { name: /Batch Cost Runs/i })).toBeDisabled();
     expect(secondaryApps.getByRole('button', { name: /Regression Studio/i })).toBeDisabled();
-    expect(secondaryApps.getByRole('button', { name: /TerraGAMA/i })).toBeDisabled();
+    expect(within(screen.getByTestId('forge-support-applications')).queryByText('TerraGAMA')).toBeNull();
     expect(secondaryApps.getByRole('button', { name: /Coefficient Preview/i })).toBeDisabled();
 
     expect(screen.queryByText(/Full TerraForge is done/i)).not.toBeInTheDocument();
@@ -481,7 +481,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(screen.queryByText('71.4%')).not.toBeInTheDocument();
   });
 
-  it('opens SalesForge, CompsForge, and IncomeForge from TerraForge Suite while keeping unverified standalone Forge apps locked', () => {
+  it('opens SalesForge and CompsForge from TerraForge Suite while flagging IncomeForge and keeping unverified standalone Forge apps locked', () => {
     mockUseCountyStats.mockReturnValue({
       stats: MOCK_STATS,
       loading: false,
@@ -496,19 +496,18 @@ describe('ForgeSuiteHome source honesty contract', () => {
     );
 
     const primaryApps = within(screen.getByTestId('forge-primary-applications'));
-    expect(primaryApps.getByRole('button', { name: /CostForge/i })).toBeEnabled();
+    expect(primaryApps.getByRole('button', { name: /Cost \+ land valuation/i })).toBeEnabled();
     const compsForgeCard = primaryApps.getByRole('button', { name: /CompsForge/i });
     expect(compsForgeCard).toBeEnabled();
     expect(compsForgeCard).toHaveTextContent(/Statewide sales comp search/i);
     expect(compsForgeCard).not.toHaveTextContent(/Benton comps pool API/i);
     const incomeForgeCard = primaryApps.getByRole('button', { name: /IncomeForge/i });
-    expect(incomeForgeCard).toBeEnabled();
-    expect(incomeForgeCard).toHaveTextContent(/Benton income approach API/i);
+    expect(incomeForgeCard).toBeDisabled();
+    expect(incomeForgeCard).toHaveTextContent(/Fails current suite gate/i);
 
     const salesForgeCard = primaryApps.getByRole('button', { name: /SalesForge/i });
     expect(salesForgeCard).toBeEnabled();
     expect(salesForgeCard).toHaveTextContent(/Benton sale qualification API/i);
-    expect(screen.getAllByText(/Standalone preview locked/i).length).toBeGreaterThan(0);
 
     fireEvent.click(salesForgeCard);
 
@@ -537,16 +536,7 @@ describe('ForgeSuiteHome source honesty contract', () => {
 
     fireEvent.click(incomeForgeCard);
 
-    expect(activateModuleMock).toHaveBeenCalledWith('income-forge', {
-      source: 'system',
-      metadata: {
-        launchContext: 'terraforge-suite',
-        dataSource: 'terrafusion-api',
-        runtimePath: 'income-approach',
-        countyId: '19190019-1919-1919-1919-191919191919',
-        taxYear: 2026,
-      },
-    });
+    expect(activateModuleMock).not.toHaveBeenCalledWith('income-forge', expect.anything());
   });
 
   it('opens CostForge from TerraForge Suite on the live triage API path', () => {
@@ -567,11 +557,11 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(runtimeStatus).toHaveTextContent(/SalesForge\s+runtime/i);
     expect(runtimeStatus).toHaveTextContent(/CostForge\s+live triage path/i);
     expect(runtimeStatus).toHaveTextContent(/CompsForge\s+runtime comps pool/i);
-    expect(runtimeStatus).toHaveTextContent(/IncomeForge\s+runtime income approach/i);
+    expect(runtimeStatus).toHaveTextContent(/IncomeForge\s+launch gap/i);
     expect(runtimeStatus).toHaveTextContent(/Metrics app-backed/i);
 
     const primaryApps = within(screen.getByTestId('forge-primary-applications'));
-    const costForgeCard = primaryApps.getByRole('button', { name: /CostForge/i });
+    const costForgeCard = primaryApps.getByRole('button', { name: /Cost \+ land valuation/i });
     expect(costForgeCard).toBeEnabled();
     expect(costForgeCard).toHaveTextContent(/Benton CostForge triage API/i);
 
@@ -606,10 +596,10 @@ describe('ForgeSuiteHome source honesty contract', () => {
     const runtimeStatus = screen.getByTestId('forge-runtime-status');
     expect(runtimeStatus).toHaveTextContent(/County Studio\s+runtime studies/i);
 
-    const countyApps = within(screen.getByTestId('forge-county-applications'));
+    const countyApps = within(screen.getByTestId('forge-support-applications'));
     const countyStudioCard = countyApps.getByRole('button', { name: /County Studio/i });
     expect(countyStudioCard).toBeEnabled();
-    expect(countyStudioCard).toHaveTextContent(/Benton County Studio studies API/i);
+    expect(countyStudioCard).toHaveTextContent(/Support: County Studio studies API/i);
     expect(screen.queryByRole('button', { name: /County Studio preview locked/i })).not.toBeInTheDocument();
 
     fireEvent.click(countyStudioCard);
@@ -765,13 +755,11 @@ describe('ForgeSuiteHome source honesty contract', () => {
     expect(screen.getByText('IncomeForge')).toBeInTheDocument();
     expect(screen.getByText('SalesForge')).toBeInTheDocument();
 
-    // The TerraDais handoff string lives in the component's getLaunchLabel —
-    // verify the source still defines it (proves the dais routing branch survives).
     const sourceFile = require('fs').readFileSync(
       require('path').resolve(__dirname, '../../pages/suites/ForgeSuiteHome.tsx'),
       'utf8',
     );
-    expect(sourceFile).toContain("workbenchTab === 'dais' ? 'Opens TerraDais workbench'");
+    expect(sourceFile).toContain('parcel-scoped Workbench Forge views are support only');
     expect(sourceFile).not.toContain('<ParcelContextBanner');
   });
 });

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -678,7 +678,7 @@ export default function ForgeSuiteHome() {
               <span className="forge-chip forge-chip--success">SalesForge runtime</span>
               <span className="forge-chip forge-chip--success">CostForge live triage path</span>
               <span className="forge-chip forge-chip--success">CompsForge runtime comps pool</span>
-              <span className="forge-chip forge-chip--success">IncomeForge runtime income approach</span>
+              <span className="forge-chip forge-chip--warn">IncomeForge launch gap</span>
               <span className="forge-chip forge-chip--success">County Studio runtime studies</span>
               <span className={`forge-chip ${countyRollupChipClass}`}>
                 {countyRollupStatus}

--- a/frontend/apps/os-shell/src/pages/suites/terraforgeCanonicalInventory.ts
+++ b/frontend/apps/os-shell/src/pages/suites/terraforgeCanonicalInventory.ts
@@ -57,11 +57,11 @@ export const TERRAFORGE_CANONICAL_INVENTORY: readonly TerraForgeCanonicalCapabil
     description:
       'Income approach lane for cap rates, NOI modeling, and rent schedule review where commercial income data is available.',
     tier: 'primary',
-    status: 'active',
+    status: 'fail',
     proofSurface: 'suite',
     moduleId: 'income-forge',
     route: '/forge',
-    chipLabel: 'Income approach',
+    chipLabel: 'Fails current suite gate',
   },
   {
     id: 'reconciliation',

--- a/frontend/apps/os-shell/src/pages/suites/terraforgeRuntimeAudit.ts
+++ b/frontend/apps/os-shell/src/pages/suites/terraforgeRuntimeAudit.ts
@@ -1,0 +1,179 @@
+import {
+  TERRAFORGE_CANONICAL_INVENTORY,
+  type TerraForgeCapabilityStatus,
+  type TerraForgeCapabilityTier,
+  type TerraForgeProofSurface,
+} from './terraforgeCanonicalInventory';
+
+export type TerraForgeRuntimeAuditStatus = 'runtime-backed' | 'not-exposed' | 'deferred' | 'fail';
+export type TerraForgeRuntimeSurface =
+  | 'standalone-module'
+  | 'shared-module'
+  | 'support-module'
+  | 'suite-card-only';
+
+export interface TerraForgeRuntimeAuditEntry {
+  id: string;
+  label: string;
+  tier: TerraForgeCapabilityTier;
+  canonicalStatus: TerraForgeCapabilityStatus;
+  auditStatus: TerraForgeRuntimeAuditStatus;
+  proofSurface: TerraForgeProofSurface;
+  runtimeSurface: TerraForgeRuntimeSurface;
+  route: string;
+  launchableFromSuite: boolean;
+  moduleId?: string;
+  componentPath?: string;
+  runtimePaths: readonly string[];
+  blocker?: string;
+}
+
+const capabilityById = new Map(TERRAFORGE_CANONICAL_INVENTORY.map((capability) => [capability.id, capability]));
+
+function capability(id: string) {
+  const found = capabilityById.get(id);
+  if (!found) {
+    throw new Error(`Missing TerraForge canonical capability: ${id}`);
+  }
+  return found;
+}
+
+function auditEntry(
+  id: string,
+  details: Omit<TerraForgeRuntimeAuditEntry, 'id' | 'label' | 'tier' | 'canonicalStatus' | 'proofSurface' | 'route' | 'moduleId'> & {
+    moduleId?: string;
+  },
+): TerraForgeRuntimeAuditEntry {
+  const canonical = capability(id);
+  return {
+    id,
+    label: canonical.label,
+    tier: canonical.tier,
+    canonicalStatus: canonical.status,
+    proofSurface: canonical.proofSurface,
+    route: canonical.route ?? '/forge',
+    moduleId: details.moduleId ?? canonical.moduleId,
+    ...details,
+  };
+}
+
+export const TERRAFORGE_RUNTIME_AUDIT: readonly TerraForgeRuntimeAuditEntry[] = [
+  auditEntry('costforge', {
+    auditStatus: 'runtime-backed',
+    runtimeSurface: 'standalone-module',
+    launchableFromSuite: true,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/cost/CostForge.tsx',
+    runtimePaths: [
+      '/costforge/dashboard-stats',
+      '/costforge/cost-matrix/benton',
+      '/costforge/calculate',
+    ],
+  }),
+  auditEntry('compsforge', {
+    auditStatus: 'runtime-backed',
+    runtimeSurface: 'standalone-module',
+    launchableFromSuite: true,
+    componentPath: 'frontend/apps/os-shell/src/pages/suites/modules/CompsForgeModule.tsx',
+    runtimePaths: [
+      '/terraforge/comps-pool',
+      '/terraforge/comps/sets/{id}/detail',
+    ],
+  }),
+  auditEntry('salesforge', {
+    auditStatus: 'runtime-backed',
+    runtimeSurface: 'standalone-module',
+    launchableFromSuite: true,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/sales/SalesForge.tsx',
+    runtimePaths: [
+      '/terraforge/sale-qualification',
+      '/terraforge/sales/{saleId}/detail',
+      '/terraforge/sales/running-stats',
+    ],
+  }),
+  auditEntry('incomeforge', {
+    auditStatus: 'fail',
+    runtimeSurface: 'standalone-module',
+    launchableFromSuite: false,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/income/IncomeForge.tsx',
+    runtimePaths: [
+      '/costforge/income-approach/cap-rates',
+      '/costforge/income-approach/market-data',
+      '/costforge/income-approach/valuation',
+    ],
+    blocker: 'IncomeForge component exists, but moduleId income-forge is not registered in the shell module registry.',
+  }),
+  auditEntry('reconciliation', {
+    auditStatus: 'not-exposed',
+    runtimeSurface: 'suite-card-only',
+    launchableFromSuite: false,
+    componentPath: 'frontend/apps/os-shell/src/pages/suites/modules/ReconciliationModule.tsx',
+    runtimePaths: [],
+    blocker: 'Reconciliation is canonical primary, but it is not exposed as an independent /forge runtime module.',
+  }),
+  auditEntry('calibration-qc', {
+    auditStatus: 'runtime-backed',
+    runtimeSurface: 'shared-module',
+    launchableFromSuite: true,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/cost/tabs/CalibrationWorkbenchTab.tsx',
+    runtimePaths: [
+      '/costforge/dashboard-stats',
+      '/terraforge/county-diagnostics',
+      '/terraforge/calibration-memo',
+    ],
+  }),
+  auditEntry('cama-characteristics', {
+    auditStatus: 'not-exposed',
+    runtimeSurface: 'suite-card-only',
+    launchableFromSuite: false,
+    runtimePaths: [],
+    blocker: 'CAMA characteristics are required as a TerraFusion data lane, but no /forge runtime surface is exposed yet.',
+  }),
+  auditEntry('valuation-notes-defensibility', {
+    auditStatus: 'not-exposed',
+    runtimeSurface: 'suite-card-only',
+    launchableFromSuite: false,
+    runtimePaths: [],
+    blocker: 'Valuation notes and defensibility support are canonical primary, but no standalone /forge runtime surface is exposed yet.',
+  }),
+  auditEntry('batch-cost-runs', {
+    auditStatus: 'deferred',
+    runtimeSurface: 'support-module',
+    launchableFromSuite: false,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/batch/BatchCostRun.tsx',
+    runtimePaths: [],
+  }),
+  auditEntry('regression-studio', {
+    auditStatus: 'deferred',
+    runtimeSurface: 'support-module',
+    launchableFromSuite: false,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/regression/RegressionStudio.tsx',
+    runtimePaths: [],
+  }),
+  auditEntry('county-studio', {
+    auditStatus: 'runtime-backed',
+    runtimeSurface: 'support-module',
+    launchableFromSuite: true,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/county-studio/CountyStudyPage.tsx',
+    runtimePaths: [
+      '/api/forge/county-studies',
+      '/api/forge/county-studies/{studyId}/segments',
+    ],
+  }),
+  auditEntry('coefficient-preview', {
+    auditStatus: 'deferred',
+    runtimeSurface: 'support-module',
+    launchableFromSuite: false,
+    componentPath: 'frontend/apps/os-shell/src/pages/forge/batch/CoefficientPreview.tsx',
+    runtimePaths: [],
+  }),
+  auditEntry('current-use-support', {
+    auditStatus: 'deferred',
+    runtimeSurface: 'support-module',
+    launchableFromSuite: false,
+    runtimePaths: [],
+  }),
+] as const;
+
+export function getTerraForgeRuntimeAudit(): readonly TerraForgeRuntimeAuditEntry[] {
+  return TERRAFORGE_RUNTIME_AUDIT;
+}


### PR DESCRIPTION
## Summary
- Adds a testable TerraForge runtime audit contract for every canonical primary/support capability.
- Reclassifies IncomeForge as a current fail because `income-forge` is not registered in the shell module registry, despite a component and service paths existing.
- Keeps Workbench/parcel-scoped surfaces out of TerraForge suite runtime proof and records not-exposed primary lanes explicitly.

## Audit findings
- Runtime-backed launchable: CostForge, CompsForge, SalesForge, Calibration / QC via CostForge, County Studio support.
- Current fail: IncomeForge launch gap (`income-forge` module ID not registered).
- Not exposed: Reconciliation, CAMA Characteristics, Valuation Notes / Defensibility.
- Deferred/support: Batch Cost Runs, Regression Studio, Coefficient Preview, Current-use Support.

## Validation
- `pnpm --dir frontend exec vitest run apps/os-shell/src/__tests__/forge/terraforgeRuntimeAudit.contract.test.ts apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx`
- `pnpm run type-check`
- `pnpm --dir frontend run type-check`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`