### PR TITLE
feat(geom-005): FIPS-keyed ArcGIS config — clean restart preserving all GEOM-002 protections

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CanonicalDebugController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CanonicalDebugController.cs
@@ -1897,7 +1897,7 @@ public class CanonicalDebugController : ControllerBase
             // ── A. D1 raw landing (full-county pull from ArcGIS REST). ──
             _logger.LogInformation("[GisPop1] A. Raw ArcGIS landing for countyId={Cid}", bentonCountyId);
             var d1 = await rawLandingSvc.LandParcelGeomsAsync(
-                bentonCountyId, operatorName, topN: null, cancellationToken);
+                "53005", bentonCountyId, operatorName, topN: null, cancellationToken);
             if (!string.Equals(d1.Status, "COMPLETED", StringComparison.OrdinalIgnoreCase))
                 return StatusCode(500, new { stage = "ArcGis-D1", error = d1.ErrorSummary, d1 });
 
@@ -2170,7 +2170,7 @@ public class CanonicalDebugController : ControllerBase
             object? gisLane = null;
             if (!skipGeometry)
             {
-                var gisD1 = await gisRawSvc.LandParcelGeomsAsync(bentonCountyId, operatorName, topN: null, cancellationToken);
+                var gisD1 = await gisRawSvc.LandParcelGeomsAsync("53005", bentonCountyId, operatorName, topN: null, cancellationToken);
                 var gisD2 = await gisTruthSvc.PromoteCountyAsync(bentonCountyId, operatorName, cancellationToken);
                 var gisD3 = await gisCanonicalProjector.ProjectCountyAsync(bentonCountyId, operatorName, cancellationToken);
                 gisLane = new { lane = "Geometry", gisD1.FeaturesLanded, gisD3.RowsProjected, gisD3.ApnCrosswalkResolved, gisD3.ApnCrosswalkUnresolved };

--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -35,6 +35,8 @@ using TerraFusion.Core.Sync.PacsWashPropOwnerValTruth;
 using TerraFusion.Core.Sync.PacsWsdorCanonical;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.PacsSources;
+using Microsoft.Extensions.Options;
+using ArcGisFeatureServiceOptions = TerraFusion.Core.Configuration.ArcGisFeatureServiceOptions;
 
 namespace TerraFusion.API.Controllers;
 
@@ -265,7 +267,8 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
             var seedTopN = fullCorpus ? (int?)null : (topN ?? 200);
 
             // Stage 1: Owner-Seed-S1.
@@ -432,7 +435,8 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
             var ownerTopN = fullCorpus ? (int?)null : (topN ?? 200);
 
             // Stage 1: Owner-S1.
@@ -742,7 +746,8 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
             var seedTopN = fullCorpus ? (int?)null : (topN ?? 200);
 
             // Stage 1: Owner-Seed-S1.
@@ -1090,7 +1095,8 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
             var seedTopN = fullCorpus ? (int?)null : (topN ?? 200);
 
             // Stage 1: Owner-Seed-S1.
@@ -1327,7 +1333,8 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
             var saleTopN = fullCorpus ? (int?)null : (topN ?? 500);
 
             // Stage 1: Sale-S1.
@@ -1522,6 +1529,7 @@ public class DoctrineDrainController : ControllerBase
         [FromServices] IArcGisRawLandingService rawLandingSvc,
         [FromServices] IArcGisTruthPromotionService truthPromotionSvc,
         [FromServices] IArcGisCanonicalProjector canonicalProjector,
+        [FromServices] IOptions<ArcGisFeatureServiceOptions> arcGisOptions,
         [FromBody] DoctrineDrainRequest? request,
         CancellationToken cancellationToken = default)
     {
@@ -1556,25 +1564,16 @@ public class DoctrineDrainController : ControllerBase
 
         try
         {
-            var bentonCountyId = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCounty = await ResolveOrCreateBentonCountyAsync(cancellationToken);
+            var bentonCountyId = bentonCounty.Id;
 
-            // Geometry lane safety: ArcGIS config is keyed by KnownBentonCountyId.
-            // If the DB already has a Benton row under a different GUID (e.g. from a
-            // prior failed seeder run), silently using that GUID would produce a
-            // GetForCounty() miss and a confusing ArcGIS config error mid-drain.
-            // Refuse explicitly before any network call so the operator can resolve
-            // the county identity conflict first.
-            if (bentonCountyId != KnownBentonCountyId)
-            {
-                return StatusCode(409, new
-                {
-                    error = $"Benton CountyId mismatch: ArcGIS config requires {KnownBentonCountyId}, " +
-                            $"but the existing county row has Id={bentonCountyId}. " +
-                            "Geometry drain refused before ArcGIS fetch.",
-                    requiredCountyId = KnownBentonCountyId,
-                    actualCountyId = bentonCountyId,
-                });
-            }
+            // GEOM-005: config is keyed by FIPS code, not GUID.
+            // Refuse before any ArcGIS network call if FipsCode is unset or has no config entry.
+            if (string.IsNullOrEmpty(bentonCounty.FipsCode))
+                return BadRequest(new { error = "Benton county row has no FipsCode — geometry drain refused." });
+
+            if (!arcGisOptions.Value.Counties.ContainsKey(bentonCounty.FipsCode))
+                return NotFound(new { error = $"No ArcGIS config entry for FIPS {bentonCounty.FipsCode}." });
 
             // Stage 1: ArcGis-D1.
             int d1FeaturesLanded = 0;
@@ -1585,7 +1584,7 @@ public class DoctrineDrainController : ControllerBase
             else
             {
                 _logger.LogInformation("[Drain:geometry] D1 ArcGIS landing for county={Cid}", bentonCountyId);
-                var d1 = await rawLandingSvc.LandParcelGeomsAsync(bentonCountyId, operatorName, geomTopN, cancellationToken);
+                var d1 = await rawLandingSvc.LandParcelGeomsAsync(bentonCounty.FipsCode, bentonCountyId, operatorName, geomTopN, cancellationToken);
                 batchIds.Add(d1.LoadBatchId);
                 if (!IsCompleted(d1.Status))
                     return await FailLaneAsync(LaneName, "ArcGis-D1", d1.ErrorSummary,
@@ -1691,12 +1690,12 @@ public class DoctrineDrainController : ControllerBase
     /// Resolve Benton (WA) county id by FIPS, then by Name+State, then
     /// create. Mirrors CanonicalDebugController's implementation.
     /// </summary>
-    private async Task<Guid> ResolveOrCreateBentonCountyAsync(CancellationToken cancellationToken)
+    private async Task<County> ResolveOrCreateBentonCountyAsync(CancellationToken cancellationToken)
     {
         var byFips = await _db.Counties
             .FirstOrDefaultAsync(c => c.FipsCode == "53005", cancellationToken)
             .ConfigureAwait(false);
-        if (byFips is not null) return byFips.Id;
+        if (byFips is not null) return byFips;
 
         var byName = await _db.Counties
             .FirstOrDefaultAsync(c =>
@@ -1704,7 +1703,7 @@ public class DoctrineDrainController : ControllerBase
                 EF.Functions.ILike(c.State, "WA"),
                 cancellationToken)
             .ConfigureAwait(false);
-        if (byName is not null) return byName.Id;
+        if (byName is not null) return byName;
 
         var county = new County
         {
@@ -1718,7 +1717,7 @@ public class DoctrineDrainController : ControllerBase
         _db.Counties.Add(county);
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("[DoctrineDrain] Created Benton county row id={Id}", county.Id);
-        return county.Id;
+        return county;
     }
 
     private static bool IsCompleted(string? status) =>

--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -1521,8 +1521,8 @@ public class DoctrineDrainController : ControllerBase
 
     /// <summary>
     /// Drain the geometry lane. ArcGIS REST D1 raw → D2 truth → D3
-    /// canonical (tf_parcel_geom + APN crosswalk). FullCorpus/TopN are
-    /// not used — the ArcGIS service pulls the full county feature set.
+    /// canonical (tf_parcel_geom + APN crosswalk). TopN bounds the
+    /// ArcGIS pull via resultRecordCount; FullCorpus=true clears the cap.
     /// </summary>
     [HttpPost("geometry")]
     public async Task<IActionResult> DrainGeometry(
@@ -1572,7 +1572,7 @@ public class DoctrineDrainController : ControllerBase
             if (string.IsNullOrEmpty(bentonCounty.FipsCode))
                 return BadRequest(new { error = "Benton county row has no FipsCode — geometry drain refused." });
 
-            if (!arcGisOptions.Value.Counties.ContainsKey(bentonCounty.FipsCode))
+            if (arcGisOptions.Value.GetForCounty(bentonCounty.FipsCode) is null)
                 return NotFound(new { error = $"No ArcGIS config entry for FIPS {bentonCounty.FipsCode}." });
 
             // Stage 1: ArcGis-D1.
@@ -1680,9 +1680,9 @@ public class DoctrineDrainController : ControllerBase
         return (operatorName, workingYear, fullCorpus, topN);
     }
 
-    // Anchor GUID matches appsettings.Development.json ArcGisFeatureServices.Counties key
-    // and DatabaseSeeder.BentonCountyId. If ResolveOrCreate falls through to creation,
-    // using this ID ensures GetForCounty(bentonCountyId) always resolves the ArcGIS config.
+    // Anchor GUID matches DatabaseSeeder.BentonCountyId. If ResolveOrCreate falls through
+    // to creation, this ID keeps the county row stable across reseeds. ArcGIS config is
+    // now keyed by FipsCode ("53005"), not by this GUID.
     private static readonly Guid KnownBentonCountyId =
         Guid.Parse("19190019-1919-1919-1919-191919191919");
 

--- a/backend/src/TerraFusion.API/appsettings.Development.json
+++ b/backend/src/TerraFusion.API/appsettings.Development.json
@@ -91,12 +91,13 @@
   },
   "ArcGisFeatureServices": {
     "Counties": {
-      "19190019-1919-1919-1919-191919191919": {
+      "53005": {
         "ParcelFeatureServiceUrl": "https://services7.arcgis.com/NURlY7V8UHl6XumF/arcgis/rest/services/Parcels_and_Assess/FeatureServer/0",
         "ApnAttributeName": "geo_id",
         "ObjectIdAttributeName": "OBJECTID",
         "OutSpatialReferenceEpsg": 4326,
-        "RequestTimeoutSeconds": 120
+        "RequestTimeoutSeconds": 120,
+        "CountyId": "19190019-1919-1919-1919-191919191919"
       }
     }
   },

--- a/backend/src/TerraFusion.Core/Configuration/ArcGisFeatureServiceOptions.cs
+++ b/backend/src/TerraFusion.Core/Configuration/ArcGisFeatureServiceOptions.cs
@@ -23,27 +23,26 @@ public sealed class ArcGisFeatureServiceOptions
     public const string SectionName = "ArcGisFeatureServices";
 
     /// <summary>
-    /// Per-county feature service definitions, keyed by the canonical
-    /// Guid string form of the CountyId. String keys (rather than
-    /// <see cref="Guid"/>) are required because
-    /// <c>Microsoft.Extensions.Configuration</c> only binds
-    /// dictionaries with string keys natively.
+    /// Per-county feature service definitions, keyed by FIPS code (e.g. "53005"
+    /// for Benton County WA). FIPS codes are immutable across DB provisioning;
+    /// County.Id GUIDs are not. String keys are required because
+    /// <c>Microsoft.Extensions.Configuration</c> only binds dictionaries with
+    /// string keys natively.
     /// </summary>
     public IDictionary<string, CountyArcGisOptions> Counties { get; set; }
         = new Dictionary<string, CountyArcGisOptions>();
 
     /// <summary>
-    /// Type-safe lookup: returns the <see cref="CountyArcGisOptions"/>
-    /// for the given <paramref name="countyId"/>, or <c>null</c> if
-    /// no configuration was bound for that county. Performs a
-    /// case-insensitive Guid-string match.
+    /// GEOM-005: type-safe lookup by FIPS code. Returns the
+    /// <see cref="CountyArcGisOptions"/> for the given
+    /// <paramref name="fipsCode"/>, or <c>null</c> if no configuration
+    /// was bound for that FIPS code. Case-insensitive.
     /// </summary>
-    public CountyArcGisOptions? GetForCounty(Guid countyId)
+    public CountyArcGisOptions? GetForCounty(string fipsCode)
     {
-        var canonical = countyId.ToString();
         foreach (var kvp in Counties)
         {
-            if (string.Equals(kvp.Key, canonical, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(kvp.Key, fipsCode, StringComparison.OrdinalIgnoreCase))
             {
                 return kvp.Value;
             }
@@ -95,4 +94,12 @@ public sealed class CountyArcGisOptions
     /// no token is required.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// GEOM-005: optional DB identity of this county. Used by the nightly
+    /// sync hosted service to resolve which row to stamp geometry against
+    /// when iterating FIPS-keyed config entries. Not required by the drain
+    /// controller (it resolves CountyId from the DB via FipsCode).
+    /// </summary>
+    public Guid? CountyId { get; set; }
 }

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisFeatureServiceClient.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisFeatureServiceClient.cs
@@ -56,18 +56,19 @@ public sealed class ArcGisFeatureServiceClient : IArcGisFeatureServiceClient
     }
 
     public async Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
+        string fipsCode,
         Guid countyId,
         int? topN,
         CancellationToken cancellationToken = default)
     {
-        var county = _options.Value.GetForCounty(countyId)
+        var county = _options.Value.GetForCounty(fipsCode)
             ?? throw new ArcGisFeatureServiceConfigurationException(
-                $"No ArcGIS feature-service configuration bound for county {countyId}.");
+                $"No ArcGIS feature-service configuration bound for FIPS {fipsCode} (county {countyId}).");
 
         if (string.IsNullOrWhiteSpace(county.ParcelFeatureServiceUrl))
         {
             throw new ArcGisFeatureServiceConfigurationException(
-                $"County {countyId} has empty ParcelFeatureServiceUrl.");
+                $"FIPS {fipsCode} (county {countyId}) has empty ParcelFeatureServiceUrl.");
         }
 
         var queryUrl = BuildQueryUrl(county, topN);

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisNightlySyncHostedService.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisNightlySyncHostedService.cs
@@ -111,25 +111,31 @@ public sealed class ArcGisNightlySyncHostedService : BackgroundService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!Guid.TryParse(key, out var countyId))
+            // GEOM-005: config is now keyed by FIPS code. Entries that lack
+            // CountyId cannot be stamped against a DB row — skip with a warning.
+            if (!arcgis.Counties.TryGetValue(key, out var countyOpts) ||
+                countyOpts.CountyId is null)
             {
                 _logger.LogWarning(
-                    "ArcGIS nightly sync: skipping malformed county key '{Key}' (not a GUID).",
+                    "ArcGIS nightly sync: skipping FIPS key '{Key}' — no CountyId configured.",
                     key);
                 continue;
             }
+
+            var fipsCode = key;
+            var countyId = countyOpts.CountyId.Value;
 
             try
             {
                 using var scope = _scopeFactory.CreateScope();
                 var sync = scope.ServiceProvider.GetRequiredService<IArcGisSyncService>();
                 var result = await sync
-                    .SyncCountyAsync(countyId, operatorName, cancellationToken)
+                    .SyncCountyAsync(fipsCode, countyId, operatorName, cancellationToken)
                     .ConfigureAwait(false);
 
                 _logger.LogInformation(
-                    "ArcGIS nightly sync: county {CountyId} {Status} (fetched={Fetched} upserted={Upserted} softDeleted={SoftDeleted})",
-                    countyId, result.Status, result.FeaturesFetched,
+                    "ArcGIS nightly sync: FIPS {FipsCode} county {CountyId} {Status} (fetched={Fetched} upserted={Upserted} softDeleted={SoftDeleted})",
+                    fipsCode, countyId, result.Status, result.FeaturesFetched,
                     result.FeaturesUpserted, result.FeaturesSoftDeleted);
             }
             catch (OperationCanceledException)
@@ -145,8 +151,8 @@ public sealed class ArcGisNightlySyncHostedService : BackgroundService
                 // anything outside its try/catch (DI scope
                 // construction, options resolution, etc.).
                 _logger.LogError(ex,
-                    "ArcGIS nightly sync: unexpected failure for county {CountyId}; continuing cycle.",
-                    countyId);
+                    "ArcGIS nightly sync: unexpected failure for FIPS {FipsCode} county {CountyId}; continuing cycle.",
+                    fipsCode, countyId);
             }
             finally
             {

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisFeatureServiceClient.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisFeatureServiceClient.cs
@@ -32,6 +32,7 @@ public interface IArcGisFeatureServiceClient
     /// invalid JSON).
     /// </exception>
     Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
+        string fipsCode,
         Guid countyId,
         int? topN,
         CancellationToken cancellationToken = default);

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisSyncService.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisSyncService.cs
@@ -27,6 +27,7 @@ public interface IArcGisSyncService
     /// features, write provenance, and close the load batch.
     /// </summary>
     Task<ArcGisSyncResult> SyncCountyAsync(
+        string fipsCode,
         Guid countyId,
         string operatorName,
         CancellationToken cancellationToken = default);

--- a/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
@@ -32,6 +32,7 @@ namespace TerraFusion.Core.Sync.ArcGisRawLanding;
 public interface IArcGisRawLandingService
 {
     Task<ArcGisRawLandingResult> LandParcelGeomsAsync(
+        string fipsCode,
         Guid countyId,
         string operatorName,
         int? topN,

--- a/backend/src/TerraFusion.Data/Services/GisTf/ArcGisSyncService.cs
+++ b/backend/src/TerraFusion.Data/Services/GisTf/ArcGisSyncService.cs
@@ -53,6 +53,7 @@ public sealed class ArcGisSyncService : IArcGisSyncService
     }
 
     public async Task<ArcGisSyncResult> SyncCountyAsync(
+        string fipsCode,
         Guid countyId,
         string operatorName,
         CancellationToken cancellationToken = default)
@@ -61,7 +62,7 @@ public sealed class ArcGisSyncService : IArcGisSyncService
         {
             SourceFamily = SourceFamilies.ArcGisRest,
             SourceSystem = "county-arcgis-rest",
-            SourceFileOrDatabase = $"county:{countyId}",
+            SourceFileOrDatabase = $"county:{countyId} fips={fipsCode}",
             SourceQueryHash = string.Empty, // populated below once URL known
             Operator = operatorName,
             Status = "IN_PROGRESS",
@@ -73,7 +74,7 @@ public sealed class ArcGisSyncService : IArcGisSyncService
         try
         {
             var features = await _client
-                .FetchParcelsAsync(countyId, topN: null, cancellationToken)
+                .FetchParcelsAsync(fipsCode, countyId, topN: null, cancellationToken)
                 .ConfigureAwait(false);
 
             // Lock in the source query hash from the first feature's

--- a/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
@@ -56,6 +56,7 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
     }
 
     public async Task<ArcGisRawLandingResult> LandParcelGeomsAsync(
+        string fipsCode,
         Guid countyId,
         string operatorName,
         int? topN,
@@ -66,14 +67,14 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
         var topNPart = topN.HasValue
             ? $" topN={topN.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)} orderByFields=OBJECTID+ASC"
             : " fullCorpus=true";
-        var queryDescriptor = $"county={countyId} f=geojson where=1=1 outSR=4326 returnGeometry=true{topNPart}";
+        var queryDescriptor = $"fips={fipsCode} county={countyId} f=geojson where=1=1 outSR=4326 returnGeometry=true{topNPart}";
         var queryHash = ComputeStableHash(queryDescriptor);
 
         var batch = new LoadBatch
         {
             SourceFamily = SourceFamilies.ArcGisRest,
             SourceSystem = "arcgis-feature-service",
-            SourceFileOrDatabase = $"county={countyId}",
+            SourceFileOrDatabase = $"county:{countyId} fips={fipsCode}",
             SourceQueryHash = queryHash,
             Operator = operatorName,
             Status = "IN_PROGRESS",
@@ -84,7 +85,7 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
 
         try
         {
-            var features = await _client.FetchParcelsAsync(countyId, topN, cancellationToken)
+            var features = await _client.FetchParcelsAsync(fipsCode, countyId, topN, cancellationToken)
                 .ConfigureAwait(false);
 
             var considered = features.Count;

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisFeatureServiceOptionsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisFeatureServiceOptionsTests.cs
@@ -38,14 +38,14 @@ public sealed class ArcGisFeatureServiceOptionsTests
     [Fact]
     public void Bind_Single_County_FromInMemoryConfiguration()
     {
-        var bentonId = "19190019-1919-1919-1919-191919191919";
+        var bentonFips = "53005";
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [$"ArcGisFeatureServices:Counties:{bentonId}:ParcelFeatureServiceUrl"]
+                [$"ArcGisFeatureServices:Counties:{bentonFips}:ParcelFeatureServiceUrl"]
                     = "https://services.arcgis.com/abc123/arcgis/rest/services/BentonParcels/FeatureServer/0",
-                [$"ArcGisFeatureServices:Counties:{bentonId}:ApnAttributeName"] = "ParcelNum",
-                [$"ArcGisFeatureServices:Counties:{bentonId}:RequestTimeoutSeconds"] = "60",
+                [$"ArcGisFeatureServices:Counties:{bentonFips}:ApnAttributeName"] = "ParcelNum",
+                [$"ArcGisFeatureServices:Counties:{bentonFips}:RequestTimeoutSeconds"] = "60",
             })
             .Build();
 
@@ -56,7 +56,7 @@ public sealed class ArcGisFeatureServiceOptionsTests
         var bound = provider.GetRequiredService<IOptions<ArcGisFeatureServiceOptions>>().Value;
 
         bound.Counties.Should().HaveCount(1);
-        var county = bound.GetForCounty(Guid.Parse(bentonId));
+        var county = bound.GetForCounty(bentonFips);
         county.Should().NotBeNull();
         county!.ParcelFeatureServiceUrl.Should().Contain("BentonParcels/FeatureServer/0");
         county.ApnAttributeName.Should().Be("ParcelNum");
@@ -71,8 +71,8 @@ public sealed class ArcGisFeatureServiceOptionsTests
     [Fact]
     public void Bind_Multiple_Counties_AllPresent()
     {
-        var countyA = "19190019-1919-1919-1919-191919191919";
-        var countyB = "20200020-2020-2020-2020-202020202020";
+        var countyA = "53005";
+        var countyB = "53007";
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -91,8 +91,8 @@ public sealed class ArcGisFeatureServiceOptionsTests
         var bound = provider.GetRequiredService<IOptions<ArcGisFeatureServiceOptions>>().Value;
 
         bound.Counties.Should().HaveCount(2);
-        bound.GetForCounty(Guid.Parse(countyA))!.BearerToken.Should().BeNull();
-        bound.GetForCounty(Guid.Parse(countyB))!.BearerToken.Should().Be("secret-b");
+        bound.GetForCounty(countyA)!.BearerToken.Should().BeNull();
+        bound.GetForCounty(countyB)!.BearerToken.Should().Be("secret-b");
     }
 
     [Fact]
@@ -112,20 +112,18 @@ public sealed class ArcGisFeatureServiceOptionsTests
         var provider = services.BuildServiceProvider();
         var bound = provider.GetRequiredService<IOptions<ArcGisFeatureServiceOptions>>().Value;
 
-        bound.GetForCounty(Guid.NewGuid()).Should().BeNull();
+        bound.GetForCounty("99999").Should().BeNull();
     }
 
     [Fact]
-    public void GetForCounty_IsCaseInsensitive_OnGuidString()
+    public void GetForCounty_IsCaseInsensitive_OnFipsKey()
     {
-        // Configuration keys may arrive in upper or lower case;
-        // GetForCounty must be tolerant.
-        var bentonId = Guid.Parse("19190019-1919-1919-1919-191919191919");
-        var upperKey = bentonId.ToString().ToUpperInvariant();
+        // Config key stored in upper-case; lookup may arrive in lower-case.
+        // GetForCounty uses OrdinalIgnoreCase so both must match.
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                [$"ArcGisFeatureServices:Counties:{upperKey}:ParcelFeatureServiceUrl"]
+                ["ArcGisFeatureServices:Counties:WA53005:ParcelFeatureServiceUrl"]
                     = "https://example/FeatureServer/0",
             })
             .Build();
@@ -136,7 +134,8 @@ public sealed class ArcGisFeatureServiceOptionsTests
         var provider = services.BuildServiceProvider();
         var bound = provider.GetRequiredService<IOptions<ArcGisFeatureServiceOptions>>().Value;
 
-        bound.GetForCounty(bentonId).Should().NotBeNull();
+        bound.GetForCounty("wa53005").Should().NotBeNull("lookup is case-insensitive");
+        bound.GetForCounty("WA53005").Should().NotBeNull("original case also matches");
     }
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisFeatureServiceClientTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisFeatureServiceClientTests.cs
@@ -29,7 +29,7 @@ public sealed class ArcGisFeatureServiceClientTests
         {
             Counties = new Dictionary<string, CountyArcGisOptions>
             {
-                [BentonId.ToString()] = new CountyArcGisOptions
+                ["53005"] = new CountyArcGisOptions
                 {
                     ParcelFeatureServiceUrl = url,
                     ApnAttributeName = apnAttr,
@@ -75,7 +75,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, body);
         var client = BuildClient(OptionsForBenton(), handler);
 
-        var result = await client.FetchParcelsAsync(BentonId, topN: null);
+        var result = await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         result.Should().HaveCount(1);
         var f = result[0];
@@ -103,7 +103,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, body);
         var client = BuildClient(OptionsForBenton(), handler);
 
-        var result = await client.FetchParcelsAsync(BentonId, topN: null);
+        var result = await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         result.Should().BeEmpty();
     }
@@ -136,7 +136,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, body);
         var client = BuildClient(OptionsForBenton(), handler);
 
-        var result = await client.FetchParcelsAsync(BentonId, topN: null);
+        var result = await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         result.Should().HaveCount(1);
         result[0].ArcGisObjectId.Should().Be(2);
@@ -169,7 +169,7 @@ public sealed class ArcGisFeatureServiceClientTests
             objectIdAttr: "FEATUREID");
         var client = BuildClient(options, handler);
 
-        var result = await client.FetchParcelsAsync(BentonId, topN: null);
+        var result = await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         result.Should().HaveCount(1);
         result[0].ArcGisObjectId.Should().Be(7);
@@ -184,7 +184,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var client = BuildClient(options, handler);
 
         var act = async () =>
-            await client.FetchParcelsAsync(Guid.NewGuid(), topN: null);
+            await client.FetchParcelsAsync("99999", Guid.NewGuid(), topN: null);
 
         await act.Should()
             .ThrowAsync<ArcGisFeatureServiceConfigurationException>()
@@ -198,7 +198,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, "{}");
         var client = BuildClient(options, handler);
 
-        var act = async () => await client.FetchParcelsAsync(BentonId, topN: null);
+        var act = async () => await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         await act.Should()
             .ThrowAsync<ArcGisFeatureServiceConfigurationException>()
@@ -211,7 +211,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.InternalServerError, "boom");
         var client = BuildClient(OptionsForBenton(), handler);
 
-        var act = async () => await client.FetchParcelsAsync(BentonId, topN: null);
+        var act = async () => await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         await act.Should().ThrowAsync<ArcGisFeatureServiceTransportException>();
     }
@@ -222,7 +222,7 @@ public sealed class ArcGisFeatureServiceClientTests
         var handler = new StubHttpMessageHandler(HttpStatusCode.OK, "{ this is not json");
         var client = BuildClient(OptionsForBenton(), handler);
 
-        var act = async () => await client.FetchParcelsAsync(BentonId, topN: null);
+        var act = async () => await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         await act.Should().ThrowAsync<ArcGisFeatureServiceTransportException>();
     }
@@ -238,7 +238,7 @@ public sealed class ArcGisFeatureServiceClientTests
             url: "https://services.arcgis.com/abc/arcgis/rest/services/Parcels/FeatureServer/0/");
         var client = BuildClient(options, handler);
 
-        await client.FetchParcelsAsync(BentonId, topN: null);
+        await client.FetchParcelsAsync("53005", BentonId, topN: null);
 
         handler.LastRequestUri!.AbsolutePath.Should().EndWith("/query");
         handler.LastRequestUri.AbsolutePath.Should().NotContain("//query");

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisNightlySyncHostedServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisNightlySyncHostedServiceTests.cs
@@ -71,9 +71,9 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
-            [CountyB.ToString()] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0" },
-            [CountyC.ToString()] = new() { ParcelFeatureServiceUrl = "https://c/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
+            ["53007"] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0", CountyId = CountyB },
+            ["53021"] = new() { ParcelFeatureServiceUrl = "https://c/FeatureServer/0", CountyId = CountyC },
         };
         var (svc, recorder) = Build(counties);
 
@@ -92,7 +92,7 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
         };
         var scheduler = new ArcGisSyncSchedulerOptions
         {
@@ -111,9 +111,9 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
-            [CountyB.ToString()] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0" },
-            [CountyC.ToString()] = new() { ParcelFeatureServiceUrl = "https://c/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
+            ["53007"] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0", CountyId = CountyB },
+            ["53021"] = new() { ParcelFeatureServiceUrl = "https://c/FeatureServer/0", CountyId = CountyC },
         };
         var (svc, recorder) = Build(
             counties,
@@ -128,19 +128,20 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     }
 
     [Fact]
-    public async Task RunOneCycle_MalformedCountyKey_IsSkipped_NotCounted()
+    public async Task RunOneCycle_EntryWithoutCountyId_IsSkipped_NotCounted()
     {
+        // GEOM-005: nightly sync skips any entry that has no CountyId configured.
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
-            ["not-a-guid"] = new() { ParcelFeatureServiceUrl = "https://x/FeatureServer/0" },
-            [CountyB.ToString()] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
+            ["no-county-id"] = new() { ParcelFeatureServiceUrl = "https://x/FeatureServer/0" }, // CountyId not set
+            ["53007"] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0", CountyId = CountyB },
         };
         var (svc, recorder) = Build(counties);
 
         var touched = await svc.RunOneCycleAsync(CancellationToken.None);
 
-        // Two valid GUIDs visited; malformed key skipped (continue).
+        // Two entries have CountyId configured; the third is skipped.
         touched.Should().Be(2);
         recorder.Calls.Select(c => c.CountyId).Should().BeEquivalentTo(new[] { CountyA, CountyB });
     }
@@ -150,8 +151,8 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
-            [CountyB.ToString()] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
+            ["53007"] = new() { ParcelFeatureServiceUrl = "https://b/FeatureServer/0", CountyId = CountyB },
         };
         using var cts = new CancellationTokenSource();
         var (svc, recorder) = Build(
@@ -182,7 +183,7 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         var counties = new Dictionary<string, CountyArcGisOptions>
         {
-            [CountyA.ToString()] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0" },
+            ["53005"] = new() { ParcelFeatureServiceUrl = "https://a/FeatureServer/0", CountyId = CountyA },
         };
         var (svc, _) = Build(counties);
 
@@ -212,7 +213,7 @@ public sealed class ArcGisNightlySyncHostedServiceTests
     {
         private readonly Func<Guid, ArcGisSyncResult>? _resultFactory;
         private readonly Func<Guid, Exception>? _throwFactory;
-        public List<(Guid CountyId, string OperatorName)> Calls { get; } = new();
+        public List<(string FipsCode, Guid CountyId, string OperatorName)> Calls { get; } = new();
 
         public RecordingSyncService(
             Func<Guid, ArcGisSyncResult>? resultFactory,
@@ -223,9 +224,9 @@ public sealed class ArcGisNightlySyncHostedServiceTests
         }
 
         public Task<ArcGisSyncResult> SyncCountyAsync(
-            Guid countyId, string operatorName, CancellationToken cancellationToken = default)
+            string fipsCode, Guid countyId, string operatorName, CancellationToken cancellationToken = default)
         {
-            Calls.Add((countyId, operatorName));
+            Calls.Add((fipsCode, countyId, operatorName));
 
             var ex = _throwFactory?.Invoke(countyId);
             if (ex is not null)

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisSyncServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisSyncServiceTests.cs
@@ -72,7 +72,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         });
         var svc = BuildService(client);
 
-        var result = await svc.SyncCountyAsync(BentonId, "test-op");
+        var result = await svc.SyncCountyAsync("53005", BentonId, "test-op");
 
         result.Status.Should().Be("COMPLETED");
         result.FeaturesFetched.Should().Be(2);
@@ -101,8 +101,8 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         var client = new FakeArcGisClient(fixedFeatures);
         var svc = BuildService(client);
 
-        await svc.SyncCountyAsync(BentonId, "test-op");
-        await svc.SyncCountyAsync(BentonId, "test-op");
+        await svc.SyncCountyAsync("53005", BentonId, "test-op");
+        await svc.SyncCountyAsync("53005", BentonId, "test-op");
 
         // Two batches; one row-set; one source_xref per geometry.
         (await _db.SyncBridgeLoadBatches.CountAsync()).Should().Be(2);
@@ -124,14 +124,14 @@ public sealed class ArcGisSyncServiceTests : IDisposable
             MakeFeature(1, "APN-1"),
             MakeFeature(2, "APN-2"),
         });
-        await BuildService(clientA).SyncCountyAsync(BentonId, "test-op");
+        await BuildService(clientA).SyncCountyAsync("53005", BentonId, "test-op");
 
         // Run 2: only feature 1 remains in source.
         var clientB = new FakeArcGisClient(new[]
         {
             MakeFeature(1, "APN-1-renamed"),
         });
-        var result = await BuildService(clientB).SyncCountyAsync(BentonId, "test-op");
+        var result = await BuildService(clientB).SyncCountyAsync("53005", BentonId, "test-op");
 
         result.FeaturesUpserted.Should().Be(1);
         result.FeaturesSoftDeleted.Should().Be(1);
@@ -152,7 +152,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
             MakeFeature(20, "Y"),
             MakeFeature(30, "Z"),
         });
-        await BuildService(client).SyncCountyAsync(BentonId, "test-op");
+        await BuildService(client).SyncCountyAsync("53005", BentonId, "test-op");
 
         var activeIds = await _db.TfParcelGeoms
             .Where(g => g.IsActive)
@@ -179,7 +179,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
     public async Task SyncRecordsCompletionGate_OnSuccess()
     {
         var client = new FakeArcGisClient(new[] { MakeFeature(1, "X") });
-        await BuildService(client).SyncCountyAsync(BentonId, "test-op");
+        await BuildService(client).SyncCountyAsync("53005", BentonId, "test-op");
 
         var completionGate = await _db.SyncBridgePromotionGateResults
             .SingleAsync(g => g.GateName == "gis-tf:arcgis-sync-completion");
@@ -194,7 +194,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
             new ArcGisFeatureServiceTransportException("simulated 500"));
         var svc = BuildService(client);
 
-        var result = await svc.SyncCountyAsync(BentonId, "test-op");
+        var result = await svc.SyncCountyAsync("53005", BentonId, "test-op");
 
         result.Status.Should().Be("FAILED");
         result.ErrorSummary.Should().Contain("simulated 500");
@@ -220,7 +220,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
             new ArcGisFeatureServiceConfigurationException("no county bound"));
         var svc = BuildService(client);
 
-        var result = await svc.SyncCountyAsync(BentonId, "test-op");
+        var result = await svc.SyncCountyAsync("53005", BentonId, "test-op");
 
         result.Status.Should().Be("FAILED");
         result.ErrorSummary.Should().Contain("no county bound");
@@ -237,7 +237,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         public FakeArcGisClient(IEnumerable<ArcGisParcelFeature> features)
             => _features = features.ToList();
         public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
-            Guid countyId, int? topN, CancellationToken cancellationToken = default)
+            string fipsCode, Guid countyId, int? topN, CancellationToken cancellationToken = default)
             => Task.FromResult(_features);
     }
 
@@ -246,7 +246,7 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         private readonly Exception _ex;
         public FailingArcGisClient(Exception ex) => _ex = ex;
         public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
-            Guid countyId, int? topN, CancellationToken cancellationToken = default)
+            string fipsCode, Guid countyId, int? topN, CancellationToken cancellationToken = default)
             => Task.FromException<IReadOnlyList<ArcGisParcelFeature>>(_ex);
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
@@ -91,7 +91,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 2, apn: "100-002"),
             Feature(countyId, 3, apn: "100-003"));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         result.Status.Should().Be("COMPLETED");
         result.FeaturesConsidered.Should().Be(3);
@@ -118,7 +118,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
         var countyId = Guid.NewGuid();
         var client = new FakeClient(Feature(countyId, 1));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         var batch = await _db.SyncBridgeLoadBatches.SingleAsync();
         batch.LoadBatchId.Should().Be(result.LoadBatchId);
@@ -142,7 +142,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             areaSqFt: 12345.67);
         var client = new FakeClient(feature);
 
-        await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         var landed = await _db.LegacyArcGisRawParcelGeoms.SingleAsync();
         landed.ArcGisObjectId.Should().Be(42);
@@ -164,7 +164,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
         var countyId = Guid.NewGuid();
         var client = new FakeClient(Feature(countyId, 1, apn: null));
 
-        await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         var landed = await _db.LegacyArcGisRawParcelGeoms.SingleAsync();
         landed.ArcGisApn.Should().BeNull();
@@ -182,7 +182,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 1, apn: "duplicate-of-1"),
             Feature(countyId, 2));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         result.Status.Should().Be("COMPLETED");
         result.FeaturesConsidered.Should().Be(3);
@@ -209,7 +209,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(benton, 1, apn: "benton-1"),
             Feature(franklin, 1, apn: "franklin-1"));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(benton, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", benton, "d1-test", topN: null);
 
         result.DuplicateObjectIds.Should().Be(0,
             "(benton,1) and (franklin,1) are distinct natural keys");
@@ -225,7 +225,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
         var countyId = Guid.NewGuid();
         var client = new FakeClient(/* no features */);
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         result.Status.Should().Be("COMPLETED");
         result.FeaturesConsidered.Should().Be(0);
@@ -255,7 +255,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 1, areaSqFt: 1000.0),
             Feature(countyId, 2, areaSqFt: 2000.0));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         var gates = await _db.SyncBridgePromotionGateResults
             .Where(g => g.LoadBatchId == result.LoadBatchId)
@@ -277,7 +277,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 2, areaSqFt: 2500.25),
             Feature(countyId, 3, areaSqFt: 1000.0));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         result.AreaSqFtSum.Should().BeApproximately(5000.75, 0.01);
 
@@ -297,7 +297,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 1),
             Feature(countyId, 2));
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         var gate = await _db.SyncBridgePromotionGateResults
             .SingleAsync(g => g.GateName == "arcgis-raw-provenance-coverage");
@@ -312,7 +312,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
         var countyId = Guid.NewGuid();
         var client = new FakeClient(throwOnFetch: true);
 
-        var result = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-test", topN: null);
+        var result = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-test", topN: null);
 
         result.Status.Should().Be("FAILED");
         result.FeaturesConsidered.Should().Be(0);
@@ -336,8 +336,8 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             Feature(countyId, 1, apn: "100-001"),
             Feature(countyId, 2, apn: "100-002"));
 
-        var run1 = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-run1", topN: null);
-        var run2 = await BuildService(client).LandParcelGeomsAsync(countyId, "d1-run2", topN: null);
+        var run1 = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-run1", topN: null);
+        var run2 = await BuildService(client).LandParcelGeomsAsync("53005", countyId, "d1-run2", topN: null);
 
         run1.LoadBatchId.Should().NotBe(run2.LoadBatchId,
             "every run gets a fresh batch id");
@@ -383,6 +383,7 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
         }
 
         public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
+            string fipsCode,
             Guid countyId,
             int? topN,
             CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

- **GEOM-005 clean restart** from `origin/main` (GEOM-002 commit `5b7de60f2`) — prior contaminated branch `feat/geometry-fips-config` was abandoned per operator order
- Changes ArcGIS feature-service config key from `County.Id` (GUID) to `County.FipsCode` (`"53005"`) so config survives any DB re-provisioning
- All GEOM-002 protections **100% preserved**: `int? topN` threading, `resultRecordCount`+`orderByFields=OBJECTID+ASC` in `BuildQueryUrl`, FullCorpus guard (400), `SourceQueryHash` includes topN/ordering

## Changes (16 files, 0 build errors)

**Interfaces & implementations:**
- `GetForCounty(Guid)` → `GetForCounty(string fipsCode)` (OrdinalIgnoreCase match)
- `CountyArcGisOptions.CountyId: Guid?` added for nightly sync row stamping
- `FetchParselsAsync` / `LandParcelGeomsAsync` / `SyncCountyAsync` all gain `string fipsCode` as first param while keeping `int? topN`
- `NightlySyncHostedService`: skip condition changed from `Guid.TryParse(key)` → `countyOpts.CountyId is null`

**DrainGeometry controller:**
- Old 409 GUID-mismatch guard **replaced** with: 400 (null `FipsCode`) + 404 (no config for FIPS)
- `IOptions<ArcGisFeatureServiceOptions>` injected as `[FromServices]`
- `LandParcelGeomsAsync` call passes `bentonCounty.FipsCode`

**Config:**
- `appsettings.Development.json`: key `"53005"` (was GUID), `CountyId` field added

**Tests (5 test files updated):**
- All existing GEOM/ArcGIS tests updated to new signatures
- `MalformedCountyKey_IsSkipped` → `EntryWithoutCountyId_IsSkipped` (reflects new skip logic)
- `GetForCounty_IsCaseInsensitive_OnGuidString` → `GetForCounty_IsCaseInsensitive_OnFipsKey`

## GEOM-002 protections verified present

- `int? topN` parameter: ✅ in all 3 interfaces, all implementations, DrainGeometry caller
- `resultRecordCount={N}&orderByFields=OBJECTID+ASC`: ✅ `BuildQueryUrl` unchanged
- FullCorpus=false/TopN=null → 400: ✅ unchanged in DrainGeometry
- `SourceQueryHash` encodes topN/fullCorpus: ✅ `LandParcelGeomsAsync` unchanged

## No geometry executed, no ArcGIS called, no DB mutated, no PACS touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Key ArcGIS geometry sync and drain paths now use FIPS codes as the stable configuration key instead of county GUIDs, while preserving existing GEOM-002 safety behavior.

Enhancements:
- ArcGIS feature-service options are now keyed and looked up by FIPS code strings, with case-insensitive matching and optional CountyId metadata for nightly sync stamping.
- DoctrineDrain and CanonicalDebug geometry flows resolve Benton County by FIPS and pass FIPS codes through to ArcGIS landing and sync services, enriching provenance/query hashes with FIPS.
- Nightly ArcGIS sync iterates FIPS-keyed config entries, skipping those without a configured CountyId and logging FIPS-aware status and error messages.
- ArcGIS geometry drain now validates that Benton County has a FipsCode and a corresponding ArcGIS config entry, failing fast with 400/404 before any network calls.

Tests:
- ArcGIS options, client, nightly sync, sync service, and raw landing tests are updated to cover FIPS-keyed configuration, FIPS-aware logging, and the new CountyId-skipping behavior.