### PR TITLE
docs(data): benton-data-quality read-only audits (GEOM/OWNER/IMPR-LAND/ADDR-001)

### DIFF
--- a/docs/data/WO_DATA_BENTON_ADDR_001_ADDRESS_LEGAL_NULL_AUDIT.md
+++ b/docs/data/WO_DATA_BENTON_ADDR_001_ADDRESS_LEGAL_NULL_AUDIT.md
@@ -1,0 +1,67 @@
+# WO-DATA-BENTON-ADDR-001 — Address / Legal Description Null Audit
+
+**Program:** P2 — Benton Data Quality
+**Date:** 2026-07-01
+**Mode:** Read-only audit (R0). No mutation, no secrets, no deployment.
+**Source:** Live anonymous `GET /api/sync/doctrine/state` + endpoint probes, snapshot `2026-07-01T16:59Z`.
+**Authority Boundary:** SW-02 not crossed (read-only). SW-03 not crossed (no credentials used).
+
+---
+
+## Honest Headline
+
+**Address and legal-description null-rates are NOT measurable from the anonymous surface.** This audit
+establishes the *boundary* precisely and specifies the exact query that would answer it, rather than
+fabricating a number.
+
+## What the anonymous surface shows
+
+| Relevant layer | Table | Rows | Carries address/legal? |
+|----------------|-------|------|------------------------|
+| Canonical spine | `tf_parcel` | 84,418 | parcel identity; address/legal not exposed anonymously |
+| Raw property | `legacy_pacs_raw_property` | 818,836 | PACS property records (situs/legal live here) |
+| Raw supp assoc | `legacy_pacs_raw_prop_supp_assoc` | 3,231,679 | supplemental property associations |
+| Raw account | `legacy_pacs_raw_account` | 439,948 | account/owner-of-record (mailing address) |
+
+The doctrine/state endpoint returns **row counts only** — no column-level null statistics. Address
+(situs), mailing address, and legal description are PACS property/account columns that are not
+projected into any anonymously-readable aggregate.
+
+## Boundary probe
+
+- `/api/properties?countyId=benton` → **401**
+- `/api/properties/count` → **401**
+- `/api/parcels` → **401**
+
+All parcel/property data endpoints that would carry address/legal are **auth-gated**. Confirmed: the
+address/legal fields are not reachable without authentication.
+
+## Exact measurement that WOULD answer this (requires authorization)
+
+Column-level null-rate needs credentialed DB read (**SW-03**) or an authenticated properties endpoint.
+The query, for a future authorized WO:
+```sql
+SELECT
+  count(*)                                            AS parcels,
+  count(*) FILTER (WHERE situs_address IS NULL OR situs_address = '')  AS null_situs,
+  count(*) FILTER (WHERE legal_desc   IS NULL OR legal_desc   = '')    AS null_legal
+FROM canonical_tf.tf_parcel;   -- exact column names to be confirmed against the canonical schema
+```
+(Canonical column names for situs/legal are not confirmable from the anonymous surface; the raw
+source is `legacy_pacs_raw_property`.)
+
+## Interpretation (bounded)
+
+- The parcel spine is complete (84,418 canonical). Whether each parcel carries a non-null situs and
+  legal description is **unknown from here** and must not be asserted.
+- The large raw property/supp-assoc/account layers indicate the source columns exist upstream; the
+  question is projection completeness into canonical, which is credentialed.
+
+## Recommendation
+
+- Do **not** publish an address/legal completeness number until measured under authorization.
+- Promote this to a credentialed follow-up (bundled with the geometry/owner/improvement credentialed
+  passes). Non-blocking for the demo; property surfaces must disclose `unavailable` for missing
+  address/legal rather than blank-fill.
+
+**WO-DATA-BENTON-ADDR-001: COMPLETE (boundary established; value gap flagged, not fabricated).**

--- a/docs/data/WO_DATA_BENTON_GEOM_001_GEOMETRY_AVAILABILITY_AUDIT.md
+++ b/docs/data/WO_DATA_BENTON_GEOM_001_GEOMETRY_AVAILABILITY_AUDIT.md
@@ -1,0 +1,58 @@
+# WO-DATA-BENTON-GEOM-001 — Geometry Availability Audit
+
+**Program:** P2 — Benton Data Quality
+**Date:** 2026-07-01
+**Mode:** Read-only audit (R0). No mutation, no secrets, no deployment.
+**Source:** Live anonymous `GET /api/sync/doctrine/state` + `/api/sync/doctrine/lanes`
+(`app-terrafusion-benton-demo.azurewebsites.net`), snapshot `2026-07-01T16:59Z`.
+**Authority Boundary:** SW-02 not crossed (read-only). SW-03 not crossed (no credentials used).
+
+---
+
+## Finding (quantified)
+
+| Metric | Value |
+|--------|-------|
+| Canonical parcels (`tf_parcel`) | 84,418 |
+| Canonical parcel geometry (`tf_parcel_geom`) | 79,199 |
+| **Parcels WITHOUT canonical geometry** | **5,219 (6.18%)** |
+| Geometry coverage | **93.82%** |
+| Geometry quarantine | 0 |
+
+## Provenance
+
+Geometry does **not** come from the PACS raw/truth lanes — the `geometry` lane reports
+`truthCount: -1, rawCount: -1` (sentinel = not sourced from PACS). It is sourced from the **ArcGIS
+feature service** via `arcgis-feature-service` → `canonical-tf-arcgis-projector`, last completed
+`2026-06-28T09:57Z`, 79,199 rows extracted and promoted (1:1, no loss).
+
+## Interpretation
+
+- The 6.18% gap (5,219 parcels) is a **real coverage gap**, not a pipeline failure: quarantine is 0
+  and the projector promoted everything it extracted. The gap is upstream — the ArcGIS feature
+  service returned geometry for 79,199 of 84,418 parcels.
+- Likely causes (not verifiable from anonymous surface): parcels created in PACS but not yet in the
+  ArcGIS parcel layer, retired/split parcels, or non-spatial account records. Confirming the cause
+  requires joining `tf_parcel` to `tf_parcel_geom` (credentialed).
+
+## Boundary
+
+- `/api/geometry` → **401** (auth-gated). Geometry rows are not exposed anonymously; only the
+  aggregate count is (via doctrine/state).
+
+## Measurement Gap (honest limit)
+
+Cannot, from the anonymous surface, identify *which* 5,219 parcels lack geometry or *why*. That needs:
+```sql
+SELECT p.parcel_id FROM canonical_tf.tf_parcel p
+LEFT JOIN canonical_tf.tf_parcel_geom g ON g.parcel_id = p.parcel_id
+WHERE g.parcel_id IS NULL;
+```
+→ requires credentialed DB read (SW-03) or an authenticated parcel/geometry endpoint. Flagged, not fabricated.
+
+## Recommendation
+
+Track "geometry coverage = 93.82%" as a demo data-quality KPI. Not blocking for the demo (Atlas/map
+surfaces should disclose `unavailable` for the 5,219 without geometry, per the honesty contract).
+
+**WO-DATA-BENTON-GEOM-001: COMPLETE (read-only).**

--- a/docs/data/WO_DATA_BENTON_IMPR_LAND_001_IMPROVEMENTS_LAND_GAP_AUDIT.md
+++ b/docs/data/WO_DATA_BENTON_IMPR_LAND_001_IMPROVEMENTS_LAND_GAP_AUDIT.md
@@ -1,0 +1,66 @@
+# WO-DATA-BENTON-IMPR-LAND-001 — Improvements / Land Endpoint Gap Audit
+
+**Program:** P2 — Benton Data Quality
+**Date:** 2026-07-01
+**Mode:** Read-only audit (R0). No mutation, no secrets, no deployment.
+**Source:** Live anonymous `GET /api/sync/doctrine/state` + `/api/sync/doctrine/lanes`, snapshot `2026-07-01T16:59Z`.
+**Authority Boundary:** SW-02 not crossed (read-only). SW-03 not crossed (no credentials used).
+
+---
+
+## Improvement Lane — Layer Counts
+
+| Layer | Table | Rows |
+|-------|-------|------|
+| Raw | `legacy_pacs_raw_imprv` | 400,576 |
+| Raw detail | `legacy_pacs_raw_imprv_detail` | 1,351,892 |
+| Raw attr | `legacy_pacs_raw_imprv_attr` | 1,870,609 |
+| Truth | `truth_pacs_imprv_current` | 300,432 |
+| Canonical | `tf_improvement` | 100,144 |
+| Canonical feature | `tf_improvement_feature` | 1,351,892 |
+| Quarantine (current) | `legacy_tf_unproven_imprv_current` | 0 |
+| Quarantine (attr) | `legacy_tf_unproven_imprv_attr` | 1,872,866 |
+
+## Land Lane — Layer Counts
+
+| Layer | Table | Rows |
+|-------|-------|------|
+| Raw | `legacy_pacs_raw_land_detail` | 352,131 |
+| Truth | `truth_pacs_land_current` | 87,767 |
+| Canonical | `tf_land` | 87,767 |
+| Quarantine | `legacy_tf_unproven_land_current` | 0 |
+
+## Findings
+
+1. **Improvements canonical = 100,144** across 84,418 parcels → **avg 1.19 improvements per parcel**
+   (many parcels have >1 structure; vacant parcels have 0). `canonical-tf-imprv-projector`
+   (last `2026-06-22T12:09Z`) extracted and promoted 100,144 (1:1, clean).
+2. **Improvement features = 1,351,892** = exactly the raw `imprv_detail` count → **avg ~13.5 features
+   per improvement**. Feature layer passes through 1:1 from raw detail.
+3. **Improvement bodies are clean** (`imprv_current` quarantine = 0), but the **attribute layer has a
+   large 1,872,866-row unproven cohort** (`imprv_attr` quarantine > raw `imprv_attr` 1,870,609 —
+   the quarantine exceeds current raw, indicating accumulated unproven attribute rows across loads).
+   This is the top improvements data-quality question.
+4. **Land canonical = truth = 87,767**, quarantine 0 → **clean 1:1 truth→canonical**. Land segments
+   (87,767) exceed parcels (84,418) by **3,349** → some parcels carry multiple land segments (1.04
+   segments/parcel avg). Raw land detail 352,131 distills to 87,767 current (24.9%).
+
+## Boundary
+
+- `/api/improvements` → **401**; `/api/land` → **401** (both auth-gated). Rows not exposed anonymously.
+
+## Measurement Gaps (honest limits)
+
+Cannot, from the anonymous surface, compute: % parcels with ≥1 improvement, distribution of
+improvements/parcel, or classify the 1,872,866 quarantined improvement-attribute rows. Needs
+credentialed read (SW-03) or authenticated endpoints. Flagged, not fabricated.
+
+## Recommendation
+
+- Land lane is **clean** — no action.
+- The **1.87M-row improvement-attribute quarantine** is the largest single quarantine cohort in the
+  whole demo DB (bigger than the 2.05M total is dominated by it) and is the highest-value credentialed
+  follow-up. Non-blocking for the demo; improvement-attribute surfaces must disclose `unavailable`
+  for unproven attributes.
+
+**WO-DATA-BENTON-IMPR-LAND-001: COMPLETE (read-only).**

--- a/docs/data/WO_DATA_BENTON_OWNER_001_OWNER_BOUNDARY_AUDIT.md
+++ b/docs/data/WO_DATA_BENTON_OWNER_001_OWNER_BOUNDARY_AUDIT.md
@@ -1,0 +1,59 @@
+# WO-DATA-BENTON-OWNER-001 — Owner Endpoint / Data Boundary Audit
+
+**Program:** P2 — Benton Data Quality
+**Date:** 2026-07-01
+**Mode:** Read-only audit (R0). No mutation, no secrets, no deployment.
+**Source:** Live anonymous `GET /api/sync/doctrine/state` + `/api/sync/doctrine/lanes`, snapshot `2026-07-01T16:59Z`.
+**Authority Boundary:** SW-02 not crossed (read-only). SW-03 not crossed (no credentials used).
+
+---
+
+## Owner Lane — Layer Counts
+
+| Layer | Table | Rows |
+|-------|-------|------|
+| Raw | `legacy_pacs_raw_owner` | 8,568,960 |
+| Truth | `truth_pacs_owner_current` | 774,760 |
+| Canonical | `tf_owner` | 97,062 |
+| Quarantine | `legacy_tf_unproven_owner_current` | 87,909 |
+| Link | `tf_parcel_owner_link` | 686,851 |
+| WSDOR val (owner) | `tf_assessment_wsdor` / `truth_pacs_wash_prop_owner_val` | 686,820 / 774,729 |
+
+## Findings
+
+1. **Aggressive distillation raw → canonical.** 8.57M raw owner rows (full PACS ownership history)
+   → 774,760 truth → **97,062 canonical current owners**. The `canonical-tf-owner-projector`
+   (last `2026-06-21T20:54Z`) extracted 774,760 and promoted 97,062 — a **12.5% promotion rate**,
+   consistent with collapsing full history to current distinct owners.
+
+2. **Parcel↔owner links = 686,851** across 84,418 parcels → **avg 8.13 links per parcel**. This is
+   ownership *history* (grantor/grantee chains), not current-owner-only. Current ownership is the
+   97,062 `tf_owner` set.
+
+3. **Quarantine cohort = 87,909 unproven owner-current rows.** Notably close to the parcel count
+   (84,418) and the wsdor quarantine (87,909, identical). This is a **real boundary**: ~87.9k
+   owner-current records did not pass truth-gate promotion and are preserved (not deleted) in
+   quarantine. `wsdor` quarantine matching owner quarantine (both 87,909) suggests the same cohort
+   fails owner-value proof together.
+
+4. **WSDOR owner-value canonical 686,820 vs truth 774,729** → 87,909 gap = exactly the quarantine
+   cohort. Internally consistent.
+
+## Boundary
+
+- `/api/owners` → **401** (auth-gated). Owner rows not exposed anonymously.
+
+## Measurement Gap (honest limit)
+
+Cannot, from the anonymous surface, determine: null owner-name rate, % parcels with a resolvable
+current owner, or the nature of the 87,909 quarantined owner-current records. Needs credentialed
+read (SW-03) or an authenticated owner endpoint. Flagged, not fabricated.
+
+## Recommendation
+
+- Treat **97,062 current owners / 686,851 ownership links** as the demo owner truth.
+- The **87,909-row unproven owner-current quarantine** is the top owner data-quality question — worth
+  a dedicated (credentialed) follow-up to classify *why* they failed proof. Non-blocking for demo;
+  owner surfaces must disclose `unavailable` where a current owner is unresolved.
+
+**WO-DATA-BENTON-OWNER-001: COMPLETE (read-only).**


### PR DESCRIPTION
## Summary

Four R0 read-only data-quality audits run autonomously under `/goal benton-data-quality /loop program`. Source: the **live anonymous** doctrine surface (`/api/sync/doctrine/state` + `/lanes`) on the Benton demo. **No credentials, no mutation, no deployment.**

## Findings

- **GEOM-001** — geometry coverage **93.82%** (79,199 / 84,418); **5,219 parcels (6.18%) lack canonical geometry**; sourced from ArcGIS (not PACS); quarantine 0.
- **OWNER-001** — 97,062 current owners distilled from 8.57M raw (12.5% promotion); 686,851 ownership links (8.13/parcel); **87,909-row unproven owner-current quarantine** is the top owner question.
- **IMPR-LAND-001** — 100,144 improvements (1.19/parcel), 1.35M features; land clean (87,767 truth=canonical, quarantine 0); **1,872,866-row improvement-attribute quarantine** = largest cohort in the DB.
- **ADDR-001** — address/legal null-rate **not measurable anonymously** (all property endpoints 401). Boundary established + exact SQL flagged as a credentialed follow-up — **not fabricated**.

## Honesty

All domain data endpoints (properties/owners/improvements/land/geometry) return **401**. Every column-level metric that needs credentials is flagged as an SW-03 follow-up, never faked. No stub counts, no stale 89,247.

## Walls

SW-02 (mutation) not crossed — read-only. SW-03 (secrets) not crossed — no credentials used. DUPE-001B remains parked at SW-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)