### PR TITLE
fix(security): require admin auth on CanonicalDebugController (WO-BACKEND-SEC-DEBUG-001)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/CanonicalDebugController.cs
+++ b/backend/src/TerraFusion.API/Controllers/CanonicalDebugController.cs
@@ -37,17 +37,25 @@ using TerraFusion.Data.Services.PacsSources;
 namespace TerraFusion.API.Controllers;
 
 /// <summary>
-/// SYNC-POP-2 debug + diagnostic surface. Active in Development only;
-/// guarded write/destructive endpoints additionally require the
-/// <c>ALLOW_DESTRUCTIVE_DEBUG</c> env var. See
-/// <c>docs/sync/sync-pop-2-findings.md</c> for the arc this controller
-/// supports.
+/// SYNC-POP-2 debug + diagnostic surface. See
+/// <c>docs/sync/sync-pop-2-findings.md</c> for the arc this controller supports.
+///
+/// Security posture (layered, WO-BACKEND-SEC-DEBUG-001):
+///   1. Environment gate — the controller is only added to the MVC feature set
+///      in Development (see Program.cs NamespaceExcludingControllerFeatureProvider);
+///      in every other environment its routes do not exist (404).
+///   2. Authorization — where it IS mapped, the whole controller requires an
+///      authenticated caller in the SystemAdmin/Administrator role. It is NO
+///      LONGER [AllowAnonymous]: destructive DB mutations can never be invoked
+///      without an admin token. Operator sync tooling must send an admin Bearer.
+///   3. Destructive env gate — truncate/destructive endpoints additionally
+///      require <c>ALLOW_DESTRUCTIVE_DEBUG=true</c> (unchanged).
 ///
 /// Endpoint posture:
-///   GET  canonical-counts                — read-only, safe in any env
-///   GET  sync-pop-2/pacs-table-columns   — read-only INFORMATION_SCHEMA query
-///   POST sync-pop-2/run-chain            — proof-run; writes legacy_pacs_raw
-///   POST sync-pop-2/truncate-raw-landing — DESTRUCTIVE, env-guarded
+///   GET  canonical-counts                — read-only counts (admin)
+///   GET  sync-pop-2/pacs-table-columns   — read-only INFORMATION_SCHEMA query (admin)
+///   POST sync-pop-2/run-chain            — proof-run; writes legacy_pacs_raw (admin)
+///   POST sync-pop-2/truncate-raw-landing — DESTRUCTIVE, admin + env-guarded
 ///
 /// The doctrine-clean alternative for production landing is the existing
 /// <c>POST /api/sync/sales/run</c> (S2-B + S3); this controller exists
@@ -56,7 +64,7 @@ namespace TerraFusion.API.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/debug")]
-[AllowAnonymous]
+[Authorize(Roles = "SystemAdmin,Administrator")]
 public class CanonicalDebugController : ControllerBase
 {
     private readonly TerraFusionDbContext _db;

--- a/backend/tests/TerraFusion.Unit.Tests/Security/CanonicalDebugControllerHardeningTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Security/CanonicalDebugControllerHardeningTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using TerraFusion.API.Controllers;
+using Xunit;
+
+namespace TerraFusion.Unit.Tests.Security;
+
+// WO-BACKEND-SEC-DEBUG-001 (SW-10): CanonicalDebugController exposes destructive
+// DB-mutation endpoints (sync/drain/populate/truncate). It must never be
+// anonymous and must require an admin role wherever it is mapped. These
+// reflection guards lock that posture so a future edit cannot silently
+// re-open anonymous access.
+[Trait("Category", "Security")]
+public sealed class CanonicalDebugControllerHardeningTests
+{
+    private static readonly Type Controller = typeof(CanonicalDebugController);
+
+    [Fact]
+    public void Class_RequiresAdminAuthorization()
+    {
+        var authorize = Controller.GetCustomAttribute<AuthorizeAttribute>(inherit: false);
+        authorize.Should().NotBeNull("the debug controller must carry [Authorize]");
+        authorize!.Roles.Should().NotBeNullOrWhiteSpace("destructive debug endpoints must be role-gated");
+
+        var roles = authorize.Roles!
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        roles.Should().Contain("Administrator");
+        roles.Should().Contain("SystemAdmin");
+    }
+
+    [Fact]
+    public void Class_IsNotAnonymous()
+    {
+        Controller.GetCustomAttribute<AllowAnonymousAttribute>(inherit: false)
+            .Should().BeNull("the debug controller must not be [AllowAnonymous]");
+    }
+
+    [Fact]
+    public void NoActionMethod_ReopensAnonymousAccess()
+    {
+        var anonymousActions = Controller
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttribute<AllowAnonymousAttribute>(inherit: false) != null)
+            .Select(m => m.Name)
+            .ToArray();
+
+        anonymousActions.Should().BeEmpty(
+            "no debug action may re-open anonymous access; found: {0}",
+            string.Join(", ", anonymousActions));
+    }
+}

--- a/docs/data/WO_BACKEND_SEC_DEBUG_001_CANONICAL_DEBUG_HARDENING.md
+++ b/docs/data/WO_BACKEND_SEC_DEBUG_001_CANONICAL_DEBUG_HARDENING.md
@@ -1,0 +1,60 @@
+# WO-BACKEND-SEC-DEBUG-001 — CanonicalDebugController Hardening
+
+**Date:** 2026-07-02
+**Authorization:** SW-10 (auth/security policy) granted by operator.
+**Risk executed:** SW-10 code change — narrowed the controller's authorization posture. Verified by build +
+tests; no live probe of new behavior possible without a deploy (SW-01), and no destructive endpoint was invoked.
+
+## Finding (from WO-BACKEND-006)
+`CanonicalDebugController` (`[Route("api/debug")]`) carried a class-level **`[AllowAnonymous]`** while exposing ~20
+**DB-mutating** POST endpoints — the SYNC-POP / drain / populate / doctrine-closure lanes, plus a DESTRUCTIVE
+`truncate-raw-landing`. `run-chain` is the operator's sync-workflow HTTP entry point (Program.cs comment ~L996).
+
+## Runtime containment as-found (re-verified live, read-only GET)
+```
+GET https://app-terrafusion-benton-demo.azurewebsites.net/api/debug/canonical-counts  →  404
+```
+The demo returns **404**, not 200 — because Program.cs (`NamespaceExcludingControllerFeatureProvider`, ~L1192)
+**excludes `CanonicalDebugController` from the MVC feature set in every non-Development environment**. So on the
+demo the routes do not exist. The `[AllowAnonymous]` hole was therefore **latent**: live only where the controller
+IS mapped (Development, or if that exclusion is ever bypassed), where anonymous callers could invoke destructive
+mutations.
+
+## Change applied (defense-in-depth; layered)
+Single-line attribute swap on the controller class:
+```diff
+- [AllowAnonymous]
++ [Authorize(Roles = "SystemAdmin,Administrator")]
+```
+Now three independent layers guard the surface:
+1. **Environment gate** (unchanged) — not mapped outside Development → 404.
+2. **Authorization** (new) — where mapped, the whole controller requires an authenticated caller in the
+   `SystemAdmin` **or** `Administrator` role. Anonymous → 401; authenticated non-admin → 403; admin → allowed.
+   Destructive mutations can no longer be invoked without an admin token.
+3. **Destructive env gate** (unchanged) — `truncate-raw-landing` still additionally requires
+   `ALLOW_DESTRUCTIVE_DEBUG=true`.
+
+Both role names are listed to match this codebase's two admin vocabularies (`AIModelsController` uses `SystemAdmin`;
+the provisioned Benton operator's `GovernmentUsers.Role` is `Administrator`) — so the legitimate admin operator is
+not locked out. The `[Authorize(Roles=…)]` pattern is already proven in `AIModelsController`.
+
+## Blast-radius check (why this is safe)
+- **No in-process caller.** Every in-repo `api/debug/` reference is a comment/docstring, not an HTTP client. The
+  Program.cs note states run-chain is invoked over HTTP by external operator tooling specifically to reuse the wired
+  DI tree — i.e. the callers are curl/scripts, not application code. Nothing internal breaks.
+- **Operator runbook implication:** operator sync tooling that POSTs to `/api/debug/*` must now send an admin
+  `Authorization: Bearer <token>` (obtain via the normal admin login; in Development, an admin dev-token). This is
+  the intended hardening, not a regression.
+- **Demo unaffected:** already 404 (excluded); this change is belt-and-suspenders if it is ever mapped there.
+
+## Verification
+- API `/warnaserror` build: **0 warnings / 0 errors**.
+- New reflection posture-guard tests (`CanonicalDebugControllerHardeningTests`): assert the class requires
+  `[Authorize]` with both admin roles, is **not** `[AllowAnonymous]`, and **no action method** re-opens anonymous
+  access. Full `Category=Security` suite: **110/110 pass** (3 new + 107 pre-existing, no regression).
+- New-behavior live proof (401/403/admin-200) is not possible without deploying the change (SW-01) and the demo
+  excludes the controller anyway; the posture-guard tests lock the contract instead. No destructive endpoint invoked.
+
+## Disposition
+Hardening **COMPLETE**. The anonymous-mutation hole is closed by construction and guarded against regression.
+Files: `CanonicalDebugController.cs` (attribute + doc), `CanonicalDebugControllerHardeningTests.cs` (new).


### PR DESCRIPTION
## WO-BACKEND-SEC-DEBUG-001 (SW-10) — Harden CanonicalDebugController

Closes the BACKEND-006 finding: class-level `[AllowAnonymous]` on a controller exposing ~20 DB-mutating sync/drain/populate endpoints + a destructive `truncate-raw-landing`.

### Change
```diff
- [AllowAnonymous]
+ [Authorize(Roles = "SystemAdmin,Administrator")]
```

### Layered posture (defense-in-depth)
1. **Env gate** (unchanged) — `NamespaceExcludingControllerFeatureProvider` excludes the controller outside Development → **404 on the demo today** (re-verified live).
2. **Authorization** (new) — where mapped: anonymous → 401, authed non-admin → 403, admin → allowed. Destructive mutations can no longer be invoked without an admin token.
3. **Destructive env gate** (unchanged) — `truncate` still needs `ALLOW_DESTRUCTIVE_DEBUG=true`.

Both role names cover the codebase's two admin vocabularies (`SystemAdmin` per AIModelsController; `Administrator` = the provisioned operator's role) so the legit operator isn't locked out.

### Blast radius
No in-process caller — every in-repo `api/debug/` reference is a comment; `run-chain` is invoked over HTTP by external operator tooling (Program.cs note). **Runbook:** operator sync tooling must now send an admin Bearer.

### Verification
- API `/warnaserror`: **0 warnings**
- `Category=Security`: **110/110** (3 new reflection posture-guards + 107 pre-existing, no regression)
- New-behavior live proof needs a deploy (SW-01) and the demo excludes the controller anyway → posture-guard tests lock the contract instead. No destructive endpoint invoked.

Evidence: `docs/data/WO_BACKEND_SEC_DEBUG_001_CANONICAL_DEBUG_HARDENING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)