### PR TITLE
docs(devops): align onboarding links

### DIFF
--- a/docs/onboarding/AGENT_START_HERE.md
+++ b/docs/onboarding/AGENT_START_HERE.md
@@ -9,6 +9,7 @@ Start with the active work order. Do not widen scope because adjacent files exis
 For onboarding and local-platform work, start with:
 
 - `docs/onboarding/DEVELOPER_ONBOARDING.md`
+- `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`
 - a dedicated clean worktree from current `origin/main`
 
 Historical worktrees, including `<user-home>\.codex-worktrees\devops-main-baseline`, are evidence of
@@ -41,10 +42,13 @@ Stop if:
 2. `AGENTS.md`
 3. The active work-order packet
 4. `docs/onboarding/DEVELOPER_ONBOARDING.md`
-5. The nearest supporting docs for your lane
+5. `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md` for local-dev command order and stop gates
+6. The nearest supporting docs for your lane
 
 For DevOps onboarding, local Docker, and Azure migration, read as applicable:
 
+- `docs/onboarding/TOOLCHAIN_TRUTH.md`
+- `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`
 - `docs/onboarding/DOCKER_DEV.md`
 - `docs/onboarding/DOCKER_TROUBLESHOOTING.md`
 - `docs/migration/build-truth-sheet.md`
@@ -87,6 +91,9 @@ Run only the commands that match the active work order. Documentation-only work 
 ## Expected Files For The DevOps Lane
 
 - `docs/onboarding/DEVELOPER_ONBOARDING.md`
+- `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`
+- `docs/onboarding/TOOLCHAIN_TRUTH.md`
+- `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`
 - `docs/onboarding/DOCKER_DEV.md`
 - `docs/onboarding/DOCKER_TROUBLESHOOTING.md`
 - `docs/agents/DEVOPS_AGENT_HANDOFF_TEMPLATE.md`

--- a/docs/onboarding/DEV_SETUP.md
+++ b/docs/onboarding/DEV_SETUP.md
@@ -4,6 +4,8 @@ This guide is supporting detail for the canonical onboarding entrypoint:
 `docs/onboarding/DEVELOPER_ONBOARDING.md`.
 
 For declared versus observed tool versions, use `docs/onboarding/TOOLCHAIN_TRUTH.md`.
+For the operator-facing local-dev command order and stop gates, use
+`docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`.
 
 Use it for local development and CI-oriented validation after confirming repo identity and worktree
 isolation. It does not authorize secrets handling, county runtime access, PACS or SQL access,
@@ -12,6 +14,8 @@ production deployment, or mutation of unrelated dirty checkouts.
 ## Repository Baseline
 
 - Canonical onboarding entrypoint: `docs/onboarding/DEVELOPER_ONBOARDING.md`
+- Local-dev operating packet: `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`
+- Smallest local-dev smoke gate: `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`
 - Worktree rule: create a dedicated clean worktree for the active work order from current
   `origin/main`
 - Historical DevOps migration baseline: `<user-home>\.codex-worktrees\devops-main-baseline` was
@@ -78,17 +82,20 @@ pnpm run check:generated
 
 1. Confirm you are in the intended worktree and branch.
 2. Read `AGENTS.md` and `docs/onboarding/DEVELOPER_ONBOARDING.md`.
-3. Run `scripts/dev/readiness.ps1`.
-4. For local Docker dev, read `docs/onboarding/DOCKER_DEV.md`.
-5. Install dependencies with `pnpm install --frozen-lockfile` only when the active work order needs it.
-6. Run the fast PR-validation command set first.
-7. Run backend build and frontend build only after the fast gates are stable.
+3. Read `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`.
+4. Run `scripts/dev/readiness.ps1`.
+5. Run `scripts/dev/bootstrap.ps1` or `scripts/dev/smoke.ps1` when local-dev evidence is needed.
+6. For local Docker dev, read `docs/onboarding/DOCKER_DEV.md`.
+7. Install dependencies with `pnpm install --frozen-lockfile` only when the active work order needs it.
+8. Run the fast PR-validation command set first.
+9. Run backend build and frontend build only after the fast gates are stable.
 
 ## Local Dev Notes
 
 - Use a dedicated clean worktree for DevOps documentation, onboarding, and Azure-first-pass work.
 - Treat the main shared checkout as evidence-only if it is dirty or conflicted.
 - Prefer the documented command surfaces over ad hoc alternatives.
+- Use `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md` when you need one boring local-dev health signal.
 - GitHub workflow history is useful reference, but Azure validation truth comes from the Azure pipeline YAML plus live Azure runs.
 - Local Docker development is documented in `docs/onboarding/DOCKER_DEV.md` and uses only
   `docker/dev/**`.

--- a/docs/onboarding/DEV_SETUP.md
+++ b/docs/onboarding/DEV_SETUP.md
@@ -7,8 +7,8 @@ For declared versus observed tool versions, use `docs/onboarding/TOOLCHAIN_TRUTH
 For the operator-facing local-dev command order and stop gates, use
 `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`.
 
-Use it for local development and CI-oriented validation after confirming repo identity and worktree
-isolation. It does not authorize secrets handling, county runtime access, PACS or SQL access,
+Use this guide for local development and CI-oriented validation after confirming repo identity and
+worktree isolation. It does not authorize secrets handling, county runtime access, PACS or SQL access,
 production deployment, or mutation of unrelated dirty checkouts.
 
 ## Repository Baseline

--- a/docs/onboarding/TROUBLESHOOTING.md
+++ b/docs/onboarding/TROUBLESHOOTING.md
@@ -5,6 +5,9 @@ Use this matrix for common local and Azure-first-pass setup failures. Keep fixes
 Start with `docs/onboarding/DEVELOPER_ONBOARDING.md`. For Docker-specific failures, use
 `docs/onboarding/DOCKER_TROUBLESHOOTING.md`.
 
+For local-dev command order and stop gates, use `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`.
+For the smallest health check, use `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md`.
+
 ## Troubleshooting Matrix
 
 | Symptom | Likely cause | How to verify | Safe first action | Escalate when |
@@ -22,6 +25,8 @@ Start with `docs/onboarding/DEVELOPER_ONBOARDING.md`. For Docker-specific failur
 | Backend SDK mismatch | local SDK differs from repo baseline | compare `dotnet --info` with `global.json` | install/use .NET `8.0.x` | restore/build still selects the wrong SDK |
 | Tier-1 tests fail unexpectedly | local deps incomplete or frontend environment drift | rerun after clean install and note first failure | capture exact command and first error line | issue appears deterministic and needs a scoped fix packet |
 | Docker local dev fails | Docker Desktop, Compose, env, or port issue | `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config` | use `docs/onboarding/DOCKER_TROUBLESHOOTING.md` | production Compose, Helm, PACS, county SQL, or secrets are implicated |
+| Local smoke gate fails | readiness or bootstrap inspect found a local prerequisite problem | `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1` | inspect the first failed child command and use `docs/onboarding/LOCAL_DEV_SMOKE_GATE.md` | fixing it would require installs, Docker startup, dependency changes, runtime code, or secrets |
+| Tool version is unclear | local tool differs from repo-declared or observed baseline | compare `package.json`, `.nvmrc`, `global.json`, and `docs/onboarding/TOOLCHAIN_TRUTH.md` | use the repo-declared version unless the active work order documents a local deviation | package-manager or SDK migration is implied |
 
 ## Common Failure Patterns
 


### PR DESCRIPTION
## Summary

Aligns onboarding links after the local-dev operating packet landed.

Scope:
- Adds the local-dev operating packet, toolchain truth, and smoke gate to agent/setup/troubleshooting paths
- Keeps `DEVELOPER_ONBOARDING.md` as the canonical entrypoint
- Clarifies local-dev command order without changing scripts or Docker config

## Non-changes

- No runtime code
- No Docker or Compose config
- No package metadata or dependency changes
- No CI/CD changes
- No secrets, county data, PACS, or SQL
- No release or deployment behavior

## Validation

- `git diff --check`
- `scripts/dev/smoke.ps1` from repo root
- `scripts/dev/smoke.ps1` from `docs/`
- `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config`