### PR TITLE
chore(devops): align local script help output

### DIFF
--- a/docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md
+++ b/docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md
@@ -47,6 +47,14 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1
 pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1
 ```
 
+Each local-dev script supports `-Help` for usage and read-only behavior notes:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1 -Help
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1 -Help
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1 -Help
+```
+
 Validate Docker local-dev config before starting any Docker service:
 
 ```powershell

--- a/scripts/dev/bootstrap.ps1
+++ b/scripts/dev/bootstrap.ps1
@@ -1,5 +1,7 @@
 [CmdletBinding()]
 param(
+    [switch]$Help,
+
     [ValidateSet("inspect")]
     [string]$Mode = "inspect"
 )
@@ -7,6 +9,27 @@ param(
 $ErrorActionPreference = "Continue"
 $hardFailures = 0
 $repoRoot = $null
+
+function Show-Usage {
+    Write-Host "TerraFusion local bootstrap"
+    Write-Host ""
+    Write-Host "Usage:"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1 -Mode inspect"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/bootstrap.ps1 -Help"
+    Write-Host ""
+    Write-Host "Modes:"
+    Write-Host "  inspect  Read-only prerequisite, repo, docs, env, and Docker Compose config checks."
+    Write-Host ""
+    Write-Host "Behavior:"
+    Write-Host "  Read-only. Does not install packages, create env files, start Docker services, restore .NET packages,"
+    Write-Host "  run migrations, read secrets, or mutate Git."
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
 
 function Write-Result {
     param(

--- a/scripts/dev/readiness.ps1
+++ b/scripts/dev/readiness.ps1
@@ -1,9 +1,28 @@
 [CmdletBinding()]
-param()
+param(
+    [switch]$Help
+)
 
 $ErrorActionPreference = "Continue"
 $hardFailures = 0
 $repoRoot = $null
+
+function Show-Usage {
+    Write-Host "TerraFusion local readiness checker"
+    Write-Host ""
+    Write-Host "Usage:"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/readiness.ps1 -Help"
+    Write-Host ""
+    Write-Host "Behavior:"
+    Write-Host "  Read-only. Checks local tools, repo identity, required docs, Docker availability, and local .env presence."
+    Write-Host "  Does not install packages, create env files, start Docker services, run migrations, read secrets, or mutate Git."
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
 
 function Write-Result {
     param(

--- a/scripts/dev/smoke.ps1
+++ b/scripts/dev/smoke.ps1
@@ -1,8 +1,27 @@
 [CmdletBinding()]
-param()
+param(
+    [switch]$Help
+)
 
 $ErrorActionPreference = "Continue"
 $hardFailures = 0
+
+function Show-Usage {
+    Write-Host "TerraFusion local smoke gate"
+    Write-Host ""
+    Write-Host "Usage:"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1"
+    Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/dev/smoke.ps1 -Help"
+    Write-Host ""
+    Write-Host "Behavior:"
+    Write-Host "  Read-only. Runs readiness.ps1 and bootstrap.ps1 inspect mode from the detected repo root."
+    Write-Host "  Does not install packages, create env files, start Docker services, run migrations, read secrets, or mutate Git."
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
 
 function Write-Result {
     param(


### PR DESCRIPTION
## Summary

Adds consistent `-Help` usage output to local-dev scripts and documents the help surface in the local-dev operating packet.

Scope:
- `scripts/dev/readiness.ps1`
- `scripts/dev/bootstrap.ps1`
- `scripts/dev/smoke.ps1`
- `docs/onboarding/LOCAL_DEV_OPERATING_PACKET.md`

## Non-changes

- No runtime code
- No Docker or Compose config
- No package metadata or dependency changes
- No CI/CD changes
- No secrets, county data, PACS, or SQL
- No release or deployment behavior

## Validation

- `git diff --check`
- `readiness.ps1 -Help`, `bootstrap.ps1 -Help`, `smoke.ps1 -Help`
- `scripts/dev/smoke.ps1` from repo root
- `scripts/dev/smoke.ps1` from `docs/`
- `docker compose -f docker/dev/compose.yaml --env-file docker/dev/.env.example config`