### PR TITLE
chore(devops): polish readiness detached head display

### DIFF
--- a/scripts/dev/readiness.ps1
+++ b/scripts/dev/readiness.ps1
@@ -23,6 +23,10 @@ function Get-CommandText {
     try {
         $output = & $Command[0] @($Command | Select-Object -Skip 1) 2>&1
         $lines = ($output | ForEach-Object { $_.ToString().Trim() }) | Where-Object { $_ }
+        if (-not $lines) {
+            return ""
+        }
+
         return [string]::Join("`n", $lines)
     }
     catch {
@@ -68,7 +72,18 @@ if ($gitAvailable) {
     }
 
     $branch = Get-CommandText -Command @("git", "branch", "--show-current")
-    Write-Result "INFO" "Git branch: $branch"
+    if ($LASTEXITCODE -eq 0 -and $branch) {
+        Write-Result "INFO" "Git branch: $branch"
+    }
+    else {
+        $shortHead = Get-CommandText -Command @("git", "rev-parse", "--short", "HEAD")
+        if ($LASTEXITCODE -eq 0 -and $shortHead) {
+            Write-Result "INFO" "Git branch: detached HEAD at $shortHead"
+        }
+        else {
+            Write-Result "WARN" "Git branch could not be determined."
+        }
+    }
 
     $status = Get-CommandText -Command @("git", "status", "--short", "--branch")
     if ($status -match "`n|\s[A-Z?]{1,2}\s") {

--- a/scripts/dev/readiness.ps1
+++ b/scripts/dev/readiness.ps1
@@ -72,16 +72,29 @@ if ($gitAvailable) {
     }
 
     $branch = Get-CommandText -Command @("git", "branch", "--show-current")
-    if ($LASTEXITCODE -eq 0 -and $branch) {
-        Write-Result "INFO" "Git branch: $branch"
-    }
-    else {
-        $shortHead = Get-CommandText -Command @("git", "rev-parse", "--short", "HEAD")
-        if ($LASTEXITCODE -eq 0 -and $shortHead) {
-            Write-Result "INFO" "Git branch: detached HEAD at $shortHead"
+    $branchExitCode = $LASTEXITCODE
+    if ($branchExitCode -eq 0) {
+        if ($branch) {
+            Write-Result "INFO" "Git branch: $branch"
         }
         else {
-            Write-Result "WARN" "Git branch could not be determined."
+            $shortHead = Get-CommandText -Command @("git", "rev-parse", "--short", "HEAD")
+            if ($LASTEXITCODE -eq 0 -and $shortHead) {
+                Write-Result "INFO" "Git branch: detached HEAD at $shortHead"
+            }
+            else {
+                Write-Result "WARN" "Git branch is empty, and the current commit could not be determined."
+            }
+        }
+    }
+    else {
+        $branchFailure = if ($branch) { " $branch" } else { "" }
+        $shortHead = Get-CommandText -Command @("git", "rev-parse", "--short", "HEAD")
+        if ($LASTEXITCODE -eq 0 -and $shortHead) {
+            Write-Result "WARN" "Git branch command failed; current commit is $shortHead.$branchFailure"
+        }
+        else {
+            Write-Result "WARN" "Git branch could not be determined.$branchFailure"
         }
     }
 


### PR DESCRIPTION
## Summary

Polishes the local readiness script so detached-HEAD worktrees report a clear branch state instead of emitting an exception.

## Scope

- `scripts/dev/readiness.ps1` only
- Read-only behavior preserved
- No Docker, Compose, Kubernetes, runtime, pipeline, workflow, package, secret, county data, PACS, or SQL changes

## Validation

- `git diff --check`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1`
- detached-HEAD readiness execution reports `Git branch: detached HEAD at <sha>`
- normal pre-commit hook passed
- normal pre-push hook passed

## Summary by Sourcery

Improve the local readiness PowerShell script’s reporting of Git branch state, including clearer handling of detached HEAD scenarios.

Enhancements:
- Handle empty command output in the readiness script without emitting exceptions.
- Report detached HEAD state with the current commit SHA when no branch name is available, and warn when the Git branch cannot be determined.