### PR TITLE
feat(audit): AuditEvents CountyId + trail index migration (WO-AU2-2)

### DIFF
--- a/backend/src/TerraFusion.Core/Entities/CollaborationEntities.cs
+++ b/backend/src/TerraFusion.Core/Entities/CollaborationEntities.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using TerraFusion.Core.DTOs;
 
 namespace TerraFusion.Core.Entities
@@ -546,6 +547,7 @@ namespace TerraFusion.Core.Entities
 
     // Audit and Compliance Entities
     [Table("AuditEvents")]
+    [Index(nameof(EntityId), nameof(Timestamp))] // WO-AU2-2: per-parcel trail lookup
     public class AuditEvent
     {
         [Key]
@@ -584,7 +586,11 @@ namespace TerraFusion.Core.Entities
         [Required]
         [StringLength(100)]
         public string SessionId { get; set; } = string.Empty;
-        
+
+        // WO-AU2-2: county context for audit-event isolation. Nullable + additive
+        // (no backfill); AU2-3 event emission will populate it going forward.
+        public Guid? CountyId { get; set; }
+
         // Navigation Properties
         [ForeignKey(nameof(UserId))]
         public virtual CollaborationUser User { get; set; } = null!;

--- a/backend/src/TerraFusion.Data/Migrations/20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex.Designer.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using TerraFusion.Data;
 namespace TerraFusion.Data.Migrations
 {
     [DbContext(typeof(TerraFusionDbContext))]
-    partial class TerraFusionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex")]
+    partial class AU2_2_AuditEventsCountyIdAndTrailIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/TerraFusion.Data/Migrations/20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex.cs
+++ b/backend/src/TerraFusion.Data/Migrations/20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TerraFusion.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AU2_2_AuditEventsCountyIdAndTrailIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CountyId",
+                table: "AuditEvents",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditEvents_EntityId_Timestamp",
+                table: "AuditEvents",
+                columns: new[] { "EntityId", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AuditEvents_EntityId_Timestamp",
+                table: "AuditEvents");
+
+            migrationBuilder.DropColumn(
+                name: "CountyId",
+                table: "AuditEvents");
+        }
+    }
+}

--- a/docs/data/WO_AU2_2_AUDITEVENTS_SCHEMA_MIGRATION.md
+++ b/docs/data/WO_AU2_2_AUDITEVENTS_SCHEMA_MIGRATION.md
@@ -1,0 +1,46 @@
+# WO-AU2-2 — AuditEvents Schema: CountyId + Trail Index
+
+**Date:** 2026-07-02
+**Authorization:** SW-02 (schema migration) granted by operator.
+**Risk executed:** SW-02 — an **additive** EF migration was **generated and committed**. It was **NOT applied** to the
+live demo DB (applying is deploy-time / SW-01; the demo's AutoMigrate will apply it on the next deploy). No live
+data was mutated; no destructive DDL.
+
+## Change
+Extends `canonical` audit schema so AU2-3 event emission can populate county-scoped, efficiently-queryable rows:
+- **`AuditEvent.CountyId`** — new `Guid?` property → `AuditEvents.CountyId uuid NULL`. Nullable + additive → existing
+  rows (0 today) get `NULL`; no backfill required. Lets a future `/api/audit/trail` enforce true county isolation
+  instead of parcel-scope-only.
+- **Index `IX_AuditEvents_EntityId_Timestamp`** on `(EntityId, Timestamp)` — the exact access pattern of
+  `/api/audit/trail` and `/api/audit/search` (filter by `EntityId`, order by `Timestamp`).
+
+Both declared on the entity in `Core` (`[Index]` attribute + property); `Core` already references EF Core, so no new
+dependency and the config stays colocated with the POCO.
+
+## Migration
+`backend/src/TerraFusion.Data/Migrations/20260703002317_AU2_2_AuditEventsCountyIdAndTrailIndex.cs`
+```csharp
+Up:   AddColumn<Guid>("CountyId", "AuditEvents", type: "uuid", nullable: true);
+      CreateIndex("IX_AuditEvents_EntityId_Timestamp", "AuditEvents", ["EntityId","Timestamp"]);
+Down: DropIndex(...); DropColumn("CountyId", ...);   // fully reversible
+```
+
+## Discipline & verification
+- **Generated with API as `--startup-project`** (`dotnet ef migrations add … --project TerraFusion.Data
+  --startup-project TerraFusion.API --context TerraFusion.Data.TerraFusionDbContext`) — per the standing rule that
+  Data-as-startup scaffolds destructive DROPs. Confirmed working: the API host ran at design time (so
+  `OnModelCreatingExtensions`, which applies the GPT/RAG configs, was set → **full model**), and the diff came out
+  clean.
+- **Migration inspected — surgical:** the generated `Up`/`Down` contain **only** the CountyId column and the one
+  index. No table drops, no GPT/RAG churn, no `DocumentAuditEvents` (the `AuditEvent` subclass) changes.
+- **Snapshot diff = 5 additions / 0 deletions**, all inside the `AuditEvent` model block.
+- **Build:** API `/warnaserror` → 0 warnings / 0 errors (entity, migration, and snapshot all compile).
+- **Not applied to any DB.** `AuditEvents` is empty, and even a populated table would be safe (nullable add + index
+  create are non-destructive). The demo applies it on next deploy (SW-01).
+
+## Scope honored / not done
+- ✅ additive nullable column · ✅ `(EntityId, Timestamp)` index · ✅ API-as-startup · ✅ generated + inspected +
+  reversible · ✅ no live-DB apply · ✅ no data mutation.
+- **Next (not authorized):** AU2-3 (`IAuditEventWriter` + curated emission, populating `CountyId`), AU2-4 (ETL
+  exclusion — already structurally true from AU2-1), AU2-5 (e2e verification). Applying this migration to the demo
+  is a deploy action (SW-01).


### PR DESCRIPTION
## WO-AU2-2 (SW-02) — AuditEvents schema: CountyId + (EntityId, Timestamp) index

Additive schema so AU2-3 emission can write county-scoped, efficiently-queryable audit rows.

### Change
- **`AuditEvent.CountyId`** → `AuditEvents.CountyId uuid NULL` (nullable + additive; `AuditEvents` is empty → no backfill).
- **`IX_AuditEvents_EntityId_Timestamp`** on `(EntityId, Timestamp)` — the exact trail/search access pattern.

Declared via `[Index]` + property on the Core POCO (Core already references EFCore).

### Migration (generated + committed, NOT applied)
```
Up:   AddColumn CountyId uuid NULL; CreateIndex IX_AuditEvents_EntityId_Timestamp (EntityId,Timestamp)
Down: DropIndex; DropColumn   // reversible
```
- Generated with **API as `--startup-project`** (`--context TerraFusionDbContext`) per the anti-destructive-scaffold rule — the API host ran at design time (`OnModelCreatingExtensions` applied → **full model**).
- **Inspected — surgical:** Up/Down contain **only** the column + index; no drops, no GPT/RAG or `DocumentAuditEvents` churn. Snapshot diff = **5 add / 0 del**.
- **Not applied to any DB** — deploy-time (SW-01) via AutoMigrate; non-destructive on the empty table.

### Verification
API `/warnaserror`: **0 warnings / 0 errors**.

### Next (unauthorized)
AU2-3 curated emission (populates CountyId) · AU2-4 ETL controls · AU2-5 e2e · applying this migration = deploy (SW-01).

Evidence: `docs/data/WO_AU2_2_AUDITEVENTS_SCHEMA_MIGRATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)