### PR TITLE
test(acceptance): harden harness truth gates

### DIFF
--- a/.github/workflows/release-lane.yml
+++ b/.github/workflows/release-lane.yml
@@ -265,7 +265,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          docker build --pull --target production -f frontend/Dockerfile -t "$FRONTEND_IMAGE" .
+          docker build --pull --target production --build-arg VITE_BUILD_SHA="$RELEASE_SHA" -f frontend/Dockerfile -t "$FRONTEND_IMAGE" .
           docker push "$FRONTEND_IMAGE"
 
       - name: Prepare runtime bundle

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,8 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
 FROM node:20-alpine AS build
 WORKDIR /app
+ARG VITE_BUILD_SHA=dev
+ENV VITE_BUILD_SHA=$VITE_BUILD_SHA
 
 # Enable corepack for pnpm
 RUN corepack enable && corepack prepare pnpm@9.0.0 --activate

--- a/os-platform/core/pilot/acceptance-truth.logic.test.mjs
+++ b/os-platform/core/pilot/acceptance-truth.logic.test.mjs
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyCapabilityObservation,
+  evaluateSurfaceObservation,
+  evaluateTerraForgeProof,
+  evaluateVisibleReleaseIdentity,
+} from './acceptance-truth.mjs';
+
+const EXPECTED_RELEASE_SHA = '6f7755090a21efc90fee423fe35b8d72805ef1e5';
+
+describe('visible release identity truth gate', () => {
+  it('fails when the visible sentinel SHA is dev', () => {
+    const result = evaluateVisibleReleaseIdentity({
+      bodyText: 'SENTINEL CONSOLE\nSHA: dev\nAPI: /api/system/health',
+      expectedReleaseSha: EXPECTED_RELEASE_SHA,
+    });
+
+    assert.equal(result.status, 'FAIL');
+    assert.equal(result.visibleSha, 'dev');
+    assert.match(result.reason, /visible shell sha/i);
+  });
+
+  it('passes only when the visible sentinel SHA matches the expected release', () => {
+    const result = evaluateVisibleReleaseIdentity({
+      bodyText: `SENTINEL CONSOLE\nSHA: ${EXPECTED_RELEASE_SHA}\nAPI: /api/system/health`,
+      expectedReleaseSha: EXPECTED_RELEASE_SHA,
+    });
+
+    assert.equal(result.status, 'PASS');
+    assert.equal(result.visibleSha, EXPECTED_RELEASE_SHA);
+  });
+});
+
+describe('surface truth evaluation', () => {
+  it('fails a ready-looking surface when the visible shell SHA is dev', () => {
+    const result = evaluateSurfaceObservation({
+      family: 'suite',
+      path: '/forge',
+      bodyText: 'TerraForge\nSENTINEL CONSOLE\nSHA: dev\nAPI: /api/system/health',
+      expectedReleaseSha: EXPECTED_RELEASE_SHA,
+      pageErrors: [],
+    });
+
+    assert.equal(result.ready, false);
+    assert.match(result.blockers.join(' | '), /visible shell sha/i);
+  });
+});
+
+describe('TerraForge primary capability classification', () => {
+  it('marks CostForge county-scope posture as shell-only', () => {
+    const result = classifyCapabilityObservation('costforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'costforge',
+      windowTitle: 'CostForge',
+      bodyText:
+        'TerraFusion · Cost Approach\nCostForge\nCounty scope required to load CostForge.\nParcels valued —\nAvg cost/sqft —',
+    });
+
+    assert.equal(result.status, 'SHELL ONLY');
+  });
+
+  it('marks SalesForge HTTP 401 as fail', () => {
+    const result = classifyCapabilityObservation('salesforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'sales-forge',
+      windowTitle: 'SalesForge',
+      bodyText:
+        'TerraForge · Sale Qualification\nSalesForge\nLive TerraFusion API\nHTTP 401\nQualified 0\nMedian ratio —\nCOD —',
+    });
+
+    assert.equal(result.status, 'FAIL');
+  });
+
+  it('marks CompsForge parcel-only blockage as wrong surface', () => {
+    const result = classifyCapabilityObservation('compsforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'comps-forge',
+      windowTitle: 'CompsForge - Sales Comparison',
+      bodyText:
+        'CompsForge - Sales Comparison\nSelect a parcel before running sales comparison.\nActive parcel is missing a county code, so CompsForge cannot load the county sales shard.\n0 scoped sales',
+    });
+
+    assert.equal(result.status, 'WRONG SURFACE');
+  });
+
+  it('marks Calibration / QC opening CostForge as wrong surface', () => {
+    const result = classifyCapabilityObservation('calibration-qc', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'costforge',
+      windowTitle: 'CostForge',
+      bodyText: 'TerraFusion · Cost Approach\nCostForge\nCounty scope required to load CostForge.',
+    });
+
+    assert.equal(result.status, 'WRONG SURFACE');
+  });
+
+  it('marks IncomeForge manual-only posture as partial', () => {
+    const result = classifyCapabilityObservation('incomeforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'income-forge',
+      windowTitle: 'IncomeForge',
+      bodyText:
+        'IncomeForge\nProperty Types 0\nLocations 0\nMarket Cap Rate 0.00%\nMedian Home $0\nMedian Income $0\nRun the valuation to calculate NOI, risk, and indicated value.',
+    });
+
+    assert.equal(result.status, 'PARTIAL');
+  });
+
+  it('marks a capability missing from the suite as missing', () => {
+    const result = classifyCapabilityObservation('reconciliation', {
+      cardVisible: false,
+      launchActionable: false,
+      launchedModuleId: null,
+      windowTitle: null,
+      bodyText: '',
+    });
+
+    assert.equal(result.status, 'MISSING');
+  });
+
+  it('requires visible app-specific runtime success for PASS', () => {
+    const result = classifyCapabilityObservation('salesforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'sales-forge',
+      windowTitle: 'SalesForge',
+      bodyText:
+        'TerraForge · Sale Qualification\nSalesForge\nLive TerraFusion API\nQualified 128\nNon-qualified 14\nPending 9\nMedian ratio 0.97\nCOD 11.2\nPRD 1.01',
+    });
+
+    assert.equal(result.status, 'PASS');
+  });
+});
+
+describe('TerraForge proof summary', () => {
+  it('fails the suite when /forge itself says Full TerraForge not done', () => {
+    const result = evaluateTerraForgeProof({
+      expectedReleaseSha: EXPECTED_RELEASE_SHA,
+      suiteBodyText:
+        `TerraForge\nSuite metrics app-backed partial\nFull TerraForge not done\nSENTINEL CONSOLE\nSHA: ${EXPECTED_RELEASE_SHA}`,
+      capabilityResults: [
+        {
+          id: 'salesforge',
+          label: 'SalesForge',
+          status: 'PASS',
+          reasons: [],
+        },
+      ],
+      supportCapabilities: [],
+      workbenchCountedAsProof: false,
+      pacsRuntimeTextFound: false,
+    });
+
+    assert.equal(result.status, 'FAIL');
+    assert.match(result.blockers.join(' | '), /full terraforge not done/i);
+  });
+});

--- a/os-platform/core/pilot/acceptance-truth.logic.test.mjs
+++ b/os-platform/core/pilot/acceptance-truth.logic.test.mjs
@@ -46,6 +46,20 @@ describe('surface truth evaluation', () => {
     assert.equal(result.ready, false);
     assert.match(result.blockers.join(' | '), /visible shell sha/i);
   });
+
+  it('detects lowercase PACS runtime text on suite surfaces', () => {
+    const result = evaluateSurfaceObservation({
+      family: 'suite',
+      path: '/forge',
+      bodyText: `TerraForge\nSENTINEL CONSOLE\nSHA: ${EXPECTED_RELEASE_SHA}\npacs export source`,
+      expectedReleaseSha: EXPECTED_RELEASE_SHA,
+      pageErrors: [],
+    });
+
+    assert.equal(result.ready, false);
+    assert.equal(result.pacsTextFound, true);
+    assert.match(result.blockers.join(' | '), /PACS-facing runtime text/i);
+  });
 });
 
 describe('TerraForge primary capability classification', () => {
@@ -133,6 +147,56 @@ describe('TerraForge primary capability classification', () => {
       windowTitle: 'SalesForge',
       bodyText:
         'TerraForge · Sale Qualification\nSalesForge\nLive TerraFusion API\nQualified 128\nNon-qualified 14\nPending 9\nMedian ratio 0.97\nCOD 11.2\nPRD 1.01',
+    });
+
+    assert.equal(result.status, 'PASS');
+  });
+
+  it('fails HTTP errors for every capability before success-looking text', () => {
+    const result = classifyCapabilityObservation('costforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'costforge',
+      windowTitle: 'CostForge',
+      bodyText: 'CostForge\nHTTP 500\nParcels valued 128\nAvg cost/sqft $226',
+    });
+
+    assert.equal(result.status, 'FAIL');
+  });
+
+  it('checks shell-only blockers before success signals', () => {
+    const result = classifyCapabilityObservation('costforge', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'costforge',
+      windowTitle: 'CostForge',
+      bodyText:
+        'CostForge\nCounty scope required to load CostForge.\nParcels valued 128\nAvg cost/sqft $226',
+    });
+
+    assert.equal(result.status, 'SHELL ONLY');
+  });
+
+  it('does not count valuation-notes title text as runtime proof', () => {
+    const result = classifyCapabilityObservation('valuation-notes-defensibility', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'valuation-notes-defensibility',
+      windowTitle: 'Valuation Notes / Defensibility',
+      bodyText: 'Valuation Notes / Defensibility',
+    });
+
+    assert.equal(result.status, 'FAIL');
+  });
+
+  it('passes valuation-notes only when rationale and evidence are visible', () => {
+    const result = classifyCapabilityObservation('valuation-notes-defensibility', {
+      cardVisible: true,
+      launchActionable: true,
+      launchedModuleId: 'valuation-notes-defensibility',
+      windowTitle: 'Valuation Notes / Defensibility',
+      bodyText:
+        'Valuation Notes / Defensibility\nRationale: reconciled income and sales signals.\nEvidence: county valuation note packet.',
     });
 
     assert.equal(result.status, 'PASS');

--- a/os-platform/core/pilot/acceptance-truth.mjs
+++ b/os-platform/core/pilot/acceptance-truth.mjs
@@ -1,0 +1,349 @@
+const HTTP_ERROR_RE = /\bHTTP\s+(401|403|500)\b/i;
+const PACS_TEXT_RE = /\bPACS\b|\bPacs\b|pacs_/;
+const VISIBLE_SHA_RE = /\bSHA:\s*([^\s]+)/i;
+
+const FORGE_SUITE_BLOCKERS = [
+  /Full TerraForge not done/i,
+  /Suite metrics app-backed partial/i,
+  /preview-locked/i,
+  /county rollup blocked/i,
+];
+
+const CAPABILITY_RULES = {
+  costforge: {
+    label: 'CostForge',
+    expectedModuleIds: ['costforge'],
+    expectedWindowTitles: [/CostForge/i],
+    shellOnlyPatterns: [
+      /County scope required to load CostForge\./i,
+      /County scope required for CostForge\./i,
+      /Parcels valued\s*—/i,
+      /Avg cost\/sqft\s*—/i,
+    ],
+    successPatterns: [/Parcels valued\s+[1-9]\d*/i, /Avg cost\/sqft\s+(?:\$)?[1-9]\d*/i],
+  },
+  compsforge: {
+    label: 'CompsForge',
+    expectedModuleIds: ['comps-forge'],
+    expectedWindowTitles: [/CompsForge/i],
+    wrongSurfacePatterns: [
+      /Select a parcel before running sales comparison\./i,
+      /missing a county code/i,
+      /county sales shard/i,
+    ],
+    shellOnlyPatterns: [/0 scoped sales/i, /Comparable sales are unavailable/i],
+    successPatterns: [/[1-9]\d*\s+scoped sales/i],
+  },
+  salesforge: {
+    label: 'SalesForge',
+    expectedModuleIds: ['sales-forge'],
+    expectedWindowTitles: [/SalesForge/i],
+    failurePatterns: [HTTP_ERROR_RE],
+    shellOnlyPatterns: [/Qualified\s+0\b/i, /Median ratio\s+—/i, /COD\s+—/i, /PRD\s+—/i],
+    successPatterns: [
+      /Qualified\s+[1-9]\d*/i,
+      /Median ratio\s+(?!—)[0-9.]+/i,
+      /COD\s+(?!—)[0-9.]+/i,
+      /PRD\s+(?!—)[0-9.]+/i,
+    ],
+    successMode: 'all',
+  },
+  incomeforge: {
+    label: 'IncomeForge',
+    expectedModuleIds: ['income-forge'],
+    expectedWindowTitles: [/IncomeForge/i],
+    failurePatterns: [HTTP_ERROR_RE],
+    honestUnavailablePatterns: [/explicitly deferred/i],
+    partialPatterns: [
+      /Run the valuation to calculate NOI, risk, and indicated value\./i,
+      /Property Types\s+0\b/i,
+      /Locations\s+0\b/i,
+      /Market Cap Rate\s+0\.00%/i,
+    ],
+    successPatterns: [
+      /Property Types\s+[1-9]\d*/i,
+      /Locations\s+[1-9]\d*/i,
+      /Market Cap Rate\s+(?!0\.00%)[0-9.]+%/i,
+      /Median Home\s+\$[1-9]\d*/i,
+      /Median Income\s+\$[1-9]\d*/i,
+    ],
+    minSuccessSignals: 2,
+  },
+  reconciliation: {
+    label: 'Reconciliation',
+    expectedModuleIds: ['reconciliation'],
+    expectedWindowTitles: [/Reconciliation/i, /Value Reconciliation/i],
+    shellOnlyPatterns: [
+      /Select a parcel to reconcile/i,
+      /Select a parcel and enter at least one positive approach indication to reconcile\./i,
+    ],
+    successPatterns: [/Reconciled Value/i, /Final Value/i, /Weighted Average/i],
+  },
+  'calibration-qc': {
+    label: 'Calibration / QC',
+    expectedModuleIds: ['calibration-qc'],
+    expectedWindowTitles: [/Calibration/i, /QC/i],
+    successPatterns: [/PRD/i, /COD/i, /segment/i],
+  },
+  'cama-characteristics': {
+    label: 'CAMA Characteristics',
+    expectedModuleIds: ['cama-characteristics'],
+    expectedWindowTitles: [/CAMA Characteristics/i],
+    shellOnlyPatterns: [
+      /Enter a parcel number to read TerraFusion CAMA characteristics\./i,
+      /No sample or fallback rows are rendered\./i,
+    ],
+    successPatterns: [/Gross Living Area/i, /Year Built/i, /Characteristic/i],
+  },
+  'valuation-notes-defensibility': {
+    label: 'Valuation Notes \/ Defensibility',
+    expectedModuleIds: ['valuation-notes-defensibility'],
+    expectedWindowTitles: [/Valuation Notes/i, /Defensibility/i],
+    shellOnlyPatterns: [
+      /Enter a parcel ID to read valuation signals and note headers\./i,
+      /No sample packets or fallback notes are rendered\./i,
+    ],
+    successPatterns: [/Valuation/i, /Notes/i, /Rationale/i, /Evidence/i],
+    minSuccessSignals: 2,
+  },
+};
+
+function hasTextMatch(text, patterns = []) {
+  return patterns.some(pattern => pattern.test(text));
+}
+
+function matchedPatterns(text, patterns = []) {
+  return patterns.filter(pattern => pattern.test(text)).map(pattern => pattern.source);
+}
+
+function countMatches(text, patterns = []) {
+  return patterns.filter(pattern => pattern.test(text)).length;
+}
+
+export function extractVisibleReleaseSha(bodyText) {
+  const match = bodyText.match(VISIBLE_SHA_RE);
+  return match?.[1] ?? null;
+}
+
+export function evaluateVisibleReleaseIdentity({ bodyText, expectedReleaseSha }) {
+  const visibleSha = extractVisibleReleaseSha(bodyText);
+  if (!visibleSha) {
+    return {
+      status: 'FAIL',
+      visibleSha: null,
+      reason: 'Visible shell SHA was not found on the rendered surface.',
+    };
+  }
+  if (visibleSha.toLowerCase() === 'dev') {
+    return {
+      status: 'FAIL',
+      visibleSha,
+      reason: 'Visible shell SHA is dev, so the rendered surface does not prove the expected release identity.',
+    };
+  }
+  if (expectedReleaseSha && visibleSha !== expectedReleaseSha) {
+    return {
+      status: 'FAIL',
+      visibleSha,
+      reason: `Visible shell SHA ${visibleSha} does not match expected release ${expectedReleaseSha}.`,
+    };
+  }
+  return {
+    status: 'PASS',
+    visibleSha,
+    reason: null,
+  };
+}
+
+export function evaluateSurfaceObservation({
+  family,
+  path,
+  bodyText,
+  expectedReleaseSha,
+  pageErrors = [],
+}) {
+  const blockers = [];
+  const releaseIdentity = evaluateVisibleReleaseIdentity({ bodyText, expectedReleaseSha });
+  if (releaseIdentity.status !== 'PASS') {
+    blockers.push(releaseIdentity.reason);
+  }
+  if (family !== 'feature' && PACS_TEXT_RE.test(bodyText)) {
+    blockers.push(`${path} exposes PACS-facing runtime text.`);
+  }
+  if (pageErrors.length > 0) {
+    blockers.push(`Browser page errors: ${pageErrors.join(' | ')}`);
+  }
+  return {
+    ready: blockers.length === 0,
+    blockers,
+    visibleReleaseSha: releaseIdentity.visibleSha,
+  };
+}
+
+export function classifyCapabilityObservation(capabilityId, observation) {
+  const rule = CAPABILITY_RULES[capabilityId];
+  if (!rule) {
+    throw new Error(`Unknown TerraForge capability rule: ${capabilityId}`);
+  }
+
+  const bodyText = observation.bodyText ?? '';
+  const reasons = [];
+
+  if (!observation.cardVisible) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'MISSING',
+      reasons: ['Primary capability card is not visible on /forge.'],
+    };
+  }
+
+  if (!observation.launchActionable) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'FAIL',
+      reasons: ['Primary capability card is not launchable from /forge.'],
+    };
+  }
+
+  if (
+    observation.launchedModuleId &&
+    Array.isArray(rule.expectedModuleIds) &&
+    !rule.expectedModuleIds.includes(observation.launchedModuleId)
+  ) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'WRONG SURFACE',
+      reasons: [
+        `Expected module ${rule.expectedModuleIds.join(' or ')}, observed ${observation.launchedModuleId}.`,
+      ],
+    };
+  }
+
+  if (
+    observation.windowTitle &&
+    Array.isArray(rule.expectedWindowTitles) &&
+    !rule.expectedWindowTitles.some(pattern => pattern.test(observation.windowTitle))
+  ) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'WRONG SURFACE',
+      reasons: [`Unexpected window title "${observation.windowTitle}".`],
+    };
+  }
+
+  if (hasTextMatch(bodyText, rule.failurePatterns)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'FAIL',
+      reasons: matchedPatterns(bodyText, rule.failurePatterns),
+    };
+  }
+
+  if (hasTextMatch(bodyText, rule.wrongSurfacePatterns)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'WRONG SURFACE',
+      reasons: matchedPatterns(bodyText, rule.wrongSurfacePatterns),
+    };
+  }
+
+  if (hasTextMatch(bodyText, rule.honestUnavailablePatterns)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'HONEST UNAVAILABLE',
+      reasons: matchedPatterns(bodyText, rule.honestUnavailablePatterns),
+    };
+  }
+
+  const successSignals = countMatches(bodyText, rule.successPatterns);
+  const requiredSignals =
+    rule.successMode === 'all'
+      ? rule.successPatterns?.length ?? 0
+      : rule.minSuccessSignals ?? (rule.successPatterns?.length ? 1 : 0);
+
+  if (requiredSignals > 0 && successSignals >= requiredSignals) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'PASS',
+      reasons,
+    };
+  }
+
+  if (hasTextMatch(bodyText, rule.shellOnlyPatterns)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'SHELL ONLY',
+      reasons: matchedPatterns(bodyText, rule.shellOnlyPatterns),
+    };
+  }
+
+  if (hasTextMatch(bodyText, rule.partialPatterns)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'PARTIAL',
+      reasons: matchedPatterns(bodyText, rule.partialPatterns),
+    };
+  }
+
+  return {
+    id: capabilityId,
+    label: rule.label,
+    status: 'FAIL',
+    reasons: ['No visible app-specific runtime success state was detected.'],
+  };
+}
+
+export function evaluateTerraForgeProof({
+  expectedReleaseSha,
+  suiteBodyText,
+  capabilityResults,
+  supportCapabilities,
+  workbenchCountedAsProof,
+  pacsRuntimeTextFound,
+}) {
+  const blockers = [];
+  const releaseIdentity = evaluateVisibleReleaseIdentity({
+    bodyText: suiteBodyText,
+    expectedReleaseSha,
+  });
+
+  if (releaseIdentity.status !== 'PASS') {
+    blockers.push(releaseIdentity.reason);
+  }
+
+  const suiteTruthBlockers = matchedPatterns(suiteBodyText, FORGE_SUITE_BLOCKERS);
+  blockers.push(...suiteTruthBlockers.map(source => `Suite posture blocker matched: /${source}/`));
+
+  if (workbenchCountedAsProof) {
+    blockers.push('Workbench parcel-scoped route appeared in TerraForge suite proof.');
+  }
+
+  if (pacsRuntimeTextFound) {
+    blockers.push('PACS-facing runtime text found on /forge.');
+  }
+
+  const nonPassingCapabilities = capabilityResults.filter(result => result.status !== 'PASS');
+  for (const capability of nonPassingCapabilities) {
+    blockers.push(
+      `${capability.label}: ${capability.status}${capability.reasons.length ? ` (${capability.reasons.join(' | ')})` : ''}`,
+    );
+  }
+
+  return {
+    status: blockers.length === 0 ? 'PASS' : 'FAIL',
+    blockers,
+    visibleReleaseSha: releaseIdentity.visibleSha,
+    capabilityResults,
+    supportCapabilities,
+  };
+}

--- a/os-platform/core/pilot/acceptance-truth.mjs
+++ b/os-platform/core/pilot/acceptance-truth.mjs
@@ -1,5 +1,5 @@
 const HTTP_ERROR_RE = /\bHTTP\s+(401|403|500)\b/i;
-const PACS_TEXT_RE = /\bPACS\b|\bPacs\b|pacs_/;
+const PACS_TEXT_RE = /\bpacs\b|pacs_/i;
 const VISIBLE_SHA_RE = /\bSHA:\s*([^\s]+)/i;
 
 const FORGE_SUITE_BLOCKERS = [
@@ -103,8 +103,8 @@ const CAPABILITY_RULES = {
       /Enter a parcel ID to read valuation signals and note headers\./i,
       /No sample packets or fallback notes are rendered\./i,
     ],
-    successPatterns: [/Valuation/i, /Notes/i, /Rationale/i, /Evidence/i],
-    minSuccessSignals: 2,
+    successPatterns: [/Rationale/i, /Evidence/i],
+    successMode: 'all',
   },
 };
 
@@ -123,6 +123,10 @@ function countMatches(text, patterns = []) {
 export function extractVisibleReleaseSha(bodyText) {
   const match = bodyText.match(VISIBLE_SHA_RE);
   return match?.[1] ?? null;
+}
+
+export function hasPacsRuntimeText(bodyText) {
+  return PACS_TEXT_RE.test(bodyText ?? '');
 }
 
 export function evaluateVisibleReleaseIdentity({ bodyText, expectedReleaseSha }) {
@@ -167,7 +171,8 @@ export function evaluateSurfaceObservation({
   if (releaseIdentity.status !== 'PASS') {
     blockers.push(releaseIdentity.reason);
   }
-  if (family !== 'feature' && PACS_TEXT_RE.test(bodyText)) {
+  const pacsTextFound = family !== 'feature' && hasPacsRuntimeText(bodyText);
+  if (pacsTextFound) {
     blockers.push(`${path} exposes PACS-facing runtime text.`);
   }
   if (pageErrors.length > 0) {
@@ -177,6 +182,7 @@ export function evaluateSurfaceObservation({
     ready: blockers.length === 0,
     blockers,
     visibleReleaseSha: releaseIdentity.visibleSha,
+    pacsTextFound,
   };
 }
 
@@ -235,6 +241,15 @@ export function classifyCapabilityObservation(capabilityId, observation) {
     };
   }
 
+  if (HTTP_ERROR_RE.test(bodyText)) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'FAIL',
+      reasons: matchedPatterns(bodyText, [HTTP_ERROR_RE]),
+    };
+  }
+
   if (hasTextMatch(bodyText, rule.failurePatterns)) {
     return {
       id: capabilityId,
@@ -262,21 +277,6 @@ export function classifyCapabilityObservation(capabilityId, observation) {
     };
   }
 
-  const successSignals = countMatches(bodyText, rule.successPatterns);
-  const requiredSignals =
-    rule.successMode === 'all'
-      ? rule.successPatterns?.length ?? 0
-      : rule.minSuccessSignals ?? (rule.successPatterns?.length ? 1 : 0);
-
-  if (requiredSignals > 0 && successSignals >= requiredSignals) {
-    return {
-      id: capabilityId,
-      label: rule.label,
-      status: 'PASS',
-      reasons,
-    };
-  }
-
   if (hasTextMatch(bodyText, rule.shellOnlyPatterns)) {
     return {
       id: capabilityId,
@@ -292,6 +292,21 @@ export function classifyCapabilityObservation(capabilityId, observation) {
       label: rule.label,
       status: 'PARTIAL',
       reasons: matchedPatterns(bodyText, rule.partialPatterns),
+    };
+  }
+
+  const successSignals = countMatches(bodyText, rule.successPatterns);
+  const requiredSignals =
+    rule.successMode === 'all'
+      ? rule.successPatterns?.length ?? 0
+      : rule.minSuccessSignals ?? (rule.successPatterns?.length ? 1 : 0);
+
+  if (requiredSignals > 0 && successSignals >= requiredSignals) {
+    return {
+      id: capabilityId,
+      label: rule.label,
+      status: 'PASS',
+      reasons,
     };
   }
 

--- a/os-platform/core/pilot/acceptance-truth.workflow.contract.test.mjs
+++ b/os-platform/core/pilot/acceptance-truth.workflow.contract.test.mjs
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const matrixScript = readFileSync(
+  join(ROOT, 'scripts', 'terraforge-production-matrix-smoke.mjs'),
+  'utf8',
+);
+const acceptanceScript = readFileSync(
+  join(ROOT, 'os-platform', 'core', 'pilot', 'os-production-acceptance-smoke.mjs'),
+  'utf8',
+);
+const truthModulePath = join(ROOT, 'os-platform', 'core', 'pilot', 'acceptance-truth.mjs');
+
+describe('acceptance harness truth repair contract', () => {
+  it('keeps the shared truth module alongside the smoke scripts', () => {
+    assert.ok(existsSync(truthModulePath));
+  });
+
+  it('routes TerraForge proof through shared truth classification instead of clickability-only checks', () => {
+    assert.match(matrixScript, /classifyCapabilityObservation/);
+    assert.match(matrixScript, /evaluateTerraForgeProof/);
+    assert.doesNotMatch(matrixScript, /card\.click\(\{\s*trial:\s*true/);
+  });
+
+  it('routes OS acceptance through visible release identity checks', () => {
+    assert.match(acceptanceScript, /evaluateSurfaceObservation/);
+    assert.match(acceptanceScript, /visibleReleaseSha|visible release/i);
+  });
+});

--- a/os-platform/core/pilot/acceptance-truth.workflow.contract.test.mjs
+++ b/os-platform/core/pilot/acceptance-truth.workflow.contract.test.mjs
@@ -12,6 +12,8 @@ const acceptanceScript = readFileSync(
   join(ROOT, 'os-platform', 'core', 'pilot', 'os-production-acceptance-smoke.mjs'),
   'utf8',
 );
+const releaseLane = readFileSync(join(ROOT, '.github', 'workflows', 'release-lane.yml'), 'utf8');
+const frontendDockerfile = readFileSync(join(ROOT, 'frontend', 'Dockerfile'), 'utf8');
 const truthModulePath = join(ROOT, 'os-platform', 'core', 'pilot', 'acceptance-truth.mjs');
 
 describe('acceptance harness truth repair contract', () => {
@@ -20,13 +22,40 @@ describe('acceptance harness truth repair contract', () => {
   });
 
   it('routes TerraForge proof through shared truth classification instead of clickability-only checks', () => {
-    assert.match(matrixScript, /classifyCapabilityObservation/);
-    assert.match(matrixScript, /evaluateTerraForgeProof/);
+    assert.match(matrixScript, /\bclassifyCapabilityObservation\s*\(/);
+    assert.match(matrixScript, /\bevaluateTerraForgeProof\s*\(\s*\{/);
     assert.doesNotMatch(matrixScript, /card\.click\(\{\s*trial:\s*true/);
   });
 
   it('routes OS acceptance through visible release identity checks', () => {
-    assert.match(acceptanceScript, /evaluateSurfaceObservation/);
-    assert.match(acceptanceScript, /visibleReleaseSha|visible release/i);
+    assert.match(acceptanceScript, /\bevaluateSurfaceObservation\s*\(\s*\{/);
+    assert.match(acceptanceScript, /expectedReleaseSha:\s*expectedReleaseSha\s*\?\?\s*evidence\.releaseSha/);
+    assert.match(acceptanceScript, /\bvisibleReleaseSha\b|visible release/i);
+  });
+
+  it('passes the release SHA into the frontend production build', () => {
+    assert.match(frontendDockerfile, /\bARG\s+VITE_BUILD_SHA=dev\b/);
+    assert.match(frontendDockerfile, /\bENV\s+VITE_BUILD_SHA=\$VITE_BUILD_SHA\b/);
+    assert.match(releaseLane, /--build-arg\s+VITE_BUILD_SHA="\$RELEASE_SHA"/);
+  });
+
+  it('waits deterministically for launched TerraForge modules', () => {
+    assert.match(matrixScript, /\bwaitForLaunchedModule\s*\(/);
+    assert.match(matrixScript, /\bpage\s*\.\s*waitForFunction\s*\(/);
+    assert.doesNotMatch(matrixScript, /waitForTimeout\s*\(\s*250\s*\)/);
+  });
+
+  it('checks disabled TerraForge cards before clicking them', () => {
+    const disabledCheckIndex = matrixScript.indexOf('launchActionable = !(await card.isDisabled())');
+    const clickIndex = matrixScript.indexOf('await card.click({ timeout: 10000 })');
+
+    assert.notEqual(disabledCheckIndex, -1);
+    assert.notEqual(clickIndex, -1);
+    assert.ok(disabledCheckIndex < clickIndex);
+  });
+
+  it('inspects markup for parcel-scoped Forge routes and records support blockers', () => {
+    assert.match(matrixScript, /\binnerHTML\b/);
+    assert.match(matrixScript, /evidence\.blockers\.push\(blocker\)/);
   });
 });

--- a/os-platform/core/pilot/os-production-acceptance-smoke.mjs
+++ b/os-platform/core/pilot/os-production-acceptance-smoke.mjs
@@ -2,6 +2,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { evaluateSurfaceObservation } from './acceptance-truth.mjs';
 
 function readArg(name) {
   const index = process.argv.indexOf(name);
@@ -68,6 +69,7 @@ async function writeEvidence(outputDir, evidence) {
       `- TerraForge matrix required: \`${evidence.guardrails.terraforgeMatrixProofRequired}\``,
       `- Workbench search support only: \`${evidence.guardrails.workbenchSearchSupportOnly}\``,
       `- Parcel-scoped workbench route visited: \`${evidence.guardrails.workbenchParcelRouteVisited}\``,
+      `- Visible release SHA: \`${evidence.visibleReleaseSha ?? 'missing'}\``,
       '',
       '## Surfaces',
       '',
@@ -119,6 +121,7 @@ async function main() {
     harnessSha: process.env.GITHUB_SHA ?? null,
     authenticated: false,
     surfaces: [],
+    visibleReleaseSha: null,
     guardrails: {
       terraforgeMatrixProofRequired: contract.guardrails.terraforgeMatrixProofRequired,
       workbenchSearchSupportOnly: contract.guardrails.workbenchSearchSupportOnly,
@@ -169,10 +172,17 @@ async function main() {
         throw new Error(`${surface.path} missing required text "${surface.requiredText}".`);
       }
 
-      const pacsTextFound =
-        surface.family !== 'feature' && /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
       const routePageErrors = pageErrors.slice(priorErrorCount);
-      const ready = routePageErrors.length === 0 && !pacsTextFound;
+      const truth = evaluateSurfaceObservation({
+        family: surface.family,
+        path: surface.path,
+        bodyText,
+        expectedReleaseSha,
+        pageErrors: routePageErrors,
+      });
+      const pacsTextFound = surface.family !== 'feature' && /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
+      const ready = truth.ready;
+      evidence.visibleReleaseSha ??= truth.visibleReleaseSha;
 
       evidence.guardrails.workbenchParcelRouteVisited =
         evidence.guardrails.workbenchParcelRouteVisited ||
@@ -185,6 +195,7 @@ async function main() {
         path: surface.path,
         visitedPath: `${visitedUrl.pathname}${visitedUrl.search}`,
         ready,
+        blockers: truth.blockers,
         pacsTextFound,
         pageErrors: routePageErrors,
       });

--- a/os-platform/core/pilot/os-production-acceptance-smoke.mjs
+++ b/os-platform/core/pilot/os-production-acceptance-smoke.mjs
@@ -177,10 +177,10 @@ async function main() {
         family: surface.family,
         path: surface.path,
         bodyText,
-        expectedReleaseSha,
+        expectedReleaseSha: expectedReleaseSha ?? evidence.releaseSha,
         pageErrors: routePageErrors,
       });
-      const pacsTextFound = surface.family !== 'feature' && /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
+      const pacsTextFound = truth.pacsTextFound;
       const ready = truth.ready;
       evidence.visibleReleaseSha ??= truth.visibleReleaseSha;
 

--- a/scripts/terraforge-production-matrix-smoke.mjs
+++ b/scripts/terraforge-production-matrix-smoke.mjs
@@ -6,6 +6,7 @@ import {
   classifyCapabilityObservation,
   evaluateTerraForgeProof,
   extractVisibleReleaseSha,
+  hasPacsRuntimeText,
 } from '../os-platform/core/pilot/acceptance-truth.mjs';
 
 const PRIMARY_CAPABILITIES = [
@@ -50,6 +51,56 @@ function requireSecret(name) {
     throw new Error(`Missing required environment variable ${name}.`);
   }
   return value;
+}
+
+async function moduleIds(page) {
+  return page
+    .locator('[data-testid="window-manager"] [data-module-id]')
+    .evaluateAll(nodes => nodes.map(node => node.getAttribute('data-module-id')).filter(Boolean));
+}
+
+async function waitForLaunchedModule(page, moduleIdsBefore) {
+  await page
+    .waitForFunction(
+      before =>
+        Array.from(document.querySelectorAll('[data-testid="window-manager"] [data-module-id]'))
+          .map(node => node.getAttribute('data-module-id'))
+          .filter(Boolean)
+          .some(moduleId => !before.includes(moduleId)),
+      moduleIdsBefore,
+      { timeout: 10000 }
+    )
+    .catch(() => undefined);
+
+  const moduleIdsAfter = await moduleIds(page);
+  const launchedModuleId =
+    moduleIdsAfter.find(moduleId => !moduleIdsBefore.includes(moduleId)) ??
+    moduleIdsAfter.at(-1) ??
+    null;
+
+  if (!launchedModuleId) {
+    return { launchedModuleId: null, moduleRoot: null };
+  }
+
+  const moduleRoot = page.locator(
+    `[data-testid="window-manager"] [data-module-id="${launchedModuleId}"]`
+  );
+  await moduleRoot.waitFor({ timeout: 10000 });
+  await page
+    .waitForFunction(
+      moduleId => {
+        const node = document.querySelector(
+          `[data-testid="window-manager"] [data-module-id="${moduleId}"]`
+        );
+        const text = node?.textContent ?? '';
+        return text.trim().length > 0 && !/\bLoading\b/i.test(text);
+      },
+      launchedModuleId,
+      { timeout: 10000 }
+    )
+    .catch(() => undefined);
+
+  return { launchedModuleId, moduleRoot };
 }
 
 async function writeEvidence(outputDir, evidence) {
@@ -137,6 +188,8 @@ async function main() {
     if (!healthResponse.ok()) {
       throw new Error(`/health returned HTTP ${healthResponse.status()}`);
     }
+    const effectiveReleaseSha = expectedReleaseSha ?? evidence.releaseSha;
+
     if (expectedReleaseSha && evidence.releaseSha !== expectedReleaseSha) {
       throw new Error(
         `Expected X-Release-Sha ${expectedReleaseSha}, got ${evidence.releaseSha ?? 'missing'}`
@@ -155,9 +208,12 @@ async function main() {
     await page.getByTestId('forge-support-applications').waitFor({ timeout: 30000 });
 
     const suiteBodyText = await page.locator('body').innerText();
+    const suiteGuardrailText = await page.locator('body').evaluate(body => body.innerHTML);
     evidence.visibleReleaseSha = extractVisibleReleaseSha(suiteBodyText);
-    evidence.guardrails.pacsRuntimeTextFound = /\bPACS\b|\bPacs\b|pacs_/.test(suiteBodyText);
-    evidence.guardrails.workbenchCountedAsProof = /\/property\/[^/\s]+\/forge/.test(suiteBodyText);
+    evidence.guardrails.pacsRuntimeTextFound = hasPacsRuntimeText(suiteBodyText);
+    evidence.guardrails.workbenchCountedAsProof =
+      /\/property\/[^/\s]+\/forge/.test(suiteBodyText) ||
+      /\/property\/[^/"'\s]+\/forge/.test(suiteGuardrailText);
 
     for (const [id, label] of PRIMARY_CAPABILITIES) {
       await page.goto(`${baseUrl}/forge`, { waitUntil: 'domcontentloaded' });
@@ -174,29 +230,17 @@ async function main() {
       let capabilityBodyText = '';
 
       if (cardVisible) {
-        const moduleIdsBefore = await page
-          .locator('[data-testid="window-manager"] [data-module-id]')
-          .evaluateAll(nodes =>
-            nodes.map(node => node.getAttribute('data-module-id')).filter(Boolean)
-          );
-        await card.click({ timeout: 10000 });
         launchActionable = !(await card.isDisabled());
-        await page.waitForTimeout(250);
-        const moduleIdsAfter = await page
-          .locator('[data-testid="window-manager"] [data-module-id]')
-          .evaluateAll(nodes =>
-            nodes.map(node => node.getAttribute('data-module-id')).filter(Boolean)
-          );
-        launchedModuleId =
-          moduleIdsAfter.find(moduleId => !moduleIdsBefore.includes(moduleId)) ??
-          moduleIdsAfter.at(-1) ??
-          null;
+      }
 
-        if (launchedModuleId) {
-          const moduleRoot = page.locator(
-            `[data-testid="window-manager"] [data-module-id="${launchedModuleId}"]`
-          );
-          await moduleRoot.waitFor({ timeout: 10000 });
+      if (cardVisible && launchActionable) {
+        const moduleIdsBefore = await moduleIds(page);
+        await card.click({ timeout: 10000 });
+        const launchedModule = await waitForLaunchedModule(page, moduleIdsBefore);
+        launchedModuleId = launchedModule.launchedModuleId;
+
+        if (launchedModule.moduleRoot) {
+          const moduleRoot = launchedModule.moduleRoot;
           capabilityBodyText = await moduleRoot.innerText();
           windowTitle =
             (await moduleRoot
@@ -238,13 +282,13 @@ async function main() {
     const missingSupport = evidence.supportCapabilities.filter(capability => !capability.visible);
 
     if (missingSupport.length > 0) {
-      throw new Error(
-        `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`
-      );
+      const blocker = `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`;
+      evidence.blockers.push(blocker);
+      throw new Error(blocker);
     }
 
     const truthResult = evaluateTerraForgeProof({
-      expectedReleaseSha,
+      expectedReleaseSha: effectiveReleaseSha,
       suiteBodyText,
       capabilityResults: evidence.primaryCapabilities,
       supportCapabilities: evidence.supportCapabilities,

--- a/scripts/terraforge-production-matrix-smoke.mjs
+++ b/scripts/terraforge-production-matrix-smoke.mjs
@@ -2,6 +2,11 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import {
+  classifyCapabilityObservation,
+  evaluateTerraForgeProof,
+  extractVisibleReleaseSha,
+} from '../os-platform/core/pilot/acceptance-truth.mjs';
 
 const PRIMARY_CAPABILITIES = [
   ['costforge', 'CostForge'],
@@ -51,7 +56,7 @@ async function writeEvidence(outputDir, evidence) {
   await mkdir(outputDir, { recursive: true });
   await writeFile(
     path.join(outputDir, 'terraforge-production-matrix-proof.json'),
-    `${JSON.stringify(evidence, null, 2)}\n`,
+    `${JSON.stringify(evidence, null, 2)}\n`
   );
   await writeFile(
     path.join(outputDir, 'terraforge-production-matrix-proof.md'),
@@ -67,14 +72,14 @@ async function writeEvidence(outputDir, evidence) {
       '',
       ...evidence.primaryCapabilities.map(
         capability =>
-          `- ${capability.label}: card=${capability.cardVisible ? 'visible' : 'missing'}, launch=${capability.launchActionable ? 'actionable' : 'blocked'}`,
+          `- ${capability.label}: status=${capability.status}, card=${capability.cardVisible ? 'visible' : 'missing'}, launch=${capability.launchActionable ? 'actionable' : 'blocked'}, visibleSha=${capability.visibleReleaseSha ?? 'missing'}`
       ),
       '',
       '## Support / Deferred',
       '',
       ...evidence.supportCapabilities.map(
         capability =>
-          `- ${capability.id}: ${capability.visible ? 'visible outside primary proof' : 'missing'}`,
+          `- ${capability.id}: ${capability.visible ? 'visible outside primary proof' : 'missing'}`
       ),
       '',
       '## Guardrails',
@@ -82,8 +87,15 @@ async function writeEvidence(outputDir, evidence) {
       `- Workbench counted as proof: \`${evidence.guardrails.workbenchCountedAsProof}\``,
       `- Endpoint-only proof accepted: \`${evidence.guardrails.endpointOnlyProofAccepted}\``,
       `- PACS-facing runtime text: \`${evidence.guardrails.pacsRuntimeTextFound}\``,
+      `- Visible release SHA: \`${evidence.visibleReleaseSha ?? 'missing'}\``,
       '',
-    ].join('\n'),
+      '## Blockers',
+      '',
+      ...(evidence.blockers.length > 0
+        ? evidence.blockers.map(blocker => `- ${blocker}`)
+        : ['- none']),
+      '',
+    ].join('\n')
   );
 }
 
@@ -109,6 +121,8 @@ async function main() {
     releaseSha: null,
     primaryCapabilities: [],
     supportCapabilities: [],
+    visibleReleaseSha: null,
+    blockers: [],
     guardrails: {
       workbenchCountedAsProof: false,
       endpointOnlyProofAccepted: false,
@@ -125,7 +139,7 @@ async function main() {
     }
     if (expectedReleaseSha && evidence.releaseSha !== expectedReleaseSha) {
       throw new Error(
-        `Expected X-Release-Sha ${expectedReleaseSha}, got ${evidence.releaseSha ?? 'missing'}`,
+        `Expected X-Release-Sha ${expectedReleaseSha}, got ${evidence.releaseSha ?? 'missing'}`
       );
     }
 
@@ -140,53 +154,110 @@ async function main() {
     await page.getByTestId('forge-primary-applications').waitFor({ timeout: 30000 });
     await page.getByTestId('forge-support-applications').waitFor({ timeout: 30000 });
 
-    const bodyText = await page.locator('body').innerText();
-    evidence.guardrails.pacsRuntimeTextFound = /\bPACS\b|\bPacs\b|pacs_/.test(bodyText);
-    evidence.guardrails.workbenchCountedAsProof = /\/property\/[^/\s]+\/forge/.test(bodyText);
+    const suiteBodyText = await page.locator('body').innerText();
+    evidence.visibleReleaseSha = extractVisibleReleaseSha(suiteBodyText);
+    evidence.guardrails.pacsRuntimeTextFound = /\bPACS\b|\bPacs\b|pacs_/.test(suiteBodyText);
+    evidence.guardrails.workbenchCountedAsProof = /\/property\/[^/\s]+\/forge/.test(suiteBodyText);
 
     for (const [id, label] of PRIMARY_CAPABILITIES) {
+      await page.goto(`${baseUrl}/forge`, { waitUntil: 'domcontentloaded' });
+      await page.getByTestId('suite-forge-root').waitFor({ timeout: 30000 });
+      await page.getByTestId('forge-primary-applications').waitFor({ timeout: 30000 });
+
       const card = page.locator(
-        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="primary-required"]`,
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="primary-required"]`
       );
       const cardVisible = await card.isVisible();
       let launchActionable = false;
+      let launchedModuleId = null;
+      let windowTitle = null;
+      let capabilityBodyText = '';
+
       if (cardVisible) {
-        await card.click({ trial: true, timeout: 10000 });
+        const moduleIdsBefore = await page
+          .locator('[data-testid="window-manager"] [data-module-id]')
+          .evaluateAll(nodes =>
+            nodes.map(node => node.getAttribute('data-module-id')).filter(Boolean)
+          );
+        await card.click({ timeout: 10000 });
         launchActionable = !(await card.isDisabled());
+        await page.waitForTimeout(250);
+        const moduleIdsAfter = await page
+          .locator('[data-testid="window-manager"] [data-module-id]')
+          .evaluateAll(nodes =>
+            nodes.map(node => node.getAttribute('data-module-id')).filter(Boolean)
+          );
+        launchedModuleId =
+          moduleIdsAfter.find(moduleId => !moduleIdsBefore.includes(moduleId)) ??
+          moduleIdsAfter.at(-1) ??
+          null;
+
+        if (launchedModuleId) {
+          const moduleRoot = page.locator(
+            `[data-testid="window-manager"] [data-module-id="${launchedModuleId}"]`
+          );
+          await moduleRoot.waitFor({ timeout: 10000 });
+          capabilityBodyText = await moduleRoot.innerText();
+          windowTitle =
+            (await moduleRoot
+              .locator('h1, h2, [aria-label="Application windows"] .window-title')
+              .first()
+              .textContent()
+              .catch(() => null)) ?? null;
+        }
       }
-      evidence.primaryCapabilities.push({ id, label, cardVisible, launchActionable });
+
+      const classification = classifyCapabilityObservation(id, {
+        cardVisible,
+        launchActionable,
+        launchedModuleId,
+        windowTitle,
+        bodyText: capabilityBodyText,
+      });
+
+      evidence.primaryCapabilities.push({
+        id,
+        label,
+        cardVisible,
+        launchActionable,
+        launchedModuleId,
+        windowTitle,
+        visibleReleaseSha: evidence.visibleReleaseSha,
+        reasons: classification.reasons,
+        status: classification.status,
+      });
     }
 
     for (const id of SUPPORT_CAPABILITIES) {
       const card = page.locator(
-        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="support-or-deferred"]`,
+        `[data-terraforge-capability-id="${id}"][data-terraforge-production-proof="support-or-deferred"]`
       );
       evidence.supportCapabilities.push({ id, visible: await card.isVisible() });
     }
 
-    const missingPrimary = evidence.primaryCapabilities.filter(
-      capability => !capability.cardVisible || !capability.launchActionable,
-    );
     const missingSupport = evidence.supportCapabilities.filter(capability => !capability.visible);
 
-    if (missingPrimary.length > 0) {
-      throw new Error(
-        `Primary TerraForge capability proof failed: ${missingPrimary.map(item => item.id).join(', ')}`,
-      );
-    }
     if (missingSupport.length > 0) {
       throw new Error(
-        `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`,
+        `Support/deferred TerraForge disclosure missing: ${missingSupport.map(item => item.id).join(', ')}`
       );
     }
-    if (evidence.guardrails.pacsRuntimeTextFound) {
-      throw new Error('PACS-facing runtime text found on /forge.');
-    }
-    if (evidence.guardrails.workbenchCountedAsProof) {
-      throw new Error('Workbench parcel-scoped route appeared in TerraForge suite proof.');
-    }
+
+    const truthResult = evaluateTerraForgeProof({
+      expectedReleaseSha,
+      suiteBodyText,
+      capabilityResults: evidence.primaryCapabilities,
+      supportCapabilities: evidence.supportCapabilities,
+      workbenchCountedAsProof: evidence.guardrails.workbenchCountedAsProof,
+      pacsRuntimeTextFound: evidence.guardrails.pacsRuntimeTextFound,
+    });
+
+    evidence.blockers = [...truthResult.blockers];
     if (pageErrors.length > 0) {
-      throw new Error(`Browser page errors: ${pageErrors.join(' | ')}`);
+      evidence.blockers.push(`Browser page errors: ${pageErrors.join(' | ')}`);
+    }
+    if (evidence.blockers.length > 0) {
+      throw new Error(`TerraForge runtime truth proof failed: ${evidence.blockers.join(' || ')}`);
     }
 
     evidence.status = 'PASS';


### PR DESCRIPTION
## Summary
- route TerraForge and OS acceptance proof through shared runtime-truth classification
- fail acceptance when the visible shell SHA is `dev` or mismatched, `/forge` declares TerraForge incomplete, or launched apps are shell-only/wrong-surface/broken
- add contract tests proving the old misleading PASS shape now fails and real PASS requires visible app-specific runtime success

## Harness gaps found
- visible release identity was not enforced against the rendered shell
- `/forge` incomplete-state language was not a failing condition
- TerraForge proof treated card visibility/clickability as sufficient
- launched app failures like visible HTTP 401/403/500 were not hard fails
- shell-only, wrong-surface, and partial states were not classified separately
- Workbench/parcel-scoped Forge could leak into suite proof by route shape instead of explicit rejection

## New failure conditions
- fail if visible sentinel SHA is missing, `dev`, or mismatched from expected release
- fail if `/forge` renders `Full TerraForge not done` or other suite blocker text
- fail if any primary TerraForge capability classifies as `SHELL ONLY`, `FAIL`, `MISSING`, or `WRONG SURFACE`
- fail if launched app text exposes visible 401/403/500 errors
- fail if Calibration/QC launches CostForge instead of a calibration surface
- fail if CompsForge requires parcel/workbench context without suite-level honest state
- fail if Workbench parcel route is counted as TerraForge suite proof
- fail if PACS runtime text appears outside approved intake/provenance contexts

## Tests
- `pnpm run type-check`
- `dotnet build backend/src/TerraFusion.API/TerraFusion.API.csproj -c Release`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- `node --test os-platform/core/pilot/os-production-acceptance-workflow.contract.test.mjs scripts/terraforge-production-proof-workflow.contract.test.mjs os-platform/core/pilot/acceptance-truth.logic.test.mjs os-platform/core/pilot/acceptance-truth.workflow.contract.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded acceptance-truth coverage with broader surface evaluation and richer TerraForge capability classification scenarios.
  * Added a Node.js workflow contract test to validate shared truth evaluation and deterministic harness behavior.

* **New Features**
  * Added centralized visible release SHA extraction/validation and surfaced it in generated proof guardrails.
  * Improved blocker collection, reporting, and per-capability evidence/status (including visible SHA and reasons).
  * Refined readiness logic for surface proofs using truth evaluation outputs.

* **Build/Chores**
  * Updated the release-lane build to pass `VITE_BUILD_SHA` into the frontend image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->