### PR TITLE
docs(backend): WO-BACKEND-007/008 — release gate + operational runbook

### DIFF
--- a/docs/data/WO_BACKEND_007_RELEASE_GATE_DEFINITION.md
+++ b/docs/data/WO_BACKEND_007_RELEASE_GATE_DEFINITION.md
@@ -1,0 +1,93 @@
+# WO-BACKEND-007 — Release Gate Definition
+
+**Program:** P3 — Backend Operational Excellence
+**Date:** 2026-07-02
+**Mode:** Docs synthesis (R1). No code, no runtime change, no deployment.
+**Sources:** Observed CI checks (this session's PRs) + `.github/workflows/*` + BACKEND-001..006 findings.
+**Authority Boundary:** SW-01/02/03/09/10 not crossed.
+
+---
+
+## 0. Purpose
+
+Define what "release-ready" means for `TerraFusion.API`, grounded in the gates that actually run and
+the runtime-truth criteria established by BACKEND-001..006. This is the **standard a backend change
+must clear** before it reaches the demo (and, later, a county). Synthesis only — it does not change
+any gate.
+
+---
+
+## 1. Gates That Actually Run (observed on this session's PRs)
+
+These are **required** status checks on `main` (block auto-merge until green):
+
+| Gate | Enforces |
+|------|----------|
+| **Warning Gate (0 warnings tolerance)** | `dotnet build TerraFusion.sln -c Release /warnaserror` → **0 emitted warnings** (`ci.yml:256`) |
+| **Backend Gate (.NET 8) / Canonical .NET Test Run** | full backend build + `TerraFusion.API.Tests` |
+| **⚙️ Backend Fast Gate** | restore + `/warnaserror` build + **unit tests incl. `TerraFusion.Unit.Tests`** (catches breaks the canonical gate misses — proven by the BACKEND-004 recovery) |
+| **Quality Gate Validation** | quality checks |
+| **Canon Gates** | canonical spine / constitution checks |
+| **Drift Guard (dotnet canonical)** · **Snyk Drift Guard** | dependency/CVE drift |
+| **Migration Apply Check** | EF migrations apply cleanly |
+| **Evidence Gate (r1:verify-evidence)** | evidence artifacts present |
+| **🔒 SEAL / 🔒 TerraFusion Seal Gate** | aggregate enforcement (fails if any sub-gate fails) |
+| **required_conversation_resolution** (branch protection) | all bot review threads resolved |
+
+**Non-blocking / informational:** CodeQL, Trivy (NEUTRAL), Frontend gates (skipped for backend-only PRs).
+
+---
+
+## 2. Runtime-Truth Criteria (from BACKEND-001..006)
+
+Beyond "it builds and tests pass," a backend release must be **honest about its runtime**. The audits
+established these criteria:
+
+| Criterion | Source | Release bar |
+|-----------|--------|-------------|
+| Health surfaces do not contradict | BACKEND-001 F1-F3 | `/health/ready` gates on real init (200 Ready / 503 NotReady) — **met (BACKEND-004)** |
+| Degraded state is reported honestly | BACKEND-001 | `/api/system/health` returns real `Degraded` (not faked Healthy) — **met** |
+| Build provenance is present | BACKEND-001 F5 | `/health` `gitSha` is a real commit when built in CI — **met (BACKEND-005)**: `GITHUB_SHA`→`InformationalVersion` |
+| 0 emitted warnings | BACKEND-002 | `/warnaserror` gate green — **met** |
+| Config truth (no misleading proofs) | BACKEND-001 F4 | `/ops/pacs/proof` should reflect the actual DB, not the dev SQLite — **OPEN** (parked WO) |
+| Auth is deny-by-default + no prod bypass | BACKEND-006 | FallbackPolicy=RequireAuthenticatedUser; dev-token `IsDevelopment()`-gated; prod secret env-driven — **met (proven)** |
+| Service topology is honest | BACKEND-003 | `/api/service-registry` should not imply an absent multi-service topology — **OPEN** (single-service demo; low priority) |
+
+---
+
+## 3. The Release Gate (definition)
+
+A backend change is **release-ready to the demo** when ALL hold:
+
+1. **All required CI gates green** (§1) — including the Fast Gate (unit tests) and Warning Gate.
+2. **Runtime-truth criteria met or explicitly waived** (§2) — no NEW health/provenance/auth regression.
+3. **Diff is intended-files-only** — verified via `git show --stat` + `gh api compare` (post-incident discipline).
+4. **Honest disclosure** — no fabricated metrics, no stale counts (`84,418` parcels, not `89,247`); degraded/unavailable states surfaced.
+5. **No unauthorized wall crossing** — SW-01 (deploy), SW-02 (mutation), SW-03 (secrets), SW-09 (runtime), SW-10 (auth) only with explicit authorization.
+
+**Promotion beyond the demo (county go-live) is SW-04** and out of scope for this gate.
+
+---
+
+## 4. Known Open Gates (not blockers for the demo; each a future WO)
+
+| Open item | Criterion | WO |
+|-----------|-----------|----|
+| `/ops/pacs/proof` reports dev SQLite (`terrafusion-dev.db`), not the Azure PG | Config truth (F4) | backend config-truth WO |
+| `CanonicalDebugController` `[AllowAnonymous]` on mutation endpoints | Auth defense-in-depth | WO-BACKEND-SEC-DEBUG-001 (operator decision) |
+| `/api/service-registry` empty / implies absent topology | Topology honesty (F1/F3 of BACKEND-003) | backend config WO |
+| App Service health-check-path points at shallow `/health` | Liveness truth (F1) | deploy WO (SW-01) — point at `/health/ready` |
+| LDAP/AD production integration stubbed (fail-closed) | Auth completeness | separate WO |
+
+---
+
+## 5. Recommendation
+
+Adopt §3 as the written **backend release gate** and reference it from the operational runbook
+(BACKEND-008). The CI gates already enforce §1; §2/§3 add the runtime-truth + honesty + intended-diff
+discipline this session proved necessary (two CI breaks were caught by §1's Fast Gate + §3's
+intended-diff check).
+
+---
+
+**WO-BACKEND-007: COMPLETE (definition).** Pairs with WO-BACKEND-008 (operational runbook).

--- a/docs/data/WO_BACKEND_008_OPERATIONAL_RUNBOOK.md
+++ b/docs/data/WO_BACKEND_008_OPERATIONAL_RUNBOOK.md
@@ -1,0 +1,93 @@
+# WO-BACKEND-008 — Backend Operational Runbook
+
+**Program:** P3 — Backend Operational Excellence
+**Date:** 2026-07-02
+**Mode:** Docs synthesis (R1). No code, no runtime change, no deployment.
+**Audience:** The operator running / demoing / debugging the TerraFusion.API backend.
+**Sources:** BACKEND-001..007 + live demo (`app-terrafusion-benton-demo.azurewebsites.net`).
+
+---
+
+## 0. What this is
+
+A single operator-facing guide to "is the backend healthy, and what do its signals mean." It
+consolidates the runtime truth established by BACKEND-001..006 so a curl check is enough to know the
+real state — no operator memory required.
+
+---
+
+## 1. Health & Readiness — endpoints and what they mean
+
+| Endpoint | Anonymous? | Healthy response | What it tells you |
+|----------|-----------|------------------|-------------------|
+| `GET /health` | yes | `{"status":"Healthy","service":"...Basic Mode","gitSha":"<sha>"}` | Process is up + **build provenance** (gitSha; real commit when CI-built — BACKEND-005). NOT a deep health check. |
+| `GET /health/ready` | yes | **200** `{"status":"Ready",...}` OR **503** `{"status":"NotReady","message":"initializing"}` | **Readiness truth (BACKEND-004):** 200 only once the host has started; 503 while initializing. Use this for load-balancer/orchestrator readiness, not `/health`. |
+| `GET /health/live` | yes | `{"status":"Live"}` | Liveness — the process is responding. |
+| `GET /api/system/health` | yes | `{"status":"Degraded"\|"Healthy","systemComponents":{...}}` | **Honest component health.** On the demo it reports `Degraded` because `ModuleLoader:false` (modules dir absent on Azure — expected posture, not an error). |
+| `GET /api/sync/doctrine/state` | yes | canonical/truth/raw/quarantine counts + `operational` | **The trustworthy data-truth surface.** `tf_parcel: 84,418` (84,388 active + 30 known dupes), `tf_sale: 90,386`. |
+| `GET /ops/pacs/proof` | yes | contract proof | ⚠️ **Reads the dev SQLite (`terrafusion-dev.db`), not the Azure PG** (BACKEND-001 F4) — do NOT treat its "reachable" as proof of the real DB until fixed. |
+| `GET /healthz`, `/healthz/proof`, `/api/health/detailed`, `/api/monitoring/*` | **no (401)** | — | Auth-gated; not for anonymous monitoring on the demo. |
+
+**Quick operator check:**
+```bash
+curl -s https://app-terrafusion-benton-demo.azurewebsites.net/health          # up + gitSha
+curl -s https://app-terrafusion-benton-demo.azurewebsites.net/health/ready     # 200 ready / 503 initializing
+curl -s https://app-terrafusion-benton-demo.azurewebsites.net/api/system/health         # Degraded? which component?
+curl -s https://app-terrafusion-benton-demo.azurewebsites.net/api/sync/doctrine/state    # real data counts
+```
+
+## 2. Reading the signals
+
+- **`/health` says Healthy but `/api/system/health` says Degraded** — expected. `/health` is a shallow
+  liveness/"Basic Mode" check; `/api/system/health` is the honest component view. `Degraded` +
+  `ModuleLoader:false` on the demo = modules intentionally not deployed (API-only demo), not a fault.
+- **`gitSha: "unknown"`** — the running binary was NOT built with a commit stamp (no `TF_GIT_SHA` and
+  no `GITHUB_SHA` at build). A CI-built binary carries a real sha (BACKEND-005). If you see "unknown"
+  on a deployed build, the deploy didn't come from CI.
+- **`/health/ready` 503** — the instance is still starting; do not route traffic yet.
+- **A `401`** on a data endpoint = the auth wall working (deny-by-default). Auth is required for
+  everything except the health/doctrine/ops surface above.
+
+## 3. Auth posture (BACKEND-006)
+
+- JWT Bearer, strict validation; **deny-by-default** (`FallbackPolicy = RequireAuthenticatedUser`).
+- **Dev-token (`/api/auth/dev-token`) is Development-only** — returns 401 in the BentonCounty/prod
+  environment (verified). Never expect a token from it in a deployed environment.
+- Production JWT secret comes from the `JwtSettings__SecretKey` env var (the API fails to start if it
+  is missing in a non-Development environment). No hardcoded prod secret.
+- **Do not** ship `VITE_DEV_PREVIEW_BYPASS_AUTH=true` or expose `/api/debug/*` mutation endpoints to a
+  public surface (see the open hardening item in §5).
+
+## 4. Common operational states
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| `/health` 404 / Azure "Welcome" page | app not started / wrong startup command | set startup `dotnet TerraFusion.API.dll`; check container log |
+| Startup crash: `Microsoft.Data.SqlClient` FileNotFound | Windows publish deployed to Linux | publish `--runtime linux-x64` |
+| Startup blocked: `[SOVEREIGN VIOLATION] Manifest not found` | `sovereign.yaml` absent | bundle `sovereign.yaml` in the deploy |
+| DB connecting to `localhost:terrafusion` | `appsettings.BentonCounty.json` localhost placeholder wins over env | provide `appsettings.BentonCounty.local.json` last-in-chain with the real connection |
+| `/api/system/health` Degraded, ModuleLoader false | modules dir absent (API-only demo) | expected — no action |
+
+(These are the exact issues resolved during WO-DEPLOY-BENTON-003C — see that evidence doc.)
+
+## 5. Known open items (each a future WO, not a demo blocker)
+
+- **`/ops/pacs/proof` config truth (F4)** — reports dev SQLite, not the Azure PG.
+- **App Service health-check path** points at shallow `/health`; should point at `/health/ready`
+  (deploy change, SW-01).
+- **`CanonicalDebugController`** `[AllowAnonymous]` on mutation endpoints — protect with `[Authorize]`
+  (WO-BACKEND-SEC-DEBUG-001, operator decision — affects the sync-workflow HTTP entry point).
+- **`/api/service-registry`** empty on the demo; implies an absent multi-service topology.
+- **LDAP/AD** production integration stubbed (fail-closed).
+
+## 6. Release gate
+
+Before a backend change reaches the demo, clear the **Release Gate** (WO-BACKEND-007 §3): all CI gates
+green (incl. Warning + Fast Gate), runtime-truth criteria met, intended-diff verified, honest
+disclosure, no unauthorized wall crossing.
+
+---
+
+**WO-BACKEND-008: COMPLETE (runbook).** With this + WO-BACKEND-007, the P3 Backend Operational
+Excellence arc (001-008) is complete: audits (001-003), fixes (004-005), proof (006), gate + runbook
+(007-008).


### PR DESCRIPTION
## Summary

Docs synthesis (R1) closing the P3 backend-excellence arc. No code, no runtime change.

## WO-BACKEND-007 — Release Gate Definition

The written "release-ready" bar for the backend: required CI gates (Warning / Backend / **Fast** / Quality / SEAL / Canon / Drift / Migration / Evidence + conversation-resolution) **plus** runtime-truth criteria from the audits (health non-contradiction, honest `Degraded`, gitSha provenance, 0 warnings, deny-by-default auth) **plus** intended-diff verification, honest disclosure, and no-unauthorized-wall. Open gates tracked (F4 pacs-proof, debug-hardening, service-registry, App Service health-check-path).

## WO-BACKEND-008 — Operational Runbook

Operator-facing guide: every health/readiness endpoint and what it means, how to read the signals (Healthy vs Degraded, `gitSha: unknown`, 503 NotReady), the auth posture, common operational states with fixes (the exact WO-DEPLOY-BENTON-003C failure modes: linux-x64 publish, sovereign.yaml, localhost DB override), known open items, and the release-gate reference.

## Arc complete

P3 backend-excellence 001-008: audits (001-003) → fixes (004-005) → proof (006) → gate + runbook (007-008).

See `docs/data/WO_BACKEND_007_RELEASE_GATE_DEFINITION.md`, `docs/data/WO_BACKEND_008_OPERATIONAL_RUNBOOK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)