### PR TITLE
ops(control-panel): add manual report review index contract

### DIFF
--- a/ops/control-panel/README.md
+++ b/ops/control-panel/README.md
@@ -39,6 +39,7 @@ Automations run
 | `control-panel.spec.json` | Control panel lanes, status model, and authority boundaries |
 | `report-schema.json` | Expected report sections for the six monitoring automations |
 | `report-intake.spec.json` | Accepted static report intake contract, lane mapping, evidence metadata, and rejection rules |
+| `review-index.spec.json` | Manual report review ledger contract for accepted CP-002 reports |
 | `launch-actions.json` | Prompt-launch actions and scoped Work Order templates |
 | `index.html` | Static read-only mockup for operator review |
 
@@ -107,6 +108,25 @@ YYYYMMDDTHHMMSSZ__<monitorId>__<reportId>.json
 ```
 
 Report intake is manual/static until a later approved Work Order. This contract does not create live ingestion, read files, activate automations, add runtime wiring, add HTML fetch calls, or create a new control plane.
+
+## Manual Report Review Index
+
+CP-002 defines the accepted static report shape. CP-003 defines the manual review and disposition shape after an accepted report exists.
+
+The review index is maintained manually by the operator. The Control Panel does not discover reports, read report files, fetch APIs, execute commands, activate automations, mutate queue truth, promote canon, or create Brain/Cortex authority.
+
+Review records may link:
+
+- source report IDs and report filenames
+- monitor IDs and Control Panel lane IDs
+- finding IDs
+- evidence IDs or report evidence IDs
+- proposed Work Order IDs
+- created Work Order IDs after a human decision
+
+Final handling records whether a finding became evidence-only, proposed Work Order, created Work Order, deferred, rejected, blocked, resolved, or no-action.
+
+Only a later separate Work Order may authorize live ingestion, UI behavior, automation activation, runtime wiring, queue mutation, canon promotion, or any execution path.
 
 ## Workspace Placeholders
 

--- a/ops/control-panel/examples/review-index.example.json
+++ b/ops/control-panel/examples/review-index.example.json
@@ -1,0 +1,133 @@
+{
+  "reviewIndexVersion": 1,
+  "createdAt": "2026-06-23T16:00:00Z",
+  "updatedAt": "2026-06-23T16:30:00Z",
+  "maintainedBy": "human-operator",
+  "scope": "Synthetic manual review ledger for accepted CP-002 reports. No protected data is included.",
+  "sourceContract": "CP-002 report-intake contract",
+  "authorityBoundary": {
+    "mode": "manual_static_review_ledger_only",
+    "doesNotDiscoverReports": true,
+    "doesNotIngestReports": true,
+    "doesNotReadFiles": true,
+    "doesNotFetchApis": true,
+    "doesNotExecuteCommands": true,
+    "doesNotActivateAutomations": true,
+    "doesNotMutateQueueCanonOrRuntime": true,
+    "doesNotCreateBrainOrCortexAuthority": true
+  },
+  "reviewRecords": [
+    {
+      "reviewId": "rev-cp3-0001",
+      "reportId": "rpt-pulse-0001",
+      "reportFilename": "20260623T150000Z__terrafusion-daily-pulse__rpt-pulse-0001.json",
+      "monitorId": "terrafusion-daily-pulse",
+      "laneId": "daily-pulse",
+      "reviewedAt": "2026-06-23T16:05:00Z",
+      "reviewedBy": "human-operator",
+      "reviewStatus": "reviewed",
+      "disposition": "accept-as-evidence",
+      "severity": "Info",
+      "linkedFindingIds": [
+        "find-pulse-0001"
+      ],
+      "linkedEvidenceIds": [
+        "ev-pulse-0001"
+      ],
+      "proposedWorkOrderIds": [],
+      "createdWorkOrderIds": [],
+      "rejectedFindingIds": [],
+      "deferredFindingIds": [],
+      "blockedFindingIds": [],
+      "evidenceRefs": [
+        "ev-pulse-0001"
+      ],
+      "reportEvidenceIds": [
+        "ev-pulse-0001"
+      ],
+      "evidenceSummary": "Synthetic pulse report reviewed as evidence-only.",
+      "evidenceLocation": "ops/control-panel/examples/report-intake.example.json",
+      "confidence": "verified",
+      "workOrderStatus": null,
+      "notes": "No Work Order needed from this synthetic informational finding.",
+      "reviewerNotes": "Retain as evidence only.",
+      "finalHandling": "evidence-only"
+    },
+    {
+      "reviewId": "rev-cp3-0002",
+      "reportId": "rpt-gov-0001",
+      "reportFilename": "20260623T143000Z__governance-drift-monitor__rpt-gov-0001.json",
+      "monitorId": "governance-drift-monitor",
+      "laneId": "governance-drift",
+      "reviewedAt": "2026-06-23T16:15:00Z",
+      "reviewedBy": "human-operator",
+      "reviewStatus": "converted-to-wo",
+      "disposition": "prepare-work-order",
+      "severity": "Needs Decision",
+      "linkedFindingIds": [
+        "find-gov-0001"
+      ],
+      "linkedEvidenceIds": [
+        "ev-gov-0001"
+      ],
+      "proposedWorkOrderIds": [
+        "WO-CANON-EXAMPLE"
+      ],
+      "createdWorkOrderIds": [],
+      "rejectedFindingIds": [],
+      "deferredFindingIds": [],
+      "blockedFindingIds": [],
+      "evidenceRefs": [
+        "ev-gov-0001"
+      ],
+      "reportEvidenceIds": [
+        "ev-gov-0001"
+      ],
+      "evidenceSummary": "Synthetic authority wording finding needs human decision before any doc cleanup.",
+      "evidenceLocation": "docs/example-authority-note.md",
+      "confidence": "medium",
+      "workOrderStatus": "proposed",
+      "notes": "Prepared as a proposed Work Order ID only; no mutation is authorized by this record.",
+      "reviewerNotes": "Human must decide whether to create the Work Order.",
+      "finalHandling": "proposed-wo"
+    },
+    {
+      "reviewId": "rev-cp3-0003",
+      "reportId": "rpt-reject-0001",
+      "reportFilename": "20260623T144500Z__governance-drift-monitor__rpt-reject-0001.json",
+      "monitorId": "governance-drift-monitor",
+      "laneId": "governance-drift",
+      "reviewedAt": "2026-06-23T16:25:00Z",
+      "reviewedBy": "human-operator",
+      "reviewStatus": "rejected",
+      "disposition": "reject",
+      "severity": "P1",
+      "linkedFindingIds": [
+        "find-reject-0001"
+      ],
+      "linkedEvidenceIds": [
+        "ev-reject-0001"
+      ],
+      "proposedWorkOrderIds": [],
+      "createdWorkOrderIds": [],
+      "rejectedFindingIds": [
+        "find-reject-0001"
+      ],
+      "deferredFindingIds": [],
+      "blockedFindingIds": [],
+      "evidenceRefs": [
+        "ev-reject-0001"
+      ],
+      "reportEvidenceIds": [
+        "ev-reject-0001"
+      ],
+      "evidenceSummary": "Synthetic report rejected because it asked the Control Panel to execute a command.",
+      "evidenceLocation": "ops/control-panel/examples/report-intake.rejected.example.json",
+      "confidence": "verified",
+      "workOrderStatus": "rejected",
+      "notes": "Boundary violation: Control Panel may prepare prompts only.",
+      "reviewerNotes": "Request a compliant static report if the finding remains relevant.",
+      "finalHandling": "rejected"
+    }
+  ]
+}

--- a/ops/control-panel/examples/review-index.example.json
+++ b/ops/control-panel/examples/review-index.example.json
@@ -61,7 +61,7 @@
       "laneId": "governance-drift",
       "reviewedAt": "2026-06-23T16:15:00Z",
       "reviewedBy": "human-operator",
-      "reviewStatus": "converted-to-wo",
+      "reviewStatus": "needs-human-decision",
       "disposition": "prepare-work-order",
       "severity": "Needs Decision",
       "linkedFindingIds": [

--- a/ops/control-panel/review-index.spec.json
+++ b/ops/control-panel/review-index.spec.json
@@ -1,0 +1,211 @@
+{
+  "id": "terrafusion-control-panel-review-index",
+  "version": 1,
+  "status": "seed-contract",
+  "reviewLedgerIdentity": {
+    "reviewIndexVersion": 1,
+    "createdAt": "2026-06-23T00:00:00Z",
+    "updatedAt": "2026-06-23T00:00:00Z",
+    "maintainedBy": "human-operator",
+    "scope": "manual review and disposition ledger for accepted CP-002 monitor reports",
+    "sourceContract": "CP-002 report-intake contract",
+    "authorityBoundary": {
+      "mode": "manual_static_review_ledger_only",
+      "controlPanelRole": "cockpit_prepare_console_findings_viewer",
+      "notBrainOrCortex": true,
+      "notAutonomousQueue": true,
+      "notRuntimeAgent": true,
+      "scopeStatement": [
+        "This review index is manual/static.",
+        "This review index does not discover reports.",
+        "This review index does not ingest reports.",
+        "This review index does not read files.",
+        "This review index does not fetch APIs.",
+        "This review index does not execute commands.",
+        "This review index does not activate automations.",
+        "This review index does not mutate queue, canon, or runtime state.",
+        "This review index does not create Brain/Cortex authority."
+      ],
+      "forbiddenCapabilities": [
+        "discover reports",
+        "ingest reports",
+        "read local files live from HTML",
+        "fetch files or APIs from HTML",
+        "execute commands from the Control Panel",
+        "activate automations",
+        "mutate repo state",
+        "change queue truth",
+        "promote canon",
+        "claim runtime authority",
+        "create a second Brain or Cortex",
+        "create an autonomous queue"
+      ]
+    }
+  },
+  "reviewRecordStructure": {
+    "required": [
+      "reviewId",
+      "reportId",
+      "reportFilename",
+      "monitorId",
+      "laneId",
+      "reviewedAt",
+      "reviewedBy",
+      "reviewStatus",
+      "disposition",
+      "severity",
+      "linkedFindingIds",
+      "linkedEvidenceIds",
+      "notes",
+      "finalHandling"
+    ],
+    "optional": [
+      "proposedWorkOrderIds",
+      "createdWorkOrderIds",
+      "rejectedFindingIds",
+      "deferredFindingIds",
+      "blockedFindingIds",
+      "evidenceRefs",
+      "reportEvidenceIds",
+      "evidenceSummary",
+      "evidenceLocation",
+      "confidence",
+      "reviewerNotes",
+      "workOrderStatus"
+    ],
+    "fields": {
+      "reviewId": "Stable identifier for this manual review record.",
+      "reportId": "Accepted CP-002 report identifier being reviewed.",
+      "reportFilename": "Static report filename, if known.",
+      "monitorId": "Monitor identifier from the CP-002 report.",
+      "laneId": "Control Panel lane identifier from the approved lane vocabulary.",
+      "reviewedAt": "UTC ISO-8601 timestamp for manual review.",
+      "reviewedBy": "Human operator who performed the review.",
+      "reviewStatus": "One of the allowed manual review statuses.",
+      "disposition": "One of the allowed manual dispositions.",
+      "severity": "Highest relevant severity/classification for the reviewed item.",
+      "linkedFindingIds": "Finding IDs from the source report or manual review.",
+      "linkedEvidenceIds": "Evidence IDs from the source report or manual review.",
+      "proposedWorkOrderIds": "Work Order IDs suggested by the report or reviewer.",
+      "createdWorkOrderIds": "Work Order IDs actually created after human decision.",
+      "rejectedFindingIds": "Finding IDs rejected by manual review.",
+      "deferredFindingIds": "Finding IDs deferred by manual review.",
+      "blockedFindingIds": "Finding IDs blocked pending decision or evidence.",
+      "notes": "Short non-sensitive operator notes.",
+      "finalHandling": "Final handling value for the reviewed item."
+    }
+  },
+  "allowedReviewStatuses": [
+    "pending-review",
+    "in-review",
+    "reviewed",
+    "needs-human-decision",
+    "converted-to-wo",
+    "deferred",
+    "rejected",
+    "blocked",
+    "resolved"
+  ],
+  "allowedDispositions": [
+    "accept-as-evidence",
+    "prepare-work-order",
+    "request-clarification",
+    "defer",
+    "reject",
+    "block-pending-decision",
+    "resolved-no-action"
+  ],
+  "allowedLaneIds": [
+    "daily-pulse",
+    "open-work-orders",
+    "governance-drift",
+    "ai-sidecar",
+    "ci-azure-health",
+    "gap-risk-register"
+  ],
+  "allowedSeverities": [
+    "P0",
+    "P1",
+    "P2",
+    "Deferred",
+    "Needs Decision",
+    "Info"
+  ],
+  "evidenceLinkage": {
+    "allowedReferenceFields": [
+      "evidenceRefs",
+      "reportEvidenceIds",
+      "linkedEvidenceIds",
+      "evidenceSummary",
+      "evidenceLocation",
+      "confidence",
+      "reviewerNotes"
+    ],
+    "rules": [
+      "Reference evidence IDs or report evidence IDs without embedding protected data or raw evidence content.",
+      "Use evidenceSummary for short non-sensitive operator summaries only.",
+      "Use evidenceLocation for static path, report ID, or external run URL references only.",
+      "Do not include secrets, credentials, county data, PACS data, owner-sensitive data, appeals evidence, exemptions evidence, valuation evidence, or protected data."
+    ]
+  },
+  "workOrderLinkage": {
+    "proposedWorkOrderIds": "Suggested Work Order IDs from the report or reviewer. These do not authorize mutation.",
+    "createdWorkOrderIds": "Work Order IDs actually created after a human decision.",
+    "allowedWorkOrderStatuses": [
+      "proposed",
+      "created",
+      "rejected",
+      "deferred",
+      "closed"
+    ],
+    "rule": "A proposed Work Order remains a proposal until a separate Work Order is created and approved by the human operator."
+  },
+  "rejectionRules": {
+    "reviewRecordMustRejectOrBlockIf": [
+      "lacks reportId or monitorId",
+      "lacks evidence for P0/P1 claims",
+      "attempts to activate automations",
+      "asks the Control Panel to execute commands",
+      "asks the HTML page to fetch/read local files",
+      "mutates repo state",
+      "changes queue truth",
+      "promotes canon",
+      "claims runtime authority",
+      "creates a second Brain/Cortex or autonomous queue",
+      "contains secrets",
+      "contains credentials",
+      "contains PACS data",
+      "contains county SQL data",
+      "contains owner-sensitive data",
+      "contains appeals evidence",
+      "contains exemptions evidence",
+      "contains valuation evidence",
+      "contains protected data"
+    ],
+    "p0P1EvidenceRule": "P0 and P1 review records require at least one linked evidence ID or report evidence ID.",
+    "protectedDataRule": "Use metadata, redacted references, or synthetic examples only. Do not embed protected operational data in the review index."
+  },
+  "finalHandlingModel": {
+    "allowedFinalHandling": [
+      "no-action",
+      "evidence-only",
+      "proposed-wo",
+      "wo-created",
+      "deferred",
+      "rejected",
+      "blocked",
+      "resolved"
+    ],
+    "meanings": {
+      "no-action": "Reviewed and no further action is needed.",
+      "evidence-only": "Retained as review evidence only.",
+      "proposed-wo": "Converted into a proposed Work Order prompt or ID.",
+      "wo-created": "A separate Work Order was created after human decision.",
+      "deferred": "Explicitly not now.",
+      "rejected": "Rejected by manual review.",
+      "blocked": "Blocked pending evidence, decision, or boundary correction.",
+      "resolved": "Resolved without additional mutation authority."
+    }
+  },
+  "exampleFile": "ops/control-panel/examples/review-index.example.json"
+}

--- a/ops/packets/WO-OPS-CP-003.md
+++ b/ops/packets/WO-OPS-CP-003.md
@@ -1,0 +1,140 @@
+# WO-OPS-CP-003 - Add Manual Report Review Index
+
+## RESULT
+
+Implemented as a static/manual review-index contract only.
+
+## OBJECTIVE
+
+Add a manual review-index contract to the TerraFusion Operations Control Panel so the operator can record how accepted CP-002 monitor reports were reviewed, dispositioned, linked to evidence, linked to proposed Work Orders, and finally handled.
+
+This Work Order does not add ingestion, implementation wiring, runtime behavior, or automation behavior.
+
+## AUTHORITY_BOUNDARY
+
+The Operations Control Panel remains a read-only cockpit / prepare console / findings viewer. It is not a TerraFusion Brain, Cortex, autonomous queue, runtime agent, scheduler, ingestion service, or mutation path.
+
+This WO does not authorize:
+
+- live report discovery
+- report ingestion
+- file reads from HTML
+- fetch/API calls
+- command execution
+- automation activation
+- runtime wiring
+- queue mutation
+- canon promotion
+- Brain/Cortex authority changes
+
+## AUTHORIZED_PATHS
+
+- `ops/control-panel/review-index.spec.json`
+- `ops/control-panel/examples/review-index.example.json`
+- `ops/control-panel/README.md`
+- `ops/packets/WO-OPS-CP-003.md`
+
+## FILES_CREATED
+
+- `ops/control-panel/review-index.spec.json`
+- `ops/control-panel/examples/review-index.example.json`
+- `ops/packets/WO-OPS-CP-003.md`
+
+## FILES_MODIFIED
+
+- `ops/control-panel/README.md`
+
+## RUNTIME_CODE_CHANGED
+
+No.
+
+## AUTOMATION_BEHAVIOR_CHANGED
+
+No.
+
+## CONTROL_PANEL_BEHAVIOR_CHANGED
+
+No runtime behavior changed. The static documentation and JSON contract define a manual review ledger shape, but the HTML page does not read reports, fetch APIs, execute commands, activate automations, or update state.
+
+## REVIEW_INDEX_CONTRACT_SUMMARY
+
+The review-index contract defines:
+
+- review ledger identity
+- review record structure
+- manual review statuses
+- manual dispositions
+- approved Control Panel lane IDs
+- severity/classification values aligned with CP-002
+- evidence linkage rules
+- Work Order linkage rules
+- rejection/blocking rules
+- final handling values
+
+Approved lane IDs:
+
+- `daily-pulse`
+- `open-work-orders`
+- `governance-drift`
+- `ai-sidecar`
+- `ci-azure-health`
+- `gap-risk-register`
+
+Approved severities:
+
+- `P0`
+- `P1`
+- `P2`
+- `Deferred`
+- `Needs Decision`
+- `Info`
+
+## REJECTION_RULES
+
+A review record must reject or block a report or finding if it:
+
+- lacks `reportId` or `monitorId`
+- lacks evidence for `P0` or `P1` claims
+- attempts to activate automations
+- asks the Control Panel to execute commands
+- asks the HTML page to fetch/read local files
+- mutates repo state
+- changes queue truth
+- promotes canon
+- claims runtime authority
+- creates a second Brain/Cortex or autonomous queue
+- contains secrets, credentials, PACS data, county SQL data, owner-sensitive data, appeals evidence, exemptions evidence, valuation evidence, or protected data
+
+## VALIDATION_RUN
+
+Safe validation run:
+
+- JSON parse validation for touched JSON files: passed
+- `git diff --check`: passed
+- scoped path review: passed
+- fetch/local file-read/command-execution API scan: passed
+
+Broad runtime builds are intentionally out of scope for this static/manual review-index contract unless local policy requires them.
+
+## EVIDENCE
+
+Evidence to attach at closeout:
+
+- JSON validation output: touched JSON files parsed successfully
+- `git diff --check` output: no whitespace errors
+- scoped file list: changes are limited to authorized CP-003 files
+- HTML fetch/local file reads added: no
+- command execution APIs added: no
+- automation definitions or runtime wiring changed: no
+
+## OPEN_RISKS
+
+- The review index is static/manual. It does not provide a rendered review-index UI.
+- Human review remains required to maintain review state and disposition.
+- Future display or ingestion behavior must be authorized by a separate Work Order and preserve the prepare-only boundary.
+
+## NEXT_RECOMMENDED_WO
+
+`WO-OPS-CP-004 - Add Static Manual Review Index View`
+
+Scope should remain static display only unless a later human-approved Work Order explicitly authorizes controlled ingestion or execution wiring.


### PR DESCRIPTION
## Summary

Implements WO-OPS-CP-003 as a static/manual review-index contract for the Operations Control Panel.

Adds:
- \\ops/control-panel/review-index.spec.json\\
- \\ops/control-panel/examples/review-index.example.json\\
- \\ops/packets/WO-OPS-CP-003.md\\
- README documentation for the Manual Report Review Index

## Authority Boundary

This remains a manual review ledger only. It does not discover reports, ingest reports, read files, fetch APIs, execute commands, activate automations, mutate queue/canon/runtime state, or create Brain/Cortex authority.

## Validation

- JSON parse validation for touched JSON files: passed
- \\git diff --check\\: passed
- Scoped path review: four authorized CP-003 files only
- Fetch/local file-read/command-execution API scan: no matches

## Runtime Impact

Runtime behavior changed: NO
Automation behavior changed: NO
Control Panel HTML behavior changed: NO
Brain/Cortex changed: NO
Canon/queue truth changed: NO