### PR TITLE
fix(sync/drain): default FullCorpus to false when request body is absent

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -2131,9 +2131,10 @@ public class DoctrineDrainController : ControllerBase
     /// <param name="OperatorName">Audit anchor on every batch this lane writes.</param>
     /// <param name="WorkingYear">PACS prop_val_yr filter for the year-grain stages
     /// (improvement, land). Default 2026 — Benton's active assessment year.</param>
-    /// <param name="FullCorpus">When true (the default), the seed source's TopN
-    /// is null (full corpus drain). When false, <paramref name="TopN"/> applies
-    /// (or a per-lane safe default if TopN is also null).</param>
+    /// <param name="FullCorpus">When true, the seed source's TopN is null
+    /// (full corpus drain). When false or omitted (the safe default),
+    /// <paramref name="TopN"/> applies (or a per-lane safe default if TopN
+    /// is also null: 200 for parcel/owner/improvement/land, 500 for sales).</param>
     /// <param name="TopN">Override the per-lane safe-default sample size. Only
     /// effective when <paramref name="FullCorpus"/> is false.</param>
     /// <param name="LaneResultId">SYNC-COMPLETE-2-V2: when supplied (typically by

--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -1637,14 +1637,14 @@ public class DoctrineDrainController : ControllerBase
         return (cs, null);
     }
 
-    private static (string OperatorName, short WorkingYear, bool FullCorpus, int? TopN)
+    internal static (string OperatorName, short WorkingYear, bool FullCorpus, int? TopN)
         NormalizeRequest(DoctrineDrainRequest? request, string laneName)
     {
         var operatorName = string.IsNullOrWhiteSpace(request?.OperatorName)
             ? $"doctrine-drain-{laneName}"
             : request!.OperatorName!.Trim();
         var workingYear = (short)(request?.WorkingYear ?? 2026);
-        var fullCorpus = request?.FullCorpus ?? true;
+        var fullCorpus = request?.FullCorpus ?? false;
         var topN = request?.TopN;
         return (operatorName, workingYear, fullCorpus, topN);
     }

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs
@@ -61,6 +61,23 @@ public sealed class DoctrineDrainNormalizeRequestTests
         operatorName.Should().Be("doctrine-drain-owner-wsdor");
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Body_with_missing_or_whitespace_operator_name_defaults_to_lane_scoped_name(string? operatorNameFromBody)
+    {
+        var request = new DoctrineDrainController.DoctrineDrainRequest(
+            OperatorName: operatorNameFromBody,
+            WorkingYear: 2026,
+            FullCorpus: false,
+            TopN: 100);
+
+        var (operatorName, _, _, _) = DoctrineDrainController.NormalizeRequest(request, "owner-wsdor");
+
+        operatorName.Should().Be("doctrine-drain-owner-wsdor");
+    }
+
     [Fact]
     public void NullBody_working_year_defaults_to_2026()
     {

--- a/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using TerraFusion.API.Controllers;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Sync.Doctrine;
+
+/// <summary>
+/// WO-DATA-004B-SCALE-001Y: verifies that NormalizeRequest defaults to
+/// FullCorpus=false (bounded) when no request body is provided.
+/// Root cause: prior default was ?? true, which caused null-body calls to
+/// silently trigger full-corpus imports. See PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md.
+/// DoctrineDrainRequest is nested inside DoctrineDrainController.
+/// NormalizeRequest is internal (InternalsVisibleTo grants access to this test assembly).
+/// </summary>
+public sealed class DoctrineDrainNormalizeRequestTests
+{
+    [Fact]
+    public void NullBody_defaults_to_FullCorpus_false_and_TopN_null()
+    {
+        var (_, _, fullCorpus, topN) = DoctrineDrainController.NormalizeRequest(null, "parcel");
+
+        fullCorpus.Should().BeFalse("a missing request body must not trigger a full-corpus import");
+        topN.Should().BeNull("TopN comes from the body; null body means no TopN override");
+    }
+
+    [Fact]
+    public void Body_with_FullCorpus_false_and_TopN_500_passes_through_bounded()
+    {
+        var request = new DoctrineDrainController.DoctrineDrainRequest(
+            OperatorName: "scale-001a",
+            WorkingYear: 2026,
+            FullCorpus: false,
+            TopN: 500);
+
+        var (_, _, fullCorpus, topN) = DoctrineDrainController.NormalizeRequest(request, "parcel");
+
+        fullCorpus.Should().BeFalse();
+        topN.Should().Be(500);
+    }
+
+    [Fact]
+    public void Body_with_FullCorpus_true_is_still_explicit_full_corpus()
+    {
+        var request = new DoctrineDrainController.DoctrineDrainRequest(
+            OperatorName: "full-run",
+            WorkingYear: 2026,
+            FullCorpus: true,
+            TopN: null);
+
+        var (_, _, fullCorpus, topN) = DoctrineDrainController.NormalizeRequest(request, "parcel");
+
+        fullCorpus.Should().BeTrue("explicit FullCorpus=true must still trigger full corpus");
+        topN.Should().BeNull();
+    }
+
+    [Fact]
+    public void NullBody_operator_name_defaults_to_lane_scoped_name()
+    {
+        var (operatorName, _, _, _) = DoctrineDrainController.NormalizeRequest(null, "owner-wsdor");
+
+        operatorName.Should().Be("doctrine-drain-owner-wsdor");
+    }
+
+    [Fact]
+    public void NullBody_working_year_defaults_to_2026()
+    {
+        var (_, workingYear, _, _) = DoctrineDrainController.NormalizeRequest(null, "parcel");
+
+        workingYear.Should().Be((short)2026);
+    }
+}

--- a/docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md
+++ b/docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md
@@ -37,7 +37,7 @@ committed. See `PACS_SYNC_SCALE_001X_TOPN_PROPAGATION_FAILURE.md` for the full i
 ## 2. The Fix
 
 **File:** `backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs`
-**Location:** `NormalizeRequest` private method, line 1647
+**Location:** `NormalizeRequest` internal method, line 1647
 
 ```csharp
 // After (SCALE-001Y patch):
@@ -54,7 +54,7 @@ to enable direct unit testing via the existing `InternalsVisibleTo` grant to `Te
 
 | Call pattern | `request` | `FullCorpus` resolved | `seedTopN` | Effect |
 |---|---|---|---|---|
-| No body (curl without -d) | `null` | `false` ← patched | `200` (per-lane default) | Bounded 200-row slice |
+| No body (curl without -d) | `null` | `false` ← patched | `200` (parcel/owner/improvement/land default) or `500` (sales default) | Bounded slice |
 | `{"FullCorpus":false,"TopN":500}` | not null | `false` | `500` | Bounded 500-row slice |
 | `{"FullCorpus":true}` | not null | `true` | `null` | Full corpus (explicit) |
 | `{"TopN":100}` (no FullCorpus key) | not null | `false` (null-coalesce) | `100` | Bounded 100-row slice |
@@ -69,12 +69,15 @@ bounded rather than full-corpus.
 The downstream logic is unchanged. Only the `FullCorpus` default changed:
 
 ```csharp
-// Parcel lane (line ~269) — same pattern in all lanes:
+// Parcel/owner/improvement/land lanes (e.g. line ~269):
 var seedTopN = fullCorpus ? (int?)null : (topN ?? 200);
+
+// Sales lane (line ~1331) — higher safe default:
+var saleTopN = fullCorpus ? (int?)null : (topN ?? 500);
 ```
 
 With the patch:
-- `FullCorpus=false` and no `TopN` → `seedTopN = 200` (per-lane safe default, not unbounded)
+- `FullCorpus=false` and no `TopN` → `seedTopN = 200` for parcel/owner/improvement/land; `500` for sales (per-lane safe defaults, not unbounded)
 - `FullCorpus=false` and `TopN=500` → `seedTopN = 500`
 - `FullCorpus=true` → `seedTopN = null` (full corpus, SQL has no TOP clause)
 
@@ -136,20 +139,20 @@ query-string TopN binding.
 
 ```bash
 # Bounded drain (recommended for scale proof):
-curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel" \
+curl -X POST "http://localhost:${TF_API_PORT:-5046}/api/sync/doctrine/drain/parcel" \
   -H "Content-Type: application/json" \
   -d '{"OperatorName":"scale-001a-parcel","WorkingYear":2026,"FullCorpus":false,"TopN":500}'
 
 # Full corpus (explicit opt-in):
-curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel" \
+curl -X POST "http://localhost:${TF_API_PORT:-5046}/api/sync/doctrine/drain/parcel" \
   -H "Content-Type: application/json" \
   -d '{"OperatorName":"full-corpus-run","WorkingYear":2026,"FullCorpus":true}'
 ```
 
-The following call form is NOW SAFE (no body → bounded at 200 rows, not full corpus):
+The following call form is NOW SAFE (no body → bounded at per-lane default, not full corpus):
 ```bash
-curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel"
-# Resolves: FullCorpus=false, TopN=null → seedTopN=200
+curl -X POST "http://localhost:${TF_API_PORT:-5046}/api/sync/doctrine/drain/parcel"
+# Resolves: FullCorpus=false, TopN=null → seedTopN=200 (parcel/owner/improvement/land) or 500 (sales)
 ```
 
 ---
@@ -159,7 +162,7 @@ curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel"
 | File | Change |
 |---|---|
 | `backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs` | `?? true` → `?? false` on line 1647; `private static` → `internal static` on `NormalizeRequest` |
-| `backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs` | New file — 5 unit tests |
+| `backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs` | New file — 8 unit tests (5 facts + 1 theory × 3 inline data) |
 | `docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md` | This file |
 
 ---

--- a/docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md
+++ b/docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md
@@ -1,0 +1,179 @@
+# WO-DATA-004B-SCALE-001Y — Drain Request Safe Default Patch
+
+**Work Order:** WO-DATA-004B-SCALE-001Y
+**Date:** 2026-06-19
+**Status:** PATCH APPLIED — No drain run. No DB mutation. No PACS contact.
+**Prerequisite evidence:** PR #1050 (SCALE-001X investigation)
+
+---
+
+## Executive Summary
+
+One-line fix to `DoctrineDrainController.NormalizeRequest`: changed the `FullCorpus`
+null-coalescing default from `true` to `false`. A missing request body now defaults to
+bounded mode (per-lane safe TopN of 200) instead of triggering a full-corpus import.
+
+Full-corpus runs still work by explicitly passing `"FullCorpus":true` in the body.
+
+---
+
+## 1. Root Cause (from SCALE-001X)
+
+`NormalizeRequest` was the drop point for TopN propagation failure:
+
+```csharp
+// Before (DoctrineDrainController.cs line 1647):
+var fullCorpus = request?.FullCorpus ?? true;
+// When request is null (no body sent) → FullCorpus=true → seedTopN=null → no SQL TOP clause → full corpus
+```
+
+SCALE-001A and SCALE-001B were called without a request body. The prior default silently
+triggered full-corpus mode on every bodyless call. SCALE-001A completed a near-full Benton
+parcel corpus import (~93%, 83,326 rows). SCALE-001B was killed after ~1 hour with 0 rows
+committed. See `PACS_SYNC_SCALE_001X_TOPN_PROPAGATION_FAILURE.md` for the full investigation.
+
+---
+
+## 2. The Fix
+
+**File:** `backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs`
+**Location:** `NormalizeRequest` private method, line 1647
+
+```csharp
+// After (SCALE-001Y patch):
+var fullCorpus = request?.FullCorpus ?? false;
+// When request is null → FullCorpus=false → seedTopN = topN ?? 200 → bounded by per-lane default
+```
+
+**Accessor change:** `NormalizeRequest` was also changed from `private static` to `internal static`
+to enable direct unit testing via the existing `InternalsVisibleTo` grant to `TerraFusion.Unit.Tests`.
+
+---
+
+## 3. Behavior Matrix After Patch
+
+| Call pattern | `request` | `FullCorpus` resolved | `seedTopN` | Effect |
+|---|---|---|---|---|
+| No body (curl without -d) | `null` | `false` ← patched | `200` (per-lane default) | Bounded 200-row slice |
+| `{"FullCorpus":false,"TopN":500}` | not null | `false` | `500` | Bounded 500-row slice |
+| `{"FullCorpus":true}` | not null | `true` | `null` | Full corpus (explicit) |
+| `{"TopN":100}` (no FullCorpus key) | not null | `false` (null-coalesce) | `100` | Bounded 100-row slice |
+
+The last row is a new safe behavior: omitting `FullCorpus` from the body now defaults to
+bounded rather than full-corpus.
+
+---
+
+## 4. seedTopN Propagation (unchanged)
+
+The downstream logic is unchanged. Only the `FullCorpus` default changed:
+
+```csharp
+// Parcel lane (line ~269) — same pattern in all lanes:
+var seedTopN = fullCorpus ? (int?)null : (topN ?? 200);
+```
+
+With the patch:
+- `FullCorpus=false` and no `TopN` → `seedTopN = 200` (per-lane safe default, not unbounded)
+- `FullCorpus=false` and `TopN=500` → `seedTopN = 500`
+- `FullCorpus=true` → `seedTopN = null` (full corpus, SQL has no TOP clause)
+
+---
+
+## 5. All Five Affected Endpoints
+
+All five drain endpoints call `NormalizeRequest` and are protected by this fix:
+
+| Endpoint | Lane |
+|---|---|
+| `POST /api/sync/doctrine/drain/parcel` | parcel |
+| `POST /api/sync/doctrine/drain/owner-wsdor` | owner-wsdor |
+| `POST /api/sync/doctrine/drain/improvement` | improvement |
+| `POST /api/sync/doctrine/drain/land` | land |
+| `POST /api/sync/doctrine/drain/sales` | sales |
+
+The geometry endpoint uses a different code path and is not affected.
+
+---
+
+## 6. Unit Tests Added
+
+**File:** `backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs`
+
+Five test cases added:
+
+| Test | Verifies |
+|---|---|
+| `NullBody_defaults_to_FullCorpus_false_and_TopN_null` | null body → FullCorpus=false, TopN=null |
+| `Body_with_FullCorpus_false_and_TopN_500_passes_through_bounded` | explicit bounded body → FullCorpus=false, TopN=500 |
+| `Body_with_FullCorpus_true_is_still_explicit_full_corpus` | explicit full-corpus body → FullCorpus=true, TopN=null |
+| `NullBody_operator_name_defaults_to_lane_scoped_name` | null body → OperatorName = "doctrine-drain-{lane}" |
+| `NullBody_working_year_defaults_to_2026` | null body → WorkingYear = 2026 |
+
+All 5 pass. No regressions in the full `TerraFusion.Unit.Tests` suite.
+
+---
+
+## 7. Prior Slice Evidence — Impact Assessment
+
+This fix does not invalidate any prior evidence. The controlled-slice drains (FIX3–FIX7B)
+all sent correct JSON bodies with `"FullCorpus":false,"TopN":100`. Those results are
+accurate and unaffected.
+
+SCALE-001A parcel import (83,326 rows, near-full corpus) was a procedural scope breach
+caused by the missing body, not by the pipeline logic. The data is technically clean
+(17/17 gates PASS). The `terrafusion_dev_clean` DB classification stands as defined in
+the SCALE-001X investigation: valid for completed WO-DATA-004B controlled slices through
+sales; additionally contains out-of-scope near-full parcel import; not clean for future
+scale proof.
+
+---
+
+## 8. Correct Drain Call Format (post-patch)
+
+Always send a JSON body. The endpoint binding is `[FromBody]` only — there is no
+query-string TopN binding.
+
+```bash
+# Bounded drain (recommended for scale proof):
+curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel" \
+  -H "Content-Type: application/json" \
+  -d '{"OperatorName":"scale-001a-parcel","WorkingYear":2026,"FullCorpus":false,"TopN":500}'
+
+# Full corpus (explicit opt-in):
+curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel" \
+  -H "Content-Type: application/json" \
+  -d '{"OperatorName":"full-corpus-run","WorkingYear":2026,"FullCorpus":true}'
+```
+
+The following call form is NOW SAFE (no body → bounded at 200 rows, not full corpus):
+```bash
+curl -X POST "http://localhost:5046/api/sync/doctrine/drain/parcel"
+# Resolves: FullCorpus=false, TopN=null → seedTopN=200
+```
+
+---
+
+## 9. Files Changed
+
+| File | Change |
+|---|---|
+| `backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs` | `?? true` → `?? false` on line 1647; `private static` → `internal static` on `NormalizeRequest` |
+| `backend/tests/TerraFusion.Unit.Tests/Sync/Doctrine/DoctrineDrainNormalizeRequestTests.cs` | New file — 5 unit tests |
+| `docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md` | This file |
+
+---
+
+## Final Report
+
+| Field | Value |
+|---|---|
+| RESULT | PATCH APPLIED |
+| FILE_CHANGED | `DoctrineDrainController.cs` line 1647 — `?? true` → `?? false` |
+| ACCESSOR_CHANGE | `NormalizeRequest` `private` → `internal` (for testability) |
+| TESTS_ADDED | 5 new unit tests in `DoctrineDrainNormalizeRequestTests.cs` — all PASS |
+| REGRESSIONS | None — full `TerraFusion.Unit.Tests` suite green |
+| DRAINS_RUN | None |
+| DB_MUTATION | None |
+| PACS_CONTACT | None |
+| NEXT_WORK_ORDER | WO-DATA-004B-SCALE-001Z — Fresh Scale DB Bootstrap |


### PR DESCRIPTION
## Summary

- `DoctrineDrainController.NormalizeRequest` previously defaulted `FullCorpus ?? true` — a missing request body silently triggered full-corpus imports
- Changed default to `?? false`: bodyless calls now resolve to bounded mode (per-lane TopN safe default of 200)
- `NormalizeRequest` changed `private → internal` to enable direct unit testing via existing `InternalsVisibleTo` grant
- 5 new unit tests added covering: null-body bounded default, bounded body pass-through, explicit full-corpus body, operator-name default, working-year default
- 3414/3414 unit tests pass — no regressions

**Root cause (from PR #1050):** SCALE-001A and SCALE-001B drain calls used `?topN=500` query-string with no body. The endpoint is `[FromBody]` only — query-string TopN is not bound. Null body → `FullCorpus=true` → full corpus.

**Prior evidence (FIX3–FIX7B) unaffected:** All prior controlled-slice drains sent correct JSON bodies with `"FullCorpus":false,"TopN":100` and remain valid.

**Explicit full-corpus still works:** `{"FullCorpus":true}` in the body triggers full corpus as before.

## Test plan

- [x] 5 new `DoctrineDrainNormalizeRequestTests` — all PASS
- [x] Full `TerraFusion.Unit.Tests` suite — 3414/3414 PASS
- [x] Pre-push gate (vitest 164/164 + security scan) — PASS
- [ ] CI Backend Gate
- [ ] CI Frontend Gate

## Evidence

`docs/data/PACS_SYNC_SCALE_001Y_SAFE_DEFAULT_PATCH.md`

**WO:** WO-DATA-004B-SCALE-001Y
**Prereq:** PR #1050 (SCALE-001X investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Doctrine drain request normalization to use a safe bounded default when no request body is provided and add coverage and documentation for the new behavior.

Bug Fixes:
- Prevent bodyless Doctrine drain calls from defaulting to full-corpus imports by defaulting FullCorpus to false instead of true.

Enhancements:
- Expose NormalizeRequest as internal to allow direct unit testing via existing InternalsVisibleTo configuration.

Documentation:
- Add SCALE-001Y evidence document describing the safe-default patch, affected endpoints, behavior matrix, and correct drain usage.

Tests:
- Add DoctrineDrainNormalizeRequest unit test suite covering null-body defaults, bounded and full-corpus behaviors, and operator/year defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default behavior for data drainage requests: bulk operations now default to selective retrieval instead of full-corpus extraction when the parameter is omitted, reducing unintended data volume.

* **Documentation**
  * Updated API documentation to reflect the new default parameter behavior and provide guidance for proper drain request configuration.

* **Tests**
  * Added unit tests validating drain request normalization and default parameter handling across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->