### PR TITLE
docs(brain): WO-WOE-010 — Goal/Loop Program Playbook Binding

### DIFF
--- a/docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md
+++ b/docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md
@@ -1,0 +1,108 @@
+# TerraFusion Goal/Loop Program Playbook
+
+**Version:** 1.0  
+**Date:** 2026-06-30  
+**Authority:** TerraFusion Brain / WO-WOE-010  
+**Classification:** Operator Doctrine — command-layer binding
+
+---
+
+## Purpose
+
+This playbook binds the Work Order Program Playbook Register to explicit `/goal` and `/loop`
+operating commands. It is the command-level layer on top of WO-WOE-009.
+
+**Before this playbook:** The operator nominates one WO at a time from the register.  
+**After this playbook:** The operator states a program intent (`/goal`) and the execution mode
+(`/loop`), and the Brain selects the next unblocked WO from the correct program file.
+
+---
+
+## The Four Primitives
+
+| Primitive | Owns | Does not own |
+|-----------|------|--------------|
+| `/goal` | Program intent, desired outcome, success condition | File mutation, merge authority |
+| `/loop` | Repeated execution inside an approved risk boundary | Scope expansion, authority walls |
+| `WO` | The governed execution packet: allowed systems, blocked systems, steps, evidence | Competing queue, autonomous self-continuation |
+| `evidence` | Proof that completion criteria were met | Future authorization by implication |
+
+---
+
+## Command Model
+
+```text
+/goal <program>
+  ↓
+selects program from PROGRAM_PLAYBOOK_REGISTER
+  ↓
+/loop <mode>
+  ↓
+executes next unblocked WO node from that program
+  ↓
+WO packet (sovereignty boundary, allowed/blocked, steps, evidence)
+  ↓
+validation + evidence
+  ↓
+PR / merge / stop gate
+  ↓
+loop continues only if same-risk and no authority wall
+```
+
+---
+
+## Output Format
+
+Every `/goal` + `/loop` cycle ends with a structured result block:
+
+```
+RESULT:        [COMPLETED | BLOCKED | STOP_GATE | EVIDENCE_ONLY]
+GOAL:          <declared program intent>
+LOOP_MODE:     <once | program | evidence | merge-watch | discovery | recovery>
+ACTIVE_PROGRAM: <program name>
+ACTIVE_WO:     <WO ID being executed>
+NEXT_WO:       <next unblocked WO in program, or NONE>
+BLOCKERS:      <list of blocking dependencies or NONE>
+EVIDENCE:      <PR URL, doc path, or validation output>
+STOP_TYPE:     [NONE | AUTHORITY_WALL | FAILED_GATE | CANONICAL_CONFLICT | BLOCKER]
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `GOAL_LOOP_PLAYBOOK.md` (this file) | Top-level doctrine and command model |
+| `goal-loop/GOAL_COMMANDS.md` | `/goal` command definitions and program mappings |
+| `goal-loop/LOOP_MODES.md` | `/loop` mode definitions, continuation rules, stop triggers |
+| `goal-loop/STOP_WALLS.md` | Exhaustive list of authority walls and their scope |
+| `goal-loop/COMMAND_TO_PROGRAM_MAP.md` | Current-state map: command → program → next WO → blockers |
+| `goal-loop/README.md` | WO-WOE-006 doctrine foundation (do not modify) |
+
+---
+
+## Current State (2026-06-30)
+
+| PR | WO | Status |
+|----|----|--------|
+| #1112 | WO-CONFIG-BENTON-001 | auto-merge queued — blocks WO-DEPLOY-BENTON-003B |
+| #1114 | WO-WOE-009 | auto-merge queued — this playbook builds on it |
+| #1115 | WO-DATA-BENTON-DUPE-001 | auto-merge queued — investigation closed |
+
+**After #1112 merges:**  
+`/goal benton-demo` + `/loop program` → next legal WO = WO-DEPLOY-BENTON-003B (preflight only, no deploy auth).
+
+**WO-DATA-BENTON-DUPE-001B** (DELETE 30 rows) requires explicit operator data-mutation authorization before execution. It is a stop wall.
+
+---
+
+## Non-Goals
+
+This playbook does not:
+
+- implement a CLI or runner
+- execute any WO autonomously without operator acknowledgement of stop walls
+- grant merge, deployment, or data-mutation authority
+- modify runtime code, appsettings, or Azure settings
+- connect to PACS or county production systems

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,28 +17,29 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-| # | Program | Status | Next WO |
-|---|---------|--------|---------|
-| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | ACTIVE | WO-DEPLOY-BENTON-003B |
-| P2 | [Benton Data Quality](programs/benton-data-quality.md) | ACTIVE | WO-DATA-BENTON-DUPE-001 |
-| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | QUEUED | WO-BACKEND-001 |
-| P4 | [Property Workbench](programs/property-workbench.md) | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | ACTIVE | WO-TERRAPILOT-P2 |
-| P6 | [Work Order Engine](programs/work-order-engine.md) | ACTIVE | WO-WOE-009 ← THIS WO |
-| P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | QUEUED | WO-BRAIN-001 |
-| P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | ACTIVE | WO-AZURE-001 |
+| # | Program | /goal command | Status | Next WO |
+|---|---------|--------------|--------|---------|
+| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003B |
+| P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-DUPE-001B |
+| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
+| P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P2 |
+| P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-010 |
+| P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
+| P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |
 
 ---
 
 ## Known Blockers (as of 2026-06-30)
 
-| Blocker | Blocking |
-|---------|---------|
-| PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B |
-| 14 duplicate parcel groups in `canonical_tf.tf_parcel` | WO-DATA-BENTON-DUPE-001 investigation |
-| No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 |
-| Backend operational truth not established | WO-BACKEND-001+ |
-| Production deployment NOT authorized | All P1 WOs after 003F |
+| Blocker | Blocking | Stop Wall |
+|---------|---------|-----------|
+| PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B | — |
+| WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
+| No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
+| Backend operational truth not established | WO-BACKEND-001+ | — |
+| Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
+| County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |
 
 ---
 
@@ -80,8 +81,38 @@ These actions require explicit operator authorization. The Brain and Claude do n
 
 ---
 
+## Goal/Loop Command Layer (WO-WOE-010)
+
+The command layer binds this register to `/goal` and `/loop` operating commands.
+
+| File | Purpose |
+|------|---------|
+| [GOAL_LOOP_PLAYBOOK.md](GOAL_LOOP_PLAYBOOK.md) | Top-level doctrine and command model |
+| [goal-loop/GOAL_COMMANDS.md](goal-loop/GOAL_COMMANDS.md) | `/goal` command definitions and program mappings |
+| [goal-loop/LOOP_MODES.md](goal-loop/LOOP_MODES.md) | `/loop` mode definitions and continuation rules |
+| [goal-loop/STOP_WALLS.md](goal-loop/STOP_WALLS.md) | Authority walls (SW-01 through SW-09) |
+| [goal-loop/COMMAND_TO_PROGRAM_MAP.md](goal-loop/COMMAND_TO_PROGRAM_MAP.md) | Current-state: command → program → next WO → blockers |
+
+**Canonical operator sequences:**
+
+```
+# Current: wait for PR #1112, then advance
+/goal benton-demo
+/loop merge-watch
+
+# After #1112 merges — run preflight
+/loop program
+
+# Investigate data quality without mutation
+/goal benton-data-quality
+/loop evidence
+```
+
+---
+
 ## Change Log
 
 | Date | Change | WO |
 |------|--------|----|
 | 2026-06-30 | Initial register created | WO-WOE-009 |
+| 2026-06-30 | Added /goal column, stop-wall column, goal/loop command layer section | WO-WOE-010 |

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -1,0 +1,189 @@
+# Command-to-Program Map
+
+**Authority:** WO-WOE-010  
+**Last Updated:** 2026-06-30  
+**Classification:** Operator Doctrine — current state snapshot
+
+This file maps every `/goal` command to its program, current next WO, blockers, allowed loop modes,
+and active stop walls. Update this file when a WO completes or a blocker resolves.
+
+---
+
+## Quick Reference Table
+
+| `/goal` command | Program | Next WO | Blocked? | Allowed /loop modes |
+|-----------------|---------|---------|----------|---------------------|
+| `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
+| `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
+| `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P2 | NO | `once`, `program`, `evidence`, `discovery` |
+| `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
+| `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
+
+---
+
+## Detailed Map
+
+### /goal benton-demo → P1
+
+**File:** [programs/benton-demo-deployment.md](../programs/benton-demo-deployment.md)  
+**Success condition:** All preflight checklist items verified; operator holds deploy authorization decision.
+
+| WO | Title | Status | Notes |
+|----|-------|--------|-------|
+| WO-DEPLOY-BENTON-002E | Migrations verified | CLOSED | 94 applied, 0 pending |
+| WO-DEPLOY-BENTON-003A | Local demo rehearsal | CLOSED | PR merged |
+| WO-CONFIG-BENTON-001 | Config gates aligned | CLOSED | PR #1112 auto-merge queued |
+| WO-DEPLOY-BENTON-003B | Azure preflight | **NEXT** | **Blocked: PR #1112 must merge first** |
+| WO-DEPLOY-BENTON-003C | App settings packet | QUEUED | After 003B |
+| WO-DEPLOY-BENTON-003D | Smoke slot deploy | QUEUED | SW-01 wall — deploy auth required |
+| WO-DEPLOY-BENTON-003E | Smoke validation | QUEUED | After 003D |
+| WO-DEPLOY-BENTON-003F | Demo authorization packet | QUEUED | SW-09 owner decision required |
+
+**Active stop walls in path:** SW-01 (003D), SW-09 (003F)
+
+**Recommended first move:**
+```
+/goal benton-demo
+/loop merge-watch
+```
+— monitors PR #1112; once merged, advances to 003B with `/loop once`.
+
+---
+
+### /goal benton-data-quality → P2
+
+**File:** [programs/benton-data-quality.md](../programs/benton-data-quality.md)  
+**Success condition:** All data anomaly groups documented and classified; cleanup WOs authorized before execution.
+
+| WO | Title | Status | Notes |
+|----|-------|--------|-------|
+| WO-DATA-BENTON-DUPE-001 | Duplicate row investigation | CLOSED | PR #1115 auto-merge queued; 30 anomalous rows documented |
+| WO-DATA-BENTON-DUPE-001B | Delete 30 anomalous rows | **NEXT** | **SW-02 WALL — data mutation, explicit auth required** |
+| WO-DATA-BENTON-ADDR-001 | Address data gap investigation | QUEUED | Read-only; after DUPE-001 |
+| WO-DATA-BENTON-GEOM-001 | Geometry data gap investigation | QUEUED | Read-only |
+| WO-DATA-BENTON-OWNER-001 | Owner data gap investigation | QUEUED | Read-only |
+| WO-DATA-BENTON-EVIDENCE-ROLLUP | Full data quality evidence packet | QUEUED | After all above |
+
+**Active stop walls:** SW-02 at WO-DATA-BENTON-DUPE-001B (explicit operator data-mutation auth required)
+
+**Recommended first move:**
+```
+/goal benton-data-quality
+/loop evidence
+```
+— collects remaining evidence on DUPE-001 without advancing to the mutation step.
+
+---
+
+### /goal backend-excellence → P3
+
+**File:** [programs/backend-operational-excellence.md](../programs/backend-operational-excellence.md)  
+**Success condition:** Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-BACKEND-001 | Runtime truth audit | **NEXT** |
+| WO-BACKEND-002 | Health check contract | QUEUED |
+| WO-BACKEND-003 | Logging and observability | QUEUED |
+| WO-BACKEND-004 | Release hygiene | QUEUED |
+| WO-BACKEND-005 | Error handling sweep | QUEUED |
+| WO-BACKEND-006 | Performance baseline | QUEUED |
+| WO-BACKEND-007 | Integration test coverage | QUEUED |
+| WO-BACKEND-008 | Operational runbook | QUEUED |
+
+No active stop walls at WO-BACKEND-001.
+
+---
+
+### /goal property-workbench → P4
+
+**File:** [programs/property-workbench.md](../programs/property-workbench.md)  
+**Success condition:** All workbench tabs have live data, honest empty states, and validated tab contracts.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-WORKBENCH-001 | Parcel dossier data contract | **NEXT** |
+| (WOs 002–010) | Tab integration, empty states, owners, geom, etc. | QUEUED |
+
+No active stop walls at WO-WORKBENCH-001.
+
+---
+
+### /goal terrapilot-maturity → P5
+
+**File:** [programs/terrapilot-tool-maturity.md](../programs/terrapilot-tool-maturity.md)  
+**Success condition:** At least one tool reaches L3 (live-integrated); L0/L1 tools disclosed as unavailable.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-TERRAPILOT-P1 | Tool maturity matrix | DONE/PARTIAL |
+| WO-TERRAPILOT-P2 | Promotion protocol | **NEXT** |
+| WO-TERRAPILOT-P3 | Handler parity audit | QUEUED |
+| WO-TERRAPILOT-P4 | Stub disclosure UI | QUEUED |
+| WO-TERRAPILOT-P5 | First live-integrated tool | QUEUED |
+| WO-TERRAPILOT-P6 | Tool promotion evidence rollup | QUEUED |
+
+No active stop walls at WO-TERRAPILOT-P2.
+
+---
+
+### /goal work-order-engine → P6
+
+**File:** [programs/work-order-engine.md](../programs/work-order-engine.md)  
+**Success condition:** Brain can query the WO engine, score next WOs, and present a plan the operator can act on.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-WOE-001–008 | Registry, scoring, query, goal/loop | DONE/MERGED |
+| WO-WOE-009 | Program Playbook Register | CLOSED — PR #1114 |
+| WO-WOE-010 | Goal/Loop Program Playbook Binding | **EXECUTING** (this WO) |
+| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED |
+
+No active stop walls at WO-WOE-011 (after 010 merges).
+
+---
+
+### /goal brain-operator → P7
+
+**File:** [programs/brain-operator-system.md](../programs/brain-operator-system.md)  
+**Success condition:** Brain authority is documented and evidence-backed; suites have domain packs, not their own brains.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-BRAIN-001 | Brain authority and capability audit | **NEXT** |
+| WO-BRAIN-002 through 009 | Domain packs, command vocab, goal/loop integration | QUEUED |
+
+No active stop walls at WO-BRAIN-001.
+
+---
+
+### /goal azure-county-runtime → P8
+
+**File:** [programs/azure-county-runtime.md](../programs/azure-county-runtime.md)  
+**Success condition:** Azure App Service requirements documented; slot strategy defined; rollback runbook exists. No county production boundary until authorized.
+
+| WO | Title | Status |
+|----|-------|--------|
+| WO-AZURE-001 | Azure App Service preflight | **NEXT** |
+| WO-AZURE-002 | App settings and secret inventory | QUEUED |
+| WO-AZURE-003 | Deployment slot strategy | QUEUED |
+| WO-AZURE-004 | Observability and log capture | QUEUED |
+| WO-AZURE-005 | Rollback and restart runbook | QUEUED |
+| WO-AZURE-006 | County-owned production boundary packet | QUEUED — **SW-01 + SW-09 wall** |
+
+Active stop walls: SW-01 and SW-09 at WO-AZURE-006.
+
+---
+
+## Update Protocol
+
+This file must be updated when:
+- A WO changes status (QUEUED → NEXT → EXECUTING → CLOSED)
+- A blocker resolves (PR merges, authorization granted)
+- A new authority wall is encountered
+- A new WO is added to a program
+
+Update and include in the same PR as the evidence for the completing WO.

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -1,0 +1,164 @@
+# /goal Command Definitions
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+---
+
+## What /goal Does
+
+`/goal` declares the desired outcome, selects the matching program from the
+[Program Playbook Register](../PROGRAM_PLAYBOOK_REGISTER.md), and names the success condition. It
+does not mutate the repository by itself.
+
+A `/goal` stays active until:
+- the program's terminal WO completes, OR
+- an authority wall is reached, OR
+- the operator explicitly changes the goal
+
+---
+
+## Command Grammar
+
+```
+/goal <program>
+/goal <program> --target <outcome>
+/goal <program> --target <outcome> --loop <mode>
+```
+
+Combining `--loop` is shorthand for running `/loop <mode>` immediately after goal selection.
+
+---
+
+## Program Commands
+
+### /goal benton-demo
+
+```
+Goal:     Make the Benton demo deploy-preflight-ready without authorizing production deployment.
+Program:  P1 — Benton Demo / Deployment Readiness
+File:     programs/benton-demo-deployment.md
+Success:  All preflight checklist items verified; operator holds the deploy authorization decision.
+```
+
+**Current state:** WO-DEPLOY-BENTON-003B is next. Blocked until PR #1112 merges.
+
+**Allowed loop modes:** `once`, `program`, `merge-watch`, `evidence`, `recovery`  
+**Blocked loop modes:** none (but WO-DEPLOY-BENTON-003D/003E require explicit deploy authorization)
+
+---
+
+### /goal benton-data-quality
+
+```
+Goal:     Explain and classify Benton data anomalies before cleanup or production claims.
+Program:  P2 — Benton Data Quality
+File:     programs/benton-data-quality.md
+Success:  All open anomaly groups are documented with evidence; cleanup WOs are authorized before execution.
+```
+
+**Current state:** WO-DATA-BENTON-DUPE-001 investigation CLOSED (PR #1115). Next: WO-DATA-BENTON-DUPE-001B (DELETE 30 rows) — **STOP WALL: data mutation, requires explicit operator authorization.**
+
+**Allowed loop modes:** `evidence`, `discovery`, `once` (for read-only WOs)  
+**Blocked loop modes:** `program` (until data-mutation authorization granted for DUPE-001B)
+
+---
+
+### /goal backend-excellence
+
+```
+Goal:     Make the backend release-gated, diagnosable, and operationally governed.
+Program:  P3 — Backend Operational Excellence
+File:     programs/backend-operational-excellence.md
+Success:  Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+```
+
+**Current state:** WO-BACKEND-001 is next (QUEUED). No blockers from current PRs.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal property-workbench
+
+```
+Goal:     Make the parcel workbench the canonical assessor experience for Benton County.
+Program:  P4 — Property Workbench
+File:     programs/property-workbench.md
+Success:  All workbench tabs have live data, honest empty states, and validated tab contracts.
+```
+
+**Current state:** WO-WORKBENCH-001 is next (QUEUED).
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal terrapilot-maturity
+
+```
+Goal:     Prevent TerraPilot manifest/handler/stub drift and mature tools toward verified integration.
+Program:  P5 — TerraPilot Tool Maturity
+File:     programs/terrapilot-tool-maturity.md
+Success:  At least one tool reaches L3 (live-integrated); no tool is represented as working at L0/L1.
+```
+
+**Current state:** WO-TERRAPILOT-P2 is next. WO-TERRAPILOT-P1 is partially done.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal work-order-engine
+
+```
+Goal:     Make TerraFusion compute next work from evidence, blockers, PR state, dependencies, and risk.
+Program:  P6 — Work Order Engine
+File:     programs/work-order-engine.md
+Success:  Brain can query the WO engine, score next WOs, and present a plan the operator can act on.
+```
+
+**Current state:** WO-WOE-010 (this WO) is executing. Next after merge: WO-WOE-010 → WO-WOE-011.
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal brain-operator
+
+```
+Goal:     Operationalize Brain/Cortex as the single governance memory and operator authority.
+Program:  P7 — AI / Brain / Operator System
+File:     programs/brain-operator-system.md
+Success:  Brain authority is documented and evidence-backed; suites have domain packs, not their own brains.
+```
+
+**Current state:** WO-BRAIN-001 is next (QUEUED).
+
+**Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+---
+
+### /goal azure-county-runtime
+
+```
+Goal:     Define Azure and county runtime boundaries without creating competing control planes.
+Program:  P8 — Azure / DevOps / County Runtime
+File:     programs/azure-county-runtime.md
+Success:  Azure App Service requirements documented; slot strategy defined; rollback runbook exists. No county-facing production boundary until authorized.
+```
+
+**Current state:** WO-AZURE-001 is next. Parallel to WO-DEPLOY-BENTON-003B but depends on P1 preflight clearing.
+
+**Allowed loop modes:** `once`, `evidence`, `discovery`  
+**Blocked loop modes:** `program` until explicit deploy authorization (WO-AZURE-006 is an authority wall)
+
+---
+
+## /goal Invariants
+
+1. A `/goal` command does not execute any WO. It sets intent and selects a program.
+2. Every `/goal` must map to exactly one program file in the register.
+3. If the selected program's next WO is at an authority wall, `/goal` must surface the wall — not route around it.
+4. `/goal` output must include: selected program, next unblocked WO, known blockers, authority walls in path.
+5. `/goal` does not grant authorization. It surfaces what is possible, not what is permitted.

--- a/docs/brain/workorders/goal-loop/LOOP_MODES.md
+++ b/docs/brain/workorders/goal-loop/LOOP_MODES.md
@@ -1,0 +1,189 @@
+# /loop Mode Definitions
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+---
+
+## What /loop Does
+
+`/loop` owns repeated execution inside an approved risk boundary. It selects the next unblocked WO
+from the active program and runs it. It continues only if the next WO is same-risk and no authority
+wall is crossed.
+
+`/loop` never expands scope beyond the active WO. It stops and reports when a wall is reached.
+
+---
+
+## Command Grammar
+
+```
+/loop once
+/loop program
+/loop evidence
+/loop merge-watch
+/loop discovery
+/loop recovery
+/loop stop
+```
+
+---
+
+## Mode Definitions
+
+### /loop once
+
+Run the next unblocked WO in the active program. Stop after that WO completes (or blocks) and emit
+a full result block.
+
+**Use when:** you want one governed step with full visibility before deciding to continue.  
+**Stops after:** first WO completes, blocks, or hits a wall.  
+**Output:** result block with next WO named but not executed.
+
+---
+
+### /loop program
+
+Continue through same-risk WOs in the active program until a terminal condition is reached.
+
+**Continues while:**
+- next WO is in the same program
+- next WO risk class is equal to or lower than the current WO
+- no authority wall is in the next WO's sovereignty boundary
+- all dependencies of the next WO are satisfied (merged PRs, completed WOs)
+- no failed validation gate in the active chain
+
+**Stops at:**
+- authority wall (deployment, data mutation, secrets, new external service)
+- failed validation gate
+- merge wall requiring human review
+- PR requiring human merge decision
+- dependency not yet satisfied (e.g., PR not merged)
+- conflicting canon between programs
+- scope expansion outside program boundary
+
+**Use when:** the operator wants autonomous progress through a defined program slice without stopping
+at every step.
+
+---
+
+### /loop evidence
+
+Do not start new implementation. Only collect missing evidence for current completed or open WOs.
+
+**Does:**
+- reads existing docs, PRs, branch state
+- writes evidence docs
+- verifies completion criteria for open WOs
+- surfaces which WOs are missing evidence
+
+**Does not:**
+- start new implementation
+- modify runtime code
+- open new PRs (except evidence-only docs PRs)
+- execute WOs that are QUEUED but not started
+
+**Use when:** you want to audit the current evidence state across a program without advancing implementation.
+
+---
+
+### /loop merge-watch
+
+Monitor queued PRs in the active program. Resolve in-scope review threads and check failures that
+are within the current WO's sovereignty. Stop at any human authority wall.
+
+**Does:**
+- checks CI status on open PRs
+- resolves lint/format/doc failures that are in-scope
+- surfaces blocking review threads for human resolution
+- re-pushes if a non-authority fix was applied
+
+**Does not:**
+- resolve review comments that require architectural decisions
+- merge PRs without auto-merge already enabled
+- bypass branch protection
+- change CI pipeline configuration
+
+**Use when:** PRs are queued with auto-merge but CI needs minor repairs.  
+**Typical usage:** `after PR push → /loop merge-watch → surface result → operator decides to continue`
+
+---
+
+### /loop discovery
+
+Read-only inventory and classification only. No writes. No implementation.
+
+**Does:**
+- reads files, branches, PRs, registry state
+- classifies gaps, blockers, missing evidence
+- maps dependency chains
+- surfaces next recommended WOs with rationale
+
+**Does not:**
+- write files (except optional discovery output doc if operator requests it)
+- open PRs
+- execute WOs
+- modify any state
+
+**Use when:** starting a new context window and need to orient; or auditing a program before committing
+to a loop mode.
+
+---
+
+### /loop recovery
+
+Only repair validation or merge issues for the active WO. No scope expansion.
+
+**Does:**
+- re-runs failing validation within current WO scope
+- fixes merge conflicts caused by unrelated upstream changes
+- re-stages and re-commits a failed pre-commit hook fix
+- re-pushes after a force-push-safe rebase
+
+**Does not:**
+- expand the WO scope
+- take on a new WO
+- modify files outside the current WO's allowed systems
+
+**Use when:** the active WO is blocked by a mechanical merge or validation issue that is clearly
+within scope.
+
+---
+
+### /loop stop
+
+Halt the current loop and emit a full result block with the stop reason.
+
+**Always valid.** The operator can issue `/loop stop` at any time.
+
+---
+
+## Continuation Rules
+
+A loop may continue to the next WO only when ALL of the following are true:
+
+1. The current WO has a COMPLETED result with evidence
+2. The next WO is in the same active program (or explicitly cross-program and approved)
+3. The next WO's risk class is not higher than the current WO
+4. The next WO has no unresolved dependencies (no pending-merge PRs that the next WO requires)
+5. The next WO does not cross an authority wall
+6. No conflicting canon between the current and next WO's sovereignty boundaries
+
+If any item is uncertain, downgrade to `/loop once` or `/loop stop`.
+
+---
+
+## Risk Class Reference
+
+| Class | Examples |
+|-------|---------|
+| R0 — Read-only | Discovery, evidence collection, SQL SELECT |
+| R1 — Docs/registry | Markdown, evidence docs, WO register updates |
+| R2 — Config/tooling | appsettings, CI config, dev tool setup |
+| R3 — Code/backend | C# service, EF migration, API endpoint |
+| R4 — Deployment | Azure deploy, App Service config, production |
+| R5 — Data mutation | DELETE/UPDATE on production or demo DB |
+| R5 — Secrets | Credential rotation, key vault, secret injection |
+
+`/loop program` may continue through same or lower risk. It must stop before crossing up a risk class
+that contains an authority wall.

--- a/docs/brain/workorders/goal-loop/STOP_WALLS.md
+++ b/docs/brain/workorders/goal-loop/STOP_WALLS.md
@@ -1,0 +1,172 @@
+# Stop Walls
+
+**Authority:** WO-WOE-010  
+**Classification:** Operator Doctrine
+
+A stop wall is an authority boundary that a `/loop` must not cross without explicit operator
+authorization. Reaching a stop wall is not a failure — it is correct behavior. The Brain surfaces
+the wall and waits.
+
+---
+
+## Always Stop For
+
+### SW-01 — Production Deployment Authorization
+
+Any action that pushes, deploys, or promotes code to a production or county-facing environment.
+
+| Blocked | Scope |
+|---------|-------|
+| Azure App Service deploy (any slot) | P1 / P8 |
+| Container image push to production registry | P1 / P8 |
+| DNS cutover or routing change | P8 |
+| County-facing UI or API enable | P1 |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-01`. Operator must
+issue explicit authorization command referencing WO ID.
+
+---
+
+### SW-02 — County Data Mutation
+
+Any write, update, delete, or truncate against county-owned production or demo data.
+
+| Blocked | Scope |
+|---------|-------|
+| DELETE duplicate rows from `canonical_tf.tf_parcel` | P2 / WO-DATA-BENTON-DUPE-001B |
+| UPDATE or UPSERT in any `canonical_tf.*` table | P2 |
+| DB reload or ETL re-run | P2 |
+| Schema migration against demo or production DB | P1 / P3 |
+| PACS data access (read or write) | P2 / all |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-02`. Identify the
+specific mutation, affected table, row count estimate, and irreversibility assessment.
+
+---
+
+### SW-03 — Secrets and Credential Handling
+
+Any action involving secrets, API keys, connection strings with real credentials, or access tokens.
+
+| Blocked | Scope |
+|---------|-------|
+| Writing secrets to files, PRs, or logs | All |
+| Rotating or regenerating credentials | P8 |
+| Injecting secrets into App Service / Key Vault | P8 |
+| Committing `.env` or `appsettings.*.local.json` with real values | All |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-03`. Never include
+credential values in stop output.
+
+---
+
+### SW-04 — Branch or Merge Strategy Conflict
+
+A conflict where the correct branch target, merge method, or rebase strategy cannot be determined
+from current evidence.
+
+| Blocked | Scope |
+|---------|-------|
+| Force-push to a shared branch | All |
+| Rebase that would rewrite commits already in review | All |
+| Merge strategy choice when PR has open review threads | All |
+| Branch deletion when other WOs may depend on it | All |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-04`. Describe the
+conflict and the two candidate resolutions.
+
+---
+
+### SW-05 — Conflicting Canon
+
+A contradiction between two authoritative documents (Constitution, Brain authority, domain pack,
+local AGENTS.md, active WO) that cannot be resolved by reading the documents.
+
+**Next step when reached:** emit `STOP_TYPE: CANONICAL_CONFLICT`. Cite both sources and the exact
+contradiction. Do not choose a resolution autonomously.
+
+---
+
+### SW-06 — Failed Validation Outside Assigned Scope
+
+A CI check, test suite, or gate failure that is not caused by changes in the current WO and cannot
+be fixed within the current WO's sovereignty boundary.
+
+**Next step when reached:** emit `STOP_TYPE: FAILED_GATE`. Identify the failing check, the last
+passing commit, and whether the failure predates this WO.
+
+---
+
+### SW-07 — Runtime Behavior Expansion
+
+A change that would alter observable API behavior, response contracts, or service startup outside
+the current WO definition.
+
+| Blocked | Scope |
+|---------|-------|
+| New API endpoint not in current WO | All |
+| Changing existing API response shape | All |
+| Modifying service startup sequence | All |
+| Adding or removing health checks | P3 |
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-07`. Propose a
+new WO scope that covers the change.
+
+---
+
+### SW-08 — New External Service Integration
+
+Wiring a new external system (API, database, service bus, storage account) not already in the
+current WO's allowed-systems list.
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-08`. Name the
+proposed integration and the program it should sit in.
+
+---
+
+### SW-09 — Owner Decision Required
+
+A choice where the operator must select between two or more legitimate options and no evidence
+exists to prefer one.
+
+**Examples:**
+- Option A vs Option C for duplicate row handling (WO-DATA-BENTON-DUPE-001)
+- Azure slot strategy choices (WO-AZURE-003)
+- Test coverage threshold decisions
+- Naming or schema design that affects public interfaces
+
+**Next step when reached:** emit `STOP_TYPE: AUTHORITY_WALL` with wall name `SW-09`. Present the
+options table (from the relevant WO or evidence doc) and wait.
+
+---
+
+## Stop Wall Output Template
+
+```
+RESULT:        STOP_GATE
+GOAL:          <active goal>
+LOOP_MODE:     <active loop mode>
+ACTIVE_PROGRAM: <program name>
+ACTIVE_WO:     <WO ID>
+NEXT_WO:       BLOCKED
+BLOCKERS:      <wall name: SW-XX — <one-line description>>
+EVIDENCE:      <doc path or NONE>
+STOP_TYPE:     AUTHORITY_WALL | CANONICAL_CONFLICT | FAILED_GATE
+WALL:          SW-XX
+WALL_DETAIL:   <what specifically triggered the wall, with evidence>
+OPERATOR_ACTION_REQUIRED: <exactly what the operator must do to unblock>
+```
+
+---
+
+## What Is NOT a Stop Wall
+
+These are NOT stop walls — the loop may proceed through them:
+
+- Pre-commit hook lint failures (fix and re-commit)
+- Prettier formatting failures (fix and re-stage)
+- Stale `index.lock` files (remove and retry)
+- Non-fast-forward push requiring `--rebase` (rebase and push)
+- Markdown spell-check warnings (fix inline)
+- CI status pending (wait, then check)
+- Missing evidence doc for a completed WO (write the doc in the current loop slice)

--- a/docs/brain/workorders/programs/work-order-engine.md
+++ b/docs/brain/workorders/programs/work-order-engine.md
@@ -39,9 +39,9 @@ Make TerraFusion compute "what's next" from evidence, dependencies, risk, PR sta
 | WO-WOE-006 | Goal + Loop Integration | **DONE/IN FLIGHT** | PR #1108 merged (docs/brain WOs connect to goal loop) |
 | WO-WOE-007 | Operator Packet / README integration | **MERGE WATCH** | PR #1110 `docs(brain): define work order operator packet` |
 | WO-WOE-008 | Evidence Rollup | **DONE** | PR #1111 merged, commit `150df914f` |
-| WO-WOE-009 | Full Program Playbook Register | **THIS WO** | This file; PR pending |
-| WO-WOE-010 | Cross-program dependency graph | **NEXT after 009** | — |
-| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | — |
+| WO-WOE-009 | Full Program Playbook Register | **CLOSED** | PR #1114 |
+| WO-WOE-010 | Goal/Loop Program Playbook Binding | **EXECUTING** | This PR |
+| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | After 010 |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the command-level layer on top of the WO-WOE-009 Program Playbook Register (PR #1114, merged). Binds all 8 programs to explicit `/goal` and `/loop` commands.

**Docs/playbook only. No runtime code. No config. No deployment.**

Supersedes PR #1116 (rebased cleanly onto main after #1114 merged).

## Files Created

- `docs/brain/workorders/GOAL_LOOP_PLAYBOOK.md` — top-level doctrine and command model
- `docs/brain/workorders/goal-loop/GOAL_COMMANDS.md` — `/goal` definitions for all 8 programs
- `docs/brain/workorders/goal-loop/LOOP_MODES.md` — 7 `/loop` modes with risk class table and continuation rules
- `docs/brain/workorders/goal-loop/STOP_WALLS.md` — 9 authority walls SW-01 through SW-09
- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md` — current-state map: command → program → next WO → blockers

## Files Updated

- `PROGRAM_PLAYBOOK_REGISTER.md` — `/goal` column; stop-wall column; canonical operator sequences section
- `programs/work-order-engine.md` — WO-009 CLOSED, WO-010 EXECUTING, WO-011 NEXT

## Canonical Sequences (after merge)

```
/goal benton-demo && /loop merge-watch   # wait for #1112
/loop program                            # after #1112 → runs WO-DEPLOY-BENTON-003B (preflight only)
/goal benton-data-quality && /loop evidence   # read-only; SW-02 blocks DUPE-001B
```

## Test plan

- [ ] 5 new markdown files present
- [ ] No runtime code changed
- [ ] `git diff --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)