### PR TITLE
docs(ops): preserve runtime production proof packet

### DIFF
--- a/os-platform/core/pilot/ops/post-phase25-release-authorization-packet-2026-03-19.md
+++ b/os-platform/core/pilot/ops/post-phase25-release-authorization-packet-2026-03-19.md
@@ -1,7 +1,7 @@
 # Post-Phase-25 Release Authorization Packet
 
 Date: 2026-03-19
-Updated: 2026-03-23
+Updated: 2026-06-16
 Status: READY
 Owner lane: Agent C
 Purpose: Reconcile sealed code/static proof with the remaining live pre-traffic conditions after Phase 25
@@ -16,6 +16,26 @@ Current decision:
 This is not a contradiction.
 
 The code, governance, and post-Phase-25 operating packet are sufficiently sealed to support release authorization work, but production traffic must remain closed until the live SRE/security pre-traffic conditions are executed and evidenced.
+
+## June 16, 2026 Runtime Proof Supersession
+
+The historical March hold context above remains part of the record, but it is no longer the current runtime-truth source for TerraFusion OS.
+
+Authenticated public production proof passed on 2026-06-16 and is preserved in:
+
+- `os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md`
+
+Current runtime-proof truth from that bundle:
+
+- acceptance run: `https://github.com/bsvalues/terrafusion_os_1.0/actions/runs/27640575591`
+- proved release SHA: `6f7755090a21efc90fee423fe35b8d72805ef1e5`
+- acceptance harness SHA: `2fa11f669bcc96f7758eb0518622b72b323fd01d`
+- authenticated TerraFusion OS acceptance: `PASS`
+- TerraForge production matrix: `PASS`
+- Workbench counted as suite proof: `false`
+- parcel-scoped workbench route used as proof: `false`
+- PACS-facing runtime text found: `false`
+- endpoint-only proof accepted: `false`
 
 ## Current Truth Sources
 
@@ -136,6 +156,7 @@ Primary sources reconciled in this packet:
 - `os-platform/core/pilot/ops/DEV-ADAPTER-README.md`
 - `os-platform/core/pilot/ops/dev-adapter-runbook-2026-03-23.md`
 - `os-platform/core/pilot/ops/local-agent-release-proof-2026-04-27.md`
+- `os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md`
 
 Traceability index:
 

--- a/os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md
+++ b/os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md
@@ -14,11 +14,13 @@
 The acceptance pass on 2026-06-16 is the first repo-owned, authenticated public production proof for the full TerraFusion OS route set after the realignment recovery work orders. That result needed a durable packet record so the exact run, release identity, and proof guardrails are preserved after PR #1038 merged.
 
 ## Proof
-- 2 passed | 0 failed | 0 skipped
+- 2 smoke proofs passed | 0 failed | 0 skipped
 - Files touched: `os-platform/core/pilot/ops/post-phase25-release-authorization-packet-2026-03-19.md`, `os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md`
 - Acceptance run: `https://github.com/bsvalues/terrafusion_os_1.0/actions/runs/27640575591`
 - Proved release SHA: `6f7755090a21efc90fee423fe35b8d72805ef1e5`
 - Acceptance harness SHA: `2fa11f669bcc96f7758eb0518622b72b323fd01d`
+- Authenticated TerraFusion OS acceptance: `PASS`
+- TerraForge production matrix: `PASS`
 
 ## Release Posture Impact
 posture tightened

--- a/os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md
+++ b/os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md
@@ -1,0 +1,27 @@
+# TerraFusion OS Runtime-Proven Production Pass — 2026-06-16
+
+**Classification**: Quality Lane — stabilization evidence packaging
+**Sealed at**: 2fa11f669bcc96f7758eb0518622b72b323fd01d (`2fa11f6`)
+
+---
+
+## What Changed
+- Added a dated ops evidence note that preserves the authenticated production acceptance run URL, the proved production release SHA, and the acceptance harness SHA.
+- Recorded the final proof guardrails that blocked the original failure modes: no Workbench substitution, no parcel-scoped substitution, no PACS runtime leakage, and no endpoint-only acceptance.
+- Wired this note into the active post-Phase-25 release authorization packet as the current runtime-proof reference.
+
+## Why It Changed
+The acceptance pass on 2026-06-16 is the first repo-owned, authenticated public production proof for the full TerraFusion OS route set after the realignment recovery work orders. That result needed a durable packet record so the exact run, release identity, and proof guardrails are preserved after PR #1038 merged.
+
+## Proof
+- 2 passed | 0 failed | 0 skipped
+- Files touched: `os-platform/core/pilot/ops/post-phase25-release-authorization-packet-2026-03-19.md`, `os-platform/core/pilot/ops/terrafusion-os-runtime-proven-production-pass-2026-06-16.md`
+- Acceptance run: `https://github.com/bsvalues/terrafusion_os_1.0/actions/runs/27640575591`
+- Proved release SHA: `6f7755090a21efc90fee423fe35b8d72805ef1e5`
+- Acceptance harness SHA: `2fa11f669bcc96f7758eb0518622b72b323fd01d`
+
+## Release Posture Impact
+posture tightened
+
+## Unchanged Risks
+This note does not replay the older March live rehearsal artifacts one by one; it preserves the June 16, 2026 authenticated public production proof bundle that supersedes the missing runtime-proof signal. Historical pre-traffic notes in the older packet remain part of the record.


### PR DESCRIPTION
## Summary
- preserve the June 16, 2026 authenticated production acceptance run and proved release SHA in the ops packet
- add a dated runtime-proof note with the acceptance run URL, release SHA, harness SHA, and final guardrails
- update the active post-Phase-25 authorization packet to reference the new runtime-proof source

## Proof
- production acceptance run 27640575591: PASS
- TerraForge production matrix: PASS
- authenticated TerraFusion OS acceptance: PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release authorization documentation to reference June 16, 2026 runtime proof validation
  * Added new operational documentation recording production runtime validation results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->