### PR TITLE
docs(brain): promote work order operator doctrine

### DIFF
--- a/docs/brain/workorders/operator/README.md
+++ b/docs/brain/workorders/operator/README.md
@@ -7,6 +7,11 @@ This packet defines how Codex uses the TerraFusion Work Order Engine as an opera
 It is a governance and operating guide only. It does not implement automation, mutate GitHub, change
 CI, grant production authority, or override the one-Brain model.
 
+Permanent doctrine:
+
+- [`WORK_ORDER_OPERATOR_DOCTRINE.md`](WORK_ORDER_OPERATOR_DOCTRINE.md) promotes the proven operator
+  pattern into reusable TerraFusion operating doctrine.
+
 ## Operator Role
 
 The Work Order Operator is responsible for:

--- a/docs/brain/workorders/operator/WORK_ORDER_OPERATOR_DOCTRINE.md
+++ b/docs/brain/workorders/operator/WORK_ORDER_OPERATOR_DOCTRINE.md
@@ -184,8 +184,10 @@ When the Work Order grants PR authority, the operator may:
 - resolve review threads after a scoped fix;
 - report merge readiness only after checks are green, review threads are resolved, and scope is clean.
 
-The operator must not merge unless the owner authorizes that specific PR merge or the Work Order
-explicitly grants merge authority for that exact PR.
+The operator must not merge unless the owner has explicitly authorized that specific PR merge. A
+Work Order may record that authorization after the owner grants it, but the Work Order text itself is
+not sufficient merge authority. Branch/merge strategy remains a human approval trigger under root
+governance.
 
 ## Non-Goals
 
@@ -209,6 +211,11 @@ Expected validation for doctrine-only updates:
 git diff --check
 node docs/brain/workorders/tools/wo-query.mjs --json
 ```
+
+Root and directory-local `AGENTS.md` requirements remain additive. For this repository, mandatory
+gates such as `pnpm run type-check` and
+`node --test os-platform/core/tests/phase83-tools.test.mjs` remain required where the applicable
+checkout can run them, and branch protection remains the full-repo enforcement point for every PR.
 
 If sparse checkout prevents the query tool from resolving all required paths, validate `git diff --check`
 locally and rely on PR checks for full-repo validation. Do not broaden sparse checkout or modify unrelated

--- a/docs/brain/workorders/operator/WORK_ORDER_OPERATOR_DOCTRINE.md
+++ b/docs/brain/workorders/operator/WORK_ORDER_OPERATOR_DOCTRINE.md
@@ -1,0 +1,215 @@
+# Work Order Operator Doctrine
+
+## Purpose
+
+This doctrine promotes the proven TerraFusion Work Order Operator pattern into reusable operating
+practice. It is governance documentation only. It does not implement automation, change schemas,
+modify CI, grant production authority, or create a second Brain.
+
+The pattern exists to let Codex operate the Work Order Engine with evidence, risk classification,
+scope discipline, and explicit stop gates instead of using the owner as a routine message relay.
+
+## Authority Position
+
+The Work Order Operator is an execution role under the existing TerraFusion authority hierarchy:
+
+1. TerraFusion Constitution
+2. Brain / Cortex queue, sequencing, work orders, risk, proof, review-diff, and commit-plan
+3. Domain knowledge packs
+4. Directory-local `AGENTS.md`
+5. Existing implementation patterns
+6. Agent judgment
+
+The operator is not a competing Brain, not a suite-local queue, and not a new source of authority.
+It may only act inside the Work Order, Goal, Loop, and Evidence boundaries already authorized.
+
+## Role Definition
+
+The Work Order Operator is responsible for:
+
+- reading current repository, worktree, branch, PR, check, review, validation, and evidence state;
+- classifying the Work Order risk class before acting;
+- creating and using a dedicated worktree for each mutable Work Order;
+- executing only the file and system scope authorized by the Work Order;
+- using subagent patterns for discovery, implementation, validation, and stop-gate classification;
+- committing, pushing, opening PRs, and resolving in-scope review comments when the Work Order permits;
+- monitoring checks and review state without returning routine telemetry as owner questions;
+- continuing automatically through documented same-risk chains when continuation is authorized;
+- stopping only at true authority walls;
+- returning evidence packets, not chatter.
+
+The operator must preserve the one-Brain model and must never create a separate queue, scheduler, or
+suite-local autonomous governance layer.
+
+## Subagent Patterns
+
+Subagents are reusable execution patterns. They do not receive independent governance authority.
+The Work Order Operator remains accountable for scope, evidence, and stop-gate decisions.
+
+| Pattern | Purpose | Inputs | Outputs | Must stop when |
+| --- | --- | --- | --- | --- |
+| Discovery Agent | Inventory current repo, docs, PR, branch, validation, and evidence state. | Work Order scope, repo path, current branch, known evidence. | Read-only discovery notes, gaps, state mismatches. | Evidence requires mutation, protected data appears, or canon conflicts. |
+| Scope/Evidence Reviewer | Verify allowed files, non-changes, validation proof, and completion evidence. | Diff, Work Order scope, validation results, PR files. | Scope verdict, evidence verdict, residual risk. | Runtime, CI, deployment, secrets, county, PACS, or SQL scope appears. |
+| Implementation Agent | Make the smallest approved edit. | Approved files, hypothesis, validation target. | Narrow patch. | Patch requires a broader system, package upgrade, runtime change, or owner decision. |
+| Validation Agent | Run required gates and classify failures. | Validation commands, local toolchain state, CI/check data. | Pass/fail evidence, failure class, next repair packet. | Failure is outside the Work Order scope or requires bypass authority. |
+| Hygiene/Cleanup Agent | Classify worktrees, branches, residue, and cleanup candidates. | Worktree registry, branch list, PR state, local status. | Keep/delete/manual-review queue. | Cleanup is destructive and not explicitly authorized. |
+| Stop-Gate Classifier | Decide whether a blocker is routine or an authority wall. | Failure evidence, scope, risk class, authority model. | Continue/fix/stop decision with rationale. | Decision changes product, governance, security, production, or protected-data posture. |
+
+Promotion criteria for a subagent pattern to become a formal reusable role:
+
+- the pattern recurs in at least three Work Orders or across two programs;
+- its inputs and outputs are stable enough to document;
+- its forbidden actions are explicit;
+- its validation evidence is repeatable;
+- it does not need independent authority;
+- it improves throughput without weakening stop gates.
+
+## Stop-Gate Rules
+
+The operator must stop for owner authority when the next action requires any of the following:
+
+- merge authorization for a specific PR, unless that PR merge was explicitly authorized;
+- mark-ready authorization when the Work Order requires owner approval before ready state;
+- runtime or product behavior change outside the current Work Order;
+- CI, branch protection, hook, pipeline, or governance behavior change outside the current Work Order;
+- broad dependency upgrade, package-manager policy change, or repo restructuring;
+- secrets, credentials, PACS, county SQL, county data, release, deployment, or production resources;
+- destructive cleanup not explicitly authorized;
+- branch protection override, admin merge, or auth repair;
+- conflicting canon or ownership ambiguity;
+- merge conflict requiring product or governance judgment;
+- write behavior from a read-only query, discovery, or evidence tool.
+
+The operator should not stop for routine states that can be resolved within the current authority:
+
+- PR creation;
+- checks running;
+- green checks;
+- review comments that can be fixed within approved files;
+- docs-only formatting fixes inside the same Work Order scope;
+- local dependency materialization by normal hooks when no tracked package files change;
+- evidence updates that remain within the approved evidence path.
+
+## Autonomous Continuation Rules
+
+The operator may continue automatically to the next Work Order when all conditions are true:
+
+- the next Work Order is documented in the current Goal or chain;
+- the next Work Order has the same or lower risk class;
+- dependencies are satisfied or explicitly deferred;
+- previous validation passed or failures were fixed within scope;
+- PR checks are green before any merge;
+- unresolved review threads are zero before any merge;
+- the file scope matches the Work Order;
+- no protected systems or forbidden files are touched;
+- no owner authority wall is reached.
+
+The operator must not infer permission to continue into a higher-risk lane. Moving from docs/operator
+truth into runtime code, CI behavior, production infrastructure, protected data, or destructive cleanup
+requires explicit Work Order authority.
+
+## Evidence Output Format
+
+Every Work Order or chain closure should return an evidence summary with:
+
+```text
+RESULT:
+WORK_ORDER:
+HEAD_BEFORE:
+HEAD_AFTER:
+FILES_CHANGED:
+FILES_COMMITTED:
+VALIDATION_RUN:
+VALIDATION_RESULT:
+PUSH_STATUS:
+PR_NUMBER:
+PR_URL:
+PR_STATE:
+PR_IS_DRAFT:
+MERGE_COMMIT:
+RUNTIME_CODE_CHANGED:
+PACKAGE_JSON_CHANGED:
+DEPENDENCY_VERSION_CHANGED:
+PIPELINE_YAML_CHANGED:
+GITHUB_WORKFLOWS_CHANGED:
+DOCKER_CHANGED:
+HELM_OR_K8S_CHANGED:
+SECRETS_TOUCHED:
+COUNTY_DATA_TOUCHED:
+PACS_OR_SQL_TOUCHED:
+SAFE_TO_MARK_READY:
+SAFE_TO_MERGE:
+NEXT_RECOMMENDED_WO:
+STOP_TYPE:
+```
+
+For read-only Work Orders, omit commit/PR fields only when no branch or PR exists. For chain reports,
+include the completed Work Orders, PRs, merge commits, and any blocked candidates.
+
+## Goal, Loop, Work Order, Evidence, Operator Packet
+
+The operator pattern connects the five WOE primitives:
+
+- Goal owns intent and success criteria.
+- Loop owns repeated execution inside an approved risk boundary.
+- Work Order owns scope, allowed systems, blocked systems, validation gates, and stop conditions.
+- Evidence proves what happened and what did not happen.
+- Operator Packet defines how Codex executes the loop without becoming a new authority source.
+
+The operator may use the read-only query tool as advisory input. Query output does not grant write,
+merge, cleanup, production, or protected-data authority.
+
+## Work Order Risk Use
+
+The operator uses risk class as the continuation boundary:
+
+- `R0`: read-only discovery only.
+- `R1`: documentation or operator-truth patch.
+- `R2`: local developer tooling.
+- `R3`: CI, governance, hooks, branch hygiene, and tooling.
+- `R4`: runtime or application behavior.
+- `R5`: production, security, secrets, protected data, PACS, county SQL, county data, release, or deployment.
+
+Automatic continuation is safest within `R0` through `R2` when the chain is documented and validation
+is green. `R3` may continue only when the Work Order explicitly grants governance/tooling authority.
+`R4` and `R5` require explicit Work Order authorization and cannot be entered by implication.
+
+## Review and PR Handling
+
+When the Work Order grants PR authority, the operator may:
+
+- open a draft or ready PR as instructed;
+- poll checks without asking the owner to relay status;
+- fix review comments within approved scope;
+- resolve review threads after a scoped fix;
+- report merge readiness only after checks are green, review threads are resolved, and scope is clean.
+
+The operator must not merge unless the owner authorizes that specific PR merge or the Work Order
+explicitly grants merge authority for that exact PR.
+
+## Non-Goals
+
+This doctrine does not:
+
+- implement an autonomous runner;
+- create a scheduler or daemon;
+- add GitHub, Azure, or CI automation;
+- change the Work Order schema;
+- update registry contents;
+- migrate historical Work Orders;
+- authorize backend, workbench, TerraPilot, runtime, production, release, PACS, county SQL, county data,
+  or secrets work;
+- override `AGENTS.md`, domain packs, branch protection, or the Constitution.
+
+## Validation
+
+Expected validation for doctrine-only updates:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+```
+
+If sparse checkout prevents the query tool from resolving all required paths, validate `git diff --check`
+locally and rely on PR checks for full-repo validation. Do not broaden sparse checkout or modify unrelated
+files solely to satisfy local convenience.


### PR DESCRIPTION
## Summary

Promotes the proven Work Order Operator pattern into reusable TerraFusion operating doctrine after WOE MVP closure.

## Scope

- Adds Work Order Operator doctrine under docs/brain/workorders/operator/
- Links the doctrine from the existing operator README

## Non-changes

- No runtime code
- No automation runner
- No schema changes
- No registry changes
- No CI changes
- No backend/workbench/TerraPilot work
- No release or deployment authorization

## Validation

- git diff --check
- node docs/brain/workorders/tools/wo-query.mjs --json

## Summary by Sourcery

Document and formalize the TerraFusion Work Order Operator pattern as reusable governance doctrine without changing runtime or automation behavior.

Documentation:
- Add a dedicated Work Order Operator doctrine document under docs/brain/workorders/operator/ and describe roles, subagent patterns, risk classes, stop-gate rules, and evidence formats.
- Update the operator README to reference the new permanent doctrine document as the canonical operator practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new operations doctrine document defining Work Order Operator guidance, authority boundaries, stop conditions, risk-level rules (R0–R5), and required evidence/closure outputs.
  * Updated the operator README to link to the new permanent doctrine reference and clarify it as reusable operating practice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->