### PR TITLE
test(backend): burn down API test nullable warnings

### DIFF
--- a/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
+++ b/backend/TerraFusion.API.Tests/AuditCorrelationTests.cs
@@ -33,7 +33,7 @@ public sealed class AuditCorrelationTests
         log!.Type.Should().StartWith("Authentication:");
         log.CorrelationId.Should().Be(correlationId);
 
-        using var doc = JsonDocument.Parse(log.Data);
+        using var doc = ParseAuditData(log.Data);
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("failed");
     }
 
@@ -54,7 +54,7 @@ public sealed class AuditCorrelationTests
         log!.Type.Should().StartWith("Authentication:");
         log.CorrelationId.Should().Be(correlationId);
 
-        using var doc = JsonDocument.Parse(log.Data);
+        using var doc = ParseAuditData(log.Data);
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("successful");
     }
 
@@ -75,7 +75,7 @@ public sealed class AuditCorrelationTests
         log!.Type.Should().StartWith("Authorization:");
         log.CorrelationId.Should().Be(correlationId);
 
-        using var doc = JsonDocument.Parse(log.Data);
+        using var doc = ParseAuditData(log.Data);
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("denied");
     }
 
@@ -96,7 +96,7 @@ public sealed class AuditCorrelationTests
         log!.Type.Should().StartWith("Authorization:");
         log.CorrelationId.Should().Be(correlationId);
 
-        using var doc = JsonDocument.Parse(log.Data);
+        using var doc = ParseAuditData(log.Data);
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("granted");
         doc.RootElement.GetProperty("Success").GetBoolean().Should().BeTrue();
     }
@@ -122,7 +122,7 @@ public sealed class AuditCorrelationTests
         log!.Type.Should().StartWith("ConfigurationChange:");
         log.CorrelationId.Should().Be(correlationId);
 
-        using var doc = JsonDocument.Parse(log.Data);
+        using var doc = ParseAuditData(log.Data);
         doc.RootElement.GetProperty("Details").GetString().Should().Contain("Configuration changed");
         doc.RootElement.GetProperty("OldValue").GetString().Should().Be("Assessor");
         doc.RootElement.GetProperty("NewValue").GetString().Should().Be("CountyAdmin");
@@ -147,7 +147,7 @@ public sealed class AuditCorrelationTests
 
         log.Should().NotBeNull();
 
-        using var doc = JsonDocument.Parse(log!.Data);
+        using var doc = ParseAuditData(log!.Data);
         doc.RootElement.GetProperty("Setting").GetString().Should().Be("Privileges:RoleAssignment");
     }
 
@@ -188,5 +188,11 @@ public sealed class AuditCorrelationTests
         var auditLogger = new AuditLogger(logger, config, accessor, provider);
 
         return (auditLogger, provider, correlationId);
+    }
+
+    private static JsonDocument ParseAuditData(string? data)
+    {
+        data.Should().NotBeNull();
+        return JsonDocument.Parse(data!);
     }
 }

--- a/backend/TerraFusion.API.Tests/Integration/CountyStudioSmokeTests.cs
+++ b/backend/TerraFusion.API.Tests/Integration/CountyStudioSmokeTests.cs
@@ -259,7 +259,8 @@ public class CountyStudioSmokeTests
 
         // ── 12. Save scenario A + promote to AdjustmentSet ───────────────────
         var savedA = await svc.SaveScenarioAsync(scenA.ScenarioId, "bsvalues");
-        Assert.Equal("Saved", savedA.Status);
+        Assert.NotNull(savedA);
+        Assert.Equal("Saved", savedA!.Status);
 
         var effectiveScope = System.Text.Json.JsonSerializer.Serialize(new
         {

--- a/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
+++ b/backend/TerraFusion.API.Tests/SystemIntegrationTests.cs
@@ -71,8 +71,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var status = await response.Content.ReadFromJsonAsync<SystemStatusReport>();
-            status.Should().NotBeNull();
+            var status = await response.Content.ReadFromJsonAsync<SystemStatusReport>()
+                ?? throw new InvalidOperationException("System status response body was empty.");
             status.OverallHealth.Should().BeGreaterThan(95.0, "System health should be excellent");
             status.TotalSubsystems.Should().Be(6, "Should have 6 subsystems");
             status.OperationalSubsystems.Should().Be(6, "All subsystems should be operational");
@@ -86,8 +86,8 @@ namespace TerraFusion.API.Tests
             var expectedSubsystems = new[] { "monitoring", "analytics", "ai-orchestration", "integration", "performance", "security" };
             foreach (var subsystemId in expectedSubsystems)
             {
-                var subsystem = status.Subsystems.FirstOrDefault(s => s.SubsystemId == subsystemId);
-                subsystem.Should().NotBeNull($"Subsystem '{subsystemId}' should exist");
+                var subsystem = status.Subsystems.FirstOrDefault(s => s.SubsystemId == subsystemId)
+                    ?? throw new InvalidOperationException($"Subsystem '{subsystemId}' was missing.");
                 subsystem.Status.Should().Be("operational", $"Subsystem '{subsystemId}' should be operational");
                 subsystem.HealthScore.Should().BeGreaterThan(90.0, $"Subsystem '{subsystemId}' should have high health score");
 
@@ -107,8 +107,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var health = await response.Content.ReadFromJsonAsync<SubsystemHealthReport>();
-            health.Should().NotBeNull();
+            var health = await response.Content.ReadFromJsonAsync<SubsystemHealthReport>()
+                ?? throw new InvalidOperationException("Subsystem health response body was empty.");
             health.TotalSubsystems.Should().Be(6);
             health.HealthySubsystems.Should().BeGreaterThanOrEqualTo(5, "Most subsystems should be healthy");
             health.AverageHealthScore.Should().BeGreaterThan(95.0, "Average health should be excellent");
@@ -136,8 +136,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var metrics = await response.Content.ReadFromJsonAsync<SystemMetricsReport>();
-            metrics.Should().NotBeNull();
+            var metrics = await response.Content.ReadFromJsonAsync<SystemMetricsReport>()
+                ?? throw new InvalidOperationException("System metrics response body was empty.");
 
             // Infrastructure metrics
             metrics.TotalRequests.Should().BeGreaterThan(0);
@@ -190,8 +190,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var analysis = await response.Content.ReadFromJsonAsync<CrossSystemAnalysisReport>();
-            analysis.Should().NotBeNull();
+            var analysis = await response.Content.ReadFromJsonAsync<CrossSystemAnalysisReport>()
+                ?? throw new InvalidOperationException("Cross-system analysis response body was empty.");
             analysis.TotalCorrelations.Should().BeGreaterThan(0);
             analysis.StrongCorrelations.Should().BeGreaterThan(0);
             analysis.OverallSystemCoherence.Should().BeGreaterThan(90.0, "System coherence should be > 90%");
@@ -225,8 +225,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var diagnostics = await response.Content.ReadFromJsonAsync<SystemDiagnosticsReport>();
-            diagnostics.Should().NotBeNull();
+            var diagnostics = await response.Content.ReadFromJsonAsync<SystemDiagnosticsReport>()
+                ?? throw new InvalidOperationException("System diagnostics response body was empty.");
             diagnostics.TotalTests.Should().BeGreaterThan(0);
             diagnostics.PassedTests.Should().BeGreaterThan(0);
             diagnostics.OverallScore.Should().BeGreaterThan(90.0, "Diagnostic score should be > 90%");
@@ -266,8 +266,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var status = await response.Content.ReadFromJsonAsync<dynamic>();
-            status.Should().NotBeNull();
+            _ = await response.Content.ReadFromJsonAsync<dynamic>()
+                ?? throw new InvalidOperationException("Monitoring status response body was empty.");
 
             _output.WriteLine("✓ Monitoring system operational");
         }
@@ -337,8 +337,8 @@ namespace TerraFusion.API.Tests
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-            var status = await response.Content.ReadFromJsonAsync<dynamic>();
-            status.Should().NotBeNull();
+            _ = await response.Content.ReadFromJsonAsync<dynamic>()
+                ?? throw new InvalidOperationException("Integration status response body was empty.");
 
             _output.WriteLine("✓ Integration system operational");
         }
@@ -689,17 +689,17 @@ namespace TerraFusion.API.Tests
     public class SystemStatusReport
     {
         public double OverallHealth { get; set; }
-        public string SystemStatus { get; set; }
+        public string SystemStatus { get; set; } = string.Empty;
         public int TotalSubsystems { get; set; }
         public int OperationalSubsystems { get; set; }
-        public List<SubsystemHealthInfo> Subsystems { get; set; }
+        public List<SubsystemHealthInfo> Subsystems { get; set; } = new();
     }
 
     public class SubsystemHealthInfo
     {
-        public string SubsystemId { get; set; }
-        public string SubsystemName { get; set; }
-        public string Status { get; set; }
+        public string SubsystemId { get; set; } = string.Empty;
+        public string SubsystemName { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
         public double HealthScore { get; set; }
     }
 
@@ -708,7 +708,7 @@ namespace TerraFusion.API.Tests
         public int TotalSubsystems { get; set; }
         public int HealthySubsystems { get; set; }
         public double AverageHealthScore { get; set; }
-        public Dictionary<string, List<string>> DependencyGraph { get; set; }
+        public Dictionary<string, List<string>> DependencyGraph { get; set; } = new();
     }
 
     public class SystemMetricsReport
@@ -735,22 +735,22 @@ namespace TerraFusion.API.Tests
         public int TotalCorrelations { get; set; }
         public int StrongCorrelations { get; set; }
         public int IdentifiedBottlenecks { get; set; }
-        public List<SystemCorrelation> Correlations { get; set; }
-        public List<OptimizationPath> OptimizationPaths { get; set; }
+        public List<SystemCorrelation> Correlations { get; set; } = new();
+        public List<OptimizationPath> OptimizationPaths { get; set; } = new();
         public double OverallSystemCoherence { get; set; }
         public int IntegrationMaturity { get; set; }
     }
 
     public class SystemCorrelation
     {
-        public string SourceSubsystem { get; set; }
-        public string TargetSubsystem { get; set; }
+        public string SourceSubsystem { get; set; } = string.Empty;
+        public string TargetSubsystem { get; set; } = string.Empty;
         public double CorrelationStrength { get; set; }
     }
 
     public class OptimizationPath
     {
-        public List<string> InvolvedSubsystems { get; set; }
+        public List<string> InvolvedSubsystems { get; set; } = new();
     }
 
     public class SystemDiagnosticsReport
@@ -758,15 +758,15 @@ namespace TerraFusion.API.Tests
         public int TotalTests { get; set; }
         public int PassedTests { get; set; }
         public double OverallScore { get; set; }
-        public string SystemHealth { get; set; }
+        public string SystemHealth { get; set; } = string.Empty;
         public double TotalDuration { get; set; }
-        public List<DiagnosticTest> Tests { get; set; }
+        public List<DiagnosticTest> Tests { get; set; } = new();
     }
 
     public class DiagnosticTest
     {
-        public string TestName { get; set; }
-        public string Status { get; set; }
+        public string TestName { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
         public double Score { get; set; }
         public double Duration { get; set; }
     }

--- a/docs/brain/workorders/evidence/WO-BACKEND-002-BUILD-WARNING-BURN-DOWN.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-002-BUILD-WARNING-BURN-DOWN.md
@@ -1,0 +1,118 @@
+# WO-BACKEND-002 — Build Warning Burn-Down Evidence
+
+Date: 2026-06-30
+
+## Scope
+
+WO-BACKEND-002 established the backend warning baseline after WO-BACKEND-001 and burned down low-risk, mechanical nullable warnings in the out-of-solution API test project.
+
+Allowed scope:
+
+- Backend build warning evidence.
+- Mechanical test-only nullability fixes.
+- No runtime behavior changes.
+- No production, deployment, secrets, county data, PACS, or SQL access.
+
+## Baseline
+
+The canonical backend solution remains warning-clean:
+
+```powershell
+dotnet build backend\TerraFusion.sln --no-restore --property:WarningLevel=999
+```
+
+Result:
+
+```text
+Build succeeded.
+0 Warning(s)
+0 Error(s)
+```
+
+WO-BACKEND-001 also identified `backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj` as an out-of-solution test project. Building that project directly initially produced 30 nullable warnings.
+
+## Mechanical Repairs
+
+The warning burn-down changed only test files:
+
+- `backend/TerraFusion.API.Tests/AuditCorrelationTests.cs`
+- `backend/TerraFusion.API.Tests/SystemIntegrationTests.cs`
+- `backend/TerraFusion.API.Tests/Integration/CountyStudioSmokeTests.cs`
+
+Changes were limited to:
+
+- Explicit non-null validation before parsing audit log JSON payloads.
+- Explicit deserialization guards in skipped aspirational integration tests.
+- Default initializers for test DTO properties.
+- A null assertion before checking a saved County Studio scenario result.
+
+No backend runtime files were changed.
+
+## Validation
+
+Out-of-solution API test warning gate:
+
+```powershell
+dotnet build backend\TerraFusion.API.Tests\TerraFusion.API.Tests.csproj --no-restore --property:WarningLevel=999
+```
+
+Result:
+
+```text
+Build succeeded.
+0 Warning(s)
+0 Error(s)
+```
+
+Canonical backend solution warning gate:
+
+```powershell
+dotnet build backend\TerraFusion.sln --no-restore --property:WarningLevel=999
+```
+
+Result:
+
+```text
+Build succeeded.
+0 Warning(s)
+0 Error(s)
+```
+
+Out-of-solution API test execution:
+
+```powershell
+dotnet test backend\TerraFusion.API.Tests\TerraFusion.API.Tests.csproj --no-build --logger "console;verbosity=minimal"
+```
+
+Result:
+
+```text
+Failed: 9, Passed: 649, Skipped: 35, Total: 693
+```
+
+Failure classes observed:
+
+- Missing Rust valuation kernel binaries.
+- Phase 12 orphan-interface guard expectations for absent interfaces.
+- Phase 13 trace-contract expectations for missing `tools/tf` CLI files.
+- Phase 14 controller security boundary expectation drift.
+- Authentication rate-limit baseline returning HTTP 500.
+- County Studio adjustment-set transition expectation drift.
+
+These failures pre-exist the nullable warning burn-down and require separate backend operational WOs. They were not patched in WO-BACKEND-002 because doing so would exceed the warning burn-down scope.
+
+## Conclusion
+
+WO-BACKEND-002 is complete for warning discipline:
+
+- Canonical backend solution build: warning-clean.
+- Out-of-solution API test build: warning-clean.
+- Runtime code changed: no.
+- Dependency changes: no.
+- Pipeline or workflow changes: no.
+
+## Next Recommended WO
+
+Proceed to `WO-BACKEND-003 — Service Registry Validation`.
+
+Carry forward the API test execution failures as backend operational gaps, not as warning-baseline failures.


### PR DESCRIPTION
WO-BACKEND-002 — Build Warning Burn-Down.\n\nScope:\n- Mechanical nullable warning fixes in backend/TerraFusion.API.Tests only.\n- Evidence packet: docs/brain/workorders/evidence/WO-BACKEND-002-BUILD-WARNING-BURN-DOWN.md.\n\nValidation:\n- dotnet build backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj --no-restore --property:WarningLevel=999: PASS, 0 warnings.\n- dotnet build backend/TerraFusion.sln --no-restore --property:WarningLevel=999: PASS, 0 warnings.\n- dotnet test backend/TerraFusion.API.Tests/TerraFusion.API.Tests.csproj --no-build: existing broader API test failures remain and are documented as follow-up operational gaps.\n- git diff --check: PASS.\n- node docs/brain/workorders/tools/wo-query.mjs --json: PASS.\n\nNon-changes:\n- No runtime code changes.\n- No package/dependency changes.\n- No pipeline or GitHub workflow changes.\n- No schema migration.\n- No production, deployment, secrets, county data, PACS, or SQL access.\n\nNext WO after merge authorization: WO-BACKEND-003 — Service Registry Validation.