### PR TITLE
docs(brain): define work order data model

### DIFF
--- a/docs/brain/workorders/schema/WORK_ORDER_DATA_MODEL.md
+++ b/docs/brain/workorders/schema/WORK_ORDER_DATA_MODEL.md
@@ -1,0 +1,234 @@
+# Work Order Data Model
+
+## Purpose
+
+The Work Order data model defines the canonical shape of a governed TerraFusion work order packet.
+It supports read-only discovery, docs/operator-truth work, local developer tooling, CI/governance
+work, runtime work, and authority-gated production/security work without creating a second Brain.
+
+The schema is a documentation and validation contract only. It does not implement a query engine,
+automation runner, PR monitor, branch mutator, or merge authority.
+
+Canonical schema:
+
+```text
+docs/brain/workorders/schema/work-order.schema.json
+```
+
+## Authority
+
+The model sits under the existing Brain/Cortex work-order lane. It must preserve the current authority
+hierarchy:
+
+1. TerraFusion Constitution
+2. Brain / Cortex queue, sequencing, risk, proof, review-diff, and commit-plan
+3. Domain knowledge packs
+4. Directory-local `AGENTS.md`
+5. Existing implementation patterns
+6. Agent judgment
+
+The model describes work-order state. It does not override any authority source above it.
+
+## Canonical Fields
+
+| Field | Required | Purpose |
+| --- | --- | --- |
+| `id` | yes | Stable work order identifier, for example `WO-WOE-002`. |
+| `title` | yes | Human-readable work order title. |
+| `program` | yes | Owning program or lane, for example Work Order Engine, DevOps, LocalOps, Backend, or Workbench. |
+| `goal` | yes | Concrete objective of the work order. |
+| `riskClass` | yes | Minimum execution risk for the work order. |
+| `status` | yes | Current lifecycle state. |
+| `dependencies` | yes | Work orders, evidence, or external states required before execution. |
+| `allowedSystems` | yes | Systems or domains the work order may touch. |
+| `blockedSystems` | yes | Systems or domains explicitly out of scope. |
+| `allowedFiles` | no | Repository-relative file/path globs allowed for writes. |
+| `blockedFiles` | no | Repository-relative file/path globs forbidden for writes. |
+| `evidenceRequired` | yes | Required proof before completion. |
+| `evidenceProduced` | no | Evidence artifacts generated while executing. |
+| `validationGates` | yes | Commands/checks required or optional for this WO. |
+| `derivedState` | no | Observed Git/GitHub/worktree/check state. |
+| `stopConditions` | yes | Conditions that force a stop or owner decision. |
+| `blockers` | no | Current blockers and required authority to resolve them. |
+| `nextCandidates` | yes | Candidate next work orders and why they follow. |
+| `authority` | no | Explicit action permissions granted by the WO. |
+| `provenance` | no | Source, timestamps, and schema version. |
+
+## Risk Classes
+
+| Class | Meaning | Examples |
+| --- | --- | --- |
+| `R0` | Read-only discovery | Inventory, audit, status poll, evidence report. |
+| `R1` | Documentation or operator-truth patch | Docs, evidence packets, decision notes, schemas. |
+| `R2` | Local developer tooling | Read-only scripts, local bootstrap, dev-only examples. |
+| `R3` | CI/governance/tooling | Pipeline gates, hooks, policy config, branch hygiene. |
+| `R4` | Runtime/application behavior | Backend, frontend, OS-platform behavior changes. |
+| `R5` | Production/security/protected-data authority | Release, deployment, secrets, PACS, county SQL, county data. |
+
+The route-table `risk_floor` is a minimum. A work order can be higher risk than a path's floor, but not
+lower.
+
+## Statuses
+
+| Status | Meaning |
+| --- | --- |
+| `proposed` | Described but not yet authorized for execution. |
+| `ready` | Dependencies are satisfied and scope is defined. |
+| `in_progress` | Actively being executed. |
+| `blocked` | Cannot proceed without blocker resolution. |
+| `deferred` | Intentionally postponed. |
+| `pr_open` | Branch has an open PR. |
+| `review` | PR or human review is active. |
+| `merged` | PR merged to main. |
+| `complete` | Completion evidence is present. |
+| `superseded` | Replaced by another WO or program decision. |
+| `cancelled` | Closed without completion. |
+
+## Dependency Model
+
+Dependencies are explicit objects, not prose-only references. Each dependency records:
+
+- `id`: work order, PR, evidence artifact, external state, or human decision
+- `status`: `required`, `satisfied`, `blocked`, `deferred`, or `unknown`
+- `evidence`: optional links to proof
+- `notes`: optional explanation
+
+Dependencies must not be inferred from naming alone. A later query tool may compute unresolved
+dependencies from this model, but WO-WOE-002 does not implement that tool.
+
+## Evidence Model
+
+Evidence has two forms:
+
+- `evidenceRequired`: what must exist before the work order can be considered complete
+- `evidenceProduced`: what the work order actually produced
+
+Evidence kinds are:
+
+- `command`
+- `file`
+- `pr`
+- `check`
+- `review`
+- `manual_attestation`
+- `external_system`
+- `other`
+
+Evidence artifacts should include a location and, when useful, freshness metadata:
+
+- observed timestamp
+- commit SHA
+- stale-after timestamp
+
+Live GitHub checks, Azure runs, and local command outputs should be treated as evidence, not as
+hand-authored truth.
+
+## Validation Gate Model
+
+Validation gates capture commands or checks required by the work order. Each gate records:
+
+- `name`
+- `command`
+- `required`
+- `result`
+- `evidence`
+
+Gate results are:
+
+- `not_run`
+- `pass`
+- `fail`
+- `skipped`
+- `blocked`
+- `unknown`
+
+A skipped gate must explain why. A blocked required gate prevents completion unless the work order
+explicitly defines that gate as non-blocking.
+
+## Derived Git and GitHub State
+
+Derived state is observed by tools and should not be maintained manually as primary authority.
+
+The model separates derived state into:
+
+- `git`: branch, head, base, ahead/behind counts, dirty state, changed files
+- `github`: PR number, PR URL, state, draft status, merge state, unresolved threads, checks
+- `worktree`: path, registered state, clean state, lock state, owner
+- `validation`: aggregate validation status and summary
+
+Derived state may become stale. Any automated query tool must refresh it before making a next-work
+recommendation.
+
+## Stop-Condition Model
+
+Stop conditions are structured so an operator can distinguish routine work from authority walls.
+
+Stop-condition types are:
+
+- `authority_wall`
+- `scope_boundary`
+- `state_mismatch`
+- `validation_failure`
+- `dependency_blocked`
+- `protected_data`
+- `production_risk`
+- `destructive_action`
+- `conflicting_canon`
+- `unknown`
+
+Examples that require a stop:
+
+- merge authority is absent
+- destructive cleanup is required
+- runtime behavior is required but the WO is docs-only
+- secrets, PACS, county SQL, county data, or protected data appear
+- branch protection or auth blocks progress
+- canon sources conflict
+
+## Next-Candidate Model
+
+`nextCandidates` records possible next work orders without automatically authorizing them.
+
+Each candidate records:
+
+- `id`
+- `reason`
+- `riskClass`
+- `blocked`
+- optional `score`
+
+WO-WOE-004 will define deterministic scoring rules. WO-WOE-002 only defines the shape that scoring can
+use later.
+
+## Authority Model
+
+The `authority` object makes explicit which actions are permitted:
+
+- `mayWrite`
+- `mayCommit`
+- `mayPush`
+- `mayOpenPr`
+- `mayMarkReady`
+- `mayMerge`
+- `mayCleanup`
+
+No omitted authority should be inferred as granted. Higher-risk actions still obey the Constitution,
+Brain/Cortex governance, domain packs, and directory-local rules.
+
+## Non-Goals
+
+WO-WOE-002 does not:
+
+- implement a query tool
+- migrate existing work orders
+- modify active work order files
+- execute a goal/loop
+- query PR state
+- mutate branches or worktrees
+- add CI behavior
+- touch runtime code
+
+## Expected Next Work
+
+WO-WOE-003 should seed a registry of known completed/current work orders using this schema. That work
+should remain data-only and should not implement automation.

--- a/docs/brain/workorders/schema/work-order.schema.json
+++ b/docs/brain/workorders/schema/work-order.schema.json
@@ -1,0 +1,607 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://terrafusion.local/schemas/work-order.schema.json",
+  "title": "TerraFusion Work Order",
+  "description": "Canonical data model for a governed TerraFusion work order packet. The schema describes state and evidence; it does not authorize automation by itself.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "title",
+    "program",
+    "goal",
+    "riskClass",
+    "status",
+    "dependencies",
+    "allowedSystems",
+    "blockedSystems",
+    "evidenceRequired",
+    "validationGates",
+    "stopConditions",
+    "nextCandidates"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^WO-[A-Z0-9]+-[0-9A-Z]+(-[A-Z0-9]+)*$",
+      "description": "Stable work order identifier, for example WO-WOE-002."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "program": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Owning program or lane, for example Work Order Engine, DevOps, LocalOps, Backend, or Workbench."
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "riskClass": {
+      "$ref": "#/$defs/riskClass"
+    },
+    "status": {
+      "$ref": "#/$defs/status"
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      }
+    },
+    "allowedSystems": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/systemScope"
+      }
+    },
+    "blockedSystems": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/systemScope"
+      }
+    },
+    "allowedFiles": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pathPattern"
+      },
+      "default": []
+    },
+    "blockedFiles": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pathPattern"
+      },
+      "default": []
+    },
+    "evidenceRequired": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evidenceRequirement"
+      }
+    },
+    "evidenceProduced": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evidenceArtifact"
+      },
+      "default": []
+    },
+    "validationGates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/validationGate"
+      }
+    },
+    "derivedState": {
+      "$ref": "#/$defs/derivedState",
+      "description": "Git, GitHub, worktree, and validation state observed by tools. This is derived evidence, not hand-authored authority."
+    },
+    "stopConditions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/stopCondition"
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/blocker"
+      },
+      "default": []
+    },
+    "nextCandidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nextCandidate"
+      }
+    },
+    "authority": {
+      "$ref": "#/$defs/authority",
+      "description": "Explicit authority granted for actions such as write, push, ready, merge, cleanup, or cloud mutation."
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    }
+  },
+  "$defs": {
+    "riskClass": {
+      "type": "string",
+      "enum": ["R0", "R1", "R2", "R3", "R4", "R5"],
+      "description": "R0 read-only; R1 docs/operator truth; R2 local developer tooling; R3 CI/governance/tooling; R4 runtime behavior; R5 production, security, protected data, release, or deployment."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "proposed",
+        "ready",
+        "in_progress",
+        "blocked",
+        "deferred",
+        "pr_open",
+        "review",
+        "merged",
+        "complete",
+        "superseded",
+        "cancelled"
+      ]
+    },
+    "dependencyStatus": {
+      "type": "string",
+      "enum": ["required", "satisfied", "blocked", "deferred", "unknown"]
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/$defs/dependencyStatus"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceRef"
+          },
+          "default": []
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "systemScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pathPattern"
+          },
+          "default": []
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "pathPattern": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repository-relative file or glob path."
+    },
+    "evidenceRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "description"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "command",
+            "file",
+            "pr",
+            "check",
+            "review",
+            "manual_attestation",
+            "external_system",
+            "other"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "evidenceArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "location"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "command_output",
+            "file",
+            "pr",
+            "check",
+            "commit",
+            "review",
+            "manual_attestation",
+            "external_system",
+            "other"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string"
+        },
+        "freshness": {
+          "$ref": "#/$defs/freshness"
+        }
+      }
+    },
+    "evidenceRef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "observedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "commit": {
+          "type": "string"
+        },
+        "staleAfter": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "validationGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command", "required"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "result": {
+          "type": "string",
+          "enum": ["not_run", "pass", "fail", "skipped", "blocked", "unknown"],
+          "default": "not_run"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceRef"
+          },
+          "default": []
+        }
+      }
+    },
+    "derivedState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "$ref": "#/$defs/gitState"
+        },
+        "github": {
+          "$ref": "#/$defs/githubState"
+        },
+        "worktree": {
+          "$ref": "#/$defs/worktreeState"
+        },
+        "validation": {
+          "$ref": "#/$defs/validationState"
+        }
+      }
+    },
+    "gitState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "type": "string"
+        },
+        "head": {
+          "type": "string"
+        },
+        "base": {
+          "type": "string"
+        },
+        "ahead": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "behind": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dirty": {
+          "type": "boolean"
+        },
+        "changedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      }
+    },
+    "githubState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "prNumber": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "prUrl": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": ["none", "open", "closed", "merged", "unknown"]
+        },
+        "isDraft": {
+          "type": "boolean"
+        },
+        "mergeState": {
+          "type": "string",
+          "enum": ["clean", "blocked", "dirty", "unstable", "unknown"]
+        },
+        "unresolvedThreads": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/checkState"
+          },
+          "default": []
+        }
+      }
+    },
+    "checkState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["queued", "in_progress", "completed", "skipped", "unknown"]
+        },
+        "conclusion": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure",
+            "cancelled",
+            "skipped",
+            "timed_out",
+            "neutral",
+            "action_required",
+            "unknown"
+          ]
+        }
+      }
+    },
+    "worktreeState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "registered": {
+          "type": "boolean"
+        },
+        "clean": {
+          "type": "boolean"
+        },
+        "locked": {
+          "type": "boolean"
+        },
+        "owner": {
+          "type": "string"
+        }
+      }
+    },
+    "validationState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allRequiredPassed": {
+          "type": "boolean"
+        },
+        "lastRunAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "stopCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "description"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "authority_wall",
+            "scope_boundary",
+            "state_mismatch",
+            "validation_failure",
+            "dependency_blocked",
+            "protected_data",
+            "production_risk",
+            "destructive_action",
+            "conflicting_canon",
+            "unknown"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "description", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "human_decision",
+            "auth",
+            "validation",
+            "scope",
+            "dependency",
+            "platform",
+            "data_protection",
+            "unknown"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["open", "resolved", "deferred", "unknown"]
+        },
+        "requiredAuthority": {
+          "type": "string"
+        }
+      }
+    },
+    "nextCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "reason", "riskClass"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "riskClass": {
+          "$ref": "#/$defs/riskClass"
+        },
+        "blocked": {
+          "type": "boolean",
+          "default": false
+        },
+        "score": {
+          "type": "number"
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mayWrite": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayCommit": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayPush": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayOpenPr": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayMarkReady": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayMerge": {
+          "type": "boolean",
+          "default": false
+        },
+        "mayCleanup": {
+          "type": "boolean",
+          "default": false
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source": {
+          "type": "string"
+        },
+        "schemaVersion": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Defines the canonical Work Order data model for TerraFusion Work Order Engine planning.

Adds:
- JSON schema for governed work order packets
- companion data model specification covering fields, risk classes, statuses, dependencies, evidence, validation gates, derived Git/GitHub state, stop conditions, and next candidates

## Scope

Schema/spec only.

## Explicit non-changes

- No query tool implemented
- No automation implemented
- No existing work orders migrated
- No runtime code changed
- No CI/CD behavior changed
- No package files changed
- No Docker/Helm/Kubernetes changed
- No secrets, county data, PACS, or SQL touched

## Validation

- JSON parse check passed
- `git diff --check`
- pre-commit quality gate passed
- pre-push quality gate passed
- unit tests: 164 passed
- backend build: passed