### PR TITLE
feat(atlas): MapLibre migration + parcel context overlay (TA-002–004)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/shell/BentonCountyMapIntegration.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/BentonCountyMapIntegration.test.tsx
@@ -3,10 +3,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-// Mock mapbox-gl so tests run in jsdom without canvas
-vi.mock('mapbox-gl', () => ({
+// Mock maplibre-gl so tests run in jsdom without canvas
+vi.mock('maplibre-gl', () => ({
   default: {
-    accessToken: '',
     Map: vi.fn().mockImplementation(() => ({
       on: vi.fn(),
       remove: vi.fn(),
@@ -40,24 +39,20 @@ describe('BentonCountyMap', () => {
       '../../shell/desktop/BentonCountyMap'
     );
     render(<BentonCountyMap onParcelSelect={onParcelSelect} className='h-full' />);
-    // Component mounts without errors; onParcelSelect is wired via Mapbox click event
-    // (Actual click would require Mapbox GL canvas simulation — just verify mount here)
+    // Component mounts without errors; onParcelSelect is wired via MapLibre click event
+    // (Actual click would require MapLibre GL canvas simulation — just verify mount here)
     expect(document.body).toBeTruthy();
   });
 
   it('renders a testid-bearing root element', async () => {
-    // Verify that when the component mounts, it renders either the map wrapper
-    // (data-testid="benton-county-map") or the error state
-    // (data-testid="benton-county-map-error") — both are valid outcomes
-    // depending on whether VITE_MAPBOX_ACCESS_TOKEN is defined in the test env.
+    // Verify that the component mounts and renders the map wrapper
+    // (data-testid="benton-county-map"). No token needed with MapLibre.
     const { default: BentonCountyMap } = await import(
       '../../shell/desktop/BentonCountyMap'
     );
     render(<BentonCountyMap />);
     const mapEl = document.querySelector('[data-testid="benton-county-map"]');
-    const errorEl = document.querySelector('[data-testid="benton-county-map-error"]');
-    // At least one of the two root elements must be present
-    expect(mapEl ?? errorEl).toBeTruthy();
+    expect(mapEl).toBeTruthy();
   });
 });
 

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.session.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.session.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * PropertyAtlas.session.test.tsx
+ *
+ * Contract test: Atlas tab persists map state (basemap, boundary toggle,
+ * center, zoom) to sessionStorage keyed by parcelId. Switching away and
+ * back restores the user's view.
+ *
+ * Session key: `tf-atlas-session:{parcelId}`
+ * Stored shape: { center: [lng, lat], zoom: number, basemap: 'satellite'|'streets', showBoundary: boolean }
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+
+// Mock pilotApi before importing component
+vi.mock('../../api/pilotApi', () => ({
+  invokeTool: vi.fn().mockResolvedValue({ success: false, error: { code: 'STUB' } }),
+}));
+
+// Provide boundary with centroid so the map + toolbar render
+const mockBoundary = {
+  data: {
+    centroid: { lat: 46.2304, lng: -119.2117, derivedFrom: 'arcgis' },
+    situsDisplay: '123 TEST ST',
+    areaAcres: 0.25,
+    areaSqFt: 10890,
+    ringJson: JSON.stringify([[-119.212, 46.231], [-119.211, 46.231], [-119.211, 46.230], [-119.212, 46.230], [-119.212, 46.231]]),
+    dimensions: null,
+    ownerName: 'TEST OWNER',
+  },
+  loading: false,
+  error: null,
+  source: 'live' as const,
+  refetch: vi.fn(),
+};
+
+const mockLayers = {
+  data: null,
+  loading: false,
+  error: null,
+  source: 'unavailable' as const,
+  refetch: vi.fn(),
+};
+
+vi.mock('../../hooks/useAtlasGis', () => ({
+  useParcelBoundary: () => mockBoundary,
+  useParcelLayers: () => mockLayers,
+}));
+
+// Lazy-import component AFTER mocks are in place
+const { PropertyAtlas } = await import('../../pages/workbench/tabs/PropertyAtlas');
+
+const SESSION_KEY = 'tf-atlas-session';
+
+function Wrapper({ parcelId }: { parcelId: string }) {
+  return (
+    <MemoryRouter initialEntries={[`/property/${parcelId}/atlas`]}>
+      <Routes>
+        <Route
+          path="/property/:parcelId"
+          element={<div><Outlet context={{ parcelId }} /></div>}
+        >
+          <Route path="atlas" element={<PropertyAtlas />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('PropertyAtlas — session persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('reflects basemap change in UI and restores it on remount', () => {
+    // Basemap changes trigger a full map re-mount; session persistence fires
+    // via the moveend handler (not the useEffect) in real MapLibre. In JSDOM
+    // the mock map doesn't fire moveend, so we test the restore path instead:
+    // seed the session, mount, verify UI matches.
+    const seed = {
+      center: [-119.5, 46.3],
+      zoom: 15,
+      basemap: 'streets',
+      showBoundary: true,
+    };
+    sessionStorage.setItem(`${SESSION_KEY}:TEST-001`, JSON.stringify(seed));
+
+    render(<Wrapper parcelId="TEST-001" />);
+
+    const streetsBtn = screen.getByTestId('basemap-streets');
+    expect(streetsBtn.className).toContain('font-semibold');
+
+    const satBtn = screen.getByTestId('basemap-satellite');
+    expect(satBtn.className).not.toContain('font-semibold');
+  });
+
+  it('writes session state when boundary is toggled off', () => {
+    render(<Wrapper parcelId="TEST-002" />);
+
+    const toggleBtn = screen.getByTestId('toggle-boundary');
+    fireEvent.click(toggleBtn);
+
+    const raw = sessionStorage.getItem(`${SESSION_KEY}:TEST-002`);
+    expect(raw).toBeTruthy();
+
+    const state = JSON.parse(raw!);
+    expect(state.showBoundary).toBe(false);
+  });
+
+  it('restores saved basemap and boundary state on mount', () => {
+    const seed = {
+      center: [-119.5, 46.3],
+      zoom: 14,
+      basemap: 'streets',
+      showBoundary: false,
+    };
+    sessionStorage.setItem(`${SESSION_KEY}:TEST-003`, JSON.stringify(seed));
+
+    render(<Wrapper parcelId="TEST-003" />);
+
+    // Streets button should be visually active (has font-semibold class)
+    const streetsBtn = screen.getByTestId('basemap-streets');
+    expect(streetsBtn.className).toContain('font-semibold');
+
+    // Satellite button should NOT be active
+    const satBtn = screen.getByTestId('basemap-satellite');
+    expect(satBtn.className).not.toContain('font-semibold');
+
+    // Boundary toggle should reflect OFF
+    const toggleBtn = screen.getByTestId('toggle-boundary');
+    expect(toggleBtn.textContent).toContain('OFF');
+  });
+
+  it('round-trips: write → unmount → remount → same state', () => {
+    // Mount and change basemap to streets + toggle boundary off
+    const { unmount } = render(<Wrapper parcelId="TEST-004" />);
+    fireEvent.click(screen.getByTestId('basemap-streets'));
+    fireEvent.click(screen.getByTestId('toggle-boundary'));
+
+    const rawAfterWrite = sessionStorage.getItem(`${SESSION_KEY}:TEST-004`);
+    expect(rawAfterWrite).toBeTruthy();
+    const stateAfterWrite = JSON.parse(rawAfterWrite!);
+
+    // Unmount (simulates tab switch)
+    unmount();
+
+    // Remount
+    render(<Wrapper parcelId="TEST-004" />);
+
+    // Storage unchanged
+    const rawAfterRemount = sessionStorage.getItem(`${SESSION_KEY}:TEST-004`);
+    expect(JSON.parse(rawAfterRemount!)).toMatchObject({
+      basemap: stateAfterWrite.basemap,
+      showBoundary: stateAfterWrite.showBoundary,
+    });
+
+    // UI reflects restored state
+    expect(screen.getByTestId('basemap-streets').className).toContain('font-semibold');
+    expect(screen.getByTestId('toggle-boundary').textContent).toContain('OFF');
+  });
+
+  it('isolates session state by parcelId', () => {
+    // Seed state for a different parcel
+    sessionStorage.setItem(
+      `${SESSION_KEY}:OTHER-PARCEL`,
+      JSON.stringify({ center: [-120, 47], zoom: 12, basemap: 'streets', showBoundary: false }),
+    );
+
+    render(<Wrapper parcelId="TEST-005" />);
+
+    // Should NOT have loaded OTHER-PARCEL's state — satellite is the default
+    const satBtn = screen.getByTestId('basemap-satellite');
+    expect(satBtn.className).toContain('font-semibold');
+
+    // Boundary default is ON
+    const toggleBtn = screen.getByTestId('toggle-boundary');
+    expect(toggleBtn.textContent).toContain('ON');
+
+    // OTHER-PARCEL's storage is untouched
+    const otherRaw = sessionStorage.getItem(`${SESSION_KEY}:OTHER-PARCEL`);
+    expect(JSON.parse(otherRaw!).basemap).toBe('streets');
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAtlas.test.tsx
@@ -51,6 +51,13 @@ const TestWrapper: React.FC<{ parcelId: string }> = ({ parcelId }) => {
 describe('PropertyAtlas', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-establish the default 'unavailable' boundary so per-test overrides don't leak
+    mockUseParcelBoundary.mockReturnValue({
+      data: null, loading: false, error: null, source: 'unavailable', refetch: vi.fn(),
+    });
+    mockUseParcelLayers.mockReturnValue({
+      data: null, loading: false, error: null, source: 'unavailable', refetch: vi.fn(),
+    });
   });
 
   describe('Rendering', () => {
@@ -73,6 +80,15 @@ describe('PropertyAtlas', () => {
     });
 
     it('displays map placeholder area', () => {
+      // Map container renders once a centroid is available (MapLibre migration)
+      mockUseParcelBoundary.mockReturnValue({
+        data: {
+          centroid: { lat: 46.2304, lng: -119.2117, derivedFrom: 'arcgis' },
+          ringJson: null, situsDisplay: '', areaAcres: 0, areaSqFt: 0,
+          dimensions: null, ownerName: '',
+        },
+        loading: false, error: null, source: 'live', refetch: vi.fn(),
+      });
       render(<TestWrapper parcelId='12345-001' />);
 
       // Should have a map container

--- a/frontend/apps/os-shell/src/pages/forge/geo/GeoForgeMap.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/geo/GeoForgeMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import './geoforge.css';
 import { useGeoForgeStore } from '@/stores/geoForgeStore';
 import { medianRatioColor, ratioPointColor, salePointRadius, codColor, prdColor, prbColor, bivariateColor } from './utils/choropleths';
@@ -8,11 +8,22 @@ import { makeCircleGeoJson, haversineDistanceMi } from './utils/geoMath';
 import { computeLISA, type LISAResult } from './utils/spatialStats';
 import type { MapLayer, ChoroMode } from './types/geoforge.types';
 
-const MAPBOX_TOKEN = (import.meta.env.VITE_MAPBOX_ACCESS_TOKEN as string | undefined) ?? '';
-mapboxgl.accessToken = MAPBOX_TOKEN;
-
 const BENTON_CENTER: [number, number] = [-119.3, 46.2];
 const BENTON_ZOOM = 10;
+
+const SATELLITE_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+  sources: {
+    esri: {
+      type: 'raster',
+      tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+      tileSize: 256,
+      attribution: 'Tiles &copy; Esri',
+    },
+  },
+  layers: [{ id: 'esri-tiles', type: 'raster', source: 'esri', minzoom: 0, maxzoom: 19 }],
+};
 
 interface Props {
   onNeighborhoodClick: (code: string) => void;
@@ -20,9 +31,9 @@ interface Props {
 }
 
 export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
-  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const hoverPopupRef = useRef<mapboxgl.Popup | null>(null);
+  const hoverPopupRef = useRef<maplibregl.Popup | null>(null);
   const {
     neighborhoodStats,
     salePoints,
@@ -44,22 +55,21 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
 
   // Initialize map once
   useEffect(() => {
-    if (!MAPBOX_TOKEN) return;
     if (!containerRef.current || mapRef.current) return;
 
-    const map = new mapboxgl.Map({
+    const map = new maplibregl.Map({
       container: containerRef.current,
-      style: 'mapbox://styles/mapbox/satellite-streets-v12',
+      style: SATELLITE_STYLE,
       center: BENTON_CENTER,
       zoom: BENTON_ZOOM,
       minZoom: 8,
       maxZoom: 18,
     });
 
-    map.addControl(new mapboxgl.NavigationControl(), 'top-right');
-    map.addControl(new mapboxgl.ScaleControl({ unit: 'imperial' }), 'bottom-left');
+    map.addControl(new maplibregl.NavigationControl(), 'top-right');
+    map.addControl(new maplibregl.ScaleControl({ unit: 'imperial' }), 'bottom-left');
 
-    const hoverPopup = new mapboxgl.Popup({
+    const hoverPopup = new maplibregl.Popup({
       closeButton: false,
       closeOnClick: false,
       offset: 12,
@@ -328,7 +338,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
         }),
     };
 
-    const src = map.getSource('neighborhoods') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('neighborhoods') as maplibregl.GeoJSONSource | undefined;
     src?.setData(geojson);
   }, [neighborhoodStats, simulationDeltaMap, choroMode, lisaMode]);
 
@@ -358,11 +368,11 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
         })),
     };
 
-    const src = map.getSource('sales') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('sales') as maplibregl.GeoJSONSource | undefined;
     src?.setData(geojson);
 
     // Mirror to KDE source
-    const kdeSrc = map.getSource('sales-kde') as mapboxgl.GeoJSONSource | undefined;
+    const kdeSrc = map.getSource('sales-kde') as maplibregl.GeoJSONSource | undefined;
     kdeSrc?.setData(geojson);
   }, [salePoints]);
 
@@ -386,7 +396,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
         })),
     };
 
-    const src = map.getSource('gwr-cells') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('gwr-cells') as maplibregl.GeoJSONSource | undefined;
     src?.setData(geojson);
   }, [gwrSurface]);
 
@@ -402,7 +412,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('comps-highlight') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('comps-highlight') as maplibregl.GeoJSONSource | undefined;
     if (!comparableSalePoints || comparableSalePoints.length === 0) {
       src?.setData({ type: 'FeatureCollection', features: [] });
       return;
@@ -422,7 +432,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
     if (!activeLayers.has('neighborhood-poly')) return;
-    const src = map.getSource('neighborhoods-poly') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('neighborhoods-poly') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     // Build lookup from neighborhoodStats for color enrichment
@@ -463,7 +473,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('yoy-change') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('yoy-change') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     if (!activeLayers.has('yoy-change')) {
@@ -498,7 +508,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('market-trend') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('market-trend') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     if (!activeLayers.has('market-trend')) {
@@ -534,7 +544,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('ratio-drift') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('ratio-drift') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     if (!activeLayers.has('ratio-drift')) {
@@ -572,7 +582,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('ratio-cliffs') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('ratio-cliffs') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     if (!activeLayers.has('ratio-cliffs') || neighborhoodStats.length === 0) {
@@ -622,7 +632,7 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
   useEffect(() => {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
-    const src = map.getSource('parcel-pts') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('parcel-pts') as maplibregl.GeoJSONSource | undefined;
     if (!src) return;
 
     if (!activeLayers.has('parcel-polygons') || !selectedNeighborhoodCode) {
@@ -653,8 +663,8 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
     const map = mapRef.current;
     if (!map?.isStyleLoaded()) return;
 
-    const ringSrc = map.getSource('comps-radius-ring') as mapboxgl.GeoJSONSource | undefined;
-    const inSrc = map.getSource('comps-radius-sales') as mapboxgl.GeoJSONSource | undefined;
+    const ringSrc = map.getSource('comps-radius-ring') as maplibregl.GeoJSONSource | undefined;
+    const inSrc = map.getSource('comps-radius-sales') as maplibregl.GeoJSONSource | undefined;
     const empty: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
 
     if (!bloomLatlng || !selectedRadiusMi) {
@@ -703,13 +713,13 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
     const saleBase = ['all', ['!', ['has', 'point_count']], monthFilter, priceFilter, classFilter];
 
     if (map.getLayer('sale-circles')) {
-      map.setFilter('sale-circles', saleBase as mapboxgl.FilterSpecification);
+      map.setFilter('sale-circles', saleBase as maplibregl.FilterSpecification);
     }
     if (map.getLayer('sale-outlier-ring')) {
       map.setFilter('sale-outlier-ring', [
         ...saleBase,
         ['==', ['get', 'isOutlier'], true],
-      ] as mapboxgl.FilterSpecification);
+      ] as maplibregl.FilterSpecification);
     }
   }, [selectedMonth, priceBand, filter.propertyClass]);
 
@@ -740,25 +750,6 @@ export function GeoForgeMap({ onNeighborhoodClick, onSaleClick }: Props) {
     }
   }, [activeLayers]);
 
-  if (!MAPBOX_TOKEN) {
-    return (
-      <div className="absolute inset-0 flex flex-col items-center justify-center bg-slate-950 gap-2 text-center px-8">
-        <div className="text-slate-400 text-[10px] font-mono uppercase tracking-widest">GeoForge Map Canvas</div>
-        <div className="text-slate-300 text-sm font-semibold mt-1">Mapbox token required</div>
-        <div className="text-slate-500 text-xs mt-1 max-w-xs leading-relaxed">
-          Add{' '}
-          <code className="text-cyan-500/80 font-mono">VITE_MAPBOX_TOKEN=pk.your_token</code>
-          {' '}to{' '}
-          <code className="text-slate-400 font-mono">frontend/apps/os-shell/.env.development</code>
-          {' '}and restart the dev server.
-        </div>
-        <div className="text-slate-600 text-[9px] mt-4">
-          All 31 analysis panels are available via the equity rail →
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
       ref={containerRef}
@@ -783,7 +774,7 @@ function choroColorForMode(
   }
 }
 
-function addYoyChangeLayer(map: mapboxgl.Map) {
+function addYoyChangeLayer(map: maplibregl.Map) {
   map.addSource('yoy-change', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -819,7 +810,7 @@ function addYoyChangeLayer(map: mapboxgl.Map) {
       visibility: 'none',
       'text-field': ['get', 'pctLabel'],
       'text-size': 10,
-      'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+      'text-font': ['Open Sans Bold'],
       'text-anchor': 'center',
       'text-allow-overlap': false,
     },
@@ -831,7 +822,7 @@ function addYoyChangeLayer(map: mapboxgl.Map) {
   });
 }
 
-function addNeighborhoodPolyLayer(map: mapboxgl.Map) {
+function addNeighborhoodPolyLayer(map: maplibregl.Map) {
   map.addSource('neighborhoods-poly', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -880,7 +871,7 @@ function addNeighborhoodPolyLayer(map: mapboxgl.Map) {
   });
 }
 
-function addNeighborhoodLayer(map: mapboxgl.Map) {
+function addNeighborhoodLayer(map: maplibregl.Map) {
   map.addSource('neighborhoods', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -918,7 +909,7 @@ function addNeighborhoodLayer(map: mapboxgl.Map) {
   });
 }
 
-function addSaleScatterLayer(map: mapboxgl.Map) {
+function addSaleScatterLayer(map: maplibregl.Map) {
   map.addSource('sales', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -961,7 +952,7 @@ function addSaleScatterLayer(map: mapboxgl.Map) {
     layout: {
       'text-field': ['get', 'point_count_abbreviated'],
       'text-size': 10,
-      'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+      'text-font': ['Open Sans Bold'],
     },
     paint: {
       'text-color': '#ffffff',
@@ -1002,7 +993,7 @@ function addSaleScatterLayer(map: mapboxgl.Map) {
   });
 }
 
-function addKdeLayer(map: mapboxgl.Map) {
+function addKdeLayer(map: maplibregl.Map) {
   map.addSource('sales-kde', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1037,7 +1028,7 @@ function addKdeLayer(map: mapboxgl.Map) {
   );
 }
 
-function addAiClusterLayer(map: mapboxgl.Map) {
+function addAiClusterLayer(map: maplibregl.Map) {
   map.addSource('ai-clusters', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1059,7 +1050,7 @@ function addAiClusterLayer(map: mapboxgl.Map) {
   });
 }
 
-function addSimulationOverlayLayer(map: mapboxgl.Map) {
+function addSimulationOverlayLayer(map: maplibregl.Map) {
   // Reuses the 'neighborhoods' source — draws amber rings on features with hasSimulation=true
   map.addLayer({
     id: 'simulation-ring',
@@ -1095,7 +1086,7 @@ function addSimulationOverlayLayer(map: mapboxgl.Map) {
   });
 }
 
-function addCompsHighlightLayer(map: mapboxgl.Map) {
+function addCompsHighlightLayer(map: maplibregl.Map) {
   map.addSource('comps-highlight', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1129,7 +1120,7 @@ function addCompsHighlightLayer(map: mapboxgl.Map) {
   });
 }
 
-function addCompsRadiusLayer(map: mapboxgl.Map) {
+function addCompsRadiusLayer(map: maplibregl.Map) {
   map.addSource('comps-radius-ring', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1170,7 +1161,7 @@ function addCompsRadiusLayer(map: mapboxgl.Map) {
   });
 }
 
-function addMarketTrendLayer(map: mapboxgl.Map) {
+function addMarketTrendLayer(map: maplibregl.Map) {
   map.addSource('market-trend', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1206,7 +1197,7 @@ function addMarketTrendLayer(map: mapboxgl.Map) {
       visibility: 'none',
       'text-field': ['get', 'pctLabel'],
       'text-size': 10,
-      'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+      'text-font': ['Open Sans Bold'],
       'text-anchor': 'center',
       'text-allow-overlap': false,
     },
@@ -1218,7 +1209,7 @@ function addMarketTrendLayer(map: mapboxgl.Map) {
   });
 }
 
-function addParcelPointsLayer(map: mapboxgl.Map) {
+function addParcelPointsLayer(map: maplibregl.Map) {
   map.addSource('parcel-pts', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1248,7 +1239,7 @@ function addParcelPointsLayer(map: mapboxgl.Map) {
   });
 }
 
-function addRatioCliffLayer(map: mapboxgl.Map) {
+function addRatioCliffLayer(map: maplibregl.Map) {
   map.addSource('ratio-cliffs', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1281,7 +1272,7 @@ function addRatioCliffLayer(map: mapboxgl.Map) {
   });
 }
 
-function addRatioDriftLayer(map: mapboxgl.Map) {
+function addRatioDriftLayer(map: maplibregl.Map) {
   map.addSource('ratio-drift', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },
@@ -1317,7 +1308,7 @@ function addRatioDriftLayer(map: mapboxgl.Map) {
       visibility: 'none',
       'text-field': ['get', 'deltaLabel'],
       'text-size': 10,
-      'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+      'text-font': ['Open Sans Bold'],
       'text-anchor': 'center',
       'text-allow-overlap': false,
     },
@@ -1329,7 +1320,7 @@ function addRatioDriftLayer(map: mapboxgl.Map) {
   });
 }
 
-function addGwrLayer(map: mapboxgl.Map) {
+function addGwrLayer(map: maplibregl.Map) {
   map.addSource('gwr-cells', {
     type: 'geojson',
     data: { type: 'FeatureCollection', features: [] },

--- a/frontend/apps/os-shell/src/pages/forge/geo/v2/GeoForgeV2Map.tsx
+++ b/frontend/apps/os-shell/src/pages/forge/geo/v2/GeoForgeV2Map.tsx
@@ -1,30 +1,36 @@
-// GeoForge v2 — Mapbox surface.
+// GeoForge v2 — MapLibre GL JS surface (ADR-0021).
 //
 // Three layers, in Lumin Bridge palette:
 //   1. Neighborhood outlines (concave-hull, from /v2/neighborhoods/outline)
 //   2. Parcel polygons at zoom >= 13 (from /v2/parcels/tiles, bbox-filtered)
 //   3. Selected neighborhood halo + parcel hover
 //
-// Basemap: Mapbox light-v11 (warm-leaning, approximate linen).
+// Basemap: OSM streets (light-weight data-viz backdrop).
 // Click neighborhood → select. Click parcel → emit.
 
 import { useEffect, useRef } from 'react';
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import type { NbhdOutlineCollection, ParcelTileCollection, ParcelTileProps } from './v2Api';
 import type { V2LayerId } from './LeftPanel';
 import type { MapContextPayload } from './mapContext';
 
-const MAPBOX_TOKEN = (
-  (import.meta.env.VITE_MAPBOX_ACCESS_TOKEN as string | undefined)
-  ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined)
-  ?? ''
-).trim();
-mapboxgl.accessToken = MAPBOX_TOKEN;
-
 const DEFAULT_CENTER: [number, number] = [-120.9, 47.35];
 const DEFAULT_ZOOM = 6.6;
 const PARCEL_ZOOM_MIN = 13;
+
+const STREETS_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  sources: {
+    osm: {
+      type: 'raster',
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    },
+  },
+  layers: [{ id: 'osm-tiles', type: 'raster', source: 'osm', minzoom: 0, maxzoom: 19 }],
+};
 
 interface Props {
   mapRef?: React.RefObject<unknown>;
@@ -56,27 +62,27 @@ export function GeoForgeV2Map({
   mapCtx,
   initialViewport,
 }: Props) {
-  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const popupRef = useRef<mapboxgl.Popup | null>(null);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
 
   // ── Init map once ─────────────────────────────────────────
   useEffect(() => {
-    if (!MAPBOX_TOKEN || !containerRef.current || mapRef.current) return;
+    if (!containerRef.current || mapRef.current) return;
 
-    const map = new mapboxgl.Map({
+    const map = new maplibregl.Map({
       container: containerRef.current,
-      style: 'mapbox://styles/mapbox/light-v11',
+      style: STREETS_STYLE,
       center: initialViewport?.center ?? DEFAULT_CENTER,
       zoom: initialViewport?.zoom ?? DEFAULT_ZOOM,
       minZoom: 6,
       maxZoom: 18,
     });
 
-    map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');
-    map.addControl(new mapboxgl.ScaleControl({ unit: 'imperial' }), 'bottom-right');
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+    map.addControl(new maplibregl.ScaleControl({ unit: 'imperial' }), 'bottom-right');
 
-    popupRef.current = new mapboxgl.Popup({
+    popupRef.current = new maplibregl.Popup({
       closeButton: false,
       closeOnClick: false,
       offset: 10,
@@ -283,7 +289,7 @@ export function GeoForgeV2Map({
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !outlines) return;
-    const src = map.getSource('nbhd-outlines') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('nbhd-outlines') as maplibregl.GeoJSONSource | undefined;
     if (src) src.setData(outlines as unknown as GeoJSON.FeatureCollection);
   }, [outlines]);
 
@@ -291,7 +297,7 @@ export function GeoForgeV2Map({
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !parcels) return;
-    const src = map.getSource('parcels') as mapboxgl.GeoJSONSource | undefined;
+    const src = map.getSource('parcels') as maplibregl.GeoJSONSource | undefined;
     if (src) src.setData(parcels as unknown as GeoJSON.FeatureCollection);
   }, [parcels]);
 
@@ -454,14 +460,6 @@ export function GeoForgeV2Map({
     };
     if (map.isStyleLoaded()) { apply(); } else { map.once('styledata', apply); }
   }, [mapCtx, visibleLayers]);
-
-  if (!MAPBOX_TOKEN) {
-    return (
-      <div className="flex items-center justify-center h-full text-slate-400 text-xs">
-        Mapbox token missing (VITE_MAPBOX_ACCESS_TOKEN or VITE_MAPBOX_TOKEN).
-      </div>
-    );
-  }
 
   return (
     <div className="relative w-full h-full">

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -148,6 +148,7 @@ interface AtlasSessionState {
   zoom: number;
   basemap: BasemapId;
   showBoundary: boolean;
+  showContext?: boolean;
 }
 
 const SESSION_KEY = 'tf-atlas-session';
@@ -388,6 +389,18 @@ function addBoundaryToMap(
 
 /* ------------------------------------------------------------------ */
 
+function ContextRow({ label, value }: { label: string; value: string | null | undefined }) {
+  if (!value) return null;
+  return (
+    <div className="flex justify-between gap-2" style={{ fontSize: 10.5 }}>
+      <span className="tf-text-dim shrink-0">{label}</span>
+      <span className="tf-text text-right truncate" title={value}>{value}</span>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+
 export const PropertyAtlas: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const activeParcel = usePropertyStore((s) => s.activeParcel);
@@ -418,6 +431,10 @@ export const PropertyAtlas: React.FC = () => {
     const s = parcelId ? loadSession(parcelId) : null;
     return s?.showBoundary ?? true;
   });
+  const [showContext, setShowContext] = useState(() => {
+    const s = parcelId ? loadSession(parcelId) : null;
+    return s?.showContext ?? false;
+  });
 
   // Refs so event handlers always read current values (fixes stale closure in moveend)
   const basemapRef = useRef(basemap);
@@ -436,8 +453,9 @@ export const PropertyAtlas: React.FC = () => {
       zoom: map.getZoom(),
       basemap,
       showBoundary,
+      showContext,
     });
-  }, [basemap, showBoundary, parcelId]);
+  }, [basemap, showBoundary, showContext, parcelId]);
 
   // Initialize MapLibre map — fires once per parcel (centroid arrival), NOT on basemap switch
   useEffect(() => {
@@ -899,14 +917,83 @@ export const PropertyAtlas: React.FC = () => {
             >
               {showBoundary ? 'Boundary ON' : 'Boundary OFF'}
             </button>
+            <button
+              type="button"
+              data-testid="toggle-context"
+              onClick={() => setShowContext((v) => !v)}
+              className={`px-2 py-0.5 rounded ${showContext ? 'tf-panel font-semibold' : 'tf-text-dim hover:tf-text'}`}
+              style={showContext ? { color: '#e8a838' } : undefined}
+            >
+              {showContext ? 'Context ON' : 'Context OFF'}
+            </button>
           </div>
 
-          <div
-            ref={mapContainerRef}
-            data-testid="atlas-map-canvas"
-            className="w-full"
-            style={{ height: 480 }}
-          />
+          <div className="relative">
+            <div
+              ref={mapContainerRef}
+              data-testid="atlas-map-canvas"
+              className="w-full"
+              style={{ height: 480 }}
+            />
+
+            {/* ── Contextual overlay panel (TA-004) ──────────────── */}
+            {showContext && (
+              <div
+                data-testid="atlas-context-overlay"
+                className="absolute top-2 right-2 rounded-lg text-xs pointer-events-auto"
+                style={{
+                  background: 'hsl(var(--tf-bg-secondary, 220 14% 12%) / 0.92)',
+                  backdropFilter: 'blur(8px)',
+                  border: '1px solid hsl(var(--tf-border, 220 13% 22%) / 0.6)',
+                  padding: '8px 10px',
+                  maxWidth: 220,
+                  zIndex: 10,
+                }}
+              >
+                <div className="font-semibold mb-1.5" style={{ color: '#e8a838', fontSize: 11 }}>
+                  Parcel Context
+                </div>
+                {layers.loading && (
+                  <div className="tf-text-dim" style={{ fontSize: 10 }}>Loading...</div>
+                )}
+                {!layers.loading && layers.source === 'unavailable' && !layers.data && (
+                  <div className="tf-text-dim" style={{ fontSize: 10 }}>No layer data available</div>
+                )}
+                {layers.data && (
+                  <div className="space-y-1">
+                    <ContextRow label="Zoning" value={
+                      layers.data.zoning?.zoneCode
+                      || layers.data.zoning?.characteristicZoning1
+                      || activeParcel?.landUseDescription
+                    } />
+                    <ContextRow label="Flood" value={
+                      layers.data.flood
+                        ? `${layers.data.flood.zone} (${layers.data.flood.risk})`
+                        : undefined
+                    } />
+                    <ContextRow label="Tax Area" value={
+                      layers.data.taxArea?.taxAreaNumber
+                        ? `${layers.data.taxArea.taxAreaNumber}${layers.data.taxArea.taxAreaDescription ? ' — ' + layers.data.taxArea.taxAreaDescription : ''}`
+                        : activeParcel?.taxDistrictCode || activeParcel?.taxDistrictName
+                    } />
+                    <ContextRow label="Land Class" value={
+                      layers.data.landClass?.landClassCode
+                      || layers.data.landClass?.landTypeCode
+                    } />
+                    {layers.data.landClass?.primaryUseCd && (
+                      <ContextRow label="Use" value={
+                        layers.data.landClass.primaryUseCd
+                        + (layers.data.landClass.subUseCd ? ` / ${layers.data.landClass.subUseCd}` : '')
+                      } />
+                    )}
+                  </div>
+                )}
+                <div className="mt-1.5 tf-text-dim" style={{ fontSize: 9 }}>
+                  Source: {layers.source === 'live' ? 'County records' : layers.source}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -32,8 +32,8 @@ import {
   useParcelLayers,
   type AtlasGisSource,
 } from '../../../hooks/useAtlasGis';
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
 
 /** Available map layers */
 const MAP_LAYERS = [
@@ -102,6 +102,69 @@ interface SpatialAnomalyState {
   result?: SpatialAnomalyResult;
   correlationId?: string;
   error?: ErrorInfo;
+}
+
+/* ------------------------------------------------------------------ */
+/*  MapLibre basemap styles (ADR-0021: no Mapbox token dependency)     */
+/* ------------------------------------------------------------------ */
+
+type BasemapId = 'streets' | 'satellite';
+
+const BASEMAP_STYLES: Record<BasemapId, maplibregl.StyleSpecification> = {
+  streets: {
+    version: 8,
+    sources: {
+      osm: {
+        type: 'raster',
+        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      },
+    },
+    layers: [{ id: 'osm-tiles', type: 'raster', source: 'osm', minzoom: 0, maxzoom: 19 }],
+  },
+  satellite: {
+    version: 8,
+    sources: {
+      esri: {
+        type: 'raster',
+        tiles: [
+          'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        ],
+        tileSize: 256,
+        attribution: 'Esri, Maxar, Earthstar Geographics',
+      },
+    },
+    layers: [{ id: 'esri-satellite', type: 'raster', source: 'esri', minzoom: 0, maxzoom: 19 }],
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Session state persistence                                          */
+/* ------------------------------------------------------------------ */
+
+interface AtlasSessionState {
+  center: [number, number];
+  zoom: number;
+  basemap: BasemapId;
+  showBoundary: boolean;
+}
+
+const SESSION_KEY = 'tf-atlas-session';
+
+function loadSession(parcelId: string): AtlasSessionState | null {
+  try {
+    const raw = sessionStorage.getItem(`${SESSION_KEY}:${parcelId}`);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveSession(parcelId: string, state: AtlasSessionState): void {
+  try {
+    sessionStorage.setItem(`${SESSION_KEY}:${parcelId}`, JSON.stringify(state));
+  } catch { /* quota exceeded — non-fatal */ }
 }
 
 function isLayerAvailabilityList(layers: QueryResult['layers']): layers is AvailableLayer[] {
@@ -297,53 +360,62 @@ export const PropertyAtlas: React.FC = () => {
   const [geographyId, setGeographyId] = useState<string>('');
   const [spatialAnomalyState, setSpatialAnomalyState] = useState<SpatialAnomalyState>({ status: 'idle' });
 
-  // ── Phase 0B: Mapbox GL JS satellite map ──────────────────────────────────
+  // ── MapLibre GL JS map (ADR-0021 locked stack) ─────────────────────────────
   const mapContainerRef = useRef<HTMLDivElement>(null);
-  const mapboxRef = useRef<mapboxgl.Map | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
   const centroidLat = boundary.data?.centroid?.lat;
   const centroidLng = boundary.data?.centroid?.lng;
 
+  // Session-persisted map state
+  const saved = parcelId ? loadSession(parcelId) : null;
+  const [basemap, setBasemap] = useState<BasemapId>(saved?.basemap ?? 'satellite');
+  const [showBoundary, setShowBoundary] = useState(saved?.showBoundary ?? true);
+
+  // Persist session state on change
+  useEffect(() => {
+    if (!parcelId || !mapRef.current) return;
+    const map = mapRef.current;
+    const center = map.getCenter();
+    saveSession(parcelId, {
+      center: [center.lng, center.lat],
+      zoom: map.getZoom(),
+      basemap,
+      showBoundary,
+    });
+  }, [basemap, showBoundary, parcelId]);
+
+  // Initialize MapLibre map
   useEffect(() => {
     const el = mapContainerRef.current;
-    if (!el || boundary.source !== 'live' || centroidLat === undefined || centroidLng === undefined) return;
+    if (!el || centroidLat === undefined || centroidLng === undefined) return;
 
-    // Remove previous instance if parcel changed
-    if (mapboxRef.current) {
-      mapboxRef.current.remove();
-      mapboxRef.current = null;
+    if (mapRef.current) {
+      mapRef.current.remove();
+      mapRef.current = null;
     }
 
-    const token = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN as string | undefined;
-    if (!token) return; // token missing — skip render
-
     try {
-      mapboxgl.accessToken = token;
-      const map = new mapboxgl.Map({
+      const sessionState = parcelId ? loadSession(parcelId) : null;
+      const map = new maplibregl.Map({
         container: el,
-        style: 'mapbox://styles/mapbox/satellite-streets-v12',
-        center: [centroidLng, centroidLat],
-        zoom: 17,
-        scrollZoom: false,
+        style: BASEMAP_STYLES[basemap],
+        center: sessionState?.center ?? [centroidLng, centroidLat],
+        zoom: sessionState?.zoom ?? 17,
         attributionControl: false,
       });
 
-      // Compact attribution
-      map.addControl(new mapboxgl.AttributionControl({ compact: true }), 'bottom-right');
-      map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');
+      map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-right');
+      map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
 
-      // Parcel centroid marker
-      const marker = new mapboxgl.Marker({ color: '#20d4c8', scale: 0.9 })
+      const situsText = boundary.data?.situsDisplay?.replace(/\r?\n/g, ', ') ?? parcelId;
+      new maplibregl.Marker({ color: '#20d4c8', scale: 0.9 })
         .setLngLat([centroidLng, centroidLat])
+        .setPopup(
+          new maplibregl.Popup({ offset: 25, closeButton: false })
+            .setHTML(`<span style="font-size:11px;font-weight:600">${situsText}</span>`)
+        )
         .addTo(map);
 
-      // Popup on hover
-      const situsText = boundary.data?.situsDisplay?.replace(/\r?\n/g, ', ') ?? parcelId;
-      marker.setPopup(
-        new mapboxgl.Popup({ offset: 25, closeButton: false })
-          .setHTML(`<span style="font-size:11px;font-weight:600">${situsText}</span>`)
-      );
-
-      // Draw parcel polygon boundary when ArcGIS ring data is available
       const ringJson = boundary.data?.ringJson;
       if (ringJson) {
         map.on('load', () => {
@@ -358,37 +430,55 @@ export const PropertyAtlas: React.FC = () => {
                   properties: {},
                 },
               });
-              // Translucent fill
               map.addLayer({
                 id: 'parcel-fill',
                 type: 'fill',
                 source: 'parcel-boundary',
-                paint: { 'fill-color': '#20d4c8', 'fill-opacity': 0.12 },
+                paint: { 'fill-color': '#20d4c8', 'fill-opacity': 0.15 },
               });
-              // Solid outline
               map.addLayer({
                 id: 'parcel-outline',
                 type: 'line',
                 source: 'parcel-boundary',
-                paint: { 'line-color': '#20d4c8', 'line-width': 2, 'line-opacity': 0.9 },
+                paint: { 'line-color': '#20d4c8', 'line-width': 2.5, 'line-opacity': 0.9 },
               });
+              if (!showBoundary) {
+                map.setLayoutProperty('parcel-fill', 'visibility', 'none');
+                map.setLayoutProperty('parcel-outline', 'visibility', 'none');
+              }
             }
-          } catch {
-            // malformed ringJson — skip polygon, marker still renders
-          }
+          } catch { /* malformed ringJson — marker still renders */ }
         });
       }
 
-      mapboxRef.current = map;
-    } catch {
-      // JSDOM / test environment — silently skip
-    }
+      // Persist zoom/center on interaction
+      map.on('moveend', () => {
+        if (!parcelId) return;
+        const c = map.getCenter();
+        saveSession(parcelId, { center: [c.lng, c.lat], zoom: map.getZoom(), basemap, showBoundary });
+      });
+
+      mapRef.current = map;
+    } catch { /* JSDOM / test environment — silently skip */ }
 
     return () => {
-      mapboxRef.current?.remove();
-      mapboxRef.current = null;
+      mapRef.current?.remove();
+      mapRef.current = null;
     };
-  }, [boundary.source, centroidLat, centroidLng, boundary.data?.situsDisplay, boundary.data?.ringJson, parcelId]);
+  // Re-mount on parcel change or basemap switch
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [centroidLat, centroidLng, boundary.data?.ringJson, parcelId, basemap]);
+
+  // Toggle parcel boundary layer visibility without re-mounting the map
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    const vis = showBoundary ? 'visible' : 'none';
+    try {
+      if (map.getLayer('parcel-fill')) map.setLayoutProperty('parcel-fill', 'visibility', vis);
+      if (map.getLayer('parcel-outline')) map.setLayoutProperty('parcel-outline', 'visibility', vis);
+    } catch { /* layer not yet added */ }
+  }, [showBoundary]);
 
   const toggleLayer = useCallback((layerId: LayerId) => {
     setSelectedLayers((prev) => {
@@ -720,36 +810,62 @@ export const PropertyAtlas: React.FC = () => {
         </div>
       )}
 
-      {/* ── Phase 0B: Map Canvas ──────────────────────────────
-          map-container always rendered so the layer/Atlas surface always has a stable mount point.
-          atlas-map-canvas (Leaflet target) only mounts when a live boundary with a centroid is available. */}
-      <div
-        data-testid="map-container"
-        className="rounded-xl overflow-hidden w-full"
-        style={{ border: '1px solid hsl(var(--tf-border, 220 13% 22%))', boxShadow: '0 4px 24px rgba(0,0,0,0.35)', minHeight: 24 }}
-      >
-        {boundary.source === 'live' && boundary.data?.centroid && (
+      {/* ── Map Canvas + Controls ─────────────────────────────── */}
+      {boundary.data?.centroid && (
+        <div
+          data-testid="map-container"
+          className="rounded-xl overflow-hidden w-full"
+          style={{ border: '1px solid hsl(var(--tf-border, 220 13% 22%))', boxShadow: '0 4px 24px rgba(0,0,0,0.35)' }}
+        >
+          {/* Map toolbar */}
+          <div className="flex items-center gap-2 px-3 py-1.5 text-xs" style={{ background: 'hsl(var(--tf-bg-secondary, 220 14% 12%))' }}>
+            <span className="tf-text-dim mr-1">Basemap:</span>
+            {(['satellite', 'streets'] as const).map((id) => (
+              <button
+                key={id}
+                type="button"
+                data-testid={`basemap-${id}`}
+                onClick={() => setBasemap(id)}
+                className={`px-2 py-0.5 rounded ${basemap === id ? 'tf-panel font-semibold' : 'tf-text-dim hover:tf-text'}`}
+                style={basemap === id ? { color: 'hsl(var(--tf-transcend-cyan-hs, 174 100%) 55%)' } : undefined}
+              >
+                {id === 'satellite' ? 'Satellite' : 'Streets'}
+              </button>
+            ))}
+            <span className="mx-2 tf-text-dim">|</span>
+            <button
+              type="button"
+              data-testid="toggle-boundary"
+              onClick={() => setShowBoundary((v) => !v)}
+              className={`px-2 py-0.5 rounded ${showBoundary ? 'tf-panel font-semibold' : 'tf-text-dim hover:tf-text'}`}
+              style={showBoundary ? { color: '#20d4c8' } : undefined}
+            >
+              {showBoundary ? 'Boundary ON' : 'Boundary OFF'}
+            </button>
+          </div>
+
           <div
             ref={mapContainerRef}
             data-testid="atlas-map-canvas"
             className="w-full"
             style={{ height: 480 }}
           />
-        )}
-      </div>
-
-      {/* ── Boundary unavailable state ────────────────────── */}
-      {!boundary.loading && !boundary.error && boundary.source === 'unavailable' && (
-        <div className="text-xs tf-text-muted p-2 tf-panel" data-testid="atlas-boundary-unavailable">
-          Boundary data not available for this parcel.
         </div>
       )}
 
-      {/* ── Honesty disclosure: full GIS geometry is not exposed on this route ── */}
-      <div className="text-[11px] tf-text-dim px-2" data-testid="atlas-geometry-disclosure">
-        This route shows boundary previews and layer availability only.
-        Full GIS geometry rendering is reserved for the dedicated Atlas suite.
-      </div>
+      {/* Loading state */}
+      {boundary.loading && (
+        <div className="text-xs tf-text-muted p-4 tf-panel rounded-xl text-center" data-testid="atlas-map-loading">
+          Loading parcel geometry...
+        </div>
+      )}
+
+      {/* No centroid available */}
+      {!boundary.loading && !boundary.data?.centroid && (
+        <div className="text-xs tf-text-muted p-4 tf-panel rounded-xl text-center" data-testid="atlas-boundary-unavailable">
+          No geometry available for this parcel. Map renders when centroid data is present.
+        </div>
+      )}
 
       {/* ── Live GIS Layer Data ─────────────────────────────── */}
       {layers.source === 'live' && layers.data && (
@@ -882,14 +998,11 @@ export const PropertyAtlas: React.FC = () => {
               <div className="text-[11px] tf-text-dim" data-testid="atlas-results-source">
                 Layer availability returned from query_parcel_layers (correlationId{queryState.correlationId ? `: ${queryState.correlationId.slice(0, 16)}` : ''}).
               </div>
-              <div className="text-[11px] tf-text-dim space-y-1">
+              <div className="text-[11px] tf-text-dim">
                 <p>
-                  Atlas layer availability is confirmed here, but the boundary and centroid shown are preview sketches. Full parcel geometry is reserved for the dedicated Atlas suite.
+                  Layer availability confirmed from county-scoped Atlas query.
+                  Boundary geometry rendered from ArcGIS sync data when available.
                 </p>
-                <p>
-                  Atlas layer availability is confirmed for this parcel, but the boundary and centroid shown on this route are preview sketches and are not the canonical authoritative geometry.
-                </p>
-                <p>Not exposed on this route yet: full geometry rendering, neighbor parcels, and live overlay editing.</p>
               </div>
               <div className='grid grid-cols-1 md:grid-cols-2 gap-2'>
                 {liveLayerCards.length > 0 ? liveLayerCards.map((layer) => (

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -345,6 +345,49 @@ function gisSourceToDisclosure(
 
 /* ------------------------------------------------------------------ */
 
+function addBoundaryToMap(
+  map: maplibregl.Map,
+  ringJson: string | null | undefined,
+  visible: boolean,
+): void {
+  if (!ringJson) return;
+  try {
+    const ring: [number, number][] = JSON.parse(ringJson);
+    if (ring.length < 3) return;
+
+    const geojson = {
+      type: 'Feature' as const,
+      geometry: { type: 'Polygon' as const, coordinates: [ring] },
+      properties: {},
+    };
+
+    const existing = map.getSource('parcel-boundary');
+    if (existing && 'setData' in existing) {
+      (existing as maplibregl.GeoJSONSource).setData(geojson);
+    } else {
+      map.addSource('parcel-boundary', { type: 'geojson', data: geojson });
+      map.addLayer({
+        id: 'parcel-fill',
+        type: 'fill',
+        source: 'parcel-boundary',
+        paint: { 'fill-color': '#20d4c8', 'fill-opacity': 0.15 },
+      });
+      map.addLayer({
+        id: 'parcel-outline',
+        type: 'line',
+        source: 'parcel-boundary',
+        paint: { 'line-color': '#20d4c8', 'line-width': 2.5, 'line-opacity': 0.9 },
+      });
+    }
+
+    const vis = visible ? 'visible' : 'none';
+    if (map.getLayer('parcel-fill')) map.setLayoutProperty('parcel-fill', 'visibility', vis);
+    if (map.getLayer('parcel-outline')) map.setLayoutProperty('parcel-outline', 'visibility', vis);
+  } catch { /* malformed ringJson — marker still renders */ }
+}
+
+/* ------------------------------------------------------------------ */
+
 export const PropertyAtlas: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const activeParcel = usePropertyStore((s) => s.activeParcel);
@@ -366,10 +409,22 @@ export const PropertyAtlas: React.FC = () => {
   const centroidLat = boundary.data?.centroid?.lat;
   const centroidLng = boundary.data?.centroid?.lng;
 
-  // Session-persisted map state
-  const saved = parcelId ? loadSession(parcelId) : null;
-  const [basemap, setBasemap] = useState<BasemapId>(saved?.basemap ?? 'satellite');
-  const [showBoundary, setShowBoundary] = useState(saved?.showBoundary ?? true);
+  // Session-persisted map state (lazy init — avoids re-parsing sessionStorage every render)
+  const [basemap, setBasemap] = useState<BasemapId>(() => {
+    const s = parcelId ? loadSession(parcelId) : null;
+    return s?.basemap ?? 'satellite';
+  });
+  const [showBoundary, setShowBoundary] = useState(() => {
+    const s = parcelId ? loadSession(parcelId) : null;
+    return s?.showBoundary ?? true;
+  });
+
+  // Refs so event handlers always read current values (fixes stale closure in moveend)
+  const basemapRef = useRef(basemap);
+  const showBoundaryRef = useRef(showBoundary);
+  const appliedBasemapRef = useRef(basemap);
+  useEffect(() => { basemapRef.current = basemap; }, [basemap]);
+  useEffect(() => { showBoundaryRef.current = showBoundary; }, [showBoundary]);
 
   // Persist session state on change
   useEffect(() => {
@@ -384,7 +439,7 @@ export const PropertyAtlas: React.FC = () => {
     });
   }, [basemap, showBoundary, parcelId]);
 
-  // Initialize MapLibre map
+  // Initialize MapLibre map — fires once per parcel (centroid arrival), NOT on basemap switch
   useEffect(() => {
     const el = mapContainerRef.current;
     if (!el || centroidLat === undefined || centroidLng === undefined) return;
@@ -396,9 +451,12 @@ export const PropertyAtlas: React.FC = () => {
 
     try {
       const sessionState = parcelId ? loadSession(parcelId) : null;
+      const initBasemap = basemapRef.current;
+      appliedBasemapRef.current = initBasemap;
+
       const map = new maplibregl.Map({
         container: el,
-        style: BASEMAP_STYLES[basemap],
+        style: BASEMAP_STYLES[initBasemap],
         center: sessionState?.center ?? [centroidLng, centroidLat],
         zoom: sessionState?.zoom ?? 17,
         attributionControl: false,
@@ -416,46 +474,19 @@ export const PropertyAtlas: React.FC = () => {
         )
         .addTo(map);
 
-      const ringJson = boundary.data?.ringJson;
-      if (ringJson) {
-        map.on('load', () => {
-          try {
-            const ring: [number, number][] = JSON.parse(ringJson);
-            if (ring.length >= 3) {
-              map.addSource('parcel-boundary', {
-                type: 'geojson',
-                data: {
-                  type: 'Feature',
-                  geometry: { type: 'Polygon', coordinates: [ring] },
-                  properties: {},
-                },
-              });
-              map.addLayer({
-                id: 'parcel-fill',
-                type: 'fill',
-                source: 'parcel-boundary',
-                paint: { 'fill-color': '#20d4c8', 'fill-opacity': 0.15 },
-              });
-              map.addLayer({
-                id: 'parcel-outline',
-                type: 'line',
-                source: 'parcel-boundary',
-                paint: { 'line-color': '#20d4c8', 'line-width': 2.5, 'line-opacity': 0.9 },
-              });
-              if (!showBoundary) {
-                map.setLayoutProperty('parcel-fill', 'visibility', 'none');
-                map.setLayoutProperty('parcel-outline', 'visibility', 'none');
-              }
-            }
-          } catch { /* malformed ringJson — marker still renders */ }
-        });
-      }
+      map.on('load', () => {
+        addBoundaryToMap(map, boundary.data?.ringJson, showBoundaryRef.current);
+      });
 
-      // Persist zoom/center on interaction
       map.on('moveend', () => {
         if (!parcelId) return;
         const c = map.getCenter();
-        saveSession(parcelId, { center: [c.lng, c.lat], zoom: map.getZoom(), basemap, showBoundary });
+        saveSession(parcelId, {
+          center: [c.lng, c.lat],
+          zoom: map.getZoom(),
+          basemap: basemapRef.current,
+          showBoundary: showBoundaryRef.current,
+        });
       });
 
       mapRef.current = map;
@@ -465,19 +496,45 @@ export const PropertyAtlas: React.FC = () => {
       mapRef.current?.remove();
       mapRef.current = null;
     };
-  // Re-mount on parcel change or basemap switch
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [centroidLat, centroidLng, boundary.data?.ringJson, parcelId, basemap]);
+  }, [centroidLat, centroidLng, parcelId]);
+
+  // Swap basemap style without destroying the map instance
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || basemap === appliedBasemapRef.current) return;
+    appliedBasemapRef.current = basemap;
+
+    map.setStyle(BASEMAP_STYLES[basemap]);
+    map.once('style.load', () => {
+      addBoundaryToMap(map, boundary.data?.ringJson, showBoundaryRef.current);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [basemap]);
+
+  // Update boundary geometry in-place when GIS data arrives or changes
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    addBoundaryToMap(map, boundary.data?.ringJson, showBoundaryRef.current);
+  }, [boundary.data?.ringJson]);
 
   // Toggle parcel boundary layer visibility without re-mounting the map
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return;
-    const vis = showBoundary ? 'visible' : 'none';
-    try {
-      if (map.getLayer('parcel-fill')) map.setLayoutProperty('parcel-fill', 'visibility', vis);
-      if (map.getLayer('parcel-outline')) map.setLayoutProperty('parcel-outline', 'visibility', vis);
-    } catch { /* layer not yet added */ }
+    if (!map) return;
+    const apply = () => {
+      const vis = showBoundary ? 'visible' : 'none';
+      try {
+        if (map.getLayer('parcel-fill')) map.setLayoutProperty('parcel-fill', 'visibility', vis);
+        if (map.getLayer('parcel-outline')) map.setLayoutProperty('parcel-outline', 'visibility', vis);
+      } catch { /* layer not yet added */ }
+    };
+    if (map.isStyleLoaded()) {
+      apply();
+    } else {
+      map.once('style.load', apply);
+    }
   }, [showBoundary]);
 
   const toggleLayer = useCallback((layerId: LayerId) => {

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAtlas.tsx
@@ -1011,6 +1011,12 @@ export const PropertyAtlas: React.FC = () => {
         </div>
       )}
 
+      {/* ── Honesty disclosure: full GIS geometry is not exposed on this route ── */}
+      <div className="text-[11px] tf-text-dim px-2" data-testid="atlas-geometry-disclosure">
+        This route shows boundary previews and layer availability only.
+        Full GIS geometry rendering is reserved for the dedicated Atlas suite.
+      </div>
+
       {/* ── Live GIS Layer Data ─────────────────────────────── */}
       {layers.source === 'live' && layers.data && (
         <div data-testid="atlas-gis-layers">
@@ -1142,11 +1148,14 @@ export const PropertyAtlas: React.FC = () => {
               <div className="text-[11px] tf-text-dim" data-testid="atlas-results-source">
                 Layer availability returned from query_parcel_layers (correlationId{queryState.correlationId ? `: ${queryState.correlationId.slice(0, 16)}` : ''}).
               </div>
-              <div className="text-[11px] tf-text-dim">
+              <div className="text-[11px] tf-text-dim space-y-1">
                 <p>
-                  Layer availability confirmed from county-scoped Atlas query.
-                  Boundary geometry rendered from ArcGIS sync data when available.
+                  Atlas layer availability is confirmed here, but the boundary and centroid shown are preview sketches. Full parcel geometry is reserved for the dedicated Atlas suite.
                 </p>
+                <p>
+                  Atlas layer availability is confirmed for this parcel, but the boundary and centroid shown on this route are preview sketches and are not the canonical authoritative geometry.
+                </p>
+                <p>Not exposed on this route yet: full geometry rendering, neighbor parcels, and live overlay editing.</p>
               </div>
               <div className='grid grid-cols-1 md:grid-cols-2 gap-2'>
                 {liveLayerCards.length > 0 ? liveLayerCards.map((layer) => (

--- a/frontend/apps/os-shell/src/shell/desktop/BentonCountyMap.tsx
+++ b/frontend/apps/os-shell/src/shell/desktop/BentonCountyMap.tsx
@@ -1,20 +1,13 @@
 /**
- * TerraFusion OS — Benton County GIS Map
+ * TerraFusion OS — Benton County GIS Map (MapLibre GL JS — ADR-0021)
  *
- * Adapted from QUARANTINE/top-level-dirs/applications/bcbs-gis-pro-production/
- * client/src/components/TerraFusionMap.tsx
- *
- * Real Mapbox GL map:
- * - Satellite-streets style centered on Benton County WA
- * - County boundary overlay
- * - Parcel layer from /api/benton-county/parcels (graceful offline fallback)
- * - Click-to-select parcel → opens PropertyWorkbench
- *
- * Token: VITE_MAPBOX_ACCESS_TOKEN in .env.development
+ * ESRI satellite basemap centered on Benton County WA.
+ * County boundary overlay + parcel layer from /api/benton-county/parcels.
+ * Click-to-select parcel → opens PropertyWorkbench.
  */
 
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import { useEffect, useRef, useState } from 'react';
 
 // ---------------------------------------------------------------------------
@@ -33,6 +26,19 @@ const BENTON_BOUNDARY_COORDS: [number, number][] = [
   [-119.875, 45.773],
 ];
 
+const SATELLITE_STYLE: maplibregl.StyleSpecification = {
+  version: 8,
+  sources: {
+    esri: {
+      type: 'raster',
+      tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+      tileSize: 256,
+      attribution: 'Tiles &copy; Esri',
+    },
+  },
+  layers: [{ id: 'esri-tiles', type: 'raster', source: 'esri', minzoom: 0, maxzoom: 19 }],
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -48,29 +54,17 @@ export interface BentonCountyMapProps {
 
 export default function BentonCountyMap({ onParcelSelect, className }: BentonCountyMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<mapboxgl.Map | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN as string | undefined;
-
-    if (!token) {
-      setError('Map requires VITE_MAPBOX_ACCESS_TOKEN — add it to .env.development');
-      setLoading(false);
-      return;
-    }
-
     if (mapRef.current || !containerRef.current) return;
 
-    mapboxgl.accessToken = token;
-
-    const map = new mapboxgl.Map({
+    const map = new maplibregl.Map({
       container: containerRef.current,
-      style: 'mapbox://styles/mapbox/satellite-streets-v12',
+      style: SATELLITE_STYLE,
       center: BENTON_CENTER,
       zoom: BENTON_ZOOM,
-      projection: 'mercator',
     });
 
     mapRef.current = map;
@@ -78,7 +72,6 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
     map.on('load', () => {
       setLoading(false);
 
-      // Resolve accent color from CSS token (Mapbox GL cannot use CSS custom properties)
       const accentHs = getComputedStyle(document.documentElement)
         .getPropertyValue('--tf-transcend-cyan-hs')
         .trim() || '190 100%';
@@ -207,20 +200,6 @@ export default function BentonCountyMap({ onParcelSelect, className }: BentonCou
       mapRef.current = null;
     };
   }, [onParcelSelect]);
-
-  if (error) {
-    return (
-      <div
-        data-testid='benton-county-map-error'
-        className='w-full h-full flex items-center justify-center'
-        style={{ background: 'hsl(var(--tf-bg))' }}
-      >
-        <span className='text-xs text-center px-6' style={{ color: 'hsl(var(--tf-destructive))' }}>
-          {error}
-        </span>
-      </div>
-    );
-  }
 
   return (
     <div data-testid='benton-county-map' className={`relative w-full h-full ${className ?? ''}`}>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,6 @@
     "leaflet": "1.9.4",
     "lodash": "^4.17.21",
     "lucide-react": "^0.540.0",
-    "mapbox-gl": "3.20.0",
     "maplibre-gl": "5.24.0",
     "monaco-editor": "0.52.2",
     "next-themes": "0.4.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.540.0",
     "mapbox-gl": "3.20.0",
+    "maplibre-gl": "5.24.0",
     "monaco-editor": "0.52.2",
     "next-themes": "0.4.6",
     "react": "18.3.1",
@@ -81,6 +82,7 @@
     "tailwind-merge": "^3.3.1",
     "three": "^0.179.1",
     "wait-on": "^8.0.4",
+    "wicket": "1.3.8",
     "zod": "^3.24.1",
     "zustand": "^4.4.7"
   },

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -38,20 +38,6 @@ class MockMapboxPopup {
   remove() {}
 }
 
-vi.mock('mapbox-gl', () => ({
-  default: {
-    accessToken: '',
-    Map: MockMapboxMap,
-    Popup: MockMapboxPopup,
-    NavigationControl: vi.fn(),
-    ScaleControl: vi.fn(),
-  },
-  Map: MockMapboxMap,
-  Popup: MockMapboxPopup,
-  NavigationControl: vi.fn(),
-  ScaleControl: vi.fn(),
-}));
-
 vi.mock('maplibre-gl', () => ({
   default: {
     Map: MockMapboxMap,

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -48,6 +48,23 @@ vi.mock('mapbox-gl', () => ({
   ScaleControl: vi.fn(),
 }));
 
+vi.mock('maplibre-gl', () => ({
+  default: {
+    Map: MockMapboxMap,
+    Marker: class { setLngLat() { return this; } setPopup() { return this; } addTo() { return this; } remove() {} },
+    Popup: MockMapboxPopup,
+    NavigationControl: vi.fn(),
+    AttributionControl: vi.fn(),
+    ScaleControl: vi.fn(),
+  },
+  Map: MockMapboxMap,
+  Marker: class { setLngLat() { return this; } setPopup() { return this; } addTo() { return this; } remove() {} },
+  Popup: MockMapboxPopup,
+  NavigationControl: vi.fn(),
+  AttributionControl: vi.fn(),
+  ScaleControl: vi.fn(),
+}));
+
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 class MockMapboxMap {
+  _center = { lng: -119.5, lat: 46.3 };
   on(_event: string, layerOrHandler?: unknown, maybeHandler?: unknown) {
     const handler = typeof layerOrHandler === 'function'
       ? layerOrHandler
@@ -16,6 +17,7 @@ class MockMapboxMap {
   addSource() { return this; }
   getSource() { return undefined; }
   addLayer() { return this; }
+  getLayer() { return undefined; }
   setFilter() { return this; }
   setLayoutProperty() { return this; }
   setPaintProperty() { return this; }
@@ -23,7 +25,9 @@ class MockMapboxMap {
   removeFeatureState() { return this; }
   getCanvas() { return document.createElement('canvas'); }
   getBounds() { return { getWest: () => -120, getSouth: () => 46, getEast: () => -119, getNorth: () => 47 }; }
+  getCenter() { return this._center; }
   getZoom() { return 10; }
+  isStyleLoaded() { return true; }
   remove() {}
 }
 

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -13,6 +13,11 @@ class MockMapboxMap {
     return this;
   }
   off() { return this; }
+  once(_event: string, handler?: unknown) {
+    if (typeof handler === 'function') queueMicrotask(() => (handler as () => void)());
+    return this;
+  }
+  setStyle() { return this; }
   addControl() { return this; }
   addSource() { return this; }
   getSource() { return undefined; }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -34,6 +34,11 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./setupTests.vitest.ts'],
     retry: 2,
+    // Use forks instead of worker_threads to avoid a Node 24 / V8 background
+    // JIT crash (SIGABRT, exit 134) that surfaces when error-boundary tests
+    // trigger heavy string concatenation and the worker isolate is torn down
+    // before the TurboFan optimization task completes.
+    pool: 'forks',
     exclude: [
       '**/node_modules/**',
       '**/dist/**',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.1.0
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint@8.57.1)(prettier@3.7.4)
@@ -456,9 +456,9 @@ importers:
       lucide-react:
         specifier: ^0.540.0
         version: 0.540.0(react@18.3.1)
-      mapbox-gl:
-        specifier: 3.20.0
-        version: 3.20.0
+      maplibre-gl:
+        specifier: 5.24.0
+        version: 5.24.0
       monaco-editor:
         specifier: 0.52.2
         version: 0.52.2
@@ -525,6 +525,9 @@ importers:
       wait-on:
         specifier: ^8.0.4
         version: 8.0.5
+      wicket:
+        specifier: 1.3.8
+        version: 1.3.8
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -615,7 +618,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.1.0
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint@8.57.1)(prettier@3.7.4)
@@ -4193,20 +4196,37 @@ packages:
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
     engines: {node: '>= 0.6'}
 
-  '@mapbox/mapbox-gl-supported@3.0.0':
-    resolution: {integrity: sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==}
-
   '@mapbox/point-geometry@1.1.0':
     resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
 
-  '@mapbox/tiny-sdf@2.0.7':
-    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
   '@mapbox/unitbezier@0.0.1':
     resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
 
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
   '@mapbox/vector-tile@2.0.4':
     resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@6.1.0':
+    resolution: {integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.11':
+    resolution: {integrity: sha512-dKvjKdITw9d0y3ndGkSqLUEpWCizMtdq8NB06cHohH/JZ2sJoM7dClR9wzJLUWykjbw9RXDFmhjjNBnNW27mzw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -7066,9 +7086,6 @@ packages:
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
-  '@types/geojson-vt@3.2.5':
-    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
-
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -7160,9 +7177,6 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
-  '@types/pbf@3.0.5':
-    resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
@@ -7256,9 +7270,6 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
-
-  '@types/supercluster@7.1.3':
-    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/testing-library__jest-dom@5.14.9':
     resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
@@ -7729,6 +7740,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8490,9 +8502,6 @@ packages:
     resolution: {integrity: sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==}
     engines: {pnpm: '>=8'}
 
-  cheap-ruler@4.0.0:
-    resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
-
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
@@ -8920,9 +8929,6 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
-
-  csscolorparser@1.0.3:
-    resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -10376,9 +10382,6 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geojson-vt@4.0.2:
-    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -10541,9 +10544,6 @@ packages:
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-
-  grid-index@1.1.0:
-    resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -11443,6 +11443,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -11865,8 +11868,9 @@ packages:
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
-  mapbox-gl@3.20.0:
-    resolution: {integrity: sha512-+rVQkf6ymUlAEJiQBZy0OiamJvQN4Uk15mRHI98PRUSmRS40GOoLJyEZEG39LEUtvmzc7qGh+4ygZfJ//O5VnQ==}
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-it@12.3.2:
     resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
@@ -11874,9 +11878,6 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
-
-  martinez-polygon-clipping@0.8.1:
-    resolution: {integrity: sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==}
 
   match-sorter@6.3.4:
     resolution: {integrity: sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==}
@@ -12685,6 +12686,10 @@ packages:
 
   pbf@4.0.1:
     resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
+  pbf@5.1.0:
+    resolution: {integrity: sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==}
     hasBin: true
 
   pe-library@0.4.1:
@@ -13684,9 +13689,6 @@ packages:
     resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
     engines: {node: '>=10.0.0'}
 
-  robust-predicates@2.0.4:
-    resolution: {integrity: sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==}
-
   rollup-plugin-visualizer@5.14.0:
     resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
     engines: {node: '>=18'}
@@ -14026,9 +14028,6 @@ packages:
     resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
     engines: {node: '>=8.0'}
 
-  splaytree@0.1.4:
-    resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
-
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -14252,9 +14251,6 @@ packages:
 
   super-three@0.173.5:
     resolution: {integrity: sha512-ecjojbhUg/5QrixwqF4s6gvtJap9XQz7TcnFUX/J8Yosgb2eE2ZUqsyqr/JczFG//6hwIaZPeAa9M5DNaM1dmQ==}
-
-  supercluster@8.0.1:
-    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -15308,6 +15304,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wicket@1.3.8:
+    resolution: {integrity: sha512-+UZsrBvp8OI+8PhStpXQw0oJedaCLncZwu7lPdcZ9BpUsyu25rztzHG+IwXGK372nuDGp+Wy4FreM/rzdWYJAg==}
 
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
@@ -18047,19 +18046,44 @@ snapshots:
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
-  '@mapbox/mapbox-gl-supported@3.0.0': {}
-
   '@mapbox/point-geometry@1.1.0': {}
 
-  '@mapbox/tiny-sdf@2.0.7': {}
+  '@mapbox/tiny-sdf@2.2.0': {}
 
   '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
 
   '@mapbox/vector-tile@2.0.4':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
       pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@6.1.0':
+    dependencies:
+      kdbush: 4.0.2
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.11':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.0
 
   '@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
@@ -23276,10 +23300,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.11
 
-  '@types/geojson-vt@3.2.5':
-    dependencies:
-      '@types/geojson': 7946.0.16
-
   '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
@@ -23383,8 +23403,6 @@ snapshots:
   '@types/pako@2.0.4': {}
 
   '@types/parse-json@4.0.2': {}
-
-  '@types/pbf@3.0.5': {}
 
   '@types/pg@8.11.6':
     dependencies:
@@ -23506,10 +23524,6 @@ snapshots:
   '@types/stats.js@0.17.4': {}
 
   '@types/statuses@2.0.6': {}
-
-  '@types/supercluster@7.1.3':
-    dependencies:
-      '@types/geojson': 7946.0.16
 
   '@types/testing-library__jest-dom@5.14.9':
     dependencies:
@@ -25172,8 +25186,6 @@ snapshots:
     dependencies:
       '@kurkle/color': 0.3.4
 
-  cheap-ruler@4.0.0: {}
-
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
@@ -25663,8 +25675,6 @@ snapshots:
   css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
-
-  csscolorparser@1.0.3: {}
 
   cssesc@3.0.0: {}
 
@@ -26674,7 +26684,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26689,7 +26699,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -27388,8 +27398,6 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  geojson-vt@4.0.2: {}
-
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
@@ -27598,8 +27606,6 @@ snapshots:
       iterall: 1.3.0
 
   graphql@16.12.0: {}
-
-  grid-index@1.1.0: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -28718,6 +28724,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json-stringify-safe@5.0.1:
     optional: true
 
@@ -29203,31 +29211,26 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
-  mapbox-gl@3.20.0:
+  maplibre-gl@5.24.0:
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/mapbox-gl-supported': 3.0.0
       '@mapbox/point-geometry': 1.1.0
-      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/tiny-sdf': 2.2.0
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.11
+      '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
-      '@types/geojson-vt': 3.2.5
-      '@types/pbf': 3.0.5
-      '@types/supercluster': 7.1.3
-      cheap-ruler: 4.0.0
-      csscolorparser: 1.0.3
       earcut: 3.0.2
-      geojson-vt: 4.0.2
       gl-matrix: 3.4.4
-      grid-index: 1.1.0
       kdbush: 4.0.2
-      martinez-polygon-clipping: 0.8.1
       murmurhash-js: 1.0.0
       pbf: 4.0.1
       potpack: 2.1.0
       quickselect: 3.0.0
-      supercluster: 8.0.1
       tinyqueue: 3.0.0
 
   markdown-it@12.3.2:
@@ -29239,12 +29242,6 @@ snapshots:
       uc.micro: 1.0.6
 
   marky@1.3.0: {}
-
-  martinez-polygon-clipping@0.8.1:
-    dependencies:
-      robust-predicates: 2.0.4
-      splaytree: 0.1.4
-      tinyqueue: 3.0.0
 
   match-sorter@6.3.4:
     dependencies:
@@ -30085,6 +30082,10 @@ snapshots:
   pathval@2.0.1: {}
 
   pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.0:
     dependencies:
       resolve-protobuf-schema: 2.1.0
 
@@ -31272,8 +31273,6 @@ snapshots:
 
   robots-parser@3.0.1: {}
 
-  robust-predicates@2.0.4: {}
-
   rollup-plugin-visualizer@5.14.0(rollup@4.54.0):
     dependencies:
       open: 8.4.2
@@ -31711,8 +31710,6 @@ snapshots:
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 
-  splaytree@0.1.4: {}
-
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -31954,10 +31951,6 @@ snapshots:
   super-animejs@3.1.0: {}
 
   super-three@0.173.5: {}
-
-  supercluster@8.0.1:
-    dependencies:
-      kdbush: 4.0.2
 
   supports-color@5.5.0:
     dependencies:
@@ -33280,6 +33273,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wicket@1.3.8: {}
 
   wide-align@1.1.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Migrate TerraAtlas from Mapbox GL to MapLibre GL JS per ADR-0021 stack lock (no token required)
- Implement BASEMAP_STYLES inline `StyleSpecification` objects (ESRI World Imagery satellite + OSM streets)
- Add toggleable property context overlay showing zoning, flood zone, tax area, land class
- Add session state persistence (`sessionStorage` keyed by parcel ID)
- Harden map mount/unmount lifecycle: eliminate re-mount on basemap switch, fix stale closures
- Session persistence contract tests (5/5 green)

## Commits

- `284913156` feat(atlas): swap Mapbox GL → MapLibre GL JS in PropertyAtlas (ADR-0021)
- `808648509` test(atlas): add session persistence contract tests
- `1f0196765` refactor(gis): migrate remaining mapbox-gl consumers to MapLibre
- `5bc566e4a` feat(atlas): finalize MapLibre baseline and close TA-002 parcel slice
- `c0e38da1f` perf(atlas): eliminate map re-mount on basemap switch, fix stale closures
- `60cdc7a36` feat(atlas): add toggleable property context overlay on map surface (TA-004)

## Scope

- **PropertyAtlas.tsx** — full MapLibre migration + context overlay + session persistence
- **BentonCountyMap.tsx, GeoForgeMap.tsx, GeoForgeV2Map.tsx** — partial MapLibre migration (TA-002.2)
- **PropertyAtlas.session.test.tsx** — new test file (session persistence contract)
- **package.json / pnpm-lock.yaml** — maplibre-gl 5.24.0 added

## Not in scope

- PHASE6 Home GIS full reconciliation (separate work order)
- GeoForge v1/v2 deep migration (30+ mapboxgl type refs each)
- No Mapbox token added; no production secrets changed

## Test plan

- [x] 164 unit tests passing (pre-push gate)
- [x] Backend build: 0 warnings, 0 errors
- [x] Session persistence: 5/5 contract tests green
- [x] Cherry-picked cleanly onto current main (zero conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate GIS map surfaces from Mapbox GL to MapLibre and introduce richer parcel context and stateful UX in PropertyAtlas.

New Features:
- Add inline MapLibre basemap styles for satellite imagery and OSM streets in PropertyAtlas.
- Introduce a toggleable parcel context overlay showing zoning, flood, tax area, and land class metadata on the atlas map.
- Persist per-parcel map session state (center, zoom, basemap, boundary/context toggles) in sessionStorage for PropertyAtlas.

Enhancements:
- Refine PropertyAtlas map lifecycle to reuse a single MapLibre instance across basemap switches and avoid stale event handlers.
- Update GeoForge and BentonCounty map views to use MapLibre with token-free satellite/streets styles and simplified UX copy.
- Enhance test MapLibre mocking to support new map APIs and geometry rendering behaviors.

Build:
- Replace mapbox-gl dependency with maplibre-gl and add wicket to the frontend dependencies.

Tests:
- Add PropertyAtlas session persistence contract tests covering per-parcel state save/restore flows.
- Tighten BentonCountyMap integration tests to assert consistent map wrapper rendering under the new MapLibre setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PropertyAtlas now saves/restores per-parcel map settings (basemap, boundary visibility, map view) and adds the Parcel Context overlay.

* **Improvements**
  * Updated Forge and Benton County maps to use MapLibre GL instead of Mapbox GL, with updated basemap styling and removed Mapbox token gating.

* **Tests**
  * Refreshed map integration/session persistence tests and MapLibre-based test mocks to match the new map setup.

* **Chores**
  * Updated frontend mapping dependencies and adjusted Vitest to use fork-based workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->