### PR TITLE
docs(brain): WO-WOE-010 — Goal/Loop Program Playbook Binding

### DIFF
--- a/docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md
+++ b/docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md
@@ -1,0 +1,108 @@
+# TerraFusion Goal/Loop Program Playbook
+
+**Version:** 1.0  
+**Date:** 2026-06-30  
+**Authority:** TerraFusion Brain / WO-WOE-010  
+**Classification:** Operator Doctrine — command-layer binding
+
+---
+
+## Purpose
+
+This playbook binds the Work Order Program Playbook Register to explicit `/goal` and `/loop`
+operating commands. It is the command-level layer on top of WO-WOE-009.
+
+**Before this playbook:** The operator nominates one WO at a time from the register.  
+**After this playbook:** The operator states a program intent (`/goal`) and the execution mode
+(`/loop`), and the Brain selects the next unblocked WO from the correct program file.
+
+---
+
+## The Four Primitives
+
+| Primitive | Owns | Does not own |
+|-----------|------|--------------|
+| `/goal` | Program intent, desired outcome, success condition | File mutation, merge authority |
+| `/loop` | Repeated execution inside an approved risk boundary | Scope expansion, authority walls |
+| `WO` | The governed execution packet: allowed systems, blocked systems, steps, evidence | Competing queue, autonomous self-continuation |
+| `evidence` | Proof that completion criteria were met | Future authorization by implication |
+
+---
+
+## Command Model
+
+```text
+/goal <program>
+  ↓
+selects program from PROGRAM_PLAYBOOK_REGISTER
+  ↓
+/loop <mode>
+  ↓
+executes next unblocked WO node from that program
+  ↓
+WO packet (sovereignty boundary, allowed/blocked, steps, evidence)
+  ↓
+validation + evidence
+  ↓
+PR / merge / stop gate
+  ↓
+loop continues only if same-risk and no authority wall
+```
+
+---
+
+## Output Format
+
+Every `/goal` + `/loop` cycle ends with a structured result block:
+
+```
+RESULT:        [COMPLETED | BLOCKED | STOP_GATE | EVIDENCE_ONLY]
+GOAL:          <declared program intent>
+LOOP_MODE:     <once | program | evidence | merge-watch | discovery | recovery>
+ACTIVE_PROGRAM: <program name>
+ACTIVE_WO:     <WO ID being executed>
+NEXT_WO:       <next unblocked WO in program, or NONE>
+BLOCKERS:      <list of blocking dependencies or NONE>
+EVIDENCE:      <PR URL, doc path, or validation output>
+STOP_TYPE:     [NONE | AUTHORITY_WALL | FAILED_GATE | CANONICAL_CONFLICT | BLOCKER]
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `GOAL_LOOP_PLAYBOOK.md` (this file) | Top-level doctrine and command model |
+| `goal-loop/GOAL_COMMANDS.md` | `/goal` command definitions and program mappings |
+| `goal-loop/LOOP_MODES.md` | `/loop` mode definitions, continuation rules, stop triggers |
+| `goal-loop/STOP_WALLS.md` | Exhaustive list of authority walls and their scope |
+| `goal-loop/COMMAND_TO_PROGRAM_MAP.md` | Current-state map: command → program → next WO → blockers |
+| `goal-loop/README.md` | WO-WOE-006 doctrine foundation (do not modify) |
+
+---
+
+## Current State (2026-06-30)
+
+| PR | WO | Status |
+|----|----|--------|
+| #1112 | WO-CONFIG-BENTON-001 | auto-merge queued — blocks WO-DEPLOY-BENTON-003B |
+| #1114 | WO-WOE-009 | auto-merge queued — this playbook builds on it |
+| #1115 | WO-DATA-BENTON-DUPE-001 | auto-merge queued — investigation closed |
+
+**After #1112 merges:**  
+`/goal benton-demo` + `/loop program` → next legal WO = WO-DEPLOY-BENTON-003B (preflight only, no deploy auth).
+
+**WO-DATA-BENTON-DUPE-001B** (DELETE 30 rows) requires explicit operator data-mutation authorization before execution. It is a stop wall.
+
+---
+
+## Non-Goals
+
+This playbook does not:
+
+- implement a CLI or runner
+- execute any WO autonomously without operator acknowledgement of stop walls
+- grant merge, deployment, or data-mutation authority
+- modify runtime code, appsettings, or Azure settings
+- connect to PACS or county production systems

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -1,0 +1,87 @@
+# TerraFusion Program Playbook Register
+
+**Version:** 1.0  
+**Date:** 2026-06-30  
+**Authority:** TerraFusion Brain / WO-WOE-009  
+**Classification:** Operator Doctrine — canonical planning surface
+
+---
+
+## Purpose
+
+This register is the canonical source of truth for all active TerraFusion work order programs. Every WO must sit inside a program. Every program has a goal, a sovereignty boundary, an ordered WO list, and explicit stop conditions.
+
+**Rule:** The next WO chosen by the operator or the Brain must be a node inside this register, not a floating suggestion.
+
+---
+
+## Current Program Summary
+
+| # | Program | Status | Next WO |
+|---|---------|--------|---------|
+| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | ACTIVE | WO-DEPLOY-BENTON-003B |
+| P2 | [Benton Data Quality](programs/benton-data-quality.md) | ACTIVE | WO-DATA-BENTON-DUPE-001 |
+| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | QUEUED | WO-BACKEND-001 |
+| P4 | [Property Workbench](programs/property-workbench.md) | QUEUED | WO-WORKBENCH-001 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | ACTIVE | WO-TERRAPILOT-P2 |
+| P6 | [Work Order Engine](programs/work-order-engine.md) | ACTIVE | WO-WOE-009 ← THIS WO |
+| P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | QUEUED | WO-BRAIN-001 |
+| P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | ACTIVE | WO-AZURE-001 |
+
+---
+
+## Known Blockers (as of 2026-06-30)
+
+| Blocker | Blocking |
+|---------|---------|
+| PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B |
+| 14 duplicate parcel groups in `canonical_tf.tf_parcel` | WO-DATA-BENTON-DUPE-001 investigation |
+| No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 |
+| Backend operational truth not established | WO-BACKEND-001+ |
+| Production deployment NOT authorized | All P1 WOs after 003F |
+
+---
+
+## Operator Decision Walls
+
+These actions require explicit operator authorization. The Brain and Claude do not initiate them:
+
+| Wall | Scope |
+|------|-------|
+| Azure App Service deployment | P1 / P8 |
+| Production / county-facing release | P1 |
+| PACS connection | P2 / data mutation |
+| Schema changes or EF migrations | All programs |
+| Data drain or reload | P2 |
+| New county enrollment | P8 |
+
+---
+
+## Execution Doctrine
+
+1. Operator or Brain nominates a WO from this register.
+2. Claude executes the WO as an operational packet (no self-initiation of walls).
+3. Each WO produces required outputs: evidence doc, config change, ADR, or runbook — per the WO definition.
+4. After WO completion, register status is updated and next recommended WO is surfaced.
+5. WOs in different programs may run in parallel if they do not share a sovereignty boundary.
+
+---
+
+## Program Files
+
+- [P1 — Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md)
+- [P2 — Benton Data Quality](programs/benton-data-quality.md)
+- [P3 — Backend Operational Excellence](programs/backend-operational-excellence.md)
+- [P4 — Property Workbench](programs/property-workbench.md)
+- [P5 — TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md)
+- [P6 — Work Order Engine](programs/work-order-engine.md)
+- [P7 — AI / Brain / Operator System](programs/brain-operator-system.md)
+- [P8 — Azure / DevOps / County Runtime](programs/azure-county-runtime.md)
+
+---
+
+## Change Log
+
+| Date | Change | WO |
+|------|--------|----|
+| 2026-06-30 | Initial register created | WO-WOE-009 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,28 +17,29 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-| # | Program | Status | Next WO |
-|---|---------|--------|---------|
-| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | ACTIVE | WO-DEPLOY-BENTON-003B |
-| P2 | [Benton Data Quality](programs/benton-data-quality.md) | ACTIVE | WO-DATA-BENTON-DUPE-001 |
-| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | QUEUED | WO-BACKEND-001 |
-| P4 | [Property Workbench](programs/property-workbench.md) | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | ACTIVE | WO-TERRAPILOT-P2 |
-| P6 | [Work Order Engine](programs/work-order-engine.md) | ACTIVE | WO-WOE-009 ← THIS WO |
-| P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | QUEUED | WO-BRAIN-001 |
-| P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | ACTIVE | WO-AZURE-001 |
+| # | Program | /goal command | Status | Next WO |
+|---|---------|--------------|--------|---------|
+| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003B |
+| P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-DUPE-001B |
+| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
+| P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P2 |
+| P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-010 |
+| P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
+| P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |
 
 ---
 
 ## Known Blockers (as of 2026-06-30)
 
-| Blocker | Blocking |
-|---------|---------|
-| PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B |
-| 14 duplicate parcel groups in `canonical_tf.tf_parcel` | WO-DATA-BENTON-DUPE-001 investigation |
-| No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 |
-| Backend operational truth not established | WO-BACKEND-001+ |
-| Production deployment NOT authorized | All P1 WOs after 003F |
+| Blocker | Blocking | Stop Wall |
+|---------|---------|-----------|
+| PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B | — |
+| WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
+| No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
+| Backend operational truth not established | WO-BACKEND-001+ | — |
+| Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
+| County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |
 
 ---
 
@@ -80,8 +81,38 @@ These actions require explicit operator authorization. The Brain and Claude do n
 
 ---
 
+## Goal/Loop Command Layer (WO-WOE-010)
+
+The command layer binds this register to `/goal` and `/loop` operating commands.
+
+| File | Purpose |
+|------|---------|
+| [GOAL_LOOP_PLAYBOOK.md](GOAL_LOOP_PLAYBOOK.md) | Top-level doctrine and command model |
+| [goal-loop/GOAL_COMMANDS.md](goal-loop/GOAL_COMMANDS.md) | `/goal` command definitions and program mappings |
+| [goal-loop/LOOP_MODES.md](goal-loop/LOOP_MODES.md) | `/loop` mode definitions and continuation rules |
+| [goal-loop/STOP_WALLS.md](goal-loop/STOP_WALLS.md) | Authority walls (SW-01 through SW-09) |
+| [goal-loop/COMMAND_TO_PROGRAM_MAP.md](goal-loop/COMMAND_TO_PROGRAM_MAP.md) | Current-state: command → program → next WO → blockers |
+
+**Canonical operator sequences:**
+
+```
+# Current: wait for PR #1112, then advance
+/goal benton-demo
+/loop merge-watch
+
+# After #1112 merges — run preflight
+/loop program
+
+# Investigate data quality without mutation
+/goal benton-data-quality
+/loop evidence
+```
+
+---
+
 ## Change Log
 
 | Date | Change | WO |
 |------|--------|----|
 | 2026-06-30 | Initial register created | WO-WOE-009 |
+| 2026-06-30 | Added /goal column, stop-wall column, goal/loop command layer section | WO-WOE-010 |

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -1,0 +1,189 @@
+# Command-to-Program Map
+
+**Authority:** WO-WOE-010  
+**Last Updated:** 2026-06-30  
+**Classification:** Operator Doctrine — current state snapshot
+
+This file maps every `/goal` command to its program, current next WO, blockers, allowed loop modes,
+and active stop walls. Update this file when a WO completes or a blocker resolves.
+
+---
+
+## Quick Reference Table
+
+| `/goal` command | Program | Next WO | Blocked? | Allowed /loop modes |
+|-----------------|---------|---------|----------|---------------------|
+| `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
+| `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
+| `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P2 | NO | `once`, `program`, `evidence`, `discovery` |
+| `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
+| `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
+
+---
+
+## Detailed Map
+
+### /goal benton-demo → P1
+
+**File:** [programs/benton-demo-deployment.md](../programs/benton-demo-deployment.md)  
+**Success condition:** All preflight checklist items verified; operator holds deploy authorization decision.
+
+| WO | Title | Status | Notes |
+|----|-------|--------|-------|
+| WO-DEPLOY-BENTON-002E | Migrations verified | CLOSED | 94 applied, 0 pending |
+| WO-DEPLOY-BENTON-003A | Local demo rehearsal | CLOSED | PR merged |
+| WO-CONFIG-BENTON-001 | Config gates aligned | CLOSED | PR #1112 auto-merge queued |
+| WO-DEPLOY-BENTON-003B | Azure preflight | **NEXT** | **Blocked: PR #1112 must merge first** |
+| WO-DEPLOY-BENTON-003C | App settings packet | QUEUED | After 003B |
+| WO-DEPLOY-BENTON-003D | Smoke slot deploy | QUEUED | SW-01 wall — deploy auth required |
+| WO-DEPLOY-BENTON-003E | Smoke validation | QUEUED | After 003D |
+| WO-DEPLOY-BENTON-003F | Demo authorization packet | QUEUED | SW-09 owner decision required |
+
+**Active stop walls in path:** SW-01 (003D), SW-09 (003F)
+
+**Recommended first move:**
+```
+/goal benton-demo
+/loop merge-watch
+```
+— monitors PR #1112; once merged, advances to 003B with `/loop once`.
+
+---
+
+### /goal benton-data-quality → P2
+
+**File:** [programs/benton-data-quality.md](../programs/benton-data-quality.md)  
+**Success condition:** All data anomaly groups documented and classified; cleanup WOs authorized before execution.
+
+| WO | Title | Status | Notes |
+|----|-------|--------|-------|
+| WO-DATA-BENTON-DUPE-001 | Duplicate row investigation | CLOSED | PR #1115 auto-merge queued; 30 anomalous rows documented |
+| WO-DATA-BENTON-DUPE-001B | Delete 30 anomalous rows | **NEXT** | **SW-02 WALL — data mutation, explicit auth required** |
+| WO-DATA-BENTON-ADDR-001 | Address data gap investigation | QUEUED | Read-only; after DUPE-001 |
+| WO-DATA-BENTON-GEOM-001 | Geometry data gap investigation | QUEUED | Read-only |
+| WO-DATA-BENTON-OWNER-001 | Owner data gap investigation | QUEUED | Read-only |
+| WO-DATA-BENTON-EVIDENCE-ROLLUP | Full data quality evidence packet | QUEUED | After all above |
+
+**Active stop walls:** SW-02 at WO-DATA-BENTON-DUPE-001B (explicit operator data-mutation auth required)
+
+**Recommended first move:**
+```
+/goal benton-data-quality
+/loop evidence
+```
+— collects remaining evidence on DUPE-001 without advancing to the mutation step.
+
+---
+
+### /goal backend-excellence → P3
+
+**File:** [programs/backend-operational-excellence.md](../programs/backend-operational-excellence.md)  
+**Success condition:** Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-BACKEND-001 | Runtime truth audit | **NEXT** |
+| WO-BACKEND-002 | Health check contract | QUEUED |
+| WO-BACKEND-003 | Logging and observability | QUEUED |
+| WO-BACKEND-004 | Release hygiene | QUEUED |
+| WO-BACKEND-005 | Error handling sweep | QUEUED |
+| WO-BACKEND-006 | Performance baseline | QUEUED |
+| WO-BACKEND-007 | Integration test coverage | QUEUED |
+| WO-BACKEND-008 | Operational runbook | QUEUED |
+
+No active stop walls at WO-BACKEND-001.
+
+---
+
+### /goal property-workbench → P4
+
+**File:** [programs/property-workbench.md](../programs/property-workbench.md)  
+**Success condition:** All workbench tabs have live data, honest empty states, and validated tab contracts.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-WORKBENCH-001 | Parcel dossier data contract | **NEXT** |
+| (WOs 002–010) | Tab integration, empty states, owners, geom, etc. | QUEUED |
+
+No active stop walls at WO-WORKBENCH-001.
+
+---
+
+### /goal terrapilot-maturity → P5
+
+**File:** [programs/terrapilot-tool-maturity.md](../programs/terrapilot-tool-maturity.md)  
+**Success condition:** At least one tool reaches L3 (live-integrated); L0/L1 tools disclosed as unavailable.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-TERRAPILOT-P1 | Tool maturity matrix | DONE/PARTIAL |
+| WO-TERRAPILOT-P2 | Promotion protocol | **NEXT** |
+| WO-TERRAPILOT-P3 | Handler parity audit | QUEUED |
+| WO-TERRAPILOT-P4 | Stub disclosure UI | QUEUED |
+| WO-TERRAPILOT-P5 | First live-integrated tool | QUEUED |
+| WO-TERRAPILOT-P6 | Tool promotion evidence rollup | QUEUED |
+
+No active stop walls at WO-TERRAPILOT-P2.
+
+---
+
+### /goal work-order-engine → P6
+
+**File:** [programs/work-order-engine.md](../programs/work-order-engine.md)  
+**Success condition:** Brain can query the WO engine, score next WOs, and present a plan the operator can act on.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-WOE-001–008 | Registry, scoring, query, goal/loop | DONE/MERGED |
+| WO-WOE-009 | Program Playbook Register | CLOSED — PR #1114 |
+| WO-WOE-010 | Goal/Loop Program Playbook Binding | **EXECUTING** (this WO) |
+| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED |
+
+No active stop walls at WO-WOE-011 (after 010 merges).
+
+---
+
+### /goal brain-operator → P7
+
+**File:** [programs/brain-operator-system.md](../programs/brain-operator-system.md)  
+**Success condition:** Brain authority is documented and evidence-backed; suites have domain packs, not their own brains.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-BRAIN-001 | Brain authority and capability audit | **NEXT** |
+| WO-BRAIN-002 through 009 | Domain packs, command vocab, goal/loop integration | QUEUED |
+
+No active stop walls at WO-BRAIN-001.
+
+---
+
+### /goal azure-county-runtime → P8
+
+**File:** [programs/azure-county-runtime.md](../programs/azure-county-runtime.md)  
+**Success condition:** Azure App Service requirements documented; slot strategy defined; rollback runbook exists. No county production boundary until authorized.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-AZURE-001 | Azure App Service preflight | **NEXT** |
+| WO-AZURE-002 | App settings and secret inventory | QUEUED |
+| WO-AZURE-003 | Deployment slot strategy | QUEUED |
+| WO-AZURE-004 | Observability and log capture | QUEUED |
+| WO-AZURE-005 | Rollback and restart runbook | QUEUED |
+| WO-AZURE-006 | County-owned production boundary packet | QUEUED — **SW-01 + SW-09 wall** |
+
+Active stop walls: SW-01 and SW-09 at WO-AZURE-006.
+
+---
+
+## Update Protocol
+
+This file must be updated when:
+- A WO changes status (QUEUED → NEXT → EXECUTING → CLOSED)
+- A blocker resolves (PR merges, authorization granted)
+- A new authority wall is encountered
+- A new WO is added to a program
+
+Update and include in the same PR as the evidence for the completing WO.

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -1,0 +1,164 @@
+# /goal Command Definitions
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+---
+
+## What /goal Does
+
+`/goal` declares the desired outcome, selects the matching program from the
+[Program Playbook Register](../PROGRAM_PLAYBOOK_REGISTER.md), and names the success condition. It
+does not mutate the repository by itself.
+
+A `/goal` stays active until:
+- the program's terminal WO completes, OR
+- an authority wall is reached, OR
+- the operator explicitly changes the goal
+
+---
+
+## Command Grammar
+
+```
+/goal <program>
+/goal <program> --target <outcome>
+/goal <program> --target <outcome> --loop <mode>
+```
+
+Combining `--loop` is shorthand for running `/loop <mode>` immediately after goal selection.
+
+---
+
+## Program Commands
+
+### /goal benton-demo
+
+```
+Goal:     Make the Benton demo deploy-preflight-ready without authorizing production deployment.
+Program:  P1 — Benton Demo / Deployment Readiness
+File:     programs/benton-demo-deployment.md
+Success:  All preflight checklist items verified; operator holds the deploy authorization decision.
+```
+
+**Current state:** WO-DEPLOY-BENTON-003B is next. Blocked until PR #1112 merges.
+
+**Allowed loop modes:** `once`, `program`, `merge-watch`, `evidence`, `recovery`  
+**Blocked loop modes:** none (but WO-DEPLOY-BENTON-003D/003E require explicit deploy authorization)
+
+---
+
+### /goal benton-data-quality
+
+```
+Goal:     Explain and classify Benton data anomalies before cleanup or production claims.
+Program:  P2 — Benton Data Quality
+File:     programs/benton-data-quality.md
+Success:  All open anomaly groups are documented with evidence; cleanup WOs are authorized before execution.
+```
+
+**Current state:** WO-DATA-BENTON-DUPE-001 investigation CLOSED (PR #1115). Next: WO-DATA-BENTON-DUPE-001B (DELETE 30 rows) — **STOP WALL: data mutation, requires explicit operator authorization.**
+
+**Allowed loop modes:** `evidence`, `discovery`, `once` (for read-only WOs)  
+**Blocked loop modes:** `program` (until data-mutation authorization granted for DUPE-001B)
+
+---
+
+### /goal backend-excellence
+
+```
+Goal:     Make the backend release-gated, diagnosable, and operationally governed.
+Program:  P3 — Backend Operational Excellence
+File:     programs/backend-operational-excellence.md
+Success:  Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+```
+
+**Current state:** WO-BACKEND-001 is next (QUEUED). No blockers from current PRs.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal property-workbench
+
+```
+Goal:     Make the parcel workbench the canonical assessor experience for Benton County.
+Program:  P4 — Property Workbench
+File:     programs/property-workbench.md
+Success:  All workbench tabs have live data, honest empty states, and validated tab contracts.
+```
+
+**Current state:** WO-WORKBENCH-001 is next (QUEUED).
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal terrapilot-maturity
+
+```
+Goal:     Prevent TerraPilot manifest/handler/stub drift and mature tools toward verified integration.
+Program:  P5 — TerraPilot Tool Maturity
+File:     programs/terrapilot-tool-maturity.md
+Success:  At least one tool reaches L3 (live-integrated); no tool is represented as working at L0/L1.
+```
+
+**Current state:** WO-TERRAPILOT-P2 is next. WO-TERRAPILOT-P1 is partially done.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal work-order-engine
+
+```
+Goal:     Make TerraFusion compute next work from evidence, blockers, PR state, dependencies, and risk.
+Program:  P6 — Work Order Engine
+File:     programs/work-order-engine.md
+Success:  Brain can query the WO engine, score next WOs, and present a plan the operator can act on.
+```
+
+**Current state:** WO-WOE-010 (this WO) is executing. Next after merge: WO-WOE-010 → WO-WOE-011.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal brain-operator
+
+```
+Goal:     Operationalize Brain/Cortex as the single governance memory and operator authority.
+Program:  P7 — AI / Brain / Operator System
+File:     programs/brain-operator-system.md
+Success:  Brain authority is documented and evidence-backed; suites have domain packs, not their own brains.
+```
+
+**Current state:** WO-BRAIN-001 is next (QUEUED).
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal azure-county-runtime
+
+```
+Goal:     Define Azure and county runtime boundaries without creating competing control planes.
+Program:  P8 — Azure / DevOps / County Runtime
+File:     programs/azure-county-runtime.md
+Success:  Azure App Service requirements documented; slot strategy defined; rollback runbook exists. No county-facing production boundary until authorized.
+```
+
+**Current state:** WO-AZURE-001 is next. Parallel to WO-DEPLOY-BENTON-003B but depends on P1 preflight clearing.
+
+**Allowed loop modes:** `once`, `evidence`, `discovery`  
+**Blocked loop modes:** `program` until explicit deploy authorization (WO-AZURE-006 is an authority wall)
+
+---
+
+## /goal Invariants
+
+1. A `/goal` command does not execute any WO. It sets intent and selects a program.
+2. Every `/goal` must map to exactly one program file in the register.
+3. If the selected program's next WO is at an authority wall, `/goal` must surface the wall — not route around it.
+4. `/goal` output must include: selected program, next unblocked WO, known blockers, authority walls in path.
+5. `/goal` does not grant authorization. It surfaces what is possible, not what is permitted.

--- a/docs/brain/workorders/goal-loop/LOOP_MODES.md
+++ b/docs/brain/workorders/goal-loop/LOOP_MODES.md
@@ -1,0 +1,189 @@
+# /loop Mode Definitions
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+---
+
+## What /loop Does
+
+`/loop` owns repeated execution inside an approved risk boundary. It selects the next unblocked WO
+from the active program and runs it. It continues only if the next WO is same-risk and no authority
+wall is crossed.
+
+`/loop` never expands scope beyond the active WO. It stops and reports when a wall is reached.
+
+---
+
+## Command Grammar
+
+```
+/loop once
+/loop program
+/loop evidence
+/loop merge-watch
+/loop discovery
+/loop recovery
+/loop stop
+```
+
+---
+
+## Mode Definitions
+
+### /loop once
+
+Run the next unblocked WO in the active program. Stop after that WO completes (or blocks) and emit
+a full result block.
+
+**Use when:** you want one governed step with full visibility before deciding to continue.  
+**Stops after:** first WO completes, blocks, or hits a wall.  
+**Output:** result block with next WO named but not executed.
+
+---
+
+### /loop program
+
+Continue through same-risk WOs in the active program until a terminal condition is reached.
+
+**Continues while:**
+- next WO is in the same program
+- next WO risk class is equal to or lower than the current WO
+- no authority wall is in the next WO's sovereignty boundary
+- all dependencies of the next WO are satisfied (merged PRs, completed WOs)
+- no failed validation gate in the active chain
+
+**Stops at:**
+- authority wall (deployment, data mutation, secrets, new external service)
+- failed validation gate
+- merge wall requiring human review
+- PR requiring human merge decision
+- dependency not yet satisfied (e.g., PR not merged)
+- conflicting canon between programs
+- scope expansion outside program boundary
+
+**Use when:** the operator wants autonomous progress through a defined program slice without stopping
+at every step.
+
+---
+
+### /loop evidence
+
+Do not start new implementation. Only collect missing evidence for current completed or open WOs.
+
+**Does:**
+- reads existing docs, PRs, branch state
+- writes evidence docs
+- verifies completion criteria for open WOs
+- surfaces which WOs are missing evidence
+
+**Does not:**
+- start new implementation
+- modify runtime code
+- open new PRs (except evidence-only docs PRs)
+- execute WOs that are QUEUED but not started
+
+**Use when:** you want to audit the current evidence state across a program without advancing implementation.
+
+---
+
+### /loop merge-watch
+
+Monitor queued PRs in the active program. Resolve in-scope review threads and check failures that
+are within the current WO's sovereignty. Stop at any human authority wall.
+
+**Does:**
+- checks CI status on open PRs
+- resolves lint/format/doc failures that are in-scope
+- surfaces blocking review threads for human resolution
+- re-pushes if a non-authority fix was applied
+
+**Does not:**
+- resolve review comments that require architectural decisions
+- merge PRs without auto-merge already enabled
+- bypass branch protection
+- change CI pipeline configuration
+
+**Use when:** PRs are queued with auto-merge but CI needs minor repairs.  
+**Typical usage:** `after PR push → /loop merge-watch → surface result → operator decides to continue`
+
+---
+
+### /loop discovery
+
+Read-only inventory and classification only. No writes. No implementation.
+
+**Does:**
+- reads files, branches, PRs, registry state
+- classifies gaps, blockers, missing evidence
+- maps dependency chains
+- surfaces next recommended WOs with rationale
+
+**Does not:**
+- write files (except optional discovery output doc if operator requests it)
+- open PRs
+- execute WOs
+- modify any state
+
+**Use when:** starting a new context window and need to orient; or auditing a program before committing
+to a loop mode.
+
+---
+
+### /loop recovery
+
+Only repair validation or merge issues for the active WO. No scope expansion.
+
+**Does:**
+- re-runs failing validation within current WO scope
+- fixes merge conflicts caused by unrelated upstream changes
+- re-stages and re-commits a failed pre-commit hook fix
+- re-pushes after a force-push-safe rebase
+
+**Does not:**
+- expand the WO scope
+- take on a new WO
+- modify files outside the current WO's allowed systems
+
+**Use when:** the active WO is blocked by a mechanical merge or validation issue that is clearly
+within scope.
+
+---
+
+### /loop stop
+
+Halt the current loop and emit a full result block with the stop reason.
+
+**Always valid.** The operator can issue `/loop stop` at any time.
+
+---
+
+## Continuation Rules
+
+A loop may continue to the next WO only when ALL of the following are true:
+
+1. The current WO has a COMPLETED result with evidence
+2. The next WO is in the same active program (or explicitly cross-program and approved)
+3. The next WO's risk class is not higher than the current WO
+4. The next WO has no unresolved dependencies (no pending-merge PRs that the next WO requires)
+5. The next WO does not cross an authority wall
+6. No conflicting canon between the current and next WO's sovereignty boundaries
+
+If any item is uncertain, downgrade to `/loop once` or `/loop stop`.
+
+---
+
+## Risk Class Reference
+
+| Class | Examples |
+|-------|---------|
+| R0 — Read-only | Discovery, evidence collection, SQL SELECT |
+| R1 — Docs/registry | Markdown, evidence docs, WO register updates |
+| R2 — Config/tooling | appsettings, CI config, dev tool setup |
+| R3 — Code/backend | C# service, EF migration, API endpoint |
+| R4 — Deployment | Azure deploy, App Service config, production |
+| R5 — Data mutation | DELETE/UPDATE on production or demo DB |
+| R5 — Secrets | Credential rotation, key vault, secret injection |
+
+`/loop program` may continue through same or lower risk. It must stop before crossing up a risk class
+that contains an authority wall.

--- a/docs/brain/workorders/goal-loop/STOP_WALLS.md
+++ b/docs/brain/workorders/goal-loop/STOP_WALLS.md
@@ -1,0 +1,172 @@
+# Stop Walls
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+A stop wall is an authority boundary that a `/loop` must not cross without explicit operator
+authorization. Reaching a stop wall is not a failure — it is correct behavior. The Brain surfaces
+the wall and waits.
+
+---
+
+## Always Stop For
+
+### SW-01 — Production Deployment Authorization
+
+Any action that pushes, deploys, or promotes code to a production or county-facing environment.
+
+| Blocked | Scope |
+|---------|-------|
+| Azure App Service deploy (any slot) | P1 / P8 |
+| Container image push to production registry | P1 / P8 |
+| DNS cutover or routing change | P8 |
+| County-facing UI or API enable | P1 |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-01`. Operator must
+issue explicit authorization command referencing WO ID.
+
+---
+
+### SW-02 — County Data Mutation
+
+Any write, update, delete, or truncate against county-owned production or demo data.
+
+| Blocked | Scope |
+|---------|-------|
+| DELETE duplicate rows from `canonical_tf.tf_parcel` | P2 / WO-DATA-BENTON-DUPE-001B |
+| UPDATE or UPSERT in any `canonical_tf.*` table | P2 |
+| DB reload or ETL re-run | P2 |
+| Schema migration against demo or production DB | P1 / P3 |
+| PACS data access (read or write) | P2 / all |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-02`. Identify the
+specific mutation, affected table, row count estimate, and irreversibility assessment.
+
+---
+
+### SW-03 — Secrets and Credential Handling
+
+Any action involving secrets, API keys, connection strings with real credentials, or access tokens.
+
+| Blocked | Scope |
+|---------|-------|
+| Writing secrets to files, PRs, or logs | All |
+| Rotating or regenerating credentials | P8 |
+| Injecting secrets into App Service / Key Vault | P8 |
+| Committing `.env` or `appsettings.*.local.json` with real values | All |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-03`. Never include
+credential values in stop output.
+
+---
+
+### SW-04 — Branch or Merge Strategy Conflict
+
+A conflict where the correct branch target, merge method, or rebase strategy cannot be determined
+from current evidence.
+
+| Blocked | Scope |
+|---------|-------|
+| Force-push to a shared branch | All |
+| Rebase that would rewrite commits already in review | All |
+| Merge strategy choice when PR has open review threads | All |
+| Branch deletion when other WOs may depend on it | All |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-04`. Describe the
+conflict and the two candidate resolutions.
+
+---
+
+### SW-05 — Conflicting Canon
+
+A contradiction between two authoritative documents (Constitution, Brain authority, domain pack,
+local AGENTS.md, active WO) that cannot be resolved by reading the documents.
+
+**Next step when reached:** emit `STOP_TYPE: CANONICAL_CONFLICT`. Cite both sources and the exact
+contradiction. Do not choose a resolution autonomously.
+
+---
+
+### SW-06 — Failed Validation Outside Assigned Scope
+
+A CI check, test suite, or gate failure that is not caused by changes in the current WO and cannot
+be fixed within the current WO's sovereignty boundary.
+
+**Next step when reached:** emit `STOP_TYPE: FAILED_GATE`. Identify the failing check, the last
+passing commit, and whether the failure predates this WO.
+
+---
+
+### SW-07 — Runtime Behavior Expansion
+
+A change that would alter observable API behavior, response contracts, or service startup outside
+the current WO definition.
+
+| Blocked | Scope |
+|---------|-------|
+| New API endpoint not in current WO | All |
+| Changing existing API response shape | All |
+| Modifying service startup sequence | All |
+| Adding or removing health checks | P3 |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-07`. Propose a
+new WO scope that covers the change.
+
+---
+
+### SW-08 — New External Service Integration
+
+Wiring a new external system (API, database, service bus, storage account) not already in the
+current WO's allowed-systems list.
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-08`. Name the
+proposed integration and the program it should sit in.
+
+---
+
+### SW-09 — Owner Decision Required
+
+A choice where the operator must select between two or more legitimate options and no evidence
+exists to prefer one.
+
+**Examples:**
+- Option A vs Option C for duplicate row handling (WO-DATA-BENTON-DUPE-001)
+- Azure slot strategy choices (WO-AZURE-003)
+- Test coverage threshold decisions
+- Naming or schema design that affects public interfaces
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-09`. Present the
+options table (from the relevant WO or evidence doc) and wait.
+
+---
+
+## Stop Wall Output Template
+
+```
+RESULT:        STOP_GATE
+GOAL:          <active goal>
+LOOP_MODE:     <active loop mode>
+ACTIVE_PROGRAM: <program name>
+ACTIVE_WO:     <WO ID>
+NEXT_WO:       BLOCKED
+BLOCKERS:      <wall name: SW-XX — <one-line description>>
+EVIDENCE:      <doc path or NONE>
+STOP_TYPE:     AUTHORITY_WALL | CANONICAL_CONFLICT | FAILED_GATE
+WALL:          SW-XX
+WALL_DETAIL:   <what specifically triggered the wall, with evidence>
+OPERATOR_ACTION_REQUIRED: <exactly what the operator must do to unblock>
+```
+
+---
+
+## What Is NOT a Stop Wall
+
+These are NOT stop walls — the loop may proceed through them:
+
+- Pre-commit hook lint failures (fix and re-commit)
+- Prettier formatting failures (fix and re-stage)
+- Stale `index.lock` files (remove and retry)
+- Non-fast-forward push requiring `--rebase` (rebase and push)
+- Markdown spell-check warnings (fix inline)
+- CI status pending (wait, then check)
+- Missing evidence doc for a completed WO (write the doc in the current loop slice)

--- a/docs/brain/workorders/programs/azure-county-runtime.md
+++ b/docs/brain/workorders/programs/azure-county-runtime.md
@@ -1,0 +1,114 @@
+# P8 — Azure / DevOps / County Runtime
+
+**Program:** P8  
+**Status:** ACTIVE  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Keep GitHub, Azure, Azure DevOps, TerraFusion Azure, and county Azure from becoming competing control planes. This program establishes a single runtime deployment boundary, defines the slot strategy, captures the observability contract, and produces the rollback/restart runbook. No county-owned production boundary is established without explicit operator authorization.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Azure App Service config read/plan | Production deployment without operator auth |
+| App settings inventory | New Azure resource creation without operator auth |
+| Deployment slot strategy doc | Schema changes |
+| Observability/log capture plan | PACS connection |
+| Rollback runbook | County-facing release |
+| CI/CD pipeline review | Bypassing PR gates |
+
+---
+
+## Key Known Facts (as of 2026-06-30)
+
+| Fact | Source |
+|------|--------|
+| Azure PG16 server: `pg-terrafusion-benton-demo.postgres.database.azure.com` | WO-DEPLOY-BENTON-002A |
+| DB: `terrafusion_benton_demo` | WO-DEPLOY-BENTON-002A |
+| Admin user: `tfadmin` (local env only, never Git) | Security constraint |
+| Connection requires SSL + Trust Server Certificate | WO-DEPLOY-BENTON-002B |
+| 94 EF migrations applied, 0 pending | WO-DEPLOY-BENTON-002D |
+| No Azure App Service yet provisioned | — |
+| Redis: not connected (NoOp cache in dev) | WO-DEPLOY-BENTON-002D |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Blocker |
+|----|-------|--------|---------|
+| WO-AZURE-001 | Azure App Service preflight, Benton demo | **NEXT** | Runs parallel to / enables P1/WO-DEPLOY-BENTON-003B |
+| WO-AZURE-002 | App settings and secret inventory | QUEUED | Parallel to 003C |
+| WO-AZURE-003 | Deployment slot strategy | QUEUED | After 001+002 |
+| WO-AZURE-004 | Observability and log capture | QUEUED | After 003D smoke |
+| WO-AZURE-005 | Rollback and restart runbook | QUEUED | After 003D smoke |
+| WO-AZURE-006 | County-owned production boundary packet | QUEUED | **Requires explicit operator authorization** |
+
+---
+
+## WO-AZURE-001 Definition
+
+**Goal:** Enumerate what an Azure App Service deployment of TerraFusion.API needs. Do not provision any resources. Produce a requirements checklist: runtime stack, required App Settings, identity/MSI, outbound network rules, PostgreSQL firewall rules, estimated slot config.
+
+**Outputs:**
+- `docs/data/WO_AZURE_001_APP_SERVICE_PREFLIGHT.md`
+- Required App Settings list (key names only, no values)
+- PostgreSQL firewall rule requirements
+
+**Do NOT:**
+- Create App Service
+- Create deployment slot
+- Provision any Azure resources
+
+---
+
+## WO-AZURE-002 Definition
+
+**Goal:** Produce the complete app settings and secrets inventory for the Benton demo deployment. For each required key: what is it, where does the value come from, how is it stored (Key Vault reference, App Setting, connection string), and who owns the secret.
+
+---
+
+## WO-AZURE-003 Definition
+
+**Goal:** Define the slot strategy: production slot (never for demo), staging slot (non-production smoke target), blue/green vs. rolling deployment decision.
+
+---
+
+## WO-AZURE-006 Definition
+
+**Goal:** Produce the county-owned production boundary packet — the formal document the operator reviews before authorizing any county-facing deployment. Requires all previous Azure WOs and P1/003F complete.
+
+**Authorization gate:** This WO exists to make the production decision explicit. The Brain does not initiate county-facing release. The operator reads 003F + AZURE-006 and explicitly authorizes.
+
+---
+
+## Dependency Chain (P8 internal)
+
+```
+001 → 002 → 003 → 004, 005 (parallel) → 006
+```
+
+## Dependency Chain (cross-program)
+
+```
+P8/AZURE-001 enables P1/003B (App Service preflight docs feed the deployment preflight)
+P8/AZURE-002 enables P1/003C (secrets inventory feeds app settings packet)
+P8/AZURE-003 enables P1/003D (slot strategy must be defined before smoke deployment)
+P1/003D enables P8/AZURE-004, 005 (observability and rollback need a live slot)
+P1/003F + P8/AZURE-006 → operator production decision
+```
+
+---
+
+## Stop Conditions
+
+- WO-AZURE-006 is a decision gate, not an execution step — stop and present to operator
+- Do not provision Azure resources without explicit operator instruction
+- Do not connect the Benton demo DB to county network until P2 data quality issues are resolved

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -1,0 +1,62 @@
+# P3 — Backend Operational Excellence
+
+**Program:** P3  
+**Status:** QUEUED  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Make the TerraFusion backend operable, diagnosable, and release-gated. This program establishes what "backend ready" means as a concrete evidence-backed contract, not a subjective judgment. No deployment until WO-BACKEND-007 (release gate definition) produces a gate the operator agrees with.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Backend code changes (non-schema) | Schema changes / EF migrations |
+| Config changes | Production deployment |
+| Build warning fixes | PACS connection |
+| Health check improvements | Data mutation |
+| ADR documents | County-facing changes |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Description |
+|----|-------|--------|-------------|
+| WO-BACKEND-001 | Backend runtime truth audit | **NEXT** | Enumerate all endpoints; verify which return data vs stubs vs 404 |
+| WO-BACKEND-002 | Build warning burn-down | QUEUED | Enumerate all `dotnet build` warnings; fix or document each |
+| WO-BACKEND-003 | Service registry validation | QUEUED | Verify all registered services have health checks; find orphaned registrations |
+| WO-BACKEND-004 | Health/readiness truth contract | QUEUED | Define what `/healthz` and `/healthz/ready` must verify for the demo to be operator-trusted |
+| WO-BACKEND-005 | Runtime configuration contract | QUEUED | Document every required runtime config key; verify all present in appsettings hierarchy |
+| WO-BACKEND-006 | Auth/security endpoint proof | QUEUED | Prove all protected endpoints reject unauthenticated requests; prove dev-token works in Development |
+| WO-BACKEND-007 | Release gate definition | QUEUED | Produce the formal "backend is release-ready" gate criteria — operator approves before 003D |
+| WO-BACKEND-008 | Backend operational packet and runbook | QUEUED | Produce final backend ops packet: startup, monitoring, restart, rollback |
+
+---
+
+## Dependency Chain
+
+```
+001 → 002 → 003 → 004 → 005 → 006 → 007 → 008
+```
+
+WO-BACKEND-007 must be operator-approved before P1/WO-DEPLOY-BENTON-003D (App Service smoke) runs.
+
+---
+
+## Interaction with P1
+
+P3 runs in parallel with P1 where possible. P1/003D is blocked on P3/007. The operator may choose to run 003D before P3/007 for demo purposes — that is a documented risk acceptance, not a default.
+
+---
+
+## Stop Conditions
+
+- If WO-BACKEND-001 finds a critical service failure that blocks the demo path, escalate to operator before continuing P1
+- If WO-BACKEND-007 produces gate criteria the operator cannot meet before the demo date, the operator decides: demo anyway with documented risk, or delay demo

--- a/docs/brain/workorders/programs/benton-data-quality.md
+++ b/docs/brain/workorders/programs/benton-data-quality.md
@@ -1,0 +1,128 @@
+# P2 — Benton Data Quality
+
+**Program:** P2  
+**Status:** ACTIVE  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Separate real Benton County data quality issues from app/config problems. Each WO investigates one data gap, produces a finding doc, and surfaces a decision: accept with documented risk, fix, or escalate to PACS reload (which requires explicit operator authorization).
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Read-only DB queries (SELECT) | Data mutation / DELETE / UPDATE |
+| Investigation docs | PACS connection |
+| Accept/acknowledge decisions | New PACS drain |
+| Evidence packets | Schema changes |
+| — | ArcGIS mutation |
+| — | New sync pass without operator go-ahead |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Blocker |
+|----|-------|--------|---------|
+| WO-DATA-BENTON-DUPE-001 | Investigate 84,418 raw rows vs 84,388 distinct parcels | **NEXT** | None |
+| WO-DATA-BENTON-ADDR-001 | Address/legalDescription null-field audit | QUEUED | None |
+| WO-DATA-BENTON-GEOM-001 | Geometry endpoint/data availability decision | QUEUED | None |
+| WO-DATA-BENTON-OWNER-001 | Owner endpoint/data boundary decision | QUEUED | None |
+| WO-DATA-BENTON-IMPR-LAND-001 | Improvements/land endpoint gap audit | QUEUED | None |
+| WO-DATA-BENTON-EVIDENCE-ROLLUP | Data truth packet for demo/prototype/release decisions | QUEUED | All above |
+
+---
+
+## WO-DATA-BENTON-DUPE-001 Definition
+
+**Goal:** Investigate and document the 14 parcel-number groups with duplicate rows in `canonical_tf.tf_parcel`. Determine root cause (source duplication in PACS, ETL bug, merge artifact). Produce findings doc. Do not mutate data.
+
+**Key facts:**
+- Raw row count: 84,418
+- Distinct parcel numbers: 84,388
+- Delta: 30 extra rows across 14 groups
+- Current impact: `db-identity.passed: False` (count gate fails); `db-content.passed: True` (distinct-based gate passes)
+
+**Investigation queries (read-only):**
+```sql
+-- Find duplicate groups
+SELECT parcel_number, COUNT(*) cnt
+FROM canonical_tf.tf_parcel
+GROUP BY parcel_number
+HAVING COUNT(*) > 1
+ORDER BY cnt DESC;
+
+-- Examine one group for pattern
+SELECT * FROM canonical_tf.tf_parcel
+WHERE parcel_number = '<duplicate_parcel_number>'
+ORDER BY updated_at;
+```
+
+**Decision output:**
+1. Accept duplicates + update `expectedBentonParcelCount` to 84,418 to match raw rows (weakens the distinct check)
+2. Fix duplicates (DELETE or MERGE — requires operator authorization + WO)
+3. Add DISTINCT to `db-identity` count query to match `db-content` behavior
+
+**Outputs:**
+- `docs/data/WO_DATA_BENTON_DUPE_001_FINDINGS.md`
+- Operator decision recommendation
+
+---
+
+## WO-DATA-BENTON-ADDR-001 Definition
+
+**Goal:** Audit why `address` and `legalDescription` are null in `canonical_tf.tf_parcel`. Determine: was address ever loaded from PACS? What PACS table/column is the source? Is there a crosswalk already in the data layer? What would a load require?
+
+**Known:** PACS text fields (address, legal) were not loaded in the current sync pass. 86,418 rows have NULL address.
+
+---
+
+## WO-DATA-BENTON-GEOM-001 Definition
+
+**Goal:** Document the geometry situation: 79,199 shapes in `gis_tf.tf_parcel_geom` vs 84,388 parcels. Are the 5,189 missing parcel geometries expected? Is a read endpoint implementable without a new sync pass?
+
+---
+
+## WO-DATA-BENTON-OWNER-001 Definition
+
+**Goal:** Document owner data: 97,062 rows (raw owners), 686,851 parcel-owner links. Is this the correct structure? Can a read endpoint be built safely for demo? What is the owner-to-parcel cardinality?
+
+---
+
+## WO-DATA-BENTON-IMPR-LAND-001 Definition
+
+**Goal:** Audit improvements and land tables in `canonical_tf`. Are rows loaded? What is the row count vs parcel count? Is a read endpoint feasible?
+
+---
+
+## WO-DATA-BENTON-EVIDENCE-ROLLUP Definition
+
+**Goal:** Produce a single data truth packet that answers: "Is the Benton demo DB accurate enough for a stakeholder demo? For a prototype? For production use?" Three distinct answer levels, each with evidence citations.
+
+---
+
+## Dependency Chain
+
+```
+DUPE-001 ─┐
+ADDR-001  ─┤
+GEOM-001  ─┼─→ EVIDENCE-ROLLUP → P1 production decision
+OWNER-001 ─┤
+IMPR-001  ─┘
+```
+
+WOs in this program can run in parallel — no cross-dependency within P2. EVIDENCE-ROLLUP requires all others complete.
+
+---
+
+## Stop Conditions
+
+- Any investigation WO that finds data corruption requiring PACS reload must stop and escalate to operator
+- Do not run a new sync pass without operator authorization
+- Do not connect PACS in any investigation WO

--- a/docs/brain/workorders/programs/benton-demo-deployment.md
+++ b/docs/brain/workorders/programs/benton-demo-deployment.md
@@ -1,0 +1,143 @@
+# P1 — Benton Demo / Deployment Readiness
+
+**Program:** P1  
+**Status:** ACTIVE  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Turn the proven Benton County demo database into a controlled Azure-ready deployment candidate without authorizing production deployment. Every WO in this program produces a concrete evidence artifact or operational control. No WO authorizes production release.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Local dev API startup | Production deployment |
+| Azure demo DB reads | PACS connection |
+| Config file changes (appsettings) | Schema changes |
+| Evidence doc creation | Data mutation |
+| Azure App Service slot config (non-production) | County-facing launch |
+| PR/merge to main | ArcGIS mutation |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Evidence |
+|----|-------|--------|---------|
+| WO-DEPLOY-BENTON-002E | Evidence closure: Browser → Vite → API → Azure PG16 | **CLOSED** | PR #1109 merged, `docs/data/WO_DEPLOY_BENTON_002_CLOSURE.md` |
+| WO-DEPLOY-BENTON-003A | Local demo rehearsal | **CLOSED** | commit `788197238`, `docs/data/WO_DEPLOY_BENTON_003A_LOCAL_DEMO_REHEARSAL.md` |
+| WO-CONFIG-BENTON-001 | County config hardening | **IN PR** | PR #1112 auto-merge queued, commit `ec0edb405`, `docs/data/WO_CONFIG_BENTON_001_EVIDENCE.md` |
+| WO-DEPLOY-BENTON-003B | Azure App Service Deployment Preflight | **NEXT** — blocked until PR #1112 merges | — |
+| WO-DEPLOY-BENTON-003C | Azure App Settings / Secret Requirements Packet | QUEUED | — |
+| WO-DEPLOY-BENTON-003D | App Service Startup Smoke (non-production slot) | QUEUED | — |
+| WO-DEPLOY-BENTON-003E | Demo Operator Runbook | QUEUED | — |
+| WO-DEPLOY-BENTON-003F | Deployment Readiness Evidence Rollup | QUEUED | — |
+
+---
+
+## WO-DEPLOY-BENTON-003B Definition
+
+**Goal:** Establish what Azure App Service requires to run TerraFusion.API with the Benton demo DB — without deploying. Output: a preflight checklist of required settings, missing secrets, open gaps.
+
+**Scope:**
+- Read App Service documentation / existing Azure config
+- Identify required env vars (`ConnectionStrings__DefaultConnection`, `ASPNETCORE_ENVIRONMENT`, `TF_SKIP_DEV_SEEDERS`)
+- Identify secrets that must be in Key Vault or App Settings (never in appsettings.json)
+- Identify any IaaS or PaaS dependencies (storage, Redis, Consul)
+- Produce preflight checklist document
+
+**Do NOT:**
+- Deploy the app
+- Create new Azure resources
+- Change appsettings.json or runtime code
+- Connect PACS
+
+**Outputs:**
+- `docs/data/WO_DEPLOY_BENTON_003B_PREFLIGHT.md` — preflight checklist
+- Missing secrets inventory
+- Required App Service settings list
+
+**Blocked Until:** PR #1112 merges (config must be on main before preflight evaluates it)
+
+---
+
+## WO-DEPLOY-BENTON-003C Definition
+
+**Goal:** Produce the complete App Service app-settings/secrets packet — every key needed for the demo deployment, with values or value sources.
+
+**Outputs:**
+- `docs/data/WO_DEPLOY_BENTON_003C_APP_SETTINGS.md`
+- Annotated settings template (no actual secrets, only key names + sources)
+
+---
+
+## WO-DEPLOY-BENTON-003D Definition
+
+**Goal:** Deploy to a non-production slot; run startup smoke and health checks; confirm Azure DB connection.
+
+**Blocked Until:** 003B + 003C complete; explicit operator authorization.
+
+---
+
+## WO-DEPLOY-BENTON-003E Definition
+
+**Goal:** Write the demo operator runbook — pre-demo checklist, startup commands, endpoint URLs, fallback language for each gap, post-demo teardown.
+
+---
+
+## WO-DEPLOY-BENTON-003F Definition
+
+**Goal:** Produce the full deployment readiness evidence rollup — all P1 WO results in a single operator decision document. Operator reviews and decides whether to authorize county-facing deployment.
+
+---
+
+## Dependency Chain
+
+```
+002E (DONE) → 003A (DONE) → CONFIG-001 (IN PR) → 003B → 003C → 003D → 003E → 003F
+```
+
+003D requires operator authorization. 003F triggers the "authorize production?" decision.
+
+---
+
+## Promotion Criteria (for production authorization)
+
+All of the following must be true:
+- [ ] 003D smoke passes in non-production slot
+- [ ] 003E runbook operator-approved
+- [ ] 003F evidence rollup reviewed by operator
+- [ ] Operator explicitly authorizes production deployment
+- [ ] WO-DATA-BENTON-DUPE-001 resolved OR accepted with documented risk
+
+---
+
+## Known Evidence (2026-06-30)
+
+| Fact | Source |
+|------|--------|
+| Parcels: 84,388 active distinct (`canonical_tf.tf_parcel`) | WO-DEPLOY-BENTON-002D proof |
+| Sales: 90,386 (`canonical_tf.tf_sale`) | WO-DEPLOY-BENTON-003A |
+| Azure DB: `terrafusion_benton_demo` on `pg-terrafusion-benton-demo.postgres.database.azure.com` | WO-DEPLOY-BENTON-002A |
+| API port: 5000 (default); Vite proxy: 3000 → 5000 | WO-DEPLOY-BENTON-002D |
+| `db-content: passed=True` | WO-CONFIG-BENTON-001 |
+| `db-identity.database: terrafusion_benton_demo` | WO-CONFIG-BENTON-001 |
+| Fixture trap: `/api/properties` returns seed data | WO-DEPLOY-BENTON-003A |
+| Address/legal null (not loaded in demo sync) | WO-DEPLOY-BENTON-003A |
+| 14 duplicate parcel groups → WO-DATA-BENTON-DUPE-001 | WO-CONFIG-BENTON-001 |
+
+---
+
+## Stop Conditions
+
+Stop P1 WOs and escalate to operator if:
+- Azure connectivity fails and cannot be resolved with config changes
+- Demo DB content is corrupted or incomplete
+- PR #1112 fails CI (investigate before next WO)
+- Operator explicitly pauses the program

--- a/docs/brain/workorders/programs/brain-operator-system.md
+++ b/docs/brain/workorders/programs/brain-operator-system.md
@@ -1,0 +1,73 @@
+# P7 — AI / Brain / Operator System
+
+**Program:** P7  
+**Status:** QUEUED  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Operationalize the one-Brain model. TerraFusion Brain (Cortex) owns queue, sequencing, WOs, risk classification, proof, review-diff, and commit-plan. Suites get domain knowledge packs, not their own brains. This program audits what exists, closes capability gaps, and formalizes the operator command vocabulary.
+
+---
+
+## Governing Rule
+
+> One TerraFusion Brain owns sequencing. Suites get domain packs. No suite brain owns WO queue or deployment gates.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Brain authority docs | Autonomous deployment |
+| Domain pack definition | Brain bypassing stop gates |
+| Operator command spec | Suite-level queue ownership |
+| Memory/provenance review | Contradicting operator decisions |
+| Agent role docs | Cross-Brain WO assignment |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Description |
+|----|-------|--------|-------------|
+| WO-BRAIN-001 | Brain authority and current capability audit | **NEXT** | What does the Brain currently do? What is documented vs. aspirational? |
+| WO-BRAIN-002 | Domain pack completeness audit | QUEUED | For each suite (Benton, Workbench, Forge), what domain knowledge is in the Brain? What's missing? |
+| WO-BRAIN-003 | Operator command vocabulary cleanup | QUEUED | What commands does the operator currently use? Which are consistent? Which are ambiguous? |
+| WO-BRAIN-004 | Goal engine maturity review | QUEUED | Is the `/goal` system working as documented? Evidence vs aspiration? |
+| WO-BRAIN-005 | Loop engine maturity review | QUEUED | Is the `/loop` system working as documented? What's the real continuation contract? |
+| WO-BRAIN-006 | Memory/provenance integration | QUEUED | Is persistent memory (project_session_operating_state.md etc.) reliably loaded? Gaps? |
+| WO-BRAIN-007 | Agent role and stop-gate policy | QUEUED | Which agents have explicit stop gates? Which can self-initiate? Policy doc. |
+| WO-BRAIN-008 | Autonomous continuation rulebook | QUEUED | When can the Brain/Claude proceed autonomously? When must it stop? Formal rulebook. |
+| WO-BRAIN-009 | Brain/WOE integration evidence packet | QUEUED | Prove the Brain can query the WO Engine, score next WOs, and present a plan to the operator |
+
+---
+
+## WO-BRAIN-001 Definition
+
+**Goal:** Audit what the TerraFusion Brain currently does vs. what is documented in `docs/brain/BRAIN_AUTHORITY.md` and `docs/brain/CORTEX_MODES.md`. Produce a capabilities truth table: capability → documented → evidence → gap.
+
+**Outputs:**
+- `docs/brain/WO_BRAIN_001_CAPABILITY_AUDIT.md`
+
+---
+
+## Dependency Chain
+
+```
+001 → 002 → 003 ─┐
+                  ├─ 004, 005, 006, 007 (can be parallel) → 008 → 009
+```
+
+WO-BRAIN-009 is the integration gate — proves the Brain+WOE system is functional end-to-end.
+
+---
+
+## Stop Conditions
+
+- If WO-BRAIN-001 finds the Brain authority docs are aspirational-only with no operational substance, update all docs to reflect reality before continuing
+- Do not add Brain capabilities that expand autonomous action scope without operator approval

--- a/docs/brain/workorders/programs/property-workbench.md
+++ b/docs/brain/workorders/programs/property-workbench.md
@@ -1,0 +1,80 @@
+# P4 — Property Workbench
+
+**Program:** P4  
+**Status:** QUEUED  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Make the parcel workbench the canonical assessor experience. The workbench is the primary UI surface for Benton County assessors — it must show real data, real routes, real tabs, and honest empty states. This program audits what exists, defines the data contracts per tab, and closes each gap with a runtime-proven endpoint or a documented honest-empty state.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Frontend UI changes | Schema changes |
+| New API read endpoints | Data mutation |
+| Route/tab contract definition | PACS connection |
+| Evidence docs | Production deployment |
+| Honest empty state components | Fake/stub data in UI |
+
+---
+
+## Context
+
+The Property Workbench is referenced in memory as "window contract + routes frozen" (from `project_workbench_identity.md`). It is the core assessor tool. Prior work established the dual-screen office model and the suite/workbench identity distinction.
+
+**Known facts:**
+- `/workbench` route returns 200 (SPA serves index.html) — API backing is not wired
+- `/dossier` route similarly returns 200 but no API endpoint
+- Parcel list API: `GET /api/counties/benton/parcels` — PROVEN (84,388 parcels)
+- Parcel detail: works via parcel number filter
+- Improvements, land, owners, geom: 404 (no read endpoints)
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Description |
+|----|-------|--------|-------------|
+| WO-WORKBENCH-001 | Current surface audit | **NEXT** | What routes/tabs/panels exist in the UI? What currently renders real data vs placeholder? |
+| WO-WORKBENCH-002 | Route and tab truth matrix | QUEUED | For each route/tab: what data source, what API, what honest-empty state should show |
+| WO-WORKBENCH-003 | Parcel detail path integration | QUEUED | Wire parcel detail view to `GET /api/counties/benton/parcels?parcelNumber=X` |
+| WO-WORKBENCH-004 | Forge tab data contract | QUEUED | CostForge / ValuForge tab: what data, what API, honest empty if not loaded |
+| WO-WORKBENCH-005 | Atlas/map tab data contract | QUEUED | Atlas map tab: geom availability (79,199 shapes), MapLibre integration decision |
+| WO-WORKBENCH-006 | Dais workflow tab contract | QUEUED | Dais tab: workflow state, appeal queue, honest empty |
+| WO-WORKBENCH-007 | Dossier/evidence tab contract | QUEUED | Dossier tab: parcel history, notes, evidence; honest empty vs placeholder |
+| WO-WORKBENCH-008 | Pilot/tool assistant contract | QUEUED | Pilot AI assistant: what tools are live vs stub in the workbench context |
+| WO-WORKBENCH-009 | Reserved office gating closure | QUEUED | Ensure "reserved" boundary check is implemented for non-workbench routes |
+| WO-WORKBENCH-010 | End-to-end parcel flow evidence packet | QUEUED | Prove full parcel flow: search → detail → forge → atlas → dossier |
+
+---
+
+## Dependency Chain
+
+```
+001 → 002 → 003 ─┐
+                  ├─ 004, 005, 006, 007, 008 (parallel) → 009 → 010
+```
+
+003 (parcel detail integration) can start after 001+002. Tabs 004-008 can be audited in parallel. 009 and 010 require all tab contracts complete.
+
+---
+
+## Operator Decision Walls
+
+- Adding new backend API endpoints requires deciding scope vs. demo timeline
+- Atlas map integration may require MapLibre token or tile service setup (operator provides)
+- If parcel detail requires a new controller, scope against P1/demo timeline
+
+---
+
+## Stop Conditions
+
+- If the surface audit (001) shows the workbench is fundamentally unrouted or broken, escalate before further tab work
+- Do not add fake/stub data to make tabs appear full — honest empty states only

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -1,0 +1,75 @@
+# P5 — TerraPilot Tool Maturity
+
+**Program:** P5  
+**Status:** ACTIVE  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Prevent "manifest green" from being mistaken for live product capability. TerraPilot exposes AI tools to assessors. A tool that is manifest-registered but not backend-integrated is NOT a working tool. This program establishes a maturity ladder, enforces honest disclosure, and promotes exactly one real integrated tool before claiming TerraPilot is "working."
+
+---
+
+## Maturity Ladder
+
+Every TerraPilot tool must be classified at one of these levels:
+
+| Level | Label | Meaning |
+|-------|-------|---------|
+| L0 | Declared | In manifest only; no handler |
+| L1 | Runnable | Handler exists; no backend integration |
+| L2 | Contract-covered | Handler + schema contract; integration spec written |
+| L3 | Live-integrated | Handler calls real backend API; response is real data |
+| L4 | Promoted | Tested, evidence-backed, operator-approved for use |
+
+A tool at L1 must be disclosed as "not yet integrated" in any UI and in any operator-facing doc.
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Description |
+|----|-------|--------|-------------|
+| WO-TERRAPILOT-P1 | Tool maturity matrix | **DONE/PARTIAL** | Enumerate all manifest-registered tools; assign current maturity level |
+| WO-TERRAPILOT-P2 | Promotion protocol | **NEXT** | Define the formal promotion gate from L1→L4; write the protocol doc |
+| WO-TERRAPILOT-P3 | Handler parity audit | QUEUED | Verify every manifest tool has a handler (no missing handlers → L0 items) |
+| WO-TERRAPILOT-P4 | Stub disclosure UI / internal diagnostics | QUEUED | Add maturity badge to tool manifest; surface L0/L1 tools as "not yet available" in UI |
+| WO-TERRAPILOT-P5 | First real backend-integrated tool | QUEUED | Promote one tool from L1 to L3 with real API integration and evidence |
+| WO-TERRAPILOT-P6 | Tool promotion evidence rollup | QUEUED | Produce final maturity state doc for all tools; sign off on L4 promotions |
+
+---
+
+## WO-TERRAPILOT-P2 Definition
+
+**Goal:** Write the formal protocol for promoting a TerraPilot tool from declared to live-integrated. The protocol defines: required evidence at each level, the review step, the operator approval gate at L3→L4, and the disclosure rule for L0/L1 tools.
+
+**Outputs:**
+- `docs/brain/workorders/programs/terrapilot-promotion-protocol.md`
+
+---
+
+## Dependency Chain
+
+```
+P1 (partial) → P2 → P3 → P4 → P5 → P6
+```
+
+P3 can begin while P2 is in progress (handler audit doesn't require the protocol doc). P5 requires P2+P3+P4.
+
+---
+
+## Stop Conditions
+
+- If P1 audit finds 0 tools at L2+, treat TerraPilot as alpha/stub — update all docs accordingly before P5
+- Do not claim TerraPilot is "functional" until at least one tool reaches L4
+
+---
+
+## Disclosure Rule
+
+Until WO-TERRAPILOT-P5 produces an L3 tool:
+- TerraPilot must be disclosed as "tool layer in development" in all demo scripts
+- No demo should show TerraPilot as a working AI assistant without a live-integrated tool

--- a/docs/brain/workorders/programs/work-order-engine.md
+++ b/docs/brain/workorders/programs/work-order-engine.md
@@ -1,0 +1,93 @@
+# P6 — Work Order Engine
+
+**Program:** P6  
+**Status:** ACTIVE  
+**Owner:** Operator (bsvalues@gmail.com)  
+**Last Updated:** 2026-06-30
+
+---
+
+## Goal
+
+Make TerraFusion compute "what's next" from evidence, dependencies, risk, PR state, branch state, validation state, and blockers — rather than relying on the operator to reason from one-off WO suggestions. The WO Engine is the canonical planning surface. This program builds it in governed read-only slices.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Read-only WO discovery | Autonomous code mutation |
+| Data model definition | Self-initiated deployments |
+| Registry seed | Operator decision override |
+| Scoring rule docs | Bypassing stop gates |
+| Goal/loop integration | — |
+| Operator query tool | — |
+| Program playbook docs | — |
+
+---
+
+## Work Orders (Status)
+
+| WO | Title | Status | Evidence |
+|----|-------|--------|---------|
+| WO-WOE-001 | Work Order System Discovery | **DONE/IN FLIGHT** | `docs/brain/workorders/active/WO-0001-*.md` and related |
+| WO-WOE-002 | Work Order Data Model | **DONE/IN FLIGHT** | Codex WO data model commits |
+| WO-WOE-003 | Work Order Registry Seed | **DONE/IN FLIGHT** | WO registry seeded |
+| WO-WOE-004 | Next-WO Scoring Rules | **DONE/IN FLIGHT** | Scoring rules defined |
+| WO-WOE-005 | Read-Only WO Query Tool | **DONE/IN FLIGHT** | Tool available in Brain |
+| WO-WOE-006 | Goal + Loop Integration | **DONE/IN FLIGHT** | PR #1108 merged (docs/brain WOs connect to goal loop) |
+| WO-WOE-007 | Operator Packet / README integration | **MERGE WATCH** | PR #1110 `docs(brain): define work order operator packet` |
+| WO-WOE-008 | Evidence Rollup | **DONE** | PR #1111 merged, commit `150df914f` |
+| WO-WOE-009 | Full Program Playbook Register | **THIS WO** | This file; PR pending |
+| WO-WOE-010 | Cross-program dependency graph | **NEXT after 009** | — |
+| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | — |
+
+---
+
+## WO-WOE-009 Definition (THIS WO)
+
+**Goal:** Create the canonical full playbook of TerraFusion work order programs so the operator no longer needs to reason from one-off next-WO suggestions.
+
+**Files created in this WO:**
+- `docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md` — master register
+- `docs/brain/workorders/programs/benton-demo-deployment.md`
+- `docs/brain/workorders/programs/benton-data-quality.md`
+- `docs/brain/workorders/programs/backend-operational-excellence.md`
+- `docs/brain/workorders/programs/property-workbench.md`
+- `docs/brain/workorders/programs/terrapilot-tool-maturity.md`
+- `docs/brain/workorders/programs/work-order-engine.md` (this file)
+- `docs/brain/workorders/programs/brain-operator-system.md`
+- `docs/brain/workorders/programs/azure-county-runtime.md`
+
+**Stop type:** Docs/registry only. No runtime code, no config changes, no deployment.
+
+---
+
+## WO-WOE-010 Definition
+
+**Goal:** Produce a cross-program dependency graph showing which programs block which others, which WOs create enabling artifacts for downstream programs, and where the critical path to demo authorization lies.
+
+**Output:** `docs/brain/workorders/CROSS_PROGRAM_DEPENDENCY_GRAPH.md` + Mermaid diagram
+
+---
+
+## WO-WOE-011 Definition
+
+**Goal:** Implement a Brain query that returns the full next-WO report: all programs, their current status, the next executable WO per program, blocking dependencies, and a recommended execution order for the current sprint.
+
+---
+
+## Dependency Chain
+
+```
+001-008 (done/in-flight) → 009 (THIS) → 010 → 011
+```
+
+010 and 011 require 009 to be stable (programs defined + statused).
+
+---
+
+## Governing Rule
+
+The WO Engine is read-only by default. It discovers, queries, scores, and reports. It does not initiate code changes, deployments, or data mutations. The operator always makes the final call on which WO to execute next.

--- a/docs/brain/workorders/programs/work-order-engine.md
+++ b/docs/brain/workorders/programs/work-order-engine.md
@@ -39,9 +39,9 @@ Make TerraFusion compute "what's next" from evidence, dependencies, risk, PR sta
 | WO-WOE-006 | Goal + Loop Integration | **DONE/IN FLIGHT** | PR #1108 merged (docs/brain WOs connect to goal loop) |
 | WO-WOE-007 | Operator Packet / README integration | **MERGE WATCH** | PR #1110 `docs(brain): define work order operator packet` |
 | WO-WOE-008 | Evidence Rollup | **DONE** | PR #1111 merged, commit `150df914f` |
-| WO-WOE-009 | Full Program Playbook Register | **THIS WO** | This file; PR pending |
-| WO-WOE-010 | Cross-program dependency graph | **NEXT after 009** | — |
-| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | — |
+| WO-WOE-009 | Full Program Playbook Register | **CLOSED** | PR #1114 |
+| WO-WOE-010 | Goal/Loop Program Playbook Binding | **EXECUTING** | This PR |
+| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | After 010 |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the command-level layer on top of the WO-WOE-009 Program Playbook Register. Binds all 8 programs to explicit `/goal` and `/loop` operating commands so the Brain can operate from program intent rather than one-off next-WO suggestions.

**This is docs/playbook only. No runtime code. No config changes. No deployment.**

## Files Created

- `docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md` — top-level doctrine and command model
- `docs/brain/workorders/goal-loop/GOAL_COMMANDS.md` — `/goal` definitions for all 8 programs, with current state, next WO, and allowed loop modes
- `docs/brain/workorders/goal-loop/LOOP_MODES.md` — `/loop` mode definitions (`once`, `program`, `evidence`, `merge-watch`, `discovery`, `recovery`, `stop`) with risk class table and continuation rules
- `docs/brain/workorders/goal-loop/STOP_WALLS.md` — 9 authority walls (SW-01 through SW-09): deployment, data mutation, secrets, branch/merge conflict, conflicting canon, failed gate, runtime expansion, new external service, owner decision
- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md` — current-state snapshot: command → program → next WO → active blockers → allowed loop modes

## Files Updated

- `PROGRAM_PLAYBOOK_REGISTER.md` — `/goal` command column added; stop-wall column added to blockers table; command-layer section with canonical operator sequences
- `programs/work-order-engine.md` — WO-009 marked CLOSED, WO-010 EXECUTING, WO-011 NEXT

## Canonical Operator Sequences (after merge)

```
# Wait for PR #1112 to merge
/goal benton-demo
/loop merge-watch

# After #1112 merges — run preflight
/loop program

# Investigate data quality without mutation  
/goal benton-data-quality
/loop evidence
```

## Test plan

- [ ] All 5 new markdown files exist with correct paths
- [ ] PROGRAM_PLAYBOOK_REGISTER.md has `/goal` column in program summary table
- [ ] STOP_WALLS.md lists SW-01 through SW-09
- [ ] COMMAND_TO_PROGRAM_MAP.md maps all 8 programs
- [ ] No runtime code changed (`git diff --name-only HEAD~1 | grep -v docs/` = empty)
- [ ] `git diff --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)