### PR TITLE
fix(health): WO-BACKEND-005 — Git SHA / build-provenance truth

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/SimpleHealthController.cs
+++ b/backend/src/TerraFusion.API/Controllers/SimpleHealthController.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,16 +25,18 @@ public class SimpleHealthController : ControllerBase
     {
         _logger.LogInformation("Simple health check requested");
 
-        // Prometheus PR-9 / HIGH #32: expose immutable artifact identity.
-        // TF_GIT_SHA is stamped at docker build time via --build-arg GIT_SHA;
-        // when running outside a container (or built without the arg) the
-        // env var is unset and we return "unknown" so the response shape is
-        // stable for clients.
-        var gitSha = Environment.GetEnvironmentVariable("TF_GIT_SHA");
-        if (string.IsNullOrWhiteSpace(gitSha))
-        {
-            gitSha = "unknown";
-        }
+        // Prometheus PR-9 / HIGH #32 + WO-BACKEND-005: expose immutable artifact
+        // identity. Resolved from the env var (docker --build-arg GIT_SHA) OR the
+        // commit stamped into the assembly at build time (SourceRevisionId, set
+        // from GITHUB_SHA in CI), so a non-docker (zip) deploy is no longer stuck
+        // reporting "unknown". Falls back to "unknown" only when neither exists.
+        var informationalVersion = Assembly
+            .GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        var gitSha = ResolveGitSha(
+            Environment.GetEnvironmentVariable("TF_GIT_SHA"),
+            informationalVersion);
 
         return Ok(new
         {
@@ -81,5 +84,38 @@ public class SimpleHealthController : ControllerBase
             Status = "Live",
             Timestamp = DateTime.UtcNow
         });
+    }
+
+    /// <summary>
+    /// Resolves the deployed commit for the /health <c>gitSha</c> field, in
+    /// priority order (WO-BACKEND-005):
+    /// <list type="number">
+    ///   <item><description><c>TF_GIT_SHA</c> env var (docker --build-arg GIT_SHA).</description></item>
+    ///   <item><description>the commit stamped into the assembly
+    ///     InformationalVersion at build time — the SDK appends
+    ///     "+&lt;sha&gt;" when <c>SourceRevisionId</c> is set (CI sets it from
+    ///     GITHUB_SHA), so a zip/non-docker deploy still carries its commit.</description></item>
+    ///   <item><description>the literal "unknown" when neither is available.</description></item>
+    /// </list>
+    /// Pure and static so it is deterministically unit-testable without an
+    /// ambient assembly or environment.
+    /// </summary>
+    public static string ResolveGitSha(string? envSha, string? informationalVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(envSha))
+        {
+            return envSha;
+        }
+
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            var plusIndex = informationalVersion.IndexOf('+');
+            if (plusIndex >= 0 && plusIndex < informationalVersion.Length - 1)
+            {
+                return informationalVersion[(plusIndex + 1)..];
+            }
+        }
+
+        return "unknown";
     }
 }

--- a/backend/src/TerraFusion.API/TerraFusion.API.csproj
+++ b/backend/src/TerraFusion.API/TerraFusion.API.csproj
@@ -8,6 +8,16 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <!--
+      WO-BACKEND-005 (build provenance / Git SHA truth): when the build
+      environment provides the commit (GitHub Actions sets GITHUB_SHA), bake it
+      into the assembly InformationalVersion — the SDK appends "+<sha>" when
+      SourceRevisionId is set. No git exec at build time, so no Warning-Gate
+      fragility. When unset (some local builds) InformationalVersion carries no
+      "+sha" and /health honestly reports gitSha="unknown". Read back at runtime
+      by SimpleHealthController.ResolveGitSha().
+    -->
+    <SourceRevisionId Condition="'$(SourceRevisionId)' == '' and '$(GITHUB_SHA)' != ''">$(GITHUB_SHA)</SourceRevisionId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetWatchBuild)' == 'true'">

--- a/backend/tests/TerraFusion.Unit.Tests/Controllers/SimpleHealthControllerGitShaTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Controllers/SimpleHealthControllerGitShaTests.cs
@@ -60,9 +60,14 @@ public sealed class SimpleHealthControllerGitShaTests
                 "PR-9 contract: /health response MUST carry a gitSha field even when the env var is unset");
 
             var gitShaValue = gitShaProperty!.GetValue(payload) as string;
-            gitShaValue.Should().Be(
-                "unknown",
-                "when TF_GIT_SHA is not set the field MUST fall back to the literal string \"unknown\" so clients can detect a non-tagged build");
+            // WO-BACKEND-005: when TF_GIT_SHA is unset the field is now resolved
+            // from the build-stamped assembly InformationalVersion (CI sets
+            // SourceRevisionId from GITHUB_SHA → a real sha; a plain local build
+            // with no stamp → "unknown"). Either way the field MUST be populated
+            // and non-empty. Deterministic sha/"unknown" branch selection is
+            // covered by ResolveGitSha_* below.
+            gitShaValue.Should().NotBeNullOrWhiteSpace(
+                "the /health gitSha field MUST always be populated — a build-stamped commit or the literal \"unknown\", never blank");
         }
         finally
         {
@@ -123,6 +128,24 @@ public sealed class SimpleHealthControllerGitShaTests
             "PR-9 is additive — the existing Status field MUST still be present");
 
         statusProperty!.GetValue(payload).Should().Be("Healthy");
+    }
+
+    // WO-BACKEND-005: deterministic coverage of the gitSha resolution priority
+    // (env → build-stamped InformationalVersion "+<sha>" → "unknown"), without
+    // depending on the ambient assembly version or process environment.
+    [Theory]
+    [InlineData("abc1234", null, "abc1234")]              // env wins when set
+    [InlineData("abc1234", "1.0.0+def5678", "abc1234")]   // env wins over the build stamp
+    [InlineData(null, "1.0.0+def5678", "def5678")]        // stamp used when env unset
+    [InlineData("", "1.0.0+def5678", "def5678")]          // blank env → stamp
+    [InlineData(null, "1.0.0", "unknown")]                // no stamp → unknown
+    [InlineData(null, null, "unknown")]                   // nothing → unknown
+    [InlineData("   ", "   ", "unknown")]                 // whitespace only → unknown
+    public void ResolveGitSha_ResolvesInPriorityOrder(string? envSha, string? informationalVersion, string expected)
+    {
+        SimpleHealthController.ResolveGitSha(envSha, informationalVersion)
+            .Should()
+            .Be(expected);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

SW-09 authorized. Done from a **fresh, clean, buildable main-based worktree** (WO-OPS-WORKTREE-001) with a trustworthy local verify loop. Fixes [BACKEND-001](docs/data/WO_BACKEND_001_RUNTIME_REALITY_AUDIT.md) finding **F5**: a non-docker (zip) deploy reported `gitSha: "unknown"` because only the docker `--build-arg` path set `TF_GIT_SHA`.

## Change

- **`TerraFusion.API.csproj`** — set `SourceRevisionId` from `GITHUB_SHA` when present → the SDK bakes the commit into `InformationalVersion` (`1.0.0+<sha>`). **No git exec at build → no Warning-Gate fragility;** when unset, no `+sha` (honest "unknown").
- **`SimpleHealthController`** — new pure/static `ResolveGitSha(env, informationalVersion)` (env → build-stamped `+sha` → `"unknown"`); `Get()` reads the assembly `InformationalVersion` as the fallback source.
- **Contract evolved** — the existing "env-unset → unknown" test now allows a build-stamped sha OR "unknown" (CI-deterministic via `NotBeNullOrWhiteSpace`), plus **7 deterministic `ResolveGitSha` cases**.

## Verified locally (clean worktree)

- `/warnaserror` **full-solution build: 0 errors**
- gitsha tests: **11/11 pass** (4 existing + 7 new)
- **End-to-end stamp proven:** `GITHUB_SHA=abcdef…` → generated `AssemblyInformationalVersionAttribute("1.0.0+abcdef…")`

## Scope

Health/provenance truth only. **No deploy, no data mutation, no secrets, no auth policy.** Diff is exactly **3 files** (verified vs main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `/health` response so the Git SHA is more reliably populated, even when the environment variable is missing or blank.
  * Added fallback detection from build metadata, with a clear priority order: environment value first, build-stamped value next, then `"unknown"`.

* **Tests**
  * Expanded coverage for Git SHA resolution across multiple input combinations to ensure consistent health output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->