### PR TITLE
docs(terrapilot): record levy rate candidate evidence

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P10 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P11 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md
@@ -14,6 +14,20 @@ This packet does not promote the tool, does not mark it `contract-covered`, and 
 backend/product integration. It records the current evidence, the missing evidence, and the stop
 gates that must remain in force before any future `backend-integrated` or `promoted` claim.
 
+## Authorization and Scope
+
+This `docs/brain/**` evidence packet is authorized by
+`WO-TERRAPILOT-P10 - summarize_levy_rate_components Evidence Packet` under the
+`GOAL-TERRAPILOT-TOOL-MATURITY` loop. The owner-approved P10 scope is evidence only:
+
+- inspect maturity metadata, registry metadata, and current handler/manifest references,
+- document current state and missing evidence before promotion,
+- update program/playbook routing only where needed for the next governance work order.
+
+This authorization does not permit runtime implementation, handler behavior changes, backend
+integration, CI workflow changes, schema/database migration, deployment, secrets, county data, PACS,
+county SQL, live DB access, or promotion to `backend-integrated`/`live`.
+
 ## Candidate
 
 | Field | Value |
@@ -41,7 +55,9 @@ gates that must remain in force before any future `backend-integrated` or `promo
 - `os-platform/core/tests/r1-contract-alignment.test.mjs`
 - `os-platform/core/tests/r1-auth-smoke.test.mjs`
 - `os-platform/core/tests/r1-live-smoke.test.mjs`
+- `os-platform/core/tests/phase83-tools.test.mjs`
 - `os-platform/core/tests/phase85-tools.test.mjs`
+- `os-platform/core/tests/tool-maturity.test.mjs`
 
 ## Current Manifest Contract
 
@@ -114,7 +130,7 @@ evidence-only and leaves `tools/registry/tool-maturity.json` unchanged.
 
 The tool must not be marked `backend-integrated` until a separate authorized work order provides:
 
-- focused live/focused validation against the owning backend service,
+- focused live validation against the owning backend service,
 - proof that the backing service is available in the intended environment,
 - auth model evidence that does not expose credentials or secrets,
 - TerraTrace/correlation evidence for a real execution path,
@@ -154,10 +170,15 @@ Validation for this evidence packet:
 
 ```powershell
 git diff --check
+pnpm run type-check
 node docs/brain/workorders/tools/wo-query.mjs --json
 node --test os-platform/core/tests/tool-maturity.test.mjs
 node --test os-platform/core/tests/phase83-tools.test.mjs
 ```
+
+Validation result: all commands passed. `pnpm run type-check` required materializing the local
+sparse checkout paths used by `tsconfig.core.json`; no tracked lockfile or runtime changes were
+kept from that local validation setup.
 
 ## Next Recommended Work
 

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md
@@ -1,0 +1,175 @@
+# WO-TERRAPILOT-P10 - summarize_levy_rate_components Evidence Packet
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Evidence only. No runtime change, no backend integration, no tool promotion.
+
+## Decision
+
+`summarize_levy_rate_components` is the first TerraPilot candidate with enough source evidence to
+prepare a future `contract-covered` metadata decision.
+
+This packet does not promote the tool, does not mark it `contract-covered`, and does not claim live
+backend/product integration. It records the current evidence, the missing evidence, and the stop
+gates that must remain in force before any future `backend-integrated` or `promoted` claim.
+
+## Candidate
+
+| Field | Value |
+|-------|-------|
+| Tool ID | `summarize_levy_rate_components` |
+| Suite | `dais` |
+| Risk | `read_only` |
+| Mode | `muse` |
+| Write lane | `null` |
+| Current maturity level | `L1` |
+| Current maturity state | `stub-contract` |
+| Current live integration flag | `false` |
+| Current disclosure | `tool layer in development` |
+
+## Evidence Reviewed
+
+- `tools/registry/terrapilot.tools.json`
+- `tools/registry/tool-maturity.json`
+- `tools/registry/tool-maturity.schema.json`
+- `docs/brain/workorders/programs/terrapilot-promotion-protocol.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P8-MATURITY-METADATA-ENFORCEMENT.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P9-FIRST-PROMOTION-CANDIDATE-DECISION.md`
+- `os-platform/core/pilot/handlers.real.ts`
+- `os-platform/core/tests/r1-contract-alignment.test.mjs`
+- `os-platform/core/tests/r1-auth-smoke.test.mjs`
+- `os-platform/core/tests/r1-live-smoke.test.mjs`
+- `os-platform/core/tests/phase85-tools.test.mjs`
+
+## Current Manifest Contract
+
+The manifest declares `summarize_levy_rate_components` as a Dais read-only TerraPilot tool.
+
+Observed manifest properties:
+
+- `toolId`: `summarize_levy_rate_components`
+- `displayName`: `Summarize Levy Rate Components`
+- `suite`: `dais`
+- `mode`: `muse`
+- `risk`: `read_only`
+- `writeLane`: `null`
+- `touches`: `levy`, `parcel`
+- `piiHandling`: `sanitize`
+- `tracePolicy`: `summary_only`
+- `officeScope`: `assessor`
+
+Observed parameter contract:
+
+- `county`: string, required, must match the execution context county
+- `taxYear`: integer, required
+- `districtCode`: string, optional
+
+## Current Handler Evidence
+
+`os-platform/core/pilot/handlers.real.ts` contains a real handler registration for the tool:
+
+- handler export: `summarizeLevyRateRealHandler`
+- registry binding: `runner.registerHandler('summarize_levy_rate_components', summarizeLevyRateRealHandler)`
+- intended backend target: `POST /api/levy-calculation/calculate-rate`
+- county boundary: `assertCountyMatch(params.county, context.countyId)`
+- auth boundary: `acquirePilotToken()`
+
+This is meaningful evidence that the tool has a concrete handler and backend target. It is not by
+itself live promotion evidence because this P10 work order did not run or change backend services,
+did not access live data, and did not update maturity metadata.
+
+## Current Test Evidence
+
+Existing tests reference the candidate:
+
+| Test file | Evidence type |
+|-----------|---------------|
+| `os-platform/core/tests/r1-contract-alignment.test.mjs` | Manifest schema and suite/risk alignment |
+| `os-platform/core/tests/r1-auth-smoke.test.mjs` | Auth-bound backend smoke path when a local backend is available |
+| `os-platform/core/tests/r1-live-smoke.test.mjs` | Backend dispatch distinction from canned/stub behavior |
+| `os-platform/core/tests/phase85-tools.test.mjs` | Contract-shaped result, sorted components, total-rate calculation, trace pair |
+| `os-platform/core/tests/phase83-tools.test.mjs` | Manifest/tool registry invariants |
+| `os-platform/core/tests/tool-maturity.test.mjs` | Maturity metadata guardrails |
+
+P10 did not start services, use credentials, access county systems, or run live backend probes.
+
+## Contract-Covered Readiness
+
+Based on current evidence, the tool is a candidate for a future `contract-covered` metadata change
+because it has:
+
+- a manifest entry with risk, suite, params schema, PII handling, trace policy, and disclosure,
+- a concrete handler reference,
+- a named backend target,
+- a county-boundary check,
+- an auth-token acquisition boundary,
+- contract and smoke tests that describe the expected behavior.
+
+The future `contract-covered` decision still needs an explicit metadata work order because P10 is
+evidence-only and leaves `tools/registry/tool-maturity.json` unchanged.
+
+## Missing Evidence Before Backend-Integrated
+
+The tool must not be marked `backend-integrated` until a separate authorized work order provides:
+
+- focused live/focused validation against the owning backend service,
+- proof that the backing service is available in the intended environment,
+- auth model evidence that does not expose credentials or secrets,
+- TerraTrace/correlation evidence for a real execution path,
+- confirmation that UI/operator disclosure remains honest,
+- rollback/demotion path if the integration fails or evidence expires.
+
+## Promotion Stop Gates
+
+Stop before any future change that would:
+
+- mark the tool `backend-integrated`,
+- mark the tool `promoted`,
+- set `liveIntegration: true`,
+- change handler behavior,
+- implement or modify backend integration,
+- start deployment or production work,
+- touch secrets, credentials, PACS, county SQL, county data, or live databases,
+- apply schema/database migrations,
+- weaken existing phase83 or maturity metadata gates.
+
+## Explicit Non-Changes
+
+- No tool was promoted.
+- No tool was marked `contract-covered`, `backend-integrated`, or `promoted`.
+- No maturity metadata was changed.
+- No backend integration was implemented.
+- No handler behavior changed.
+- No product/runtime behavior changed.
+- No CI workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+
+## Validation
+
+Validation for this evidence packet:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+## Next Recommended Work
+
+`WO-TERRAPILOT-P11 - Contract-Covered Metadata Decision`
+
+Recommended scope:
+
+- decide whether `summarize_levy_rate_components` should move from `stub-contract` to
+  `contract-covered`,
+- if authorized, update maturity metadata only after confirming the P10 evidence still applies,
+- do not mark the tool `backend-integrated`,
+- do not set `liveIntegration: true`,
+- do not implement backend integration,
+- do not touch runtime behavior, CI workflows, deployment, schema/database migration, secrets,
+  county data, PACS, county SQL, or live DB access.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P10 | YES — live promotion remains an owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P11 | YES — live promotion remains an owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -128,12 +128,14 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P7 | Evidence rollup | COMPLETE IN PR |
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | COMPLETE IN PR |
 | WO-TERRAPILOT-P9 | First promotion candidate decision | COMPLETE IN PR |
-| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **NEXT — EVIDENCE PACKET** |
+| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | COMPLETE IN PR |
+| WO-TERRAPILOT-P11 | Contract-covered metadata decision | **NEXT — METADATA DECISION** |
 
-WO-TERRAPILOT-P10 may proceed only as a narrow decision/evidence packet for a candidate contract,
-owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and
-rollback/demotion path. Any runtime promotion, backend integration, deployment, secrets, county data,
-PACS, live DB access, or schema migration is a stop wall before any separate runtime promotion WO.
+WO-TERRAPILOT-P11 may proceed only as a narrow metadata decision for whether
+`summarize_levy_rate_components` should move from `stub-contract` to `contract-covered` based on P10
+evidence. Any runtime promotion, backend integration, `liveIntegration: true` claim, deployment,
+secrets, county data, PACS, live DB access, or schema migration is a stop wall before any separate
+runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -42,7 +42,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P7 | Evidence rollup | **COMPLETE IN PR** | Roll up P2-P6 evidence and stop before live promotion |
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | **COMPLETE IN PR** | Add machine-readable maturity metadata and focused tests without promoting tools |
 | WO-TERRAPILOT-P9 | First promotion candidate decision | **COMPLETE IN PR** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
-| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **NEXT — EVIDENCE PACKET** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
+| WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **COMPLETE IN PR** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
+| WO-TERRAPILOT-P11 | Contract-covered metadata decision | **NEXT — METADATA DECISION** | Decide whether P10 evidence is sufficient to move `summarize_levy_rate_components` to `contract-covered`, without claiming live integration |
 
 ---
 
@@ -58,7 +59,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) → P2 → P3 → P4 → P5 → P6 → P7 → P8 → P9 decision → P10 evidence packet
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -67,6 +68,10 @@ decisions.
 
 P8 adds enforcement metadata and static tests only. It does not move any tool to `backend-integrated`
 or `promoted`.
+
+P10 records candidate evidence only. P11 may decide whether `summarize_levy_rate_components` can move
+to `contract-covered`, but it must still stop before `backend-integrated`, `liveIntegration: true`,
+or `promoted` unless a separate operator-authorized runtime work order exists.
 
 ---
 


### PR DESCRIPTION
WO-TERRAPILOT-P10 evidence packet for summarize_levy_rate_components. Scope is TerraPilot governance/evidence and program routing only. No runtime code, handler behavior, maturity metadata promotion, backend integration, CI workflow, schema/database migration, deployment, secrets, county data, PACS, SQL, or live DB access.