### PR TITLE
docs(terrapilot): WO-TERRAPILOT-P2..P6 — promotion protocol + maturity audit

### DIFF
--- a/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
+++ b/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
@@ -1,0 +1,114 @@
+# TerraPilot Tool Promotion Protocol
+
+**WO:** WO-TERRAPILOT-P2
+**Program:** P5 — TerraPilot Tool Maturity
+**Date:** 2026-07-01
+**Authority:** Operator Doctrine — the formal L0→L4 promotion gate
+**Classification:** Protocol (docs). No runtime change, no tool promoted by this document.
+
+---
+
+## 0. Purpose
+
+Prevent "manifest green" from being mistaken for live capability. A tool that is manifest-registered
+but not backend-integrated is **not** a working tool. This protocol defines the required evidence,
+review, and approval to move a TerraPilot tool up the maturity ladder — and the disclosure rule that
+holds until a tool is genuinely live.
+
+---
+
+## 1. The Maturity Ladder (canonical)
+
+| Level | Label | Definition | Disclosure required in UI/docs |
+|-------|-------|------------|-------------------------------|
+| **L0** | Declared | In manifest/registry only; **no handler** | "not available" |
+| **L1** | Runnable | Handler exists but returns stub/canned/empty; **no backend integration** | "not yet integrated (stub)" |
+| **L2** | Contract-covered | Handler + schema/contract + integration spec written; still stub data | "contract-covered, not live" |
+| **L3** | Live-integrated | Handler calls a **real backend/API** returning **real data**; trace emitted | "live" (source badge) |
+| **L4** | Promoted | L3 + tests + evidence doc + **operator approval** | "live, approved" |
+
+**Rule:** a tool below L3 must be disclosed as not-live in every UI surface and operator-facing doc.
+Green contract coverage (L2) is **not** live capability.
+
+---
+
+## 2. Promotion Gates (evidence required to advance)
+
+### L0 → L1 (Declared → Runnable)
+- A handler is registered in the tool dispatcher (toolId → handler) and returns a **well-formed,
+  honestly-labeled stub** (`source:"stub"`, no fabricated domain data).
+- Evidence: handler file:line; a probe showing the stub response with `source:"stub"`.
+
+### L1 → L2 (Runnable → Contract-covered)
+- Request/response **schema** defined and validated; an **integration spec** documents the real
+  backend endpoint/service the handler will call and the data mapping.
+- A **contract test** asserts the schema and the stub-disclosure (badge/`source` field).
+- Evidence: schema location; spec doc; passing contract test.
+
+### L2 → L3 (Contract-covered → Live-integrated) — **the real bar**
+- Handler calls a **real** service/DbContext/API (not a stub) and returns **real data**.
+- The response carries a **live** source marker (not `stub`), and a **trace event** is emitted
+  (immutable, correlation-id).
+- Verified by a **live probe** (or authenticated live test) showing real data, and by the
+  handler no longer returning the stub branch.
+- **This step changes runtime behavior → crosses SW-09** and, if it wires a new backend/LLM,
+  **SW-08/SW-10**. It requires explicit operator authorization (it is not a docs WO).
+- Evidence: live probe output with real data; trace event; handler diff removing the stub path.
+
+### L3 → L4 (Live-integrated → Promoted)
+- L3 evidence **plus**: unit/contract/e2e tests green; an **evidence rollup doc**; and **operator
+  approval** recorded (named approver, date, WO id).
+- Only at L4 may a demo/doc present the tool as a working assistant.
+
+---
+
+## 3. Review Step
+
+Each promotion PR must:
+1. Cite the current level and the target level.
+2. Attach the evidence listed in §2 for the target gate.
+3. For L2→L3 and above: name the stop wall(s) crossed (SW-08/09/10) and the authorization reference.
+4. Pass the honesty contract (no fabricated data; stub disclosed until L3; source badge correct).
+
+A tool may not skip levels. L2→L3 may not be self-approved by the executing agent — it is an
+operator authority wall.
+
+---
+
+## 4. Disclosure Rule (in force now)
+
+Until WO-TERRAPILOT-P5 produces a genuine **L3** tool:
+- TerraPilot is disclosed as **"tool layer in development"** in all demo scripts and docs.
+- No demo presents TerraPilot as a working AI assistant.
+- The deployed pilot surface already models this correctly: `/api/pilot/health` returns
+  `{"status":"degraded","runtimeOnline":false,"message":"Pilot runtime offline — using .NET fallback
+  stubs"}`; `/api/pilot/tools` and `/api/pilot/traces` return `source:"stub"`, `runtimeOnline:false`.
+  **This honest degraded disclosure is the target behavior for all L0/L1 tools — preserve it.**
+
+---
+
+## 5. Stop Walls In This Program
+
+| Wall | Where |
+|------|-------|
+| SW-09 runtime behavior | any L2→L3 promotion (handler starts returning real data) |
+| SW-08 external integration | wiring a new backend/LLM/service for a tool |
+| SW-10 auth/security | if a tool requires new auth scope or exposes protected data |
+| SW-03 secrets | if integration needs credentials (LLM keys, DB) |
+
+WO-TERRAPILOT-P3/P4/P6 (handler parity, stub disclosure, evidence rollup) are **read-only/docs (R0/R1)**
+and cross no wall. **P5 is a candidate *review*** (read-only) — the actual L2→L3 promotion it
+recommends is a separate, operator-authorized WO.
+
+---
+
+## 6. Change Log
+
+| Date | Change | WO |
+|------|--------|----|
+| 2026-07-01 | Protocol authored | WO-TERRAPILOT-P2 |
+
+---
+
+**WO-TERRAPILOT-P2: COMPLETE.** Enables P3 (handler parity), P4 (stub disclosure), P5 (candidate
+review), P6 (rollup).

--- a/docs/data/WO_TERRAPILOT_P3_P6_MATURITY_AUDIT.md
+++ b/docs/data/WO_TERRAPILOT_P3_P6_MATURITY_AUDIT.md
@@ -1,0 +1,162 @@
+# WO-TERRAPILOT-P3..P6 — Tool Maturity Audit (Evidence Packet)
+
+**Program:** P5 — TerraPilot Tool Maturity
+**Date:** 2026-07-01
+**Mode:** Read-only (R0). No code change, no tool promoted, no runtime change, no secrets, no deployment.
+**Sources:** `main` source (`tools/registry/terrapilot.tools.json`, `os-platform/core/pilot/*`) +
+live anonymous probes of the deployed demo (`2026-07-01`).
+**Ladder:** L0 Declared · L1 Runnable(stub) · L2 Contract-covered · L3 Live-integrated · L4 Promoted
+(see [terrapilot-promotion-protocol.md](../brain/workorders/programs/terrapilot-promotion-protocol.md), WO-P2).
+
+---
+
+## WO-TERRAPILOT-P3 — Handler Parity Audit
+
+**Verified counts** (`registerHandler` cross-referenced against declared toolIds):
+
+| Metric | Count | Source |
+|--------|-------|--------|
+| Declared tools | **117** | `tools/registry/terrapilot.tools.json` (v2.0.0) |
+| Stub handler registrations | 80 | `os-platform/core/pilot/handlers.ts` |
+| Real handler registrations | 54 | `os-platform/core/pilot/handlers.real.ts` (55 `backendGet/Post/Put` markers) |
+| **Union handled** | **117** | stub ∪ real |
+| **L0 orphans (declared, no handler)** | **0** | — |
+| **L3-capable in code** (real handler, matches declared id) | **54** | 0 real handlers unmatched |
+| **L1 stub-only** | **63** | declared − real |
+
+**Findings:**
+- **Handler parity is 100%** — every declared tool has at least a stub handler. No L0 orphans. (This
+  corrects a casual "45% coverage" read: coverage of *real* handlers is 54/117 (46%), but *handler
+  parity* is 117/117.)
+- **54 tools (46%) are L3-capable in code** — `handlers.real.ts` calls real backends (CostForge,
+  Levy, Properties, Dossier, PILT) via `backendGet/Post/Put` + `acquirePilotToken`, overriding the
+  stub at startup.
+- **63 tools (54%) are L1 stub-only** — canned/deterministic responses, no backend call.
+
+**Risk distribution (manifest):** read_only 74 · write_low 31 · write_high 11 · irreversible 1.
+**Muse/LLM-mode tools:** 27.
+
+---
+
+## WO-TERRAPILOT-P4 — Stub Disclosure Diagnostics
+
+### Endpoint-level disclosure — EXEMPLARY ✅ (deployed demo probes)
+| Endpoint | Response | Honest? |
+|----------|----------|---------|
+| `/api/pilot/health` | `{"status":"degraded","runtimeOnline":false,"message":"Pilot runtime offline — using .NET fallback stubs"}` | ✅ explicit |
+| `/api/pilot/tools` | `{"tools":[],"source":"stub","runtimeOnline":false}` | ✅ |
+| `/api/pilot/traces` | `{"events":[],"total":0,"source":"stub","runtimeOnline":false}` | ✅ |
+| `/api/pilot/manifest` | 401 (auth-gated) | — |
+
+The deployed pilot surface **discloses its stub/offline state on every endpoint** rather than faking
+tools or data. This is the target behavior the promotion protocol §4 says to preserve.
+
+### The deeper truth — deployed-live count is ZERO
+`runtimeOnline:false` means the **Node pilot runtime (port 4317) is not deployed**; the .NET API
+serves fallback stubs. Therefore **none of the 54 L3-capable handlers is reachable on the demo** —
+they live in the un-deployed Node runtime. **Deployed-live tools = 0.** "Real handler in code" ≠
+"deployed-live" — this is the maturity guard one level deeper than "manifest green ≠ live."
+
+### Per-tool payload disclosure — INCONSISTENT ⚠️
+Endpoint-level disclosure is honest, but individual stub handler payloads in `handlers.ts` are
+uneven: some carry a stub marker (e.g. `source: 'WA DOR ... stub'` ~line 1164), others return
+canned domain text with **no per-payload `source:"stub"`** (e.g. `summarizeDossierHandler` returns a
+summary + `payloadRef` with no stub flag). A caller reading only the payload could miss that it is
+stubbed. **Recommendation:** every stub handler payload should carry a `source:"stub"` /
+`runtimeOnline:false` marker, matching the endpoint envelope.
+
+---
+
+## WO-TERRAPILOT-P5 — First Real Backend-Integrated Tool Candidate Review (read-only)
+
+**Goal:** identify the single best candidate to promote L2→L3 first — **review only; no promotion**
+(actual promotion crosses SW-09/SW-10/SW-01 and needs authorization).
+
+**Selection criteria:** `read_only` (no write-lane risk), calls a **stable, already-existing** backend
+endpoint, low PII, small blast radius.
+
+**Candidates (from the 54 L3-capable, read_only):**
+| Tool | Backend call | Notes |
+|------|--------------|-------|
+| `summarize_levy_rate_components` | `POST /api/levy-calculation/calculate-rate` | read_only; Levy math |
+| `explain_model_results` | `GET /api/costforge/{parcelId}/breakdown` | read_only; CostForge |
+| `compare_assessed_value_history` | `GET /api/properties/{parcelId}` | read_only; property history |
+| `summarize_parcel_casefile` | `GET /api/dossier/parcels/{parcelId}/casefile` | read_only; dossier |
+| `calculate_pilt_payment` | `GET /api/pilt/districts` | read_only; PILT |
+
+**Recommendation:** **`explain_model_results`** (or `summarize_levy_rate_components`) as the first
+L3 — read_only, single GET, no mutation, self-contained CostForge/Levy data. **Blockers to L3-on-demo
+(each a separate authorized WO):**
+- Node pilot runtime not deployed → deploy it **or** port the one handler to the .NET API (**SW-01/SW-09**)
+- Its backend endpoint (`/api/costforge/*`) is **401** on the demo → needs the auth/session decision (**SW-10**)
+- If Muse/LLM narration is included, `ANTHROPIC_API_KEY` is required (**SW-03**) — pick a **non-Muse**
+  read_only tool for the first L3 to avoid the LLM dependency.
+
+**This WO promotes nothing.** It recommends the candidate and names the walls.
+
+---
+
+## WO-TERRAPILOT-P6 — Tool Promotion Evidence Rollup
+
+### Verified maturity state (per the L0–L4 ladder)
+| Level | Definition | Count | Basis |
+|-------|-----------|-------|-------|
+| L0 Declared (no handler) | manifest only | **0** | 100% parity |
+| L1 Runnable (stub) | stub handler, no backend | **63** in code; **117 effective on demo** | runtime offline → all served as stubs |
+| L2 Contract-covered | schema + spec | (all 117 schema-covered via `terrapilot.tools.schema.json`; per-tool integration specs not individually verified) | — |
+| L3 Live-integrated | real handler returning real data | **54 in code · 0 deployed-live** | Node runtime offline on demo |
+| L4 Promoted | L3 + tests + operator approval | **0** | — |
+
+### Verdict (against the program's stop condition)
+The program says: *"If P1 finds 0 tools at L2+, treat TerraPilot as alpha/stub."* Here **54 tools are
+L3-capable in code**, so TerraPilot is beyond alpha in the codebase — but **0 tools are deployed-live**,
+so on the running demo TerraPilot is a **stub layer**. Per the **disclosure rule** (protocol §4),
+TerraPilot must still be disclosed as **"tool layer in development"** until at least one tool is
+**deployed-live (L3 on the running runtime)** with evidence — which has not happened.
+
+### Two maturity vocabularies (reconcile — doc-vs-doc gap)
+1. **Program ladder** L0–L4 (per-tool) — used here.
+2. **`tools/registry/autonomy-viewer`** IMM5 (Initial→Developing→Defined→Managed→Optimizing) —
+   system-level CMM, not per-tool.
+These are different axes. Recommend a short note in the autonomy-viewer model pointing to the L0–L4
+per-tool ladder as the canonical **tool** maturity vocabulary (a future docs WO).
+
+### Rollup findings
+- 117 declared · 100% handler parity · 54 L3-capable-in-code · **0 deployed-live** · 0 L4.
+- Endpoint-level stub disclosure is exemplary; per-tool payload disclosure is inconsistent (P4).
+- First-L3 candidate: `explain_model_results` (read_only), blocked by SW-01/09/10 (P5).
+- TerraPilot correctly remains "in development" per the disclosure rule.
+
+---
+
+## Stop Walls Respected
+
+| Wall | Status |
+|------|--------|
+| SW-01 deployment | not crossed (read-only) |
+| SW-02 data mutation | not crossed |
+| SW-03 secrets | not crossed (no LLM key handled) |
+| SW-08 external integration | not crossed |
+| SW-09 runtime behavior | not crossed (no tool promoted) |
+| SW-10 auth/security | not crossed |
+
+**No tool promoted stub→live.** P5 is review-only; the L2→L3 promotion it recommends is a separate,
+operator-authorized WO.
+
+---
+
+## Evidence Log
+
+- Manifest: `tools/registry/terrapilot.tools.json` (117 tools, v2.0.0), `terrapilot.tools.schema.json`
+- Handlers: `os-platform/core/pilot/handlers.ts` (80 stub regs), `handlers.real.ts` (54 real regs, 55 backend calls)
+- Dispatch/governance: `os-platform/core/pilot/ToolRunner.ts` (write-lane/risk/county-isolation gates), `PilotController.ts`
+- Maturity model: `tools/registry/autonomy-viewer` (IMM5, system-level)
+- LLM: `os-platform/core/pilot/local-agent/{claudeAdapter,localOpsProvider,modelAdapter}.ts` (gated by ANTHROPIC_API_KEY)
+- Deployed probes (anon): `/api/pilot/{health,tools,traces}` all `runtimeOnline:false`/`source:"stub"`; `/api/pilot/manifest` 401
+- Verified counts: declared 117; parity 117/117 (L0=0); real 54; stub-only 63; muse 27; risk 74/31/11/1
+
+---
+
+**WO-TERRAPILOT-P3..P6: COMPLETE (read-only).** R0/docs queue for this program exhausted. The next
+step — promoting the first tool to **deployed-live L3** — crosses SW-01/SW-09/SW-10 and requires
+explicit operator authorization (per WO-P2 §2 L2→L3 gate).


### PR DESCRIPTION
## Summary

`terrapilot-maturity` under `/loop program` — read-only/docs. **No tool promoted stub→live.** Runs P2 (protocol) + P3–P6 (audit).

## P2 — Promotion Protocol (canonical)

`docs/brain/workorders/programs/terrapilot-promotion-protocol.md` — the L0→L4 ladder, per-gate evidence requirements, the **L2→L3 operator-authority wall** (real integration = SW-08/09/10), and the disclosure rule for sub-L3 tools.

## P3–P6 — Maturity Audit (verified counts)

- **117 declared** tools; **100% handler parity** (0 L0 orphans — union of 80 stub + 54 real registrations = 117).
- **54 L3-capable in code** (`handlers.real.ts` real backend calls); **63 L1 stub-only**; 27 muse/LLM; risk 74/31/11/1.
- **Deployed-live = 0** — the Node pilot runtime is offline on the demo (`/api/pilot/health` = *"using .NET fallback stubs"*, `runtimeOnline:false`), so the 54 real handlers are unreachable. **"Real handler in code" ≠ "deployed-live."**
- **Stub disclosure:** endpoint-level **exemplary** (health/tools/traces all `runtimeOnline:false`); per-tool payload disclosure **inconsistent** (some stubs omit a `source:"stub"` marker).
- **P5 first-L3 candidate:** `explain_model_results` (read_only) — blocked by SW-01/09/10 (runtime not deployed, endpoint auth-gated).
- Two maturity vocabularies (program L0–L4 vs autonomy-viewer IMM5) — flagged to reconcile.
- **Verdict:** 54 L3-capable in code but **0 deployed-live** → TerraPilot correctly stays "tool layer in development."

## Walls

SW-01/02/03/08/09/10 not crossed. P5 is review-only.

See `docs/data/WO_TERRAPILOT_P3_P6_MATURITY_AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)