### PR TITLE
docs(terrapilot): enforce tool maturity metadata

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P8 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P9 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md
@@ -35,6 +35,19 @@ The new static test validates:
   trace evidence,
 - any future `promoted` claim requires operator approval, promotion date, and rollback path.
 
+The guard is wired into the existing `test:governed` command so required core-governance paths run
+the maturity parity and promotion-evidence checks instead of relying on a manual one-off command.
+
+The JSON metadata also points to `tools/registry/tool-maturity.schema.json`, and that schema encodes
+the same core invariants for editor and schema-aware validation:
+
+- state-to-level consistency,
+- non-live tools require disclosure,
+- `backend-integrated` requires live integration plus contract, backing service, verification
+  command, and trace evidence,
+- `promoted` requires live integration plus operator approval, promotion date, rollback path, and
+  backend-integration evidence.
+
 ## Current Metadata Baseline
 
 All current TerraPilot manifest tools are recorded as:
@@ -53,7 +66,7 @@ and contract shape; they do not prove live backend/product integration.
 - No tool was marked `backend-integrated`.
 - No backend integration was added.
 - No runtime behavior changed.
-- No CI workflow changed.
+- No CI workflow changed. The existing governed test script now includes the maturity guard.
 - No schema migration or database operation was performed.
 - No deployment behavior changed.
 - No secrets, credentials, county data, PACS, county SQL, or live database access were used.

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md
@@ -1,0 +1,77 @@
+# WO-TERRAPILOT-P8 — Maturity Metadata Enforcement
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-02
+**Mode:** Governance metadata and focused tests only.
+
+## Purpose
+
+P8 converts the TerraPilot maturity doctrine into an enforceable machine-readable baseline. It does
+not promote tools, wire live backend integrations, alter handler behavior, or change product runtime
+behavior.
+
+## Files Added
+
+- `tools/registry/tool-maturity.json`
+- `tools/registry/tool-maturity.schema.json`
+- `os-platform/core/tests/tool-maturity.test.mjs`
+
+## Files Updated
+
+- `docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md`
+- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md`
+- `docs/brain/workorders/programs/terrapilot-tool-maturity.md`
+
+## Enforcement Added
+
+The new static test validates:
+
+- every manifest tool has exactly one maturity metadata entry,
+- maturity states map to the documented L0-L4 ladder,
+- non-live tools keep an operator/UI disclosure,
+- no current tool is `backend-integrated` or `promoted`,
+- any future `backend-integrated` claim requires contract, backing service, verification command, and
+  trace evidence,
+- any future `promoted` claim requires operator approval, promotion date, and rollback path.
+
+## Current Metadata Baseline
+
+All current TerraPilot manifest tools are recorded as:
+
+- `level`: `L1`
+- `state`: `stub-contract`
+- `liveIntegration`: `false`
+- `disclosureRequired`: `true`
+
+This is intentionally conservative. Handler registration and green manifest gates prove registration
+and contract shape; they do not prove live backend/product integration.
+
+## Explicit Non-Changes
+
+- No tool was promoted.
+- No tool was marked `backend-integrated`.
+- No backend integration was added.
+- No runtime behavior changed.
+- No CI workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+
+## Validation
+
+Expected validation:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+## Next Step
+
+`WO-TERRAPILOT-P9 — First promotion candidate decision`
+
+P9 is an owner decision wall. Any attempt to move a tool toward `backend-integrated` or `promoted`
+requires a separate authorized runtime work order.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P8 | YES — maturity metadata enforcement requires a separate implementation WO | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P9 | YES — first live-promotion candidate requires owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -126,11 +126,12 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P5 | Handler / manifest / maturity parity evidence | COMPLETE IN PR |
 | WO-TERRAPILOT-P6 | Tooling operator packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P7 | Evidence rollup | COMPLETE IN PR |
-| WO-TERRAPILOT-P8 | Maturity metadata enforcement | **NEXT — separate implementation WO** |
+| WO-TERRAPILOT-P8 | Maturity metadata enforcement | COMPLETE IN PR |
+| WO-TERRAPILOT-P9 | First promotion candidate decision | **NEXT — OWNER DECISION** |
 
 WO-TERRAPILOT-P8 may proceed only as a narrow metadata/test implementation. Any runtime promotion,
 backend integration, deployment, secrets, county data, PACS, live DB access, or schema migration is a
-stop wall.
+stop wall. WO-TERRAPILOT-P9 is an owner decision wall before any separate runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -40,7 +40,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P5 | Handler / manifest / maturity parity evidence | **COMPLETE IN PR** | Prove handler parity and current maturity state from manifest and handlers |
 | WO-TERRAPILOT-P6 | Tooling operator packet | **COMPLETE IN PR** | Package operator rules for future TerraPilot maturity work |
 | WO-TERRAPILOT-P7 | Evidence rollup | **COMPLETE IN PR** | Roll up P2-P6 evidence and stop before live promotion |
-| WO-TERRAPILOT-P8 | Maturity metadata enforcement | **NEXT** | Add machine-readable maturity metadata and focused tests without promoting tools |
+| WO-TERRAPILOT-P8 | Maturity metadata enforcement | **COMPLETE IN PR** | Add machine-readable maturity metadata and focused tests without promoting tools |
+| WO-TERRAPILOT-P9 | First promotion candidate decision | **NEXT — OWNER DECISION** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
 
 ---
 
@@ -56,12 +57,15 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7
+P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7 → P8 → P9 decision
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
 order because it changes tool behavior and may require deployment, auth, secrets, or county data
 decisions.
+
+P8 adds enforcement metadata and static tests only. It does not move any tool to `backend-integrated`
+or `promoted`.
 
 ---
 

--- a/os-platform/core/tests/tool-maturity.test.mjs
+++ b/os-platform/core/tests/tool-maturity.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * TerraPilot tool maturity metadata guard.
+ *
+ * This test is intentionally static. It verifies governance metadata and
+ * prevents "manifest green" or handler parity from being treated as live
+ * backend/product integration.
+ */
+
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const MANIFEST_PATH = resolve(__dirname, '../../../tools/registry/terrapilot.tools.json');
+const MATURITY_PATH = resolve(__dirname, '../../../tools/registry/tool-maturity.json');
+
+const VALID_STATES = new Set([
+  'declared',
+  'stub-contract',
+  'contract-covered',
+  'backend-integrated',
+  'promoted',
+]);
+
+const STATE_TO_LEVEL = {
+  declared: 'L0',
+  'stub-contract': 'L1',
+  'contract-covered': 'L2',
+  'backend-integrated': 'L3',
+  promoted: 'L4',
+};
+
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+const maturity = JSON.parse(readFileSync(MATURITY_PATH, 'utf8'));
+
+describe('TerraPilot tool maturity metadata', () => {
+  it('has one maturity entry for every manifest tool and no extras', () => {
+    const manifestIds = manifest.tools.map(tool => tool.toolId).sort();
+    const maturityIds = maturity.tools.map(tool => tool.toolId).sort();
+
+    assert.deepStrictEqual(
+      maturityIds,
+      manifestIds,
+      'tool-maturity.json must exactly match manifest tool IDs'
+    );
+  });
+
+  it('uses valid protocol states and matching maturity ladder levels', () => {
+    const violations = maturity.tools.filter(tool => {
+      return !VALID_STATES.has(tool.state) || STATE_TO_LEVEL[tool.state] !== tool.level;
+    });
+
+    assert.deepStrictEqual(
+      violations,
+      [],
+      'maturity state must map to the documented L0-L4 ladder'
+    );
+  });
+
+  it('keeps non-live tools disclosed as not live', () => {
+    const violations = maturity.tools.filter(tool => {
+      return !tool.liveIntegration && (!tool.disclosureRequired || !tool.disclosure);
+    });
+
+    assert.deepStrictEqual(
+      violations,
+      [],
+      'non-live tools must retain an operator/UI disclosure'
+    );
+  });
+
+  it('does not currently promote or mark any tool backend-integrated', () => {
+    const liveClaims = maturity.tools.filter(tool => {
+      return tool.state === 'backend-integrated' || tool.state === 'promoted' || tool.liveIntegration;
+    });
+
+    assert.deepStrictEqual(
+      liveClaims,
+      [],
+      'P8 metadata enforcement must not promote any tool or claim live backend integration'
+    );
+  });
+
+  it('requires full evidence for any future backend-integrated claim', () => {
+    const violations = maturity.tools.filter(tool => {
+      if (tool.state !== 'backend-integrated') return false;
+
+      return (
+        tool.level !== 'L3' ||
+        tool.liveIntegration !== true ||
+        !tool.evidence?.contract ||
+        !tool.evidence?.backingService ||
+        !tool.evidence?.verificationCommand ||
+        !tool.evidence?.traceEvidence
+      );
+    });
+
+    assert.deepStrictEqual(
+      violations,
+      [],
+      'backend-integrated tools require contract, backing service, verification, and trace evidence'
+    );
+  });
+
+  it('requires operator approval for any future promoted claim', () => {
+    const violations = maturity.tools.filter(tool => {
+      if (tool.state !== 'promoted') return false;
+
+      return (
+        tool.level !== 'L4' ||
+        tool.liveIntegration !== true ||
+        !tool.promotion?.operatorApproval ||
+        !tool.promotion?.promotionDate ||
+        !tool.promotion?.rollbackPath
+      );
+    });
+
+    assert.deepStrictEqual(
+      violations,
+      [],
+      'promoted tools require live integration plus operator approval, date, and rollback path'
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "lint:check": "eslint \"**/*.{ts,tsx}\"",
     "type-check": "tsc -p tsconfig.core.json",
     "typecheck:core": "tsc -p tsconfig.core.json",
-    "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs && node --test os-platform/core/pilot/june10-*.test.mjs",
+    "test:governed": "pnpm run type-check && node --test os-platform/core/tests/phase83-tools.test.mjs && node --test os-platform/core/tests/tool-maturity.test.mjs && node --test os-platform/core/pilot/june10-*.test.mjs",
     "test:governance:ui": "vitest run tests/governance/noNewRawColors.contract.test.ts tests/governance/uiTokenBaseline.contract.test.ts tests/governance/ratchetGuardScope.contract.test.ts tests/governance/tfHsAnchorsDefined.contract.test.ts",
     "lint:platform": "node scripts/platform-lint.mjs",
     "doctor": "node scripts/doctor.mjs",

--- a/tools/registry/tool-maturity.json
+++ b/tools/registry/tool-maturity.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./tool-maturity.schema.json",
   "schemaVersion": "1.0.0",
   "generatedBy": "WO-TERRAPILOT-P8",
   "generatedOn": "2026-07-02",

--- a/tools/registry/tool-maturity.json
+++ b/tools/registry/tool-maturity.json
@@ -1,0 +1,2356 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedBy": "WO-TERRAPILOT-P8",
+  "generatedOn": "2026-07-02",
+  "purpose": "Machine-readable TerraPilot tool maturity metadata. This file is governance metadata only; it does not promote tools or change runtime behavior.",
+  "maturityStates": [
+    "declared",
+    "stub-contract",
+    "contract-covered",
+    "backend-integrated",
+    "promoted"
+  ],
+  "defaultDisclosure": "tool layer in development",
+  "tools": [
+    {
+      "toolId": "route_to_parcel",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "assign_task",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "check_cert_status",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "run_valuation_model",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "assemble_boe_packet",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "draft_notice",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "draft_appeal_response",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_value_change",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_model_results",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_dossier",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "synthesize_evidence",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "generate_commissioner_memo",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "request_trace_redaction",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_senior_exemption_impact",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_parcel_casefile",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "compare_assessed_value_history",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_levy_rate_components",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_model_inputs",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "draft_value_change_notice",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "draft_boe_appeal_response",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_sales_comps_rationale",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "generate_morning_brief",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "classify_county_finding",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "propose_rate_adjustment",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "apply_rate_adjustment_to_draft",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "rerun_ratio_study",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "compare_matrix_versions",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "flag_parcel_data_issue",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_spatial_anomaly",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "open_appeal_packet",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "generate_calibration_memo",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "export_equalization_package",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "export_audit_bundle",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "search_trace_by_correlation",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "add_dossier_note",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "query_parcel_layers",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "calculate_pilt_payment",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "run_income_valuation",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "calculate_depreciation",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "check_exemption_eligibility",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "process_exemption_renewal",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "file_appeal",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "schedule_boe_hearing",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "get_certification_progress",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "sign_off_certification_step",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "queue_notice_for_mailing",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "get_queue_statistics",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "escalate_task",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "search_recorded_documents",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "get_title_chain",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_recording_fees",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "record_document",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "release_lien",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_parcel_recordings",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "get_tax_statement",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "explain_tax_breakdown",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "record_payment",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "check_delinquency_status",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "create_installment_plan",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "summarize_collection_stats",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "initiate_tax_sale",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "audit_roll_summary",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "check_levy_compliance",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "submit_audit_finding",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "reconcile_cross_office",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "generate_compliance_report",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_ping",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_doctor",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_gatefast",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_corpus_status",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_list_dir",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_read_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_write_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_search_files",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_terminal_exec",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_create_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_delete_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_rename_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_diff_files",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_git_status",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_file_outline",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_diagnostics",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_bookmarks",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_file_index",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_recent_files",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_symbol_search",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_snippets",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_minimap",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_editor_settings",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_find_replace",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_format_file",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_editor_layout",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_folding_ranges",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_line_markers",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_hover_info",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_goto_definition",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_completions",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_editor_themes",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_code_actions",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_find_references",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_rename_symbol",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_signature_help",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_document_highlights",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_git_diff",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_document_links",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "canon_inlay_hints",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_calculate_rollback",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_calculate_interest",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_evaluate_penalty_exceptions",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_initiate_removal",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_enroll_parcel",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_get_interest_rates",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "cu_list_classifications",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "report_generate_rollback_notice",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "report_generate_levy_certification",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "report_generate_cost_valuation",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    },
+    {
+      "toolId": "report_generate_ratio_study",
+      "level": "L1",
+      "state": "stub-contract",
+      "liveIntegration": false,
+      "disclosureRequired": true,
+      "disclosure": "tool layer in development",
+      "owner": "TerraPilot Tool Maturity Program",
+      "evidence": {
+        "manifest": "tools/registry/terrapilot.tools.json",
+        "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+      },
+      "promotion": {
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
+      }
+    }
+  ]
+}

--- a/tools/registry/tool-maturity.schema.json
+++ b/tools/registry/tool-maturity.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tool-maturity.schema.json",
+  "title": "TerraPilot Tool Maturity Metadata Schema",
+  "description": "Governance schema for TerraPilot maturity metadata. It records evidence status only and does not promote tools.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "generatedBy",
+    "generatedOn",
+    "purpose",
+    "maturityStates",
+    "defaultDisclosure",
+    "tools"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "generatedBy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generatedOn": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "purpose": {
+      "type": "string",
+      "minLength": 1
+    },
+    "maturityStates": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "declared",
+          "stub-contract",
+          "contract-covered",
+          "backend-integrated",
+          "promoted"
+        ]
+      },
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true
+    },
+    "defaultDisclosure": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ToolMaturity"
+      }
+    }
+  },
+  "definitions": {
+    "Level": {
+      "enum": [
+        "L0",
+        "L1",
+        "L2",
+        "L3",
+        "L4"
+      ]
+    },
+    "State": {
+      "enum": [
+        "declared",
+        "stub-contract",
+        "contract-covered",
+        "backend-integrated",
+        "promoted"
+      ]
+    },
+    "ToolMaturity": {
+      "type": "object",
+      "required": [
+        "toolId",
+        "level",
+        "state",
+        "liveIntegration",
+        "disclosureRequired",
+        "disclosure",
+        "owner",
+        "evidence",
+        "promotion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "toolId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "level": {
+          "$ref": "#/definitions/Level"
+        },
+        "state": {
+          "$ref": "#/definitions/State"
+        },
+        "liveIntegration": {
+          "type": "boolean"
+        },
+        "disclosureRequired": {
+          "type": "boolean"
+        },
+        "disclosure": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "object",
+          "required": [
+            "manifest",
+            "handlerParity",
+            "promotionProtocol"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "manifest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "handlerParity": {
+              "type": "string",
+              "minLength": 1
+            },
+            "promotionProtocol": {
+              "type": "string",
+              "minLength": 1
+            },
+            "contract": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "backingService": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "verificationCommand": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "traceEvidence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "promotion": {
+          "type": "object",
+          "required": [
+            "targetState",
+            "operatorApproval",
+            "promotionDate",
+            "rollbackPath"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "targetState": {
+              "enum": [
+                "declared",
+                "stub-contract",
+                "contract-covered",
+                "backend-integrated",
+                "promoted",
+                null
+              ]
+            },
+            "operatorApproval": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "promotionDate": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "rollbackPath": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/registry/tool-maturity.schema.json
+++ b/tools/registry/tool-maturity.schema.json
@@ -5,6 +5,7 @@
   "description": "Governance schema for TerraPilot maturity metadata. It records evidence status only and does not promote tools.",
   "type": "object",
   "required": [
+    "$schema",
     "schemaVersion",
     "generatedBy",
     "generatedOn",
@@ -15,6 +16,9 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "const": "./tool-maturity.schema.json"
+    },
     "schemaVersion": {
       "const": "1.0.0"
     },
@@ -89,6 +93,191 @@
         "promotion"
       ],
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "declared"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "const": "L0"
+              },
+              "liveIntegration": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "stub-contract"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "const": "L1"
+              },
+              "liveIntegration": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "contract-covered"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "const": "L2"
+              },
+              "liveIntegration": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "liveIntegration": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "disclosureRequired": {
+                "const": true
+              },
+              "disclosure": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "backend-integrated"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "const": "L3"
+              },
+              "liveIntegration": {
+                "const": true
+              },
+              "evidence": {
+                "required": [
+                  "contract",
+                  "backingService",
+                  "verificationCommand",
+                  "traceEvidence"
+                ],
+                "properties": {
+                  "contract": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "backingService": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "verificationCommand": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "traceEvidence": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "const": "promoted"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "level": {
+                "const": "L4"
+              },
+              "liveIntegration": {
+                "const": true
+              },
+              "evidence": {
+                "required": [
+                  "contract",
+                  "backingService",
+                  "verificationCommand",
+                  "traceEvidence"
+                ],
+                "properties": {
+                  "contract": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "backingService": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "verificationCommand": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "traceEvidence": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "promotion": {
+                "properties": {
+                  "operatorApproval": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "promotionDate": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "rollbackPath": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
       "properties": {
         "toolId": {
           "type": "string",


### PR DESCRIPTION
WO-TERRAPILOT-P8 — Maturity metadata enforcement. Adds machine-readable TerraPilot tool maturity metadata, schema, focused static tests, and evidence. No tool is promoted, no backend integration is added, no runtime behavior changes, no CI/schema/deployment changes, and no secrets/county/PACS/SQL access. Next step is WO-TERRAPILOT-P9 owner decision before any separate runtime promotion WO.