### PR TITLE
ci(forge): add production matrix proof workflow

### DIFF
--- a/.github/workflows/terraforge-production-matrix-proof.yml
+++ b/.github/workflows/terraforge-production-matrix-proof.yml
@@ -1,0 +1,93 @@
+name: terraforge-production-matrix-proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Deployed release SHA expected from /health
+        required: true
+        type: string
+      base_url:
+        description: Production public URL; defaults to production PUBLIC_URL variable
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  proof:
+    name: TerraForge production matrix proof
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      INPUT_BASE_URL: ${{ inputs.base_url }}
+      PRODUCTION_PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+      TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}
+      TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}
+    steps:
+      - name: Checkout deployed release SHA
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Enable pnpm
+        shell: bash
+        run: corepack enable
+
+      - name: Install dependencies
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Resolve production proof inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_url="${INPUT_BASE_URL:-${PRODUCTION_PUBLIC_URL:-}}"
+          base_url="${base_url%/}"
+
+          if [ -z "$base_url" ]; then
+            echo "Missing production base URL. Set workflow input base_url or production PUBLIC_URL variable."
+            exit 1
+          fi
+
+          for required in RELEASE_SHA TF_PROVISIONED_AUTH_EMAIL TF_PROVISIONED_AUTH_PASSWORD; do
+            if [ -z "${!required:-}" ]; then
+              echo "Missing required production proof input: ${required}"
+              exit 1
+            fi
+          done
+
+          {
+            printf 'TF_PRODUCTION_BASE_URL=%s\n' "$base_url"
+            printf 'TF_EXPECTED_RELEASE_SHA=%s\n' "$RELEASE_SHA"
+          } >> "$GITHUB_ENV"
+
+      - name: Run TerraForge production matrix smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/terraforge-production-matrix-smoke.mjs \
+            --base-url "$TF_PRODUCTION_BASE_URL" \
+            --expected-sha "$TF_EXPECTED_RELEASE_SHA" \
+            --output "artifacts/terraforge-production-matrix/${TF_EXPECTED_RELEASE_SHA}"
+
+      - name: Upload TerraForge production proof
+        uses: actions/upload-artifact@v7
+        with:
+          name: terraforge-production-matrix-proof-${{ inputs.release_sha }}
+          path: artifacts/terraforge-production-matrix/${{ inputs.release_sha }}/
+          if-no-files-found: error

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const workflow = readFileSync(
+  join(ROOT, '.github', 'workflows', 'terraforge-production-matrix-proof.yml'),
+  'utf8',
+);
+
+describe('TerraForge production proof workflow', () => {
+  it('is manual, production-scoped, and checks out the deployed release SHA', () => {
+    assert.ok(workflow.includes('workflow_dispatch:'));
+    assert.ok(workflow.includes('environment: production'));
+    assert.ok(workflow.includes('ref: ${{ inputs.release_sha }}'));
+    assert.ok(workflow.includes('TF_EXPECTED_RELEASE_SHA=%s'));
+  });
+
+  it('runs the authenticated TerraForge production matrix smoke with production secrets', () => {
+    assert.ok(workflow.includes('TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}'));
+    assert.ok(workflow.includes('TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}'));
+    assert.ok(workflow.includes('node scripts/terraforge-production-matrix-smoke.mjs'));
+    assert.ok(workflow.includes('--expected-sha "$TF_EXPECTED_RELEASE_SHA"'));
+  });
+
+  it('does not contain deploy, provisioner, or DB mutation paths', () => {
+    assert.doesNotMatch(workflow, /docker compose .*up -d/);
+    assert.doesNotMatch(workflow, /AuthProvisioner/);
+    assert.doesNotMatch(workflow, /allow_db_mutation/i);
+    assert.doesNotMatch(workflow, /MigrateAsync|database update|SaveChangesAsync/i);
+  });
+
+  it('uploads durable TerraForge production proof artifacts', () => {
+    assert.ok(workflow.includes('actions/upload-artifact@v7'));
+    assert.ok(workflow.includes('terraforge-production-matrix-proof-${{ inputs.release_sha }}'));
+    assert.ok(workflow.includes('if-no-files-found: error'));
+  });
+});


### PR DESCRIPTION
## Summary
- Add a manual production-scoped TerraForge matrix proof workflow.
- The workflow checks out the deployed release SHA, uses production auth secrets, runs `scripts/terraforge-production-matrix-smoke.mjs`, and uploads proof artifacts.
- Add a focused contract test ensuring the workflow has no deploy/provisioner/DB mutation path.

## Verification
- `node --test scripts/terraforge-production-proof-workflow.contract.test.mjs`
- `node --check scripts/terraforge-production-matrix-smoke.mjs`
- `git diff --check`