### PR TITLE
feat(geom-011): ArcGIS resultOffset pagination for full-corpus geometry drain

### DIFF
--- a/backend/TerraFusion.API.Tests/GIS/ArcGisRawLandingServicePagedTests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/ArcGisRawLandingServicePagedTests.cs
@@ -1,0 +1,242 @@
+// WO-DATA-004C-GEOM-011 — Service-level behaviour tests for LandParcelGeomsPagedAsync.
+//
+// Verifies loop-control contract:
+//   * Multi-page runs land features across all pages.
+//   * exceededTransferLimit=false does NOT terminate the loop.
+//   * Empty page terminates the loop.
+//   * Cross-page duplicate objectIds do not stop pagination.
+//   * PageSize <= 0 throws ArgumentOutOfRangeException.
+//
+// No ArcGIS network calls — IArcGisFeatureServiceClient is mocked.
+// No PACS. In-memory EF DB.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using TerraFusion.Core.GIS.ArcGisRest;
+using TerraFusion.Data;
+using TerraFusion.Data.Services.LegacyArcGisRaw;
+using Xunit;
+
+namespace TerraFusion.API.Tests.GIS;
+
+public sealed class ArcGisRawLandingServicePagedTests
+{
+    private static readonly Guid TestCountyId = Guid.Parse("19190019-1919-1919-1919-191919191919");
+    private const string TestFips = "53005";
+
+    // ── Multi-page: all features from both pages are landed ───────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_TwoPages_LandsBothPages()
+    {
+        var (svc, client) = Build();
+
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(2000);
+
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MakeFeatures(1, 1000), false))   // page 0: objectIds 1-1000, exceededLimit=false
+            .ReturnsAsync((MakeFeatures(1001, 1000), false)) // page 1: objectIds 1001-2000
+            .ReturnsAsync((Array.Empty<ArcGisParcelFeature>(), false)); // safety: empty stop
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "test-op", pageSize: 1000, topN: null);
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(2000, result.FeaturesConsidered);
+        Assert.Equal(2000, result.FeaturesLanded);
+        Assert.Equal(0, result.DuplicateObjectIds);
+        Assert.True(result.PaginatedMode);
+
+        // Exactly 2 page fetches were needed.
+        client.Verify(c => c.FetchPageAsync(
+            TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ── exceededTransferLimit=false must NOT stop the loop ────────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_ExceededTransferLimitFalse_ContinuesToNextPage()
+    {
+        var (svc, client) = Build();
+
+        // preflightCount = 1500, pageSize = 1000 → 2 pages needed
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(1500);
+
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MakeFeatures(1, 1000), false))  // page 0 — server says false (no limit hit)
+            .ReturnsAsync((MakeFeatures(1001, 500), false)) // page 1 — remaining 500
+            .ReturnsAsync((Array.Empty<ArcGisParcelFeature>(), false));
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "test-op", pageSize: 1000, topN: null);
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1500, result.FeaturesConsidered);
+        // Both pages must have been fetched.
+        client.Verify(c => c.FetchPageAsync(
+            TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ── Empty page terminates the loop ───────────────────────────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_EmptyPage_StopsImmediately()
+    {
+        var (svc, client) = Build();
+
+        // preflightCount = 5000 → we'd need 5 pages, but page 2 is empty → stops at page 2
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(5000);
+
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MakeFeatures(1, 1000), true))   // page 0 — 1000 features
+            .ReturnsAsync((Array.Empty<ArcGisParcelFeature>(), false)) // page 1 — empty → STOP
+            .ReturnsAsync((MakeFeatures(1001, 1000), false)); // page 2 — should NOT be reached
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "test-op", pageSize: 1000, topN: null);
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1000, result.FeaturesConsidered);
+        // Must stop after the empty page — page 2 must not be fetched.
+        client.Verify(c => c.FetchPageAsync(
+            TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ── Cross-page dedup does NOT stop pagination ─────────────────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_CrossPageDuplicates_DoNotStopPagination()
+    {
+        var (svc, client) = Build();
+
+        // preflightCount = 2000, but page 2 has 500 objectId duplicates from page 1.
+        // totalConsidered still accumulates to 2000 across 2 pages → terminates correctly.
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(2000);
+
+        var page1Features = MakeFeatures(1, 1000);
+        // Page 2: 500 duplicates (ids 501-1000) + 500 fresh (ids 1001-1500)
+        var page2Features = MakeFeatures(501, 1000);
+
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((page1Features, false))
+            .ReturnsAsync((page2Features, false))
+            .ReturnsAsync((Array.Empty<ArcGisParcelFeature>(), false));
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "test-op", pageSize: 1000, topN: null);
+
+        Assert.Equal("COMPLETED", result.Status);
+        // Both pages fetched — duplicates don't stop the loop.
+        client.Verify(c => c.FetchPageAsync(
+            TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        // Dedup reduces landed vs considered.
+        Assert.Equal(2000, result.FeaturesConsidered);
+        Assert.Equal(500, result.DuplicateObjectIds);
+        Assert.Equal(1500, result.FeaturesLanded);
+    }
+
+    // ── topN cap respected ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_TopNCap_StopsAfterTopNConsidered()
+    {
+        var (svc, client) = Build();
+
+        // corpus = 89247 but operator caps at topN=1500
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(89247);
+
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MakeFeatures(1, 1000), false))   // page 0
+            .ReturnsAsync((MakeFeatures(1001, 500), false))  // page 1 — 500 of the 1500 cap
+            .ReturnsAsync((MakeFeatures(1501, 1000), false)); // should NOT be reached
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "test-op", pageSize: 1000, topN: 1500);
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(1500, result.FeaturesConsidered);
+        client.Verify(c => c.FetchPageAsync(
+            TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ── PageSize <= 0 throws immediately ────────────────────────────────
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_PageSizeZero_ThrowsArgumentOutOfRange()
+    {
+        var (svc, _) = Build();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            svc.LandParcelGeomsPagedAsync(TestFips, TestCountyId, "op", pageSize: 0, topN: null));
+    }
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_PageSizeNegative_ThrowsArgumentOutOfRange()
+    {
+        var (svc, _) = Build();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            svc.LandParcelGeomsPagedAsync(TestFips, TestCountyId, "op", pageSize: -1, topN: null));
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private static (ArcGisRawLandingService svc, Mock<IArcGisFeatureServiceClient> client) Build()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var configMock = new Mock<IConfiguration>();
+        configMock.Setup(c => c["ConnectionStrings:DefaultConnection"]).Returns($"Data Source={dbName}.db");
+
+        var opts = new DbContextOptionsBuilder<TerraFusionDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+
+        var db = new TerraFusionDbContext(opts, configMock.Object);
+        var client = new Mock<IArcGisFeatureServiceClient>();
+        var svc = new ArcGisRawLandingService(db, client.Object, NullLogger<ArcGisRawLandingService>.Instance);
+
+        return (svc, client);
+    }
+
+    private static IReadOnlyList<ArcGisParcelFeature> MakeFeatures(long startObjectId, int count)
+    {
+        var features = new List<ArcGisParcelFeature>(count);
+        for (var i = 0; i < count; i++)
+        {
+            features.Add(new ArcGisParcelFeature
+            {
+                CountyId = TestCountyId,
+                ArcGisObjectId = startObjectId + i,
+                ArcGisApn = $"APN-{startObjectId + i}",
+                GeomWkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+                CentroidLat = 46.2,
+                CentroidLon = -119.3,
+                AreaSqFt = 5000.0,
+                SourceServiceUrl = "https://test.arcgis.example/FeatureServer/0",
+            });
+        }
+        return features;
+    }
+}

--- a/backend/TerraFusion.API.Tests/GIS/GeomSliceControlPaginationTests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/GeomSliceControlPaginationTests.cs
@@ -1,0 +1,154 @@
+// WO-DATA-004C-GEOM-011 — Pagination URL behavior tests.
+//
+// Verifies that FetchPageAsync and FetchCountAsync build the correct ArcGIS
+// REST query URLs. No ArcGIS network calls — HTTP is captured by CapturingHandler.
+// No EF/DB. No PACS.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TerraFusion.Core.Configuration;
+using TerraFusion.Core.GIS.ArcGisRest;
+using Xunit;
+
+namespace TerraFusion.API.Tests.GIS;
+
+public class GeomSliceControlPaginationTests
+{
+    private const string BentonFips = "53005";
+    private static readonly Guid BentonId = Guid.Parse("19190019-1919-1919-1919-191919191919");
+    private const string ServiceBase = "https://test.arcgis.example/FeatureServer/0";
+
+    // ── FetchPageAsync URL construction ───────────────────────────────────
+
+    [Fact]
+    public async Task FetchPageAsync_FirstPage_UrlContainsResultRecordCount1000()
+    {
+        var (sut, h) = Build();
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 0, pageSize: 1000, CancellationToken.None);
+        Assert.Contains("resultRecordCount=1000", h.CapturedUri ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task FetchPageAsync_FirstPage_UrlContainsResultOffsetZero()
+    {
+        var (sut, h) = Build();
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 0, pageSize: 1000, CancellationToken.None);
+        Assert.Contains("resultOffset=0", h.CapturedUri ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task FetchPageAsync_SecondPage_UrlContainsResultOffset1000()
+    {
+        var (sut, h) = Build();
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 1000, pageSize: 1000, CancellationToken.None);
+        Assert.Contains("resultOffset=1000", h.CapturedUri ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task FetchPageAsync_UrlContainsOrderByObjectIdAsc()
+    {
+        var (sut, h) = Build();
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 0, pageSize: 1000, CancellationToken.None);
+        Assert.Contains("orderByFields=OBJECTID+ASC", h.CapturedUri ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task FetchPageAsync_UrlContainsFGeojson()
+    {
+        var (sut, h) = Build();
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 0, pageSize: 1000, CancellationToken.None);
+        Assert.Contains("f=geojson", h.CapturedUri ?? string.Empty);
+    }
+
+    // ── FetchCountAsync URL construction ─────────────────────────────────
+
+    [Fact]
+    public async Task FetchCountAsync_UrlContainsReturnCountOnly()
+    {
+        var (sut, h) = Build(countResponse: true);
+        await sut.FetchCountAsync(BentonFips, CancellationToken.None);
+        Assert.Contains("returnCountOnly=true", h.CapturedUri ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task FetchCountAsync_UrlContainsFJson()
+    {
+        var (sut, h) = Build(countResponse: true);
+        await sut.FetchCountAsync(BentonFips, CancellationToken.None);
+        Assert.Contains("f=json", h.CapturedUri ?? string.Empty);
+    }
+
+    // ── FetchPageAsync URL is distinct from FetchParcelsAsync URL ─────────
+
+    [Fact]
+    public async Task FetchPageAsync_UrlDiffersFromFetchParcels_NoPaginationParams()
+    {
+        var (sut, pagingHandler) = Build();
+        var (sutFull, fullHandler) = Build();
+
+        await sut.FetchPageAsync(BentonFips, BentonId, offset: 0, pageSize: 1000, CancellationToken.None);
+        await sutFull.FetchParcelsAsync(BentonFips, BentonId, topN: null, CancellationToken.None);
+
+        // The non-paged URL must NOT contain resultOffset or resultRecordCount.
+        Assert.DoesNotContain("resultOffset", fullHandler.CapturedUri ?? string.Empty);
+        // The paged URL must contain both.
+        Assert.Contains("resultOffset=0", pagingHandler.CapturedUri ?? string.Empty);
+        Assert.Contains("resultRecordCount=1000", pagingHandler.CapturedUri ?? string.Empty);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private static (ArcGisFeatureServiceClient sut, CapturingHandler handler) Build(
+        bool countResponse = false)
+    {
+        var body = countResponse
+            ? "{\"count\":89247}"
+            : "{\"type\":\"FeatureCollection\",\"features\":[],\"exceededTransferLimit\":false}";
+
+        var handler = new CapturingHandler(body);
+        var http = new HttpClient(handler);
+        var factory = new StubHttpClientFactory(http);
+
+        var opts = new ArcGisFeatureServiceOptions();
+        opts.Counties[BentonFips] = new CountyArcGisOptions
+        {
+            ParcelFeatureServiceUrl = ServiceBase,
+            ApnAttributeName = "geo_id",
+            ObjectIdAttributeName = "OBJECTID",
+            OutSpatialReferenceEpsg = 4326,
+            RequestTimeoutSeconds = 30,
+            PageSize = 1000,
+        };
+
+        return (new ArcGisFeatureServiceClient(
+            factory,
+            Options.Create(opts),
+            NullLogger<ArcGisFeatureServiceClient>.Instance), handler);
+    }
+
+    private sealed class CapturingHandler(string responseBody) : HttpMessageHandler
+    {
+        public string? CapturedUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedUri = request.RequestUri?.ToString();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+}

--- a/backend/TerraFusion.API.Tests/GIS/GeomSliceControlTests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/GeomSliceControlTests.cs
@@ -21,6 +21,7 @@ public class GeomSliceControlTests
 {
     private static readonly Guid BentonId =
         Guid.Parse("19190019-1919-1919-1919-191919191919");
+    private const string BentonFips = "53005";
 
     // ── URL construction ──────────────────────────────────────────────────
 
@@ -28,7 +29,7 @@ public class GeomSliceControlTests
     public async Task FetchParcels_TopN100_UrlContainsResultRecordCount()
     {
         var (sut, h) = Build();
-        await sut.FetchParcelsAsync(BentonId, topN: 100, CancellationToken.None);
+        await sut.FetchParcelsAsync(BentonFips, BentonId, 100, CancellationToken.None);
         Assert.Contains("resultRecordCount=100", h.CapturedUri ?? string.Empty);
     }
 
@@ -36,7 +37,7 @@ public class GeomSliceControlTests
     public async Task FetchParcels_TopN100_UrlContainsOrderByObjectId()
     {
         var (sut, h) = Build();
-        await sut.FetchParcelsAsync(BentonId, topN: 100, CancellationToken.None);
+        await sut.FetchParcelsAsync(BentonFips, BentonId, 100, CancellationToken.None);
         Assert.Contains("orderByFields=OBJECTID", h.CapturedUri ?? string.Empty);
     }
 
@@ -44,7 +45,7 @@ public class GeomSliceControlTests
     public async Task FetchParcels_NullTopN_UrlHasNoResultRecordCount()
     {
         var (sut, h) = Build();
-        await sut.FetchParcelsAsync(BentonId, topN: null, CancellationToken.None);
+        await sut.FetchParcelsAsync(BentonFips, BentonId, null, CancellationToken.None);
         Assert.DoesNotContain("resultRecordCount", h.CapturedUri ?? string.Empty);
     }
 
@@ -54,8 +55,8 @@ public class GeomSliceControlTests
         var (sut100, h100) = Build();
         var (sut500, h500) = Build();
 
-        await sut100.FetchParcelsAsync(BentonId, topN: 100, CancellationToken.None);
-        await sut500.FetchParcelsAsync(BentonId, topN: 500, CancellationToken.None);
+        await sut100.FetchParcelsAsync(BentonFips, BentonId, 100, CancellationToken.None);
+        await sut500.FetchParcelsAsync(BentonFips, BentonId, 500, CancellationToken.None);
 
         Assert.NotEqual(h100.CapturedUri, h500.CapturedUri);
     }
@@ -116,7 +117,7 @@ public class GeomSliceControlTests
         var factory = new StubHttpClientFactory(http);
 
         var opts = new ArcGisFeatureServiceOptions();
-        opts.Counties[BentonId.ToString()] = new CountyArcGisOptions
+        opts.Counties[BentonFips] = new CountyArcGisOptions
         {
             ParcelFeatureServiceUrl = "https://test.arcgis.example/FeatureServer/0",
             ApnAttributeName = "geo_id",

--- a/backend/TerraFusion.API.Tests/GIS/GeomSliceControlV2Tests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/GeomSliceControlV2Tests.cs
@@ -29,6 +29,7 @@ using TerraFusion.Core.Entities.GisTf;
 using TerraFusion.Core.GIS.ArcGisRest;
 using TerraFusion.Core.Sync.ArcGisRawLanding;
 using TerraFusion.Data;
+using TfDb = TerraFusion.Data.TerraFusionDbContext;
 using Xunit;
 
 namespace TerraFusion.API.Tests.GIS;
@@ -203,18 +204,18 @@ public sealed class GeomSliceControlV2Tests
     /// (simulating a stale random-GUID row); when null the DB starts empty so
     /// ResolveOrCreate will create the canonical KnownBentonId row.
     /// </summary>
-    private static (DoctrineDrainController controller, TerraFusionDbContext db)
+    private static (DoctrineDrainController controller, TfDb db)
         BuildController(Guid? bentonIdOverride = null)
     {
         var dbName = Guid.NewGuid().ToString();
         var configMock = new Mock<IConfiguration>();
         configMock.Setup(c => c["ConnectionStrings:DefaultConnection"]).Returns($"Data Source={dbName}.db");
 
-        var opts = new DbContextOptionsBuilder<TerraFusionDbContext>()
+        var opts = new DbContextOptionsBuilder<TfDb>()
             .UseInMemoryDatabase(databaseName: dbName)
             .Options;
 
-        var db = new TerraFusionDbContext(opts, configMock.Object);
+        var db = new TfDb(opts, configMock.Object);
 
         if (bentonIdOverride.HasValue)
         {

--- a/backend/TerraFusion.API.Tests/GIS/GeomSliceControlV2Tests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/GeomSliceControlV2Tests.cs
@@ -20,8 +20,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using TerraFusion.API.Controllers;
+using TerraFusion.Core.Configuration;
 using TerraFusion.Core.Entities;
 using TerraFusion.Core.Entities.GisTf;
 using TerraFusion.Core.GIS.ArcGisRest;
@@ -46,6 +48,7 @@ public sealed class GeomSliceControlV2Tests
             rawLandingSvc: null!,
             truthPromotionSvc: null!,
             canonicalProjector: null!,
+            arcGisOptions: BuildArcGisOptions(KnownBentonId),
             request: null,
             cancellationToken: CancellationToken.None);
 
@@ -60,6 +63,7 @@ public sealed class GeomSliceControlV2Tests
             rawLandingSvc: null!,
             truthPromotionSvc: null!,
             canonicalProjector: null!,
+            arcGisOptions: BuildArcGisOptions(KnownBentonId),
             request: new DoctrineDrainController.DoctrineDrainRequest(null, null, false, null),
             cancellationToken: CancellationToken.None);
 
@@ -78,7 +82,8 @@ public sealed class GeomSliceControlV2Tests
         var (controller, _) = BuildController();
         var mockSvc = new Mock<IArcGisRawLandingService>();
         mockSvc
-            .Setup(s => s.LandParcelGeomsAsync(It.IsAny<Guid>(), It.IsAny<string>(),
+            .Setup(s => s.LandParcelGeomsAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(),
                 It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ArcGisRawLandingResult
             {
@@ -95,6 +100,7 @@ public sealed class GeomSliceControlV2Tests
             rawLandingSvc: mockSvc.Object,
             truthPromotionSvc: null!,
             canonicalProjector: null!,
+            arcGisOptions: BuildArcGisOptions(KnownBentonId),
             request: new DoctrineDrainController.DoctrineDrainRequest(null, null, false, 100),
             cancellationToken: CancellationToken.None);
 
@@ -157,6 +163,7 @@ public sealed class GeomSliceControlV2Tests
             rawLandingSvc: mockSvc.Object,
             truthPromotionSvc: null!,
             canonicalProjector: null!,
+            arcGisOptions: BuildArcGisOptions(KnownBentonId),
             request: new DoctrineDrainController.DoctrineDrainRequest(null, null, false, 100),
             cancellationToken: CancellationToken.None);
 
@@ -175,13 +182,14 @@ public sealed class GeomSliceControlV2Tests
             rawLandingSvc: mockSvc.Object,
             truthPromotionSvc: null!,
             canonicalProjector: null!,
+            arcGisOptions: BuildArcGisOptions(KnownBentonId),
             request: new DoctrineDrainController.DoctrineDrainRequest(null, null, false, 100),
             cancellationToken: CancellationToken.None);
 
         // LandParcelGeomsAsync must never be called when county identity is wrong.
         mockSvc.Verify(
             s => s.LandParcelGeomsAsync(
-                It.IsAny<Guid>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(),
                 It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Never,
             "ArcGIS fetch must not be initiated when BentonCountyId does not match the configured GUID");
@@ -227,6 +235,17 @@ public sealed class GeomSliceControlV2Tests
             NullLogger<DoctrineDrainController>.Instance);
 
         return (controller, db);
+    }
+
+    private static IOptions<ArcGisFeatureServiceOptions> BuildArcGisOptions(Guid? configuredCountyId = null)
+    {
+        var opts = new ArcGisFeatureServiceOptions();
+        opts.Counties["53005"] = new CountyArcGisOptions
+        {
+            ParcelFeatureServiceUrl = "https://fake.arcgis.example/FeatureServer/0",
+            CountyId = configuredCountyId,
+        };
+        return Options.Create(opts);
     }
 
     // Mirrors the queryDescriptor logic in ArcGisRawLandingService.LandParcelGeomsAsync.

--- a/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
+++ b/backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs
@@ -1572,8 +1572,23 @@ public class DoctrineDrainController : ControllerBase
             if (string.IsNullOrEmpty(bentonCounty.FipsCode))
                 return BadRequest(new { error = "Benton county row has no FipsCode — geometry drain refused." });
 
-            if (arcGisOptions.Value.GetForCounty(bentonCounty.FipsCode) is null)
+            var arcGisCounty = arcGisOptions.Value.GetForCounty(bentonCounty.FipsCode);
+            if (arcGisCounty is null)
                 return NotFound(new { error = $"No ArcGIS config entry for FIPS {bentonCounty.FipsCode}." });
+
+            // GEOM-011: identity guard — if config has an explicit CountyId it must match the DB row.
+            if (arcGisCounty.CountyId.HasValue && arcGisCounty.CountyId.Value != bentonCounty.Id)
+            {
+                return StatusCode(409, new
+                {
+                    error = $"ArcGIS config CountyId ({arcGisCounty.CountyId}) does not match Benton DB row Id ({bentonCounty.Id}). " +
+                            "Resolve identity conflict before running the geometry drain.",
+                });
+            }
+
+            // GEOM-011: paged when FullCorpus=true or topN exceeds a single ArcGIS page.
+            var pageSize = arcGisCounty.PageSize;
+            var usePaged = fullCorpus || (geomTopN.HasValue && geomTopN.Value > pageSize);
 
             // Stage 1: ArcGis-D1.
             int d1FeaturesLanded = 0;
@@ -1583,8 +1598,14 @@ public class DoctrineDrainController : ControllerBase
             }
             else
             {
-                _logger.LogInformation("[Drain:geometry] D1 ArcGIS landing for county={Cid}", bentonCountyId);
-                var d1 = await rawLandingSvc.LandParcelGeomsAsync(bentonCounty.FipsCode, bentonCountyId, operatorName, geomTopN, cancellationToken);
+                _logger.LogInformation("[Drain:geometry] D1 ArcGIS landing for county={Cid} paged={Paged}", bentonCountyId, usePaged);
+                ArcGisRawLandingResult d1;
+                if (usePaged)
+                    d1 = await rawLandingSvc.LandParcelGeomsPagedAsync(
+                        bentonCounty.FipsCode, bentonCountyId, operatorName, pageSize, geomTopN, cancellationToken);
+                else
+                    d1 = await rawLandingSvc.LandParcelGeomsAsync(
+                        bentonCounty.FipsCode, bentonCountyId, operatorName, geomTopN, cancellationToken);
                 batchIds.Add(d1.LoadBatchId);
                 if (!IsCompleted(d1.Status))
                     return await FailLaneAsync(LaneName, "ArcGis-D1", d1.ErrorSummary,

--- a/backend/src/TerraFusion.Core/Configuration/ArcGisFeatureServiceOptions.cs
+++ b/backend/src/TerraFusion.Core/Configuration/ArcGisFeatureServiceOptions.cs
@@ -102,4 +102,11 @@ public sealed class CountyArcGisOptions
     /// controller (it resolves CountyId from the DB via FipsCode).
     /// </summary>
     public Guid? CountyId { get; set; }
+
+    /// <summary>
+    /// GEOM-011: number of features to request per page when using ArcGIS
+    /// pagination (resultOffset + resultRecordCount). Defaults to 1000.
+    /// Must not exceed the ArcGIS server's maxRecordCount (~2000 for Benton).
+    /// </summary>
+    public int PageSize { get; set; } = 1000;
 }

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisFeatureServiceClient.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisFeatureServiceClient.cs
@@ -123,6 +123,109 @@ public sealed class ArcGisFeatureServiceClient : IArcGisFeatureServiceClient
         return results;
     }
 
+    public async Task<(IReadOnlyList<ArcGisParcelFeature> Features, bool ExceededLimit)> FetchPageAsync(
+        string fipsCode,
+        Guid countyId,
+        int offset,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var county = _options.Value.GetForCounty(fipsCode)
+            ?? throw new ArcGisFeatureServiceConfigurationException(
+                $"No ArcGIS feature-service configuration bound for FIPS {fipsCode} (county {countyId}).");
+
+        if (string.IsNullOrWhiteSpace(county.ParcelFeatureServiceUrl))
+            throw new ArcGisFeatureServiceConfigurationException(
+                $"FIPS {fipsCode} (county {countyId}) has empty ParcelFeatureServiceUrl.");
+
+        var queryUrl = BuildPageUrl(county, offset, pageSize);
+        using var http = _httpClientFactory.CreateClient(HttpClientName);
+        http.Timeout = TimeSpan.FromSeconds(county.RequestTimeoutSeconds);
+
+        if (!string.IsNullOrEmpty(county.BearerToken))
+            http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", county.BearerToken);
+
+        ArcGisGeoJsonFeatureCollection? payload;
+        try
+        {
+            payload = await http.GetFromJsonAsync<ArcGisGeoJsonFeatureCollection>(
+                queryUrl, JsonOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS page request failed for county {countyId} offset={offset}: {ex.Message}", ex);
+        }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS page request timed out after {county.RequestTimeoutSeconds}s for county {countyId} offset={offset}.", ex);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS page response was not valid JSON for county {countyId} offset={offset}: {ex.Message}", ex);
+        }
+
+        if (payload?.Features is null || payload.Features.Count == 0)
+            return (Array.Empty<ArcGisParcelFeature>(), false);
+
+        var pageResults = new List<ArcGisParcelFeature>(payload.Features.Count);
+        foreach (var feature in payload.Features)
+        {
+            var projected = TryProject(feature, countyId, county);
+            if (projected is not null)
+                pageResults.Add(projected);
+        }
+        return (pageResults, payload.ExceededTransferLimit);
+    }
+
+    public async Task<int> FetchCountAsync(
+        string fipsCode,
+        CancellationToken cancellationToken = default)
+    {
+        var county = _options.Value.GetForCounty(fipsCode)
+            ?? throw new ArcGisFeatureServiceConfigurationException(
+                $"No ArcGIS feature-service configuration bound for FIPS {fipsCode}.");
+
+        if (string.IsNullOrWhiteSpace(county.ParcelFeatureServiceUrl))
+            throw new ArcGisFeatureServiceConfigurationException(
+                $"FIPS {fipsCode} has empty ParcelFeatureServiceUrl.");
+
+        var countUrl = BuildCountUrl(county);
+        using var http = _httpClientFactory.CreateClient(HttpClientName);
+        http.Timeout = TimeSpan.FromSeconds(county.RequestTimeoutSeconds);
+
+        if (!string.IsNullOrEmpty(county.BearerToken))
+            http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", county.BearerToken);
+
+        ArcGisCountResponse? response;
+        try
+        {
+            response = await http.GetFromJsonAsync<ArcGisCountResponse>(
+                countUrl, JsonOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS count request failed for FIPS {fipsCode}: {ex.Message}", ex);
+        }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS count request timed out after {county.RequestTimeoutSeconds}s for FIPS {fipsCode}.", ex);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArcGisFeatureServiceTransportException(
+                $"ArcGIS count response was not valid JSON for FIPS {fipsCode}: {ex.Message}", ex);
+        }
+
+        return response?.Count ?? 0;
+    }
+
     private static string BuildQueryUrl(CountyArcGisOptions county, int? topN = null)
     {
         var separator = county.ParcelFeatureServiceUrl.EndsWith('/') ? "query" : "/query";
@@ -132,6 +235,31 @@ public sealed class ArcGisFeatureServiceClient : IArcGisFeatureServiceClient
             : string.Empty;
         return $"{county.ParcelFeatureServiceUrl}{separator}" +
                $"?f=geojson&where=1%3D1&outFields=*&outSR={sr}&returnGeometry=true{limit}";
+    }
+
+    // GEOM-011: paged query URL — resultOffset + resultRecordCount + deterministic OBJECTID order.
+    private static string BuildPageUrl(CountyArcGisOptions county, int offset, int pageSize)
+    {
+        var separator = county.ParcelFeatureServiceUrl.EndsWith('/') ? "query" : "/query";
+        var sr = county.OutSpatialReferenceEpsg.ToString(CultureInfo.InvariantCulture);
+        return $"{county.ParcelFeatureServiceUrl}{separator}" +
+               $"?f=geojson&where=1%3D1&outFields=*&outSR={sr}&returnGeometry=true" +
+               $"&resultRecordCount={pageSize.ToString(CultureInfo.InvariantCulture)}" +
+               $"&resultOffset={offset.ToString(CultureInfo.InvariantCulture)}" +
+               $"&orderByFields=OBJECTID+ASC";
+    }
+
+    // GEOM-011: count-only URL for preflight; returns {"count": N} not GeoJSON.
+    private static string BuildCountUrl(CountyArcGisOptions county)
+    {
+        var separator = county.ParcelFeatureServiceUrl.EndsWith('/') ? "query" : "/query";
+        return $"{county.ParcelFeatureServiceUrl}{separator}?f=json&where=1%3D1&returnCountOnly=true";
+    }
+
+    // JsonOptions has PropertyNameCaseInsensitive=true, so "count" → Count without an attribute.
+    private sealed record ArcGisCountResponse
+    {
+        public int Count { get; init; }
     }
 
     private ArcGisParcelFeature? TryProject(

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisGeoJson.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisGeoJson.cs
@@ -20,6 +20,9 @@ internal sealed class ArcGisGeoJsonFeatureCollection
 
     [JsonPropertyName("features")]
     public List<ArcGisGeoJsonFeature> Features { get; set; } = new();
+
+    [JsonPropertyName("exceededTransferLimit")]
+    public bool ExceededTransferLimit { get; set; }
 }
 
 internal sealed class ArcGisGeoJsonFeature

--- a/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisFeatureServiceClient.cs
+++ b/backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisFeatureServiceClient.cs
@@ -36,6 +36,25 @@ public interface IArcGisFeatureServiceClient
         Guid countyId,
         int? topN,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// GEOM-011: fetches one page of parcel polygons using resultOffset pagination.
+    /// Returns the features and whether the server signalled exceededTransferLimit.
+    /// </summary>
+    Task<(IReadOnlyList<ArcGisParcelFeature> Features, bool ExceededLimit)> FetchPageAsync(
+        string fipsCode,
+        Guid countyId,
+        int offset,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// GEOM-011: returns the total feature count from the ArcGIS service
+    /// via returnCountOnly=true. Used as a preflight before paged landing.
+    /// </summary>
+    Task<int> FetchCountAsync(
+        string fipsCode,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs
@@ -37,6 +37,19 @@ public interface IArcGisRawLandingService
         string operatorName,
         int? topN,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// GEOM-011: paged variant — uses ArcGIS resultOffset pagination to
+    /// land more features than the server's single-request maxRecordCount.
+    /// Routes to this method when FullCorpus=true or topN &gt; pageSize.
+    /// </summary>
+    Task<ArcGisRawLandingResult> LandParcelGeomsPagedAsync(
+        string fipsCode,
+        Guid countyId,
+        string operatorName,
+        int pageSize,
+        int? topN,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>Slice D1: outcome of one landing run.</summary>
@@ -65,4 +78,10 @@ public sealed record ArcGisRawLandingResult
     public required double AreaSqFtSum { get; init; }
 
     public string? ErrorSummary { get; init; }
+
+    /// <summary>GEOM-011: total pages fetched (0 for non-paged runs).</summary>
+    public int TotalPages { get; init; }
+
+    /// <summary>GEOM-011: true when LandParcelGeomsPagedAsync was used.</summary>
+    public bool PaginatedMode { get; init; }
 }

--- a/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
@@ -173,6 +173,185 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
         }
     }
 
+    public async Task<ArcGisRawLandingResult> LandParcelGeomsPagedAsync(
+        string fipsCode,
+        Guid countyId,
+        string operatorName,
+        int pageSize,
+        int? topN,
+        CancellationToken cancellationToken = default)
+    {
+        // Preflight: get total feature count so we know when to stop and can set the safety cap.
+        int preflightCount;
+        try
+        {
+            preflightCount = await _client.FetchCountAsync(fipsCode, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var countErr = $"FetchCountAsync failed: {ex.GetType().Name}: {ex.Message}";
+            _logger.LogError(ex, "ArcGIS paged landing: preflight count failed for fips={Fips}", fipsCode);
+            return new ArcGisRawLandingResult
+            {
+                LoadBatchId = Guid.Empty,
+                Status = "FAILED",
+                FeaturesConsidered = 0,
+                FeaturesLanded = 0,
+                DuplicateObjectIds = 0,
+                AreaSqFtSum = 0d,
+                ErrorSummary = countErr,
+            };
+        }
+
+        _logger.LogInformation(
+            "ArcGIS paged landing preflight: fips={Fips} county={CountyId} preflightCount={Count} pageSize={PageSize} topN={TopN}",
+            fipsCode, countyId, preflightCount, pageSize, topN);
+
+        // Effective max: topN cap or full preflight count.
+        var effectiveMax = topN.HasValue ? Math.Min(topN.Value, preflightCount) : preflightCount;
+        // Safety cap: 2× pages needed plus 1.
+        var maxPages = (int)Math.Ceiling((double)preflightCount / pageSize) * 2 + 1;
+
+        var baseDescriptor = $"fips={fipsCode} county={countyId} f=geojson where=1=1 outSR=4326 returnGeometry=true paged=true pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}";
+
+        var batch = new LoadBatch
+        {
+            SourceFamily = SourceFamilies.ArcGisRest,
+            SourceSystem = "arcgis-feature-service",
+            SourceFileOrDatabase = $"county:{countyId} fips={fipsCode}",
+            SourceQueryHash = ComputeStableHash(baseDescriptor),
+            Operator = operatorName,
+            Status = "IN_PROGRESS",
+            StartedAt = DateTime.UtcNow,
+        };
+        _db.SyncBridgeLoadBatches.Add(batch);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var seenKeys = new HashSet<(Guid, long)>();
+            int totalConsidered = 0, totalLanded = 0, totalDuplicates = 0;
+            double totalAreaSum = 0d;
+            int pageIndex = 0;
+
+            while (pageIndex < maxPages && totalLanded < effectiveMax)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var offset = pageIndex * pageSize;
+                var remaining = effectiveMax - totalLanded;
+                var thisPageSize = Math.Min(pageSize, remaining);
+
+                var (features, exceededLimit) = await _client.FetchPageAsync(
+                    fipsCode, countyId, offset, thisPageSize, cancellationToken).ConfigureAwait(false);
+
+                totalConsidered += features.Count;
+
+                if (features.Count == 0)
+                {
+                    _logger.LogInformation("[Paged:D1] page={Page} returned 0 features — stopping", pageIndex);
+                    break;
+                }
+
+                var now = DateTime.UtcNow;
+                var pageDescriptor = $"{baseDescriptor} offset={offset.ToString(CultureInfo.InvariantCulture)}";
+                var pageQueryHash = ComputeStableHash(pageDescriptor);
+
+                foreach (var feature in features)
+                {
+                    var key = (feature.CountyId, feature.ArcGisObjectId);
+                    if (!seenKeys.Add(key))
+                    {
+                        totalDuplicates++;
+                        continue;
+                    }
+
+                    _db.LegacyArcGisRawParcelGeoms.Add(new LegacyArcGisRawParcelGeom
+                    {
+                        CountyId = feature.CountyId,
+                        ArcGisObjectId = feature.ArcGisObjectId,
+                        ArcGisApn = feature.ArcGisApn,
+                        GeomWkt = feature.GeomWkt,
+                        CentroidLat = feature.CentroidLat,
+                        CentroidLon = feature.CentroidLon,
+                        AreaSqFt = feature.AreaSqFt,
+                        SourceServiceUrl = feature.SourceServiceUrl,
+                        LoadBatchId = batch.LoadBatchId,
+                        SourceQueryHash = pageQueryHash,
+                        SourceRowHash = ComputeRowHash(feature),
+                        LandedAt = now,
+                    });
+                    totalLanded++;
+                    totalAreaSum += feature.AreaSqFt;
+                }
+
+                // Per-page save keeps memory bounded across large corpus.
+                await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "[Paged:D1] page={Page} offset={Offset} features={Count} exceeded={Exceeded} totalLanded={Total}",
+                    pageIndex, offset, features.Count, exceededLimit, totalLanded);
+
+                pageIndex++;
+
+                // Stop: no more pages signalled, short page, or landed everything.
+                if (!exceededLimit || features.Count < thisPageSize)
+                    break;
+            }
+
+            await WriteGatesAsync(
+                batch, totalConsidered, totalLanded, totalDuplicates, totalAreaSum,
+                cancellationToken).ConfigureAwait(false);
+
+            batch.Status = "COMPLETED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.RowsExtracted = totalConsidered;
+            batch.RowsPromoted = totalLanded;
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "ArcGIS paged landing COMPLETED. batch={BatchId} county={CountyId} pages={Pages} considered={Considered} landed={Landed} dupes={Dups}",
+                batch.LoadBatchId, countyId, pageIndex, totalConsidered, totalLanded, totalDuplicates);
+
+            return new ArcGisRawLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "COMPLETED",
+                FeaturesConsidered = totalConsidered,
+                FeaturesLanded = totalLanded,
+                DuplicateObjectIds = totalDuplicates,
+                AreaSqFtSum = totalAreaSum,
+                TotalPages = pageIndex,
+                PaginatedMode = true,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var summary = $"{ex.GetType().Name}: {ex.Message}";
+            batch.Status = "FAILED";
+            batch.CompletedAt = DateTime.UtcNow;
+            batch.ErrorSummary = summary;
+            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            _logger.LogError(ex,
+                "ArcGIS paged landing FAILED. batch={BatchId} county={CountyId} summary={Summary}",
+                batch.LoadBatchId, countyId, summary);
+
+            return new ArcGisRawLandingResult
+            {
+                LoadBatchId = batch.LoadBatchId,
+                Status = "FAILED",
+                FeaturesConsidered = 0,
+                FeaturesLanded = 0,
+                DuplicateObjectIds = 0,
+                AreaSqFtSum = 0d,
+                ErrorSummary = summary,
+                TotalPages = 0,
+                PaginatedMode = true,
+            };
+        }
+    }
+
     private async Task WriteGatesAsync(
         LoadBatch batch,
         int considered,

--- a/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
@@ -181,6 +181,9 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
         int? topN,
         CancellationToken cancellationToken = default)
     {
+        if (pageSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "PageSize must be greater than zero.");
+
         // Preflight: get total feature count so we know when to stop and can set the safety cap.
         int preflightCount;
         try
@@ -209,8 +212,11 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
 
         // Effective max: topN cap or full preflight count.
         var effectiveMax = topN.HasValue ? Math.Min(topN.Value, preflightCount) : preflightCount;
+        // targetCount: how many features to collect before stopping.
+        // Drive the loop on this, not on exceededTransferLimit (advisory only).
+        var targetCount = Math.Min(preflightCount, effectiveMax);
         // Safety cap: 2× pages needed plus 1.
-        var maxPages = (int)Math.Ceiling((double)preflightCount / pageSize) * 2 + 1;
+        var maxPages = (int)Math.Ceiling((double)targetCount / pageSize) * 2 + 1;
 
         var baseDescriptor = $"fips={fipsCode} county={countyId} f=geojson where=1=1 outSR=4326 returnGeometry=true paged=true pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}";
 
@@ -234,12 +240,15 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
             double totalAreaSum = 0d;
             int pageIndex = 0;
 
-            while (pageIndex < maxPages && totalLanded < effectiveMax)
+            while (pageIndex < maxPages)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // Primary termination: we've seen enough of the corpus.
+                if (totalConsidered >= targetCount) break;
+
                 var offset = pageIndex * pageSize;
-                var remaining = effectiveMax - totalLanded;
+                var remaining = targetCount - totalConsidered;
                 var thisPageSize = Math.Min(pageSize, remaining);
 
                 var (features, exceededLimit) = await _client.FetchPageAsync(
@@ -288,15 +297,16 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
                 // Per-page save keeps memory bounded across large corpus.
                 await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+                if (exceededLimit)
+                    _logger.LogDebug(
+                        "[Paged:D1] page={Page} server set exceededTransferLimit (advisory — continuing to next page)",
+                        pageIndex);
+
                 _logger.LogInformation(
-                    "[Paged:D1] page={Page} offset={Offset} features={Count} exceeded={Exceeded} totalLanded={Total}",
-                    pageIndex, offset, features.Count, exceededLimit, totalLanded);
+                    "[Paged:D1] page={Page} offset={Offset} features={Count} exceeded={Exceeded} totalConsidered={Total}",
+                    pageIndex, offset, features.Count, exceededLimit, totalConsidered);
 
                 pageIndex++;
-
-                // Stop: no more pages signalled, short page, or landed everything.
-                if (!exceededLimit || features.Count < thisPageSize)
-                    break;
             }
 
             await WriteGatesAsync(

--- a/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisSyncServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/GisTf/ArcGisRest/ArcGisSyncServiceTests.cs
@@ -239,6 +239,11 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
             string fipsCode, Guid countyId, int? topN, CancellationToken cancellationToken = default)
             => Task.FromResult(_features);
+        public Task<(IReadOnlyList<ArcGisParcelFeature> Features, bool ExceededLimit)> FetchPageAsync(
+            string fipsCode, Guid countyId, int offset, int pageSize, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<int> FetchCountAsync(string fipsCode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
     }
 
     private sealed class FailingArcGisClient : IArcGisFeatureServiceClient
@@ -248,5 +253,10 @@ public sealed class ArcGisSyncServiceTests : IDisposable
         public Task<IReadOnlyList<ArcGisParcelFeature>> FetchParcelsAsync(
             string fipsCode, Guid countyId, int? topN, CancellationToken cancellationToken = default)
             => Task.FromException<IReadOnlyList<ArcGisParcelFeature>>(_ex);
+        public Task<(IReadOnlyList<ArcGisParcelFeature> Features, bool ExceededLimit)> FetchPageAsync(
+            string fipsCode, Guid countyId, int offset, int pageSize, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<int> FetchCountAsync(string fipsCode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
     }
 }

--- a/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/LegacyArcGisRaw/ArcGisRawLandingServiceTests.cs
@@ -395,5 +395,12 @@ public sealed class ArcGisRawLandingServiceTests : IDisposable
             }
             return Task.FromResult(_features);
         }
+
+        public Task<(IReadOnlyList<ArcGisParcelFeature> Features, bool ExceededLimit)> FetchPageAsync(
+            string fipsCode, Guid countyId, int offset, int pageSize, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<int> FetchCountAsync(string fipsCode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
     }
 }

--- a/docs/sync/PACS_SYNC_GEOM_011_ARCGIS_PAGINATION_IMPLEMENTATION.md
+++ b/docs/sync/PACS_SYNC_GEOM_011_ARCGIS_PAGINATION_IMPLEMENTATION.md
@@ -127,5 +127,5 @@ No proof runs were executed in this implementation slice per work order.
 - No ArcGIS calls outside authorized probe runs
 - No DB mutated outside authorized drains
 - No PACS touched
-- Git mutations confined to worktree `C:\Users\bsval\tf-geom-011-pagination` only
+- Git mutations confined to the dedicated GEOM-011 worktree only
 - No secrets committed

--- a/docs/sync/PACS_SYNC_GEOM_011_ARCGIS_PAGINATION_IMPLEMENTATION.md
+++ b/docs/sync/PACS_SYNC_GEOM_011_ARCGIS_PAGINATION_IMPLEMENTATION.md
@@ -1,0 +1,131 @@
+# GEOM-011: ArcGIS Pagination Implementation
+
+**Work Order**: WO-DATA-004C-GEOM-011  
+**Branch**: feat/geom-011-arcgis-pagination  
+**Status**: IMPLEMENTATION COMPLETE — build green, 0 errors, 0 warnings  
+**Date**: 2026-06-20  
+
+---
+
+## Problem
+
+GEOM-009 confirmed that ArcGIS Feature Service returns at most ~1,974 features per request (server `maxRecordCount` ≈ 2,000). Even `FullCorpus=true` hit the same ceiling. Full Benton corpus is ~89,247 parcels — every single-request drain was silently truncated at ~2%.
+
+---
+
+## Solution
+
+Implement `resultOffset` + `resultRecordCount` + deterministic `orderByFields=OBJECTID+ASC` pagination at the D1 landing layer. A preflight `returnCountOnly=true` request establishes how many features to expect, then a loop pages through until all features are landed.
+
+---
+
+## Files Changed
+
+### New interface methods
+**`backend/src/TerraFusion.Core/GIS/ArcGisRest/IArcGisFeatureServiceClient.cs`**
+- `FetchPageAsync(fipsCode, countyId, offset, pageSize, ct)` → `(IReadOnlyList<ArcGisParcelFeature>, bool ExceededLimit)`
+- `FetchCountAsync(fipsCode, ct)` → `int`
+
+### New config field
+**`backend/src/TerraFusion.Core/Configuration/ArcGisFeatureServiceOptions.cs`**  
+- `CountyArcGisOptions.PageSize` — default 1000; controls `resultRecordCount` per page
+
+### GeoJSON model
+**`backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisGeoJson.cs`**  
+- `ArcGisGeoJsonFeatureCollection.ExceededTransferLimit` — deserializes `exceededTransferLimit` from ArcGIS response
+
+### Client implementation
+**`backend/src/TerraFusion.Core/GIS/ArcGisRest/ArcGisFeatureServiceClient.cs`**  
+- `FetchPageAsync` — issues `?resultRecordCount=N&resultOffset=O&orderByFields=OBJECTID+ASC`
+- `FetchCountAsync` — issues `?f=json&returnCountOnly=true`, deserializes `{"count": N}`
+- `BuildPageUrl` — deterministic paged URL builder
+- `BuildCountUrl` — count-only URL builder
+- `ArcGisCountResponse` — private record for count deserialization
+
+### Landing service
+**`backend/src/TerraFusion.Core/Sync/ArcGisRawLanding/IArcGisRawLandingService.cs`**
+- `LandParcelGeomsPagedAsync(fipsCode, countyId, operatorName, pageSize, topN?, ct)` added to interface
+- `ArcGisRawLandingResult.TotalPages` + `PaginatedMode` added
+
+**`backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs`**
+- `LandParcelGeomsPagedAsync` implementation:
+  - Preflight `FetchCountAsync` → abort on failure
+  - Single root `LoadBatch` for the whole paged run
+  - Per-page `FetchPageAsync` loop
+  - Cross-page `HashSet<(Guid, long)>` deduplication
+  - Per-page `SaveChangesAsync` (memory bounded)
+  - Per-page `SourceQueryHash` encodes offset for provenance traceability
+  - Safety cap: `ceil(preflightCount / pageSize) * 2 + 1` max pages
+  - Stop conditions: empty page, `!exceededTransferLimit`, short page, `totalLanded >= effectiveMax`
+  - `WriteGatesAsync` once at end on root batch
+
+### Controller routing
+**`backend/src/TerraFusion.API/Controllers/DoctrineDrainController.cs`**
+- **Identity guard (409)**: if `arcGisCounty.CountyId` is set and doesn't match DB row ID → refuse before any ArcGIS call
+- **Paged routing**: `FullCorpus=true` OR `topN > pageSize` → `LandParcelGeomsPagedAsync`; otherwise falls back to existing `LandParcelGeomsAsync` (backward compatible)
+
+### Tests
+**`backend/TerraFusion.API.Tests/GIS/GeomSliceControlV2Tests.cs`** — fixed pre-existing compile errors:
+- Added `IOptions<ArcGisFeatureServiceOptions>` parameter to all `DrainGeometry` calls
+- Fixed `LandParcelGeomsAsync` mock signature: was `(Guid, string, int?, CancellationToken)` → correct `(string, Guid, string, int?, CancellationToken)`
+- Added `BuildArcGisOptions(Guid?)` helper
+- 409 identity-mismatch tests now wire correctly
+
+**`backend/TerraFusion.API.Tests/GIS/GeomSliceControlPaginationTests.cs`** — NEW (8 tests):
+1. `FetchPageAsync_FirstPage_UrlContainsResultRecordCount1000`
+2. `FetchPageAsync_FirstPage_UrlContainsResultOffsetZero`
+3. `FetchPageAsync_SecondPage_UrlContainsResultOffset1000`
+4. `FetchPageAsync_UrlContainsOrderByObjectIdAsc`
+5. `FetchPageAsync_UrlContainsFGeojson`
+6. `FetchCountAsync_UrlContainsReturnCountOnly`
+7. `FetchCountAsync_UrlContainsFJson`
+8. `FetchPageAsync_UrlDiffersFromFetchParcels_NoPaginationParams`
+
+---
+
+## Build Verification
+
+```
+dotnet build TerraFusion.sln --no-incremental -v q
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+Time Elapsed 00:02:53
+```
+
+---
+
+## Routing Logic Summary
+
+```
+DrainGeometry(request):
+  geomTopN = fullCorpus ? null : topN
+  pageSize  = arcGisCounty.PageSize          // default 1000
+  usePaged  = fullCorpus || (topN > pageSize)
+
+  if usePaged:
+    LandParcelGeomsPagedAsync(fipsCode, countyId, op, pageSize, geomTopN)
+  else:
+    LandParcelGeomsAsync(fipsCode, countyId, op, geomTopN)   // backward compat
+```
+
+---
+
+## NOT Done Here (Next Gates)
+
+- **GEOM-011A**: `TopN=2000` proof run (requires operator go-ahead)
+- **GEOM-011B**: `TopN=5000` proof run (after 011A passes)
+- **GEOM-011C**: `FullCorpus=true` full-corpus run (after 011B passes)
+
+No proof runs were executed in this implementation slice per work order.
+
+---
+
+## Security Controls Honoured
+
+- No geometry execution
+- No ArcGIS calls outside authorized probe runs
+- No DB mutated outside authorized drains
+- No PACS touched
+- Git mutations confined to worktree `C:\Users\bsval\tf-geom-011-pagination` only
+- No secrets committed


### PR DESCRIPTION
## Summary

- **ArcGIS server limit**: single requests cap at ~1,974 features (server maxRecordCount ≈ 2,000). GEOM-009 confirmed full-corpus pulls were silently truncated at ~2% of Benton's 89,247 parcels.
- **Solution**: ArcGIS `resultOffset` pagination — preflight count + paged loop with `resultRecordCount` / `resultOffset` / `orderByFields=OBJECTID+ASC`.
- **Routing**: `FullCorpus=true` OR `topN > pageSize` → `LandParcelGeomsPagedAsync`; small `topN` falls back to existing single-request path (backward-compatible).
- **Identity guard**: 409 if `arcGisCounty.CountyId` (config) doesn't match Benton DB row ID — refuses before any ArcGIS call.

## Files changed

| File | Change |
|------|--------|
| `ArcGisGeoJson.cs` | Add `ExceededTransferLimit bool` |
| `ArcGisFeatureServiceOptions.cs` | Add `PageSize` (default 1000) |
| `IArcGisFeatureServiceClient.cs` | Add `FetchPageAsync` + `FetchCountAsync` |
| `ArcGisFeatureServiceClient.cs` | Implement paged URL builder + count URL builder |
| `IArcGisRawLandingService.cs` | Add `LandParcelGeomsPagedAsync` + `TotalPages`/`PaginatedMode` |
| `ArcGisRawLandingService.cs` | Implement paged loop (preflight, per-page save, cross-page dedup, safety cap) |
| `DoctrineDrainController.cs` | 409 identity guard + paged routing in D1 stage |
| `GeomSliceControlV2Tests.cs` | Fix pre-existing compile errors (mock param order, missing `arcGisOptions`) |
| `GeomSliceControlPaginationTests.cs` | NEW — 8 tests covering paged URL behavior |
| `PACS_SYNC_GEOM_011_ARCGIS_PAGINATION_IMPLEMENTATION.md` | Evidence doc |

## Test plan

- [x] `dotnet build TerraFusion.sln` → 0 errors, 0 warnings
- [x] Pre-commit quality gate passed
- [x] Pre-push quality gate passed (164 unit tests green, Release build clean)
- [x] 8 new pagination unit tests in `GeomSliceControlPaginationTests.cs`
- [ ] GEOM-011A: `TopN=2000` proof run — pending operator go-ahead after merge
- [ ] GEOM-011B: `TopN=5000` proof run — after 011A passes
- [ ] GEOM-011C: `FullCorpus=true` full-corpus proof run — after 011B passes

**No ArcGIS calls, no DB mutations, no PACS touched in this slice.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce ArcGIS resultOffset-based pagination for large parcel geometry drains and wire it into the geometry drain pipeline with appropriate safeguards.

New Features:
- Add paged ArcGIS parcel landing workflow that uses resultOffset/resultRecordCount with preflight count and cross-page deduplication.
- Expose paginated and count-only ArcGIS feature-service methods and configuration, including page size and transfer-limit signaling.
- Extend geometry drain result model to report pagination metadata such as total pages and whether pagination was used.

Bug Fixes:
- Guard geometry drains with a 409 response when ArcGIS configuration county identity does not match the Benton county DB row, preventing misrouted pulls.
- Fix DoctrineDrainController geometry tests by correcting service mock signatures and wiring required ArcGIS options.

Enhancements:
- Route geometry drains to the paged landing path automatically when requesting full corpus or more records than a single ArcGIS page.
- Improve logging and error handling for paged ArcGIS requests and landing batches, including preflight failures and completion summaries.

Documentation:
- Add GEOM-011 implementation document describing ArcGIS pagination design, routing rules, and verification steps.
- Add dedicated tests documenting pagination URL construction and separation from existing non-paged queries.

Tests:
- Add pagination-focused tests for ArcGIS client URL construction and ensure non-paged queries remain unchanged.
- Update existing geometry drain tests to cover the new identity guard behavior and dependency wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled ArcGIS feature service pagination to reliably process large parcel result sets.
  * Added configurable page size (default 1,000) and a count-only preflight to plan retrieval.
  * Improved raw landing to report pagination mode and total pages.

* **Bug Fixes**
  * Updated drainage behavior to select paged vs non-paged loading based on workload size.
  * Added clearer error handling for missing county FIPS codes and county identity conflicts.

* **Tests**
  * Expanded coverage for pagination URL/query parameters and paging behavior.

* **Documentation**
  * Added GEOM-011 documentation for ArcGIS pagination implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->