### PR TITLE
chore(devops): align bootstrap with Docker reality

### DIFF
--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -40,6 +40,17 @@ Run these commands from the repository root of the intended worktree. The first 
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
 ```
 
+For a fuller inspect-only local bootstrap, run:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1
+```
+
+Bootstrap inspect mode reports Git/worktree state, required tools, required docs, local Docker env
+presence, and read-only Docker Compose config validation for the bare, tooling, frontend, and backend
+profiles. It does not install dependencies, create env files, start Docker services, restore .NET
+packages, run migrations, read secrets, or mutate Git.
+
 The first Docker command is:
 
 ```powershell

--- a/docs/onboarding/DOCKER_DEV.md
+++ b/docs/onboarding/DOCKER_DEV.md
@@ -45,8 +45,8 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
 docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config
 ```
 
-The bare Compose config command validates the file and placeholder env values. It is expected to
-render `services: {}` because local-dev services are only enabled through profiles.
+The bare Compose config command validates the file and placeholder env values. It may render
+`services: {}` because local-dev services are only enabled through profiles.
 
 Validate the profile-specific service definitions before running a toolbox or local service:
 
@@ -61,7 +61,7 @@ docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example --p
 | Command | Purpose | Creates Docker resources? | Starts long-running service? | Cleanup command | Safe for audit? |
 | --- | --- | --- | --- | --- | --- |
 | `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1` | Check local prerequisites and repo path assumptions. | No | No | Not needed | Yes |
-| `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config` | Validate YAML and placeholder env rendering. Expected to show `services: {}` because services are profile-gated. | No | No | Not needed | Yes |
+| `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config` | Validate YAML and placeholder env rendering. May show `services: {}` because services are profile-gated. | No | No | Not needed | Yes |
 | `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example --profile tooling config` | Validate toolbox service definitions. | No | No | Not needed | Yes |
 | `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example --profile frontend config` | Validate frontend service definition. | No | No | Not needed | Yes |
 | `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example --profile backend config` | Validate backend restore-check service definition. | No | No | Not needed | Yes |

--- a/scripts/dev/bootstrap.ps1
+++ b/scripts/dev/bootstrap.ps1
@@ -92,14 +92,14 @@ function Test-ComposeConfig {
         return
     }
 
-    $args = @("compose", "-f", $composeFile, "--env-file", $envFile)
+    $composeArgs = @("compose", "-f", $composeFile, "--env-file", $envFile)
     foreach ($profile in $Profiles) {
-        $args += @("--profile", $profile)
+        $composeArgs += @("--profile", $profile)
     }
-    $args += "config"
+    $composeArgs += "config"
 
     $label = if ($Profiles.Count -gt 0) { "profile '$($Profiles -join ",")'" } else { "bare profile-gated" }
-    $output = Get-CommandText -Command (@("docker") + $args)
+    $output = Get-CommandText -Command (@("docker") + $composeArgs)
     if ($LASTEXITCODE -eq 0) {
         Write-Result "PASS" "Docker Compose $label config validates."
     }
@@ -171,6 +171,7 @@ $requiredPaths = @(
     "docs/onboarding/DEV_SETUP.md",
     "docs/onboarding/DEVELOPER_ONBOARDING.md",
     "docs/onboarding/DOCKER_DEV.md",
+    "docs/onboarding/DOCKER_TROUBLESHOOTING.md",
     "docker/dev/compose.yaml",
     "docker/dev/.env.example"
 )

--- a/scripts/dev/bootstrap.ps1
+++ b/scripts/dev/bootstrap.ps1
@@ -75,6 +75,39 @@ function Test-RequiredPath {
     return $false
 }
 
+function Test-ComposeConfig {
+    param(
+        [string[]]$Profiles = @()
+    )
+
+    if (-not $repoRoot) {
+        Write-Result "WARN" "Skipping Docker Compose config validation because the repository root could not be determined."
+        return
+    }
+
+    $composeFile = Join-Path -Path $repoRoot -ChildPath "docker/dev/compose.yaml"
+    $envFile = Join-Path -Path $repoRoot -ChildPath "docker/dev/.env.example"
+    if (-not (Test-Path -LiteralPath $composeFile) -or -not (Test-Path -LiteralPath $envFile)) {
+        Write-Result "WARN" "Skipping Docker Compose config validation because docker/dev/compose.yaml or docker/dev/.env.example is missing."
+        return
+    }
+
+    $args = @("compose", "-f", $composeFile, "--env-file", $envFile)
+    foreach ($profile in $Profiles) {
+        $args += @("--profile", $profile)
+    }
+    $args += "config"
+
+    $label = if ($Profiles.Count -gt 0) { "profile '$($Profiles -join ",")'" } else { "bare profile-gated" }
+    $output = Get-CommandText -Command (@("docker") + $args)
+    if ($LASTEXITCODE -eq 0) {
+        Write-Result "PASS" "Docker Compose $label config validates."
+    }
+    else {
+        Write-Result "WARN" "Docker Compose $label config failed. Review docs/onboarding/DOCKER_TROUBLESHOOTING.md. $output"
+    }
+}
+
 Write-Result "INFO" "TerraFusion bootstrap mode: $Mode"
 Write-Result "INFO" "Bootstrap inspect mode is read-only. It does not install, restore, start services, create env files, run migrations, read secrets, or mutate Git."
 Write-Result "INFO" "Current path: $(Get-Location)"
@@ -155,6 +188,13 @@ if ($repoRoot) {
     else {
         Write-Result "WARN" "Local Docker env file is absent. Use placeholders from docker/dev/.env.example if local Docker dev needs a .env file."
     }
+
+    if ($dockerAvailable) {
+        Test-ComposeConfig
+        Test-ComposeConfig -Profiles @("tooling")
+        Test-ComposeConfig -Profiles @("frontend")
+        Test-ComposeConfig -Profiles @("backend")
+    }
 }
 else {
     Write-Result "WARN" "Skipping repo-relative path checks because the repository root could not be determined."
@@ -163,6 +203,7 @@ else {
 Write-Result "INFO" "Next docs:"
 Write-Result "INFO" "- docs/onboarding/DEV_SETUP.md"
 Write-Result "INFO" "- docs/onboarding/DOCKER_DEV.md"
+Write-Result "INFO" "- docs/onboarding/DOCKER_TROUBLESHOOTING.md"
 
 if ($hardFailures -gt 0) {
     Write-Host "FAIL: Bootstrap inspect completed with $hardFailures hard failure(s)."


### PR DESCRIPTION
WO-DEVOPS-006H: Aligns the inspect-only bootstrap helper with the documented Docker local-dev truth. Bootstrap now performs read-only Docker Compose config validation for bare, tooling, frontend, and backend profiles and points to the current onboarding/troubleshooting docs.\n\nScope: local dev script and onboarding docs only.\n\nValidation:\n- git diff --check\n- scripts/dev/readiness.ps1\n- scripts/dev/bootstrap.ps1 from repo root\n- scripts/dev/bootstrap.ps1 from docs/\n- docker compose config for bare, tooling, frontend, and backend profiles\n\nNon-changes:\n- No runtime code\n- No Docker/Compose config changes\n- No CI/CD changes\n- No package/dependency changes\n- No secrets, county data, PACS, SQL, release, or deployment behavior.