### PR TITLE
fix(geom-011b-h1): detach per-page geometry entities to bound ChangeTracker (full-corpus hardening)

### DIFF
--- a/backend/TerraFusion.API.Tests/GIS/ArcGisRawLandingServicePagedTests.cs
+++ b/backend/TerraFusion.API.Tests/GIS/ArcGisRawLandingServicePagedTests.cs
@@ -19,6 +19,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using TerraFusion.Core.Entities.LegacyArcGisRaw;
 using TerraFusion.Core.GIS.ArcGisRest;
 using TerraFusion.Data;
 using TerraFusion.Data.Services.LegacyArcGisRaw;
@@ -201,9 +202,45 @@ public sealed class ArcGisRawLandingServicePagedTests
             svc.LandParcelGeomsPagedAsync(TestFips, TestCountyId, "op", pageSize: -1, topN: null));
     }
 
+    // ── GEOM-011B-H1: ChangeTracker does not accumulate geometry across pages ──
+
+    [Fact]
+    public async Task LandParcelGeomsPagedAsync_DoesNotAccumulateTrackedGeometryEntitiesAcrossPages()
+    {
+        var (svc, client, db) = BuildWithDb();
+
+        // 3 full pages of 1000 → 3000 landed across multiple page saves.
+        client.Setup(c => c.FetchCountAsync(TestFips, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(3000);
+        client.SetupSequence(c => c.FetchPageAsync(
+                TestFips, TestCountyId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MakeFeatures(1, 1000), false))
+            .ReturnsAsync((MakeFeatures(1001, 1000), false))
+            .ReturnsAsync((MakeFeatures(2001, 1000), false))
+            .ReturnsAsync((Array.Empty<ArcGisParcelFeature>(), false));
+
+        var result = await svc.LandParcelGeomsPagedAsync(
+            TestFips, TestCountyId, "op", pageSize: 1000, topN: null);
+
+        Assert.Equal("COMPLETED", result.Status);
+        Assert.Equal(3000, result.FeaturesLanded);
+
+        // Hardening contract: landed geometry entities are detached after each page save,
+        // so the ChangeTracker retains none of the 3000 rows. Without the fix this would
+        // equal 3000 (full accumulation across the run).
+        var trackedGeoms = db.ChangeTracker.Entries<LegacyArcGisRawParcelGeom>().Count();
+        Assert.Equal(0, trackedGeoms);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────
 
     private static (ArcGisRawLandingService svc, Mock<IArcGisFeatureServiceClient> client) Build()
+    {
+        var (svc, client, _) = BuildWithDb();
+        return (svc, client);
+    }
+
+    private static (ArcGisRawLandingService svc, Mock<IArcGisFeatureServiceClient> client, TerraFusionDbContext db) BuildWithDb()
     {
         var dbName = Guid.NewGuid().ToString();
         var configMock = new Mock<IConfiguration>();
@@ -217,7 +254,7 @@ public sealed class ArcGisRawLandingServicePagedTests
         var client = new Mock<IArcGisFeatureServiceClient>();
         var svc = new ArcGisRawLandingService(db, client.Object, NullLogger<ArcGisRawLandingService>.Instance);
 
-        return (svc, client);
+        return (svc, client, db);
     }
 
     private static IReadOnlyList<ArcGisParcelFeature> MakeFeatures(long startObjectId, int count)

--- a/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+++ b/backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
@@ -297,6 +297,18 @@ public sealed class ArcGisRawLandingService : IArcGisRawLandingService
                 // Per-page save keeps memory bounded across large corpus.
                 await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+                // GEOM-011B-H1: detach the geometry entities just persisted so the EF
+                // ChangeTracker does not accumulate thousands of landed rows across pages
+                // during a full-corpus (~80k row) run — a memory/throughput risk flagged in
+                // GEOM-011B review. Only the page's LegacyArcGisRawParcelGeom entries are
+                // detached; the LoadBatch entity stays tracked so the COMPLETED finalize
+                // below (and the FAILED update in the catch path) still persist correctly.
+                // A blanket ChangeTracker.Clear() would detach the batch and break those
+                // updates, so detaching by type is the batch-safe equivalent.
+                foreach (var entry in _db.ChangeTracker
+                             .Entries<LegacyArcGisRawParcelGeom>().ToList())
+                    entry.State = EntityState.Detached;
+
                 if (exceededLimit)
                     _logger.LogDebug(
                         "[Paged:D1] page={Page} server set exceededTransferLimit (advisory — continuing to next page)",

--- a/docs/sync/PACS_SYNC_GEOM_011B_H1_FULL_CORPUS_HARDENING.md
+++ b/docs/sync/PACS_SYNC_GEOM_011B_H1_FULL_CORPUS_HARDENING.md
@@ -1,0 +1,107 @@
+# GEOM-011B-H1: ArcGIS Pagination Full-Corpus Hardening
+
+**Work Order**: WO-DATA-004C-GEOM-011B-H1
+**Base**: main @ `9c3f2f67e` (branch `fix/geom-011b-h1-pagination-hardening`)
+**Date**: 2026-06-20
+**Type**: Code hardening only. No full corpus. No GEOM-011C. No live ArcGIS (tests use mocks). No PACS. No DB mutation except in-memory test DB.
+
+---
+
+## Finding being addressed
+
+GEOM-011B (TopN=5,000) passed, but the ArcGIS server under-fills every page, so a
+full-corpus run will issue ~80–90 page requests. CodeRabbit flagged that the D1 paged
+landing loop calls `SaveChangesAsync` per page but never detaches the persisted entities,
+so the EF `ChangeTracker` would **accumulate every landed geometry row** across all pages.
+At full corpus (~80k rows) this is a memory and change-detection throughput risk that could
+turn a clean proof into a performance/OOM failure.
+
+---
+
+## Hardening approach
+
+After each successful per-page `SaveChangesAsync`, detach the geometry entities that were
+just persisted, so the tracker holds none of them going into the next page:
+
+```csharp
+// Per-page save keeps memory bounded across large corpus.
+await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+// GEOM-011B-H1: detach the geometry entities just persisted so the EF ChangeTracker
+// does not accumulate thousands of landed rows across pages during a full-corpus run.
+foreach (var entry in _db.ChangeTracker
+             .Entries<LegacyArcGisRawParcelGeom>().ToList())
+    entry.State = EntityState.Detached;
+```
+
+### Why detach-by-type instead of `ChangeTracker.Clear()`
+
+A blanket `ChangeTracker.Clear()` would also detach the `LoadBatch` (`batch`) entity, which
+is created before the loop and updated **after** it (`batch.Status = "COMPLETED"`,
+`RowsExtracted`, `RowsPromoted`) and in the catch path (`batch.Status = "FAILED"`). A
+detached batch would silently not persist those updates. Detaching only the page's
+`LegacyArcGisRawParcelGeom` entries removes the bulk (1000/page) while keeping the single
+`LoadBatch` tracked — satisfying requirement #4 (preserve transaction/batch semantics).
+
+---
+
+## Why it is safe
+
+- **Entities are already persisted** before detach — `SaveChangesAsync` returns before the
+  loop body detaches. Detach only drops change-tracking, not data.
+- **Batch semantics preserved** — the `LoadBatch` stays tracked; COMPLETED/FAILED finalize
+  updates persist exactly as before.
+- **Cross-page dedup preserved** — dedup uses an in-memory `HashSet<(Guid,long)> seenKeys`,
+  independent of the EF tracker. Detaching entities does not affect it.
+- **Pagination stop logic unchanged** — loop still terminates on
+  `totalConsidered >= targetCount` or an empty page. No change to TopN / full-corpus guard.
+- **D2 (truth promotion) and D3 (canonical projection) untouched** — change is confined to
+  the D1 paged landing loop in `LandParcelGeomsPagedAsync`.
+- **Non-paged `LandParcelGeomsAsync` untouched.**
+
+---
+
+## ChangeTracker behavior
+
+| | Before H1 | After H1 |
+|---|---|---|
+| Geometry entities tracked after page N | N × pageSize (cumulative) | 0 (detached each page) |
+| `LoadBatch` tracked | yes | yes (unchanged) |
+| Peak tracked geometry entities | full landed count (~80k at corpus) | ≤ one page (~1000) |
+
+---
+
+## Tests / build
+
+- **New test**: `ArcGisRawLandingServicePagedTests.LandParcelGeomsPagedAsync_DoesNotAccumulateTrackedGeometryEntitiesAcrossPages`
+  — lands 3,000 rows across 3 pages, then asserts
+  `db.ChangeTracker.Entries<LegacyArcGisRawParcelGeom>().Count() == 0`.
+  Without the fix this would be 3,000.
+- **Paged service tests**: 8/8 PASS (7 prior + 1 new).
+- **All GIS tests**: 46/46 PASS (no regression).
+- **Build**: TerraFusion.Data Release — 0 warnings, 0 errors.
+
+---
+
+## Final Report
+
+```
+RESULT                   PASS — hardening applied, tests green
+FILES_CHANGED            backend/src/TerraFusion.Data/Services/LegacyArcGisRaw/ArcGisRawLandingService.cs
+                         backend/TerraFusion.API.Tests/GIS/ArcGisRawLandingServicePagedTests.cs
+                         docs/sync/PACS_SYNC_GEOM_011B_H1_FULL_CORPUS_HARDENING.md
+HARDENING_APPROACH       Detach per-page LegacyArcGisRawParcelGeom entities after each
+                         SaveChangesAsync; LoadBatch stays tracked (batch-safe equivalent
+                         of ChangeTracker.Clear()).
+CHANGETRACKER_BEHAVIOR   Peak tracked geometry entities reduced from full landed count to
+                         ≤ one page; LoadBatch tracking preserved.
+PAGINATION_LOGIC_CHANGED NO (targetCount/totalConsidered stop logic unchanged)
+D2_D3_CHANGED            NO
+TESTS                    Paged service 8/8 PASS (incl. new accumulation test); all GIS 46/46 PASS
+BUILD_STATUS             TerraFusion.Data Release: 0 warnings / 0 errors
+FULL_CORPUS_RUN          NO — no full corpus executed; no live ArcGIS (mocks only)
+LOCAL_COMMIT_OR_PR       local commit on fix/geom-011b-h1-pagination-hardening (see git log)
+NEXT_WORK_ORDER          WO-DATA-004C-GEOM-011C — Full-corpus demo (LOCKED; review H1 first)
+```
+
+No full corpus ran. GEOM-011C remains LOCKED pending review of this hardening.


### PR DESCRIPTION
## GEOM-011B-H1 — Full-Corpus Pagination Hardening (promotion)

Promotes the **only code change** from the GEOM-011 proof set to main: the D1 paged
landing loop now detaches per-page geometry entities so the EF ChangeTracker does not
accumulate thousands of landed rows across pages during a full-corpus (~80k) run.

Cherry-picked from local `fix/geom-011b-h1-pagination-hardening` (`36ae415d1`). Proof-run
artifacts, dumps, and evidence-only commits excluded.

### Change
After each per-page `SaveChangesAsync`, detach the page's `LegacyArcGisRawParcelGeom`
entries. **Detach-by-type, not `ChangeTracker.Clear()`** — a blanket clear would detach
the `LoadBatch` entity and break the COMPLETED finalize and FAILED catch-path status
persistence. This keeps the single batch tracked while removing the bulk (~1000/page).

### Scope (verified)
- Pagination stop logic: **unchanged** (`totalConsidered >= targetCount` / empty-page)
- TopN / FullCorpus guard: **unchanged**
- FIPS config behavior: **unchanged**
- D2 truth promotion / D3 canonical projection: **unchanged**
- Non-paged `LandParcelGeomsAsync`: **unchanged**

### Tests
- New: `LandParcelGeomsPagedAsync_DoesNotAccumulateTrackedGeometryEntitiesAcrossPages`
  lands 3,000 rows / 3 pages, asserts 0 tracked geometry entities after run (would be 3,000 without the fix).
- Paged service 8/8 PASS; all GIS 46/46 PASS; TerraFusion.Data Release build clean.

### Safety
No geometry run, no ArcGIS calls (tests mock), no DB mutation, no PACS. GEOM-011C full-corpus
remains LOCKED and is **not** affected or authorized by this PR.

Evidence: docs/sync/PACS_SYNC_GEOM_011B_H1_FULL_CORPUS_HARDENING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound EF ChangeTracker memory usage during paged ArcGIS raw parcel geometry landing by detaching per-page geometry entities, and add coverage and documentation for the new hardening behavior.

Enhancements:
- Detach per-page LegacyArcGisRawParcelGeom entities after each paged save to prevent EF ChangeTracker from accumulating large numbers of tracked rows during full-corpus runs.

Documentation:
- Document the GEOM-011B-H1 full-corpus pagination hardening, including rationale, safety analysis, and test/build verification results.

Tests:
- Add paged landing test that verifies geometry entities are not accumulated in the ChangeTracker across multiple pages, using an in-memory DB context helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized memory usage during large-scale paged data synchronization operations by preventing accumulation of previously persisted records across multiple pages.

* **Tests**
  * Added test coverage verifying proper memory management behavior in pagination scenarios.

* **Documentation**
  * Added documentation detailing pagination hardening improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->