### PR TITLE
ci(forge): disable setup-node pnpm autocache

### DIFF
--- a/.github/workflows/terraforge-production-matrix-proof.yml
+++ b/.github/workflows/terraforge-production-matrix-proof.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
 
       - name: Enable pnpm
         shell: bash

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -37,6 +37,7 @@ describe('TerraForge production proof workflow', () => {
   it('pins GitHub Actions and avoids persisted checkout credentials', () => {
     const actionRefs = [...workflow.matchAll(/uses:\s*([^\s#]+)/g)].map((match) => match[1]);
 
+    assert.ok(workflow.includes('package-manager-cache: false'));
     assert.deepEqual(actionRefs, [
       'actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd',
       'actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444',

--- a/scripts/terraforge-production-proof-workflow.contract.test.mjs
+++ b/scripts/terraforge-production-proof-workflow.contract.test.mjs
@@ -34,7 +34,7 @@ describe('TerraForge production proof workflow', () => {
     assert.ok(workflow.includes('Missing production PUBLIC_URL variable; refusing to run production proof with secrets.'));
   });
 
-  it('pins GitHub Actions and avoids persisted checkout credentials', () => {
+  it('pins GitHub Actions and disables persisted or implicit package-manager credentials/cache', () => {
     const actionRefs = [...workflow.matchAll(/uses:\s*([^\s#]+)/g)].map((match) => match[1]);
 
     assert.ok(workflow.includes('package-manager-cache: false'));


### PR DESCRIPTION
## Summary
- disable setup-node package-manager auto cache for the production TerraForge proof workflow
- lock the no-autocache behavior in the workflow contract test

## Verification
- node --test scripts/terraforge-production-proof-workflow.contract.test.mjs
- git diff --check

## Production proof retry context
- Previous run: https://github.com/bsvalues/terrafusion_os_1.0/actions/runs/27626256790
- Failure: setup-node attempted to execute pnpm before Corepack enabled it
- This PR does not deploy, provision auth, or mutate DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment workflow configuration to explicitly disable package manager caching during Node.js environment setup.

* **Tests**
  * Enhanced workflow validation tests to verify package manager cache settings are correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->