### PR TITLE
docs(terrapilot): record first promotion decision

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P9 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P10 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P9-FIRST-PROMOTION-CANDIDATE-DECISION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P9-FIRST-PROMOTION-CANDIDATE-DECISION.md
@@ -1,0 +1,129 @@
+# WO-TERRAPILOT-P9 - First Promotion Candidate Decision
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Decision/evidence only. No runtime change, no backend integration, no tool promotion.
+
+## Decision
+
+No TerraPilot tool is ready to move to `backend-integrated` or `promoted`.
+
+The first safe next step is not live promotion. The next step is a separate evidence work order that
+attempts to raise one read-only candidate from `stub-contract` to `contract-covered` by documenting
+its contract, owning service, backing target, auth boundary, verification plan, trace requirement,
+UI disclosure rule, and rollback/demotion path.
+
+Recommended candidate for that future evidence packet:
+
+- `summarize_levy_rate_components`
+
+This recommendation does not promote the tool and does not mark it live.
+
+## Evidence Reviewed
+
+- `docs/brain/workorders/programs/terrapilot-promotion-protocol.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P7-EVIDENCE-ROLLUP.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md`
+- `tools/registry/tool-maturity.json`
+- `tools/registry/tool-maturity.schema.json`
+- `os-platform/core/tests/tool-maturity.test.mjs`
+
+## Current Maturity Metadata
+
+Observed from `tools/registry/tool-maturity.json`:
+
+| Metric | Value |
+|--------|-------|
+| Total TerraPilot tools | 117 |
+| `stub-contract` tools | 117 |
+| `contract-covered` tools | 0 |
+| `backend-integrated` tools | 0 |
+| `promoted` tools | 0 |
+| `liveIntegration: true` tools | 0 |
+
+All current tools remain `L1` / `stub-contract` and keep `liveIntegration: false`.
+
+## Why No Tool Is Ready
+
+The P8 schema and test guard require a future `backend-integrated` claim to include:
+
+- `liveIntegration: true`,
+- `level: L3`,
+- contract evidence,
+- backing service evidence,
+- verification command,
+- trace evidence.
+
+A future `promoted` claim additionally requires:
+
+- `level: L4`,
+- operator approval,
+- promotion date,
+- rollback path.
+
+No current tool metadata contains those fields, and this P9 packet does not create them.
+
+## Candidate Rationale
+
+`summarize_levy_rate_components` remains the best first evidence candidate because P4 already
+classified it as a read-only candidate with real handler registration. It is still blocked from live
+promotion because it lacks:
+
+- live backend probe,
+- backing service proof,
+- auth boundary documentation,
+- trace evidence,
+- operator approval.
+
+Those blockers are appropriate. They prevent a green manifest or real handler registration from
+being mistaken for a live assessor-facing tool.
+
+## Explicit Non-Changes
+
+- No tool was promoted.
+- No tool was marked `contract-covered`, `backend-integrated`, or `promoted`.
+- No maturity metadata was changed.
+- No backend integration was implemented.
+- No handler behavior changed.
+- No product/runtime behavior changed.
+- No GitHub Actions workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+
+## Validation
+
+Validation for this decision packet:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+P8 post-merge validation also confirmed:
+
+- P8 files exist on `origin/main`,
+- `tool-maturity.test.mjs` passes from the updated main baseline,
+- `phase83-tools.test.mjs` passes from the updated main baseline.
+
+AJV schema validation was attempted from the clean P9 worktree, but `ajv` was not installed in that
+worktree without running a package install. No install was performed in P9.
+
+## Next Recommended Work
+
+`WO-TERRAPILOT-P10 - Contract-Covered Candidate Evidence Packet`
+
+Recommended scope:
+
+- candidate: `summarize_levy_rate_components`,
+- decision/evidence only unless separately authorized,
+- document contract, owner, backing target, auth boundary, verification method, trace requirement,
+  UI disclosure, and rollback/demotion path,
+- do not mark the tool `backend-integrated`,
+- do not implement live backend integration,
+- do not touch secrets, county data, PACS, county SQL, live DB, schema migrations, deployment, or
+  runtime behavior without a separate owner-authorized work order.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P9 | YES — first live-promotion candidate requires owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P10 | YES — live promotion remains an owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -127,11 +127,13 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P6 | Tooling operator packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P7 | Evidence rollup | COMPLETE IN PR |
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | COMPLETE IN PR |
-| WO-TERRAPILOT-P9 | First promotion candidate decision | **NEXT — OWNER DECISION** |
+| WO-TERRAPILOT-P9 | First promotion candidate decision | COMPLETE IN PR |
+| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **NEXT — EVIDENCE PACKET** |
 
-WO-TERRAPILOT-P8 may proceed only as a narrow metadata/test implementation. Any runtime promotion,
-backend integration, deployment, secrets, county data, PACS, live DB access, or schema migration is a
-stop wall. WO-TERRAPILOT-P9 is an owner decision wall before any separate runtime promotion WO.
+WO-TERRAPILOT-P10 may proceed only as a narrow decision/evidence packet for a candidate contract,
+owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and
+rollback/demotion path. Any runtime promotion, backend integration, deployment, secrets, county data,
+PACS, live DB access, or schema migration is a stop wall before any separate runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -3,7 +3,7 @@
 **Program:** P5  
 **Status:** ACTIVE  
 **Owner:** Operator (bsvalues@gmail.com)  
-**Last Updated:** 2026-07-02
+**Last Updated:** 2026-07-03
 
 ---
 
@@ -41,7 +41,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P6 | Tooling operator packet | **COMPLETE IN PR** | Package operator rules for future TerraPilot maturity work |
 | WO-TERRAPILOT-P7 | Evidence rollup | **COMPLETE IN PR** | Roll up P2-P6 evidence and stop before live promotion |
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | **COMPLETE IN PR** | Add machine-readable maturity metadata and focused tests without promoting tools |
-| WO-TERRAPILOT-P9 | First promotion candidate decision | **NEXT — OWNER DECISION** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
+| WO-TERRAPILOT-P9 | First promotion candidate decision | **COMPLETE IN PR** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
+| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **NEXT — EVIDENCE PACKET** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
 
 ---
 
@@ -57,7 +58,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7 → P8 → P9 decision
+P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7 → P8 → P9 decision → P10 evidence packet
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work


### PR DESCRIPTION
WO-TERRAPILOT-P9: decision/evidence packet for first TerraPilot promotion candidate. Records that no tool is ready for backend-integrated or promoted state; recommends a future contract-covered evidence packet for summarize_levy_rate_components. No runtime behavior, backend integration, CI workflow, schema migration, deployment, secrets, county data, PACS, SQL, or live DB access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new evidence/decision document for a TerraPilot work order.
  * Recorded current maturity status, validation results, and the next safe step for advancing a single read-only candidate.
  * Clarified that no tools are being promoted or changed yet, and listed what remains unmet before progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->