### PR TITLE
docs(brain): define work-order scoring rules

### DIFF
--- a/docs/brain/workorders/scoring/README.md
+++ b/docs/brain/workorders/scoring/README.md
@@ -66,12 +66,12 @@ Scores must be computed from normalized factor values in the range `0.0` to `1.0
 
 | Score | Verdict | Meaning |
 | ---: | --- | --- |
-| 85.0-100.0 | `recommend` | Strong next WO if no hard exclusions apply. |
-| 70.0-84.999 | `eligible` | Safe candidate, but not necessarily the best next step. |
-| 50.0-69.999 | `defer` | Do not start automatically; needs stronger evidence or lower-risk alternatives first. |
-| 0.0-49.999 | `weak` | Not useful enough to start unless explicitly chosen by the operator. |
+| `85 <= score <= 100` | `recommend` | Strong next WO if no hard exclusions apply. |
+| `70 <= score < 85` | `eligible` | Safe candidate, but not necessarily the best next step. |
+| `50 <= score < 70` | `defer` | Do not start automatically; needs stronger evidence or lower-risk alternatives first. |
+| `0 <= score < 50` | `weak` | Not useful enough to start unless explicitly chosen by the operator. |
 
-Scores are evaluated as decimals without implicit rounding. Hard exclusions always produce `blocked` outside the numeric band table regardless of score.
+Scores are evaluated as decimals without implicit rounding. Bands use lower-inclusive and upper-exclusive comparisons, except `recommend`, which includes the maximum score of `100`. Hard exclusions always produce `blocked` outside the numeric band table regardless of score.
 
 ## Tie-Breakers
 

--- a/docs/brain/workorders/scoring/README.md
+++ b/docs/brain/workorders/scoring/README.md
@@ -1,0 +1,113 @@
+# Work Order Next-Candidate Scoring
+
+This packet defines the deterministic scoring policy for selecting the next Work Order (WO) from the registry. It does not execute work, query GitHub, mutate repository state, or override human authority gates.
+
+## Purpose
+
+The Work Order Engine needs a repeatable way to answer "what is next?" without turning the operator into a message bus. Scoring is advisory until a higher-level Goal + Loop packet authorizes execution.
+
+The selector must:
+
+- exclude candidates that violate authority boundaries before scoring;
+- prefer dependency-cleared, evidence-backed, same-risk work;
+- penalize active blockers and ambiguous state;
+- produce explainable reasons for the recommendation;
+- preserve deterministic tie-breaking.
+
+## Inputs
+
+Candidate scoring uses only registry and evidence fields defined by the Work Order data model:
+
+- `riskClass`
+- `status`
+- `dependencies`
+- `allowedSystems`
+- `blockedSystems`
+- `evidence`
+- `validationGates`
+- `gitState`
+- `githubState`
+- `stopConditions`
+- `nextCandidates`
+
+Live repository, GitHub, Azure, filesystem, or secret inspection belongs to future tools. This scoring packet only defines the rule contract.
+
+## Hard Exclusions
+
+A candidate is not eligible for scoring if any hard exclusion is true:
+
+- dependency is not cleared;
+- status is `complete`, `cancelled`, or `superseded`;
+- risk class is above the current operator authority;
+- candidate requires secrets, credentials, protected data, PACS, county SQL, production deployment, release, or destructive cleanup without explicit authorization;
+- canonical evidence is missing for a prerequisite WO;
+- active PR, branch, or worktree state is ambiguous and the WO is not explicitly a read-only audit;
+- the next step would require runtime, CI, Docker, Kubernetes, or production expansion outside the current authorized chain.
+
+Hard exclusions return `blocked`, not a low score.
+
+## Weighted Factors
+
+Eligible candidates are scored on a 100 point scale:
+
+| Factor | Weight | Direction | Meaning |
+| --- | ---: | --- | --- |
+| Dependency readiness | 25 | higher is better | Required upstream WOs are complete or explicitly waived. |
+| Risk/authority fit | 20 | higher is better | Candidate stays within current authorized risk class. |
+| Evidence readiness | 15 | higher is better | Required evidence exists and is recent enough for execution. |
+| Operational value | 15 | higher is better | Candidate closes an active lane, unlocks follow-up work, or reduces operator friction. |
+| Scope size/reversibility | 10 | higher is better | Smaller, reversible changes outrank broad or hard-to-revert work. |
+| Safety margin | 10 | higher is better | Candidate avoids protected systems and has clear stop gates. |
+| Blocker pressure | 5 | higher is better | Fewer known blockers, review threads, auth walls, or unstable checks. |
+
+Scores must be computed from normalized factor values in the range `0.0` to `1.0` multiplied by the factor weight.
+
+## Decision Bands
+
+| Score | Verdict | Meaning |
+| ---: | --- | --- |
+| 85-100 | `recommend` | Strong next WO if no hard exclusions apply. |
+| 70-84 | `eligible` | Safe candidate, but not necessarily the best next step. |
+| 50-69 | `defer` | Do not start automatically; needs stronger evidence or lower-risk alternatives first. |
+| 0-49 | `weak` | Not useful enough to start unless explicitly chosen by the operator. |
+
+Hard exclusions always produce `blocked` regardless of numeric score.
+
+## Tie-Breakers
+
+If two candidates have the same score, apply tie-breakers in order:
+
+1. Lower risk class wins.
+2. Fewer unresolved blockers wins.
+3. More recently completed dependency chain wins.
+4. Candidate that closes the current active lane wins.
+5. Lexicographically smaller WO ID wins.
+
+Tie-breakers must be stable and must not use wall-clock randomness.
+
+## Output Shape
+
+A scoring result must include:
+
+- candidate WO ID;
+- verdict;
+- score;
+- factor breakdown;
+- hard exclusions, if any;
+- blockers;
+- evidence references used;
+- next recommended action.
+
+The companion schema and rules files define the machine-readable contract used by future read-only query tooling.
+
+## Non-Goals
+
+This packet does not:
+
+- create an execution engine;
+- query PR status;
+- merge PRs;
+- open or mutate worktrees;
+- migrate existing WO artifacts;
+- change CI/CD behavior;
+- change runtime code.

--- a/docs/brain/workorders/scoring/README.md
+++ b/docs/brain/workorders/scoring/README.md
@@ -25,8 +25,8 @@ Candidate scoring uses only registry and evidence fields defined by the Work Ord
 - `blockedSystems`
 - `evidence`
 - `validationGates`
-- `gitState`
-- `githubState`
+- `derivedState.git`
+- `derivedState.github`
 - `stopConditions`
 - `nextCandidates`
 
@@ -66,12 +66,12 @@ Scores must be computed from normalized factor values in the range `0.0` to `1.0
 
 | Score | Verdict | Meaning |
 | ---: | --- | --- |
-| 85-100 | `recommend` | Strong next WO if no hard exclusions apply. |
-| 70-84 | `eligible` | Safe candidate, but not necessarily the best next step. |
-| 50-69 | `defer` | Do not start automatically; needs stronger evidence or lower-risk alternatives first. |
-| 0-49 | `weak` | Not useful enough to start unless explicitly chosen by the operator. |
+| 85.0-100.0 | `recommend` | Strong next WO if no hard exclusions apply. |
+| 70.0-84.999 | `eligible` | Safe candidate, but not necessarily the best next step. |
+| 50.0-69.999 | `defer` | Do not start automatically; needs stronger evidence or lower-risk alternatives first. |
+| 0.0-49.999 | `weak` | Not useful enough to start unless explicitly chosen by the operator. |
 
-Hard exclusions always produce `blocked` regardless of numeric score.
+Scores are evaluated as decimals without implicit rounding. Hard exclusions always produce `blocked` outside the numeric band table regardless of score.
 
 ## Tie-Breakers
 

--- a/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
@@ -1,0 +1,173 @@
+{
+  "schemaVersion": "1.0.0",
+  "policyId": "terrafusion-next-work-order-scoring-v1",
+  "description": "Deterministic advisory scoring policy for selecting the next TerraFusion Work Order from registry evidence.",
+  "hardExclusions": [
+    {
+      "id": "dependency-not-cleared",
+      "description": "A required upstream Work Order is not complete, waived, or explicitly superseded.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "terminal-status",
+      "description": "Candidate is already complete, cancelled, or superseded.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "risk-exceeds-authority",
+      "description": "Candidate risk class exceeds the current Goal + Loop authority boundary.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "protected-system-required",
+      "description": "Candidate requires secrets, credentials, protected data, PACS, county SQL, production deployment, release, or destructive cleanup without explicit authorization.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "missing-prerequisite-evidence",
+      "description": "Required prerequisite evidence is missing or not linked from the registry.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "ambiguous-state",
+      "description": "Active PR, branch, worktree, or validation state is ambiguous and the candidate is not explicitly a read-only audit.",
+      "verdict": "blocked"
+    },
+    {
+      "id": "scope-expansion-required",
+      "description": "Candidate would require runtime, CI, Docker, Kubernetes, or production expansion outside the current authorized chain.",
+      "verdict": "blocked"
+    }
+  ],
+  "factors": [
+    {
+      "id": "dependency-readiness",
+      "label": "Dependency readiness",
+      "weight": 25,
+      "direction": "higher-is-better",
+      "description": "Required upstream Work Orders are complete or explicitly waived."
+    },
+    {
+      "id": "risk-authority-fit",
+      "label": "Risk and authority fit",
+      "weight": 20,
+      "direction": "higher-is-better",
+      "description": "Candidate remains inside the current authorized risk class and stop-gate model."
+    },
+    {
+      "id": "evidence-readiness",
+      "label": "Evidence readiness",
+      "weight": 15,
+      "direction": "higher-is-better",
+      "description": "Required evidence exists, is current, and is linked from the registry."
+    },
+    {
+      "id": "operational-value",
+      "label": "Operational value",
+      "weight": 15,
+      "direction": "higher-is-better",
+      "description": "Candidate closes an active lane, unlocks follow-up work, or reduces operator friction."
+    },
+    {
+      "id": "scope-reversibility",
+      "label": "Scope size and reversibility",
+      "weight": 10,
+      "direction": "higher-is-better",
+      "description": "Smaller, easier-to-revert Work Orders score higher than broad or irreversible work."
+    },
+    {
+      "id": "safety-margin",
+      "label": "Safety margin",
+      "weight": 10,
+      "direction": "higher-is-better",
+      "description": "Candidate avoids protected systems and has clear stop conditions."
+    },
+    {
+      "id": "blocker-pressure",
+      "label": "Blocker pressure",
+      "weight": 5,
+      "direction": "higher-is-better",
+      "description": "Candidates with fewer known blockers, review threads, auth walls, or unstable checks score higher."
+    }
+  ],
+  "decisionBands": [
+    {
+      "verdict": "recommend",
+      "minimumScore": 85,
+      "maximumScore": 100,
+      "description": "Strong next candidate when no hard exclusions apply."
+    },
+    {
+      "verdict": "eligible",
+      "minimumScore": 70,
+      "maximumScore": 84,
+      "description": "Safe candidate, but not necessarily the best next step."
+    },
+    {
+      "verdict": "defer",
+      "minimumScore": 50,
+      "maximumScore": 69,
+      "description": "Do not start automatically unless higher-value or lower-risk candidates are unavailable."
+    },
+    {
+      "verdict": "weak",
+      "minimumScore": 0,
+      "maximumScore": 49,
+      "description": "Not useful enough to start unless explicitly selected."
+    },
+    {
+      "verdict": "blocked",
+      "minimumScore": 0,
+      "maximumScore": 100,
+      "description": "A hard exclusion prevents automatic selection regardless of numeric score."
+    }
+  ],
+  "tieBreakers": [
+    {
+      "order": 1,
+      "id": "lower-risk-class",
+      "description": "Lower risk class wins."
+    },
+    {
+      "order": 2,
+      "id": "fewer-unresolved-blockers",
+      "description": "Candidate with fewer unresolved blockers wins."
+    },
+    {
+      "order": 3,
+      "id": "newer-dependency-evidence",
+      "description": "Candidate whose dependency chain has more recent completion evidence wins."
+    },
+    {
+      "order": 4,
+      "id": "active-lane-closure",
+      "description": "Candidate that closes the current active lane wins."
+    },
+    {
+      "order": 5,
+      "id": "lexicographic-work-order-id",
+      "description": "Lexicographically smaller Work Order ID wins."
+    }
+  ],
+  "resultContract": {
+    "requiredFields": [
+      "workOrderId",
+      "verdict",
+      "score",
+      "factorBreakdown",
+      "hardExclusions",
+      "blockers",
+      "evidenceReferences",
+      "nextRecommendedAction"
+    ],
+    "scoreRange": {
+      "minimum": 0,
+      "maximum": 100
+    },
+    "factorValueRange": {
+      "minimum": 0,
+      "maximum": 1
+    },
+    "hardExclusionVerdict": "blocked"
+  }
+}

--- a/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
@@ -95,24 +95,32 @@
       "verdict": "recommend",
       "minimumScore": 85,
       "maximumScore": 100,
+      "minimumInclusive": true,
+      "maximumInclusive": true,
       "description": "Strong next candidate when no hard exclusions apply."
     },
     {
       "verdict": "eligible",
       "minimumScore": 70,
-      "maximumScore": 84.999,
+      "maximumScore": 85,
+      "minimumInclusive": true,
+      "maximumInclusive": false,
       "description": "Safe candidate, but not necessarily the best next step."
     },
     {
       "verdict": "defer",
       "minimumScore": 50,
-      "maximumScore": 69.999,
+      "maximumScore": 70,
+      "minimumInclusive": true,
+      "maximumInclusive": false,
       "description": "Do not start automatically unless higher-value or lower-risk candidates are unavailable."
     },
     {
       "verdict": "weak",
       "minimumScore": 0,
-      "maximumScore": 49.999,
+      "maximumScore": 50,
+      "minimumInclusive": true,
+      "maximumInclusive": false,
       "description": "Not useful enough to start unless explicitly selected."
     }
   ],

--- a/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.rules.json
@@ -100,26 +100,20 @@
     {
       "verdict": "eligible",
       "minimumScore": 70,
-      "maximumScore": 84,
+      "maximumScore": 84.999,
       "description": "Safe candidate, but not necessarily the best next step."
     },
     {
       "verdict": "defer",
       "minimumScore": 50,
-      "maximumScore": 69,
+      "maximumScore": 69.999,
       "description": "Do not start automatically unless higher-value or lower-risk candidates are unavailable."
     },
     {
       "verdict": "weak",
       "minimumScore": 0,
-      "maximumScore": 49,
+      "maximumScore": 49.999,
       "description": "Not useful enough to start unless explicitly selected."
-    },
-    {
-      "verdict": "blocked",
-      "minimumScore": 0,
-      "maximumScore": 100,
-      "description": "A hard exclusion prevents automatic selection regardless of numeric score."
     }
   ],
   "tieBreakers": [

--- a/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
@@ -109,7 +109,14 @@
     "decisionBand": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["verdict", "minimumScore", "maximumScore", "description"],
+      "required": [
+        "verdict",
+        "minimumScore",
+        "maximumScore",
+        "minimumInclusive",
+        "maximumInclusive",
+        "description"
+      ],
       "properties": {
         "verdict": {
           "enum": ["recommend", "eligible", "defer", "weak"]
@@ -123,6 +130,12 @@
           "type": "number",
           "minimum": 0,
           "maximum": 100
+        },
+        "minimumInclusive": {
+          "type": "boolean"
+        },
+        "maximumInclusive": {
+          "type": "boolean"
         },
         "description": {
           "type": "string",

--- a/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://terrafusion.local/schemas/next-work-order-scoring.schema.json",
+  "title": "TerraFusion Next Work Order Scoring Policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "policyId",
+    "description",
+    "hardExclusions",
+    "factors",
+    "decisionBands",
+    "tieBreakers",
+    "resultContract"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^1\\.0\\.0$"
+    },
+    "policyId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hardExclusions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/hardExclusion"
+      }
+    },
+    "factors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/factor"
+      }
+    },
+    "decisionBands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/decisionBand"
+      }
+    },
+    "tieBreakers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/tieBreaker"
+      }
+    },
+    "resultContract": {
+      "$ref": "#/$defs/resultContract"
+    }
+  },
+  "$defs": {
+    "hardExclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "verdict"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verdict": {
+          "const": "blocked"
+        }
+      }
+    },
+    "factor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "weight", "direction", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "weight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "direction": {
+          "enum": ["higher-is-better", "lower-is-better"]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "decisionBand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "minimumScore", "maximumScore", "description"],
+      "properties": {
+        "verdict": {
+          "enum": ["recommend", "eligible", "defer", "weak", "blocked"]
+        },
+        "minimumScore": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "maximumScore": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "tieBreaker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["order", "id", "description"],
+      "properties": {
+        "order": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "resultContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requiredFields",
+        "scoreRange",
+        "factorValueRange",
+        "hardExclusionVerdict"
+      ],
+      "properties": {
+        "requiredFields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "scoreRange": {
+          "$ref": "#/$defs/numericRange"
+        },
+        "factorValueRange": {
+          "$ref": "#/$defs/numericRange"
+        },
+        "hardExclusionVerdict": {
+          "const": "blocked"
+        }
+      }
+    },
+    "numericRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum"],
+      "properties": {
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
+++ b/docs/brain/workorders/scoring/next-work-order-scoring.schema.json
@@ -21,7 +21,8 @@
     },
     "policyId": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "^[a-z0-9-]+$"
     },
     "description": {
       "type": "string",
@@ -111,15 +112,15 @@
       "required": ["verdict", "minimumScore", "maximumScore", "description"],
       "properties": {
         "verdict": {
-          "enum": ["recommend", "eligible", "defer", "weak", "blocked"]
+          "enum": ["recommend", "eligible", "defer", "weak"]
         },
         "minimumScore": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "maximum": 100
         },
         "maximumScore": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "maximum": 100
         },


### PR DESCRIPTION
## Summary

WO-WOE-004 defines deterministic next-Work-Order scoring rules for the Work Order Engine.

Scope:
- adds the scoring policy documentation
- adds a JSON schema for scoring policy shape
- adds a machine-readable rules file for future read-only query tooling

## Non-changes

- No runtime code changed
- No CI/CD behavior changed
- No query tool implemented yet
- No existing Work Orders migrated
- No protected data, secrets, county data, PACS, or SQL touched

## Validation

- JSON parse validation
- factor weights total 100
- `git diff --check`
- normal pre-commit hook
- normal pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic “next work order” scoring policy with hard exclusions, weighted factor scoring, verdict bands, and stable tie-breakers.
* **Documentation**
  * Published the scoring specification covering eligibility rules, required output fields, score/factor ranges, hard-exclusion behavior, and decision-band boundary semantics.
  * Added a strict validation schema and example policy definition to standardize how the scoring policy is structured and consumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->