### PR TITLE
docs(data): Benton demo DB completion evidence packet — all 6 lanes, S6 canonical state

### DIFF
--- a/docs/data/BENTON_DEMO_DB_COMPLETION_FINAL_SUMMARY.md
+++ b/docs/data/BENTON_DEMO_DB_COMPLETION_FINAL_SUMMARY.md
@@ -1,0 +1,149 @@
+# Benton Demo DB — Completion Final Summary
+
+**Date:** 2026-06-28  
+**Classification:** Evidence/Canonicalization Only  
+**Status:** ALL LANES COMPLETE
+
+---
+
+## 1. Target Database
+
+```
+terrafusion_benton_demo
+```
+
+Hosted in Docker container `terrafusion-postgres-dev` (pgvector/pgvector:pg16).  
+Local Postgres at `localhost:5432`.
+
+---
+
+## 2. Final Lane Counts
+
+All counts verified post-S6 snapshot.
+
+| Lane | Canonical Table | Count |
+|------|----------------|------:|
+| Parcel | `canonical_tf.tf_parcel` | 84,418 |
+| Owner | `canonical_tf.tf_owner` | 97,062 |
+| Owner Link | `canonical_tf.tf_parcel_owner_link` | 686,851 |
+| WSDOR | `canonical_tf.tf_assessment_wsdor` | 686,820 |
+| Improvement | `canonical_tf.tf_improvement` | 100,144 |
+| Improvement Features | `canonical_tf.tf_improvement_feature` | 1,351,892 |
+| Land | `canonical_tf.tf_land` | 87,767 |
+| Sales | `canonical_tf.tf_sale` | 90,386 |
+| Geometry | `gis_tf.tf_parcel_geom` | 79,199 |
+
+**Geometry layer (all three tiers):**
+
+| Layer | Table | Count |
+|-------|-------|------:|
+| Raw | `legacy_arcgis_raw.parcel_geom` | 79,199 |
+| Truth | `truth_arcgis.parcel_geom_current` | 79,199 |
+| Canonical | `gis_tf.tf_parcel_geom` | 79,199 |
+
+---
+
+## 3. Source Systems
+
+| Lane | Source System | Connection |
+|------|--------------|-----------|
+| Parcel, Owner, Improvement, Land | PACS OLTP (`pacs_oltp_verify`) | `localhost,21433` — Windows SQL Server 2019, Docker container `tf-pacs-current-verify` |
+| Sales | Restored PACS sales DB (`pacs_oltp_sales_restore`) | `localhost,1433` — Windows SQL Server 2019, Docker container `tf-pacs-bak-restore`. PR #1071 wired `PacsSalesConnection`. |
+| Geometry | ArcGIS REST API | Benton County FIPS 53005, paginated endpoint. GEOM-011 pagination + H1 hardening (feat/geom-011-arcgis-pagination, fix/geom-011b-h1-pagination-hardening) required before full-corpus run was stable. |
+
+All sources were **read-only**. No writes to PACS or ArcGIS at any point.
+
+---
+
+## 4. Important Known Warnings
+
+These are carry-forward from run results and must not be treated as failures.
+
+### Sales Lane (WO-DATA-FINALIZE-SALES-002B)
+
+| Warning | Value | Interpretation |
+|---------|-------|---------------|
+| `truth-pacs-supp-aware-join` noSuppPointer | 194,757 rows | Valid sales with no supplemental pointer. Normal Benton characteristic — many sales have no sup record. Not a data quality failure. |
+| `truth-pacs-sale-pre-conversion-share` | 70.06% (66,473 / 94,875) | 70% of promoted truth rows are pre-ProVal-conversion sales. Expected for Benton's large historical corpus predating the 2017 ProVal conversion. Not a data quality failure. |
+
+### Quarantine
+
+| Metric | Value |
+|--------|-------|
+| Cumulative quarantine total | 2,053,173 |
+| Sales lane delta | +4,489 |
+| Geometry lane delta | 0 |
+| QUARANTINED batch records | 0 |
+
+### Zombie Batches (Historical — Deferred)
+
+9 orphaned `IN_PROGRESS` batch records from prior cancelled runs (Jun 21–26). None from any
+completed lane run. All successful drains ran after these and wrote correct data. Cleanup
+deferred — these are metadata only with no downstream impact.
+
+| SourceFamily | Operator | Date |
+|-------------|----------|------|
+| PACS_OLTP | claude-finalize-owner-wsdor-full-v1 (×4) | 2026-06-21 |
+| PACS_OLTP | claude-finalize-owner-wsdor-full-v2 | 2026-06-21 |
+| PACS_OLTP | finalize-improvement-full-v1/v2/v3 | 2026-06-22 |
+| PACS_OLTP | claude-finalize-s4r-land-rebuild-v1 | 2026-06-26 |
+
+---
+
+## 5. Snapshots
+
+All snapshots stored at `C:\Users\bsval\tf-db-archives\`.
+
+| Snapshot | File | Size | Notes |
+|----------|------|-----:|-------|
+| S3 post-improvement | `terrafusion_benton_demo_S3_post_improvement.dump` | (see S3 evidence) | After improvement + imprv_feature lanes |
+| S4 post-land | `terrafusion_benton_demo_S4_post_land.dump` | 2,252,914,854 bytes (~2.25 GB) | After land lane rebuild |
+| S5 post-sales | `terrafusion_benton_demo_S5_post_sales.dump` | 1,725,235,200 bytes (~1.73 GB) | After sales lane (compressed smaller due to column data profile) |
+| **S6 complete** | `terrafusion_benton_demo_S6_complete.dump` | **2,507,328,204 bytes (~2.51 GB)** | **All 6 lanes complete. First full Benton demo state.** |
+
+**S6 restore command:**
+```bash
+pg_restore -U postgres -d <target_db> -Fc -j 4 /tmp/S6_complete.dump
+```
+
+---
+
+## 6. Safety
+
+| Check | Status |
+|-------|--------|
+| `terrafusion_dev_clean` untouched | CONFIRMED — 4 seed rows, unchanged throughout all runs |
+| PACS source read-only | CONFIRMED — no writes to `pacs_oltp_verify` or `pacs_oltp_sales_restore` |
+| ArcGIS source read-only | CONFIRMED — geometry drain reads only, no ArcGIS mutations |
+| No active drains at snapshot time | CONFIRMED |
+| Dump files not committed | CONFIRMED — dumps in `tf-db-archives/`, gitignored |
+| Secrets not printed or committed | CONFIRMED — SA password in gitignored `appsettings.Development.local.json` only |
+| Evidence docs secret scan | CLEAN — no passwords, no tokens, no connection strings |
+
+---
+
+## 7. Final Status
+
+**The Benton demo database (`terrafusion_benton_demo`) is complete for all data loading lanes:**
+
+- ✅ Parcel — 84,418 canonical parcels
+- ✅ Owner / WSDOR — 97,062 owners, 686,820 WSDOR assessment rows
+- ✅ Improvement — 100,144 improvements, 1,351,892 features
+- ✅ Land — 87,767 land segments
+- ✅ Sales — 90,386 canonical sales (440,274 raw rows landed)
+- ✅ Geometry — 79,199 parcel polygons from ArcGIS
+
+**Remaining work is deployment/promotion, not data loading.**  
+The S6 snapshot is the authoritative restore point for the complete Benton demo state.
+
+---
+
+## Evidence Documents (This PR)
+
+| Document | Work Order | Covers |
+|----------|-----------|--------|
+| `BENTON_DEMO_SALES_FULL_RUN_RESULTS.md` | WO-DATA-FINALIZE-SALES-002B | Full sales drain — 440,274 landed, 94,875 promoted |
+| `BENTON_DEMO_S5_POST_SALES_SNAPSHOT.md` | WO-DATA-FINALIZE-S5 | Post-sales snapshot — 1.725 GB, all 5 pre-geometry lanes |
+| `BENTON_DEMO_GEOM_FULL_RUN_RESULTS.md` | GEOM-011C | Full geometry drain — 79,199 rows, 13/13 gates pass |
+| `BENTON_DEMO_S6_COMPLETE_DB_SNAPSHOT.md` | WO-DATA-FINALIZE-S6 | Final complete snapshot — 2.507 GB, all 6 lanes |
+| `BENTON_DEMO_DB_COMPLETION_FINAL_SUMMARY.md` | WO-DATA-FINALIZE-PR | This document — canonical final state record |

--- a/docs/data/BENTON_DEMO_GEOM_FULL_RUN_RESULTS.md
+++ b/docs/data/BENTON_DEMO_GEOM_FULL_RUN_RESULTS.md
@@ -1,0 +1,144 @@
+# Benton Demo Geometry Full Run Results
+
+**WO:** GEOM-011C  
+**Date:** 2026-06-28  
+**Operator:** claude-geom-011c-benton-full  
+**Branch:** wo/geom-011c (worktree at `C:\Users\bsval\tf-worktrees\wo-sales-002b`)
+
+---
+
+## Summary
+
+Full-corpus geometry drain from ArcGIS REST against S5 baseline. All six data lanes are now
+complete: parcel, owner-wsdor, improvement, land, sales, and geometry.
+
+---
+
+## Prerequisites Verified (Pre-Drain)
+
+| Gate | Status |
+|------|--------|
+| Docker Desktop recovered after laptop restart | PASS |
+| `terrafusion-postgres-dev` started, WAL recovery complete (~13 min) | PASS |
+| `tf-pacs-current-verify` started | PASS |
+| S5 restore counts intact post-recovery | PASS |
+| API health on `:5046` | PASS (HTTP 200) |
+| Branch `wo/geom-011c` confirmed active | PASS |
+| `geom_drain_body.json`: FullCorpus=true, TopN=null | PASS |
+
+---
+
+## S5 Baseline Counts (Pre-Drain)
+
+| Table | Count |
+|-------|-------|
+| `canonical_tf.tf_parcel` | 84,418 |
+| `canonical_tf.tf_land` | 87,767 |
+| `canonical_tf.tf_sale` | 90,386 |
+| `canonical_tf.tf_improvement` | 100,144 |
+| Geometry tables | 0 (not yet loaded) |
+
+---
+
+## Geometry Drain Execution
+
+**Endpoint:** `POST http://localhost:5046/api/sync/doctrine/drain/geometry`  
+**Body:**
+```json
+{
+  "OperatorName": "claude-geom-011c-benton-full",
+  "WorkingYear": 2026,
+  "FullCorpus": true,
+  "TopN": null
+}
+```
+
+**Source:** ArcGIS REST API (Benton County FIPS 53005)  
+**Target DB:** `terrafusion_benton_demo` @ `localhost:5432`  
+**Started:** 02:53:45 (2026-06-28)  
+**Ended:** 02:57:59 (2026-06-28)  
+**Duration:** 253.75 seconds (~4.2 minutes)
+
+---
+
+## Drain Results
+
+| Metric | Value |
+|--------|-------|
+| Status | **Succeeded** |
+| `rowsLanded` | **79,199** |
+| `rowsPromotedToTruth` | **79,199** |
+| `rowsCanonicalized` | **79,199** |
+| `rowsQuarantinedThisLane` | **0** |
+| Gates PASS | **13** |
+| Gates WARN | 0 |
+| Gates FAIL | 0 |
+| Quarantine before | 2,053,173 |
+| Quarantine after | 2,053,173 |
+| Quarantine delta | 0 |
+
+**Batch IDs:**
+- `eafbde28-b7b9-420b-be7d-f4db2c8430be`
+- `b1f22e89-3134-440e-89fe-0ae6faa1953a`
+- `d5e1b26b-32ef-42bd-9088-fb9ebbf0cc5b`
+
+---
+
+## Post-Drain DB State
+
+| Table | Count |
+|-------|-------|
+| `legacy_arcgis_raw.parcel_geom` | 79,199 |
+| `truth_arcgis.parcel_geom_current` | 79,199 |
+| `gis_tf.tf_parcel_geom` | 79,199 |
+| `canonical_tf.tf_parcel` | 84,418 (unchanged) |
+| `canonical_tf.tf_land` | 87,767 (unchanged) |
+| `canonical_tf.tf_sale` | 90,386 (unchanged) |
+| `canonical_tf.tf_improvement` | 100,144 (unchanged) |
+
+---
+
+## All Lanes Complete — Full Picture
+
+| Lane | Canonical Table | Count |
+|------|----------------|-------|
+| Parcel | `canonical_tf.tf_parcel` | 84,418 |
+| Owner | `canonical_tf.tf_owner` | 97,062 |
+| Owner Link | `canonical_tf.tf_parcel_owner_link` | 686,851 |
+| WSDOR | `canonical_tf.tf_assessment_wsdor` | 686,820 |
+| Improvement | `canonical_tf.tf_improvement` | 100,144 |
+| Imprv Features | `canonical_tf.tf_improvement_feature` | 1,351,892 |
+| Land | `canonical_tf.tf_land` | 87,767 |
+| Sales | `canonical_tf.tf_sale` | 90,386 |
+| **Geometry** | `gis_tf.tf_parcel_geom` | **79,199** |
+
+---
+
+## Operator Constraints Honored
+
+- PACS SA password: not printed, not committed
+- Original PACS source (`pacs_oltp_verify`): not touched
+- `terrafusion_dev_clean`: not touched
+- No manual table mutations
+- No other lane reruns
+
+---
+
+## Final Report
+
+| Field | Value |
+|-------|-------|
+| RESULT | Succeeded |
+| DB_TARGET | terrafusion_benton_demo |
+| BASELINE | S5 (post-sales) |
+| SOURCE | ArcGIS REST, FIPS 53005, FullCorpus=true |
+| ENDPOINT | POST /api/sync/doctrine/drain/geometry |
+| ROWS_LANDED | 79,199 |
+| ROWS_PROMOTED | 79,199 |
+| ROWS_CANONICALIZED | 79,199 |
+| ROWS_QUARANTINED | 0 |
+| GATE_STATUS | 13 PASS / 0 WARN / 0 FAIL |
+| QUARANTINE_STATUS | delta=0, cumulative=2,053,173 |
+| DURATION | 253.75 sec |
+| ALL_LANES_COMPLETE | YES |
+| NEXT_STEP | Operator decision — S6 snapshot or PR |

--- a/docs/data/BENTON_DEMO_S5_POST_SALES_SNAPSHOT.md
+++ b/docs/data/BENTON_DEMO_S5_POST_SALES_SNAPSHOT.md
@@ -1,0 +1,149 @@
+# Benton Demo S5 Post-Sales Snapshot
+
+**WO:** WO-DATA-FINALIZE-S5  
+**Date:** 2026-06-28  
+**Branch:** wo/sales-002b (fresh worktree from origin/main)
+
+---
+
+## Summary
+
+Post-sales-completion snapshot of `terrafusion_benton_demo`. All five data-load lanes are complete: parcel, owner-wsdor, improvement, land, and sales. Geometry remains hard-blocked (GEOM-011C).
+
+---
+
+## Completed Lane Counts (canonical_tf)
+
+| Table | Count |
+|-------|-------|
+| `canonical_tf.tf_parcel` | 84,418 |
+| `canonical_tf.tf_owner` | 97,062 |
+| `canonical_tf.tf_parcel_owner_link` | 686,851 |
+| `canonical_tf.tf_assessment_wsdor` | 686,820 |
+| `canonical_tf.tf_improvement` | 100,144 |
+| `canonical_tf.tf_improvement_feature` | 1,351,892 |
+| `canonical_tf.tf_land` | 87,767 |
+| `canonical_tf.tf_sale` | 90,386 |
+
+---
+
+## Sales Lane — Carry-Forward Warnings
+
+These appeared in WO-DATA-FINALIZE-SALES-002B and must carry forward to the final Benton demo data completion report.
+
+### WARN 1: `truth-pacs-supp-aware-join`
+- **noSuppPointer:** 194,757 rows with no supplemental pointer match
+- **Interpretation:** Valid sales with no sup record (normal for many Benton sales, not a data quality failure)
+
+### WARN 2: `truth-pacs-sale-pre-conversion-share`
+- **Pre-conversion share:** 70.06% (66,473 / 94,875 promoted rows)
+- **Threshold:** ≤5.00%
+- **Interpretation:** 70% of promoted truth rows are pre-ProVal-conversion sales. Known Benton characteristic (large historical corpus predating 2017 ProVal conversion). Not a data quality failure.
+
+---
+
+## Sales Lane Gate Summary
+
+| Status | Count |
+|--------|-------|
+| PASS | 29 |
+| WARN | 2 |
+| FAIL | 0 |
+
+---
+
+## Quarantine Status
+
+| Metric | Value |
+|--------|-------|
+| Quarantine delta from sales lane | +4,489 |
+| Cumulative quarantine (2,048,684 → 2,053,173) | 2,053,173 |
+| `sync_bridge.load_batch` QUARANTINED rows | 0 |
+| `sync_bridge.load_batch` SUCCEEDED/COMPLETED rows | 81 |
+
+---
+
+## Zombie / Batch Hygiene
+
+### A. Current Sales Run Health
+
+| Check | Result |
+|-------|--------|
+| Sales drain status | Succeeded |
+| Zombie IN_PROGRESS batch from SALES-002B | **0** |
+| Active IN_PROGRESS sales batch post-drain | **0** |
+| Sales batch IDs cleanly closed | Yes (7 batches, all terminal) |
+
+The sales drain started and completed cleanly. No open/stuck batch records were created by WO-DATA-FINALIZE-SALES-002B.
+
+### B. Historical Batch Hygiene
+
+9 orphaned `IN_PROGRESS` records exist in `sync_bridge.load_batch`. These were **not created by SALES-002B** and are carry-forward artifacts from prior cancelled drain attempts.
+
+| LoadBatchId (truncated) | SourceFamily | Operator | StartedAt | Status |
+|------------------------|--------------|----------|-----------|--------|
+| `2d59a7e5` | PACS_OLTP | claude-finalize-s4r-land-rebuild-v1 | 2026-06-26 18:35 | IN_PROGRESS |
+| `37674f41` | PACS_OLTP | finalize-improvement-full-v3 | 2026-06-22 08:40 | IN_PROGRESS |
+| `d70bb70a` | PACS_OLTP | finalize-improvement-full-v2 | 2026-06-22 06:07 | IN_PROGRESS |
+| `4c733901` | PACS_OLTP | finalize-improvement-full-v1 | 2026-06-22 00:51 | IN_PROGRESS |
+| `9dd7f995` | PACS_OLTP | claude-finalize-owner-wsdor-full-v2 | 2026-06-21 20:27 | IN_PROGRESS |
+| `8852d015` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:22 | IN_PROGRESS |
+| `c90b40b2` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:18 | IN_PROGRESS |
+| `5cbb4c42` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:12 | IN_PROGRESS |
+| `87a6e7a6` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:11 | IN_PROGRESS |
+
+**Classification:** Historical/orphaned from prior cancelled owner-wsdor (Jun 21) and improvement (Jun 22) attempts, plus one land-rebuild cancellation (Jun 26).  
+**Impact:** None — successful drains ran after these and wrote correct data. These records are metadata only.  
+**S5 state:** S5 snapshot includes these historical zombie metadata records.  
+**Cleanup:** Deferred — this is a snapshot WO, not a batch-repair WO.
+
+---
+
+## Snapshot
+
+**File:** `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S5_post_sales.dump`  
+**Size:** 1,725,235,200 bytes (~1.725 GB)  
+**Method:** `pg_dump -Fc -j 1` inside container (`docker exec terrafusion-postgres-dev pg_dump -U postgres -Fc -f /tmp/S5_post_sales.dump terrafusion_benton_demo`) → `docker cp` to host  
+**Source:** `terrafusion_benton_demo` @ localhost:5432  
+**Restore command:** `pg_restore -U postgres -d <target_db> -Fc -j 4 /tmp/S5_post_sales.dump`
+
+---
+
+## Other Checks
+
+| Check | Result |
+|-------|--------|
+| `terrafusion_dev_clean` Properties count | 4 (seed data, untouched) |
+| Geometry lane | Hard-blocked (GEOM-011C) |
+| Any drain run | No — snapshot only |
+| Any DB mutation | No — read-only verification + pg_dump only |
+
+---
+
+## Operator Constraints Honored
+
+- GEOM-011C: not started
+- No drain run
+- No code changes
+- No manual DB mutations
+- PACS: not touched
+- `terrafusion_dev_clean`: untouched
+
+---
+
+## Final Report
+
+| Field | Value |
+|-------|-------|
+| RESULT | Complete |
+| SNAPSHOT | `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S5_post_sales.dump` |
+| SNAPSHOT_SIZE | 1,725,235,200 bytes (~1.725 GB) |
+| LANE_COUNTS | parcel=84,418 / owner=97,062 / owner_link=686,851 / wsdor=686,820 / improvement=100,144 / imprv_feature=1,351,892 / land=87,767 / sale=90,386 |
+| SALES_WARNINGS | WARN1: noSuppPointer=194,757 (no supp pointer, not a failure) / WARN2: pre-conversion=70.06% (known Benton historical corpus, not a failure) |
+| SALES_ZOMBIE_STATUS | 0 — sales drain created no zombie batches |
+| HISTORICAL_ZOMBIE_BATCHES | 9 orphaned IN_PROGRESS records from prior owner-wsdor (Jun 21) + improvement (Jun 22) + land (Jun 26) cancelled runs; not from SALES-002B; cleanup deferred |
+| QUARANTINE_STATUS | Sales delta +4,489; cumulative 2,053,173; 0 QUARANTINED batch records |
+| DEV_CLEAN_TOUCHED | No (4 seed rows confirmed) |
+| FILES_CHANGED | docs/data/BENTON_DEMO_S5_POST_SALES_SNAPSHOT.md |
+| LOCAL_COMMIT | Pending |
+| NEXT_WORK_ORDER | Operator decision — GEOM-011C checklist review before geometry full-corpus |

--- a/docs/data/BENTON_DEMO_S6_COMPLETE_DB_SNAPSHOT.md
+++ b/docs/data/BENTON_DEMO_S6_COMPLETE_DB_SNAPSHOT.md
@@ -1,0 +1,166 @@
+# Benton Demo S6 Complete DB Snapshot
+
+**WO:** WO-DATA-FINALIZE-S6  
+**Date:** 2026-06-28  
+**Branch:** wo/geom-011c (worktree at `C:\Users\bsval\tf-worktrees\wo-sales-002b`)
+
+---
+
+## Summary
+
+Post-geometry snapshot of `terrafusion_benton_demo`. All six data-load lanes are complete:
+parcel, owner-wsdor, improvement, land, sales, and geometry. This is the first fully populated
+Benton demo database state.
+
+---
+
+## Final Lane Counts (All Layers)
+
+### Canonical Layer
+
+| Table | Count |
+|-------|-------|
+| `canonical_tf.tf_parcel` | 84,418 |
+| `canonical_tf.tf_owner` | 97,062 |
+| `canonical_tf.tf_parcel_owner_link` | 686,851 |
+| `canonical_tf.tf_assessment_wsdor` | 686,820 |
+| `canonical_tf.tf_improvement` | 100,144 |
+| `canonical_tf.tf_improvement_feature` | 1,351,892 |
+| `canonical_tf.tf_land` | 87,767 |
+| `canonical_tf.tf_sale` | 90,386 |
+
+### Geometry Layer
+
+| Table | Count |
+|-------|-------|
+| `legacy_arcgis_raw.parcel_geom` | 79,199 |
+| `truth_arcgis.parcel_geom_current` | 79,199 |
+| `gis_tf.tf_parcel_geom` | 79,199 |
+
+---
+
+## GEOM-011C Confirmation
+
+| Metric | Value |
+|--------|-------|
+| `rowsLanded` | 79,199 |
+| `rowsPromotedToTruth` | 79,199 |
+| `rowsCanonicalized` | 79,199 |
+| `rowsQuarantinedThisLane` | 0 |
+| Gate status | 13 PASS / 0 WARN / 0 FAIL |
+| Quarantine delta | 0 |
+| Duration | 253.75 sec (~4.2 min) |
+| Commit | `2fb35a117` |
+| Source | ArcGIS REST, FIPS 53005, FullCorpus=true |
+
+---
+
+## Batch Hygiene
+
+### Active Drain Check
+
+| Check | Result |
+|-------|--------|
+| Active `IN_PROGRESS` batch from GEOM-011C | **0** — geometry drain completed cleanly |
+| Geometry batches | 3 records, all terminal (`COMPLETED`) |
+
+### Historical Zombie Batches (Carry-Forward from S5)
+
+9 orphaned `IN_PROGRESS` records from prior cancelled runs — **unchanged from S5**.
+
+| LoadBatchId (truncated) | SourceFamily | Operator | StartedAt |
+|------------------------|--------------|----------|-----------|
+| `87a6e7a6` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:11 |
+| `5cbb4c42` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:12 |
+| `c90b40b2` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:18 |
+| `8852d015` | PACS_OLTP | claude-finalize-owner-wsdor-full-v1 | 2026-06-21 16:22 |
+| `9dd7f995` | PACS_OLTP | claude-finalize-owner-wsdor-full-v2 | 2026-06-21 20:27 |
+| `4c733901` | PACS_OLTP | finalize-improvement-full-v1 | 2026-06-22 00:51 |
+| `d70bb70a` | PACS_OLTP | finalize-improvement-full-v2 | 2026-06-22 06:07 |
+| `37674f41` | PACS_OLTP | finalize-improvement-full-v3 | 2026-06-22 08:40 |
+| `2d59a7e5` | PACS_OLTP | claude-finalize-s4r-land-rebuild-v1 | 2026-06-26 18:35 |
+
+**Classification:** Historical/orphaned from prior cancelled owner-wsdor (Jun 21), improvement
+(Jun 22), and land-rebuild (Jun 26) attempts. Not from any geometry run. Cleanup deferred.
+
+---
+
+## Batch Summary
+
+| Status | Count |
+|--------|-------|
+| COMPLETED | 84 |
+| IN_PROGRESS (historical zombies) | 9 |
+| CANCELLED | 3 |
+| FAILED | 5 |
+
+---
+
+## Quarantine Status
+
+| Metric | Value |
+|--------|-------|
+| Cumulative quarantine | 2,053,173 |
+| GEOM-011C quarantine delta | 0 |
+| `sync_bridge.load_batch` QUARANTINED rows | 0 |
+
+---
+
+## Snapshot
+
+**File:** `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S6_complete.dump`  
+**Size:** 2,507,328,204 bytes (~2.507 GB)  
+**Delta from S5:** +782,092,804 bytes (~782 MB — geometry layer)  
+**Method:** `pg_dump -Fc` inside container (`docker exec terrafusion-postgres-dev pg_dump -U postgres -Fc -f /tmp/S6_complete.dump terrafusion_benton_demo`) → `docker cp` to host  
+**Started:** 14:16:55  
+**Ended:** 14:25:14  
+**Duration:** ~8 min 19 sec  
+**pg_dump exit:** 0  
+**cp exit:** 0  
+**Restore command:** `pg_restore -U postgres -d <target_db> -Fc -j 4 /tmp/S6_complete.dump`
+
+---
+
+## Other Checks
+
+| Check | Result |
+|-------|--------|
+| `terrafusion_dev_clean` Properties count | 4 (seed data, untouched) |
+| Any drain run | No — snapshot + read-only verification only |
+| Any DB mutation | No |
+| ArcGIS touched | No — drain already completed before this WO |
+| PACS touched | No |
+| Code changed | No |
+
+---
+
+## Operator Constraints Honored
+
+- PACS SA password: not printed, not committed
+- Original PACS source: not touched
+- ArcGIS: not touched
+- No drain run
+- No code changes
+- No PR opened
+- `terrafusion_dev_clean`: untouched (4 seed rows confirmed)
+- No manual DB mutations
+
+---
+
+## Final Report
+
+| Field | Value |
+|-------|-------|
+| RESULT | Complete |
+| DB_TARGET | terrafusion_benton_demo |
+| SNAPSHOT | `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S6_complete.dump` |
+| SNAPSHOT_SIZE | 2,507,328,204 bytes (~2.507 GB) |
+| FINAL_LANE_COUNTS | parcel=84,418 / owner=97,062 / owner_link=686,851 / wsdor=686,820 / improvement=100,144 / imprv_feature=1,351,892 / land=87,767 / sale=90,386 / geom=79,199 |
+| GEOMETRY_STATUS | Complete — 79,199 landed/promoted/canonicalized, 0 quarantined |
+| GATE_STATUS | 13 PASS / 0 WARN / 0 FAIL |
+| QUARANTINE_STATUS | delta=0, cumulative=2,053,173, 0 QUARANTINED batch records |
+| ZOMBIE_BATCH_STATUS | 9 historical zombies (Jun 21-26, not from GEOM-011C); 0 new zombies from geometry; cleanup deferred |
+| DEV_CLEAN_TOUCHED | No (4 seed rows confirmed) |
+| FILES_CHANGED | docs/data/BENTON_DEMO_S6_COMPLETE_DB_SNAPSHOT.md |
+| LOCAL_COMMIT | Pending |
+| NEXT_WORK_ORDER | Operator decision — PR / evidence packet |

--- a/docs/data/BENTON_DEMO_SALES_FULL_RUN_RESULTS.md
+++ b/docs/data/BENTON_DEMO_SALES_FULL_RUN_RESULTS.md
@@ -1,0 +1,156 @@
+# Benton Demo Sales Full Run Results
+
+**WO:** WO-DATA-FINALIZE-SALES-002B  
+**Date:** 2026-06-28  
+**Operator:** claude-finalize-sales-full-v3-windows-restore  
+**Branch:** wo/sales-002b (fresh worktree from origin/main)
+
+---
+
+## Summary
+
+Full sales drain against restored S4 baseline. Source: Windows SQL Server 2019 `pacs_oltp_sales_restore` (validated, PR #1071 merged). Target: `terrafusion_benton_demo` restored from S4 snapshot.
+
+---
+
+## Prerequisites Verified
+
+| Gate | Status |
+|------|--------|
+| PR #1071 merged (PacsSalesConnection wiring) | PASS |
+| S4 snapshot exists (2.25 GB) | PASS |
+| `pacs_oltp_sales_restore` DBCC PHYSICAL_ONLY | PASS |
+| Sales join count validated: 440,274 | PASS |
+| Fresh worktree from origin/main | PASS — `wo/sales-002b` |
+| No pre-existing merge conflicts | PASS |
+
+---
+
+## S4 Restore (Pre-Drain State)
+
+**Source:** `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S4_post_land.dump` (2,252,914,854 bytes)  
+**Target:** `terrafusion_benton_demo` (dropped/recreated, then restored via `pg_restore -j 4`)
+
+| Table | Count | Expected |
+|-------|-------|----------|
+| `legacy_pacs_raw.property` | 766,480 | ✓ |
+| `legacy_pacs_raw.owner` | 8,568,960 | ✓ |
+| `truth_pacs.imprv_current` | 300,432 | ✓ |
+| `truth_pacs.land_current` | 87,767 | ✓ S4 land |
+| `truth_pacs.sale` | 0 | ✓ clean |
+| `canonical_tf.tf_sale` | 0 | ✓ clean |
+| Zombie IN_PROGRESS sales batch | 0 | ✓ no zombie |
+
+---
+
+## Sales Drain Execution
+
+**Endpoint:** `POST http://localhost:5046/api/sync/doctrine/drain/sales`  
+**Body:**
+```json
+{
+  "OperatorName": "claude-finalize-sales-full-v3-windows-restore",
+  "WorkingYear": 2026,
+  "FullCorpus": true,
+  "TopN": null
+}
+```
+
+**API:** worktree `wo/sales-002b` at `localhost:5046`  
+**Sales Source:** `pacs_oltp_sales_restore` @ `localhost,1433` (Windows SQL Server 2019)  
+**Target DB:** `terrafusion_benton_demo` @ `localhost:5432`  
+**Started:** 17:22:13 (2026-06-27)  
+**Ended:** 22:38:53 (2026-06-27)  
+**Duration:** 19,000 seconds (~5.28 hours)
+
+---
+
+## Drain Results
+
+| Metric | Value |
+|--------|-------|
+| Status | **Succeeded** |
+| `rowsLanded` | **440,274** (full corpus) |
+| `rowsPromotedToTruth` | **94,875** |
+| `rowsCanonicalized` | **90,386** |
+| `rowsQuarantinedThisLane` | 4,489 |
+| Gates PASS | 29 |
+| Gates WARN | 2 |
+| Gates FAIL | 0 |
+| Quarantine before | 2,048,684 |
+| Quarantine after | 2,053,173 |
+| Quarantine delta | +4,489 |
+| Next recommended lane | geometry (hard-blocked) |
+
+**Batch IDs:**
+- `db123ff9-f691-494d-8088-06392326b1e4`
+- `a3cb4656-724e-48ac-bf39-2b5f4a39253a`
+- `e2262599-37c3-4ddf-9f81-3ec1870a3d3a`
+- `3a375d7c-6c37-443d-bd7b-00c0d9b24a10`
+- `6d640e0e-bd7e-4b4b-ab49-08b2119e57f7`
+- `7c052b6c-734a-4a51-8818-926a61ce6f98`
+- `7da3e046-b95d-4805-b295-75198b709d03`
+
+---
+
+## Gate WARNs (not failures)
+
+### 1. `truth-pacs-supp-aware-join` — WARN
+- **Stage:** RAW_TO_TRUTH
+- **Detail:** `noSuppPointer=194,757 staleSupNum=0`
+- **Meaning:** 194,757 raw sale rows had no supplemental pointer match. These are valid sales with no sup record (expected behavior for many Benton sales).
+
+### 2. `truth-pacs-sale-pre-conversion-share` — WARN
+- **Stage:** RAW_TO_TRUTH
+- **Detail:** `preConversion=66,473 total=94,875 threshold=5.00% actual=70.06%`
+- **Meaning:** 70% of promoted truth rows are pre-ProVal-conversion sales. This is a known Benton characteristic (large historical corpus predating the 2017 ProVal conversion). Not a data quality failure — expected given the full-corpus run.
+
+---
+
+## Post-Run DB State
+
+| Table | Count |
+|-------|-------|
+| `legacy_pacs_raw.sale` | 440,274 |
+| `truth_pacs.sale` | 94,875 |
+| `canonical_tf.tf_sale` | 90,386 |
+| Zombie IN_PROGRESS batch | 0 |
+| `terrafusion_dev_clean` | 4 rows (seed, untouched) |
+
+---
+
+## Operator Constraints Honored
+
+- PACS SA password: not printed, not committed
+- Original PACS source (`pacs_oltp_verify`): not touched
+- `pacs_oltp_sales_restore`: read-only source (no mutations)
+- Conflicted worktree (`claude/forensic-estate-audit-4kzp3e`): quarantined, not touched
+- Geometry: not run
+- Other lanes: not run
+- `terrafusion_dev_clean`: untouched (confirmed 4 seed rows)
+- No manual table mutations outside approved S4 restore
+
+---
+
+## Final Report
+
+| Field | Value |
+|-------|-------|
+| RESULT | Succeeded |
+| DB_TARGET | terrafusion_benton_demo |
+| RESTORE_STATUS | PASS — S4 (87,767 land rows confirmed) |
+| SALES_SOURCE | pacs_oltp_sales_restore @ localhost,1433 |
+| SOURCE_CORPUS_ROWS | 440,274 |
+| ENDPOINT | POST /api/sync/doctrine/drain/sales |
+| FULL_CORPUS | true |
+| TOPN | null |
+| ROWS_LANDED | 440,274 |
+| ROWS_PROMOTED | 94,875 |
+| ROWS_CANONICALIZED | 90,386 |
+| GATE_STATUS | 29 PASS / 2 WARN / 0 FAIL |
+| QUARANTINE_STATUS | +4,489 (2,048,684 → 2,053,173) |
+| ZOMBIE_BATCH_STATUS | 0 — clean |
+| DEV_CLEAN_TOUCHED | No (4 seed rows, unchanged) |
+| ERRORS | None |
+| LOCAL_COMMIT | Pending (see below) |
+| NEXT_WORK_ORDER | GEOM-011C (hard-blocked) or operator-directed |

--- a/docs/data/BENTON_DEMO_SALES_FULL_RUN_RESULTS.md
+++ b/docs/data/BENTON_DEMO_SALES_FULL_RUN_RESULTS.md
@@ -45,7 +45,7 @@ Full sales drain against restored S4 baseline. Source: Windows SQL Server 2019 `
 
 ## Sales Drain Execution
 
-**Endpoint:** `POST http://localhost:5046/api/sync/doctrine/drain/sales`  
+**Endpoint:** `POST http://localhost:${TF_API_PORT:-5046}/api/sync/doctrine/drain/sales`  
 **Body:**
 ```json
 {

--- a/docs/data/WO_DEPLOY_BENTON_001_PROMOTION_PLAN.md
+++ b/docs/data/WO_DEPLOY_BENTON_001_PROMOTION_PLAN.md
@@ -1,0 +1,208 @@
+# WO-DEPLOY-BENTON-001 — Benton Demo DB Promotion Plan
+
+**Date:** 2026-06-28  
+**Status:** PLANNING — awaiting operator target decision  
+**Prerequisite:** WO-DATA-FINALIZE-PR complete, PR #1092 open, S6 snapshot preserved
+
+---
+
+## 1. Current State (Baseline)
+
+| Item | State |
+|------|-------|
+| S6 dump | `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S6_complete.dump` (2.507 GB) |
+| Local postgres container | `terrafusion-postgres-dev` running, S6 data live at `localhost:5432` |
+| Local API | Port 5046, `wo/geom-011c` worktree — temporary, not the main dev stack |
+| PACS containers | `tf-pacs-current-verify` :21433, `tf-pacs-bak-restore` :21434 — running |
+| Azure CLI | Not authenticated (`az login` required before any Azure steps) |
+| Prod compose | `backend/docker-compose.prod.yml` exists (`postgres:16-alpine`, named `terrafusion-postgres-prod`) |
+
+---
+
+## 2. Promotion Target Options
+
+### Option A — Local Demo Runtime (Lowest friction, immediate)
+
+Wire the completed S6 data into the **main dev stack** so the full application runs against real
+Benton data on this machine.
+
+**What it means:**
+- Rename or snapshot `terrafusion_benton_demo` → `terrafusion_dev` (or update the API
+  `DefaultConnection` to point at `terrafusion_benton_demo` directly)
+- Start the main dev stack (`TF_API_PORT=5046 VITE_PORT=3000 pnpm run dev`) against S6 data
+- Run smoke tests on the frontend with real parcel/owner/improvement/land/sales/geometry data
+
+**Prerequisites:**
+- Merge PR #1092 first
+- Decide DB name: keep `terrafusion_benton_demo` as the live name, or restore into `terrafusion`
+
+**Risk:** Low. Everything is already local. No secrets leave the machine.
+
+**Blocker:** None — can be executed immediately.
+
+---
+
+### Option B — Azure Dev/Test Environment (Demo-ready, shareable)
+
+Restore S6 into an **Azure Database for PostgreSQL Flexible Server** in a dev/test resource group.
+
+**What it means:**
+- Provision Azure PostgreSQL (or use existing, if one exists)
+- Upload S6 dump → restore via `pg_restore` on the Azure server
+- Update `appsettings.{env}.json` with Azure connection string
+- Deploy API + frontend to Azure App Service or Container App
+- Run smoke tests against Azure endpoint
+
+**Prerequisites:**
+- `az login` — operator must authenticate
+- Azure subscription and resource group identified
+- Decide: Flexible Server (recommended for pg_restore support) vs Azure DB for PostgreSQL
+- Cost estimate: Flexible Server B1ms ~$13/month for dev tier
+
+**Risk:** Medium. Connection strings go in Azure Key Vault or App Service settings, not committed.
+Dump upload is ~2.5 GB — takes ~5-10 min on typical connection.
+
+**Blockers:**
+- Azure CLI auth (`az login`)
+- Operator decision on subscription/resource group
+- Azure PostgreSQL provisioning (~5-10 min)
+
+---
+
+### Option C — Benton-Owned Environment (Future, county handoff)
+
+Deliver S6 as a restore package to Benton County's own infrastructure.
+
+**What it means:**
+- Package: S6 dump + restore procedure doc + connection string template + smoke test checklist
+- County receives: portable archive, instructions, validation gates
+- County runs restore on their environment (on-prem or county cloud)
+
+**Prerequisites:**
+- County has a PostgreSQL 16 target (or we provision one)
+- Transfer mechanism for 2.5 GB dump (secure file transfer, Azure Blob, or physical)
+- County DBA or operator to execute restore
+
+**Risk:** Low for us (read-only delivery). Restore authority stays with county.
+
+**Blockers:**
+- County environment decision (out of scope for this WO, future WO)
+- Secure transfer method
+
+---
+
+## 3. Restore Procedure (Common to all targets)
+
+This procedure is target-agnostic. Adapt connection vars per environment.
+
+```bash
+# 1. Create target database
+psql -U postgres -h <HOST> -c "CREATE DATABASE terrafusion_benton_demo;"
+
+# 2. Copy dump to target host (or use docker cp for local)
+# For local: already at C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S6_complete.dump
+# For Azure: upload via az storage blob upload or scp
+
+# 3. Restore (parallel, 4 jobs)
+pg_restore -U postgres -h <HOST> -d terrafusion_benton_demo -Fc -j 4 <dump_path>
+
+# 4. Verify row counts (run against restored DB)
+psql -U postgres -h <HOST> -d terrafusion_benton_demo -c "
+SELECT 'parcel' as lane, COUNT(*) FROM canonical_tf.tf_parcel
+UNION ALL SELECT 'owner', COUNT(*) FROM canonical_tf.tf_owner
+UNION ALL SELECT 'land', COUNT(*) FROM canonical_tf.tf_land
+UNION ALL SELECT 'sale', COUNT(*) FROM canonical_tf.tf_sale
+UNION ALL SELECT 'improvement', COUNT(*) FROM canonical_tf.tf_improvement
+UNION ALL SELECT 'geom', COUNT(*) FROM gis_tf.tf_parcel_geom;
+"
+
+# Expected:
+# parcel      84,418
+# owner       97,062
+# land        87,767
+# sale        90,386
+# improvement 100,144
+# geom        79,199
+```
+
+---
+
+## 4. Connection String Templates
+
+**Local (current):**
+```
+Host=localhost;Database=terrafusion_benton_demo;Username=postgres;Password=<local>;Port=5432;Command Timeout=600;Timeout=30
+```
+
+**Azure Flexible Server:**
+```
+Host=<server>.postgres.database.azure.com;Database=terrafusion_benton_demo;Username=<admin>@<server>;Password=<vault-secret>;Port=5432;SSL Mode=Require;Trust Server Certificate=False
+```
+
+**Never commit** — always in `appsettings.{Env}.local.json` (gitignored) or Azure Key Vault / App Service configuration.
+
+---
+
+## 5. Smoke Tests (Post-Restore Validation)
+
+Run against the target API after restore and deploy.
+
+| Test | Endpoint | Expected |
+|------|----------|---------|
+| Health check | `GET /health` | HTTP 200 |
+| Parcel count | `GET /api/sync/status` or equivalent | parcel=84,418 |
+| Single parcel fetch | `GET /api/parcels/{known_pin}` | HTTP 200, data present |
+| Owner lookup | `GET /api/owners?parcelId=...` | HTTP 200 |
+| Sales lane status | Sync status endpoint | sale=90,386 |
+| Geometry present | `GET /api/parcels/{pin}/geometry` | HTTP 200, coordinates present |
+| No active drain | Batch status check | 0 IN_PROGRESS (excl. 9 historical zombies) |
+
+---
+
+## 6. Secrets / Connection String Management
+
+| Secret | Local | Azure |
+|--------|-------|-------|
+| Postgres password | `appsettings.Development.local.json` (gitignored) | Azure Key Vault or App Service Config |
+| PACS SA password | `appsettings.Development.local.json` (gitignored) | Key Vault (only if PACS sync needed in cloud) |
+| ArcGIS (geometry) | No credential needed for read-only REST | Same |
+
+**Rule:** No connection strings or passwords in committed files. Ever.
+
+---
+
+## 7. Decision Gate
+
+Operator must choose a path before execution begins.
+
+| Decision | Options |
+|----------|---------|
+| **Primary target** | A (local demo), B (Azure dev/test), C (county handoff) |
+| **DB name in target** | `terrafusion_benton_demo` (preserve) or `terrafusion` (rename to match dev stack) |
+| **Azure subscription** | (if B) — which sub, which resource group |
+| **PACS in cloud** | (if B) — include PACS SQL containers in Azure, or local-only |
+| **Merge PR #1092 first?** | Recommended yes before any deployment |
+
+---
+
+## 8. Recommended Immediate Next Step
+
+**Merge PR #1092 first.** It's the canonical record and should land on main before any deployment
+work starts.
+
+Then: operator declares target (A, B, or C), and execution begins on the chosen path as a
+separate WO (e.g., WO-DEPLOY-BENTON-001A for local, WO-DEPLOY-BENTON-001B for Azure).
+
+---
+
+## Final Report
+
+| Field | Value |
+|-------|-------|
+| RESULT | Plan complete — awaiting operator target decision |
+| S6_RESTORE_POINT | `C:\Users\bsval\tf-db-archives\terrafusion_benton_demo_S6_complete.dump` (2.507 GB) |
+| TARGET_OPTIONS | A=local demo / B=Azure dev-test / C=county handoff |
+| AZURE_CLI_STATUS | Not authenticated — `az login` required for Option B |
+| IMMEDIATE_BLOCKER | None for Option A; `az login` + subscription for Option B |
+| RECOMMENDED_FIRST_STEP | Merge PR #1092, then declare target |
+| NEXT_WORK_ORDER | WO-DEPLOY-BENTON-001A/B/C per operator decision |


### PR DESCRIPTION
## Summary

Final evidence packet for the completed Benton demo database. All six data-loading lanes are complete and preserved in the S6 snapshot.

**Target DB:** `terrafusion_benton_demo`  
**Snapshot:** `terrafusion_benton_demo_S6_complete.dump` (2,507,328,204 bytes / ~2.51 GB)

### Final Lane Counts

| Lane | Count |
|------|------:|
| Parcel | 84,418 |
| Owner | 97,062 |
| Owner Link | 686,851 |
| WSDOR | 686,820 |
| Improvement | 100,144 |
| Improvement Features | 1,351,892 |
| Land | 87,767 |
| Sales | 90,386 |
| **Geometry** | **79,199** |

### Files Included

- `BENTON_DEMO_SALES_FULL_RUN_RESULTS.md` — WO-DATA-FINALIZE-SALES-002B: 440,274 landed, 94,875 promoted, 29/31 gates pass
- `BENTON_DEMO_S5_POST_SALES_SNAPSHOT.md` — WO-DATA-FINALIZE-S5: 1.725 GB post-sales snapshot
- `BENTON_DEMO_GEOM_FULL_RUN_RESULTS.md` — GEOM-011C: 79,199 rows, 13/13 gates pass, 0 quarantined
- `BENTON_DEMO_S6_COMPLETE_DB_SNAPSHOT.md` — WO-DATA-FINALIZE-S6: 2.507 GB, all 6 lanes verified
- `BENTON_DEMO_DB_COMPLETION_FINAL_SUMMARY.md` — Canonical final state record

### Safety

- No dump files committed (dumps in `tf-db-archives/`, gitignored)
- No code changes — docs/evidence only
- No secrets — SA password in gitignored local settings only
- Secret scan: clean
- PACS source: read-only throughout
- ArcGIS source: read-only throughout
- `terrafusion_dev_clean`: untouched (4 seed rows confirmed)

### Known Carry-Forward Warnings (Not Failures)

- Sales `noSuppPointer` = 194,757 — valid Benton sales with no supplemental pointer
- Sales pre-conversion share = 70.06% — expected for Benton historical corpus (pre-2017 ProVal conversion)
- 9 historical zombie `IN_PROGRESS` batch records (Jun 21–26, cancelled runs) — cleanup deferred
- Cumulative quarantine = 2,053,173

### Next Workstream

Remaining work is **deployment/promotion**, not data loading. S6 is the authoritative restore point.

## Test plan

- [ ] Verify 5 docs/data files only in diff
- [ ] Confirm no .dump files in tree
- [ ] Confirm no credential strings in evidence docs
- [ ] Confirm final counts match S6 evidence doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Benton Demo documentation covering full sales run results, geometry full run execution, S5 post-sales snapshot status, and complete S6 database completion with verified lane/table row counts.
  * Included sales/geometry gate outcomes (PASS/WARN/FAIL), quarantine and batch hygiene details, and consolidated final result tables.
  * Documented snapshot artifacts with restore commands/timings plus operator safety/verification checklists.
  * Added a promotion runbook for WO-DEPLOY-BENTON-001 describing restore/verification steps for target environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->