### PR TITLE
docs(devops): consolidate local onboarding entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,24 @@ TerraFusion OS is a **county property-assessment platform** targeting Washington
 
 ## Quick Start
 
-Start with the canonical onboarding guide:
+Start with the canonical onboarding guide. It is the first page for new developers and agents:
 
 - [Developer Onboarding](docs/onboarding/DEVELOPER_ONBOARDING.md)
 - [Local Docker Dev](docs/onboarding/DOCKER_DEV.md)
 - [Docker Troubleshooting](docs/onboarding/DOCKER_TROUBLESHOOTING.md)
 
-The short manual path below is useful after you have confirmed repo identity, worktree isolation, and
-local readiness.
+The first safe local commands are read-only:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
+docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config
+```
+
+The Docker config command validates local-dev YAML and placeholder env values. It is expected to
+render `services: {}` until you choose a profile in [Local Docker Dev](docs/onboarding/DOCKER_DEV.md).
+
+The short manual path below is useful only after you have confirmed repo identity, worktree
+isolation, and local readiness.
 
 ```bash
 # Clone

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Start with the canonical onboarding guide. It is the first page for new develope
 - [Local Docker Dev](docs/onboarding/DOCKER_DEV.md)
 - [Docker Troubleshooting](docs/onboarding/DOCKER_TROUBLESHOOTING.md)
 
-The first safe local commands are read-only:
+After cloning, run the first safe local commands from the repository root. They are read-only:
 
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
 docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config
 ```
 
-The Docker config command validates local-dev YAML and placeholder env values. It is expected to
-render `services: {}` until you choose a profile in [Local Docker Dev](docs/onboarding/DOCKER_DEV.md).
+The Docker config command validates local-dev YAML and placeholder env values. It may render
+`services: {}` until you choose a profile in [Local Docker Dev](docs/onboarding/DOCKER_DEV.md).
 
 The short manual path below is useful only after you have confirmed repo identity, worktree
 isolation, and local readiness.

--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -34,7 +34,7 @@ Use this path before trying ad hoc setup commands:
 4. Choose a profile-specific Docker command only after config validation passes.
 5. Clean up only the local-dev Compose project when you are done.
 
-The first local command is:
+Run these commands from the repository root of the intended worktree. The first local command is:
 
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1

--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -24,6 +24,42 @@ production systems, county data, PACS, county SQL, secrets, Helm, Kubernetes, or
 5. `docs/onboarding/DOCKER_TROUBLESHOOTING.md` when Docker fails.
 6. `docs/onboarding/AGENT_START_HERE.md` for agent handoff and preflight.
 
+## Canonical Local-Dev Path
+
+Use this path before trying ad hoc setup commands:
+
+1. Confirm repo identity and clean worktree state.
+2. Run the read-only readiness checker.
+3. Validate Docker local-dev Compose with placeholder env values.
+4. Choose a profile-specific Docker command only after config validation passes.
+5. Clean up only the local-dev Compose project when you are done.
+
+The first local command is:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
+```
+
+The first Docker command is:
+
+```powershell
+docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config
+```
+
+That Docker command is read-only and may render `services: {}` because local-dev services are
+profile-gated. Use `docs/onboarding/DOCKER_DEV.md` for the profile-specific validation and run
+commands.
+
+Cleanup is limited to the local-dev Compose project:
+
+```powershell
+docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example down
+docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example down --volumes
+```
+
+Use `down --volumes` only when you intentionally want to remove local Docker cache volumes. Do not
+use global Docker prune commands as part of onboarding.
+
 ## Repo Identity Check
 
 From the checkout you intend to use:

--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -50,15 +50,9 @@ That Docker command is read-only and may render `services: {}` because local-dev
 profile-gated. Use `docs/onboarding/DOCKER_DEV.md` for the profile-specific validation and run
 commands.
 
-Cleanup is limited to the local-dev Compose project:
-
-```powershell
-docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example down
-docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example down --volumes
-```
-
-Use `down --volumes` only when you intentionally want to remove local Docker cache volumes. Do not
-use global Docker prune commands as part of onboarding.
+Cleanup is limited to the local-dev Compose project. Use the command truth table in
+`docs/onboarding/DOCKER_DEV.md` for the current cleanup command and whether it removes cache volumes.
+Do not use global Docker prune commands as part of onboarding.
 
 ## Repo Identity Check
 

--- a/docs/onboarding/DEV_SETUP.md
+++ b/docs/onboarding/DEV_SETUP.md
@@ -45,7 +45,8 @@ Top-level surfaces you will use most often:
 
 ## First Commands
 
-Before installing dependencies or running builds, run the read-only readiness checker:
+Before installing dependencies or running builds, follow the canonical path in
+`docs/onboarding/DEVELOPER_ONBOARDING.md`. The first command is the read-only readiness checker:
 
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1


### PR DESCRIPTION
WO-DEVOPS-006G: Consolidates the local developer onboarding entrypoint so new contributors know where to start, which read-only readiness and Docker config commands to run first, how profile-gated Compose validation works, how local-dev cleanup is scoped, and what not to touch.\n\nScope: docs only.\n\nValidation:\n- git diff --check\n- scripts/dev/readiness.ps1\n- scripts/dev/bootstrap.ps1 from repo root\n- scripts/dev/bootstrap.ps1 from docs/\n- docker compose config for bare, tooling, frontend, and backend profiles\n\nNon-changes:\n- No runtime code\n- No Docker/Compose config changes\n- No CI/CD changes\n- No package/dependency changes\n- No secrets, county data, PACS, SQL, release, or deployment behavior.