### PR TITLE
docs(workbench): add evidence rollup

### DIFF
--- a/docs/brain/workorders/evidence/WO-WORKBENCH-011-EVIDENCE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-WORKBENCH-011-EVIDENCE-ROLLUP.md
@@ -1,0 +1,120 @@
+# WO-WORKBENCH-011 - Property Workbench Evidence Rollup
+
+RESULT: PASS
+WORK_ORDER: WO-WORKBENCH-011
+GOAL: GOAL-PROPERTY-WORKBENCH-CANONICAL-ASSESSOR-EXPERIENCE
+LOOP: LOOP-PROPERTY-WORKBENCH-CANONICAL-ASSESSOR-EXPERIENCE
+
+## Purpose
+
+Close the Program 3 Property Workbench evidence baseline after the WO-WORKBENCH-001 through
+WO-WORKBENCH-010 packets merged to `origin/main`.
+
+This packet is an evidence rollup only. It does not certify production readiness, authorize release,
+change runtime behavior, change CI, alter schemas, touch deployment, or access secrets, county data,
+PACS, SQL, or live databases.
+
+## Evidence Chain
+
+| WO | Packet | PR | Merge commit | Status |
+| --- | --- | --- | --- | --- |
+| WO-WORKBENCH-001 | Workbench Reality Audit | #1142 | `4515829d1e1b3802aa72837e780671a81686cd0f` | Merged |
+| WO-WORKBENCH-002 | Routing / Deep-Link Truth | #1143 | `347259f8aa5cf8fe091fcfe386a166995df28ad2` | Merged |
+| WO-WORKBENCH-003 | Tab + Tool Maturity Classification | #1144 | `15623604a5358cbf13db8717f69485459d693e2d` | Merged |
+| WO-WORKBENCH-004 | Forge Surface Truth | #1145 | `fa99fc01b73ed23e10f00336fab1bc1d819b804d` | Merged |
+| WO-WORKBENCH-005 | Atlas Surface Truth | #1146 | `d655cde705ebb3ec6d82488a2f02d9c263b059ce` | Merged |
+| WO-WORKBENCH-006 | Dais Surface Truth | #1147 | `98bc9ccbccaf3169601e6208fcec8ddc5fcfb514` | Merged |
+| WO-WORKBENCH-007 | Dossier Surface Truth | #1148 | `e163c9293e9960d3c1c47de57a980b03cd3ef96f` | Merged |
+| WO-WORKBENCH-008 | Pilot Integration Truth | #1149 | `eeb91e762058e86ec5f0f577124a8d1b512d3ec1` | Merged |
+| WO-WORKBENCH-009 | End-to-End Parcel Flow Evidence | #1150 | `6be49839fb383d5a4330076ffd6f3e2a675e6582` | Merged |
+| WO-WORKBENCH-010 | Property Workbench Operational Packet | #1151 | `85ede391b004b8c378a5fd4773474ba35bf9423e` | Merged |
+
+## Files Verified On Main
+
+- `docs/brain/workorders/evidence/WO-WORKBENCH-001-WORKBENCH-REALITY-AUDIT.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-002-ROUTING-DEEP-LINK-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-003-TAB-TOOL-MATURITY-CLASSIFICATION.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-004-FORGE-SURFACE-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-005-ATLAS-SURFACE-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-006-DAIS-SURFACE-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-007-DOSSIER-SURFACE-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-008-PILOT-INTEGRATION-TRUTH.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-009-END-TO-END-PARCEL-FLOW-EVIDENCE.md`
+- `docs/brain/workorders/evidence/WO-WORKBENCH-010-PROPERTY-WORKBENCH-OPERATIONAL-PACKET.md`
+
+## Proven
+
+- Property Workbench now has an evidence-backed baseline for its canonical assessor-experience role.
+- The current route and deep-link shape is documented, including known drift and tab routing boundaries.
+- Runtime tabs and tool surfaces are classified by maturity instead of being treated as equally complete.
+- Forge, Atlas, Dais, Dossier, and Pilot integration each have a surface-truth evidence packet.
+- End-to-end parcel flow has an evidence packet that connects shell, route, tab, parcel, and tool surface observations.
+- The operational packet defines ownership, validation expectations, rollback posture, promotion criteria, and done criteria.
+- The evidence chain was merged through PRs and normal branch protection rather than direct commits to `main`.
+
+## Partial
+
+- The Workbench is evidenced as a canonical assessor-experience baseline, not as a production-complete runtime.
+- Surface implementation depth remains mixed across Forge, Atlas, Dais, Dossier, and Pilot.
+- Tool invocation and confirmation models are documented, but not all governed tool behaviors are proven end-to-end.
+- Backend, auth, and service dependencies remain separate operational concerns where noted by the individual packets.
+- County isolation and live county runtime behavior are not certified by this Program 3 evidence chain.
+
+## Missing / Deferred
+
+- Production release authorization and production deployment evidence.
+- Live county data, PACS, SQL, and shared database validation.
+- Runtime code fixes for any surface drift classified by the evidence packets.
+- Schema or migration proof for county runtime flows.
+- Full production-like assessor journey smoke testing with live services.
+- Follow-up promotion decisions for surfaces that are classified as partial, scaffolded, or adapter-dependent.
+
+## Explicit Non-Claims
+
+- This rollup does not authorize release.
+- This rollup does not authorize deployment.
+- This rollup does not authorize production infrastructure, Kubernetes, Helm, or cloud resources.
+- This rollup does not prove PACS connectivity.
+- This rollup does not prove county data readiness.
+- This rollup does not prove live SQL behavior.
+- This rollup does not change runtime code.
+- This rollup does not change CI.
+- This rollup does not change schemas, migrations, or package versions.
+
+## Validation Summary
+
+Validation performed for this packet:
+
+- Verified PR #1142 through #1151 are merged and have merge commits.
+- Verified all WO-WORKBENCH-001 through WO-WORKBENCH-010 evidence files exist on `origin/main`.
+- `git diff --check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node scripts/spec-gates/workbench-compliance.mjs`
+
+The PR checks for the individual evidence packets completed before merge. This rollup adds no
+runtime, CI, schema, deployment, package, or data-surface changes.
+
+## Next Recommended Program / Lane
+
+NEXT_RECOMMENDED_PROGRAM: Program 4 - TerraPilot
+
+Rationale: Program 3 established the Property Workbench assessor-experience evidence baseline and
+identified Pilot integration as a governed action surface. The next highest-leverage lane is
+TerraPilot registry, handler parity, contract parity, maturity metadata, and promotion protocol.
+
+## Done / Not Done
+
+Done:
+
+- Program 3 evidence baseline is complete through WO-WORKBENCH-010.
+- This rollup ties the Workbench chain to PRs, merge commits, validation posture, non-claims, and next lane.
+- Property Workbench is evidenced as the canonical assessor-experience baseline.
+
+Not done:
+
+- Production readiness.
+- Runtime remediation.
+- Live county, PACS, SQL, or deployment validation.
+- TerraPilot implementation.
+
+STOP_TYPE: PROPERTY_WORKBENCH_EVIDENCE_ROLLUP_READY_FOR_REVIEW

--- a/docs/brain/workorders/evidence/WO-WORKBENCH-011-EVIDENCE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-WORKBENCH-011-EVIDENCE-ROLLUP.md
@@ -96,11 +96,13 @@ runtime, CI, schema, deployment, package, or data-surface changes.
 
 ## Next Recommended Program / Lane
 
-NEXT_RECOMMENDED_PROGRAM: Program 4 - TerraPilot
+NEXT_RECOMMENDED_PROGRAM: P5 - TerraPilot Tool Maturity
+NEXT_RECOMMENDED_WO: WO-TERRAPILOT-P2 - Promotion protocol
 
 Rationale: Program 3 established the Property Workbench assessor-experience evidence baseline and
-identified Pilot integration as a governed action surface. The next highest-leverage lane is
-TerraPilot registry, handler parity, contract parity, maturity metadata, and promotion protocol.
+identified Pilot integration as a governed action surface. The registered next TerraPilot lane is
+P5 - TerraPilot Tool Maturity, with WO-TERRAPILOT-P2 as the next work order. That lane governs the
+promotion protocol before handler parity, maturity metadata, and real integration work are claimed.
 
 ## Done / Not Done
 


### PR DESCRIPTION
WO-WORKBENCH-011 evidence rollup for Program 3 Property Workbench. Scope is docs/evidence only: summarizes WO-WORKBENCH-001 through WO-WORKBENCH-010, PRs, merge commits, proven/partial/missing posture, validation, non-claims, and next recommended lane. No runtime code, CI, schema, deployment, package, secrets, county data, PACS, SQL, or live DB changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Property Workbench Evidence Rollup” page.
  * Consolidated the work order evidence chain into a single closure record.
  * Clearly states what’s verified versus partial/missing, and documents explicit non-claims.
  * Includes validation status/checks, review readiness, and the recommended next TerraPilot lane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->