### PR TITLE
chore(devops): add local dev smoke gate

### DIFF
--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -58,8 +58,9 @@ For the smallest local-dev health gate, run:
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1
 ```
 
-The smoke gate wraps readiness plus bootstrap inspect and is documented in
-`docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`.
+Run that command from the repository root. If you are in a subdirectory, use a path that resolves
+from the current directory, such as `..\scripts\dev\smoke.ps1` from `docs/`. The smoke gate wraps
+readiness plus bootstrap inspect and is documented in `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`.
 
 The first Docker command is:
 

--- a/docs/onboarding/DEVELOPER_ONBOARDING.md
+++ b/docs/onboarding/DEVELOPER_ONBOARDING.md
@@ -21,8 +21,9 @@ production systems, county data, PACS, county SQL, secrets, Helm, Kubernetes, or
 2. This guide.
 3. `docs/onboarding/DEV_SETUP.md` for tool versions and command truth.
 4. `docs/onboarding/DOCKER_DEV.md` for local Docker dev commands.
-5. `docs/onboarding/DOCKER_TROUBLESHOOTING.md` when Docker fails.
-6. `docs/onboarding/AGENT_START_HERE.md` for agent handoff and preflight.
+5. `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md` for the smallest local-dev health check.
+6. `docs/onboarding/DOCKER_TROUBLESHOOTING.md` when Docker fails.
+7. `docs/onboarding/AGENT_START_HERE.md` for agent handoff and preflight.
 
 ## Canonical Local-Dev Path
 
@@ -50,6 +51,15 @@ Bootstrap inspect mode reports Git/worktree state, required tools, required docs
 presence, and read-only Docker Compose config validation for the bare, tooling, frontend, and backend
 profiles. It does not install dependencies, create env files, start Docker services, restore .NET
 packages, run migrations, read secrets, or mutate Git.
+
+For the smallest local-dev health gate, run:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1
+```
+
+The smoke gate wraps readiness plus bootstrap inspect and is documented in
+`docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`.
 
 The first Docker command is:
 
@@ -163,6 +173,7 @@ Stop and escalate when work requires any of these:
 ## Next Guide Links
 
 - `docs/onboarding/DEV_SETUP.md`
+- `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`
 - `docs/onboarding/DOCKER_DEV.md`
 - `docs/onboarding/DOCKER_TROUBLESHOOTING.md`
 - `docs/onboarding/TROUBLESHOOTING.md`

--- a/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
+++ b/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
@@ -15,14 +15,20 @@ authorize writes outside the local-dev smoke gate scope.
 
 ## Command
 
-Run from the repository root or any subdirectory inside the intended worktree:
+From the repository root of the intended worktree, run:
 
 ```powershell
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1
 ```
 
-If you are in a subdirectory, use a repo-root-relative path or invoke it through PowerShell after
-resolving the script path.
+If you are in a subdirectory, invoke the script with a path that is valid from the current directory.
+For example, from `docs/`:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File ..\scripts\dev\smoke.ps1
+```
+
+The script locates the repository root after PowerShell has successfully opened the script file.
 
 ## What It Runs
 

--- a/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
+++ b/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
@@ -4,6 +4,15 @@ The local dev smoke gate is the smallest boring check for a TerraFusion develope
 that the documented local-dev command surface is reachable without installing packages, starting
 services, creating env files, running migrations, reading secrets, or mutating Git.
 
+## Authorization
+
+This document and `scripts/dev/smoke.ps1` are created under `WO-DEVOPS-006J - Local Dev Smoke Gate`
+in the TerraFusion local development chain. The authorized lane is local developer tooling and
+onboarding documentation only.
+
+This work order does not expand the root Core Governance Surface, modify repo-shape policy, or
+authorize writes outside the local-dev smoke gate scope.
+
 ## Command
 
 Run from the repository root or any subdirectory inside the intended worktree:

--- a/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
+++ b/docs/onboarding/LOCAL_DEV_SMOKE_GATE.md
@@ -1,0 +1,75 @@
+# Local Dev Smoke Gate
+
+The local dev smoke gate is the smallest boring check for a TerraFusion developer worktree. It proves
+that the documented local-dev command surface is reachable without installing packages, starting
+services, creating env files, running migrations, reading secrets, or mutating Git.
+
+## Command
+
+Run from the repository root or any subdirectory inside the intended worktree:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1
+```
+
+If you are in a subdirectory, use a repo-root-relative path or invoke it through PowerShell after
+resolving the script path.
+
+## What It Runs
+
+The smoke gate runs:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1
+```
+
+`bootstrap.ps1` performs read-only Docker Compose config validation for:
+
+- bare profile-gated config
+- `tooling`
+- `frontend`
+- `backend`
+
+## Pass Criteria
+
+The smoke gate passes when readiness and bootstrap inspect complete with no hard failures.
+
+Warnings are allowed for expected local-only conditions, including:
+
+- missing `docker/dev/.env`
+- dirty status in an active work-order branch
+- local tool version warnings that do not block the current work order
+
+## Failure Criteria
+
+The smoke gate fails when:
+
+- the current path is not inside a Git worktree
+- `scripts/dev/readiness.ps1` is missing or fails
+- `scripts/dev/bootstrap.ps1` is missing or fails
+- required local-dev docs or Docker placeholder files are missing
+
+## Non-Goals
+
+This smoke gate does not prove:
+
+- production readiness
+- release readiness
+- runtime application correctness
+- package install success
+- frontend dependency install success
+- backend restore/build success
+- Kubernetes or Helm readiness
+- county runtime readiness
+
+## Stop Gates
+
+Stop and route through a separate work order if passing the smoke gate would require:
+
+- real secrets, tokens, or credentials
+- county data, PACS, or county SQL
+- production Docker, Helm, Kubernetes, deployment, or release behavior
+- package dependency changes
+- runtime product behavior changes
+- destructive Docker or filesystem cleanup

--- a/scripts/dev/smoke.ps1
+++ b/scripts/dev/smoke.ps1
@@ -23,12 +23,25 @@ function Invoke-SmokeStep {
     )
 
     Write-Result "INFO" "Running smoke step: $Name"
-    & pwsh -NoProfile -ExecutionPolicy Bypass -File $ScriptPath
-    if ($LASTEXITCODE -eq 0) {
+    $pwshCommand = Get-Command pwsh -ErrorAction SilentlyContinue
+    if (-not $pwshCommand) {
+        Write-Result "FAIL" "pwsh is not available; cannot run $Name."
+        return
+    }
+
+    & $pwshCommand.Source -NoProfile -ExecutionPolicy Bypass -File $ScriptPath
+    $stepStarted = $?
+    $stepExitCode = $LASTEXITCODE
+    if ($stepStarted -and $stepExitCode -eq 0) {
         Write-Result "PASS" "$Name completed."
     }
     else {
-        Write-Result "FAIL" "$Name failed with exit code $LASTEXITCODE."
+        if ($null -eq $stepExitCode) {
+            Write-Result "FAIL" "$Name failed before an exit code was reported."
+        }
+        else {
+            Write-Result "FAIL" "$Name failed with exit code $stepExitCode."
+        }
     }
 }
 
@@ -50,11 +63,18 @@ Write-Result "INFO" "TerraFusion local smoke gate is read-only."
 Write-Result "INFO" "It does not install packages, create env files, start Docker services, run migrations, read secrets, or mutate Git."
 Write-Result "INFO" "Current path: $(Get-Location)"
 
-$repoRoot = Get-RepoRoot
-if (-not $repoRoot) {
-    Write-Result "FAIL" "Current path is not inside a Git worktree."
+$gitCommand = Get-Command git -ErrorAction SilentlyContinue
+if (-not $gitCommand) {
+    Write-Result "FAIL" "git is not available; install Git or add it to PATH before running local smoke checks."
 }
 else {
+    $repoRoot = Get-RepoRoot
+}
+
+if ($gitCommand -and -not $repoRoot) {
+    Write-Result "FAIL" "Current path is not inside a Git worktree."
+}
+elseif ($repoRoot) {
     Write-Result "PASS" "Git repository root: $repoRoot"
 
     $readiness = Join-Path -Path $repoRoot -ChildPath "scripts/dev/readiness.ps1"

--- a/scripts/dev/smoke.ps1
+++ b/scripts/dev/smoke.ps1
@@ -1,0 +1,84 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Continue"
+$hardFailures = 0
+
+function Write-Result {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet("PASS", "WARN", "FAIL", "INFO")][string]$Level,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    Write-Host "$Level`: $Message"
+    if ($Level -eq "FAIL") {
+        $script:hardFailures++
+    }
+}
+
+function Invoke-SmokeStep {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$ScriptPath
+    )
+
+    Write-Result "INFO" "Running smoke step: $Name"
+    & pwsh -NoProfile -ExecutionPolicy Bypass -File $ScriptPath
+    if ($LASTEXITCODE -eq 0) {
+        Write-Result "PASS" "$Name completed."
+    }
+    else {
+        Write-Result "FAIL" "$Name failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Get-RepoRoot {
+    try {
+        $root = & git rev-parse --show-toplevel 2>&1
+        if ($LASTEXITCODE -eq 0 -and $root) {
+            return $root.ToString().Trim()
+        }
+    }
+    catch {
+        return $null
+    }
+
+    return $null
+}
+
+Write-Result "INFO" "TerraFusion local smoke gate is read-only."
+Write-Result "INFO" "It does not install packages, create env files, start Docker services, run migrations, read secrets, or mutate Git."
+Write-Result "INFO" "Current path: $(Get-Location)"
+
+$repoRoot = Get-RepoRoot
+if (-not $repoRoot) {
+    Write-Result "FAIL" "Current path is not inside a Git worktree."
+}
+else {
+    Write-Result "PASS" "Git repository root: $repoRoot"
+
+    $readiness = Join-Path -Path $repoRoot -ChildPath "scripts/dev/readiness.ps1"
+    $bootstrap = Join-Path -Path $repoRoot -ChildPath "scripts/dev/bootstrap.ps1"
+
+    if (-not (Test-Path -LiteralPath $readiness)) {
+        Write-Result "FAIL" "Missing readiness script: scripts/dev/readiness.ps1"
+    }
+    else {
+        Invoke-SmokeStep -Name "readiness" -ScriptPath $readiness
+    }
+
+    if (-not (Test-Path -LiteralPath $bootstrap)) {
+        Write-Result "FAIL" "Missing bootstrap script: scripts/dev/bootstrap.ps1"
+    }
+    else {
+        Invoke-SmokeStep -Name "bootstrap inspect" -ScriptPath $bootstrap
+    }
+}
+
+if ($hardFailures -gt 0) {
+    Write-Host "FAIL: Local smoke gate completed with $hardFailures hard failure(s)."
+    exit 1
+}
+
+Write-Result "PASS" "Local smoke gate completed with no hard failures."
+exit 0


### PR DESCRIPTION
WO-DEVOPS-006J: Adds a read-only local dev smoke gate that wraps readiness and bootstrap inspect, plus onboarding documentation for pass/fail criteria and boundaries.\n\nScope: local-dev script and onboarding docs only.\n\nValidation:\n- git diff --check\n- scripts/dev/smoke.ps1 from repo root\n- scripts/dev/smoke.ps1 from docs/\n- docker compose config for bare, tooling, frontend, and backend profiles\n\nNon-changes:\n- No runtime code\n- No Docker/Compose config changes\n- No CI/CD changes\n- No package/dependency changes\n- No secrets, county data, PACS, SQL, release, or deployment behavior.