### PR TITLE
feat(audit): AuditableEntityInterceptor for audit-field stamping (WO-AU2-1)

### DIFF
--- a/backend/src/TerraFusion.API/Program.cs
+++ b/backend/src/TerraFusion.API/Program.cs
@@ -2267,8 +2267,12 @@ builder.Services.AddAutoMapper(
 // Program.cs references both assemblies, so it can bridge them safely.
 TerraFusion.Data.TerraFusionDbContext.OnModelCreatingExtensions = TerraFusion.AI.Data.GptAiEntityConfigurations.Apply;
 
-// Register database context with SQLite fallback
-builder.Services.AddDbContext<TerraFusion.Data.TerraFusionDbContext>(options =>
+// Register database context with SQLite fallback.
+// WO-AU2-1: the primary (request-pipeline) context carries the audit-field
+// stamping interceptor. CLI/ETL/seeding hosts build their own contexts above
+// and deliberately do NOT get it (no bulk audit stamping).
+builder.Services.AddScoped<TerraFusion.Data.Auditing.AuditableEntityInterceptor>();
+builder.Services.AddDbContext<TerraFusion.Data.TerraFusionDbContext>((sp, options) =>
 {
   var connectionString = ResolvePrimaryConnectionString(builder.Configuration, builder.Environment);
   var provider = builder.Configuration["DatabaseProvider"];
@@ -2287,6 +2291,8 @@ builder.Services.AddDbContext<TerraFusion.Data.TerraFusionDbContext>(options =>
     // SQLite for development
     options.UseSqlite(ResolveSqliteConnectionString(connectionString, builder.Environment.ContentRootPath));
   }
+
+  options.AddInterceptors(sp.GetRequiredService<TerraFusion.Data.Auditing.AuditableEntityInterceptor>());
 });
 
 // Register TerraFusionContext (Identity context for TerraGaiaService)

--- a/backend/src/TerraFusion.Data/Auditing/AuditableEntityInterceptor.cs
+++ b/backend/src/TerraFusion.Data/Auditing/AuditableEntityInterceptor.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using TerraFusion.Core.Auth;
+using TerraFusion.Core.Entities;
+
+namespace TerraFusion.Data.Auditing;
+
+/// <summary>
+/// WO-AU2-1 — the AuditableEntityInterceptor referenced by the WS-3
+/// <see cref="IAuditableEntity"/> entities (CapRateSet, CostFactorSet,
+/// DepreciationSchedule, LandScheduleSet, ParcelValuation). Stamps the audit
+/// FIELDS only:
+///   - Added:    CreatedAt/By + UpdatedAt/By = now / current actor
+///   - Modified: UpdatedAt/By = now / current actor (Created* preserved)
+///
+/// Actor is sourced from <see cref="IRequestUserContextAccessor"/>; it falls
+/// back to "system" when there is no authenticated request user (background /
+/// non-request saves, or if the accessor is unavailable).
+///
+/// This does NOT emit AuditEvents rows — domain audit-event emission is AU2-3.
+/// Wired only to the primary request-pipeline DbContext registration, so
+/// CLI/ETL/bulk hosts do not run it (they build their own DbContext scopes).
+/// </summary>
+public sealed class AuditableEntityInterceptor : SaveChangesInterceptor
+{
+    private const string SystemActor = "system";
+
+    private readonly IRequestUserContextAccessor _userContext;
+
+    public AuditableEntityInterceptor(IRequestUserContextAccessor userContext)
+        => _userContext = userContext;
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        Stamp(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        Stamp(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    /// <summary>Stamps tracked <see cref="IAuditableEntity"/> entries. Public for unit testing.</summary>
+    public void Stamp(DbContext? context)
+    {
+        if (context is null) return;
+
+        var actor = ResolveActor();
+        var now = DateTime.UtcNow;
+
+        foreach (var entry in context.ChangeTracker.Entries<IAuditableEntity>())
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    entry.Entity.CreatedAt = now;
+                    entry.Entity.CreatedBy = actor;
+                    entry.Entity.UpdatedAt = now;
+                    entry.Entity.UpdatedBy = actor;
+                    break;
+
+                case EntityState.Modified:
+                    // Preserve original Created*; refresh Updated* only.
+                    entry.Entity.UpdatedAt = now;
+                    entry.Entity.UpdatedBy = actor;
+                    break;
+            }
+        }
+    }
+
+    private string ResolveActor()
+    {
+        try
+        {
+            var ctx = _userContext.Current;
+            return ctx.IsAuthenticated && !string.IsNullOrWhiteSpace(ctx.UserId)
+                ? ctx.UserId!
+                : SystemActor;
+        }
+        catch
+        {
+            // Never let audit stamping break a save.
+            return SystemActor;
+        }
+    }
+}

--- a/backend/tests/TerraFusion.Unit.Tests/Audit/AuditableEntityInterceptorTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Audit/AuditableEntityInterceptorTests.cs
@@ -1,0 +1,107 @@
+using System;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using TerraFusion.Core.Auth;
+using TerraFusion.Core.Entities;
+using TerraFusion.Data.Auditing;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace TerraFusion.Unit.Tests.Audit;
+
+// WO-AU2-1 (SW-09): AuditableEntityInterceptor stamps CreatedAt/By + UpdatedAt/By
+// on IAuditableEntity instances during SaveChanges, actor from
+// IRequestUserContextAccessor (fallback "system"). Tested in isolation with a
+// tiny DbContext + test entity so the assertion is about the interceptor, not
+// the full TerraFusion model.
+[Trait("Category", "Audit")]
+public sealed class AuditableEntityInterceptorTests
+{
+    private sealed class FakeUserContext : IRequestUserContextAccessor
+    {
+        public RequestUserContext Current { get; set; } = RequestUserContext.Anonymous;
+    }
+
+    private sealed class Sample : IAuditableEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public string CreatedBy { get; set; } = string.Empty;
+        public string? UpdatedBy { get; set; }
+    }
+
+    private sealed class SampleDbContext : DbContext
+    {
+        public SampleDbContext(DbContextOptions<SampleDbContext> options) : base(options) { }
+        public DbSet<Sample> Samples => Set<Sample>();
+    }
+
+    private static SampleDbContext NewDb(IRequestUserContextAccessor accessor, string name)
+    {
+        var options = new DbContextOptionsBuilder<SampleDbContext>()
+            .UseInMemoryDatabase($"AuditInt-{name}-{Guid.NewGuid()}")
+            .AddInterceptors(new AuditableEntityInterceptor(accessor))
+            .Options;
+        return new SampleDbContext(options);
+    }
+
+    [Fact]
+    public async Task Added_StampsAllFour_FromAuthenticatedUser()
+    {
+        var accessor = new FakeUserContext
+        {
+            Current = new RequestUserContext(true, "user-42", "county-1", Array.Empty<string>())
+        };
+        await using var db = NewDb(accessor, nameof(Added_StampsAllFour_FromAuthenticatedUser));
+
+        var e = new Sample { Name = "x" };
+        db.Samples.Add(e);
+        await db.SaveChangesAsync();
+
+        e.CreatedBy.Should().Be("user-42");
+        e.UpdatedBy.Should().Be("user-42");
+        e.CreatedAt.Should().NotBe(default);
+        e.UpdatedAt.Should().Be(e.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Added_NoAuthenticatedUser_StampsSystem()
+    {
+        var accessor = new FakeUserContext(); // Anonymous
+        await using var db = NewDb(accessor, nameof(Added_NoAuthenticatedUser_StampsSystem));
+
+        var e = new Sample { Name = "x" };
+        db.Samples.Add(e);
+        await db.SaveChangesAsync();
+
+        e.CreatedBy.Should().Be("system");
+        e.UpdatedBy.Should().Be("system");
+    }
+
+    [Fact]
+    public async Task Modified_RefreshesUpdatedOnly_PreservesCreated()
+    {
+        var accessor = new FakeUserContext
+        {
+            Current = new RequestUserContext(true, "creator", null, Array.Empty<string>())
+        };
+        await using var db = NewDb(accessor, nameof(Modified_RefreshesUpdatedOnly_PreservesCreated));
+
+        var e = new Sample { Name = "x" };
+        db.Samples.Add(e);
+        await db.SaveChangesAsync();
+        var createdAt = e.CreatedAt;
+        var createdBy = e.CreatedBy;
+
+        accessor.Current = new RequestUserContext(true, "editor", null, Array.Empty<string>());
+        e.Name = "y";
+        await db.SaveChangesAsync();
+
+        e.CreatedBy.Should().Be(createdBy, "Created* must be preserved on update");
+        e.CreatedAt.Should().Be(createdAt);
+        e.UpdatedBy.Should().Be("editor", "Updated* must reflect the editing actor");
+        e.UpdatedAt.Should().BeOnOrAfter(createdAt);
+    }
+}

--- a/docs/data/WO_AU2_1_AUDIT_FIELD_STAMPING.md
+++ b/docs/data/WO_AU2_1_AUDIT_FIELD_STAMPING.md
@@ -1,0 +1,48 @@
+# WO-AU2-1 — Audit-Field Stamping Interceptor
+
+**Date:** 2026-07-02
+**Authorization:** SW-09 (code), AU2-1 scope: *stamping only* — no schema migration, no domain audit-event
+emission, no ETL/bulk audit rows, no deployment, verify with focused tests + existing gates.
+**Risk executed:** SW-09 — new interceptor on the primary request-pipeline DbContext. Verified by build + tests.
+
+## What existed vs what was missing
+Pre-existing WS-3 scaffolding on `main`:
+- `TerraFusion.Core.Entities.IAuditableEntity` interface (`CreatedAt`, `UpdatedAt`, `string CreatedBy`, `string? UpdatedBy`).
+- **5 entities already implement it** — `CapRateSet`, `CostFactorSet`, `DepreciationSchedule`, `LandScheduleSet`,
+  `ParcelValuation` — with comments stating they are "stamped automatically by AuditableEntityInterceptor".
+- **The interceptor was never built** (only comments referenced it) → those audit fields were not auto-stamped.
+
+AU2-1 builds the missing interceptor against the existing interface. **No new entity was marked** (the nullable-
+`CreatedBy` domain entities like `Appeal` use a different convention and were deliberately left out of scope — that
+would be new marking, not stamping infrastructure), and **no schema changed**.
+
+## Change
+- **New:** `backend/src/TerraFusion.Data/Auditing/AuditableEntityInterceptor.cs` — a `SaveChangesInterceptor` that,
+  on `SavingChanges`/`SavingChangesAsync`, stamps tracked `IAuditableEntity` entries:
+  - **Added** → `CreatedAt/By` + `UpdatedAt/By` = now / actor.
+  - **Modified** → `UpdatedAt/By` = now / actor (Created* preserved).
+  - Actor from `IRequestUserContextAccessor.Current` (`UserId` when authenticated, else `"system"`); the resolve is
+    wrapped in try/catch so audit stamping can never break a save.
+  - **Stamping only** — it does not write `AuditEvents` rows (that is AU2-3).
+- **Wiring:** `Program.cs` primary registration (`builder.Services.AddDbContext<TerraFusionDbContext>`, ~L2271)
+  changed to the `(sp, options)` overload and now calls
+  `options.AddInterceptors(sp.GetRequiredService<AuditableEntityInterceptor>())`; the interceptor is registered
+  `AddScoped` (request-scoped, so the actor accessor is request-scoped). **Only** this registration is touched — the
+  27 CLI/ETL/seeding `AddDbContext` scopes elsewhere in Program.cs are left alone, so **bulk/ETL saves are not
+  stamped by this interceptor** (honoring the "no ETL/bulk audit rows" constraint by construction).
+
+## Verification
+- API `/warnaserror` build: **0 warnings / 0 errors** (nullability matches — interface `string CreatedBy` aligns
+  with the 5 entities' existing non-null `CreatedBy`).
+- New `AuditableEntityInterceptorTests` (isolated tiny DbContext + test `IAuditableEntity`): **3/3** —
+  authenticated add stamps all four from the user; anonymous add stamps `"system"`; modify refreshes `Updated*`
+  and preserves `Created*`. Full `Category=Audit`: **9/9** (3 new + 6 pre-existing, no regression).
+- Runtime end-to-end proof (a real logged-in save stamping a Forge entity) needs a deploy (SW-01) and was not run;
+  the isolated interceptor test proves the stamping behavior through the real EF SaveChanges pipeline.
+
+## Scope honored / not done
+- ✅ stamping only · ✅ `IRequestUserContextAccessor` actor · ✅ no schema migration · ✅ no `AuditEvents` emission ·
+  ✅ ETL/bulk excluded (wired to primary context only) · ✅ no deployment · ✅ tests + existing gates.
+- **Next (not authorized):** AU2-2 (`AuditEvents` +CountyId/index migration, SW-02), AU2-3 (curated event emission),
+  AU2-4 (ETL exclusion controls — largely already true here), AU2-5 (e2e verify). Extending `IAuditableEntity` to
+  more user-facing domain entities is also follow-on marking work, not part of AU2-1.


### PR DESCRIPTION
## WO-AU2-1 (SW-09) — Audit-field stamping interceptor

Implements the `AuditableEntityInterceptor` that WS-3's `IAuditableEntity` entities (`CapRateSet`, `CostFactorSet`, `DepreciationSchedule`, `LandScheduleSet`, `ParcelValuation`) already reference in comments **but which was never built** — so their audit fields weren't being auto-stamped.

### Change
- **New** `AuditableEntityInterceptor : SaveChangesInterceptor` — Added → stamps `CreatedAt/By`+`UpdatedAt/By`; Modified → `UpdatedAt/By` only (Created* preserved). Actor from `IRequestUserContextAccessor` (fallback `"system"`; try/catch so stamping can't break a save). **Stamping only — no `AuditEvents` emission** (that's AU2-3).
- **Wiring:** only the **primary request-pipeline** `AddDbContext` (Program.cs ~L2271, `(sp,options)` + `AddScoped`). The 27 CLI/ETL/seeding scopes are untouched → **bulk/ETL saves aren't stamped**, honoring the scope's "no ETL/bulk audit rows" by construction.

### Scope honored
stamping only ✅ · `IRequestUserContextAccessor` actor ✅ · **no schema migration** ✅ · no `AuditEvents` emission ✅ · ETL/bulk excluded ✅ · no deploy ✅ · no new entity marking ✅

### Verification
- API `/warnaserror`: **0 warnings** (interface `string CreatedBy` matches the 5 entities' non-null field)
- `AuditableEntityInterceptorTests` (isolated DbContext): **3/3** (authed→user, anon→system, modify preserves Created*)
- `Category=Audit`: **9/9** (no regression). Runtime e2e needs a deploy (SW-01), not run.

### Next (unauthorized)
AU2-2 migration (SW-02) · AU2-3 curated emission · AU2-4 ETL controls · AU2-5 e2e · extending the marker to more entities.

Evidence: `docs/data/WO_AU2_1_AUDIT_FIELD_STAMPING.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)