### PR TITLE
ci(forge): expose production matrix proof workflow

### DIFF
--- a/.github/workflows/terraforge-production-matrix-proof.yml
+++ b/.github/workflows/terraforge-production-matrix-proof.yml
@@ -1,0 +1,93 @@
+name: terraforge-production-matrix-proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Deployed release SHA expected from /health
+        required: true
+        type: string
+      base_url:
+        description: Production public URL; defaults to production PUBLIC_URL variable
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  proof:
+    name: TerraForge production matrix proof
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      INPUT_BASE_URL: ${{ inputs.base_url }}
+      PRODUCTION_PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+      TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}
+      TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}
+    steps:
+      - name: Checkout deployed release SHA
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Enable pnpm
+        shell: bash
+        run: corepack enable
+
+      - name: Install dependencies
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Resolve production proof inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_url="${INPUT_BASE_URL:-${PRODUCTION_PUBLIC_URL:-}}"
+          base_url="${base_url%/}"
+
+          if [ -z "$base_url" ]; then
+            echo "Missing production base URL. Set workflow input base_url or production PUBLIC_URL variable."
+            exit 1
+          fi
+
+          for required in RELEASE_SHA TF_PROVISIONED_AUTH_EMAIL TF_PROVISIONED_AUTH_PASSWORD; do
+            if [ -z "${!required:-}" ]; then
+              echo "Missing required production proof input: ${required}"
+              exit 1
+            fi
+          done
+
+          {
+            printf 'TF_PRODUCTION_BASE_URL=%s\n' "$base_url"
+            printf 'TF_EXPECTED_RELEASE_SHA=%s\n' "$RELEASE_SHA"
+          } >> "$GITHUB_ENV"
+
+      - name: Run TerraForge production matrix smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/terraforge-production-matrix-smoke.mjs \
+            --base-url "$TF_PRODUCTION_BASE_URL" \
+            --expected-sha "$TF_EXPECTED_RELEASE_SHA" \
+            --output "artifacts/terraforge-production-matrix/${TF_EXPECTED_RELEASE_SHA}"
+
+      - name: Upload TerraForge production proof
+        uses: actions/upload-artifact@v7
+        with:
+          name: terraforge-production-matrix-proof-${{ inputs.release_sha }}
+          path: artifacts/terraforge-production-matrix/${{ inputs.release_sha }}/
+          if-no-files-found: error

--- a/.github/workflows/terraforge-production-matrix-proof.yml
+++ b/.github/workflows/terraforge-production-matrix-proof.yml
@@ -29,16 +29,25 @@ jobs:
       TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}
     steps:
       - name: Checkout deployed release SHA
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify release contains TerraForge proof smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f scripts/terraforge-production-matrix-smoke.mjs || {
+            echo "Release SHA does not contain scripts/terraforge-production-matrix-smoke.mjs"
+            exit 1
+          }
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
-          cache: pnpm
 
       - name: Enable pnpm
         shell: bash
@@ -58,9 +67,26 @@ jobs:
           set -euo pipefail
           base_url="${INPUT_BASE_URL:-${PRODUCTION_PUBLIC_URL:-}}"
           base_url="${base_url%/}"
+          trusted_url="${PRODUCTION_PUBLIC_URL:-}"
+          trusted_url="${trusted_url%/}"
 
           if [ -z "$base_url" ]; then
             echo "Missing production base URL. Set workflow input base_url or production PUBLIC_URL variable."
+            exit 1
+          fi
+
+          if [ -z "$trusted_url" ]; then
+            echo "Missing production PUBLIC_URL variable; refusing to run production proof with secrets."
+            exit 1
+          fi
+
+          if [[ "$base_url" != https://* ]]; then
+            echo "Production base URL must use https."
+            exit 1
+          fi
+
+          if [ "$base_url" != "$trusted_url" ]; then
+            echo "base_url must match production PUBLIC_URL before using production secrets."
             exit 1
           fi
 
@@ -86,7 +112,7 @@ jobs:
             --output "artifacts/terraforge-production-matrix/${TF_EXPECTED_RELEASE_SHA}"
 
       - name: Upload TerraForge production proof
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: terraforge-production-matrix-proof-${{ inputs.release_sha }}
           path: artifacts/terraforge-production-matrix/${{ inputs.release_sha }}/

--- a/scripts/terraforge-production-matrix-smoke.mjs
+++ b/scripts/terraforge-production-matrix-smoke.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const PRIMARY_CAPABILITIES = [
+  ['costforge', 'CostForge'],
+  ['compsforge', 'CompsForge'],
+  ['salesforge', 'SalesForge'],
+  ['incomeforge', 'IncomeForge'],
+  ['reconciliation', 'Reconciliation'],
+  ['calibration-qc', 'Calibration / QC'],
+  ['cama-characteristics', 'CAMA Characteristics'],
+  ['valuation-notes-defensibility', 'Valuation Notes / Defensibility'],
+];
+
+const SUPPORT_CAPABILITIES = [
+  'batch-cost-runs',
+  'regression-studio',
+  'county-studio',
+  'coefficient-preview',
+  'current-use-support',
+];
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  return process.argv[index + 1];
+}
+
+function normalizeBaseUrl(raw) {
+  if (!raw) {
+    throw new Error('Missing --base-url or TF_PRODUCTION_BASE_URL.');
+  }
+  const parsed = new URL(raw);
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function requireSecret(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}.`);
+  }
+  return value;
+}
+
+async function writeEvidence(outputDir, evidence) {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, 'terraforge-production-matrix-proof.json'),
+    `${JSON.stringify(evidence, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(outputDir, 'terraforge-production-matrix-proof.md'),
+    [
+      '# TerraForge Production Matrix Proof',
+      '',
+      `Status: \`${evidence.status}\``,
+      `Checked: \`${evidence.checkedAt}\``,
+      `Base URL: \`${evidence.baseUrl}\``,
+      `Release SHA: \`${evidence.releaseSha ?? 'not-reported'}\``,
+      '',
+      '## Primary Capabilities',
+      '',
+      ...evidence.primaryCapabilities.map(
+        capability =>
+          `- ${capability.label}: card=${capability.cardVisible ? 'visible' : 'missing'}, launch=${capability.launchActionable ? 'actionable' : 'blocked'}`,
+      ),
+      '',
+      '## Support / Deferred',
+      '',
+      ...evidence.supportCapabilities.map(
+        capability =>
+          `- ${capability.id}: ${capability.visible ? 'visible outside primary proof' : 'missing'}`,
+      ),
+      '',
+      '## Guardrails',
+      '',
+      `- Workbench counted as proof: \`${evidence.guardrails.workbenchCountedAsProof}\``,
+      `- Endpoint-only proof accepted: \`${evidence.guardrails.endpointOnlyProofAccepted}\``,
+      `- PACS-facing runtime text: \`${evidence.guardrails.pacsRuntimeTextFound}\``,
+      '',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  const baseUrl = normalizeBaseUrl(readArg('--base-url') ?? process.env.TF_PRODUCTION_BASE_URL);
+  const expectedReleaseSha = readArg('--expected-sha') ?? process.env.TF_EXPECTED_RELEASE_SHA;
+  const email = requireSecret('TF_PROVISIONED_AUTH_EMAIL');
+  const password = requireSecret('TF_PROVISIONED_AUTH_PASSWORD');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outputDir =
+    readArg('--output') ?? path.join('artifacts', 'terraforge-production-matrix', stamp);
+
+  const { chromium } = await import('playwright');
+  const browser = await chromium.launch({ headless: process.env.TF_SMOKE_HEADLESS !== '0' });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  const evidence = {
+    status: 'FAIL',
+    checkedAt: new Date().toISOString(),
+    baseUrl,
+    releaseSha: null,
+    primaryCapabilities: [],
+    supportCapabilities: [],
+    guardrails: {
+      workbenchCountedAsProof: false,
+      endpointOnlyProofAccepted: false,
+      pacsRuntimeTextFound: false,
+    },
+    errors: [],
+  };
+
+  try {
+    const healthResponse = await page.request.get(`${baseUrl}/health`, { timeout: 15000 });
+    evidence.releaseSha = healthResponse.headers()['x-release-sha'] ?? null;
+    if (!healthResponse.ok()) {
+      throw new Error(`/health returned HTTP ${healthResponse.status()}`);
+    }
+    if (expectedReleaseSha && evidence.releaseSha !== expectedReleaseSha) {
+      throw new Error(
+        `Expected X-Release-Sha ${expectedReleaseSha}, got ${evidence.releaseSha ?? 'missing'}`,
+      );
+    }
+
+    await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' });
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: /enter terrafusion os/i }).click();
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => undefined);
+
+    await page.goto(`${baseUrl}/forge`, { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('suite-forge-root').waitFor({ timeout: 30000 });
+    await page.getByTestId('forge-primary-applications').waitFor({ timeout: 30000 });
+    await page.getByTestId('forge-support-applications').waitFor({ timeout: 30000 });
+
+    const bodyText = await page.locator('body').innerText();
+    evidence.guardrails.pacsRuntimeTextFound = /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
+    evidence.guardrails.workbenchCountedAsProof = /\/property\/[^/\s]+\/forge/.test(bodyText);
+
+    for (const [id, label] of PRIMARY_CAPABILITIES) {
+      const card = page.locator(
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="primary-required"]`,
+      );
+      const cardVisible = await card.isVisible();
+      let launchActionable = false;
+      if (cardVisible) {
+        await card.click({ trial: true, timeout: 10000 });
+        launchActionable = !(await card.isDisabled());
+      }
+      evidence.primaryCapabilities.push({ id, label, cardVisible, launchActionable });
+    }
+
+    for (const id of SUPPORT_CAPABILITIES) {
+      const card = page.locator(
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="support-or-deferred"]`,
+      );
+      evidence.supportCapabilities.push({ id, visible: await card.isVisible() });
+    }
+
+    const missingPrimary = evidence.primaryCapabilities.filter(
+      capability => !capability.cardVisible || !capability.launchActionable,
+    );
+    const missingSupport = evidence.supportCapabilities.filter(capability => !capability.visible);
+
+    if (missingPrimary.length > 0) {
+      throw new Error(
+        `Primary TerraForge capability proof failed: ${missingPrimary.map(item => item.id).join(', ')}`,
+      );
+    }
+    if (missingSupport.length > 0) {
+      throw new Error(
+        `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`,
+      );
+    }
+    if (evidence.guardrails.pacsRuntimeTextFound) {
+      throw new Error('PACS-facing runtime text found on /forge.');
+    }
+    if (evidence.guardrails.workbenchCountedAsProof) {
+      throw new Error('Workbench parcel-scoped route appeared in TerraForge suite proof.');
+    }
+    if (pageErrors.length > 0) {
+      throw new Error(`Browser page errors: ${pageErrors.join(' | ')}`);
+    }
+
+    evidence.status = 'PASS';
+  } catch (error) {
+    evidence.errors.push(error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    await mkdir(outputDir, { recursive: true }).catch(() => undefined);
+    await page
+      .screenshot({
+        path: path.join(outputDir, 'terraforge-production-matrix.png'),
+        fullPage: true,
+      })
+      .catch(() => undefined);
+    await browser.close();
+    await writeEvidence(outputDir, evidence);
+    process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '..');
@@ -8,6 +8,7 @@ const workflow = readFileSync(
   join(ROOT, '.github', 'workflows', 'terraforge-production-matrix-proof.yml'),
   'utf8',
 );
+const smokeScriptPath = join(ROOT, 'scripts', 'terraforge-production-matrix-smoke.mjs');
 
 describe('TerraForge production proof workflow', () => {
   it('is manual, production-scoped, and checks out the deployed release SHA', () => {
@@ -19,6 +20,7 @@ describe('TerraForge production proof workflow', () => {
   });
 
   it('runs the authenticated TerraForge production matrix smoke with production secrets', () => {
+    assert.ok(existsSync(smokeScriptPath));
     assert.ok(workflow.includes('TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}'));
     assert.ok(workflow.includes('TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}'));
     assert.ok(workflow.includes('test -f scripts/terraforge-production-matrix-smoke.mjs'));

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const workflow = readFileSync(
+  join(ROOT, '.github', 'workflows', 'terraforge-production-matrix-proof.yml'),
+  'utf8',
+);
+
+describe('TerraForge production proof workflow', () => {
+  it('is manual, production-scoped, and checks out the deployed release SHA', () => {
+    assert.ok(workflow.includes('workflow_dispatch:'));
+    assert.ok(workflow.includes('environment: production'));
+    assert.ok(workflow.includes('ref: ${{ inputs.release_sha }}'));
+    assert.ok(workflow.includes('TF_EXPECTED_RELEASE_SHA=%s'));
+  });
+
+  it('runs the authenticated TerraForge production matrix smoke with production secrets', () => {
+    assert.ok(workflow.includes('TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}'));
+    assert.ok(workflow.includes('TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}'));
+    assert.ok(workflow.includes('node scripts/terraforge-production-matrix-smoke.mjs'));
+    assert.ok(workflow.includes('--expected-sha "$TF_EXPECTED_RELEASE_SHA"'));
+  });
+
+  it('does not contain deploy, provisioner, or DB mutation paths', () => {
+    assert.doesNotMatch(workflow, /docker compose .*up -d/);
+    assert.doesNotMatch(workflow, /AuthProvisioner/);
+    assert.doesNotMatch(workflow, /allow_db_mutation/i);
+    assert.doesNotMatch(workflow, /MigrateAsync|database update|SaveChangesAsync/i);
+  });
+
+  it('uploads durable TerraForge production proof artifacts', () => {
+    assert.ok(workflow.includes('actions/upload-artifact@v7'));
+    assert.ok(workflow.includes('terraforge-production-matrix-proof-${{ inputs.release_sha }}'));
+    assert.ok(workflow.includes('if-no-files-found: error'));
+  });
+});

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -14,14 +14,36 @@ describe('TerraForge production proof workflow', () => {
     assert.ok(workflow.includes('workflow_dispatch:'));
     assert.ok(workflow.includes('environment: production'));
     assert.ok(workflow.includes('ref: ${{ inputs.release_sha }}'));
+    assert.ok(workflow.includes('persist-credentials: false'));
     assert.ok(workflow.includes('TF_EXPECTED_RELEASE_SHA=%s'));
   });
 
   it('runs the authenticated TerraForge production matrix smoke with production secrets', () => {
     assert.ok(workflow.includes('TF_PROVISIONED_AUTH_EMAIL: ${{ secrets.TF_PROVISIONED_AUTH_EMAIL }}'));
     assert.ok(workflow.includes('TF_PROVISIONED_AUTH_PASSWORD: ${{ secrets.TF_PROVISIONED_AUTH_PASSWORD }}'));
+    assert.ok(workflow.includes('test -f scripts/terraforge-production-matrix-smoke.mjs'));
     assert.ok(workflow.includes('node scripts/terraforge-production-matrix-smoke.mjs'));
     assert.ok(workflow.includes('--expected-sha "$TF_EXPECTED_RELEASE_SHA"'));
+  });
+
+  it('restricts production secrets to the trusted production URL', () => {
+    assert.ok(workflow.includes('Production base URL must use https.'));
+    assert.ok(workflow.includes('base_url must match production PUBLIC_URL before using production secrets.'));
+    assert.ok(workflow.includes('Missing production PUBLIC_URL variable; refusing to run production proof with secrets.'));
+  });
+
+  it('pins GitHub Actions and avoids persisted checkout credentials', () => {
+    const actionRefs = [...workflow.matchAll(/uses:\s*([^\s#]+)/g)].map((match) => match[1]);
+
+    assert.deepEqual(actionRefs, [
+      'actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd',
+      'actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444',
+      'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+    ]);
+
+    for (const actionRef of actionRefs) {
+      assert.match(actionRef, /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[a-f0-9]{40}$/);
+    }
   });
 
   it('does not contain deploy, provisioner, or DB mutation paths', () => {
@@ -32,7 +54,7 @@ describe('TerraForge production proof workflow', () => {
   });
 
   it('uploads durable TerraForge production proof artifacts', () => {
-    assert.ok(workflow.includes('actions/upload-artifact@v7'));
+    assert.ok(workflow.includes('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'));
     assert.ok(workflow.includes('terraforge-production-matrix-proof-${{ inputs.release_sha }}'));
     assert.ok(workflow.includes('if-no-files-found: error'));
   });


### PR DESCRIPTION
## Summary
- Add the manual TerraForge production matrix proof workflow to the default branch so GitHub can dispatch it.
- The workflow checks out the deployed release SHA before running the existing production smoke script from that SHA.
- Add a static contract test proving the workflow is proof-only: no deploy, provisioner, or DB mutation path.

## Verification
- `node --test scripts/terraforge-production-proof-workflow.contract.test.mjs`
- `git diff --check`

## Production safety
- No deployment step.
- No production DB mutation step.
- No AuthProvisioner.
- Uses production environment secrets only for authenticated smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually-triggered production matrix smoke test workflow that validates the deployed release (via the specified SHA) and production URL gating, then produces SHA-scoped proof artifacts (including screenshots and evidence).

* **Tests**
  * Added contract tests to ensure the production workflow enforces expected inputs, secret usage, URL trust checks, pinned GitHub Actions versions, and required artifact upload behavior.

* **New Features**
  * Introduced a Playwright-based production smoke test script that performs login/UI checks and writes structured evidence to an output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->