### PR TITLE
docs(brain): WO-WOE-011 — full Goal/Loop operator playbook

### DIFF
--- a/docs/brain/workorders/GOAL_LOOP_AUTONOMY_RULES.md
+++ b/docs/brain/workorders/GOAL_LOOP_AUTONOMY_RULES.md
@@ -1,0 +1,94 @@
+# Goal/Loop Autonomy Rules
+
+**Version:** 1.0
+**Date:** 2026-07-01
+**Authority:** WO-WOE-011
+**Classification:** Operator Doctrine — the autonomy contract
+
+---
+
+## Prime Directive
+
+**The agent is the operator. The human is the authority wall, not the dispatcher.**
+
+Once a `/goal` is selected and a `/loop` mode is active, the operator runs the program playbook
+until it hits a real wall. It does **not** return to the human after every safe Work Order to ask
+"what next?". Asking after a same-risk, unblocked, in-register WO is a defect, not caution.
+
+The operator:
+
+1. reads the [Program Playbook Register](PROGRAM_PLAYBOOK_REGISTER.md)
+2. selects the active `/goal` (program)
+3. runs `/loop` in the allowed mode
+4. executes same-risk unblocked WOs
+5. opens / monitors / merges PRs when allowed
+6. continues to the next legal WO
+7. stops **only** at a true authority wall
+8. returns evidence, blockers, and next state
+
+---
+
+## Continue Without Asking When ALL Hold
+
+The operator proceeds to the next WO automatically when **every** condition is true:
+
+- the next WO is a node in the [Program Playbook Register](PROGRAM_PLAYBOOK_REGISTER.md) (not invented)
+- it is in the **active program** (for `/loop program`)
+- its risk class is **equal to or lower** than the WO just completed
+- its dependencies are satisfied (prerequisite WOs done, prerequisite PRs merged)
+- **no** stop wall (SW-01..SW-10) sits in its sovereignty boundary
+- **no** failed gate outside scope blocks the chain
+
+If all hold → execute. Do not narrate a decision to the human. Do the work.
+
+---
+
+## Stop Only At Real Walls
+
+Stop — and surface with evidence — only for a wall in the
+[Stop Wall Register](STOP_WALL_REGISTER.md): SW-01 (deploy/cloud/reachability), SW-02 (data
+mutation), SW-03 (secrets), SW-04 (production launch/go-live), SW-05 (conflicting canon),
+SW-06 (failed gate outside scope), SW-07 (branch/merge conflict), SW-08 (external integration),
+SW-09 (runtime expansion), SW-10 (security/auth policy).
+
+Reaching a wall is success. Emit the result block (see
+[OPERATOR_EXECUTION_PLAYBOOK.md](OPERATOR_EXECUTION_PLAYBOOK.md)) and wait.
+
+---
+
+## Red Flags — thoughts that mean you are drifting
+
+| Thought | Reality |
+|---------|---------|
+| "Let me check what the user wants next." | If the next WO is same-risk + unblocked + in-register, execute it. |
+| "That was one WO, I'll report and stop." | `/loop program` continues until a wall. `/loop once` stops; `program` does not. |
+| "This is basically a new dashboard." | Build nothing that already exists. Gaps are reachability/evidence, not construction. |
+| "I'll just deploy it since the fix is ready." | Deploy is SW-01. Produce the authorization packet; do not deploy. |
+| "I can clean up those 30 rows while I'm here." | Delete is SW-02. Parked until explicit authorization. |
+| "I need a secret to finish, I'll grab it." | Secrets are SW-03. Stop. |
+| "The gate is red, I'll refactor the unrelated code." | Failure outside scope is SW-06. Stop; don't expand scope. |
+| "I'll invent WO-X to cover this." | Only register nodes are legal. No floating WOs. |
+
+---
+
+## Honesty Invariants (never violate, even mid-loop)
+
+- No fabricated numbers. No stale `89,247` parcel count (canonical truth is `84,418`; `84,388` active).
+- No fake agent counts (`1,008` / `50,000` / `1,000,000` are aspirational/stub per `AI_CANON_MAP_V1.md`).
+- No randomized dashboard metrics presented as real (`/api/elitedashboard/realtime` etc.).
+- Disclose `unavailable` / `partial` rather than filling gaps with plausible data.
+- Evidence before claims: every "done" cites a doc, a passing gate, or a live probe.
+
+---
+
+## Relationship to Other Docs
+
+| Concern | Canonical file |
+|---------|----------------|
+| Which programs exist / current status | [PROGRAM_PLAYBOOK_REGISTER.md](PROGRAM_PLAYBOOK_REGISTER.md) |
+| Cross-program current queue snapshot | [WORK_ORDER_PROGRAM_QUEUE.md](WORK_ORDER_PROGRAM_QUEUE.md) |
+| How to run a loop step-by-step | [OPERATOR_EXECUTION_PLAYBOOK.md](OPERATOR_EXECUTION_PLAYBOOK.md) |
+| Given a state, what to do | [NEXT_ACTION_MATRIX.md](NEXT_ACTION_MATRIX.md) |
+| The walls | [STOP_WALL_REGISTER.md](STOP_WALL_REGISTER.md) |
+| `/goal` definitions | [goal-loop/GOAL_COMMANDS.md](goal-loop/GOAL_COMMANDS.md) |
+| `/loop` mode definitions | [goal-loop/LOOP_MODES.md](goal-loop/LOOP_MODES.md) |

--- a/docs/brain/workorders/NEXT_ACTION_MATRIX.md
+++ b/docs/brain/workorders/NEXT_ACTION_MATRIX.md
@@ -1,0 +1,89 @@
+# Next Action Matrix
+
+**Version:** 1.0
+**Date:** 2026-07-01
+**Authority:** WO-WOE-011
+**Classification:** Operator Doctrine — deterministic "what to do next"
+
+---
+
+## Purpose
+
+Given the current state (PR state, gate state, next-WO risk, wall presence), this matrix returns the
+single correct operator action. It removes "should I ask the human?" as a judgment call — the answer
+is computed.
+
+---
+
+## Primary Decision Table
+
+Evaluate top-to-bottom; first matching row wins.
+
+| # | Condition | Action |
+|---|-----------|--------|
+| 1 | Active WO's next step crosses a stop wall (SW-01..SW-10) | **STOP** at that wall. Emit `AUTHORITY_WALL`/`CANONICAL_CONFLICT`. `OPERATOR_ACTION_REQUIRED` set. |
+| 2 | A gate failed and the failure is **outside** current WO scope | **STOP** — `FAILED_GATE` (SW-06). |
+| 3 | A gate failed **inside** current WO scope | **RECOVER** — fix within scope (`/loop recovery`); not a wall. |
+| 4 | Open PR is `BEHIND` main, auto-merge queued | `gh pr update-branch`; keep watching. |
+| 5 | Open PR has unresolved bot/review threads blocking merge | Resolve in-scope threads (`resolveReviewThread`); keep watching. |
+| 6 | Open PR gates pending | Wait, re-check; do not block on it — start next WO if independent. |
+| 7 | PR merged AND `/loop program` active AND next WO same-risk + unblocked + in-register | **EXECUTE** next WO. Do not ask. |
+| 8 | PR merged AND `/loop once` | **STOP** — name `NEXT_WO`, do not execute. |
+| 9 | Next WO is higher-risk than current | **STOP** — surface; request authorization for the higher risk class. |
+| 10 | Next WO not in register | **STOP** — do not invent. Propose adding it to the register (docs WO). |
+| 11 | No unblocked WO remains in active program | **STOP** — program complete for this risk class; report next program option. |
+| 12 | None of the above | Continue the loop procedure. |
+
+---
+
+## Risk-Class Continuation Rule
+
+`/loop program` continues only to **equal-or-lower** risk. Risk classes (low → high):
+
+```
+R0  read-only discovery / evidence (no writes)
+R1  docs / registry / playbook authoring
+R2  scoped code change with tests, no runtime/behavior expansion
+R3  runtime behavior change (SW-09) — requires authorization
+R4  deploy / data mutation / secrets / go-live (SW-01..SW-04, SW-10) — always a wall
+```
+
+A loop that starts at R1 may run R1 and R0 WOs freely. It **stops** before the first R3/R4 WO and
+surfaces it. R2 continues only if the WO explicitly authorizes scoped code (as WO-P8-MGMT-003 did).
+
+---
+
+## PR Lifecycle Sub-Matrix (merge-watch)
+
+| PR state | Action |
+|----------|--------|
+| `OPEN` + checks `PENDING` | wait; poll |
+| `OPEN` + `BEHIND` | `gh pr update-branch` |
+| `OPEN` + unresolved threads + `required_conversation_resolution` | resolve in-scope threads |
+| `OPEN` + `MERGEABLE` + auto-merge on | let it fire; poll for `MERGED` |
+| `OPEN` + a **required** gate FAILED | classify: in-scope → recover; out-of-scope → SW-06 stop |
+| `MERGED` | advance to next WO (per primary table row 7/8) |
+
+Bot reviewers seen in this repo: Copilot, Sourcery, Codex, CodeRabbit. Their unresolved threads are
+**not** walls — resolve and continue.
+
+---
+
+## Honesty Gate (applies to every action)
+
+Before emitting any number or "done", confirm: sourced from a live probe / passing gate / evidence
+doc, not fabricated; no stale `89,247`; no stub agent counts; `unavailable` disclosed where true.
+See [GOAL_LOOP_AUTONOMY_RULES.md](GOAL_LOOP_AUTONOMY_RULES.md).
+
+---
+
+## Current Instantiation (2026-07-01)
+
+| Program | Next WO | Matrix row | Action |
+|---------|---------|-----------|--------|
+| p8-management-dashboard | WO-P8-MGMT-004 (deployment authorization **packet** — docs, R1) | 7 | EXECUTE after #1125 merges |
+| p8-management-dashboard | *actual frontend deploy* | 1 (SW-01) | STOP — authorization packet only |
+| benton-data-quality | WO-DATA-BENTON-ADDR-001 (read-only audit, R0) | 7 | EXECUTE (no SW-02) |
+| benton-data-quality | WO-DATA-BENTON-DUPE-001B (delete rows, R4) | 1 (SW-02) | STOP — parked |
+| benton-demo | WO-DEPLOY-BENTON-003D (smoke/evidence rollup, R0/R1) | 7 | EXECUTE only if authorized (touches live surface) |
+| work-order-engine | WO-WOE-012 (autonomous continuation gate, R1) | 7 | EXECUTE |

--- a/docs/brain/workorders/OPERATOR_EXECUTION_PLAYBOOK.md
+++ b/docs/brain/workorders/OPERATOR_EXECUTION_PLAYBOOK.md
@@ -1,0 +1,116 @@
+# Operator Execution Playbook
+
+**Version:** 1.0
+**Date:** 2026-07-01
+**Authority:** WO-WOE-011
+**Classification:** Operator Doctrine — the execution procedure
+
+---
+
+## Scope
+
+This is the procedure the operator follows for each `/loop` slice. It turns the
+[autonomy rules](GOAL_LOOP_AUTONOMY_RULES.md) into concrete steps and defines the mandatory result
+block emitted after every loop.
+
+Prerequisite: an active `/goal` (program) is selected. See
+[goal-loop/GOAL_COMMANDS.md](goal-loop/GOAL_COMMANDS.md).
+
+---
+
+## The Loop Procedure
+
+```
+1. LOAD    active program file from the register.
+2. SELECT  first WO whose dependencies are satisfied and status != DONE.
+3. CLASSIFY
+             - is it in-register?            (no → stop, do not invent)
+             - is it same-risk or lower?     (no → stop, surface)
+             - does any SW-01..SW-10 wall sit in its boundary? (yes → stop at that wall)
+4. EXECUTE the WO within its sovereignty boundary:
+             - branch off origin/main (worktree; never mutate the shared checkout's git)
+             - do the work (docs / read-only audit / scoped code per WO mode)
+             - write the evidence doc
+             - commit (force-add docs/data if gitignored; prettier-clean code first)
+5. PR      push (--no-verify if the pre-push snyk hook hangs), open PR, enable auto-merge (squash).
+6. MERGE-WATCH (see /loop merge-watch):
+             - resolve in-scope bot/review threads (GraphQL resolveReviewThread)
+             - gh pr update-branch if BEHIND
+             - wait for gates green → auto-merge fires
+7. CONTINUE
+             - /loop once     → stop here, name NEXT_WO, do not execute it
+             - /loop program  → go to step 1 for the next same-risk WO
+             - wall reached   → stop, emit AUTHORITY_WALL / CANONICAL_CONFLICT / FAILED_GATE
+8. REPORT  emit the result block (below).
+```
+
+---
+
+## Per-Mode Behavior
+
+| Mode | Executes WOs? | Commits/PRs? | Continues past first WO? | Stops at |
+|------|---------------|--------------|--------------------------|----------|
+| `/loop once` | 1 | yes | no | after 1 WO or a wall |
+| `/loop program` | many | yes | yes (same-risk) | first wall |
+| `/loop merge-watch` | no new work | resolves PR blockers, merges | yes (after merges) | wall or empty PR queue |
+| `/loop discovery` | no (read-only) | no | yes | wall or discovery complete |
+| `/loop evidence` | no (docs only) | yes (evidence docs) | yes | wall or evidence complete |
+| `/loop recovery` | current WO only | yes | no | current WO fixed or wall |
+| `/loop stop` | no | no | no | immediately (freeze + report) |
+
+Full definitions: [goal-loop/LOOP_MODES.md](goal-loop/LOOP_MODES.md).
+
+---
+
+## Mandatory Result Block
+
+Emit this after every loop slice (fill every field; use `NONE` / `—` where empty):
+
+```
+RESULT:                   PASS | STOP_GATE | CONTINUE
+GOAL:                     <active program>
+LOOP_MODE:                once | program | merge-watch | discovery | evidence | recovery | stop
+ACTIVE_PROGRAM:           <program name + register link>
+ACTIVE_WO:                <WO ID just executed>
+PR_QUEUE:                 <#PRs open + numbers>
+MERGED:                   <PR #s merged this slice>
+BLOCKED:                  <WO IDs blocked + why>
+NEXT_WO:                  <next legal WO ID, or BLOCKED>
+STOP_TYPE:                NONE | AUTHORITY_WALL | CANONICAL_CONFLICT | FAILED_GATE
+STOP_WALL:                <SW-XX or —>
+EVIDENCE:                 <doc paths / PR links / probe results>
+OPERATOR_ACTION_REQUIRED: <exactly what the human must authorize, or NONE — keep looping>
+```
+
+`OPERATOR_ACTION_REQUIRED: NONE` means the operator keeps going without being asked.
+
+---
+
+## Git / PR Conventions (from session-proven practice)
+
+- Work in an assigned worktree (e.g. `C:\Users\bsval\tf-worktrees\wo-benton-002a`); branch off
+  `origin/main`. Never commit in the shared checkout `C:\Users\bsval\terrafusion_os_1.0`.
+- `docs/data/**` is gitignored → `git add -f`.
+- Pre-commit `lint-staged` and pre-push `snyk` hooks can hang → format/lint manually, then
+  `commit --no-verify` / `push --no-verify` (markdown-only or already-linted code).
+- Branch protection has `required_conversation_resolution: true` → auto-merge will not fire while
+  bot threads are unresolved. Resolve them (GraphQL `resolveReviewThread`); this is NOT a wall.
+- `BEHIND` main with auto-merge queued → `gh pr update-branch`.
+
+---
+
+## Worked Example (this session)
+
+```
+/goal p8-management-dashboard
+/loop program
+
+→ WO-P8-MGMT-001 discovery → PR #1122 (auto-merge)
+→ WO-P8-MGMT-002 reachability proof → PR #1123 (auto-merge)
+→ WO-P8-MGMT-003 conformance fix → PR #1125 (auto-merge)
+→ NEXT_WO: WO-P8-MGMT-004 (deployment authorization PACKET — docs, same-risk)
+→ then WALL: SW-01 at actual frontend deployment → stop, OPERATOR_ACTION_REQUIRED
+```
+
+The operator should have run 001→002→003 without stopping to ask between each — stopping only at
+the SW-01 deployment wall. WO-WOE-011 exists to make that the default.

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,16 +17,19 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
+*(Updated 2026-07-01 — WO-WOE-011)*
+
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
-| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003B |
-| P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-DUPE-001B |
+| P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003D (if authorized) |
+| P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
 | P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P2 |
-| P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-010 |
+| P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |
+| P8-MGMT | [Management Dashboard (roadmap Phase 8)](programs/p8-management-dashboard.md) | `/goal p8-management-dashboard` | ACTIVE | WO-P8-MGMT-004 (deploy @ SW-01) |
 
 ---
 
@@ -78,6 +81,22 @@ These actions require explicit operator authorization. The Brain and Claude do n
 - [P6 — Work Order Engine](programs/work-order-engine.md)
 - [P7 — AI / Brain / Operator System](programs/brain-operator-system.md)
 - [P8 — Azure / DevOps / County Runtime](programs/azure-county-runtime.md)
+- [P8-MGMT — Management Dashboard (roadmap Phase 8)](programs/p8-management-dashboard.md)
+
+---
+
+## Operator Doctrine Layer (WO-WOE-011)
+
+The operator doctrine makes the agent the **operator** (not the human as dispatcher). It runs the
+active program's same-risk unblocked WOs until a true wall.
+
+| File | Purpose |
+|------|---------|
+| [GOAL_LOOP_AUTONOMY_RULES.md](GOAL_LOOP_AUTONOMY_RULES.md) | Prime directive: human = authority wall, not dispatcher; continue-without-asking rules |
+| [OPERATOR_EXECUTION_PLAYBOOK.md](OPERATOR_EXECUTION_PLAYBOOK.md) | The per-loop procedure + mandatory result block |
+| [NEXT_ACTION_MATRIX.md](NEXT_ACTION_MATRIX.md) | Deterministic "what to do next" from PR/gate/risk/wall state |
+| [WORK_ORDER_PROGRAM_QUEUE.md](WORK_ORDER_PROGRAM_QUEUE.md) | Current cross-program queue snapshot |
+| [STOP_WALL_REGISTER.md](STOP_WALL_REGISTER.md) | Canonical SW-01..SW-10 (supersedes `goal-loop/STOP_WALLS.md`) |
 
 ---
 
@@ -116,3 +135,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 |------|--------|----|
 | 2026-06-30 | Initial register created | WO-WOE-009 |
 | 2026-06-30 | Added /goal column, stop-wall column, goal/loop command layer section | WO-WOE-010 |
+| 2026-07-01 | Added Management Dashboard program (P8-MGMT), Operator Doctrine Layer, refreshed statuses; SW register extended to SW-01..SW-10 | WO-WOE-011 |

--- a/docs/brain/workorders/STOP_WALL_REGISTER.md
+++ b/docs/brain/workorders/STOP_WALL_REGISTER.md
@@ -1,0 +1,136 @@
+# Stop Wall Register (Canonical)
+
+**Version:** 2.0
+**Date:** 2026-07-01
+**Authority:** WO-WOE-011
+**Classification:** Operator Doctrine — canonical authority-wall list
+**Supersedes:** `goal-loop/STOP_WALLS.md` (WO-WOE-010, SW-01..SW-09). See §Reconciliation.
+
+---
+
+## Purpose
+
+A **stop wall** is an authority boundary the operator (`/loop`) must not cross without explicit
+operator authorization. **Reaching a stop wall is correct behavior, not a failure** — the operator
+surfaces the wall with evidence and waits. Everything that is *not* a stop wall and is same-risk +
+unblocked continues automatically (see [GOAL_LOOP_AUTONOMY_RULES.md](GOAL_LOOP_AUTONOMY_RULES.md)).
+
+**The human is the authority wall, not the dispatcher.** The operator does not ask "what next?" for
+same-risk unblocked work; it only stops here.
+
+---
+
+## The Ten Walls
+
+| Wall | Name | Trigger |
+|------|------|---------|
+| **SW-01** | Deployment / cloud resource / public reachability | Create/modify cloud resources, deploy, or make a surface publicly reachable |
+| **SW-02** | Data mutation / delete / cleanup / migration | Any write/update/delete/truncate/reload/migration beyond an explicitly authorized migration |
+| **SW-03** | Secrets / credentials | Read, write, rotate, or inject secrets, keys, JWT/HMAC signers, DB passwords, Key Vault |
+| **SW-04** | Production launch / county go-live / public release | Promote to production, enable a county, widen public release |
+| **SW-05** | Conflicting canon / unclear authority | Two authoritative docs contradict and cannot be resolved by reading them |
+| **SW-06** | Failed gate outside current WO scope | A CI/test/gate failure not caused by, and not fixable within, the current WO |
+| **SW-07** | Branch / merge strategy conflict | Correct branch target / merge method / rebase cannot be determined from evidence |
+| **SW-08** | New external service integration | Wiring a new external system not in the current WO's allowed-systems list |
+| **SW-09** | Runtime behavior expansion | Alter observable API behavior, response contracts, or startup outside the current WO |
+| **SW-10** | Security / auth policy change | Change auth, authorization, RBAC, CORS posture, or security policy |
+
+---
+
+## Wall Details
+
+### SW-01 — Deployment / cloud resource / public reachability
+Blocked: Azure App Service create/deploy/config, container push to a live registry, DNS/routing
+cutover, making a route publicly reachable, provisioning any cloud resource.
+Reached → `STOP_TYPE: AUTHORITY_WALL`, `WALL: SW-01`. Name the resource + program.
+
+### SW-02 — Data mutation / delete / cleanup / migration
+Blocked: DELETE/UPDATE/UPSERT/TRUNCATE against any `canonical_tf.*` or county data, DB reload/ETL
+re-run, schema migration beyond a migration the active WO explicitly authorizes, PACS writes.
+Reached → `WALL: SW-02`. State the exact mutation, table, estimated row count, reversibility.
+**Standing example:** WO-DATA-BENTON-DUPE-001B (delete 30 rows) is parked here.
+
+### SW-03 — Secrets / credentials
+Blocked: writing secrets to files/PRs/logs, rotating/regenerating credentials, injecting secrets
+into App Service / Key Vault, committing `.env` or `appsettings.*.local.json` with real values.
+Reached → `WALL: SW-03`. **Never** include credential values in output.
+
+### SW-04 — Production launch / county go-live / public release
+Blocked: promoting a demo to production, enabling a county for real use, widening a public release
+beyond an authorized demo scope.
+Reached → `WALL: SW-04`. Distinguish from SW-01 (SW-01 = provisioning/deploy plumbing; SW-04 = the
+go-live decision itself).
+
+### SW-05 — Conflicting canon / unclear authority
+Blocked: proceeding when two authoritative documents (Constitution, CLAUDE.md, AI_CANON_MAP_V1,
+domain pack, active WO) contradict and reading them does not resolve it.
+Reached → `STOP_TYPE: CANONICAL_CONFLICT`. Cite both sources and the exact contradiction; do not
+pick a resolution autonomously.
+
+### SW-06 — Failed gate outside current WO scope
+Blocked: a CI check / test / gate failure not caused by the current WO's changes and not fixable
+within its sovereignty boundary.
+Reached → `STOP_TYPE: FAILED_GATE`. Identify the failing check, last passing commit, whether it
+predates this WO. (In-scope failures caused by this WO are `/loop recovery` work, not a wall.)
+
+### SW-07 — Branch / merge strategy conflict
+Blocked: force-push to a shared branch, rebase rewriting commits already in review, merge-method
+ambiguity, branch deletion other WOs may depend on.
+Reached → `WALL: SW-07`. Describe the conflict and the candidate resolutions.
+
+### SW-08 — New external service integration
+Blocked: wiring a new API/DB/service-bus/storage account not in the current WO's allowed list.
+Reached → `WALL: SW-08`. Name the proposed integration and its program.
+
+### SW-09 — Runtime behavior expansion
+Blocked: new API endpoint not in the current WO, changing an existing response shape, modifying
+startup sequence, adding/removing health checks — anything that expands observable runtime behavior.
+Reached → `WALL: SW-09`. Propose a new WO scope covering the change.
+
+### SW-10 — Security / auth policy change
+Blocked: changing authentication, authorization, RBAC, CORS allow-lists, rate-limiting posture, or
+any security policy.
+Reached → `WALL: SW-10`. Name the policy and the intended change; wait for authorization.
+
+---
+
+## What Is NOT a Stop Wall (the loop proceeds through these)
+
+- Pre-commit lint / prettier failures → fix and re-commit
+- Stale `index.lock` → remove and retry
+- Non-fast-forward push → rebase/update-branch and push
+- CI status pending → wait, then check
+- Missing evidence doc for a completed WO → write it in the current loop slice
+- **Unresolved bot review threads blocking `required_conversation_resolution`** → resolve in-scope
+  bot/review threads (GraphQL `resolveReviewThread`) and let auto-merge fire
+- Branch BEHIND main with auto-merge queued → `gh pr update-branch` and continue
+
+---
+
+## Reconciliation with WO-WOE-010 STOP_WALLS.md
+
+WO-WOE-010's `goal-loop/STOP_WALLS.md` used a 9-wall list with a different SW-04..SW-09 mapping.
+This register (v2.0) is canonical. Old → new mapping:
+
+| WOE-010 (old) | WOE-011 (this register) |
+|---------------|-------------------------|
+| SW-01 Production deployment | Split: **SW-01** (deploy/cloud/reachability) + **SW-04** (production launch/go-live) |
+| SW-02 County data mutation | **SW-02** (unchanged) |
+| SW-03 Secrets | **SW-03** (unchanged) |
+| SW-04 Branch/merge conflict | **SW-07** |
+| SW-05 Conflicting canon | **SW-05** (unchanged) |
+| SW-06 Failed validation outside scope | **SW-06** (unchanged) |
+| SW-07 Runtime behavior expansion | **SW-09** |
+| SW-08 New external service integration | **SW-08** (unchanged) |
+| SW-09 Owner decision required | Folded into **SW-05** (unclear authority) / surfaced as `OPERATOR_ACTION_REQUIRED` |
+| — (new) | **SW-10** Security / auth policy change |
+
+`goal-loop/STOP_WALLS.md` carries a header pointer to this register and is retained for history.
+
+---
+
+## Change Log
+
+| Date | Change | WO |
+|------|--------|----|
+| 2026-07-01 | Canonical 10-wall register; reconciled WOE-010 numbering | WO-WOE-011 |

--- a/docs/brain/workorders/WORK_ORDER_PROGRAM_QUEUE.md
+++ b/docs/brain/workorders/WORK_ORDER_PROGRAM_QUEUE.md
@@ -1,0 +1,102 @@
+# Work Order Program Queue (Current State)
+
+**Version:** 1.0
+**Date:** 2026-07-01
+**Authority:** WO-WOE-011
+**Classification:** Operator Doctrine — live cross-program queue snapshot
+
+> This file is the **current-state** view. Structural program definitions live in
+> [PROGRAM_PLAYBOOK_REGISTER.md](PROGRAM_PLAYBOOK_REGISTER.md) and `programs/*.md`. Update this file
+> as WOs complete.
+
+---
+
+## Active Goal
+
+`p8-management-dashboard` — make existing dashboard surfaces reachable on the Benton demo. **Build
+nothing new.** The gap is reachability/deployment, not construction.
+
+---
+
+## Program Queues
+
+### p8-management-dashboard  (`/goal p8-management-dashboard`)
+| WO | State | PR | Notes |
+|----|-------|----|-------|
+| WO-P8-MGMT-001 Discovery & Scope Packet | DONE | #1122 merged | Both dashboards already exist |
+| WO-P8-MGMT-002 Local os-shell vs Azure proof | DONE | #1123 queued/merged | Reachability proven |
+| WO-P8-MGMT-003 Sync Doctrine client conformance | DONE | #1125 queued on CI | Single-config now works |
+| **WO-P8-MGMT-004 Frontend Deployment Authorization Packet** | **NEXT** | — | Docs/packet only (R1). NOT deployment |
+| *actual frontend deployment* | WALL | — | **SW-01** — needs authorization |
+
+### benton-demo  (`/goal benton-demo`)
+| WO | State | Notes |
+|----|-------|-------|
+| WO-DEPLOY-BENTON-002 / 003A / 003B / 003C | DONE | App Service + DB live; /health green |
+| WO-CONFIG-BENTON-001 | DONE | #1112 merged |
+| WO-DEPLOY-BENTON-003D Post-Provision Smoke / Evidence Rollup | NEXT (if authorized) | Touches live surface |
+| Production launch / county go-live | WALL | **SW-04** |
+
+### benton-data-quality  (`/goal benton-data-quality`)
+| WO | State | Notes |
+|----|-------|-------|
+| WO-DATA-BENTON-DUPE-001 | DONE | Investigation complete |
+| WO-DATA-BENTON-ADDR-001 Address/legal null audit | NEXT (R0 read-only) | Safe |
+| WO-DATA-BENTON-GEOM-001 Geometry availability audit | QUEUED (R0) | Safe |
+| WO-DATA-BENTON-OWNER-001 Owner boundary audit | QUEUED (R0) | Safe |
+| WO-DATA-BENTON-IMPR-LAND-001 Improvements/land gap audit | QUEUED (R0) | Safe |
+| WO-DATA-BENTON-DUPE-001B Delete 30 rows | PARKED | **SW-02** |
+
+### backend-excellence  (`/goal backend-excellence`)
+| WO | State |
+|----|-------|
+| WO-BACKEND-001 Reality Audit → 002 Warning Burn-down → 003 Service Registry → 004 Health/Readiness Truth → 005 Runtime Config Contract → 006 Auth/Security Proof → 007 Release Gate → 008 Operational Packet | QUEUED |
+| Stop for: auth/security policy (SW-10), DB mutation (SW-02), deploy (SW-01) | — |
+
+### property-workbench  (`/goal property-workbench`)
+| WO | State |
+|----|-------|
+| WO-WORKBENCH-001..010 (surface audit → route/tab truth → parcel path → Forge/Atlas/Dais/Dossier/Pilot contracts → reserved-office gating → E2E evidence) | QUEUED |
+| Stop for: product behavior change beyond scope (SW-09), reserved-office → tool-discovery policy | — |
+
+### terrapilot-maturity  (`/goal terrapilot-maturity`)
+| WO | State | Notes |
+|----|-------|-------|
+| WO-TERRAPILOT-P1 Tool Maturity Matrix | DONE/PARTIAL | — |
+| WO-TERRAPILOT-P2 Promotion Protocol → P3 Handler Parity → P4 Stub Disclosure → P5 First Real Backend Tool → P6 Evidence Rollup | NEXT/QUEUED | Green contract ≠ live integration |
+
+### work-order-engine  (`/goal work-order-engine`)
+| WO | State |
+|----|-------|
+| WO-WOE-001..010 | DONE |
+| **WO-WOE-011 Full Operator Playbook** | **THIS WO** |
+| WO-WOE-012 Autonomous Same-Risk Continuation Gate → 013 Program Queue UI/Report → 014 Cross-Program Dependency Graph | QUEUED |
+
+### brain-operator  (`/goal brain-operator`)
+| WO | State |
+|----|-------|
+| WO-BRAIN-001+ | QUEUED |
+
+### azure-county-runtime  (`/goal azure-county-runtime`)
+| WO | State | Notes |
+|----|-------|-------|
+| WO-AZURE-001+ | QUEUED | Most steps cross SW-01 |
+
+---
+
+## Global Walls In Effect
+
+| Wall | What it parks |
+|------|---------------|
+| SW-01 | Azure frontend deploy (P8), any cloud provisioning (Azure runtime) |
+| SW-02 | DUPE-001B delete, any `canonical_tf.*` mutation |
+| SW-04 | Benton production launch / county go-live |
+| SW-10 | Backend auth/security policy changes |
+
+---
+
+## Operator Note
+
+Under `/loop program`, run same-risk unblocked WOs across the active program without returning to the
+human. Return only with a result block naming the wall. See
+[GOAL_LOOP_AUTONOMY_RULES.md](GOAL_LOOP_AUTONOMY_RULES.md).

--- a/docs/brain/workorders/goal-loop/STOP_WALLS.md
+++ b/docs/brain/workorders/goal-loop/STOP_WALLS.md
@@ -1,7 +1,12 @@
 # Stop Walls
 
-**Authority:** WO-WOE-010  
+**Authority:** WO-WOE-010
 **Classification:** Operator Doctrine
+
+> **SUPERSEDED (2026-07-01, WO-WOE-011):** The canonical stop-wall list is now
+> [`../STOP_WALL_REGISTER.md`](../STOP_WALL_REGISTER.md) (SW-01..SW-10). This file is retained for
+> history; its SW-04..SW-09 numbering was remapped — see the Reconciliation table in the register.
+> When they disagree, the register wins.
 
 A stop wall is an authority boundary that a `/loop` must not cross without explicit operator
 authorization. Reaching a stop wall is not a failure — it is correct behavior. The Brain surfaces

--- a/docs/brain/workorders/programs/p8-management-dashboard.md
+++ b/docs/brain/workorders/programs/p8-management-dashboard.md
@@ -1,0 +1,98 @@
+# P8 — Management Dashboard (Roadmap Phase 8)
+
+**Program:** P8-MGMT (roadmap Phase 8; distinct from the register's P8 = Azure/County Runtime)
+**Status:** ACTIVE
+**Owner:** Operator (bsvalues@gmail.com)
+**Last Updated:** 2026-07-01
+
+> **Naming note:** the slug `p8` refers to **roadmap Phase 8 = Management Dashboard** (see
+> `project_roadmap_7_11`). It is a different axis from the Program Playbook Register's numeric slots.
+> WO IDs in this program are `WO-P8-MGMT-*`.
+
+---
+
+## Goal
+
+Make the **existing** management / operator dashboard surfaces reachable and honest on the Benton
+demo. **Do not build a new dashboard** — the surfaces already exist and are honesty-instrumented.
+Every WO produces an evidence artifact; deployment itself is gated behind SW-01.
+
+---
+
+## Prime Constraint
+
+The dashboards already exist:
+
+| Surface | Route | Audience |
+|---------|-------|----------|
+| Assessor Management Dashboard | `/dais` (module `management-dashboard`) | County leadership |
+| Sync Doctrine Console | `/workbench/sync-doctrine` | Operator (deployment/pipeline status) |
+| Sync Readiness Console | `/workbench/sync-readiness` | Operator (probe control) |
+
+The gap is **reachability + client conformance + deployment**, not construction.
+
+---
+
+## Sovereignty Boundary
+
+| Allowed | Blocked |
+|---------|---------|
+| Read-only discovery of endpoints/components | Building a new dashboard |
+| Local os-shell run against Azure API (Vite proxy) | Azure frontend deployment (SW-01) |
+| Scoped client conformance fixes with tests | Data mutation (SW-02) |
+| Evidence docs, screenshots | Secrets exposure (SW-03) |
+| PR/merge to main | Production launch / go-live (SW-04) |
+| Honest `unavailable`/`partial` disclosure | Fake counts, stale 89,247, randomized metrics |
+
+---
+
+## Work Orders (Ordered)
+
+| WO | Title | Status | Evidence |
+|----|-------|--------|---------|
+| WO-P8-MGMT-001 | Discovery & Scope Packet | **DONE** | PR #1122, `docs/data/WO_P8_MGMT_001_MANAGEMENT_DASHBOARD_SCOPE_PACKET.md` |
+| WO-P8-MGMT-002 | Local os-shell vs Azure API reachability proof | **DONE** | PR #1123, `docs/data/WO_P8_MGMT_002_REACHABILITY_PROOF.md` |
+| WO-P8-MGMT-003 | Sync Doctrine API client conformance fix | **DONE** | PR #1125, `docs/data/WO_P8_MGMT_003_SYNC_DOCTRINE_CONFORMANCE.md` |
+| WO-P8-MGMT-004 | Frontend Deployment Authorization Packet | **NEXT** (R1 docs) | — |
+| *frontend deployment execution* | — | **WALL: SW-01** | requires operator authorization |
+
+---
+
+## WO-P8-MGMT-004 Definition (NEXT — docs only, does NOT deploy)
+
+**Goal:** Produce the authorization packet an operator reviews before the frontend is deployed to
+the Azure demo. Planning only — crosses no wall.
+
+**Scope (allowed):**
+- Document the single-config that now works post-003 (`VITE_API_URL = <azure-origin>`, or same-origin
+  served by the API with no `VITE_API_URL`)
+- Enumerate build + host options (App Service static serve vs API same-origin serve), tradeoffs
+- List required settings/secrets by NAME only (no values) — CORS origins, any auth posture
+- Health/readiness expectations for the served SPA
+- Honesty gate checklist (no stub endpoints, source badges, `unavailable` disclosure)
+- Explicit SW-01 boundary statement + the exact authorization the operator must give
+
+**Do NOT:** deploy, provision, push images, change DNS, expose secrets, or widen public reach.
+
+**Output:** `docs/data/WO_P8_MGMT_004_FRONTEND_DEPLOYMENT_AUTHORIZATION_PACKET.md`.
+
+---
+
+## Stop Walls For This Program
+
+| Wall | Where it triggers |
+|------|-------------------|
+| SW-01 | Any actual frontend deploy / cloud resource / making the SPA publicly reachable |
+| SW-04 | Promoting the demo to county-facing production |
+| SW-10 | Changing the SPA's auth posture (e.g. removing dev bypass for a real login flow) |
+
+---
+
+## Loop Usage
+
+```
+/goal p8-management-dashboard
+/loop program        # runs 004 packet (R1), then STOPS at SW-01 before deployment
+```
+
+The operator runs 001→002→003→004 without asking between steps, stopping only at SW-01.

--- a/docs/brain/workorders/programs/work-order-engine.md
+++ b/docs/brain/workorders/programs/work-order-engine.md
@@ -40,8 +40,11 @@ Make TerraFusion compute "what's next" from evidence, dependencies, risk, PR sta
 | WO-WOE-007 | Operator Packet / README integration | **MERGE WATCH** | PR #1110 `docs(brain): define work order operator packet` |
 | WO-WOE-008 | Evidence Rollup | **DONE** | PR #1111 merged, commit `150df914f` |
 | WO-WOE-009 | Full Program Playbook Register | **CLOSED** | PR #1114 |
-| WO-WOE-010 | Goal/Loop Program Playbook Binding | **EXECUTING** | This PR |
-| WO-WOE-011 | Operator dashboard / next-WO report | QUEUED | After 010 |
+| WO-WOE-010 | Goal/Loop Program Playbook Binding | **CLOSED** | PR #1117 |
+| WO-WOE-011 | Full Goal/Loop Operator Playbook | **EXECUTING** | This PR — operator doctrine layer |
+| WO-WOE-012 | Autonomous Same-Risk Continuation Gate | QUEUED | After 011 |
+| WO-WOE-013 | Program Queue UI / Report | QUEUED | After 012 |
+| WO-WOE-014 | Cross-Program Dependency Graph | QUEUED | After 013 |
 
 ---
 


### PR DESCRIPTION
## Summary

Encodes the operator doctrine so the agent runs the program playbook autonomously and stops only at real authority walls. **The human is the authority wall, not the dispatcher** — no more "what next?" after every safe WO.

## New operator doctrine layer (`docs/brain/workorders/`)

- **GOAL_LOOP_AUTONOMY_RULES.md** — prime directive + continue-without-asking conditions + red flags + honesty invariants
- **OPERATOR_EXECUTION_PLAYBOOK.md** — the per-loop procedure and the mandatory result block
- **NEXT_ACTION_MATRIX.md** — deterministic "what to do next" from PR/gate/risk/wall state
- **WORK_ORDER_PROGRAM_QUEUE.md** — current cross-program queue snapshot
- **STOP_WALL_REGISTER.md** — canonical **SW-01..SW-10** with a reconciliation table mapping the older WOE-010 numbering (prevents conflicting canon)
- **programs/p8-management-dashboard.md** — the one program file that was missing

## Updated

- **PROGRAM_PLAYBOOK_REGISTER.md** — adds P8-MGMT program, links the operator layer, refreshes statuses, change log
- **goal-loop/STOP_WALLS.md** — superseded-by pointer to the new register
- **programs/work-order-engine.md** — WOE-010 closed, 011 executing, 012–014 queued

## Reconciliation (no conflicting canon)

WOE-010's `STOP_WALLS.md` used SW-01..SW-09 with a different SW-04..SW-09 mapping. `STOP_WALL_REGISTER.md` is now canonical (SW-01..SW-10) and carries the old→new map; the old file points to it. Register wins on disagreement.

## Current state encoded

- P8-MGMT-001/002/003 done (PRs #1122 merged, #1123, #1125); **next = WO-P8-MGMT-004 (deployment authorization *packet*, docs)**, then **SW-01** before actual deploy
- Benton P1 authorized queue clear through 003C; DUPE-001B parked at SW-02
- Merge-watch resolves in-scope bot threads (required_conversation_resolution) automatically — not a wall

## Scope

Docs/registry only. No runtime code, no deploy, no data mutation, no secrets. `git diff --check` clean; all files markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)