### PR TITLE
feat(brain): add read-only work-order query tool

### DIFF
--- a/docs/brain/workorders/tools/README.md
+++ b/docs/brain/workorders/tools/README.md
@@ -1,0 +1,45 @@
+# Work Order Query Tool
+
+`wo-query.mjs` is the first read-only query tool for the TerraFusion Work Order Engine.
+
+It answers:
+
+- current active lane;
+- completed Work Orders;
+- blocked Work Orders;
+- next recommended Work Order;
+- why that Work Order is next.
+
+## Contract
+
+The tool is intentionally read-only:
+
+- reads registry JSON;
+- reads scoring rules JSON;
+- computes advisory scores locally;
+- writes only to stdout;
+- does not query GitHub;
+- does not inspect worktrees;
+- does not create, edit, stage, commit, push, or merge.
+
+## Usage
+
+```powershell
+node docs/brain/workorders/tools/wo-query.mjs
+node docs/brain/workorders/tools/wo-query.mjs --json
+node docs/brain/workorders/tools/wo-query.mjs --authority R1
+node docs/brain/workorders/tools/wo-query.mjs --registry docs/brain/workorders/registry/work-order-registry.seed.json
+```
+
+## Output
+
+Text output is designed for operators. JSON output is designed for future Goal + Loop integration.
+
+The recommendation is advisory. It does not authorize execution, merge, deployment, protected data access, or destructive cleanup.
+
+## Validation
+
+```powershell
+node --test docs/brain/workorders/tools/wo-query.test.mjs
+node docs/brain/workorders/tools/wo-query.mjs --json
+```

--- a/docs/brain/workorders/tools/wo-query.mjs
+++ b/docs/brain/workorders/tools/wo-query.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REGISTRY = "docs/brain/workorders/registry/work-order-registry.seed.json";
+const DEFAULT_RULES = "docs/brain/workorders/scoring/next-work-order-scoring.rules.json";
+const RISK_ORDER = ["R0", "R1", "R2", "R3", "R4", "R5"];
+const TERMINAL_STATUSES = new Set(["complete", "merged", "cancelled", "superseded"]);
+const ACTIVE_STATUSES = new Set(["in_progress", "pr_open"]);
+const SELECTABLE_STATUSES = new Set(["ready", "planned", "proposed"]);
+const BLOCKED_STATUSES = new Set(["blocked", "failed", "needs_human", "deferred"]);
+
+function parseArgs(argv) {
+  const args = {
+    registry: DEFAULT_REGISTRY,
+    rules: DEFAULT_RULES,
+    authority: "R2",
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--registry") {
+      args.registry = argv[++index];
+    } else if (arg === "--rules") {
+      args.rules = argv[++index];
+    } else if (arg === "--authority") {
+      args.authority = argv[++index];
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!RISK_ORDER.includes(args.authority)) {
+    throw new Error(`Unsupported authority risk class: ${args.authority}`);
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage: node docs/brain/workorders/tools/wo-query.mjs [options]",
+    "",
+    "Options:",
+    "  --json                  Print machine-readable JSON.",
+    `  --registry <path>       Registry JSON path. Default: ${DEFAULT_REGISTRY}`,
+    `  --rules <path>          Scoring rules JSON path. Default: ${DEFAULT_RULES}`,
+    "  --authority <R0-R5>     Current authority boundary. Default: R2",
+    "  --help                  Show this help.",
+  ].join("\n");
+}
+
+function repoRoot() {
+  const current = path.dirname(fileURLToPath(import.meta.url));
+  let dir = current;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
+    dir = path.dirname(dir);
+  }
+  throw new Error("Could not locate repo root from wo-query.mjs");
+}
+
+function readJson(root, relativePath) {
+  const fullPath = path.resolve(root, relativePath);
+  return JSON.parse(fs.readFileSync(fullPath, "utf8"));
+}
+
+function riskRank(riskClass) {
+  const rank = RISK_ORDER.indexOf(riskClass);
+  return rank === -1 ? Number.POSITIVE_INFINITY : rank;
+}
+
+function dependencyReadiness(record) {
+  const dependencies = Array.isArray(record.dependencies) ? record.dependencies : [];
+  if (dependencies.length === 0) return 1;
+  const satisfied = dependencies.filter((dependency) =>
+    ["satisfied", "complete", "merged", "waived", "superseded"].includes(dependency.status),
+  ).length;
+  return satisfied / dependencies.length;
+}
+
+function evidenceReadiness(record) {
+  const required = Array.isArray(record.evidenceRequired) ? record.evidenceRequired : [];
+  const produced = Array.isArray(record.evidenceProduced) ? record.evidenceProduced : [];
+  if (required.length === 0) return produced.length > 0 ? 1 : 0.75;
+  return Math.min(1, produced.length / required.length);
+}
+
+function operationalValue(record) {
+  const nextCandidates = Array.isArray(record.nextCandidates) ? record.nextCandidates.length : 0;
+  const programBonus = record.program === "Work Order Engine" ? 0.2 : 0;
+  const statusBonus = SELECTABLE_STATUSES.has(record.status) ? 0.2 : ACTIVE_STATUSES.has(record.status) ? 0.1 : 0;
+  return Math.min(1, 0.5 + programBonus + statusBonus + Math.min(nextCandidates * 0.1, 0.2));
+}
+
+function scopeReversibility(record) {
+  const allowedFiles = Array.isArray(record.allowedFiles) ? record.allowedFiles.length : 0;
+  const allowedSystems = Array.isArray(record.allowedSystems) ? record.allowedSystems.length : 0;
+  const size = allowedFiles + allowedSystems;
+  if (size === 0) return 0.7;
+  if (size <= 3) return 1;
+  if (size <= 6) return 0.8;
+  return 0.5;
+}
+
+function safetyMargin(record) {
+  const blockedSystems = Array.isArray(record.blockedSystems) ? record.blockedSystems : [];
+  const stopConditions = Array.isArray(record.stopConditions) ? record.stopConditions : [];
+  const hasProtectedBlock = JSON.stringify(blockedSystems).match(/secret|credential|PACS|county|production|deploy/i);
+  const stopGateBonus = stopConditions.length > 0 ? 0.2 : 0;
+  return Math.min(1, (hasProtectedBlock ? 0.8 : 0.6) + stopGateBonus);
+}
+
+function blockerPressure(record) {
+  const blockers = Array.isArray(record.blockers) ? record.blockers : [];
+  if (blockers.length === 0) return 1;
+  if (blockers.length === 1) return 0.75;
+  if (blockers.length === 2) return 0.5;
+  return 0.25;
+}
+
+function hardExclusions(record, authority) {
+  const exclusions = [];
+  if (TERMINAL_STATUSES.has(record.status)) exclusions.push("terminal-status");
+  if (ACTIVE_STATUSES.has(record.status)) exclusions.push("active-work-order");
+  if (!TERMINAL_STATUSES.has(record.status) && !ACTIVE_STATUSES.has(record.status) && !SELECTABLE_STATUSES.has(record.status)) {
+    exclusions.push("unsupported-status");
+  }
+  if (riskRank(record.riskClass) > riskRank(authority)) exclusions.push("risk-exceeds-authority");
+  if (dependencyReadiness(record) < 1) exclusions.push("dependency-not-cleared");
+
+  const blockedText = JSON.stringify(record.blockedSystems ?? []);
+  const allowedText = JSON.stringify(record.allowedSystems ?? []);
+  if (/secret|credential|PACS|county SQL|production deployment|release|destructive/i.test(`${blockedText} ${allowedText}`)) {
+    if (riskRank(record.riskClass) >= riskRank("R3")) exclusions.push("protected-system-required");
+  }
+
+  if (record.status === "unknown") exclusions.push("ambiguous-state");
+  return exclusions;
+}
+
+function factorValues(record, authority) {
+  return {
+    "dependency-readiness": dependencyReadiness(record),
+    "risk-authority-fit": riskRank(record.riskClass) <= riskRank(authority) ? 1 : 0,
+    "evidence-readiness": evidenceReadiness(record),
+    "operational-value": operationalValue(record),
+    "scope-reversibility": scopeReversibility(record),
+    "safety-margin": safetyMargin(record),
+    "blocker-pressure": blockerPressure(record),
+  };
+}
+
+function verdictFor(score, bands) {
+  const match = bands.find((band) => {
+    const minOk = band.minimumInclusive ? score >= band.minimumScore : score > band.minimumScore;
+    const maxOk = band.maximumInclusive ? score <= band.maximumScore : score < band.maximumScore;
+    return minOk && maxOk;
+  });
+  if (!match) throw new Error(`No scoring band matched score ${score}`);
+  return match.verdict;
+}
+
+function scoreRecord(record, rules, authority) {
+  const exclusions = hardExclusions(record, authority);
+  const values = factorValues(record, authority);
+  const factorBreakdown = rules.factors.map((factor) => {
+    const value = values[factor.id] ?? 0;
+    return {
+      id: factor.id,
+      value,
+      weight: factor.weight,
+      contribution: Number((value * factor.weight).toFixed(3)),
+    };
+  });
+  const score = Number(factorBreakdown.reduce((sum, factor) => sum + factor.contribution, 0).toFixed(3));
+  return {
+    workOrderId: record.id,
+    title: record.title,
+    program: record.program,
+    riskClass: record.riskClass,
+    status: record.status,
+    verdict: exclusions.length > 0 ? "blocked" : verdictFor(score, rules.decisionBands),
+    score,
+    factorBreakdown,
+    hardExclusions: exclusions,
+    blockers: record.blockers ?? [],
+    evidenceReferences: (record.evidenceProduced ?? []).map((evidence) => evidence.location ?? evidence.description),
+    nextRecommendedAction: exclusions.length > 0 ? "Resolve hard exclusions before execution." : "Eligible for Goal + Loop selection.",
+  };
+}
+
+function summarize(registry, rules, authority) {
+  const records = registry.records ?? [];
+  const scored = records.map((record) => scoreRecord(record, rules, authority));
+  const completed = records.filter((record) => TERMINAL_STATUSES.has(record.status)).map((record) => record.id);
+  const blocked = scored.filter((record) => record.verdict === "blocked").map((record) => ({
+    id: record.workOrderId,
+    reasons: record.hardExclusions,
+  }));
+  const activeLane = records.find((record) => ACTIVE_STATUSES.has(record.status))?.program ?? null;
+  const ranked = scored
+    .filter((record) => record.verdict !== "blocked" && SELECTABLE_STATUSES.has(record.status))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (riskRank(a.riskClass) !== riskRank(b.riskClass)) return riskRank(a.riskClass) - riskRank(b.riskClass);
+      return a.workOrderId.localeCompare(b.workOrderId);
+    });
+  const next = ranked[0] ?? null;
+
+  return {
+    schemaVersion: "0.1.0",
+    mode: "read-only",
+    authority,
+    registry: {
+      schemaVersion: registry.schemaVersion,
+      generatedBy: registry.generatedBy,
+      recordCount: records.length,
+    },
+    scoringPolicy: {
+      policyId: rules.policyId,
+      schemaVersion: rules.schemaVersion,
+    },
+    activeLane,
+    completedWorkOrders: completed,
+    blockedWorkOrders: blocked,
+    nextRecommendedWorkOrder: next,
+    rankedCandidates: ranked,
+  };
+}
+
+function printText(summary) {
+  const lines = [
+    "WORK ORDER QUERY",
+    `Mode: ${summary.mode}`,
+    `Authority: ${summary.authority}`,
+    `Registry records: ${summary.registry.recordCount}`,
+    `Active lane: ${summary.activeLane ?? "none"}`,
+    `Completed WOs: ${summary.completedWorkOrders.length ? summary.completedWorkOrders.join(", ") : "none"}`,
+    `Blocked WOs: ${summary.blockedWorkOrders.length}`,
+    "",
+    "Next recommended WO:",
+  ];
+
+  if (summary.nextRecommendedWorkOrder) {
+    const next = summary.nextRecommendedWorkOrder;
+    lines.push(`- ${next.workOrderId}: ${next.title}`);
+    lines.push(`- Program: ${next.program}`);
+    lines.push(`- Risk: ${next.riskClass}`);
+    lines.push(`- Score: ${next.score}`);
+    lines.push(`- Verdict: ${next.verdict}`);
+    lines.push(`- Why: ${next.nextRecommendedAction}`);
+  } else {
+    lines.push("- none");
+  }
+
+  return lines.join("\n");
+}
+
+export {
+  parseArgs,
+  summarize,
+  scoreRecord,
+  verdictFor,
+  hardExclusions,
+};
+
+if (path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1] ?? "")) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      console.log(usage());
+      process.exit(0);
+    }
+    const root = repoRoot();
+    const registry = readJson(root, args.registry);
+    const rules = readJson(root, args.rules);
+    const summary = summarize(registry, rules, args.authority);
+    console.log(args.json ? JSON.stringify(summary, null, 2) : printText(summary));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/docs/brain/workorders/tools/wo-query.mjs
+++ b/docs/brain/workorders/tools/wo-query.mjs
@@ -7,10 +7,19 @@ import { fileURLToPath } from "node:url";
 const DEFAULT_REGISTRY = "docs/brain/workorders/registry/work-order-registry.seed.json";
 const DEFAULT_RULES = "docs/brain/workorders/scoring/next-work-order-scoring.rules.json";
 const RISK_ORDER = ["R0", "R1", "R2", "R3", "R4", "R5"];
+const COMPLETED_STATUSES = new Set(["complete", "merged"]);
 const TERMINAL_STATUSES = new Set(["complete", "merged", "cancelled", "superseded"]);
-const ACTIVE_STATUSES = new Set(["in_progress", "pr_open"]);
-const SELECTABLE_STATUSES = new Set(["ready", "planned", "proposed"]);
-const BLOCKED_STATUSES = new Set(["blocked", "failed", "needs_human", "deferred"]);
+const ACTIVE_STATUSES = new Set(["in_progress", "pr_open", "review"]);
+const SELECTABLE_STATUSES = new Set(["ready", "proposed"]);
+const BLOCKED_STATUSES = new Set(["blocked", "deferred"]);
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
 
 function parseArgs(argv) {
   const args = {
@@ -25,11 +34,14 @@ function parseArgs(argv) {
     if (arg === "--json") {
       args.json = true;
     } else if (arg === "--registry") {
-      args.registry = argv[++index];
+      args.registry = readOptionValue(argv, index, arg);
+      index += 1;
     } else if (arg === "--rules") {
-      args.rules = argv[++index];
+      args.rules = readOptionValue(argv, index, arg);
+      index += 1;
     } else if (arg === "--authority") {
-      args.authority = argv[++index];
+      args.authority = readOptionValue(argv, index, arg);
+      index += 1;
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
     } else {
@@ -130,7 +142,13 @@ function hardExclusions(record, authority) {
   const exclusions = [];
   if (TERMINAL_STATUSES.has(record.status)) exclusions.push("terminal-status");
   if (ACTIVE_STATUSES.has(record.status)) exclusions.push("active-work-order");
-  if (!TERMINAL_STATUSES.has(record.status) && !ACTIVE_STATUSES.has(record.status) && !SELECTABLE_STATUSES.has(record.status)) {
+  if (BLOCKED_STATUSES.has(record.status)) exclusions.push("blocked-status");
+  if (
+    !TERMINAL_STATUSES.has(record.status) &&
+    !ACTIVE_STATUSES.has(record.status) &&
+    !SELECTABLE_STATUSES.has(record.status) &&
+    !BLOCKED_STATUSES.has(record.status)
+  ) {
     exclusions.push("unsupported-status");
   }
   if (riskRank(record.riskClass) > riskRank(authority)) exclusions.push("risk-exceeds-authority");
@@ -144,6 +162,49 @@ function hardExclusions(record, authority) {
 
   if (record.status === "unknown") exclusions.push("ambiguous-state");
   return exclusions;
+}
+
+function unresolvedBlockerCount(record) {
+  const blockers = Array.isArray(record.blockers) ? record.blockers : [];
+  return blockers.filter((blocker) => blocker.status !== "resolved").length;
+}
+
+function evidenceTimestamp(record) {
+  const evidence = Array.isArray(record.evidenceProduced) ? record.evidenceProduced : [];
+  const timestamps = evidence
+    .flatMap((artifact) => [
+      artifact.freshness?.observedAt,
+      artifact.generatedAt,
+      artifact.completedAt,
+      artifact.createdAt,
+    ])
+    .filter(Boolean)
+    .map((value) => Date.parse(value))
+    .filter((value) => !Number.isNaN(value));
+  return timestamps.length > 0 ? Math.max(...timestamps) : 0;
+}
+
+function topFactorSummary(score) {
+  return [...score.factorBreakdown]
+    .sort((a, b) => b.contribution - a.contribution || a.id.localeCompare(b.id))
+    .slice(0, 3)
+    .map((factor) => `${factor.id} ${factor.contribution}`)
+    .join(", ");
+}
+
+function blockedSummary(exclusions) {
+  if (exclusions.length === 0) return "No hard exclusions.";
+  return `Hard exclusions: ${exclusions.join(", ")}.`;
+}
+
+function recommendationText(score, rank = null, activeLane = null) {
+  if (score.verdict === "blocked") {
+    return `Resolve before execution. ${blockedSummary(score.hardExclusions)}`;
+  }
+  const rankText = rank === null ? "Candidate" : `Rank ${rank}`;
+  const laneText = activeLane && score.program === activeLane ? " Continues the active lane." : "";
+  const blockerText = `${score.blockers.length} known blocker${score.blockers.length === 1 ? "" : "s"}.`;
+  return `${rankText}: ${score.verdict} at ${score.score}. Top factors: ${topFactorSummary(score)}. ${blockerText}${laneText}`;
 }
 
 function factorValues(record, authority) {
@@ -193,25 +254,67 @@ function scoreRecord(record, rules, authority) {
     hardExclusions: exclusions,
     blockers: record.blockers ?? [],
     evidenceReferences: (record.evidenceProduced ?? []).map((evidence) => evidence.location ?? evidence.description),
-    nextRecommendedAction: exclusions.length > 0 ? "Resolve hard exclusions before execution." : "Eligible for Goal + Loop selection.",
+    nextRecommendedAction: null,
   };
+}
+
+function compareByTieBreaker(a, b, tieBreaker, recordById, activeLane) {
+  const aRecord = recordById.get(a.workOrderId) ?? {};
+  const bRecord = recordById.get(b.workOrderId) ?? {};
+
+  if (tieBreaker.id === "lower-risk-class") {
+    return riskRank(a.riskClass) - riskRank(b.riskClass);
+  }
+  if (tieBreaker.id === "fewer-unresolved-blockers") {
+    return unresolvedBlockerCount(aRecord) - unresolvedBlockerCount(bRecord);
+  }
+  if (tieBreaker.id === "newer-dependency-evidence") {
+    return evidenceTimestamp(bRecord) - evidenceTimestamp(aRecord);
+  }
+  if (tieBreaker.id === "active-lane-closure") {
+    const aActive = activeLane && a.program === activeLane ? 1 : 0;
+    const bActive = activeLane && b.program === activeLane ? 1 : 0;
+    return bActive - aActive;
+  }
+  if (tieBreaker.id === "lexicographic-work-order-id") {
+    return a.workOrderId.localeCompare(b.workOrderId);
+  }
+  return 0;
+}
+
+function compareCandidates(a, b, rules, recordById, activeLane) {
+  if (b.score !== a.score) return b.score - a.score;
+  const tieBreakers = Array.isArray(rules.tieBreakers) ? rules.tieBreakers : [];
+  for (const tieBreaker of tieBreakers) {
+    const result = compareByTieBreaker(a, b, tieBreaker, recordById, activeLane);
+    if (result !== 0) return result;
+  }
+  return a.workOrderId.localeCompare(b.workOrderId);
 }
 
 function summarize(registry, rules, authority) {
   const records = registry.records ?? [];
-  const scored = records.map((record) => scoreRecord(record, rules, authority));
-  const completed = records.filter((record) => TERMINAL_STATUSES.has(record.status)).map((record) => record.id);
-  const blocked = scored.filter((record) => record.verdict === "blocked").map((record) => ({
-    id: record.workOrderId,
-    reasons: record.hardExclusions,
-  }));
+  const recordById = new Map(records.map((record) => [record.id, record]));
   const activeLane = records.find((record) => ACTIVE_STATUSES.has(record.status))?.program ?? null;
+  const scored = records.map((record) => {
+    const score = scoreRecord(record, rules, authority);
+    score.nextRecommendedAction = recommendationText(score, null, activeLane);
+    return score;
+  });
+  const completed = records.filter((record) => COMPLETED_STATUSES.has(record.status)).map((record) => record.id);
+  const blocked = scored
+    .filter((record) => record.verdict === "blocked")
+    .filter((record) => !record.hardExclusions.includes("terminal-status") && !record.hardExclusions.includes("active-work-order"))
+    .map((record) => ({
+      id: record.workOrderId,
+      reasons: record.hardExclusions,
+    }));
   const ranked = scored
     .filter((record) => record.verdict !== "blocked" && SELECTABLE_STATUSES.has(record.status))
-    .sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      if (riskRank(a.riskClass) !== riskRank(b.riskClass)) return riskRank(a.riskClass) - riskRank(b.riskClass);
-      return a.workOrderId.localeCompare(b.workOrderId);
+    .sort((a, b) => compareCandidates(a, b, rules, recordById, activeLane))
+    .map((record, index) => {
+      record.nextRecommendedAction = recommendationText(record, index + 1, activeLane);
+      return record;
     });
   const next = ranked[0] ?? null;
 

--- a/docs/brain/workorders/tools/wo-query.test.mjs
+++ b/docs/brain/workorders/tools/wo-query.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { hardExclusions, scoreRecord, summarize, verdictFor } from "./wo-query.mjs";
+import { hardExclusions, parseArgs, scoreRecord, summarize, verdictFor } from "./wo-query.mjs";
 
 const rules = {
   policyId: "test-policy",
@@ -20,9 +20,22 @@ const rules = {
     { verdict: "defer", minimumScore: 50, maximumScore: 70, minimumInclusive: true, maximumInclusive: false },
     { verdict: "weak", minimumScore: 0, maximumScore: 50, minimumInclusive: true, maximumInclusive: false },
   ],
+  tieBreakers: [
+    { order: 1, id: "lower-risk-class" },
+    { order: 2, id: "fewer-unresolved-blockers" },
+    { order: 3, id: "newer-dependency-evidence" },
+    { order: 4, id: "active-lane-closure" },
+    { order: 5, id: "lexicographic-work-order-id" },
+  ],
 };
 
 describe("wo-query scoring", () => {
+  it("rejects options with missing values", () => {
+    assert.throws(() => parseArgs(["--registry"]), /Missing value for --registry/);
+    assert.throws(() => parseArgs(["--rules", "--json"]), /Missing value for --rules/);
+    assert.throws(() => parseArgs(["--authority", "--registry"]), /Missing value for --authority/);
+  });
+
   it("maps decimal score boundaries deterministically", () => {
     assert.equal(verdictFor(84.9995, rules.decisionBands), "eligible");
     assert.equal(verdictFor(85, rules.decisionBands), "recommend");
@@ -31,8 +44,16 @@ describe("wo-query scoring", () => {
   });
 
   it("blocks terminal records", () => {
-    const record = { id: "WO-1", status: "merged", riskClass: "R1", dependencies: [] };
+    const record = { id: "WO-TEST-001", status: "merged", riskClass: "R1", dependencies: [] };
     assert.deepEqual(hardExclusions(record, "R2"), ["terminal-status"]);
+  });
+
+  it("supports canonical blocked and review statuses without unsupported-status", () => {
+    const blocked = { id: "WO-TEST-002-BLOCKED", status: "blocked", riskClass: "R1", dependencies: [] };
+    const review = { id: "WO-TEST-003-REVIEW", status: "review", riskClass: "R1", dependencies: [] };
+
+    assert.deepEqual(hardExclusions(blocked, "R2"), ["blocked-status"]);
+    assert.deepEqual(hardExclusions(review, "R2"), ["active-work-order"]);
   });
 
   it("does not select active PR work as the next recommendation", () => {
@@ -41,7 +62,7 @@ describe("wo-query scoring", () => {
       generatedBy: "test",
       records: [
         {
-          id: "WO-ACTIVE",
+          id: "WO-TEST-004-ACTIVE",
           title: "Active",
           program: "Test",
           status: "pr_open",
@@ -49,7 +70,7 @@ describe("wo-query scoring", () => {
           dependencies: [],
         },
         {
-          id: "WO-READY",
+          id: "WO-TEST-005-READY",
           title: "Ready",
           program: "Test",
           status: "ready",
@@ -66,7 +87,7 @@ describe("wo-query scoring", () => {
 
     const summary = summarize(registry, rules, "R2");
     assert.equal(summary.activeLane, "Test");
-    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-READY");
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-TEST-005-READY");
   });
 
   it("produces an advisory next recommendation without mutating registry data", () => {
@@ -75,7 +96,7 @@ describe("wo-query scoring", () => {
       generatedBy: "test",
       records: [
         {
-          id: "WO-A",
+          id: "WO-TEST-006-DONE",
           title: "Done",
           program: "Test",
           status: "complete",
@@ -83,7 +104,7 @@ describe("wo-query scoring", () => {
           dependencies: [],
         },
         {
-          id: "WO-B",
+          id: "WO-TEST-007-READY",
           title: "Ready",
           program: "Test",
           status: "ready",
@@ -100,9 +121,10 @@ describe("wo-query scoring", () => {
 
     const summary = summarize(registry, rules, "R2");
     assert.equal(summary.mode, "read-only");
-    assert.deepEqual(summary.completedWorkOrders, ["WO-A"]);
-    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-B");
+    assert.deepEqual(summary.completedWorkOrders, ["WO-TEST-006-DONE"]);
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-TEST-007-READY");
     assert.notEqual(summary.nextRecommendedWorkOrder.verdict, "blocked");
+    assert.match(summary.nextRecommendedWorkOrder.nextRecommendedAction, /Rank 1:/);
   });
 
   it("treats required future evidence as a score input, not a hard preselection blocker", () => {
@@ -111,7 +133,7 @@ describe("wo-query scoring", () => {
       generatedBy: "test",
       records: [
         {
-          id: "WO-EVIDENCE",
+          id: "WO-TEST-008-EVIDENCE",
           title: "Needs Evidence",
           program: "Test",
           status: "ready",
@@ -123,13 +145,13 @@ describe("wo-query scoring", () => {
     };
 
     const summary = summarize(registry, rules, "R2");
-    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-EVIDENCE");
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-TEST-008-EVIDENCE");
     assert.equal(summary.nextRecommendedWorkOrder.hardExclusions.length, 0);
   });
 
   it("returns blocked verdict when risk exceeds authority", () => {
     const record = {
-      id: "WO-R3",
+      id: "WO-TEST-009-R3",
       title: "Governance",
       program: "Test",
       status: "ready",
@@ -139,5 +161,63 @@ describe("wo-query scoring", () => {
     const result = scoreRecord(record, rules, "R1");
     assert.equal(result.verdict, "blocked");
     assert.ok(result.hardExclusions.includes("risk-exceeds-authority"));
+  });
+
+  it("reports blocked work orders without counting terminal or active records", () => {
+    const registry = {
+      schemaVersion: "0.1.0",
+      generatedBy: "test",
+      records: [
+        { id: "WO-TEST-010-COMPLETE", title: "Complete", program: "Test", status: "complete", riskClass: "R1", dependencies: [] },
+        { id: "WO-TEST-011-CANCELLED", title: "Cancelled", program: "Test", status: "cancelled", riskClass: "R1", dependencies: [] },
+        { id: "WO-TEST-012-REVIEW", title: "Review", program: "Test", status: "review", riskClass: "R1", dependencies: [] },
+        { id: "WO-TEST-013-BLOCKED", title: "Blocked", program: "Test", status: "blocked", riskClass: "R1", dependencies: [] },
+      ],
+    };
+
+    const summary = summarize(registry, rules, "R2");
+    assert.deepEqual(summary.completedWorkOrders, ["WO-TEST-010-COMPLETE"]);
+    assert.deepEqual(summary.blockedWorkOrders, [{ id: "WO-TEST-013-BLOCKED", reasons: ["blocked-status"] }]);
+    assert.equal(summary.activeLane, "Test");
+  });
+
+  it("uses configured tie-breakers before lexicographic fallback", () => {
+    const registry = {
+      schemaVersion: "0.1.0",
+      generatedBy: "test",
+      records: [
+        {
+          id: "WO-TEST-014-A",
+          title: "Higher blocker pressure",
+          program: "Other",
+          status: "ready",
+          riskClass: "R1",
+          dependencies: [],
+          blockers: [{ id: "B1", status: "open" }],
+          evidenceProduced: [{ location: "old.md", freshness: { observedAt: "2026-01-01T00:00:00Z" } }],
+        },
+        {
+          id: "WO-TEST-015-B",
+          title: "Fewer blockers",
+          program: "Other",
+          status: "ready",
+          riskClass: "R1",
+          dependencies: [],
+          evidenceProduced: [{ location: "new.md", freshness: { observedAt: "2026-02-01T00:00:00Z" } }],
+        },
+        {
+          id: "WO-TEST-016-ACTIVE",
+          title: "Active lane",
+          program: "Active",
+          status: "review",
+          riskClass: "R1",
+          dependencies: [],
+        },
+      ],
+    };
+
+    const summary = summarize(registry, rules, "R2");
+    assert.equal(summary.activeLane, "Active");
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-TEST-015-B");
   });
 });

--- a/docs/brain/workorders/tools/wo-query.test.mjs
+++ b/docs/brain/workorders/tools/wo-query.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { hardExclusions, scoreRecord, summarize, verdictFor } from "./wo-query.mjs";
+
+const rules = {
+  policyId: "test-policy",
+  schemaVersion: "1.0.0",
+  factors: [
+    { id: "dependency-readiness", weight: 25 },
+    { id: "risk-authority-fit", weight: 20 },
+    { id: "evidence-readiness", weight: 15 },
+    { id: "operational-value", weight: 15 },
+    { id: "scope-reversibility", weight: 10 },
+    { id: "safety-margin", weight: 10 },
+    { id: "blocker-pressure", weight: 5 },
+  ],
+  decisionBands: [
+    { verdict: "recommend", minimumScore: 85, maximumScore: 100, minimumInclusive: true, maximumInclusive: true },
+    { verdict: "eligible", minimumScore: 70, maximumScore: 85, minimumInclusive: true, maximumInclusive: false },
+    { verdict: "defer", minimumScore: 50, maximumScore: 70, minimumInclusive: true, maximumInclusive: false },
+    { verdict: "weak", minimumScore: 0, maximumScore: 50, minimumInclusive: true, maximumInclusive: false },
+  ],
+};
+
+describe("wo-query scoring", () => {
+  it("maps decimal score boundaries deterministically", () => {
+    assert.equal(verdictFor(84.9995, rules.decisionBands), "eligible");
+    assert.equal(verdictFor(85, rules.decisionBands), "recommend");
+    assert.equal(verdictFor(49.9999, rules.decisionBands), "weak");
+    assert.equal(verdictFor(50, rules.decisionBands), "defer");
+  });
+
+  it("blocks terminal records", () => {
+    const record = { id: "WO-1", status: "merged", riskClass: "R1", dependencies: [] };
+    assert.deepEqual(hardExclusions(record, "R2"), ["terminal-status"]);
+  });
+
+  it("does not select active PR work as the next recommendation", () => {
+    const registry = {
+      schemaVersion: "0.1.0",
+      generatedBy: "test",
+      records: [
+        {
+          id: "WO-ACTIVE",
+          title: "Active",
+          program: "Test",
+          status: "pr_open",
+          riskClass: "R1",
+          dependencies: [],
+        },
+        {
+          id: "WO-READY",
+          title: "Ready",
+          program: "Test",
+          status: "ready",
+          riskClass: "R1",
+          dependencies: [],
+          evidenceProduced: [{ location: "evidence.md" }],
+          evidenceRequired: [{ kind: "doc" }],
+          allowedFiles: ["docs/**"],
+          blockedSystems: [{ name: "Runtime" }],
+          stopConditions: [{ type: "scope_boundary" }],
+        },
+      ],
+    };
+
+    const summary = summarize(registry, rules, "R2");
+    assert.equal(summary.activeLane, "Test");
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-READY");
+  });
+
+  it("produces an advisory next recommendation without mutating registry data", () => {
+    const registry = {
+      schemaVersion: "0.1.0",
+      generatedBy: "test",
+      records: [
+        {
+          id: "WO-A",
+          title: "Done",
+          program: "Test",
+          status: "complete",
+          riskClass: "R1",
+          dependencies: [],
+        },
+        {
+          id: "WO-B",
+          title: "Ready",
+          program: "Test",
+          status: "ready",
+          riskClass: "R1",
+          dependencies: [],
+          evidenceProduced: [{ location: "evidence.md" }],
+          evidenceRequired: [{ kind: "doc" }],
+          allowedFiles: ["docs/**"],
+          blockedSystems: [{ name: "Runtime" }],
+          stopConditions: [{ type: "scope_boundary" }],
+        },
+      ],
+    };
+
+    const summary = summarize(registry, rules, "R2");
+    assert.equal(summary.mode, "read-only");
+    assert.deepEqual(summary.completedWorkOrders, ["WO-A"]);
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-B");
+    assert.notEqual(summary.nextRecommendedWorkOrder.verdict, "blocked");
+  });
+
+  it("treats required future evidence as a score input, not a hard preselection blocker", () => {
+    const registry = {
+      schemaVersion: "0.1.0",
+      generatedBy: "test",
+      records: [
+        {
+          id: "WO-EVIDENCE",
+          title: "Needs Evidence",
+          program: "Test",
+          status: "ready",
+          riskClass: "R1",
+          dependencies: [],
+          evidenceRequired: [{ kind: "file" }],
+        },
+      ],
+    };
+
+    const summary = summarize(registry, rules, "R2");
+    assert.equal(summary.nextRecommendedWorkOrder.workOrderId, "WO-EVIDENCE");
+    assert.equal(summary.nextRecommendedWorkOrder.hardExclusions.length, 0);
+  });
+
+  it("returns blocked verdict when risk exceeds authority", () => {
+    const record = {
+      id: "WO-R3",
+      title: "Governance",
+      program: "Test",
+      status: "ready",
+      riskClass: "R3",
+      dependencies: [],
+    };
+    const result = scoreRecord(record, rules, "R1");
+    assert.equal(result.verdict, "blocked");
+    assert.ok(result.hardExclusions.includes("risk-exceeds-authority"));
+  });
+});


### PR DESCRIPTION
## Summary

WO-WOE-005 adds the first read-only Work Order query tool.

It can answer:
- active lane
- completed Work Orders
- blocked Work Orders
- next recommended Work Order
- why that Work Order is next

## Scope

- `docs/brain/workorders/tools/README.md`
- `docs/brain/workorders/tools/wo-query.mjs`
- `docs/brain/workorders/tools/wo-query.test.mjs`

## Non-changes

- No runtime code changed
- No CI/CD behavior changed
- No registry migration
- No GitHub querying
- No write behavior
- No autonomous execution
- No protected data, secrets, county data, PACS, or SQL touched

## Validation

- `node --test docs/brain/workorders/tools/wo-query.test.mjs`
- `node docs/brain/workorders/tools/wo-query.mjs --json`
- `node docs/brain/workorders/tools/wo-query.mjs --authority R1`
- `git diff --check`
- normal pre-commit hook
- normal pre-push hook

## Summary by Sourcery

Introduce a read-only Work Order query tool that reports lane status and recommends the next work order based on scoring rules.

New Features:
- Add a CLI tool to query the Work Order registry and scoring policy to summarize active, completed, blocked, and next recommended work orders.
- Provide both human-readable text and JSON outputs for work order recommendations and scoring details.

Enhancements:
- Define scoring, exclusion, and recommendation logic for work orders based on risk, dependencies, evidence, and operational factors.

Documentation:
- Document the Work Order query tool contract, usage, and validation commands in the brain/workorders tools README.

Tests:
- Add tests covering scoring band boundaries, exclusion rules, recommendation behavior, and read-only operation of the Work Order query tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line work order query tool that reports active, completed, and blocked work orders, plus the next recommended item.
  * Supports both readable text and JSON output, with configurable inputs.

* **Documentation**
  * Added usage guidance, output expectations, and validation examples for the new tool.

* **Tests**
  * Added coverage for scoring, blocking rules, recommendation selection, and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->