### PR TITLE
ops(control-panel): add read-only operations prepare console

### DIFF
--- a/ops/control-panel/README.md
+++ b/ops/control-panel/README.md
@@ -1,0 +1,89 @@
+# TerraFusion Operations Control Panel
+
+**Status:** Seed specification  
+**Work Order:** `ops/packets/WO-OPS-CP-001.md`  
+**Authority:** Read-only operator surface  
+
+## Purpose
+
+The TerraFusion Operations Control Panel is a read-only operator console for turning automation findings into governed decisions. Automations act as sensors. This panel classifies their reports, shows operator status, and prepares scoped launch prompts for Codex or Claude.
+
+The control panel does not execute automations, mutate files, stage changes, commit, open pull requests, promote canon, or update queue truth.
+
+It is not a TerraFusion Brain, Cortex, autonomous queue, or runtime agent. The authority model is:
+
+```text
+Operations Control Panel = cockpit / prompt launcher / findings viewer
+Brain / Cortex = governance authority
+Codex / Claude = execution agents under Work Orders
+Human = promotion authority
+```
+
+## Operating Model
+
+```text
+Automations run
+-> reports are produced
+-> findings are classified
+-> control panel shows status
+-> human selects next action
+-> Codex/Claude gets a scoped Work Order
+-> agent reports back
+-> control panel status is updated by human review
+```
+
+## Files
+
+| File | Role |
+|------|------|
+| `control-panel.spec.json` | Control panel lanes, status model, and authority boundaries |
+| `report-schema.json` | Expected report sections for the six monitoring automations |
+| `launch-actions.json` | Prompt-launch actions and scoped Work Order templates |
+| `index.html` | Static read-only mockup for operator review |
+
+## First-Version Boundary
+
+This seed version is prompt-launch only:
+
+- It shows representative automation lanes.
+- It provides governed launch action definitions.
+- It gives operators copy-paste prompts for Codex or Claude.
+- It does not call local agent commands.
+- It does not call the Codex scheduler.
+- It does not write report state back to the repo.
+
+## Activation Sequence
+
+1. Keep all six monitors paused until the operator approves useful signal levels.
+2. Activate `TerraFusion Daily Pulse` first.
+3. Activate `Work Order and Todo Tracker` second.
+4. Collect several reports and tune noisy sections.
+5. Use this control panel to prepare governed Work Order prompts.
+6. Add controlled execution wiring only after a separate approved Work Order.
+
+## Safety Rule
+
+Launch actions must name a governed workflow, not an arbitrary fix.
+
+Use:
+
+```text
+WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution
+Mode: docs/control only
+Authority: human approved
+Mutation: only after explicit approval
+```
+
+Do not use:
+
+```text
+Fix AI Sidecar drift
+```
+
+## Review Checklist
+
+- [ ] Report sections match the six paused automations.
+- [ ] Launch prompts are scoped to Work Orders.
+- [ ] Every launch action states forbidden actions.
+- [ ] Mutation is blocked unless a separate Work Order explicitly authorizes it.
+- [ ] No runtime product code is wired to this seed panel.

--- a/ops/control-panel/README.md
+++ b/ops/control-panel/README.md
@@ -52,6 +52,16 @@ This seed version is prompt-launch only:
 - It does not call the Codex scheduler.
 - It does not write report state back to the repo.
 
+## Workspace Placeholders
+
+The seed uses placeholders instead of developer-local paths:
+
+- `${TERRAFUSION_WORKSPACE}`: canonical TerraFusion OS workspace.
+- `${TERRAFUSION_PLATFORM_ROOT}`: optional platform reference workspace.
+- `${TERRAFUSION_PLATFORM_SIDECAR_PATH}`: optional AI sidecar package path.
+
+Operators must replace these placeholders before copying prompts into an agent session.
+
 ## Activation Sequence
 
 1. Keep all six monitors paused until the operator approves useful signal levels.

--- a/ops/control-panel/control-panel.spec.json
+++ b/ops/control-panel/control-panel.spec.json
@@ -1,0 +1,131 @@
+{
+  "id": "terrafusion-operations-control-panel",
+  "version": 1,
+  "status": "seed",
+  "workOrder": "ops/packets/WO-OPS-CP-001.md",
+  "authority": {
+    "mode": "read_only_operator_surface",
+    "identityBoundary": "cockpit_prompt_launcher_findings_viewer_not_brain_or_runtime_agent",
+    "canonicalWorkspace": "C:\\Users\\bsval\\terrafusion_os_1.0",
+    "referenceWorkspace": "C:\\Users\\bsval\\TerraFusion-Platform",
+    "allowedOutputs": [
+      "governance findings report",
+      "prioritized blocker list",
+      "proposed Work Order",
+      "human decision list",
+      "copy-paste agent prompt",
+      "evidence packet outline"
+    ],
+    "forbiddenActions": [
+      "edit files",
+      "stage files",
+      "commit",
+      "open pull requests",
+      "change canon",
+      "change queue truth",
+      "promote artifacts into canon",
+      "modify automation wiring",
+      "mutate runtime behavior",
+      "run destructive commands"
+    ]
+  },
+  "statusModel": {
+    "green": "No blocker; lane is ready for review or next governed action.",
+    "yellow": "Attention needed; work can proceed after operator review.",
+    "red": "Blocked; human decision or prerequisite required before action.",
+    "paused": "Automation exists but is not active.",
+    "unknown": "No report has been reviewed yet."
+  },
+  "lanes": [
+    {
+      "id": "daily-pulse",
+      "title": "Daily Pulse",
+      "automationId": "terrafusion-daily-pulse",
+      "defaultStatus": "paused",
+      "primaryQuestion": "What changed, what is blocked, and what needs attention today?",
+      "expectedCadence": "weekdays at 9:00 AM",
+      "recommendedFirstAction": "mark-reviewed"
+    },
+    {
+      "id": "open-work-orders",
+      "title": "Open Work Orders",
+      "automationId": "work-order-and-todo-tracker",
+      "defaultStatus": "paused",
+      "primaryQuestion": "Which WOs, TODOs, blockers, and decisions need prioritization?",
+      "expectedCadence": "daily at 9:00 AM",
+      "recommendedFirstAction": "draft-work-order"
+    },
+    {
+      "id": "blockers",
+      "title": "Blockers",
+      "automationId": "work-order-and-todo-tracker",
+      "defaultStatus": "unknown",
+      "primaryQuestion": "What prevents safe progress?",
+      "expectedCadence": "derived from daily tracker",
+      "recommendedFirstAction": "escalate-human-decision"
+    },
+    {
+      "id": "gap-risk-register",
+      "title": "Gap / Risk Register",
+      "automationId": "project-gap-and-risk-register-monitor",
+      "defaultStatus": "paused",
+      "primaryQuestion": "Which risks are P0 containment, P1 execution, P2 planned, deferred, or decision-bound?",
+      "expectedCadence": "Fridays at 9:00 AM",
+      "recommendedFirstAction": "create-evidence-packet"
+    },
+    {
+      "id": "governance-drift",
+      "title": "Governance Drift",
+      "automationId": "governance-drift-monitor",
+      "defaultStatus": "paused",
+      "primaryQuestion": "Are there canon, path identity, authority stack, or duplicate truth conflicts?",
+      "expectedCadence": "Mondays at 9:00 AM",
+      "recommendedFirstAction": "run-read-only-recon"
+    },
+    {
+      "id": "ai-sidecar",
+      "title": "AI Sidecar",
+      "automationId": "ai-sidecar-governance-monitor",
+      "defaultStatus": "paused",
+      "primaryQuestion": "Is the AI Improvement Sidecar ready for ratification?",
+      "expectedCadence": "Mondays at 9:00 AM until ratified",
+      "recommendedFirstAction": "prepare-ai-sidecar-ratification"
+    },
+    {
+      "id": "ci-azure-health",
+      "title": "CI / Azure Health",
+      "automationId": "ci-azure-pipeline-health-monitor",
+      "defaultStatus": "paused",
+      "primaryQuestion": "Are pipeline files, first-run evidence, and split-brain risks understood?",
+      "expectedCadence": "daily during activation; weekly after stable",
+      "recommendedFirstAction": "prepare-pr-plan"
+    },
+    {
+      "id": "human-decisions",
+      "title": "Human Decisions Needed",
+      "automationId": null,
+      "defaultStatus": "unknown",
+      "primaryQuestion": "Which choices require operator approval before work continues?",
+      "expectedCadence": "derived from all reports",
+      "recommendedFirstAction": "escalate-human-decision"
+    },
+    {
+      "id": "prepare-next-work-order",
+      "title": "Prepare Next Work Order",
+      "automationId": null,
+      "defaultStatus": "unknown",
+      "primaryQuestion": "What is the next governed action with bounded authority?",
+      "expectedCadence": "operator-driven",
+      "recommendedFirstAction": "draft-work-order"
+    }
+  ],
+  "reportIngestion": {
+    "currentVersion": "manual",
+    "acceptedInputs": [
+      "automation report pasted by operator",
+      "saved report reviewed by operator",
+      "human-entered status summary"
+    ],
+    "futureVersion": "Read saved automation artifacts after a separately approved wiring Work Order."
+  }
+}

--- a/ops/control-panel/control-panel.spec.json
+++ b/ops/control-panel/control-panel.spec.json
@@ -6,8 +6,8 @@
   "authority": {
     "mode": "read_only_operator_surface",
     "identityBoundary": "cockpit_prompt_launcher_findings_viewer_not_brain_or_runtime_agent",
-    "canonicalWorkspace": "C:\\Users\\bsval\\terrafusion_os_1.0",
-    "referenceWorkspace": "C:\\Users\\bsval\\TerraFusion-Platform",
+    "canonicalWorkspace": "${TERRAFUSION_WORKSPACE}",
+    "referenceWorkspace": "${TERRAFUSION_PLATFORM_ROOT}",
     "allowedOutputs": [
       "governance findings report",
       "prioritized blocker list",

--- a/ops/control-panel/index.html
+++ b/ops/control-panel/index.html
@@ -329,7 +329,7 @@
     <p class="subtitle">Read-only operator console for turning automation findings into governed Work Orders, evidence packets, and human decisions.</p>
     <section class="authority" aria-label="Authority boundaries">
       <div class="metric"><span>Mode</span><strong>Prompt-launch only</strong></div>
-      <div class="metric"><span>Workspace</span><strong>C:\Users\bsval\terrafusion_os_1.0</strong></div>
+      <div class="metric"><span>Workspace</span><strong>${TERRAFUSION_WORKSPACE}</strong></div>
       <div class="metric"><span>Mutation</span><strong>Separate approval required</strong></div>
       <div class="metric"><span>Work Order</span><strong>WO-OPS-CP-001</strong></div>
     </section>
@@ -358,6 +358,19 @@
   </main>
 
   <script>
+    const WORKSPACE = "${TERRAFUSION_WORKSPACE}";
+    const SIDECAR_REFERENCE = "${TERRAFUSION_PLATFORM_SIDECAR_PATH}";
+    const sharedPromptRules = [
+      "Read and follow AGENTS.md before acting.",
+      "Respect PATH_CANON_REGISTER.md and CANON_INDEX.md when present.",
+      "Do not edit files unless this prompt explicitly authorizes mutation.",
+      "Do not stage files.",
+      "Do not commit.",
+      "Do not open pull requests.",
+      "Do not change canon or queue truth unless the Work Order explicitly authorizes it.",
+      "Report findings, blockers, validation steps, and next safe action."
+    ].join(" ");
+
     const lanes = [
       {
         id: "daily-pulse",
@@ -452,16 +465,16 @@
     ];
 
     const prompts = {
-      "draft-work-order": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.",
-      "run-read-only-recon": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
-      "open-codex-prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nUse the selected lane report as context and propose the smallest governed next action. Do not modify files or automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points.",
-      "create-evidence-packet": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
-      "prepare-pr-plan": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
+      "draft-work-order": `Workspace: ${WORKSPACE}\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.`,
+      "run-read-only-recon": `Workspace: ${WORKSPACE}\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.`,
+      "open-codex-prompt": `Workspace: ${WORKSPACE}\n\nUse the selected lane report as context and propose the smallest governed next action. ${sharedPromptRules} Do not modify automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points.`,
+      "create-evidence-packet": `Workspace: ${WORKSPACE}\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.`,
+      "prepare-pr-plan": `Workspace: ${WORKSPACE}\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.`,
       "mark-reviewed": "Operator action only. Record outside this seed panel that the report was reviewed. No agent execution is required.",
       "defer": "Operator action only. Defer the finding with a reason and revisit date. No repo mutation is authorized by this control panel seed.",
-      "escalate-human-decision": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION.",
-      "prepare-ai-sidecar-ratification": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\nReference path if present: C:\\Users\\bsval\\TerraFusion-Platform\\terrafusion_ai_improvement_sidecar_dev_package\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.",
-      "prepare-canon-cleanup": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+      "escalate-human-decision": `Workspace: ${WORKSPACE}\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION.`,
+      "prepare-ai-sidecar-ratification": `Workspace: ${WORKSPACE}\nReference path if present: ${SIDECAR_REFERENCE}\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.`,
+      "prepare-canon-cleanup": `Workspace: ${WORKSPACE}\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.`
     };
 
     const labels = {

--- a/ops/control-panel/index.html
+++ b/ops/control-panel/index.html
@@ -1,0 +1,547 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TerraFusion Operations Control Panel</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f9fb;
+      --panel: #ffffff;
+      --ink: #16202a;
+      --muted: #5b6876;
+      --line: #d9e1ea;
+      --green: #1b7f45;
+      --yellow: #a66b00;
+      --red: #b42318;
+      --paused: #667085;
+      --blue: #1d5f99;
+      --blue-dark: #153f66;
+      --soft-blue: #e9f3fb;
+      --soft-green: #eaf7ef;
+      --soft-yellow: #fff4db;
+      --soft-red: #fdecec;
+      --soft-gray: #eef1f4;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+    }
+
+    header {
+      background: #102334;
+      color: #fff;
+      padding: 24px clamp(18px, 4vw, 44px);
+      border-bottom: 4px solid #3a8bc2;
+    }
+
+    .topline {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(26px, 4vw, 42px);
+      line-height: 1.05;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      margin: 8px 0 0;
+      max-width: 860px;
+      color: #d6e5f1;
+      font-size: 15px;
+      line-height: 1.5;
+    }
+
+    .authority {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(150px, 1fr));
+      gap: 12px;
+      margin-top: 22px;
+    }
+
+    .metric {
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      padding: 12px;
+      border-radius: 6px;
+      min-height: 78px;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .metric span {
+      display: block;
+      color: #b8ccdc;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .metric strong {
+      display: block;
+      margin-top: 7px;
+      font-size: 16px;
+      line-height: 1.25;
+    }
+
+    main {
+      padding: 22px clamp(18px, 4vw, 44px) 42px;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 18px;
+      flex-wrap: wrap;
+    }
+
+    .tabs {
+      display: inline-flex;
+      padding: 3px;
+      background: var(--soft-gray);
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      gap: 3px;
+    }
+
+    .tab {
+      border: 0;
+      border-radius: 5px;
+      padding: 9px 12px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 14px;
+    }
+
+    .tab.active {
+      background: #fff;
+      color: var(--ink);
+      box-shadow: 0 1px 2px rgba(16, 35, 52, 0.12);
+    }
+
+    .summary {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(260px, 1fr));
+      gap: 14px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      min-height: 260px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      box-shadow: 0 1px 2px rgba(16, 35, 52, 0.05);
+    }
+
+    .card-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 18px;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      padding: 5px 9px;
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .badge::before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .green {
+      color: var(--green);
+      background: var(--soft-green);
+    }
+
+    .yellow {
+      color: var(--yellow);
+      background: var(--soft-yellow);
+    }
+
+    .red {
+      color: var(--red);
+      background: var(--soft-red);
+    }
+
+    .paused,
+    .unknown {
+      color: var(--paused);
+      background: var(--soft-gray);
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: 110px 1fr;
+      gap: 8px 10px;
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+
+    dt {
+      color: var(--muted);
+    }
+
+    dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: auto;
+    }
+
+    button {
+      font: inherit;
+    }
+
+    .action {
+      border: 1px solid var(--blue);
+      background: var(--blue);
+      color: #fff;
+      border-radius: 6px;
+      padding: 9px 11px;
+      cursor: pointer;
+      font-size: 13px;
+      line-height: 1;
+    }
+
+    .action.secondary {
+      background: #fff;
+      color: var(--blue-dark);
+    }
+
+    .panel {
+      margin-top: 18px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .panel h2 {
+      margin-bottom: 12px;
+    }
+
+    .prompt-box {
+      width: 100%;
+      min-height: 210px;
+      resize: vertical;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 12px;
+      font-family: Consolas, "Courier New", monospace;
+      font-size: 13px;
+      line-height: 1.45;
+      color: var(--ink);
+      background: #fbfcfd;
+    }
+
+    .copy-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 10px;
+      flex-wrap: wrap;
+    }
+
+    .notice {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    @media (max-width: 1100px) {
+      .authority,
+      .grid {
+        grid-template-columns: repeat(2, minmax(240px, 1fr));
+      }
+    }
+
+    @media (max-width: 720px) {
+      .authority,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+
+      dl {
+        grid-template-columns: 1fr;
+      }
+
+      dt {
+        font-weight: 700;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="topline">
+      <h1>TerraFusion Operations Control Panel</h1>
+      <span class="badge paused">Seed</span>
+    </div>
+    <p class="subtitle">Read-only operator console for turning automation findings into governed Work Orders, evidence packets, and human decisions.</p>
+    <section class="authority" aria-label="Authority boundaries">
+      <div class="metric"><span>Mode</span><strong>Prompt-launch only</strong></div>
+      <div class="metric"><span>Workspace</span><strong>C:\Users\bsval\terrafusion_os_1.0</strong></div>
+      <div class="metric"><span>Mutation</span><strong>Separate approval required</strong></div>
+      <div class="metric"><span>Work Order</span><strong>WO-OPS-CP-001</strong></div>
+    </section>
+  </header>
+
+  <main>
+    <div class="toolbar">
+      <div class="tabs" aria-label="Lane filters">
+        <button class="tab active" data-filter="all">All</button>
+        <button class="tab" data-filter="paused">Paused</button>
+        <button class="tab" data-filter="attention">Attention</button>
+      </div>
+      <div class="summary">Six monitors are paused for review. Operator launch actions produce prompts, not autonomous runs.</div>
+    </div>
+
+    <section class="grid" id="laneGrid" aria-label="Operations lanes"></section>
+
+    <section class="panel" aria-label="Launch prompt">
+      <h2>Launch Prompt</h2>
+      <textarea id="promptBox" class="prompt-box" readonly>Select a lane action to prepare a governed prompt.</textarea>
+      <div class="copy-row">
+        <button class="action" id="copyPrompt">Copy Prompt</button>
+        <span class="notice" id="copyStatus">No prompt selected.</span>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const lanes = [
+      {
+        id: "daily-pulse",
+        title: "Daily Pulse",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "Awaiting first operator-approved run.",
+        blocker: "Automation paused.",
+        next: "Activate after review if useful.",
+        actions: ["mark-reviewed", "open-codex-prompt"]
+      },
+      {
+        id: "open-work-orders",
+        title: "Open Work Orders",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "WO/TODO tracker is defined but paused.",
+        blocker: "No report baseline yet.",
+        next: "Run after Daily Pulse signal is accepted.",
+        actions: ["draft-work-order", "defer"]
+      },
+      {
+        id: "blockers",
+        title: "Blockers",
+        status: "unknown",
+        lastRun: "Derived lane",
+        topFinding: "No blocker report has been ingested.",
+        blocker: "Needs source report.",
+        next: "Escalate only after a monitor identifies a decision.",
+        actions: ["escalate-human-decision", "create-evidence-packet"]
+      },
+      {
+        id: "gap-risk-register",
+        title: "Gap / Risk Register",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "Weekly gap register is defined but paused.",
+        blocker: "No evidence baseline yet.",
+        next: "Use after Daily Pulse and tracker establish cadence.",
+        actions: ["create-evidence-packet", "draft-work-order"]
+      },
+      {
+        id: "governance-drift",
+        title: "Governance Drift",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "Canon/path authority monitor is defined but paused.",
+        blocker: "No drift report baseline yet.",
+        next: "Run read-only recon before any doc cleanup WO.",
+        actions: ["run-read-only-recon", "prepare-canon-cleanup"]
+      },
+      {
+        id: "ai-sidecar",
+        title: "AI Sidecar",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "Sidecar monitor is defined but paused.",
+        blocker: "Constitution is not ratified into canon yet.",
+        next: "Draft ratification WO after monitor report.",
+        actions: ["prepare-ai-sidecar-ratification", "create-evidence-packet"]
+      },
+      {
+        id: "ci-azure-health",
+        title: "CI / Azure Health",
+        status: "paused",
+        lastRun: "Not active",
+        topFinding: "Pipeline health monitor is defined but paused.",
+        blocker: "No activation report baseline yet.",
+        next: "Prepare PR plan only after repo-side evidence review.",
+        actions: ["prepare-pr-plan", "run-read-only-recon"]
+      },
+      {
+        id: "human-decisions",
+        title: "Human Decisions Needed",
+        status: "unknown",
+        lastRun: "Derived lane",
+        topFinding: "No decision queue has been compiled.",
+        blocker: "Needs findings from active monitors.",
+        next: "Create a decision memo from the selected blocker.",
+        actions: ["escalate-human-decision", "defer"]
+      },
+      {
+        id: "prepare-next-work-order",
+        title: "Prepare Next Work Order",
+        status: "unknown",
+        lastRun: "Operator-driven",
+        topFinding: "Next WO depends on monitor findings.",
+        blocker: "Human selection required.",
+        next: "Choose the smallest governed action.",
+        actions: ["draft-work-order", "open-codex-prompt"]
+      }
+    ];
+
+    const prompts = {
+      "draft-work-order": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.",
+      "run-read-only-recon": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
+      "open-codex-prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nUse the selected lane report as context and propose the smallest governed next action. Do not modify files or automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points.",
+      "create-evidence-packet": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
+      "prepare-pr-plan": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION.",
+      "mark-reviewed": "Operator action only. Record outside this seed panel that the report was reviewed. No agent execution is required.",
+      "defer": "Operator action only. Defer the finding with a reason and revisit date. No repo mutation is authorized by this control panel seed.",
+      "escalate-human-decision": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION.",
+      "prepare-ai-sidecar-ratification": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\nReference path if present: C:\\Users\\bsval\\TerraFusion-Platform\\terrafusion_ai_improvement_sidecar_dev_package\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION.",
+      "prepare-canon-cleanup": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+    };
+
+    const labels = {
+      "draft-work-order": "Draft Work Order",
+      "run-read-only-recon": "Run Read-Only Recon",
+      "open-codex-prompt": "Open Codex Prompt",
+      "create-evidence-packet": "Create Evidence Packet",
+      "prepare-pr-plan": "Prepare PR Plan",
+      "mark-reviewed": "Mark Reviewed",
+      "defer": "Defer",
+      "escalate-human-decision": "Escalate to Human Decision",
+      "prepare-ai-sidecar-ratification": "Prepare AI Sidecar Ratification",
+      "prepare-canon-cleanup": "Prepare Canon Cleanup Plan"
+    };
+
+    const grid = document.getElementById("laneGrid");
+    const promptBox = document.getElementById("promptBox");
+    const copyStatus = document.getElementById("copyStatus");
+
+    function render(filter) {
+      grid.innerHTML = "";
+      lanes
+        .filter((lane) => {
+          if (filter === "paused") return lane.status === "paused";
+          if (filter === "attention") return lane.status === "yellow" || lane.status === "red" || lane.status === "unknown";
+          return true;
+        })
+        .forEach((lane) => {
+          const card = document.createElement("article");
+          card.className = "card";
+          card.innerHTML = `
+            <div class="card-head">
+              <h2>${lane.title}</h2>
+              <span class="badge ${lane.status}">${lane.status.toUpperCase()}</span>
+            </div>
+            <dl>
+              <dt>Last Run</dt><dd>${lane.lastRun}</dd>
+              <dt>Top Finding</dt><dd>${lane.topFinding}</dd>
+              <dt>Blocker</dt><dd>${lane.blocker}</dd>
+              <dt>Next Action</dt><dd>${lane.next}</dd>
+            </dl>
+            <div class="actions">
+              ${lane.actions.map((action, index) => `<button class="action ${index ? "secondary" : ""}" data-action="${action}" data-lane="${lane.title}">${labels[action]}</button>`).join("")}
+            </div>
+          `;
+          grid.appendChild(card);
+        });
+    }
+
+    document.querySelectorAll(".tab").forEach((tab) => {
+      tab.addEventListener("click", () => {
+        document.querySelectorAll(".tab").forEach((item) => item.classList.remove("active"));
+        tab.classList.add("active");
+        render(tab.dataset.filter);
+      });
+    });
+
+    grid.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-action]");
+      if (!button) return;
+      const prompt = prompts[button.dataset.action] || "";
+      promptBox.value = `Lane: ${button.dataset.lane}\nAction: ${labels[button.dataset.action]}\n\n${prompt}`;
+      copyStatus.textContent = "Prompt prepared.";
+    });
+
+    document.getElementById("copyPrompt").addEventListener("click", async () => {
+      if (!promptBox.value || promptBox.value === "Select a lane action to prepare a governed prompt.") {
+        copyStatus.textContent = "No prompt selected.";
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(promptBox.value);
+        copyStatus.textContent = "Prompt copied.";
+      } catch {
+        promptBox.select();
+        copyStatus.textContent = "Prompt selected for manual copy.";
+      }
+    });
+
+    render("all");
+  </script>
+</body>
+</html>

--- a/ops/control-panel/launch-actions.json
+++ b/ops/control-panel/launch-actions.json
@@ -1,0 +1,89 @@
+{
+  "id": "terrafusion-control-panel-launch-actions",
+  "version": 1,
+  "status": "seed",
+  "sharedPromptRules": [
+    "Read and follow AGENTS.md before acting.",
+    "Respect PATH_CANON_REGISTER.md and CANON_INDEX.md when present.",
+    "Do not edit files unless this prompt explicitly authorizes mutation.",
+    "Do not stage files.",
+    "Do not commit.",
+    "Do not open pull requests.",
+    "Do not change canon or queue truth unless the Work Order explicitly authorizes it.",
+    "Report findings, blockers, validation steps, and next safe action."
+  ],
+  "actions": [
+    {
+      "id": "draft-work-order",
+      "label": "Draft Work Order",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "run-read-only-recon",
+      "label": "Run Read-Only Recon",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "open-codex-prompt",
+      "label": "Open Codex Prompt",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nUse the selected lane report as context and propose the smallest governed next action. Do not modify files or automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points."
+    },
+    {
+      "id": "create-evidence-packet",
+      "label": "Create Evidence Packet",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "prepare-pr-plan",
+      "label": "Prepare PR Plan",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "mark-reviewed",
+      "label": "Mark Reviewed",
+      "mode": "operator_note",
+      "mutation": "manual_only",
+      "prompt": "Operator action only. Record outside this seed panel that the report was reviewed. No agent execution is required."
+    },
+    {
+      "id": "defer",
+      "label": "Defer",
+      "mode": "operator_note",
+      "mutation": "manual_only",
+      "prompt": "Operator action only. Defer the finding with a reason and revisit date. No repo mutation is authorized by this control panel seed."
+    },
+    {
+      "id": "escalate-human-decision",
+      "label": "Escalate to Human Decision",
+      "mode": "prompt_launch",
+      "mutation": "none",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "prepare-ai-sidecar-ratification",
+      "label": "Prepare AI Sidecar Ratification",
+      "mode": "prompt_launch",
+      "workOrder": "WO-AI-SIDECAR-001",
+      "mutation": "requires_separate_approval",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\nReference path if present: C:\\Users\\bsval\\TerraFusion-Platform\\terrafusion_ai_improvement_sidecar_dev_package\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+    },
+    {
+      "id": "prepare-canon-cleanup",
+      "label": "Prepare Canon Cleanup Plan",
+      "mode": "prompt_launch",
+      "workOrder": "WO-CANON-001",
+      "mutation": "requires_separate_approval",
+      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+    }
+  ]
+}

--- a/ops/control-panel/launch-actions.json
+++ b/ops/control-panel/launch-actions.json
@@ -18,35 +18,35 @@
       "label": "Draft Work Order",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nDraft a governed TerraFusion Work Order from the latest provided automation report. Read AGENTS.md, CANON_INDEX.md, PATH_CANON_REGISTER.md, and any lane-specific authority files before drafting. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output only: RESULT, PROPOSED_WORK_ORDER, AUTHORITY_REFERENCES, SCOPE, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
     },
     {
       "id": "run-read-only-recon",
       "label": "Run Read-Only Recon",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nRun read-only reconnaissance for the selected TerraFusion lane. Inspect only the paths named by the operator or by the relevant automation report. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Produce: RESULT, WORKSPACES_CHECKED, FILES_INSPECTED, FINDINGS, AUTHORITY_CONFLICTS, BLOCKERS, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
     },
     {
       "id": "open-codex-prompt",
       "label": "Open Codex Prompt",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nUse the selected lane report as context and propose the smallest governed next action. Do not modify files or automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nUse the selected lane report as context and propose the smallest governed next action. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Do not modify automation wiring. Do not promote anything into canon. Return a Codex-ready prompt with: objective, allowed paths, forbidden actions, validation gates, expected report sections, and human approval points."
     },
     {
       "id": "create-evidence-packet",
       "label": "Create Evidence Packet",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nPrepare an evidence packet outline for the selected finding. Read relevant authority documents first. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, EVIDENCE_SOURCES, BEFORE_STATE, CLAIMS_TO_VERIFY, VALIDATION_COMMANDS, EXPECTED_PROOF, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
     },
     {
       "id": "prepare-pr-plan",
       "label": "Prepare PR Plan",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nPrepare a PR plan for the selected Work Order without editing files. Identify exact allowed paths, forbidden paths, required gates, rollback class, evidence outputs, and review risks. Do not stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, PR_SCOPE, FILES_ALLOWED, FILES_FORBIDDEN, VALIDATION_GATES, ROLLBACK_PLAN, BLOCKERS, HUMAN_DECISIONS_REQUIRED, NEXT_SAFE_ACTION."
     },
     {
       "id": "mark-reviewed",
@@ -67,7 +67,7 @@
       "label": "Escalate to Human Decision",
       "mode": "prompt_launch",
       "mutation": "none",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nSummarize the selected blocker as a human decision memo. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, DECISION_REQUIRED, CONTEXT, OPTIONS, RISKS, RECOMMENDATION, CONSEQUENCE_OF_NO_DECISION, NEXT_SAFE_ACTION."
     },
     {
       "id": "prepare-ai-sidecar-ratification",
@@ -75,7 +75,7 @@
       "mode": "prompt_launch",
       "workOrder": "WO-AI-SIDECAR-001",
       "mutation": "requires_separate_approval",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\nReference path if present: C:\\Users\\bsval\\TerraFusion-Platform\\terrafusion_ai_improvement_sidecar_dev_package\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\nReference path if present: ${TERRAFUSION_PLATFORM_SIDECAR_PATH}\n\nDraft WO-AI-SIDECAR-001 - Ratify AI Improvement Sidecar Constitution. Mode: docs/control only. Authority: human approved. Mutation: only after explicit approval in a separate execution step. Inspect the sidecar constitution, queue template, eval/trace pipeline design, README, and operator HTML where present. Do not edit files, stage files, commit, open PRs, promote canon, update queues, modify automation wiring, or mutate runtime behavior. Output: RESULT, ARTIFACT_INVENTORY, CANONICAL_LOCATION_RECOMMENDATION, DRIFT_FINDINGS, RATIFICATION_SCOPE, EXCLUSIONS, VALIDATION_PLAN, PROPOSED_WORK_ORDER, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
     },
     {
       "id": "prepare-canon-cleanup",
@@ -83,7 +83,7 @@
       "mode": "prompt_launch",
       "workOrder": "WO-CANON-001",
       "mutation": "requires_separate_approval",
-      "prompt": "Workspace: C:\\Users\\bsval\\terrafusion_os_1.0\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
+      "prompt": "Workspace: ${TERRAFUSION_WORKSPACE}\n\nDraft WO-CANON-001 - Document Authority Cleanup. Mode: scoped doc banners/index only. Mutation requires worktree plus PR after explicit approval. Inspect authority stack files and identify stale or conflicting documents. Do not edit files, stage files, commit, open PRs, change canon, change queue truth, or mutate runtime behavior. Output: RESULT, AUTHORITY_STACK_STATUS, PATH_CANON_STATUS, CONFLICTS, PROPOSED_DOC_FIXES, EXCLUSIONS, VALIDATION_PLAN, HUMAN_DECISIONS_REQUIRED, BLOCKERS, NEXT_SAFE_ACTION."
     }
   ]
 }

--- a/ops/control-panel/report-schema.json
+++ b/ops/control-panel/report-schema.json
@@ -1,0 +1,128 @@
+{
+  "id": "terrafusion-control-panel-report-schema",
+  "version": 1,
+  "status": "seed",
+  "classificationLevels": ["P0", "P1", "P2", "Deferred", "Needs Decision"],
+  "commonFields": {
+    "result": "green | yellow | red | paused | unknown",
+    "lastRun": "ISO-8601 timestamp or human-readable run label",
+    "topFinding": "single highest-signal finding",
+    "blocker": "single blocking condition or none",
+    "recommendedNextAction": "operator-approved next action",
+    "evidence": "report path, pasted report reference, or unavailable"
+  },
+  "automationReports": [
+    {
+      "automationId": "terrafusion-daily-pulse",
+      "title": "TerraFusion Daily Pulse",
+      "requiredSections": [
+        "RESULT",
+        "CURRENT_BRANCH_AND_WORKTREE_STATUS",
+        "RECENT_CHANGES",
+        "ACTIVE_WORK_ORDERS",
+        "OPEN_BLOCKERS",
+        "TOP_5_NEXT_ACTIONS",
+        "HUMAN_DECISIONS_NEEDED",
+        "RISKS",
+        "SAFE_NEXT_STEP"
+      ]
+    },
+    {
+      "automationId": "work-order-and-todo-tracker",
+      "title": "Work Order and Todo Tracker",
+      "requiredSections": [
+        "RESULT",
+        "OPEN_WORK_ORDERS",
+        "ACTIVE_TODOS",
+        "BLOCKERS",
+        "DEFERRED_ITEMS",
+        "STALE_ITEMS",
+        "DUPLICATE_OR_CONFLICTING_ITEMS",
+        "PRIORITY_RECOMMENDATION",
+        "PROPOSED_NEXT_WORK_ORDER",
+        "HUMAN_DECISIONS_REQUIRED"
+      ]
+    },
+    {
+      "automationId": "governance-drift-monitor",
+      "title": "Governance Drift Monitor",
+      "requiredSections": [
+        "RESULT",
+        "AUTHORITY_STACK_STATUS",
+        "PATH_CANON_STATUS",
+        "CONFLICTING_AUTHORITY_CLAIMS",
+        "STALE_OR_HISTORICAL_DOC_RISKS",
+        "DUPLICATE_TRUTH_RISKS",
+        "MISSING_CANON_LINKS",
+        "RECOMMENDED_BANNER_OR_DOC_FIXES",
+        "PROPOSED_WORK_ORDER",
+        "HUMAN_DECISIONS_REQUIRED"
+      ]
+    },
+    {
+      "automationId": "ai-sidecar-governance-monitor",
+      "title": "AI Improvement Sidecar Monitor",
+      "requiredSections": [
+        "RESULT",
+        "SIDECAR_ARTIFACT_INVENTORY",
+        "CANONICAL_LOCATION_STATUS",
+        "MIRROR_OR_REFERENCE_STATUS",
+        "DRIFT_FINDINGS",
+        "AUTHORITY_CONFLICTS",
+        "MISSING_FILES",
+        "RATIFICATION_READINESS",
+        "PROPOSED_WORK_ORDER",
+        "HUMAN_DECISIONS_REQUIRED",
+        "NEXT_SAFE_ACTION"
+      ]
+    },
+    {
+      "automationId": "ci-azure-pipeline-health-monitor",
+      "title": "CI Azure Pipeline Health Monitor",
+      "requiredSections": [
+        "RESULT",
+        "PIPELINE_FILES_STATUS",
+        "PR_VALIDATION_STATUS",
+        "MAIN_BUILD_STATUS",
+        "FIRST_RUN_FAILURES",
+        "YAML_OR_PATH_ISSUES",
+        "SECRET_OR_DEPLOYMENT_CREEP_RISKS",
+        "GITHUB_AZURE_SPLIT_BRAIN_RISKS",
+        "ALLOWED_FIXES_ONLY",
+        "PROPOSED_WORK_ORDER",
+        "HUMAN_DECISIONS_REQUIRED"
+      ]
+    },
+    {
+      "automationId": "project-gap-and-risk-register-monitor",
+      "title": "Project Gap and Risk Register Monitor",
+      "requiredSections": [
+        "RESULT",
+        "P0_CONTAINMENT_ITEMS",
+        "P1_EXECUTION_GAPS",
+        "P2_PLANNED_GAPS",
+        "DEFERRED_ITEMS",
+        "NEEDS_HUMAN_DECISION",
+        "RESOLVED_THIS_WEEK",
+        "NEW_THIS_WEEK",
+        "STALE_OR_REPEATED_GAPS",
+        "RECOMMENDED_NEXT_3_WORK_ORDERS",
+        "BLOCKERS"
+      ]
+    }
+  ],
+  "readinessRules": [
+    {
+      "id": "ready-for-ratification",
+      "description": "A lane may be marked ready for ratification when all required artifacts exist, no authority conflicts remain, no missing files are reported, and the proposed Work Order is scoped to human-approved promotion."
+    },
+    {
+      "id": "blocked-by-dirty-worktree",
+      "description": "A dirty or ambiguous worktree is a blocker for mutation, but not for read-only monitoring."
+    },
+    {
+      "id": "blocked-by-authority-conflict",
+      "description": "Conflicting canon, path identity, queue truth, or architecture authority claims require human decision before a governed prompt or Work Order proceeds."
+    }
+  ]
+}

--- a/ops/packets/WO-OPS-CP-001.md
+++ b/ops/packets/WO-OPS-CP-001.md
@@ -110,6 +110,7 @@ Repair CI
 |-------|--------|----------------|
 | JSON validity | Parse all JSON files | All JSON files parse successfully |
 | HTML static load | Open `ops/control-panel/index.html` | Cards and launch prompt panel render |
+| Config integration | Open HTML and inspect browser console | JSON-backed lanes and launch actions display without console errors |
 | No runtime wiring | Inspect deliverables | No local command execution, scheduler API, or repo mutation wiring exists |
 | Scope containment | Git diff/path review | Changes are limited to authorized operations paths |
 

--- a/ops/packets/WO-OPS-CP-001.md
+++ b/ops/packets/WO-OPS-CP-001.md
@@ -1,0 +1,141 @@
+# WO-OPS-CP-001 - TerraFusion Operations Control Panel Seed
+**Status:** Draft  
+**Date:** 2026-06-22  
+**Owner:** TerraFusion OS Engineering  
+**Classification:** Operational Governance  
+**Authorized paths:** `ops/control-panel/**`, `ops/packets/WO-OPS-CP-001.md`  
+
+---
+
+## Objective
+
+Create a read-only TerraFusion Operations Control Panel seed that aggregates the six TerraFusion monitoring automation lanes, classifies findings, and prepares governed launch prompts for Codex or Claude.
+
+This Work Order establishes an operator console pattern for:
+
+```text
+Monitor -> classify -> report -> draft WO if needed -> human decides
+```
+
+It does not authorize autonomous remediation.
+
+---
+
+## Scope
+
+### This WO does
+
+- Create the control panel seed under `ops/control-panel/`.
+- Define the lane model for Daily Pulse, Work Orders, Blockers, Gap/Risk, Governance Drift, AI Sidecar, CI/Azure Health, Human Decisions, and Prepare Next Work Order.
+- Define report section expectations for the six paused automations.
+- Define prompt-launch actions for governed next steps.
+- Provide a static HTML operator mockup.
+
+### This WO does not do
+
+- Edit runtime product code.
+- Execute automations.
+- Activate automations.
+- Wire scheduler APIs.
+- Stage files.
+- Commit.
+- Open pull requests.
+- Promote anything into canon.
+- Change queue truth.
+- Modify runtime behavior.
+- Authorize autonomous fixes.
+
+---
+
+## Deliverables
+
+| Deliverable | Path |
+|-------------|------|
+| Operator README | `ops/control-panel/README.md` |
+| Control panel specification | `ops/control-panel/control-panel.spec.json` |
+| Report schema | `ops/control-panel/report-schema.json` |
+| Launch actions | `ops/control-panel/launch-actions.json` |
+| Static control panel mockup | `ops/control-panel/index.html` |
+| Work Order packet | `ops/packets/WO-OPS-CP-001.md` |
+
+---
+
+## Authority Boundary
+
+The control panel is an operator surface. It prepares prompts and decision packets only.
+
+It is not a TerraFusion Brain, Cortex, autonomous queue, or runtime agent. Codex and Claude remain execution agents under scoped Work Orders. Human approval remains the promotion authority.
+
+All mutation remains gated by:
+
+1. Human approval.
+2. A scoped Work Order.
+3. Path-specific authorization.
+4. Evidence and validation gates.
+5. Separate execution from this seed panel.
+
+---
+
+## Launch Action Standard
+
+Launch actions must name a governed workflow, not a broad fix.
+
+Allowed examples:
+
+```text
+Draft Work Order
+Run Read-Only Recon
+Open Codex Prompt
+Create Evidence Packet
+Prepare PR Plan
+Mark Reviewed
+Defer
+Escalate to Human Decision
+```
+
+Disallowed examples:
+
+```text
+Fix governance drift automatically
+Promote sidecar into canon
+Clean up docs
+Repair CI
+```
+
+---
+
+## Validation Plan
+
+| Check | Method | Pass condition |
+|-------|--------|----------------|
+| JSON validity | Parse all JSON files | All JSON files parse successfully |
+| HTML static load | Open `ops/control-panel/index.html` | Cards and launch prompt panel render |
+| No runtime wiring | Inspect deliverables | No local command execution, scheduler API, or repo mutation wiring exists |
+| Scope containment | Git diff/path review | Changes are limited to authorized operations paths |
+
+---
+
+## Evidence Pack
+
+To close this WO, attach:
+
+- File list created.
+- JSON parse result.
+- Static HTML review result.
+- Statement that no automations were activated.
+- Statement that no runtime code was wired.
+
+---
+
+## Human Decisions Required
+
+- Whether `TerraFusion Daily Pulse` should be activated first.
+- Whether Work Order/Todo Tracker should be activated after the first Daily Pulse report.
+- Whether future report ingestion should read saved automation outputs from disk or remain manual paste-only.
+- Whether controlled execution wiring should be proposed in a later Work Order.
+
+---
+
+## Next Safe Action
+
+Review `ops/control-panel/index.html` locally, then activate only the Daily Pulse automation if the seed panel and monitor definitions are acceptable.


### PR DESCRIPTION
## Summary

WO-OPS-CP-001 landed a read-only Operations Control Panel seed. It aggregates monitor lanes conceptually and prepares governed copy-paste launch prompts. It does not execute automations, mutate files, change canon, create PRs, or alter runtime behavior.

## Scope

- Adds operations/control-panel/README.md
- Adds operations/control-panel/control-panel.spec.json
- Adds operations/control-panel/report-schema.json
- Adds operations/control-panel/launch-actions.json
- Adds operations/control-panel/index.html
- Adds operations/packets/WO-OPS-CP-001.md

## Validation

- JSON parse validation for control-panel JSON artifacts
- pnpm run type-check
- node --test os-platform/core/tests/phase83-tools.test.mjs

## Authority Boundary

Operations Control Panel = cockpit / prompt launcher / findings viewer. Brain / Cortex remains governance authority. Codex / Claude remain execution agents under scoped Work Orders. Human approval remains promotion authority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Operations Control Panel: a read-only operator surface for monitoring automation findings and preparing governed work order prompts
  * Added interactive dashboard with multiple operational lanes for classifying findings and tracking status
  * Enabled operators to compose and launch scoped execution prompts with built-in safety constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->