### PR TITLE
test(workbench): recut parcel load suppression contract

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.productionSmoke.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.productionSmoke.test.tsx
@@ -12,11 +12,21 @@ const navigateMock = vi.fn();
 const storeState: {
   activeParcel: unknown;
   activeParcelLoading: boolean;
+  activeParcelLoadingParcelId: string | null;
   activeParcelError: { status?: number; message: string; path?: string } | null;
 } = {
   activeParcel: null,
   activeParcelLoading: false,
+  activeParcelLoadingParcelId: null,
   activeParcelError: null,
+};
+
+const authState = {
+  isAuthenticated: true,
+  countyId: 'benton',
+  userId: 'u-smoke',
+  roles: ['Assessor'],
+  token: 'jwt' as string | null,
 };
 
 vi.mock('../../stores/propertyStore', () => ({
@@ -42,13 +52,7 @@ vi.mock('../../auth/useSession', () => ({
 }));
 
 vi.mock('../../auth/useAuthContext', () => ({
-  useAuthContext: () => ({
-    isAuthenticated: true,
-    countyId: 'benton',
-    userId: 'u-smoke',
-    roles: ['Assessor'],
-    token: 'jwt',
-  }),
+  useAuthContext: () => authState,
   toOsActor: () => ({ countyId: 'benton', userId: 'u-smoke', roles: ['Assessor'] }),
 }));
 
@@ -96,8 +100,36 @@ describe('PropertyWorkbench production smoke blockers', () => {
     Object.assign(storeState, {
       activeParcel: null,
       activeParcelLoading: false,
+      activeParcelLoadingParcelId: null,
       activeParcelError: null,
     });
+    Object.assign(authState, {
+      isAuthenticated: true,
+      countyId: 'benton',
+      userId: 'u-smoke',
+      roles: ['Assessor'],
+      token: 'jwt',
+    });
+  });
+
+  it('loads the route parcel through the store without requiring a Workbench bootstrap token', () => {
+    authState.token = null;
+
+    renderWorkbench();
+
+    expect(screen.queryByTestId('workbench-auth-bootstrap')).not.toBeInTheDocument();
+    expect(selectParcelMock).toHaveBeenCalledTimes(1);
+    expect(selectParcelMock).toHaveBeenCalledWith('GATE-TEST-001');
+  });
+
+  it('does not duplicate the same parcel load while it is already in flight', () => {
+    storeState.activeParcelLoading = true;
+    storeState.activeParcelLoadingParcelId = 'GATE-TEST-001';
+
+    renderWorkbench();
+
+    expect(screen.getByText(/Loading property GATE-TEST-001/i)).toBeInTheDocument();
+    expect(selectParcelMock).not.toHaveBeenCalled();
   });
 
   it('renders a hard property evidence blocker when authenticated parcel load returns 401', () => {


### PR DESCRIPTION
## Summary
- Recut the #927 Workbench parcel-load fix from current `main` without carrying the stale stacked branch history.
- Current `main` already contains the runtime guard: route-driven `selectParcel(parcelId)`, no Workbench auth-bootstrap blocker, in-flight parcel-load dedupe, and hard evidence blocker rendering.
- This PR locks that narrow behavior in the current topology by extending the existing Workbench production smoke contract.

## Scope
- Touches only `frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.productionSmoke.test.tsx`.
- Excludes backend, migrations, pilot, package, and old stacked-branch changes from #927.

## Verification
- `pnpm exec vitest run frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbench.productionSmoke.test.tsx`
- `pnpm run type-check`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- pre-push hook: unit tests, security scan, performance benchmark, AI monitor, government compliance lint, backend build, frontend build

Supersedes #927.

## Summary by Sourcery

Extend the PropertyWorkbench production smoke test to lock in current parcel-load behavior around auth and in-flight requests.

Tests:
- Add coverage to ensure route-driven parcel selection occurs without requiring a Workbench bootstrap token.
- Add coverage to ensure duplicate parcel loads are suppressed while a parcel load for the same ID is already in flight.