### PR TITLE
fix(sync): recut improvement-projector atomicity transaction

### DIFF
--- a/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
+++ b/backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Entities.CanonicalTf;
 using TerraFusion.Core.Entities.LegacyPacsRaw;
@@ -187,6 +188,17 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
             var priorAttrQuarantine = canonicalAttrQuarantineCandidates
                 .Where(q => attrTruthKeys.Contains((q.PropValYr, q.SupNum, q.PropId, q.ImprvId)))
                 .ToList();
+
+            // 2026-05-18 atomicity fix: wrap DELETE-then-INSERT in a single
+            // EF transaction so an INSERT-side failure (e.g. PACS varchar(32)
+            // overflow on imprv_attr.IAttrValCd) rolls back the DELETE too.
+            // Without this wrap, a single failing chunk wipes ALL prior chunks'
+            // canonical work for the same truth-batch parcel set. See
+            // os-platform/core/pilot/evidence/2026-05-18-improvement-projector-regression.md.
+            var supportsTransactions = _db.Database.IsRelational();
+            await using IDbContextTransaction? canonicalTxn = supportsTransactions
+                ? await _db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false)
+                : null;
 
             if (priorFeatures.Count > 0)
                 _db.TfImprovementFeatures.RemoveRange(priorFeatures);
@@ -446,6 +458,12 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
             batch.RowsPromoted = improvementsProjected;
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+            // 2026-05-18 atomicity fix: commit the DELETE+INSERT transaction
+            // only on success path. On exception, the `using var canonicalTxn`
+            // dispose rolls back, preserving prior chunks' canonical work.
+            if (canonicalTxn is not null)
+                await canonicalTxn.CommitAsync(cancellationToken).ConfigureAwait(false);
+
             _logger.LogInformation(
                 "canonical_tf.tf_improvement projection COMPLETED. batch={BatchId} considered={Considered} improvements={Improvements} features={Features} quarantined={Quarantined} attrConsidered={AttrConsidered} attrResolved={AttrResolved} attrQuarantined={AttrQuarantined}",
                 batch.LoadBatchId, considered, improvementsProjected, featuresProjected, quarantined,
@@ -471,10 +489,25 @@ public sealed class PacsImprvCanonicalProjector : IPacsImprvCanonicalProjector
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             var summary = $"{ex.GetType().Name}: {ex.Message}";
-            batch.Status = "FAILED";
-            batch.CompletedAt = DateTime.UtcNow;
-            batch.ErrorSummary = summary;
-            await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // 2026-05-18 atomicity fix: when `using var canonicalTxn` disposes
+            // on exception unwind, the DELETE+INSERT is rolled back. Clear the
+            // EF change tracker so the FAILED status write below does not try
+            // to re-apply the same projection changes that just failed; then
+            // re-fetch the batch row (committed outside the rolled-back txn at
+            // line 80) on a fresh implicit transaction.
+            _db.ChangeTracker.Clear();
+
+            var failedBatch = await _db.SyncBridgeLoadBatches
+                .FirstOrDefaultAsync(b => b.LoadBatchId == batch.LoadBatchId, CancellationToken.None)
+                .ConfigureAwait(false);
+            if (failedBatch != null)
+            {
+                failedBatch.Status = "FAILED";
+                failedBatch.CompletedAt = DateTime.UtcNow;
+                failedBatch.ErrorSummary = summary;
+                await _db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+            }
 
             _logger.LogError(ex,
                 "canonical_tf.tf_improvement projection FAILED. batch={BatchId} summary={Summary}",

--- a/os-platform/core/pilot/evidence/2026-05-18-improvement-projector-regression.md
+++ b/os-platform/core/pilot/evidence/2026-05-18-improvement-projector-regression.md
@@ -1,0 +1,156 @@
+# Improvement Projector Regression — 2026-05-18
+
+The documented projector atomicity bug
+(`os-platform/core/pilot/evidence/2026-05-17-projector-delete-insert-atomicity-bug.md`, commit
+`766cf9c7f`) fired in production tonight. **Eighteen successful strict-serial
+improvement chunks produced ~135K canonical_tf.tf_improvement_feature rows
+across a ~20-hour drain run; v19's projector hit the varchar(32) overflow and
+rolled back the DELETE+INSERT cycle, wiping the entire canonical_tf accumulation
+back to session-start baseline.**
+
+## The damage
+
+| Layer | 2026-05-17 evening session-start | 2026-05-18 post-v19 | Net Δ |
+|---|---:|---:|---:|
+| `legacy_pacs_raw.imprv_attr` | 813,305 | 956,223 | **+142,918 ✓** |
+| `legacy_pacs_raw.imprv` | 246,888 | 257,414 | **+10,526 ✓** |
+| `truth_pacs.imprv_current` | 12,725 | 23,251 | **+10,526 ✓** |
+| `truth_pacs.parcel_spine` | 554,349 | 563,849 | **+9,500 ✓** |
+| `truth_pacs.land_current` | 5,805 | 5,805 | 0 |
+| `truth_pacs.owner_current` | 1,560,520 | 1,560,520 | 0 |
+| `canonical_tf.tf_parcel` | 3,199,521 | 3,199,021 | -500 |
+| `canonical_tf.tf_owner` | 203,716 | 203,716 | 0 |
+| **`canonical_tf.tf_improvement`** | **247** | **247** | **0 (REGRESSED from peak 801)** |
+| **`canonical_tf.tf_improvement_feature`** | **1,520** | **1,520** | **0 (REGRESSED from peak 136,890)** |
+| `canonical_tf.tf_land` | 2,153 | 2,153 | 0 |
+| `canonical_tf.tf_sale` | 721 | 721 | 0 |
+
+Net session canonical-improvement gain: **0** (after peak of +135,370).
+
+Net session truth+landing-layer gain: **+173,470 rows** (persisted; available
+for re-projection).
+
+## What happened
+
+Eighteen strict-serial improvement TopN=500 chunks fired sequentially through
+the evening (operators `claude-strict-serial-improvement-tn500-v2` through
+`-v19`). The pattern:
+
+- 12 sub-batches per chunk completed quickly (PACS extracts + truth promoters)
+- Each chunk's canonical-tf-imprv-projector (the 13th sub-batch) committed
+  ~5,490 new `canonical_tf.tf_improvement_feature` rows
+- Of 18 chunks: 14 reported HTTP 200 with clean termination; 4 stalled at the
+  final batch-status-commit phase but had already persisted their feature
+  INSERTs
+
+Through v18, `canonical_tf.tf_improvement_feature` had grown from 1,520 →
+136,890 (+135,370 features). Counts were verified after each chunk via direct
+PG queries.
+
+v19 fired at `2026-05-18T17:40:35Z`. Its 12 prior sub-batches completed
+normally. The canonical-tf-imprv-projector sub-batch — `PacsImprvCanonicalProjector.ProjectAsync`
+— began its DELETE-then-INSERT cycle:
+
+1. DELETE prior canonical_tf.tf_improvement_feature rows for the truth batch's
+   parcel set — `SaveChangesAsync` at line 203 — **committed**.
+2. INSERT new canonical_tf.tf_improvement_feature rows + new
+   canonical_tf.tf_improvement rows.
+3. Somewhere during step 2 (most likely): hit one of the 60 known
+   `legacy_pacs_raw.imprv_attr.IAttrValCd` rows with value > 32 chars,
+   causing `PostgresException 22001: value too long for type character
+   varying(32)`. The catch-block recorded the FAILED status via a third
+   `SaveChangesAsync` at line 477, but the original transaction was already
+   rolled back.
+
+The DELETE at step 1 was committed; the INSERTs at step 2 never persisted.
+**Net effect: every canonical_tf.tf_improvement and tf_improvement_feature row
+for that truth batch's parcel set was deleted with no replacement.**
+
+Because each chunk's projector DELETEs ALL prior projections for the same
+truth-batch's parcel set (regardless of which earlier chunk added them), and
+the truth-batch's parcel set is approximately the same 554 parcels across all
+chunks, the v19 DELETE effectively wiped EVERY prior chunk's work for that
+parcel set.
+
+## Why this fired despite strict-serial discipline
+
+Strict-serial firing prevents the *concurrency*-class of failures
+(`DbUpdateConcurrencyException` on `canonical_tf.tf_parcel` RowVersion locks).
+It does NOT prevent the *single-chunk atomicity* failure mode. A single chunk
+that hits the varchar(32) overflow rolls back its own work AND wipes prior
+chunks' work for the same parcel set — strict-serial or not.
+
+Equivalently: **the documented atomicity bug is the root cause; strict-serial
+is necessary but not sufficient.**
+
+## What the truth layer holds
+
+The truth layer accumulated +10,526 new `truth_pacs.imprv_current` rows tonight
+(12,725 → 23,251) plus +142,918 `legacy_pacs_raw.imprv_attr` rows. These rows
+encode the source state for ALL prior chunks' canonical work. A future
+strict-serial chunk that runs against the fixed projector WILL re-project all
+~135K features from the truth rows — the data is not permanently lost, just
+the canonical projection is.
+
+## Required fix before resuming drains
+
+Per `os-platform/core/pilot/evidence/2026-05-17-projector-delete-insert-atomicity-bug.md`:
+
+Wrap the DELETE and INSERT phases of
+`PacsImprvCanonicalProjector.ProjectAsync` in a single
+`BeginTransactionAsync` / `CommitAsync` block:
+
+```csharp
+using var txn = await _db.Database.BeginTransactionAsync(cancellationToken);
+try {
+    // ... existing DELETE logic (line 191-203) ...
+    if (priorFeatures.Count + ... > 0)
+        await _db.SaveChangesAsync(cancellationToken);
+
+    // ... existing INSERT/projection logic ...
+
+    batch.Status = "COMPLETED";
+    batch.RowsExtracted = considered;
+    batch.RowsPromoted = improvementsProjected;
+    await _db.SaveChangesAsync(cancellationToken);
+
+    await txn.CommitAsync(cancellationToken);
+} catch (Exception ex) when (ex is not OperationCanceledException) {
+    await txn.RollbackAsync(cancellationToken);
+    // record FAILED batch row in a fresh DbContext
+    throw;
+}
+```
+
+Also recommended (independent of atomicity fix):
+
+- Widen `canonical_tf.tf_improvement_feature.FeatureCode` from varchar(32) to
+  varchar(64) via EF migration, so the 60 known overflow rows can land
+  successfully. Per `os-platform/core/pilot/evidence/2026-05-17-varchar32-overflow-finding.md`.
+
+Either fix alone reduces the failure rate; both fixes together close the
+regression class.
+
+## Next-session protocol
+
+1. Apply the projector transaction-wrap fix (~20-line C# edit).
+2. Apply the varchar(64) widening migration.
+3. Restart backend at the fixed SHA.
+4. Fire ONE strict-serial improvement TopN=500 chunk. Verify
+   `canonical_tf.tf_improvement_feature` grows by exactly +5,490 and the
+   batch row reaches COMPLETED status normally.
+5. Continue firing chunks until source exhaustion (`legacy_pacs_raw.imprv_attr`
+   stabilizes at PACS-equivalent total). The truth layer is ready to be
+   re-projected fully.
+
+Until the fixes land, any new improvement chunk has a probability ~4% of
+re-triggering the regression. **Stop firing.**
+
+## This artifact is
+
+A controlled-abort evidence note for the 2026-05-18 regression. ATTEMPT-grade
+data, not seal. The 7-clause anti-cheat seal in
+`project_benton_truth_singular_gate.md` still requires all 6 lanes complete +
+hostile-reviewer trace + API readback. Tonight's accumulated truth layer is a
+real step forward; canonical projection of it is still pending the projector
+fix.

--- a/os-platform/core/pilot/evidence/2026-05-18-projector-atomicity-fix-verified.md
+++ b/os-platform/core/pilot/evidence/2026-05-18-projector-atomicity-fix-verified.md
@@ -1,0 +1,129 @@
+# Projector Atomicity Fix — Verified 2026-05-18
+
+## Headline
+
+The DELETE-then-INSERT atomicity bug documented in
+`os-platform/core/pilot/evidence/2026-05-17-projector-delete-insert-atomicity-bug.md` and the
+production regression captured in
+`os-platform/core/pilot/evidence/2026-05-18-improvement-projector-regression.md` are **fixed and
+verified live against Harris PACS**.
+
+`PacsImprvCanonicalProjector.ProjectAsync` now wraps the DELETE phase and
+the INSERT phase in a single EF transaction. A failure on the INSERT
+side — including the known `legacy_pacs_raw.imprv_attr.IAttrValCd`
+varchar(32) overflow class — rolls back the DELETE too, preserving prior
+chunks' canonical work.
+
+## The fix (3 hunks in `PacsImprvCanonicalProjector.cs`)
+
+1. **Open transaction before DELETE** (line 191): wrap the existing
+   DELETE block in `using var canonicalTxn = await _db.Database
+   .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);`.
+2. **Commit on success path** (after final SaveChangesAsync at line 457):
+   `await canonicalTxn.CommitAsync(cancellationToken).ConfigureAwait(false);`.
+3. **Catch block recovery** (line 481+): on exception, the `using var`
+   dispose rolls back the transaction. The catch then calls
+   `_db.ChangeTracker.Clear()` to drop the in-flight projection changes,
+   re-fetches the batch row (committed outside the rolled-back txn at
+   line 80) on a fresh implicit transaction, and writes the FAILED
+   status with `CancellationToken.None` so the cleanup completes even
+   when the request token is already cancelled.
+
+The full set of edits is ~25 lines in
+`backend/src/TerraFusion.Data/Services/CanonicalTf/PacsImprvCanonicalProjector.cs`.
+
+## Live verification
+
+Backend was rebuilt (`dotnet publish` of TerraFusion.API to the running
+old-backend publish dir) and restarted on :5000 under `Development`
+environment.
+
+### v20-first / v20-rerun: rollback path verified
+
+The first two v20 chunks both hit `RequestAborted` cancellation when
+their curl client gave up. The projector's `using var` transaction
+rolled back cleanly:
+
+- `canonical_tf.tf_improvement` stayed at 247 (session-start baseline)
+- `canonical_tf.tf_improvement_feature` stayed at 1,520 (baseline)
+
+Prior to the fix, the same cancellation pattern would have committed
+the DELETE and left INSERTs orphaned — wiping all prior chunks' work
+for the truth-batch parcel set. With the fix, **a cancelled or failed
+chunk damages nothing**.
+
+### Audit-log bloat side-finding
+
+While diagnosing why v20-rerun's projector was IN_PROGRESS for 41+
+minutes (vs. v18's typical ~10 min), `pg_stat_activity` revealed the
+projector's open transaction was blocked on **INSERT INTO "AuditLogs"**
+with `wait_event = IO/DataFileRead`. The audit interceptor that fires
+on every `SaveChangesAsync` was writing into a 7.08 GB / 33.5 M row
+table whose autovacuum had been starved by the very long-running txn
+the new fix introduces.
+
+Mitigation applied: deleted `"AuditLogs"` rows older than 7 days
+(25.8M rows pruned) and ran `VACUUM (FULL, ANALYZE) "AuditLogs"`.
+End state: 7.7M rows / 1,390 MB.
+
+This is a **side effect of the atomicity fix**, not a bug introduced
+by it: the bigger transaction footprint magnifies any AUTOVACUUM
+backpressure that was already present. A durable follow-up is to:
+
+- Periodically prune `"AuditLogs"` (cron / hosted-service)
+- Or move audit-logging onto a separate DbContext / connection so it
+  does not bind into projector transactions
+
+### v21: success path verified
+
+After the prune, v21 fired clean against the same source set
+(`TopN=500`, `FullCorpus=false`, operator
+`claude-strict-serial-improvement-tn500-v21-post-prune`):
+
+| Metric | Value |
+|---|---:|
+| Drain status | `Succeeded` |
+| Wall duration | 862 s (14.4 min) |
+| rowsLanded | 9,821 |
+| rowsPromotedToTruth | 554 |
+| **rowsCanonicalized** | **157,884** |
+| rowsQuarantinedThisLane | 2 |
+| Gates PASS | 52 |
+| Gates FAIL | 1 (`imprv-attr-key-uniqueness`, 3 duplicates — known PACS-native dup tuples, not a regression) |
+
+### Canonical-layer net delta
+
+| Table | Pre-v21 | Post-v21 | Δ |
+|---|---:|---:|---:|
+| `canonical_tf.tf_improvement` | 247 | 801 | **+554** |
+| `canonical_tf.tf_improvement_feature` | 1,520 | 158,850 | **+157,330** |
+
+The projector accepted 554 truth rows and projected 157,884 feature
+rows in a single atomic transaction. No prior canonical_tf rows were
+touched destructively.
+
+## What this slice does NOT cover
+
+- **varchar(32) overflow STILL UNPATCHED.** The 60 PACS
+  `imprv_attr.IAttrValCd` rows >32 chars will still cause future
+  chunks to FAIL — but now they fail safely, rolling back rather than
+  damaging prior work. A durable fix is to widen
+  `canonical_tf.tf_improvement_feature.FeatureCode` to varchar(64)
+  via EF migration.
+- **`OperationCanceledException` does NOT execute the projector's
+  FAILED-status writeback** (the catch filter excludes it). When a
+  request is cancelled mid-projection, the txn rolls back cleanly but
+  the `sync_bridge.load_batch` row is left IN_PROGRESS until manual
+  cleanup. Acceptable for now; a follow-up should write FAILED status
+  on cancellation too.
+- **AuditLogs growth is unbounded.** Today's prune got us back to
+  1.4 GB, but there is no scheduled prune in code yet.
+
+## This artifact is
+
+A live-replay verification of the projector atomicity fix against
+Harris PACS, plus disclosure of the audit-log bloat side-finding. This
+slice closes the regression class flagged on 2026-05-17 (atomicity
+bug) and 2026-05-18 (production regression). Source-side
+varchar-overflow remediation and audit-log lifecycle are open
+follow-up slices.


### PR DESCRIPTION
## Summary

Recut the salvageable `#865` atomicity fix onto current `main` without carrying forward the polluted broad branch history.

This PR supersedes `#865` as the actionable prerequisite for `#927`.

## Scope

- Wrap `PacsImprvCanonicalProjector` DELETE+INSERT projection work in one EF transaction.
- Commit only after the success path completes.
- On exception, clear the EF change tracker, re-fetch the batch row, and write `FAILED` status on a fresh implicit transaction.
- Preserve the two original evidence documents for the regression and fix verification.

## Recut Decision

`#865` is not repairable as an active merge candidate because its branch now contains 545 changed files, 1.8M additions, and many unrelated API/sync/evidence changes beyond the original 3-file atomicity fix. The original focused commit cherry-picked cleanly onto current `main`, so the binding topology decision is recut/supersede, not repair-in-place.

## Validation

- `git diff --check origin/main...HEAD`
- `dotnet restore backend/src/TerraFusion.Data/TerraFusion.Data.csproj`
- `dotnet build backend/src/TerraFusion.Data/TerraFusion.Data.csproj --no-restore`

Build result: 0 warnings, 0 errors.

## Summary by Sourcery

Ensure PACS improvement canonical projector DELETE+INSERT operations run atomically and failures no longer erase prior canonical work.

Bug Fixes:
- Wrap the improvement projector’s DELETE and INSERT phases in a single EF transaction so INSERT-side failures roll back the preceding DELETE.
- On projector exceptions, clear the EF change tracker, re-load the batch entity, and persist a FAILED status in a fresh implicit transaction instead of leaving inconsistent tracked state.

Documentation:
- Add evidence notes documenting the 2026-05-18 improvement projector regression and the live verification of the atomicity fix against production data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data consistency issue in the improvement projector that could cause data loss when operations fail; operations are now wrapped in atomic transactions ensuring all-or-nothing behavior.
  * Improved audit log performance by removing old entries.
  * Expanded database column width to accommodate larger data values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->