### PR TITLE
ops(control-panel): add static report intake contract

### DIFF
--- a/ops/control-panel/README.md
+++ b/ops/control-panel/README.md
@@ -38,6 +38,7 @@ Automations run
 |------|------|
 | `control-panel.spec.json` | Control panel lanes, status model, and authority boundaries |
 | `report-schema.json` | Expected report sections for the six monitoring automations |
+| `report-intake.spec.json` | Accepted static report intake contract, lane mapping, evidence metadata, and rejection rules |
 | `launch-actions.json` | Prompt-launch actions and scoped Work Order templates |
 | `index.html` | Static read-only mockup for operator review |
 
@@ -51,6 +52,61 @@ This seed version is prompt-launch only:
 - It does not call local agent commands.
 - It does not call the Codex scheduler.
 - It does not write report state back to the repo.
+
+## Report Intake Contract
+
+Reports are static monitor outputs reviewed by a human operator before they influence Work Orders. The accepted shape is defined in `report-intake.spec.json`.
+
+The intake contract defines:
+
+- Report identity metadata: `reportId`, `monitorId`, `monitorName`, `generatedAt`, source details, workspace, branch, and optional commit SHA.
+- Monitor lane mapping for the six approved monitor IDs.
+- Severity values: `P0`, `P1`, `P2`, `Deferred`, `Decision`, and `Info`.
+- Status values: `new`, `reviewed`, `converted-to-wo`, `deferred`, `blocked`, `resolved`, and `rejected`.
+- Required report sections: `summary`, `findings`, `evidence`, `recommendedActions`, `humanDecisionsRequired`, `blockers`, and `nextSafeAction`.
+- Evidence metadata for commands, paths, excerpts, timestamps, confidence, and notes.
+
+Approved monitor IDs map to lanes as follows:
+
+| Monitor ID | Lane |
+|------------|------|
+| `terrafusion-daily-pulse` | `daily-pulse` |
+| `work-order-and-todo-tracker` | `work-orders` |
+| `governance-drift-monitor` | `governance-drift` |
+| `ai-sidecar-governance-monitor` | `ai-sidecar` |
+| `ci-azure-pipeline-health-monitor` | `ci-azure` |
+| `project-gap-and-risk-register-monitor` | `gap-risk` |
+
+Severity meanings:
+
+| Severity | Meaning |
+|----------|---------|
+| `P0` | Stop work / containment |
+| `P1` | Next execution |
+| `P2` | Planned |
+| `Deferred` | Explicitly not now |
+| `Decision` | Needs Bill / human decision |
+| `Info` | Informational only |
+
+Reports or findings are rejected if they ask the Control Panel to execute commands, activate automations, read local files live, fetch files or APIs from HTML, mutate repo state, change queue truth, promote canon, claim runtime authority, create a second Brain/Cortex or autonomous queue, lack required identity metadata, lack evidence for `P0` or `P1` claims, or include secret, credential, county data, PACS, owner-sensitive, appeals, exemptions, valuation evidence, or protected data content.
+
+A report becomes a proposed Work Order only through human review:
+
+```text
+report remains evidence/input
+-> human reviews finding
+-> Control Panel prepares a Work Order prompt
+-> separate Work Order authorizes any mutation
+-> report status may be marked converted-to-wo only by human review
+```
+
+Recommended report filename:
+
+```text
+YYYYMMDDTHHMMSSZ__<monitorId>__<reportId>.json
+```
+
+Report intake is manual/static until a later approved Work Order. This contract does not create live ingestion, read files, activate automations, add runtime wiring, add HTML fetch calls, or create a new control plane.
 
 ## Workspace Placeholders
 

--- a/ops/control-panel/README.md
+++ b/ops/control-panel/README.md
@@ -61,7 +61,7 @@ The intake contract defines:
 
 - Report identity metadata: `reportId`, `monitorId`, `monitorName`, `generatedAt`, source details, workspace, branch, and optional commit SHA.
 - Monitor lane mapping for the six approved monitor IDs.
-- Severity values: `P0`, `P1`, `P2`, `Deferred`, `Decision`, and `Info`.
+- Severity values: `P0`, `P1`, `P2`, `Deferred`, `Needs Decision`, and `Info`.
 - Status values: `new`, `reviewed`, `converted-to-wo`, `deferred`, `blocked`, `resolved`, and `rejected`.
 - Required report sections: `summary`, `findings`, `evidence`, `recommendedActions`, `humanDecisionsRequired`, `blockers`, and `nextSafeAction`.
 - Evidence metadata for commands, paths, excerpts, timestamps, confidence, and notes.
@@ -71,11 +71,11 @@ Approved monitor IDs map to lanes as follows:
 | Monitor ID | Lane |
 |------------|------|
 | `terrafusion-daily-pulse` | `daily-pulse` |
-| `work-order-and-todo-tracker` | `work-orders` |
+| `work-order-and-todo-tracker` | `open-work-orders` |
 | `governance-drift-monitor` | `governance-drift` |
 | `ai-sidecar-governance-monitor` | `ai-sidecar` |
-| `ci-azure-pipeline-health-monitor` | `ci-azure` |
-| `project-gap-and-risk-register-monitor` | `gap-risk` |
+| `ci-azure-pipeline-health-monitor` | `ci-azure-health` |
+| `project-gap-and-risk-register-monitor` | `gap-risk-register` |
 
 Severity meanings:
 
@@ -85,7 +85,7 @@ Severity meanings:
 | `P1` | Next execution |
 | `P2` | Planned |
 | `Deferred` | Explicitly not now |
-| `Decision` | Needs Bill / human decision |
+| `Needs Decision` | Needs Bill / human decision |
 | `Info` | Informational only |
 
 Reports or findings are rejected if they ask the Control Panel to execute commands, activate automations, read local files live, fetch files or APIs from HTML, mutate repo state, change queue truth, promote canon, claim runtime authority, create a second Brain/Cortex or autonomous queue, lack required identity metadata, lack evidence for `P0` or `P1` claims, or include secret, credential, county data, PACS, owner-sensitive, appeals, exemptions, valuation evidence, or protected data content.

--- a/ops/control-panel/examples/report-intake.example.json
+++ b/ops/control-panel/examples/report-intake.example.json
@@ -1,0 +1,53 @@
+{
+  "reportId": "rpt-gov-0001",
+  "monitorId": "governance-drift-monitor",
+  "monitorName": "Governance Drift Monitor",
+  "generatedAt": "2026-06-23T14:30:00Z",
+  "sourceType": "manual-paste",
+  "sourceRunId": null,
+  "sourceRunUrl": null,
+  "workspace": "${TERRAFUSION_WORKSPACE}",
+  "branch": "codex/example-read-only",
+  "commitSha": "0000000000000000000000000000000000000000",
+  "status": "new",
+  "summary": "Synthetic example report showing accepted report intake shape. No protected data is included.",
+  "findings": [
+    {
+      "findingId": "find-gov-0001",
+      "title": "Static authority wording needs review",
+      "severity": "Decision",
+      "lane": "governance-drift",
+      "description": "Synthetic finding: a document title may sound authoritative and should be reviewed before planning depends on it.",
+      "evidenceRefs": [
+        "ev-gov-0001"
+      ],
+      "affectedPaths": [
+        "docs/example-authority-note.md"
+      ],
+      "proposedAction": "Prepare a scoped Work Order prompt for human review.",
+      "proposedWorkOrderId": "WO-CANON-EXAMPLE",
+      "rejectionReason": null
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "ev-gov-0001",
+      "type": "human-note",
+      "source": "Synthetic example only",
+      "path": "docs/example-authority-note.md",
+      "command": null,
+      "excerpt": "Example excerpt without protected content.",
+      "timestamp": "2026-06-23T14:30:00Z",
+      "confidence": "medium",
+      "notes": "This example is safe for documentation because it contains no operational data."
+    }
+  ],
+  "recommendedActions": [
+    "Prepare a Work Order prompt; do not mutate files from the Control Panel."
+  ],
+  "humanDecisionsRequired": [
+    "Decide whether this synthetic authority wording would require a doc cleanup Work Order."
+  ],
+  "blockers": [],
+  "nextSafeAction": "Human reviews the finding and decides whether to prepare a Work Order prompt."
+}

--- a/ops/control-panel/examples/report-intake.example.json
+++ b/ops/control-panel/examples/report-intake.example.json
@@ -15,7 +15,7 @@
     {
       "findingId": "find-gov-0001",
       "title": "Static authority wording needs review",
-      "severity": "Decision",
+      "severity": "Needs Decision",
       "lane": "governance-drift",
       "description": "Synthetic finding: a document title may sound authoritative and should be reviewed before planning depends on it.",
       "evidenceRefs": [

--- a/ops/control-panel/examples/report-intake.rejected.example.json
+++ b/ops/control-panel/examples/report-intake.rejected.example.json
@@ -1,0 +1,45 @@
+{
+  "reportId": "rpt-reject-0001",
+  "monitorId": "governance-drift-monitor",
+  "monitorName": "Governance Drift Monitor",
+  "generatedAt": "2026-06-23T14:45:00Z",
+  "sourceType": "manual-paste",
+  "workspace": "${TERRAFUSION_WORKSPACE}",
+  "branch": "codex/example-read-only",
+  "status": "rejected",
+  "summary": "Synthetic rejected example. It is rejected because it asks the Control Panel to execute a command.",
+  "findings": [
+    {
+      "findingId": "find-reject-0001",
+      "title": "Rejected command execution request",
+      "severity": "P1",
+      "lane": "governance-drift",
+      "description": "This synthetic finding is rejected because the proposed action asks the Control Panel to execute a command.",
+      "evidenceRefs": [
+        "ev-reject-0001"
+      ],
+      "affectedPaths": [],
+      "proposedAction": "Execute a command from the Control Panel.",
+      "proposedWorkOrderId": null,
+      "rejectionReason": "Control Panel must not execute commands; it may only prepare governed prompts and decision packets."
+    }
+  ],
+  "evidence": [
+    {
+      "evidenceId": "ev-reject-0001",
+      "type": "human-note",
+      "source": "Synthetic example only",
+      "timestamp": "2026-06-23T14:45:00Z",
+      "confidence": "verified",
+      "notes": "No protected data is included."
+    }
+  ],
+  "recommendedActions": [],
+  "humanDecisionsRequired": [
+    "Confirm rejection and request a prepare-only report if the finding is still relevant."
+  ],
+  "blockers": [
+    "Report violates the Control Panel authority boundary."
+  ],
+  "nextSafeAction": "Reject this report and request a compliant static report."
+}

--- a/ops/control-panel/report-intake.spec.json
+++ b/ops/control-panel/report-intake.spec.json
@@ -68,19 +68,19 @@
     ],
     "allowedLanes": [
       "daily-pulse",
-      "work-orders",
+      "open-work-orders",
       "governance-drift",
       "ai-sidecar",
-      "ci-azure",
-      "gap-risk"
+      "ci-azure-health",
+      "gap-risk-register"
     ],
     "mapping": {
       "terrafusion-daily-pulse": "daily-pulse",
-      "work-order-and-todo-tracker": "work-orders",
+      "work-order-and-todo-tracker": "open-work-orders",
       "governance-drift-monitor": "governance-drift",
       "ai-sidecar-governance-monitor": "ai-sidecar",
-      "ci-azure-pipeline-health-monitor": "ci-azure",
-      "project-gap-and-risk-register-monitor": "gap-risk"
+      "ci-azure-pipeline-health-monitor": "ci-azure-health",
+      "project-gap-and-risk-register-monitor": "gap-risk-register"
     }
   },
   "severityModel": {
@@ -89,7 +89,7 @@
       "P1",
       "P2",
       "Deferred",
-      "Decision",
+      "Needs Decision",
       "Info"
     ],
     "meanings": {
@@ -97,7 +97,7 @@
       "P1": "Next execution.",
       "P2": "Planned.",
       "Deferred": "Explicitly not now.",
-      "Decision": "Needs Bill / human decision.",
+      "Needs Decision": "Needs Bill / human decision.",
       "Info": "Informational only."
     }
   },

--- a/ops/control-panel/report-intake.spec.json
+++ b/ops/control-panel/report-intake.spec.json
@@ -1,0 +1,250 @@
+{
+  "id": "terrafusion-control-panel-report-intake",
+  "version": 1,
+  "status": "seed-contract",
+  "authorityBoundary": {
+    "mode": "static_report_contract_only",
+    "controlPanelRole": "cockpit_prepare_console_findings_viewer",
+    "notBrainOrCortex": true,
+    "notAutonomousQueue": true,
+    "notRuntimeAgent": true,
+    "scopeStatement": [
+      "This spec does not create live ingestion.",
+      "This spec does not read files.",
+      "This spec does not activate automations.",
+      "This spec does not add runtime wiring.",
+      "This spec does not create a new control plane.",
+      "This spec only defines the accepted report contract."
+    ],
+    "forbiddenCapabilities": [
+      "execute commands from the Control Panel",
+      "activate automations",
+      "read local files live from HTML",
+      "fetch files or APIs from HTML",
+      "mutate repo state",
+      "change queue truth",
+      "promote canon",
+      "claim runtime authority",
+      "create a second Brain or Cortex",
+      "create an autonomous queue"
+    ]
+  },
+  "reportIdentity": {
+    "required": [
+      "reportId",
+      "monitorId",
+      "monitorName",
+      "generatedAt",
+      "sourceType",
+      "workspace",
+      "branch"
+    ],
+    "optional": [
+      "sourceRunId",
+      "sourceRunUrl",
+      "commitSha"
+    ],
+    "fieldDescriptions": {
+      "reportId": "Stable unique report identifier within the monitor output stream.",
+      "monitorId": "One of the allowed monitor identifiers.",
+      "monitorName": "Human-readable monitor name.",
+      "generatedAt": "UTC ISO-8601 timestamp for report generation.",
+      "sourceType": "Manual paste, saved automation report, human-entered summary, or other approved static source.",
+      "sourceRunId": "Optional automation run identifier when available.",
+      "sourceRunUrl": "Optional URL to source run evidence when available.",
+      "workspace": "Workspace inspected by the monitor.",
+      "branch": "Branch inspected by the monitor.",
+      "commitSha": "Commit SHA inspected by the monitor when available."
+    }
+  },
+  "monitorLaneMapping": {
+    "allowedMonitorIds": [
+      "terrafusion-daily-pulse",
+      "work-order-and-todo-tracker",
+      "governance-drift-monitor",
+      "ai-sidecar-governance-monitor",
+      "ci-azure-pipeline-health-monitor",
+      "project-gap-and-risk-register-monitor"
+    ],
+    "allowedLanes": [
+      "daily-pulse",
+      "work-orders",
+      "governance-drift",
+      "ai-sidecar",
+      "ci-azure",
+      "gap-risk"
+    ],
+    "mapping": {
+      "terrafusion-daily-pulse": "daily-pulse",
+      "work-order-and-todo-tracker": "work-orders",
+      "governance-drift-monitor": "governance-drift",
+      "ai-sidecar-governance-monitor": "ai-sidecar",
+      "ci-azure-pipeline-health-monitor": "ci-azure",
+      "project-gap-and-risk-register-monitor": "gap-risk"
+    }
+  },
+  "severityModel": {
+    "allowedSeverities": [
+      "P0",
+      "P1",
+      "P2",
+      "Deferred",
+      "Decision",
+      "Info"
+    ],
+    "meanings": {
+      "P0": "Stop work / containment.",
+      "P1": "Next execution.",
+      "P2": "Planned.",
+      "Deferred": "Explicitly not now.",
+      "Decision": "Needs Bill / human decision.",
+      "Info": "Informational only."
+    }
+  },
+  "statusModel": {
+    "allowedStatuses": [
+      "new",
+      "reviewed",
+      "converted-to-wo",
+      "deferred",
+      "blocked",
+      "resolved",
+      "rejected"
+    ],
+    "humanOnlyStatuses": [
+      "reviewed",
+      "converted-to-wo",
+      "deferred",
+      "resolved"
+    ]
+  },
+  "requiredReportStructure": {
+    "required": [
+      "summary",
+      "findings",
+      "evidence",
+      "recommendedActions",
+      "humanDecisionsRequired",
+      "blockers",
+      "nextSafeAction"
+    ],
+    "fields": {
+      "summary": "Short operator-readable result summary.",
+      "findings": "Array of finding objects.",
+      "evidence": "Array of evidence metadata objects.",
+      "recommendedActions": "Array of prepare-only recommended actions.",
+      "humanDecisionsRequired": "Array of decisions that require human review.",
+      "blockers": "Array of blocker descriptions.",
+      "nextSafeAction": "Single next action that preserves the Control Panel authority boundary."
+    }
+  },
+  "findingStructure": {
+    "required": [
+      "findingId",
+      "title",
+      "severity",
+      "lane",
+      "description",
+      "evidenceRefs",
+      "affectedPaths",
+      "proposedAction"
+    ],
+    "optional": [
+      "proposedWorkOrderId",
+      "rejectionReason"
+    ],
+    "fields": {
+      "findingId": "Stable finding identifier within the report.",
+      "title": "Short finding title.",
+      "severity": "One of the allowed severity values.",
+      "lane": "One of the allowed lanes.",
+      "description": "Finding details without protected data content.",
+      "evidenceRefs": "Array of evidenceId references.",
+      "affectedPaths": "Array of repo or workspace paths, if relevant and safe to disclose.",
+      "proposedAction": "Prepare-only next action.",
+      "proposedWorkOrderId": "Optional Work Order identifier proposed by the monitor.",
+      "rejectionReason": "Required when the finding status is rejected."
+    }
+  },
+  "evidenceMetadata": {
+    "required": [
+      "evidenceId",
+      "type",
+      "source",
+      "timestamp",
+      "confidence"
+    ],
+    "optional": [
+      "path",
+      "command",
+      "excerpt",
+      "notes"
+    ],
+    "fields": {
+      "evidenceId": "Stable evidence identifier referenced by findings.",
+      "type": "file-path, command-output, run-url, human-note, schema-check, or other static evidence type.",
+      "source": "Source report, static path, run URL, or human note.",
+      "path": "Optional path to non-sensitive evidence.",
+      "command": "Optional command that produced evidence; descriptive only, not executable by the Control Panel.",
+      "excerpt": "Short non-sensitive excerpt.",
+      "timestamp": "UTC ISO-8601 timestamp for the evidence.",
+      "confidence": "low, medium, high, or verified.",
+      "notes": "Additional non-sensitive operator notes."
+    }
+  },
+  "rejectionRules": {
+    "reportOrFindingMustBeRejectedIf": [
+      "asks the Control Panel to execute commands",
+      "asks the Control Panel to activate automations",
+      "asks the Control Panel to read local files live",
+      "asks the HTML page to fetch files or APIs",
+      "mutates repo state",
+      "changes queue truth",
+      "promotes canon",
+      "claims runtime authority",
+      "creates a second Brain/Cortex or autonomous queue",
+      "lacks required identity metadata",
+      "lacks evidence for P0/P1 claims",
+      "contains secret content",
+      "contains credential content",
+      "contains county data",
+      "contains PACS data",
+      "contains owner-sensitive records",
+      "contains appeals data",
+      "contains exemptions data",
+      "contains valuation evidence",
+      "contains protected data content"
+    ],
+    "p0P1EvidenceRule": "P0 and P1 findings require at least one evidenceRef that resolves to an evidence entry.",
+    "protectedDataRule": "Use metadata, redacted path references, or synthetic examples only. Do not include protected operational data in report intake examples."
+  },
+  "conversionRule": {
+    "steps": [
+      "report remains evidence/input",
+      "human reviews finding",
+      "Control Panel prepares a Work Order prompt",
+      "separate Work Order authorizes any mutation",
+      "report status may be marked converted-to-wo only by human review, not automatically"
+    ],
+    "automaticConversionAllowed": false,
+    "mutationRequiresSeparateWorkOrder": true
+  },
+  "namingConvention": {
+    "recommendedFilename": "YYYYMMDDTHHMMSSZ__<monitorId>__<reportId>.json",
+    "timestampFormat": "UTC basic ISO-8601 without separators, for example 20260623T143000Z",
+    "examples": [
+      "20260623T143000Z__governance-drift-monitor__rpt-gov-0001.json",
+      "20260623T150000Z__terrafusion-daily-pulse__rpt-pulse-0001.json"
+    ]
+  },
+  "acceptedSourceTypes": [
+    "manual-paste",
+    "saved-static-report",
+    "human-entered-summary",
+    "automation-run-summary"
+  ],
+  "exampleFiles": {
+    "accepted": "ops/control-panel/examples/report-intake.example.json",
+    "rejected": "ops/control-panel/examples/report-intake.rejected.example.json"
+  }
+}

--- a/ops/packets/WO-OPS-CP-002.md
+++ b/ops/packets/WO-OPS-CP-002.md
@@ -1,0 +1,138 @@
+# WO-OPS-CP-002 - Attach Report Intake Format to Operations Control Panel
+
+## RESULT
+
+Implemented as a static report-intake contract only.
+
+## OBJECTIVE
+
+Extend the TerraFusion Operations Control Panel with an accepted report shape, naming convention, lane mapping, evidence metadata model, severity/status model, rejection rules, and Work Order conversion rules.
+
+This Work Order does not add implementation wiring.
+
+## AUTHORITY_BOUNDARY
+
+The Operations Control Panel remains a read-only cockpit / prepare console / findings viewer. It is not a TerraFusion Brain, Cortex, autonomous queue, runtime agent, scheduler, or mutation path.
+
+This WO does not authorize:
+
+- live execution
+- automation activation
+- file mutation from HTML
+- fetch calls
+- runtime wiring
+- a new control plane
+- canon promotion
+- queue truth changes
+- Brain/Cortex authority changes
+
+## AUTHORIZED_PATHS
+
+- `ops/control-panel/**`
+- `ops/packets/WO-OPS-CP-002.md`
+
+## FILES_CREATED
+
+- `ops/control-panel/report-intake.spec.json`
+- `ops/control-panel/examples/report-intake.example.json`
+- `ops/control-panel/examples/report-intake.rejected.example.json`
+- `ops/packets/WO-OPS-CP-002.md`
+
+## FILES_MODIFIED
+
+- `ops/control-panel/README.md`
+
+## RUNTIME_CODE_CHANGED
+
+No.
+
+## AUTOMATION_BEHAVIOR_CHANGED
+
+No.
+
+## CONTROL_PANEL_BEHAVIOR_CHANGED
+
+No runtime behavior changed. The static documentation and JSON contract define the shape of acceptable report intake, but the HTML page does not read files, fetch APIs, execute commands, or update report state.
+
+## REPORT_CONTRACT_SUMMARY
+
+The report intake contract defines:
+
+- report identity metadata
+- approved monitor IDs
+- monitor-to-lane mapping
+- severity meanings
+- report statuses
+- required accepted report sections
+- finding structure
+- evidence metadata structure
+- rejection rules
+- conversion rules for report-to-Work-Order flow
+- recommended report filename convention
+
+Approved monitor IDs:
+
+- `terrafusion-daily-pulse`
+- `work-order-and-todo-tracker`
+- `governance-drift-monitor`
+- `ai-sidecar-governance-monitor`
+- `ci-azure-pipeline-health-monitor`
+- `project-gap-and-risk-register-monitor`
+
+Approved lanes:
+
+- `daily-pulse`
+- `work-orders`
+- `governance-drift`
+- `ai-sidecar`
+- `ci-azure`
+- `gap-risk`
+
+## REJECTION_RULES
+
+A report or finding must be rejected if it:
+
+- asks the Control Panel to execute commands
+- asks the Control Panel to activate automations
+- asks the Control Panel to read local files live
+- asks the HTML page to fetch files or APIs
+- mutates repo state
+- changes queue truth
+- promotes canon
+- claims runtime authority
+- creates a second Brain/Cortex or autonomous queue
+- lacks required identity metadata
+- lacks evidence for `P0` or `P1` claims
+- contains secret, credential, county data, PACS, owner-sensitive, appeals, exemptions, valuation evidence, or protected data content
+
+## VALIDATION_RUN
+
+Safe validation run:
+
+- JSON parse validation for all JSON files touched or created: passed
+- `git diff --check`: passed
+- scoped path review: passed
+
+Broad runtime builds are intentionally out of scope for this static report-contract WO unless local policy requires them.
+
+## EVIDENCE
+
+Evidence to attach at closeout:
+
+- JSON validation output: all control-panel JSON files parsed successfully
+- `git diff --check` output: no whitespace errors
+- scoped file list: changes are limited to `ops/control-panel/**` and `ops/packets/WO-OPS-CP-002.md`
+- HTML fetch/local file reads added: no
+- automation definitions or runtime wiring changed: no
+
+## OPEN_RISKS
+
+- The contract is static. It does not yet provide a rendered report intake view.
+- Human review remains required to mark reports reviewed, rejected, or converted to Work Orders.
+- Future display wiring must be authorized by a separate Work Order and preserve the prepare-only boundary.
+
+## NEXT_RECOMMENDED_WO
+
+`WO-OPS-CP-003 - Add Static Report Review View to Operations Control Panel`
+
+Scope should remain static display only unless a later human-approved Work Order explicitly authorizes controlled ingestion or execution wiring.

--- a/ops/packets/WO-OPS-CP-002.md
+++ b/ops/packets/WO-OPS-CP-002.md
@@ -82,11 +82,11 @@ Approved monitor IDs:
 Approved lanes:
 
 - `daily-pulse`
-- `work-orders`
+- `open-work-orders`
 - `governance-drift`
 - `ai-sidecar`
-- `ci-azure`
-- `gap-risk`
+- `ci-azure-health`
+- `gap-risk-register`
 
 ## REJECTION_RULES
 


### PR DESCRIPTION
## Summary

WO-OPS-CP-002 attaches a static report-intake contract to the Operations Control Panel. It defines accepted report shape, naming convention, lane mapping, evidence metadata, severity/status model, rejection rules, and Work Order conversion rules.

## Authority Boundary

This is report-contract only. It does not add live execution, automation activation, file mutation from HTML, fetch calls, runtime wiring, a new control plane, canon promotion, queue truth changes, or Brain/Cortex authority changes.

## Scope

- Updates ops/control-panel/README.md
- Adds ops/control-panel/report-intake.spec.json
- Adds ops/control-panel/examples/report-intake.example.json
- Adds ops/control-panel/examples/report-intake.rejected.example.json
- Adds ops/packets/WO-OPS-CP-002.md

## Validation

- JSON parse validation for all touched/created control-panel JSON files
- git diff --check
- scoped path review
- scan for HTML fetch/local file-read/command-execution API patterns

Broad runtime builds were intentionally not run because this WO is static/report-contract only and the requested validation scope excludes broad runtime builds unless required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established Report Intake Contract specification defining accepted report structure, metadata requirements, evidence standards, and rejection criteria for the Operations Control Panel.
  * Added comprehensive example files demonstrating proper report formatting and invalid submission scenarios.
  * Defined authority boundaries, approved monitor IDs, severity classifications, and report conversion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->