### PR TITLE
ci(release): require explicit DB mutation approval

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_db_mutation:
+        description: Explicitly allow production/staging DB mutation during release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -46,6 +51,7 @@ jobs:
       TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}
       VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
       PROVISION_AUTH: ${{ inputs.provision_auth }}
+      ALLOW_DB_MUTATION: ${{ inputs.allow_db_mutation }}
       TF_EXPECTED_JUNE10_DB_NAME: ${{ vars.TF_EXPECTED_JUNE10_DB_NAME }}
       TF_EXPECTED_JUNE10_DB_PROVIDER: ${{ vars.TF_EXPECTED_JUNE10_DB_PROVIDER }}
     steps:
@@ -94,6 +100,16 @@ jobs:
           PUBLIC_URL="${PUBLIC_URL%/}"
           TF_EXPECTED_JUNE10_DB_NAME="${TF_EXPECTED_JUNE10_DB_NAME:-terrafusion.db}"
           TF_EXPECTED_JUNE10_DB_PROVIDER="${TF_EXPECTED_JUNE10_DB_PROVIDER:-Sqlite}"
+          if [ "${ALLOW_DB_MUTATION}" = "true" ]; then
+            TF_SKIP_AUTO_MIGRATE=false
+          else
+            TF_SKIP_AUTO_MIGRATE=true
+          fi
+
+          if [ "${PROVISION_AUTH}" = "true" ] && [ "${ALLOW_DB_MUTATION}" != "true" ]; then
+            echo "provision_auth requires allow_db_mutation=true"
+            exit 1
+          fi
 
           for required in DEPLOY_HOST DEPLOY_USER PUBLIC_URL DEPLOY_SSH_KEY TF_PROVISIONED_AUTH_EMAIL TF_PROVISIONED_AUTH_PASSWORD; do
             if [ -z "${!required:-}" ]; then
@@ -126,6 +142,7 @@ jobs:
             printf 'FRONTEND_IMAGE=%s\n' "$FRONTEND_IMAGE"
             printf 'DEPLOYED_AT=%s\n' "$DEPLOYED_AT"
             printf 'ASPNETCORE_ENV_LABEL=%s\n' "$ASPNETCORE_ENV_LABEL"
+            printf 'TF_SKIP_AUTO_MIGRATE=%s\n' "$TF_SKIP_AUTO_MIGRATE"
             printf 'TF_EXPECTED_JUNE10_DB_NAME=%s\n' "$TF_EXPECTED_JUNE10_DB_NAME"
             printf 'TF_EXPECTED_JUNE10_DB_PROVIDER=%s\n' "$TF_EXPECTED_JUNE10_DB_PROVIDER"
           } >> "$GITHUB_ENV"
@@ -274,6 +291,7 @@ jobs:
           TF_PUBLIC_HOST=${PUBLIC_HOST}
           TF_BACKEND_IMAGE=${BACKEND_IMAGE}
           TF_FRONTEND_IMAGE=${FRONTEND_IMAGE}
+          TF_SKIP_AUTO_MIGRATE=${TF_SKIP_AUTO_MIGRATE}
           TF_EXPECTED_JUNE10_DB_NAME=${TF_EXPECTED_JUNE10_DB_NAME}
           TF_EXPECTED_JUNE10_DB_PROVIDER=${TF_EXPECTED_JUNE10_DB_PROVIDER}
           EOF

--- a/backend/src/TerraFusion.API/HostedServices/AutoMigrateHostedService.cs
+++ b/backend/src/TerraFusion.API/HostedServices/AutoMigrateHostedService.cs
@@ -22,17 +22,26 @@ public sealed class AutoMigrateHostedService : IHostedService
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<AutoMigrateHostedService> _logger;
+    private readonly IConfiguration _configuration;
 
     public AutoMigrateHostedService(
         IServiceScopeFactory scopeFactory,
-        ILogger<AutoMigrateHostedService> logger)
+        ILogger<AutoMigrateHostedService> logger,
+        IConfiguration configuration)
     {
         _scopeFactory = scopeFactory;
         _logger = logger;
+        _configuration = configuration;
     }
 
     public async Task StartAsync(CancellationToken ct)
     {
+        if (_configuration.GetValue<bool>("TF_SKIP_AUTO_MIGRATE"))
+        {
+            _logger.LogInformation("AutoMigrate skipped because TF_SKIP_AUTO_MIGRATE=true");
+            return;
+        }
+
         try
         {
             using var scope = _scopeFactory.CreateScope();

--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -2336,17 +2336,25 @@ using (var scope = app.Services.CreateScope())
 {
   try
   {
-    var databaseInitializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializationService>();
-    await databaseInitializer.InitializeAsync();
+    if (app.Configuration.GetValue<bool>("TF_SKIP_AUTO_MIGRATE"))
+    {
+      var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("StartupDatabaseMutation");
+      logger.LogInformation("Startup database mutation skipped because TF_SKIP_AUTO_MIGRATE=true");
+    }
+    else
+    {
+      var databaseInitializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializationService>();
+      await databaseInitializer.InitializeAsync();
 
-    var dbContext = scope.ServiceProvider.GetRequiredService<TerraFusion.Data.TerraFusionDbContext>();
-    var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("GPTSeeder");
+      var dbContext = scope.ServiceProvider.GetRequiredService<TerraFusion.Data.TerraFusionDbContext>();
+      var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("GPTSeeder");
 
-    var seeder = new TerraFusion.AI.Seeds.GPTConfigurationSeeder(dbContext,
-        scope.ServiceProvider.GetRequiredService<ILogger<TerraFusion.AI.Seeds.GPTConfigurationSeeder>>());
-    await seeder.SeedAllGPTsAsync();
+      var seeder = new TerraFusion.AI.Seeds.GPTConfigurationSeeder(dbContext,
+          scope.ServiceProvider.GetRequiredService<ILogger<TerraFusion.AI.Seeds.GPTConfigurationSeeder>>());
+      await seeder.SeedAllGPTsAsync();
 
-    logger.LogInformation("GPT configurations seeded successfully");
+      logger.LogInformation("GPT configurations seeded successfully");
+    }
   }
   catch (Exception ex)
   {

--- a/backend/src/TerraFusion.API/Services/DatabaseInitializationService.cs
+++ b/backend/src/TerraFusion.API/Services/DatabaseInitializationService.cs
@@ -17,20 +17,31 @@ public class DatabaseInitializationService : IDatabaseInitializationService
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ILogger<DatabaseInitializationService> _logger;
+    private readonly IConfiguration _configuration;
     private bool _isInitialized = false;
     private bool _isInitializing = false;
     private string _lastError = string.Empty;
 
     public DatabaseInitializationService(
         IServiceScopeFactory serviceScopeFactory,
-        ILogger<DatabaseInitializationService> logger)
+        ILogger<DatabaseInitializationService> logger,
+        IConfiguration configuration)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
+        _configuration = configuration;
     }
 
     public async System.Threading.Tasks.Task InitializeAsync()
     {
+        if (_configuration.GetValue<bool>("TF_SKIP_AUTO_MIGRATE"))
+        {
+            _isInitialized = true;
+            _lastError = string.Empty;
+            _logger.LogInformation("Startup database initialization skipped because TF_SKIP_AUTO_MIGRATE=true");
+            return;
+        }
+
         if (_isInitialized || _isInitializing)
         {
             _logger.LogInformation("Database already initialized or initializing");

--- a/backend/tests/TerraFusion.Unit.Tests/HostedServices/AutoMigrateHostedServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/HostedServices/AutoMigrateHostedServiceTests.cs
@@ -42,7 +42,10 @@ public sealed class AutoMigrateHostedServiceTests
         var provider = services.BuildServiceProvider();
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
         var logger = new CapturingLogger<AutoMigrateHostedService>();
-        var svc = new AutoMigrateHostedService(scopeFactory, logger);
+        var svc = new AutoMigrateHostedService(
+            scopeFactory,
+            logger,
+            provider.GetRequiredService<IConfiguration>());
         return (svc, logger);
     }
 
@@ -53,7 +56,7 @@ public sealed class AutoMigrateHostedServiceTests
         // a misconfigured DI graph or a transient resolution failure.
         var scopeFactory = new ThrowingScopeFactory(new InvalidOperationException("boom"));
         var logger = new CapturingLogger<AutoMigrateHostedService>();
-        var svc = new AutoMigrateHostedService(scopeFactory, logger);
+        var svc = new AutoMigrateHostedService(scopeFactory, logger, new ConfigurationBuilder().Build());
 
         // Act: must not throw.
         Func<Task> act = () => svc.StartAsync(CancellationToken.None);
@@ -108,7 +111,7 @@ public sealed class AutoMigrateHostedServiceTests
         // Arrange: any service instance — StopAsync has no work to do.
         var scopeFactory = new ThrowingScopeFactory(new InvalidOperationException("never reached"));
         var logger = new CapturingLogger<AutoMigrateHostedService>();
-        var svc = new AutoMigrateHostedService(scopeFactory, logger);
+        var svc = new AutoMigrateHostedService(scopeFactory, logger, new ConfigurationBuilder().Build());
 
         // Act.
         var task = svc.StopAsync(CancellationToken.None);
@@ -119,6 +122,28 @@ public sealed class AutoMigrateHostedServiceTests
         await task; // sanity: does not throw.
         logger.Entries.Should().BeEmpty(
             because: "StopAsync should not log anything");
+    }
+
+    [Fact]
+    public async Task StartAsync_when_skip_auto_migrate_true_does_not_create_a_database_scope()
+    {
+        var scopeFactory = new ThrowingScopeFactory(new InvalidOperationException("database mutation attempted"));
+        var logger = new CapturingLogger<AutoMigrateHostedService>();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TF_SKIP_AUTO_MIGRATE"] = "true",
+            })
+            .Build();
+        var svc = new AutoMigrateHostedService(scopeFactory, logger, configuration);
+
+        Func<Task> act = () => svc.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync("production release lanes must be able to boot without auto migration");
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("TF_SKIP_AUTO_MIGRATE=true"));
+        logger.Entries.Should().NotContain(e => e.Level >= LogLevel.Warning);
     }
 
     // ------------------------------------------------------------------------

--- a/backend/tests/TerraFusion.Unit.Tests/Services/DatabaseInitializationServiceNoMutationTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Services/DatabaseInitializationServiceNoMutationTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TerraFusion.API.Services;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Services;
+
+public sealed class DatabaseInitializationServiceNoMutationTests
+{
+    [Fact]
+    public async Task InitializeAsync_when_skip_auto_migrate_true_does_not_create_a_database_scope()
+    {
+        var scopeFactory = new ThrowingScopeFactory(new InvalidOperationException("database mutation attempted"));
+        var logger = new CapturingLogger<DatabaseInitializationService>();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TF_SKIP_AUTO_MIGRATE"] = "true",
+            })
+            .Build();
+
+        var service = new DatabaseInitializationService(scopeFactory, logger, configuration);
+
+        Func<Task> act = () => service.InitializeAsync();
+
+        await act.Should().NotThrowAsync("production release lanes must be able to boot without startup DB mutation");
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("TF_SKIP_AUTO_MIGRATE=true"));
+        logger.Entries.Should().NotContain(e =>
+            e.Level >= LogLevel.Warning,
+            "the skip path must not touch the database scope or report initialization failure");
+    }
+
+    private sealed class ThrowingScopeFactory : IServiceScopeFactory
+    {
+        private readonly Exception _exception;
+
+        public ThrowingScopeFactory(Exception exception) => _exception = exception;
+
+        public IServiceScope CreateScope() => throw _exception;
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = new();
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+}

--- a/ops/prod/runtime-compose.template.yml
+++ b/ops/prod/runtime-compose.template.yml
@@ -31,6 +31,7 @@ services:
       DatabaseProvider: Sqlite
       ConnectionStrings__DefaultConnection: Data Source=data/terrafusion.db
       TF_STATE_MESH_ENFORCE: 'true'
+      TF_SKIP_AUTO_MIGRATE: ${TF_SKIP_AUTO_MIGRATE:-true}
     volumes:
       - ./data:/app/data
       - ./docs/spec-lock:/app/docs/spec-lock:ro

--- a/scripts/release-lane-no-mutation.contract.test.mjs
+++ b/scripts/release-lane-no-mutation.contract.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+const releaseLane = readFileSync(join(ROOT, '.github', 'workflows', 'release-lane.yml'), 'utf8');
+const runtimeCompose = readFileSync(
+  join(ROOT, 'ops', 'prod', 'runtime-compose.template.yml'),
+  'utf8'
+);
+const autoMigrateHostedService = readFileSync(
+  join(ROOT, 'backend', 'src', 'TerraFusion.API', 'HostedServices', 'AutoMigrateHostedService.cs'),
+  'utf8'
+);
+const databaseInitializationService = readFileSync(
+  join(ROOT, 'backend', 'src', 'TerraFusion.API', 'Services', 'DatabaseInitializationService.cs'),
+  'utf8'
+);
+const program = readFileSync(join(ROOT, 'backend', 'src', 'TerraFusion.API', 'Program.cs'), 'utf8');
+
+describe('release lane no-mutation guard', () => {
+  it('requires explicit approval before the release lane permits DB mutation', () => {
+    assert.match(releaseLane, /allow_db_mutation:[\s\S]*?default:\s*false/);
+    assert.ok(releaseLane.includes('ALLOW_DB_MUTATION: ${{ inputs.allow_db_mutation }}'));
+    assert.ok(releaseLane.includes('TF_SKIP_AUTO_MIGRATE=true'));
+    assert.ok(releaseLane.includes('TF_SKIP_AUTO_MIGRATE=${TF_SKIP_AUTO_MIGRATE}'));
+  });
+
+  it('blocks AuthProvisioner unless mutation approval is also present', () => {
+    assert.ok(releaseLane.includes('PROVISION_AUTH'));
+    assert.ok(releaseLane.includes('ALLOW_DB_MUTATION'));
+    assert.ok(releaseLane.includes('provision_auth requires allow_db_mutation=true'));
+  });
+
+  it('defaults runtime compose to skip startup migration and initialization mutation', () => {
+    assert.ok(runtimeCompose.includes('TF_SKIP_AUTO_MIGRATE: ${TF_SKIP_AUTO_MIGRATE:-true}'));
+  });
+
+  it('backend startup code honors TF_SKIP_AUTO_MIGRATE before creating mutation scopes', () => {
+    assert.ok(autoMigrateHostedService.includes('GetValue<bool>("TF_SKIP_AUTO_MIGRATE")'));
+    assert.ok(databaseInitializationService.includes('GetValue<bool>("TF_SKIP_AUTO_MIGRATE")'));
+    assert.ok(program.includes('GetValue<bool>("TF_SKIP_AUTO_MIGRATE")'));
+
+    const guardIndex = program.indexOf('GetValue<bool>("TF_SKIP_AUTO_MIGRATE")');
+    const seederIndex = program.indexOf('GPTConfigurationSeeder');
+    assert.ok(
+      guardIndex >= 0 && seederIndex > guardIndex,
+      'Program.cs must check TF_SKIP_AUTO_MIGRATE before GPT seeding can write to DB'
+    );
+
+    const dbInitGuardIndex = databaseInitializationService.indexOf(
+      'GetValue<bool>("TF_SKIP_AUTO_MIGRATE")'
+    );
+    const createScopeIndex = databaseInitializationService.indexOf('CreateScope()');
+    assert.ok(
+      dbInitGuardIndex >= 0 && createScopeIndex > dbInitGuardIndex,
+      'DatabaseInitializationService must check TF_SKIP_AUTO_MIGRATE before creating a DB scope'
+    );
+  });
+});

--- a/tests/deployment-truth-gate.test.mjs
+++ b/tests/deployment-truth-gate.test.mjs
@@ -301,6 +301,47 @@ describe('D. CI release gate coverage', () => {
     assert.ok(hasTest, 'PR gate must include test step');
     assert.ok(hasLint, 'PR gate must include lint step');
   });
+
+  it('D8: release-lane.yml defaults production startup database mutation off', () => {
+    const content = readFileSync(join(WORKFLOWS, 'release-lane.yml'), 'utf8');
+    assert.ok(
+      content.includes('allow_db_mutation:'),
+      'Release lane must expose explicit allow_db_mutation approval',
+    );
+    assert.match(
+      content,
+      /allow_db_mutation:[\s\S]*?default:\s*false/,
+      'allow_db_mutation must default to false',
+    );
+    assert.ok(
+      content.includes('TF_SKIP_AUTO_MIGRATE=true'),
+      'Release lane must write TF_SKIP_AUTO_MIGRATE=true when mutation is not approved',
+    );
+    assert.ok(
+      content.includes('TF_SKIP_AUTO_MIGRATE=${TF_SKIP_AUTO_MIGRATE}'),
+      'Runtime release.env must carry the resolved startup mutation guard',
+    );
+  });
+
+  it('D9: release-lane.yml refuses AuthProvisioner without mutation approval', () => {
+    const content = readFileSync(join(WORKFLOWS, 'release-lane.yml'), 'utf8');
+    assert.ok(
+      content.includes('PROVISION_AUTH') && content.includes('ALLOW_DB_MUTATION'),
+      'Release lane must validate provision_auth against allow_db_mutation',
+    );
+    assert.ok(
+      content.includes('provision_auth requires allow_db_mutation=true'),
+      'Release lane must fail fast when AuthProvisioner is requested without mutation approval',
+    );
+  });
+
+  it('D10: runtime compose keeps startup migrations disabled unless release lane opts in', () => {
+    const content = readFileSync(join(ROOT, 'ops', 'prod', 'runtime-compose.template.yml'), 'utf8');
+    assert.ok(
+      content.includes("TF_SKIP_AUTO_MIGRATE: ${TF_SKIP_AUTO_MIGRATE:-true}"),
+      'Runtime compose must default TF_SKIP_AUTO_MIGRATE to true',
+    );
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add a release-lane `allow_db_mutation` input defaulting to false.
- Set `TF_SKIP_AUTO_MIGRATE=true` in runtime releases unless DB mutation is explicitly approved.
- Fail fast if `provision_auth=true` is requested without `allow_db_mutation=true`.
- Make backend startup initialization, GPT seeding, and AutoMigrate honor `TF_SKIP_AUTO_MIGRATE` before creating DB mutation scopes.
- Add focused no-mutation contract tests plus release-lane deployment truth assertions.

## Verification
- `node --test scripts/release-lane-no-mutation.contract.test.mjs`
- `node --test --test-name-pattern D8 tests/deployment-truth-gate.test.mjs`
- `node --test --test-name-pattern D9 tests/deployment-truth-gate.test.mjs`
- `node --test --test-name-pattern D10 tests/deployment-truth-gate.test.mjs`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release`
- `pnpm run type-check`
- `pnpm --dir frontend exec vitest run apps/os-shell/src/__tests__/forge/terraforgeProductionMatrix.contract.test.ts apps/os-shell/src/__tests__/forge/terraforgeRuntimeAudit.contract.test.ts apps/os-shell/src/__tests__/forge/terraforgeCanonicalInventory.contract.test.tsx apps/os-shell/src/__tests__/forge/forgeSuiteHome.contract.test.tsx apps/os-shell/src/__tests__/forge/terraforgeModuleBoundaries.contract.test.ts apps/os-shell/src/__tests__/forge/forgeSuiteSourceHonesty.contract.test.tsx apps/os-shell/src/__tests__/shell/forgeSuiteSourceHonesty.contract.test.tsx`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `git diff --check`
- push hook: unit tests, security scan, performance benchmark, AI swarm monitor, compliance lint, backend solution build/publish all passed

## Note
- `dotnet test backend/tests/TerraFusion.Unit.Tests/TerraFusion.Unit.Tests.csproj --filter "FullyQualifiedName~DatabaseInitializationServiceNoMutationTests|FullyQualifiedName~AutoMigrateHostedServiceTests" --no-restore` is blocked by existing unrelated compile errors in `PacsImprvCanonicalProjectorTests`, `PacsSaleTruthPromoterTests`, `PacsImprvCurrentTruthPromoterTests`, and `ParcelGeometryNeighborControllerTests`; the new constructor errors are gone and the API build passes.