### PR TITLE
WO-FORGE-005: TerraForge production matrix proof

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx
@@ -104,6 +104,11 @@ describe('/forge canonical suite rendering', () => {
 
     for (const capability of getTerraForgeCanonicalInventory().filter((entry) => entry.tier === 'primary')) {
       expect(within(primary).getByText(capability.label)).toBeDefined();
+      const proofCard = primary.querySelector(`[data-terraforge-capability-id="${capability.id}"]`);
+      expect(proofCard).toBeTruthy();
+      expect(proofCard).toHaveAttribute('data-terraforge-tier', 'primary');
+      expect(proofCard).toHaveAttribute('data-terraforge-proof-surface', 'suite');
+      expect(proofCard).toHaveAttribute('data-terraforge-production-proof', 'primary-required');
     }
   });
 
@@ -115,6 +120,11 @@ describe('/forge canonical suite rendering', () => {
     for (const capability of getTerraForgeCanonicalInventory().filter((entry) => entry.tier !== 'primary')) {
       expect(within(support).getByText(capability.label)).toBeDefined();
       expect(within(primary).queryByText(capability.label)).toBeNull();
+      const proofCard = support.querySelector(`[data-terraforge-capability-id="${capability.id}"]`);
+      expect(proofCard).toBeTruthy();
+      expect(proofCard).toHaveAttribute('data-terraforge-tier', capability.tier);
+      expect(proofCard).toHaveAttribute('data-terraforge-proof-surface', 'support');
+      expect(proofCard).toHaveAttribute('data-terraforge-production-proof', 'support-or-deferred');
     }
   });
 

--- a/frontend/apps/os-shell/src/__tests__/forge/terraforgeProductionMatrix.contract.test.ts
+++ b/frontend/apps/os-shell/src/__tests__/forge/terraforgeProductionMatrix.contract.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { isModuleRegistered } from '../../config/moduleComponents';
+import { getTerraForgeCanonicalInventory } from '../../pages/suites/terraforgeCanonicalInventory';
+import {
+  getTerraForgeProductionMatrix,
+  type TerraForgeProductionMatrixEntry,
+} from '../../pages/suites/terraforgeProductionMatrix';
+
+const forbiddenPacsRuntimeUi = /\bPACS\b|\bPacs\b|pacs_/;
+
+function byId(entries: readonly TerraForgeProductionMatrixEntry[], id: string): TerraForgeProductionMatrixEntry {
+  const entry = entries.find((candidate) => candidate.id === id);
+  if (!entry) {
+    throw new Error(`Missing TerraForge production matrix entry: ${id}`);
+  }
+  return entry;
+}
+
+describe('TerraForge production matrix proof contract', () => {
+  it('covers the canonical TerraForge inventory exactly', () => {
+    const canonicalIds = getTerraForgeCanonicalInventory().map((capability) => capability.id);
+    const matrixIds = getTerraForgeProductionMatrix().map((entry) => entry.id);
+
+    expect(matrixIds).toEqual(canonicalIds);
+    expect(matrixIds).not.toContain('workbench-forge');
+    expect(matrixIds).not.toContain('terra-gama');
+  });
+
+  it('requires authenticated public browser proof for every primary capability', () => {
+    const matrix = getTerraForgeProductionMatrix();
+    const primaryIds = getTerraForgeCanonicalInventory()
+      .filter((capability) => capability.tier === 'primary')
+      .map((capability) => capability.id);
+
+    expect(primaryIds).toEqual([
+      'costforge',
+      'compsforge',
+      'salesforge',
+      'incomeforge',
+      'reconciliation',
+      'calibration-qc',
+      'cama-characteristics',
+      'valuation-notes-defensibility',
+    ]);
+
+    for (const id of primaryIds) {
+      const entry = byId(matrix, id);
+      expect(entry.proofMode, id).toBe('authenticated-public-browser-smoke');
+      expect(entry.proofStatus, id).toBe('requires-public-smoke');
+      expect(entry.route, id).toBe('/forge');
+      expect(entry.proofSurface, id).toBe('suite');
+      expect(entry.runtimeAuditStatus, id).toBe('runtime-backed');
+      expect(entry.launchableFromSuite, id).toBe(true);
+      expect(entry.moduleId, id).toBeTruthy();
+      expect(isModuleRegistered(entry.moduleId!), id).toBe(true);
+      expect(entry.runtimePaths.length, id).toBeGreaterThan(0);
+      expect(entry.endpointOnlyProofAllowed, id).toBe(false);
+      expect(entry.workbenchProofAllowed, id).toBe(false);
+      expect(entry.requiredEvidence.join('\n'), id).toMatch(/authenticated public production session/);
+    }
+  });
+
+  it('keeps support and deferred tools out of primary production proof', () => {
+    const matrix = getTerraForgeProductionMatrix();
+    const supportOrDeferred = matrix.filter((entry) => entry.tier !== 'primary');
+
+    expect(supportOrDeferred.map((entry) => entry.id)).toEqual([
+      'batch-cost-runs',
+      'regression-studio',
+      'county-studio',
+      'coefficient-preview',
+      'current-use-support',
+    ]);
+
+    for (const entry of supportOrDeferred) {
+      expect(entry.proofMode, entry.id).toBe('support-or-deferred-disclosure');
+      expect(entry.proofStatus, entry.id).toBe('not-primary-proof');
+      expect(entry.proofSurface, entry.id).toBe('support');
+      expect(entry.endpointOnlyProofAllowed, entry.id).toBe(false);
+      expect(entry.workbenchProofAllowed, entry.id).toBe(false);
+      expect(entry.requiredEvidence.join('\n'), entry.id).toMatch(/not counted as primary/i);
+    }
+  });
+
+  it('does not allow endpoint-only, Workbench, parcel-route, or PACS-facing proof leakage', () => {
+    for (const entry of getTerraForgeProductionMatrix()) {
+      expect(entry.endpointOnlyProofAllowed, entry.id).toBe(false);
+      expect(entry.workbenchProofAllowed, entry.id).toBe(false);
+      expect(entry.route, entry.id).not.toMatch(/^\/property\//);
+      expect(entry.runtimePaths.every((path) => !path.startsWith('/property/')), entry.id).toBe(true);
+
+      const runtimeFacingText = [
+        entry.id,
+        entry.label,
+        entry.route,
+        entry.moduleId ?? '',
+        ...entry.runtimePaths,
+        ...entry.requiredEvidence,
+      ].join('\n');
+      expect(runtimeFacingText, entry.id).not.toMatch(forbiddenPacsRuntimeUi);
+    }
+  });
+});

--- a/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
+++ b/frontend/apps/os-shell/src/pages/suites/ForgeSuiteHome.tsx
@@ -912,6 +912,10 @@ export default function ForgeSuiteHome() {
                   key={mod.id}
                   type="button"
                   className="forge-card forge-card--primary"
+                  data-terraforge-capability-id={mod.id}
+                  data-terraforge-tier={mod.tier}
+                  data-terraforge-proof-surface={mod.proofSurface}
+                  data-terraforge-production-proof="primary-required"
                   onClick={() => handleModuleLaunch(mod)}
                   disabled={!isJune10RuntimeForgeModule(mod) || mod.truthState === 'queued'}
                   title={!isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}
@@ -943,6 +947,10 @@ export default function ForgeSuiteHome() {
                   key={mod.id}
                   type="button"
                   className="forge-card forge-card--secondary"
+                  data-terraforge-capability-id={mod.id}
+                  data-terraforge-tier={mod.tier}
+                  data-terraforge-proof-surface={mod.proofSurface}
+                  data-terraforge-production-proof="support-or-deferred"
                   onClick={() => handleModuleLaunch(mod)}
                   disabled={!isJune10RuntimeForgeModule(mod) || mod.truthState === 'queued'}
                   title={!isJune10RuntimeForgeModule(mod) ? JUNE_10_FORGE_NOTICE : undefined}

--- a/frontend/apps/os-shell/src/pages/suites/terraforgeProductionMatrix.ts
+++ b/frontend/apps/os-shell/src/pages/suites/terraforgeProductionMatrix.ts
@@ -1,0 +1,81 @@
+import {
+  TERRAFORGE_CANONICAL_INVENTORY,
+  type TerraForgeCapabilityTier,
+  type TerraForgeProofSurface,
+} from './terraforgeCanonicalInventory';
+import {
+  TERRAFORGE_RUNTIME_AUDIT,
+  type TerraForgeRuntimeAuditStatus,
+  type TerraForgeRuntimeSurface,
+} from './terraforgeRuntimeAudit';
+
+export type TerraForgeProductionProofMode =
+  | 'authenticated-public-browser-smoke'
+  | 'support-or-deferred-disclosure';
+
+export type TerraForgeProductionProofStatus =
+  | 'requires-public-smoke'
+  | 'not-primary-proof';
+
+export interface TerraForgeProductionMatrixEntry {
+  id: string;
+  label: string;
+  tier: TerraForgeCapabilityTier;
+  proofSurface: TerraForgeProofSurface;
+  route: string;
+  moduleId?: string;
+  runtimeAuditStatus: TerraForgeRuntimeAuditStatus;
+  runtimeSurface: TerraForgeRuntimeSurface;
+  launchableFromSuite: boolean;
+  runtimePaths: readonly string[];
+  proofMode: TerraForgeProductionProofMode;
+  proofStatus: TerraForgeProductionProofStatus;
+  endpointOnlyProofAllowed: false;
+  workbenchProofAllowed: false;
+  requiredEvidence: readonly string[];
+}
+
+const auditById = new Map(TERRAFORGE_RUNTIME_AUDIT.map((entry) => [entry.id, entry]));
+
+export const TERRAFORGE_PRODUCTION_MATRIX: readonly TerraForgeProductionMatrixEntry[] =
+  TERRAFORGE_CANONICAL_INVENTORY.map((capability) => {
+    const audit = auditById.get(capability.id);
+    if (!audit) {
+      throw new Error(`Missing TerraForge runtime audit entry: ${capability.id}`);
+    }
+
+    const isPrimary = capability.tier === 'primary';
+
+    return {
+      id: capability.id,
+      label: capability.label,
+      tier: capability.tier,
+      proofSurface: capability.proofSurface,
+      route: capability.route ?? '/forge',
+      moduleId: capability.moduleId,
+      runtimeAuditStatus: audit.auditStatus,
+      runtimeSurface: audit.runtimeSurface,
+      launchableFromSuite: audit.launchableFromSuite,
+      runtimePaths: audit.runtimePaths,
+      proofMode: isPrimary ? 'authenticated-public-browser-smoke' : 'support-or-deferred-disclosure',
+      proofStatus: isPrimary ? 'requires-public-smoke' : 'not-primary-proof',
+      endpointOnlyProofAllowed: false,
+      workbenchProofAllowed: false,
+      requiredEvidence: isPrimary
+        ? [
+            'authenticated public production session',
+            '/forge TerraForge Suite surface loaded from the release SHA under test',
+            'canonical primary capability card visible in the primary suite section',
+            'capability is launchable through the suite module registry',
+            'runtime-backed API or service path disclosed by the matrix',
+          ]
+        : [
+            'capability appears only in support/deferred section',
+            'capability is not counted as primary TerraForge production proof',
+          ],
+    };
+  });
+
+export function getTerraForgeProductionMatrix(): readonly TerraForgeProductionMatrixEntry[] {
+  return TERRAFORGE_PRODUCTION_MATRIX;
+}

--- a/scripts/terraforge-production-matrix-smoke.mjs
+++ b/scripts/terraforge-production-matrix-smoke.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const PRIMARY_CAPABILITIES = [
+  ['costforge', 'CostForge'],
+  ['compsforge', 'CompsForge'],
+  ['salesforge', 'SalesForge'],
+  ['incomeforge', 'IncomeForge'],
+  ['reconciliation', 'Reconciliation'],
+  ['calibration-qc', 'Calibration / QC'],
+  ['cama-characteristics', 'CAMA Characteristics'],
+  ['valuation-notes-defensibility', 'Valuation Notes / Defensibility'],
+];
+
+const SUPPORT_CAPABILITIES = [
+  'batch-cost-runs',
+  'regression-studio',
+  'county-studio',
+  'coefficient-preview',
+  'current-use-support',
+];
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  return process.argv[index + 1];
+}
+
+function normalizeBaseUrl(raw) {
+  if (!raw) {
+    throw new Error('Missing --base-url or TF_PRODUCTION_BASE_URL.');
+  }
+  const parsed = new URL(raw);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function requireSecret(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}.`);
+  }
+  return value;
+}
+
+async function writeEvidence(outputDir, evidence) {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, 'terraforge-production-matrix-proof.json'),
+    `${JSON.stringify(evidence, null, 2)}\n`
+  );
+  await writeFile(
+    path.join(outputDir, 'terraforge-production-matrix-proof.md'),
+    [
+      '# TerraForge Production Matrix Proof',
+      '',
+      `Status: \`${evidence.status}\``,
+      `Checked: \`${evidence.checkedAt}\``,
+      `Base URL: \`${evidence.baseUrl}\``,
+      `Release SHA: \`${evidence.releaseSha ?? 'not-reported'}\``,
+      '',
+      '## Primary Capabilities',
+      '',
+      ...evidence.primaryCapabilities.map(
+        capability =>
+          `- ${capability.label}: card=${capability.cardVisible ? 'visible' : 'missing'}, launch=${capability.launchActionable ? 'actionable' : 'blocked'}`
+      ),
+      '',
+      '## Support / Deferred',
+      '',
+      ...evidence.supportCapabilities.map(
+        capability =>
+          `- ${capability.id}: ${capability.visible ? 'visible outside primary proof' : 'missing'}`
+      ),
+      '',
+      '## Guardrails',
+      '',
+      `- Workbench counted as proof: \`${evidence.guardrails.workbenchCountedAsProof}\``,
+      `- Endpoint-only proof accepted: \`${evidence.guardrails.endpointOnlyProofAccepted}\``,
+      `- PACS-facing runtime text: \`${evidence.guardrails.pacsRuntimeTextFound}\``,
+      '',
+    ].join('\n')
+  );
+}
+
+async function main() {
+  const baseUrl = normalizeBaseUrl(readArg('--base-url') ?? process.env.TF_PRODUCTION_BASE_URL);
+  const expectedReleaseSha = readArg('--expected-sha') ?? process.env.TF_EXPECTED_RELEASE_SHA;
+  const email = requireSecret('TF_PROVISIONED_AUTH_EMAIL');
+  const password = requireSecret('TF_PROVISIONED_AUTH_PASSWORD');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outputDir =
+    readArg('--output') ?? path.join('artifacts', 'terraforge-production-matrix', stamp);
+
+  const { chromium } = await import('playwright');
+  const browser = await chromium.launch({ headless: process.env.TF_SMOKE_HEADLESS !== '0' });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  const evidence = {
+    status: 'FAIL',
+    checkedAt: new Date().toISOString(),
+    baseUrl,
+    releaseSha: null,
+    primaryCapabilities: [],
+    supportCapabilities: [],
+    guardrails: {
+      workbenchCountedAsProof: false,
+      endpointOnlyProofAccepted: false,
+      pacsRuntimeTextFound: false,
+    },
+    errors: [],
+  };
+
+  try {
+    const healthResponse = await page.request.get(`${baseUrl}/health`, { timeout: 15000 });
+    evidence.releaseSha = healthResponse.headers()['x-release-sha'] ?? null;
+    if (!healthResponse.ok()) {
+      throw new Error(`/health returned HTTP ${healthResponse.status()}`);
+    }
+    if (expectedReleaseSha && evidence.releaseSha !== expectedReleaseSha) {
+      throw new Error(
+        `Expected X-Release-Sha ${expectedReleaseSha}, got ${evidence.releaseSha ?? 'missing'}`
+      );
+    }
+
+    await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: /enter terrafusion os/i }).click();
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => undefined);
+
+    await page.goto(`${baseUrl}/forge`, { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('suite-forge-root').waitFor({ timeout: 30000 });
+    await page.getByTestId('forge-primary-applications').waitFor({ timeout: 30000 });
+    await page.getByTestId('forge-support-applications').waitFor({ timeout: 30000 });
+
+    const bodyText = await page.locator('body').innerText();
+    evidence.guardrails.pacsRuntimeTextFound = /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
+    evidence.guardrails.workbenchCountedAsProof = /\/property\/[^/\s]+\/forge/.test(bodyText);
+
+    for (const [id, label] of PRIMARY_CAPABILITIES) {
+      const card = page.locator(
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="primary-required"]`
+      );
+      const cardVisible = await card.isVisible();
+      let launchActionable = false;
+      if (cardVisible) {
+        await card.click({ trial: true, timeout: 10000 });
+        launchActionable = !(await card.isDisabled());
+      }
+      evidence.primaryCapabilities.push({ id, label, cardVisible, launchActionable });
+    }
+
+    for (const id of SUPPORT_CAPABILITIES) {
+      const card = page.locator(
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="support-or-deferred"]`
+      );
+      evidence.supportCapabilities.push({ id, visible: await card.isVisible() });
+    }
+
+    const missingPrimary = evidence.primaryCapabilities.filter(
+      capability => !capability.cardVisible || !capability.launchActionable
+    );
+    const missingSupport = evidence.supportCapabilities.filter(capability => !capability.visible);
+
+    if (missingPrimary.length > 0) {
+      throw new Error(
+        `Primary TerraForge capability proof failed: ${missingPrimary.map(item => item.id).join(', ')}`
+      );
+    }
+    if (missingSupport.length > 0) {
+      throw new Error(
+        `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`
+      );
+    }
+    if (evidence.guardrails.pacsRuntimeTextFound) {
+      throw new Error('PACS-facing runtime text found on /forge.');
+    }
+    if (evidence.guardrails.workbenchCountedAsProof) {
+      throw new Error('Workbench parcel-scoped route appeared in TerraForge suite proof.');
+    }
+    if (pageErrors.length > 0) {
+      throw new Error(`Browser page errors: ${pageErrors.join(' | ')}`);
+    }
+
+    evidence.status = 'PASS';
+  } catch (error) {
+    evidence.errors.push(error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    await mkdir(outputDir, { recursive: true }).catch(() => undefined);
+    await page
+      .screenshot({
+        path: path.join(outputDir, 'terraforge-production-matrix.png'),
+        fullPage: true,
+      })
+      .catch(() => undefined);
+    await browser.close();
+    await writeEvidence(outputDir, evidence);
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a testable TerraForge production matrix for every frozen canonical capability.
- Marks every primary capability as requiring authenticated public browser smoke proof, not endpoint-only proof.
- Adds stable `/forge` proof selectors that distinguish primary proof from support/deferred tools.
- Adds a read-only production matrix smoke runner for post-merge public proof.

## Guardrails
- Workbench Forge remains excluded from TerraForge Suite proof.
- Endpoint 200 alone is explicitly disallowed as production proof.
- Support/deferred tools are represented but not counted as primary proof.
- PACS-facing runtime language remains blocked by the Forge PACS boundary guard.

## Validation
- `pnpm --dir frontend exec vitest run apps/os-shell/src/__tests__/forge/terraforgeProductionMatrix.contract.test.ts apps/os-shell/src/__tests__/forge/terraforgeRuntimeAudit.contract.test.ts apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx`
- `pnpm run type-check`
- `pnpm --dir frontend run type-check`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `node --check scripts/terraforge-production-matrix-smoke.mjs`
- `git diff --check`

## Post-merge proof
After merge and deployment, run:

```bash
TF_PROVISIONED_AUTH_EMAIL=... TF_PROVISIONED_AUTH_PASSWORD=... node scripts/terraforge-production-matrix-smoke.mjs --base-url <public-url> --expected-sha <merge-sha>
```