### PR TITLE
docs(terrapilot): record contract-covered metadata decision

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-01 — WO-WOE-011)*
+*(Updated 2026-07-03 — WO-TERRAPILOT-P11)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P11 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P12 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P11-CONTRACT-COVERED-METADATA-DECISION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P11-CONTRACT-COVERED-METADATA-DECISION.md
@@ -1,0 +1,111 @@
+# WO-TERRAPILOT-P11 - Contract-Covered Metadata Decision
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Evidence/governance decision only. No metadata mutation, no runtime change, no backend
+integration, no live promotion.
+
+## Decision
+
+`summarize_levy_rate_components` remains a valid first candidate for a future
+`contract-covered` maturity metadata change, but this P11 packet does not change
+`tools/registry/tool-maturity.json`.
+
+Reason: moving a tool from `stub-contract` to `contract-covered` is not live/backend integration,
+but it is still a maturity-state claim. That claim should be made only in a narrow follow-up work
+order that explicitly authorizes the metadata change and records the exact evidence carried forward
+from P10.
+
+## Inputs Reviewed
+
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md`
+- `tools/registry/tool-maturity.json`
+- `tools/registry/tool-maturity.schema.json`
+- `tools/registry/terrapilot.tools.json`
+- `docs/brain/workorders/programs/terrapilot-tool-maturity.md`
+- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md`
+
+## Current Metadata State
+
+`summarize_levy_rate_components` remains:
+
+| Field | Current value |
+|-------|---------------|
+| `level` | `L1` |
+| `state` | `stub-contract` |
+| `liveIntegration` | `false` |
+| `disclosureRequired` | `true` |
+| `disclosure` | `tool layer in development` |
+
+## P10 Evidence Carried Forward
+
+P10 established that the candidate has:
+
+- a manifest entry with suite, risk, parameter schema, PII handling, trace policy, and disclosure,
+- a concrete handler reference,
+- a named backend target,
+- a county-boundary check,
+- an auth-token acquisition boundary,
+- static contract and smoke tests that describe expected behavior.
+
+That evidence is enough to justify a future `contract-covered` metadata-change packet. It is not
+enough to claim `backend-integrated`, `liveIntegration: true`, or `promoted`.
+
+## Metadata Change Stop Gate
+
+A follow-up metadata-change work order may update only `tools/registry/tool-maturity.json` and
+evidence/routing docs if it confirms:
+
+- P10 evidence still applies to `summarize_levy_rate_components`,
+- the tool remains read-only,
+- `liveIntegration` remains `false`,
+- disclosure remains honest and required,
+- no handler behavior changes,
+- no backend integration is implemented,
+- no runtime behavior changes,
+- no CI workflow changes,
+- no schema/database migration occurs,
+- no deployment, secrets, county data, PACS, county SQL, or live DB access is used.
+
+## Explicit Non-Changes
+
+- No maturity metadata changed.
+- No tool was marked `contract-covered`.
+- No tool was marked `backend-integrated`.
+- No tool was marked `promoted`.
+- No `liveIntegration: true` claim was made.
+- No handler behavior changed.
+- No backend integration was implemented.
+- No runtime/product behavior changed.
+- No CI workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+
+## Validation
+
+Validation for this decision packet:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+## Next Recommended Work
+
+`WO-TERRAPILOT-P12 - Contract-Covered Metadata Change Authorization Packet`
+
+Recommended scope:
+
+- decide whether to explicitly authorize moving `summarize_levy_rate_components` from
+  `stub-contract` to `contract-covered`,
+- if authorized, update only maturity metadata and supporting evidence/routing docs,
+- keep `liveIntegration: false`,
+- do not mark the tool `backend-integrated`,
+- do not mark the tool `promoted`,
+- do not implement backend integration,
+- do not touch runtime behavior, CI workflows, deployment, schema/database migration, secrets,
+  county data, PACS, county SQL, or live DB access.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P11 | YES — live promotion remains an owner decision and separate runtime WO | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P12 | YES — metadata promotion and live promotion remain owner decisions | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -129,13 +129,14 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | COMPLETE IN PR |
 | WO-TERRAPILOT-P9 | First promotion candidate decision | COMPLETE IN PR |
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | COMPLETE IN PR |
-| WO-TERRAPILOT-P11 | Contract-covered metadata decision | **NEXT — METADATA DECISION** |
+| WO-TERRAPILOT-P11 | Contract-covered metadata decision | COMPLETE IN PR |
+| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **NEXT — OWNER DECISION** |
 
-WO-TERRAPILOT-P11 may proceed only as a narrow metadata decision for whether
-`summarize_levy_rate_components` should move from `stub-contract` to `contract-covered` based on P10
-evidence. Any runtime promotion, backend integration, `liveIntegration: true` claim, deployment,
-secrets, county data, PACS, live DB access, or schema migration is a stop wall before any separate
-runtime promotion WO.
+WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
+future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
+is the next owner-decision packet for whether to authorize that metadata change. Any runtime
+promotion, backend integration, `liveIntegration: true` claim, deployment, secrets, county data, PACS,
+live DB access, or schema migration is a stop wall before any separate runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -1,7 +1,7 @@
 # Command-to-Program Map
 
 **Authority:** WO-WOE-010  
-**Last Updated:** 2026-06-30  
+**Last Updated:** 2026-07-03
 **Classification:** Operator Doctrine — current state snapshot
 
 This file maps every `/goal` command to its program, current next WO, blockers, allowed loop modes,

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -72,7 +72,7 @@ or `promoted`.
 
 P10 records candidate evidence only. P11 records that `summarize_levy_rate_components` remains a
 candidate for `contract-covered`, but it does not change maturity metadata. P12 is the owner-decision
-packet for any actual metadata change. All P5 work must still stop before `backend-integrated`,
+packet for any actual metadata change. All TerraPilot maturity work must still stop before `backend-integrated`,
 `liveIntegration: true`, or `promoted` unless a separate operator-authorized runtime work order
 exists.
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -43,7 +43,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P8 | Maturity metadata enforcement | **COMPLETE IN PR** | Add machine-readable maturity metadata and focused tests without promoting tools |
 | WO-TERRAPILOT-P9 | First promotion candidate decision | **COMPLETE IN PR** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **COMPLETE IN PR** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
-| WO-TERRAPILOT-P11 | Contract-covered metadata decision | **NEXT — METADATA DECISION** | Decide whether P10 evidence is sufficient to move `summarize_levy_rate_components` to `contract-covered`, without claiming live integration |
+| WO-TERRAPILOT-P11 | Contract-covered metadata decision | **COMPLETE IN PR** | Decide whether P10 evidence is sufficient to justify a follow-up `contract-covered` metadata-change packet, without mutating metadata or claiming live integration |
+| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **NEXT — OWNER DECISION** | Decide whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
 
 ---
 
@@ -59,7 +60,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -69,9 +70,11 @@ decisions.
 P8 adds enforcement metadata and static tests only. It does not move any tool to `backend-integrated`
 or `promoted`.
 
-P10 records candidate evidence only. P11 may decide whether `summarize_levy_rate_components` can move
-to `contract-covered`, but it must still stop before `backend-integrated`, `liveIntegration: true`,
-or `promoted` unless a separate operator-authorized runtime work order exists.
+P10 records candidate evidence only. P11 records that `summarize_levy_rate_components` remains a
+candidate for `contract-covered`, but it does not change maturity metadata. P12 is the owner-decision
+packet for any actual metadata change. All P5 work must still stop before `backend-integrated`,
+`liveIntegration: true`, or `promoted` unless a separate operator-authorized runtime work order
+exists.
 
 ---
 


### PR DESCRIPTION
WO-TERRAPILOT-P11 evidence/governance decision for summarize_levy_rate_components. Scope: docs/brain work-order evidence and program routing only. No maturity metadata mutation, no backend integration, no liveIntegration true claim, no promoted/backend-integrated claim, no runtime code, CI workflow, schema/database migration, deployment, secrets, county data, PACS, SQL, or live DB access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated program and command mapping references to the latest snapshot date.
  * Clarified the TerraPilot work-order path by introducing a new owner-decision step for the next stage.
  * Added a detailed decision record outlining the current status, reviewed inputs, and conditions for follow-up work.
  * Reworded guidance to make the approval flow and stop conditions for future changes easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->