### PR TITLE
docs(data): WO-DATA-004B-FIX2B — PACS attach + vintage proof

### DIFF
--- a/docs/data/PACS_CURRENT_SOURCE_ATTACH_RESULTS.md
+++ b/docs/data/PACS_CURRENT_SOURCE_ATTACH_RESULTS.md
@@ -1,0 +1,62 @@
+# WO-DATA-004B-FIX2B — PACS Current Source Attach Results
+
+**Work Order:** WO-DATA-004B-FIX2B  
+**Date:** 2026-06-17  
+**Status:** ATTACH SUCCEEDED — read-only vintage queries complete
+
+---
+
+## Container
+
+| Field | Value |
+|---|---|
+| Container name | `tf-pacs-current-verify` |
+| Image | `mcr.microsoft.com/mssql/server:2022-latest` |
+| SQL Server version | 2022 (RTM-CU25, 16.0.4255.1) |
+| Port | **21433** |
+| Restart policy | `--restart=no` |
+| Mounts | `D:/TerraFusion_PACS_Verification/source-copy:/mnt/pacs-copy` only |
+
+**Note:** SQL Server 2019 was attempted first but failed — MDF is database version 957 (SQL Server 2022 format); SQL Server 2019 supports only up to version 904. SQL Server 2022 container was used instead.
+
+---
+
+## Files Attached
+
+| File | Path in container | Size (bytes) |
+|---|---|---|
+| MDF | `/mnt/pacs-copy/pacs_oltp.mdf` | 572,901,883,904 |
+| LDF | `/mnt/pacs-copy/pacs_oltp_log.ldf` | 1,073,618,944 |
+
+Attached as database name: **`pacs_oltp_verify`** (DB ID = 5)
+
+---
+
+## Attach Status
+
+**ATTACH_SUCCESS** — `CREATE DATABASE pacs_oltp_verify ON ... FOR ATTACH` returned DB ID 5 with no errors.
+
+---
+
+## Source Volume Integrity
+
+Container mounts inspected via `docker inspect`:
+
+```
+type=bind  src=D:/TerraFusion_PACS_Verification/source-copy  dst=/mnt/pacs-copy
+```
+
+- `tf_mssql_data` Docker volume: **NOT mounted**
+- E: drive: **NOT mounted**
+- Original PACS source: **NOT touched**
+
+---
+
+## Mutations
+
+- No drains run
+- No imports run
+- No promotions run
+- No TerraFusion DB mutations
+- No writes to `tf_mssql_data` volume
+- SQL Server may have written recovery logs to the LDF during attach (standard behavior — these writes are to the D: copy only, not the source volume)

--- a/docs/data/PACS_CURRENT_SOURCE_ATTACH_RESULTS.md
+++ b/docs/data/PACS_CURRENT_SOURCE_ATTACH_RESULTS.md
@@ -54,9 +54,7 @@ type=bind  src=D:/TerraFusion_PACS_Verification/source-copy  dst=/mnt/pacs-copy
 
 ## Mutations
 
-- No drains run
-- No imports run
-- No promotions run
-- No TerraFusion DB mutations
-- No writes to `tf_mssql_data` volume
-- SQL Server may have written recovery logs to the LDF during attach (standard behavior — these writes are to the D: copy only, not the source volume)
+- **Original PACS source**: NOT touched. `tf_mssql_data` volume not mounted.
+- **TerraFusion DB**: NOT mutated.
+- **Drains / imports / promotions / projections**: NONE.
+- **D: verification copy**: SQL Server attach/recovery writes occurred to `pacs_oltp_log.ldf` on D: only. This is standard SQL Server attach behavior — the engine writes recovery completion markers to the log file. These writes are confined to the D: copy; the source volume is unaffected.

--- a/docs/data/PACS_CURRENT_SOURCE_VINTAGE_PROOF.md
+++ b/docs/data/PACS_CURRENT_SOURCE_VINTAGE_PROOF.md
@@ -1,0 +1,122 @@
+# WO-DATA-004B-FIX2B — PACS Current Source Vintage Proof
+
+**Work Order:** WO-DATA-004B-FIX2B  
+**Date:** 2026-06-17  
+**Decision: A — Current source proven**
+
+---
+
+## Query Results
+
+### Database Identity
+
+```sql
+SELECT DB_NAME() AS database_name;
+-- Result: pacs_oltp_verify
+```
+
+SQL Server 2022 (RTM-CU25, 16.0.4255.1)
+
+---
+
+### Owner Vintage (Critical Gate)
+
+```sql
+SELECT
+  COUNT(*) AS owner_rows,
+  MIN(owner_tax_yr) AS min_owner_tax_yr,
+  MAX(owner_tax_yr) AS max_owner_tax_yr,
+  SUM(CASE WHEN sup_num = 0 AND owner_tax_yr >= 2018 THEN 1 ELSE 0 END) AS qualifying_owner_rows
+FROM owner;
+```
+
+| Metric | Value |
+|---|---|
+| owner_rows | **2,539,100** |
+| min_owner_tax_yr | 1980 |
+| max_owner_tax_yr | **2026** |
+| qualifying_owner_rows (sup_num=0, year≥2018) | **809,396** |
+
+---
+
+### Property Date Range
+
+```sql
+SELECT
+  COUNT(*) AS property_rows,
+  MIN(prop_create_dt) AS min_prop_create_dt,
+  MAX(prop_create_dt) AS max_prop_create_dt
+FROM property;
+```
+
+| Metric | Value |
+|---|---|
+| property_rows | 128,949 |
+| min_prop_create_dt | 1900-01-01 (sentinel/legacy) |
+| max_prop_create_dt | **2026-01-14** |
+
+---
+
+### Sale Date Range
+
+Date column discovered: `sl_dt` (column name differs from legacy ProVal schema).
+
+```sql
+SELECT
+  COUNT(*) AS sale_rows,
+  MIN(sl_dt) AS min_sale_dt,
+  MAX(sl_dt) AS max_sale_dt,
+  SUM(CASE WHEN sl_dt >= '2018-01-01' THEN 1 ELSE 0 END) AS post_2018_sales
+FROM sale;
+```
+
+| Metric | Value |
+|---|---|
+| sale_rows | 425,251 |
+| min_sl_dt | 1899-12-31 (sentinel/legacy) |
+| max_sl_dt | **2026-01-13** |
+| post_2018_sales | **62,042** |
+
+---
+
+## Decision
+
+### **A — Current source proven**
+
+Evidence:
+- `max_owner_tax_yr = 2026` — data extends through current tax year
+- `qualifying_owner_rows = 809,396` — 809K rows pass the `sup_num = 0 AND owner_tax_yr >= 2018` filter that the Sync drain uses
+- `max_prop_create_dt = 2026-01-14` — property records current through January 2026
+- `max_sl_dt = 2026-01-13` — sales current through January 2026
+- `post_2018_sales = 62,042` — substantial qualifying sale cohort for ratio studies
+
+This is definitively the current/live Harris PACS database, not the historical Dec-2015 snapshot.
+
+---
+
+## Source Integrity Confirmation
+
+- `tf_mssql_data` Docker volume: NOT mounted into verification container
+- Original MDF: NOT touched — only the D: copy was attached
+- No drains, imports, promotions, or TerraFusion DB mutations occurred
+
+---
+
+## Technical Note: SQL Server Version Discovery
+
+The MDF is database compatibility version 957 (SQL Server 2022). SQL Server 2019 (max version 904) rejected the attach with error 948. The verification used SQL Server 2022 Developer Edition, which successfully attached the file.
+
+This confirms the PACS host runs SQL Server 2022.
+
+---
+
+## Next Work Order
+
+**WO-DATA-004B-FIX2C — Controlled Sync Drain (Post-2018 Filter)**
+
+Prerequisites now satisfied:
+- Copy is byte-exact and verified (FIX2A)
+- Attach succeeded, vintage proven (FIX2B)
+- 809,396 qualifying rows confirmed in source
+
+The drain filter `sup_num = 0 AND owner_tax_yr >= 2018` will produce substantial results. Proceed with controlled drain rerun.


### PR DESCRIPTION
## Decision A — Current source proven

Attached the D: copy of `pacs_oltp.mdf` to an isolated SQL Server 2022 container (`tf-pacs-current-verify`, port 21433). Read-only vintage queries confirm this is the live/current Harris PACS database.

## Query Results

| Query | Result |
|---|---|
| owner_rows | 2,539,100 |
| max_owner_tax_yr | **2026** |
| qualifying_owner_rows (sup_num=0, yr≥2018) | **809,396** |
| max_prop_create_dt | 2026-01-14 |
| max_sale_dt (sl_dt) | 2026-01-13 |
| post_2018_sales | 62,042 |

## Technical notes

- MDF is database version 957 → **requires SQL Server 2022** (2019 rejected it with error 948)
- `tf_mssql_data` volume was NOT mounted; only `D:/TerraFusion_PACS_Verification/source-copy:/mnt/pacs-copy`
- No drains, imports, promotions, or TerraFusion DB mutations

## Files (docs-only)

- `docs/data/PACS_CURRENT_SOURCE_ATTACH_RESULTS.md`
- `docs/data/PACS_CURRENT_SOURCE_VINTAGE_PROOF.md`

## Next work order

**WO-DATA-004B-FIX2C** — Controlled Sync drain (post-2018 filter). 809,396 qualifying owner rows confirmed in source.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on data source attachment verification and validation results.
  * Added documentation confirming the integrity and vintage authenticity of the current PACS data source with supporting validation queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->