### PR TITLE
docs(terrapilot): define tool maturity promotion protocol

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P2 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P8 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
@@ -37,11 +37,11 @@ Candidate queue:
 
 | Candidate | Current evidence | Promotion blockers |
 |-----------|------------------|--------------------|
-| `summarize_levy_rate_components` | Declared read-only tool with real handler registration. | Needs live backend probe, auth boundary, trace evidence, and operator approval. |
-| `compare_assessed_value_history` | Declared read-only tool with real handler registration. | Needs backing endpoint proof, auth boundary, trace evidence, and operator approval. |
-| `summarize_parcel_casefile` | Declared read-only tool with real handler registration. | Needs Dossier backing-service proof, auth boundary, trace evidence, and operator approval. |
-| `calculate_pilt_payment` | Declared read-only tool with real handler registration. | Needs PILT backing-service proof, auth boundary, trace evidence, and operator approval. |
-| `explain_model_results` | Declared read-only Muse tool with real handler registration. | Requires live backend proof and may require LLM/key decision if narration depends on Muse. |
+| `summarize_levy_rate_components` | Manifest-declared read-only tool with real handler registration. | Needs live backend probe, auth boundary, trace evidence, and operator approval. |
+| `compare_assessed_value_history` | Manifest-declared read-only tool with real handler registration. | Needs backing endpoint proof, auth boundary, trace evidence, and operator approval. |
+| `summarize_parcel_casefile` | Manifest-declared read-only tool with real handler registration. | Needs Dossier backing-service proof, auth boundary, trace evidence, and operator approval. |
+| `calculate_pilt_payment` | Manifest-declared read-only tool with real handler registration. | Needs PILT backing-service proof, auth boundary, trace evidence, and operator approval. |
+| `explain_model_results` | Manifest-declared read-only Muse tool with real handler registration. | Requires live backend proof and may require LLM/key decision if narration depends on Muse. |
 
 No candidate is promoted by this evidence packet.
 
@@ -57,7 +57,7 @@ Observed results:
 
 | Metric | Count |
 |--------|-------|
-| Declared manifest tools | 117 |
+| Manifest-declared tools | 117 |
 | Stub handler registrations | 80 |
 | Real handler registrations | 54 |
 | Union handled tools | 117 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
@@ -1,8 +1,8 @@
 # WO-TERRAPILOT-P3-P6 - Tool Maturity Evidence
 
-**Program:** P5 - TerraPilot Tool Maturity  
-**Date:** 2026-07-02  
-**Mode:** Governance/evidence. No runtime change, no backend integration, no tool promotion.  
+**Program:** P5 - TerraPilot Tool Maturity
+**Date:** 2026-07-02
+**Mode:** Governance/evidence. No runtime change, no backend integration, no tool promotion.
 **Sources:** `tools/registry/terrapilot.tools.json`, `os-platform/core/pilot/handlers.ts`,
 `os-platform/core/pilot/handlers.real.ts`, and current P5 program canon.
 

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md
@@ -1,0 +1,112 @@
+# WO-TERRAPILOT-P3-P6 - Tool Maturity Evidence
+
+**Program:** P5 - TerraPilot Tool Maturity  
+**Date:** 2026-07-02  
+**Mode:** Governance/evidence. No runtime change, no backend integration, no tool promotion.  
+**Sources:** `tools/registry/terrapilot.tools.json`, `os-platform/core/pilot/handlers.ts`,
+`os-platform/core/pilot/handlers.real.ts`, and current P5 program canon.
+
+## WO-TERRAPILOT-P3 - Maturity Metadata Enforcement Review
+
+Current state:
+
+- `tools/registry/tool-maturity.json` does not exist.
+- `tools/registry/TOOL_PROMOTION_POLICY.md` does not exist.
+- `os-platform/core/pilot/tool-promotion.test.mjs` does not exist.
+- `os-platform/core/pilot/TOOL_MATURITY.md` does not exist.
+
+Conclusion:
+
+TerraPilot has a manifest and handler registry, but it does not yet have a dedicated
+machine-readable maturity metadata file or focused promotion enforcement test. This PR does not add
+runtime enforcement because the current work order is governance/evidence only. The safe next
+implementation slice is a separate metadata-enforcement WO that adds exact maturity fields and tests
+without promoting tools.
+
+## WO-TERRAPILOT-P4 - Stub-to-Live Promotion Candidate Queue
+
+Candidate selection criteria:
+
+- `read_only` risk preferred.
+- Existing real handler registration preferred.
+- Existing backend/API target preferred.
+- No write lane, schema migration, deployment, secret, PACS, county SQL, county data, or live DB access.
+- No LLM/Muse dependency for the first promotion if a non-Muse read-only candidate exists.
+
+Candidate queue:
+
+| Candidate | Current evidence | Promotion blockers |
+|-----------|------------------|--------------------|
+| `summarize_levy_rate_components` | Declared read-only tool with real handler registration. | Needs live backend probe, auth boundary, trace evidence, and operator approval. |
+| `compare_assessed_value_history` | Declared read-only tool with real handler registration. | Needs backing endpoint proof, auth boundary, trace evidence, and operator approval. |
+| `summarize_parcel_casefile` | Declared read-only tool with real handler registration. | Needs Dossier backing-service proof, auth boundary, trace evidence, and operator approval. |
+| `calculate_pilt_payment` | Declared read-only tool with real handler registration. | Needs PILT backing-service proof, auth boundary, trace evidence, and operator approval. |
+| `explain_model_results` | Declared read-only Muse tool with real handler registration. | Requires live backend proof and may require LLM/key decision if narration depends on Muse. |
+
+No candidate is promoted by this evidence packet.
+
+## WO-TERRAPILOT-P5 - Handler / Manifest / Maturity Parity Evidence
+
+Read-only count script:
+
+```powershell
+node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync('tools/registry/terrapilot.tools.json','utf8')); const ids=new Set(m.tools.map(t=>t.toolId)); const regs=f=>[...fs.readFileSync(f,'utf8').matchAll(/registerHandler\\(\\s*['\\\"]([^'\\\"]+)['\\\"]/g)].map(x=>x[1]); const stub=new Set(regs('os-platform/core/pilot/handlers.ts')); const real=new Set(regs('os-platform/core/pilot/handlers.real.ts')); const union=new Set([...stub,...real]); console.log({manifest:ids.size, stub:stub.size, real:real.size, union:union.size, missing:[...ids].filter(id=>!union.has(id))});"
+```
+
+Observed results:
+
+| Metric | Count |
+|--------|-------|
+| Declared manifest tools | 117 |
+| Stub handler registrations | 80 |
+| Real handler registrations | 54 |
+| Union handled tools | 117 |
+| Missing handlers | 0 |
+| Stub-only tools | 63 |
+
+Manifest risk distribution:
+
+| Risk | Count |
+|------|-------|
+| `read_only` | 74 |
+| `write_low` | 31 |
+| `write_high` | 11 |
+| `irreversible` | 1 |
+
+Mode distribution:
+
+| Mode | Count |
+|------|-------|
+| `pilot` | 90 |
+| `muse` | 27 |
+
+Conclusion:
+
+Handler parity is complete at the manifest/handler level. The maturity gap is not missing handlers;
+it is the lack of explicit maturity metadata, live-probe evidence, and operator-approved promotion
+records.
+
+## WO-TERRAPILOT-P6 - Tooling Operator Packet
+
+Operator rules for future P5 work:
+
+1. Treat manifest validation as registration proof only.
+2. Treat handler parity as runnable/stub proof only unless live evidence exists.
+3. Do not mark a tool `backend-integrated` without backing service evidence and validation output.
+4. Do not mark a tool `promoted` without operator approval, date, owner, rollback path, and UI
+   disclosure update.
+5. Prefer read-only, non-Muse, low-blast-radius candidates for the first promotion.
+6. Stop before any work requiring runtime behavior, deployment, secrets, PACS, county SQL, county
+   data, live DB, or schema migration authority.
+
+## Stop Walls Respected
+
+| Wall | Status |
+|------|--------|
+| Runtime behavior | Not crossed |
+| Backend integration | Not implemented |
+| Deployment | Not touched |
+| Secrets/credentials | Not touched |
+| PACS/county SQL/county data/live DB | Not touched |
+| Schema migration/data mutation | Not touched |
+| Tool promotion | Not performed |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
@@ -18,7 +18,7 @@
 ## Proven
 
 - TerraPilot manifest currently declares 117 tools.
-- Manifest/handler parity is complete: 117 declared tools have at least one handler registration.
+- Manifest/handler parity is complete: 117 manifest-declared tools have at least one handler registration.
 - 54 tools have real-handler registrations in `handlers.real.ts`.
 - 63 tools are stub-only by handler-registration comparison.
 - No handler-orphan L0 gap was found.

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
@@ -1,0 +1,69 @@
+# WO-TERRAPILOT-P7 - Evidence Rollup
+
+**Program:** P5 - TerraPilot Tool Maturity  
+**Date:** 2026-07-02  
+**Scope:** P2-P7 governance/evidence closeout. No runtime code changed.
+
+## Completed Work Orders
+
+| WO | Result | Evidence |
+|----|--------|----------|
+| WO-TERRAPILOT-P2 | Promotion protocol defined. | `docs/brain/workorders/programs/terrapilot-promotion-protocol.md` |
+| WO-TERRAPILOT-P3 | Maturity metadata enforcement reviewed. | `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md` |
+| WO-TERRAPILOT-P4 | Stub-to-live candidate queue identified. | `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md` |
+| WO-TERRAPILOT-P5 | Handler/manifest parity evidenced. | `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md` |
+| WO-TERRAPILOT-P6 | Tooling operator packet defined. | `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md` |
+| WO-TERRAPILOT-P7 | Program evidence rolled up. | This file. |
+
+## Proven
+
+- TerraPilot manifest currently declares 117 tools.
+- Manifest/handler parity is complete: 117 declared tools have at least one handler registration.
+- 54 tools have real-handler registrations in `handlers.real.ts`.
+- 63 tools are stub-only by handler-registration comparison.
+- No handler-orphan L0 gap was found.
+- No tool was promoted by this program closeout.
+
+## Partial
+
+- A dedicated machine-readable maturity metadata file is not present.
+- A focused promotion enforcement test is not present.
+- Some tools are real-handler capable in code, but this rollup does not prove deployed-live behavior.
+- First-promotion candidates are queued, not implemented.
+
+## Missing
+
+- `tools/registry/tool-maturity.json` or equivalent maturity metadata.
+- Focused promotion-policy test coverage.
+- Per-tool live probe evidence.
+- Operator-approved promotion records.
+- UI/operator disclosure verification tied to a machine-readable maturity state.
+
+## Not Overclaimed
+
+This rollup does not claim TerraPilot is production-ready, deployed-live, or operator-approved for
+live tool execution. It only proves current registry/handler maturity evidence and defines the
+promotion rules required before such claims can be made.
+
+## Validation Summary
+
+Required local validation for this PR:
+
+- `git diff --check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node --test os-platform/core/tests/phase83-tools.test.mjs`
+
+Core runtime and package dependency validation are not expanded by this docs/governance work.
+
+## Next Recommended Work
+
+`WO-TERRAPILOT-P8 - Maturity Metadata Enforcement`:
+
+- Add exact machine-readable maturity metadata for each tool.
+- Add focused tests that prevent `backend-integrated` or `promoted` without required evidence.
+- Preserve stub disclosure until a separate operator-authorized runtime promotion WO exists.
+
+## Program Status
+
+P5 governance/evidence baseline is ready for PR review. Runtime promotion remains blocked by
+operator authority and future implementation WOs.

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md
@@ -1,7 +1,7 @@
 # WO-TERRAPILOT-P7 - Evidence Rollup
 
-**Program:** P5 - TerraPilot Tool Maturity  
-**Date:** 2026-07-02  
+**Program:** P5 - TerraPilot Tool Maturity
+**Date:** 2026-07-02
 **Scope:** P2-P7 governance/evidence closeout. No runtime code changed.
 
 ## Completed Work Orders

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P2 | NO | `once`, `program`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P8 | YES — maturity metadata enforcement requires a separate implementation WO | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -115,18 +115,22 @@ No active stop walls at WO-WORKBENCH-001.
 ### /goal terrapilot-maturity → P5
 
 **File:** [programs/terrapilot-tool-maturity.md](../programs/terrapilot-tool-maturity.md)  
-**Success condition:** At least one tool reaches L3 (live-integrated); L0/L1 tools disclosed as unavailable.
+**Success condition:** TerraPilot maturity claims are governed by protocol, evidence, and machine-readable metadata before any live promotion is attempted.
 
 | WO | Title | Status |
 |----|-------|--------|
 | WO-TERRAPILOT-P1 | Tool maturity matrix | DONE/PARTIAL |
-| WO-TERRAPILOT-P2 | Promotion protocol | **NEXT** |
-| WO-TERRAPILOT-P3 | Handler parity audit | QUEUED |
-| WO-TERRAPILOT-P4 | Stub disclosure UI | QUEUED |
-| WO-TERRAPILOT-P5 | First live-integrated tool | QUEUED |
-| WO-TERRAPILOT-P6 | Tool promotion evidence rollup | QUEUED |
+| WO-TERRAPILOT-P2 | Promotion protocol | COMPLETE IN PR |
+| WO-TERRAPILOT-P3 | Maturity metadata enforcement review | COMPLETE IN PR |
+| WO-TERRAPILOT-P4 | Stub-to-live promotion candidate queue | COMPLETE IN PR |
+| WO-TERRAPILOT-P5 | Handler / manifest / maturity parity evidence | COMPLETE IN PR |
+| WO-TERRAPILOT-P6 | Tooling operator packet | COMPLETE IN PR |
+| WO-TERRAPILOT-P7 | Evidence rollup | COMPLETE IN PR |
+| WO-TERRAPILOT-P8 | Maturity metadata enforcement | **NEXT — separate implementation WO** |
 
-No active stop walls at WO-TERRAPILOT-P2.
+WO-TERRAPILOT-P8 may proceed only as a narrow metadata/test implementation. Any runtime promotion,
+backend integration, deployment, secrets, county data, PACS, live DB access, or schema migration is a
+stop wall.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
+++ b/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
@@ -1,114 +1,66 @@
 # TerraPilot Tool Promotion Protocol
 
 **WO:** WO-TERRAPILOT-P2
-**Program:** P5 — TerraPilot Tool Maturity
-**Date:** 2026-07-01
-**Authority:** Operator Doctrine — the formal L0→L4 promotion gate
-**Classification:** Protocol (docs). No runtime change, no tool promoted by this document.
+**Program:** P5 - TerraPilot Tool Maturity
+**Date:** 2026-07-02
+**Authority:** Work Order Operator doctrine
+**Classification:** Protocol. No runtime change, no backend integration, no tool promotion.
 
----
+## Purpose
 
-## 0. Purpose
+TerraPilot must not present manifest registration, contract coverage, or a stub response as live
+product capability. This protocol defines the minimum evidence required before a tool can move from
+`stub-contract` to `backend-integrated` or `promoted`.
 
-Prevent "manifest green" from being mistaken for live capability. A tool that is manifest-registered
-but not backend-integrated is **not** a working tool. This protocol defines the required evidence,
-review, and approval to move a TerraPilot tool up the maturity ladder — and the disclosure rule that
-holds until a tool is genuinely live.
+## Maturity States
 
----
+| State | Meaning | Minimum evidence |
+|-------|---------|------------------|
+| `declared` | Tool exists in the manifest only. | Manifest entry with risk, write lane, and schema fields. |
+| `stub-contract` | Handler exists and returns an honest stub or deterministic contract response. | Handler registration, contract-shaped response, and stub disclosure. |
+| `contract-covered` | Contract and integration target are documented, but handler is not proven live. | Request/response contract, owning service, integration target, and verification plan. |
+| `backend-integrated` | Handler calls a real backend/API and returns real data. | Handler evidence, backing service, auth model, trace evidence, and live/focused validation. |
+| `promoted` | Backend-integrated tool is approved for operator-facing use. | All backend-integrated evidence plus operator approval, date, owner, rollback path, and UI disclosure update. |
 
-## 1. The Maturity Ladder (canonical)
+## Required Promotion Evidence
 
-| Level | Label | Definition | Disclosure required in UI/docs |
-|-------|-------|------------|-------------------------------|
-| **L0** | Declared | In manifest/registry only; **no handler** | "not available" |
-| **L1** | Runnable | Handler exists but returns stub/canned/empty; **no backend integration** | "not yet integrated (stub)" |
-| **L2** | Contract-covered | Handler + schema/contract + integration spec written; still stub data | "contract-covered, not live" |
-| **L3** | Live-integrated | Handler calls a **real backend/API** returning **real data**; trace emitted | "live" (source badge) |
-| **L4** | Promoted | L3 + tests + evidence doc + **operator approval** | "live, approved" |
+Every promotion request must name:
 
-**Rule:** a tool below L3 must be disclosed as not-live in every UI surface and operator-facing doc.
-Green contract coverage (L2) is **not** live capability.
+- Current state and target state.
+- Tool ID and manifest location.
+- Owner and owning service.
+- Backing endpoint, service, or data source.
+- Integration surface and auth boundary.
+- Verification method and exact command/probe.
+- TerraTrace/correlation evidence requirement.
+- UI/operator disclosure rule.
+- Rollback or demotion path.
+- Promotion date and approving operator for `promoted`.
 
----
+## Stop Gates
 
-## 2. Promotion Gates (evidence required to advance)
+A tool may not move to `backend-integrated` or `promoted` inside a docs/evidence work order. Stop and
+open a separate authorized implementation work order if promotion requires:
 
-### L0 → L1 (Declared → Runnable)
-- A handler is registered in the tool dispatcher (toolId → handler) and returns a **well-formed,
-  honestly-labeled stub** (`source:"stub"`, no fabricated domain data).
-- Evidence: handler file:line; a probe showing the stub response with `source:"stub"`.
+- Runtime behavior changes.
+- Backend integration or handler rewiring.
+- Deployment or service startup changes.
+- Secrets, credentials, Key Vault, PACS, county SQL, county data, or live database access.
+- Schema migration or data mutation.
+- New auth scope or protected data exposure.
 
-### L1 → L2 (Runnable → Contract-covered)
-- Request/response **schema** defined and validated; an **integration spec** documents the real
-  backend endpoint/service the handler will call and the data mapping.
-- A **contract test** asserts the schema and the stub-disclosure (badge/`source` field).
-- Evidence: schema location; spec doc; passing contract test.
+## Disclosure Rule
 
-### L2 → L3 (Contract-covered → Live-integrated) — **the real bar**
-- Handler calls a **real** service/DbContext/API (not a stub) and returns **real data**.
-- The response carries a **live** source marker (not `stub`), and a **trace event** is emitted
-  (immutable, correlation-id).
-- Verified by a **live probe** (or authenticated live test) showing real data, and by the
-  handler no longer returning the stub branch.
-- **This step changes runtime behavior → crosses SW-09** and, if it wires a new backend/LLM,
-  **SW-08/SW-10**. It requires explicit operator authorization (it is not a docs WO).
-- Evidence: live probe output with real data; trace event; handler diff removing the stub path.
+Until a tool is `backend-integrated`, every UI, operator packet, and demo script must describe it as
+not live. Acceptable labels include:
 
-### L3 → L4 (Live-integrated → Promoted)
-- L3 evidence **plus**: unit/contract/e2e tests green; an **evidence rollup doc**; and **operator
-  approval** recorded (named approver, date, WO id).
-- Only at L4 may a demo/doc present the tool as a working assistant.
+- `stub-contract`
+- `contract-covered, not live`
+- `tool layer in development`
 
----
+Green manifest validation is not a live-capability claim.
 
-## 3. Review Step
+## Completion
 
-Each promotion PR must:
-1. Cite the current level and the target level.
-2. Attach the evidence listed in §2 for the target gate.
-3. For L2→L3 and above: name the stop wall(s) crossed (SW-08/09/10) and the authorization reference.
-4. Pass the honesty contract (no fabricated data; stub disclosed until L3; source badge correct).
-
-A tool may not skip levels. L2→L3 may not be self-approved by the executing agent — it is an
-operator authority wall.
-
----
-
-## 4. Disclosure Rule (in force now)
-
-Until WO-TERRAPILOT-P5 produces a genuine **L3** tool:
-- TerraPilot is disclosed as **"tool layer in development"** in all demo scripts and docs.
-- No demo presents TerraPilot as a working AI assistant.
-- The deployed pilot surface already models this correctly: `/api/pilot/health` returns
-  `{"status":"degraded","runtimeOnline":false,"message":"Pilot runtime offline — using .NET fallback
-  stubs"}`; `/api/pilot/tools` and `/api/pilot/traces` return `source:"stub"`, `runtimeOnline:false`.
-  **This honest degraded disclosure is the target behavior for all L0/L1 tools — preserve it.**
-
----
-
-## 5. Stop Walls In This Program
-
-| Wall | Where |
-|------|-------|
-| SW-09 runtime behavior | any L2→L3 promotion (handler starts returning real data) |
-| SW-08 external integration | wiring a new backend/LLM/service for a tool |
-| SW-10 auth/security | if a tool requires new auth scope or exposes protected data |
-| SW-03 secrets | if integration needs credentials (LLM keys, DB) |
-
-WO-TERRAPILOT-P3/P4/P6 (handler parity, stub disclosure, evidence rollup) are **read-only/docs (R0/R1)**
-and cross no wall. **P5 is a candidate *review*** (read-only) — the actual L2→L3 promotion it
-recommends is a separate, operator-authorized WO.
-
----
-
-## 6. Change Log
-
-| Date | Change | WO |
-|------|--------|----|
-| 2026-07-01 | Protocol authored | WO-TERRAPILOT-P2 |
-
----
-
-**WO-TERRAPILOT-P2: COMPLETE.** Enables P3 (handler parity), P4 (stub disclosure), P5 (candidate
-review), P6 (rollup).
+WO-TERRAPILOT-P2 is complete when this protocol exists and subsequent P5 evidence uses it as the
+promotion gate.

--- a/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
+++ b/docs/brain/workorders/programs/terrapilot-promotion-protocol.md
@@ -22,6 +22,18 @@ product capability. This protocol defines the minimum evidence required before a
 | `backend-integrated` | Handler calls a real backend/API and returns real data. | Handler evidence, backing service, auth model, trace evidence, and live/focused validation. |
 | `promoted` | Backend-integrated tool is approved for operator-facing use. | All backend-integrated evidence plus operator approval, date, owner, rollback path, and UI disclosure update. |
 
+Protocol state mapping:
+
+- L0 `Declared` maps to `declared`.
+- L1 `Runnable` maps to `stub-contract`.
+- L2 `Contract-covered` maps to `contract-covered`.
+- L3 `Live-integrated` maps to `backend-integrated`.
+- L4 `Promoted` maps to `promoted`.
+
+Tools may not skip states. A tool cannot be marked `backend-integrated` until `contract-covered`
+evidence exists, and it cannot be marked `promoted` until `backend-integrated` evidence and operator
+approval exist.
+
 ## Required Promotion Evidence
 
 Every promotion request must name:

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -34,12 +34,13 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO | Title | Status | Description |
 |----|-------|--------|-------------|
 | WO-TERRAPILOT-P1 | Tool maturity matrix | **DONE/PARTIAL** | Enumerate all manifest-registered tools; assign current maturity level |
-| WO-TERRAPILOT-P2 | Promotion protocol | **COMPLETE IN PR** | Define the formal promotion gate from stub-contract to live/backend-integrated |
+| WO-TERRAPILOT-P2 | Promotion protocol | **COMPLETE IN PR** | Define the formal promotion gate from L1/stub-contract to L3/backend-integrated and L4/promoted |
 | WO-TERRAPILOT-P3 | Maturity metadata enforcement review | **COMPLETE IN PR** | Inspect whether machine-readable maturity metadata exists and where enforcement should live |
 | WO-TERRAPILOT-P4 | Stub-to-live promotion candidate queue | **COMPLETE IN PR** | Identify first promotion candidates without promoting them |
 | WO-TERRAPILOT-P5 | Handler / manifest / maturity parity evidence | **COMPLETE IN PR** | Prove handler parity and current maturity state from manifest and handlers |
 | WO-TERRAPILOT-P6 | Tooling operator packet | **COMPLETE IN PR** | Package operator rules for future TerraPilot maturity work |
 | WO-TERRAPILOT-P7 | Evidence rollup | **COMPLETE IN PR** | Roll up P2-P6 evidence and stop before live promotion |
+| WO-TERRAPILOT-P8 | Maturity metadata enforcement | **NEXT** | Add machine-readable maturity metadata and focused tests without promoting tools |
 
 ---
 
@@ -74,6 +75,6 @@ decisions.
 
 ## Disclosure Rule
 
-Until WO-TERRAPILOT-P5 produces an L3 tool:
+Until a future operator-authorized implementation WO produces an L3/L4 tool:
 - TerraPilot must be disclosed as "tool layer in development" in all demo scripts
 - No demo should show TerraPilot as a working AI assistant without a live-integrated tool

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -3,13 +3,13 @@
 **Program:** P5  
 **Status:** ACTIVE  
 **Owner:** Operator (bsvalues@gmail.com)  
-**Last Updated:** 2026-06-30
+**Last Updated:** 2026-07-02
 
 ---
 
 ## Goal
 
-Prevent "manifest green" from being mistaken for live product capability. TerraPilot exposes AI tools to assessors. A tool that is manifest-registered but not backend-integrated is NOT a working tool. This program establishes a maturity ladder, enforces honest disclosure, and promotes exactly one real integrated tool before claiming TerraPilot is "working."
+Prevent "manifest green" from being mistaken for live product capability. TerraPilot exposes AI tools to assessors. A tool that is manifest-registered but not backend-integrated is NOT a working tool. This program establishes a maturity ladder, enforces honest disclosure, and makes promotion evidence explicit before any live/backend-integrated claim.
 
 ---
 
@@ -34,11 +34,12 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO | Title | Status | Description |
 |----|-------|--------|-------------|
 | WO-TERRAPILOT-P1 | Tool maturity matrix | **DONE/PARTIAL** | Enumerate all manifest-registered tools; assign current maturity level |
-| WO-TERRAPILOT-P2 | Promotion protocol | **NEXT** | Define the formal promotion gate from L1→L4; write the protocol doc |
-| WO-TERRAPILOT-P3 | Handler parity audit | QUEUED | Verify every manifest tool has a handler (no missing handlers → L0 items) |
-| WO-TERRAPILOT-P4 | Stub disclosure UI / internal diagnostics | QUEUED | Add maturity badge to tool manifest; surface L0/L1 tools as "not yet available" in UI |
-| WO-TERRAPILOT-P5 | First real backend-integrated tool | QUEUED | Promote one tool from L1 to L3 with real API integration and evidence |
-| WO-TERRAPILOT-P6 | Tool promotion evidence rollup | QUEUED | Produce final maturity state doc for all tools; sign off on L4 promotions |
+| WO-TERRAPILOT-P2 | Promotion protocol | **COMPLETE IN PR** | Define the formal promotion gate from stub-contract to live/backend-integrated |
+| WO-TERRAPILOT-P3 | Maturity metadata enforcement review | **COMPLETE IN PR** | Inspect whether machine-readable maturity metadata exists and where enforcement should live |
+| WO-TERRAPILOT-P4 | Stub-to-live promotion candidate queue | **COMPLETE IN PR** | Identify first promotion candidates without promoting them |
+| WO-TERRAPILOT-P5 | Handler / manifest / maturity parity evidence | **COMPLETE IN PR** | Prove handler parity and current maturity state from manifest and handlers |
+| WO-TERRAPILOT-P6 | Tooling operator packet | **COMPLETE IN PR** | Package operator rules for future TerraPilot maturity work |
+| WO-TERRAPILOT-P7 | Evidence rollup | **COMPLETE IN PR** | Roll up P2-P6 evidence and stop before live promotion |
 
 ---
 
@@ -54,17 +55,20 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) → P2 → P3 → P4 → P5 → P6
+P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7
 ```
 
-P3 can begin while P2 is in progress (handler audit doesn't require the protocol doc). P5 requires P2+P3+P4.
+P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
+order because it changes tool behavior and may require deployment, auth, secrets, or county data
+decisions.
 
 ---
 
 ## Stop Conditions
 
-- If P1 audit finds 0 tools at L2+, treat TerraPilot as alpha/stub — update all docs accordingly before P5
-- Do not claim TerraPilot is "functional" until at least one tool reaches L4
+- If maturity metadata cannot be enforced without runtime changes, stop and record the gap.
+- If a promotion candidate requires backend, auth, secrets, county data, PACS, live DB, deployment, or runtime behavior changes, stop before implementation.
+- Do not claim TerraPilot is "functional" until at least one tool reaches L4.
 
 ---
 


### PR DESCRIPTION
P5 TerraPilot Tool Maturity evidence/governance baseline. Scope: promotion protocol, maturity metadata enforcement review, stub-to-live candidate queue, handler/manifest/maturity parity evidence, tooling operator packet, and evidence rollup. No runtime code, backend integration, tool promotion, CI, schema, deployment, secrets, county data, PACS, SQL, or live DB changes.