### PR TITLE
docs(terrapilot): define contract-covered metadata authorization

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-03 — WO-TERRAPILOT-P11)*
+*(Updated 2026-07-03 — WO-TERRAPILOT-P12)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P12 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P13 (owner authorization required) |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P12-CONTRACT-COVERED-METADATA-CHANGE-AUTHORIZATION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P12-CONTRACT-COVERED-METADATA-CHANGE-AUTHORIZATION.md
@@ -1,0 +1,106 @@
+# WO-TERRAPILOT-P12 - Contract-Covered Metadata Change Authorization Packet
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Authorization packet only. No metadata mutation, no runtime change, no backend integration,
+no live promotion.
+
+## Decision Required
+
+The owner must decide whether to authorize a future narrow metadata-change work order for
+`summarize_levy_rate_components`.
+
+This packet does not make that change. It defines the exact proposed change, proof required before
+and after, rollback path, validation gates, and stop walls.
+
+## Proposed Future Metadata Change
+
+If authorized in a separate work order, update only the `summarize_levy_rate_components` entry in
+`tools/registry/tool-maturity.json`:
+
+| Field | Current value | Proposed future value |
+|-------|---------------|-----------------------|
+| `level` | `L1` | `L2` |
+| `state` | `stub-contract` | `contract-covered` |
+| `liveIntegration` | `false` | `false` |
+| `disclosureRequired` | `true` | `true` |
+| `disclosure` | `tool layer in development` | `tool layer in development` |
+
+The proposed future change is a contract-coverage metadata claim only. It must not claim live
+backend integration, production readiness, or promoted user-facing capability.
+
+## Required Proof Before Metadata Change
+
+A future metadata-change work order must verify:
+
+- P10 evidence remains current and unchanged in meaning,
+- P11 decision remains valid,
+- `summarize_levy_rate_components` still has a manifest entry with read-only risk,
+- the handler reference and backend target are still present,
+- county-boundary and auth-token acquisition boundaries are still present,
+- `liveIntegration` will remain `false`,
+- disclosure remains required and honest,
+- no handler behavior change is included,
+- no backend implementation or integration is included,
+- no runtime behavior, CI workflow, schema/database, deployment, secrets, county data, PACS, county
+  SQL, or live DB access is included.
+
+## Required Validation After Metadata Change
+
+If the future metadata-change work order is authorized, validation must include:
+
+```powershell
+git diff --check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+If the future work order touches package or TypeScript boundaries, it must also run:
+
+```powershell
+pnpm run type-check
+```
+
+## Owner Decision Choices
+
+The owner decision for the next work order is one of:
+
+| Choice | Meaning |
+|--------|---------|
+| Authorize metadata change | Permit a narrow PR that changes only the maturity metadata and supporting evidence/routing docs. |
+| Hold for more evidence | Keep the tool at `L1` / `stub-contract` until additional non-live evidence is recorded. |
+| Defer to runtime integration WO | Stop the metadata path and require a separate runtime/backend integration work order before any maturity movement. |
+
+## Rollback Path
+
+If a future metadata-change PR is merged and later found to overclaim evidence, rollback is:
+
+1. Revert only the `summarize_levy_rate_components` maturity entry to `L1` / `stub-contract`.
+2. Keep `liveIntegration: false`.
+3. Keep disclosure required.
+4. Add a follow-up evidence note explaining why the metadata claim was rolled back.
+5. Do not change handler behavior or backend integration while rolling back metadata.
+
+## Explicit Non-Changes
+
+- No maturity metadata changed.
+- No tool was marked `contract-covered`.
+- No tool was marked `backend-integrated`.
+- No tool was marked `promoted`.
+- No `liveIntegration: true` claim was made.
+- No handler behavior changed.
+- No backend integration was implemented.
+- No runtime/product behavior changed.
+- No CI workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+
+## Next Recommended Work
+
+`WO-TERRAPILOT-P13 - Contract-Covered Metadata Change`
+
+This is an owner-authorized follow-up only. It must not begin unless the owner chooses
+`Authorize metadata change` for `summarize_levy_rate_components`.

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P12-CONTRACT-COVERED-METADATA-CHANGE-AUTHORIZATION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P12-CONTRACT-COVERED-METADATA-CHANGE-AUTHORIZATION.md
@@ -30,6 +30,19 @@ If authorized in a separate work order, update only the `summarize_levy_rate_com
 The proposed future change is a contract-coverage metadata claim only. It must not claim live
 backend integration, production readiness, or promoted user-facing capability.
 
+The future metadata-change work order must also update the machine-readable evidence fields for
+this tool rather than only flipping `level` and `state`. The required `evidence` object must record
+the L2 proof references for:
+
+- `contract`,
+- `backingService`,
+- `verificationCommand`,
+- `traceEvidence`.
+
+Those references must point to the request/response contract evidence, owning/backing service
+evidence, verification method, and trace/evidence packet that justify `contract-covered` while
+keeping `liveIntegration: false`.
+
 ## Required Proof Before Metadata Change
 
 A future metadata-change work order must verify:
@@ -52,15 +65,10 @@ If the future metadata-change work order is authorized, validation must include:
 
 ```powershell
 git diff --check
+pnpm run type-check
 node docs/brain/workorders/tools/wo-query.mjs --json
 node --test os-platform/core/tests/tool-maturity.test.mjs
 node --test os-platform/core/tests/phase83-tools.test.mjs
-```
-
-If the future work order touches package or TypeScript boundaries, it must also run:
-
-```powershell
-pnpm run type-check
 ```
 
 ## Owner Decision Choices
@@ -78,10 +86,11 @@ The owner decision for the next work order is one of:
 If a future metadata-change PR is merged and later found to overclaim evidence, rollback is:
 
 1. Revert only the `summarize_levy_rate_components` maturity entry to `L1` / `stub-contract`.
-2. Keep `liveIntegration: false`.
-3. Keep disclosure required.
-4. Add a follow-up evidence note explaining why the metadata claim was rolled back.
-5. Do not change handler behavior or backend integration while rolling back metadata.
+2. Revert any supporting evidence/routing docs changed by P13.
+3. Keep `liveIntegration: false`.
+4. Keep disclosure required.
+5. Add a follow-up evidence note explaining why the metadata claim was rolled back.
+6. Do not change handler behavior or backend integration while rolling back metadata.
 
 ## Explicit Non-Changes
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P12 | YES — metadata promotion and live promotion remain owner decisions | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P13 | YES — metadata change and live promotion remain owner decisions | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -130,13 +130,15 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P9 | First promotion candidate decision | COMPLETE IN PR |
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | COMPLETE IN PR |
-| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **NEXT — OWNER DECISION** |
+| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | COMPLETE IN PR |
+| WO-TERRAPILOT-P13 | Contract-covered metadata change | **NEXT — OWNER AUTHORIZATION REQUIRED** |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
-is the next owner-decision packet for whether to authorize that metadata change. Any runtime
-promotion, backend integration, `liveIntegration: true` claim, deployment, secrets, county data, PACS,
-live DB access, or schema migration is a stop wall before any separate runtime promotion WO.
+records the exact owner-decision packet for whether to authorize that metadata change. WO-TERRAPILOT-P13
+must not start unless the owner explicitly authorizes the metadata change. Any runtime promotion,
+backend integration, `liveIntegration: true` claim, deployment, secrets, county data, PACS, live DB
+access, or schema migration is a stop wall before any separate runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -44,7 +44,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P9 | First promotion candidate decision | **COMPLETE IN PR** | Decide whether a separate runtime WO may attempt the first L2/L3 candidate |
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **COMPLETE IN PR** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | **COMPLETE IN PR** | Decide whether P10 evidence is sufficient to justify a follow-up `contract-covered` metadata-change packet, without mutating metadata or claiming live integration |
-| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **NEXT — OWNER DECISION** | Decide whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
+| WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **COMPLETE IN PR** | Record the owner-decision packet for whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
+| WO-TERRAPILOT-P13 | Contract-covered metadata change | **NEXT — OWNER AUTHORIZATION REQUIRED** | If authorized, update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
 
 ---
 
@@ -60,7 +61,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -71,10 +72,10 @@ P8 adds enforcement metadata and static tests only. It does not move any tool to
 or `promoted`.
 
 P10 records candidate evidence only. P11 records that `summarize_levy_rate_components` remains a
-candidate for `contract-covered`, but it does not change maturity metadata. P12 is the owner-decision
-packet for any actual metadata change. All TerraPilot maturity work must still stop before `backend-integrated`,
-`liveIntegration: true`, or `promoted` unless a separate operator-authorized runtime work order
-exists.
+candidate for `contract-covered`, but it does not change maturity metadata. P12 records the owner
+authorization packet for any actual metadata change. P13 must not start unless that metadata change is
+explicitly authorized. All TerraPilot maturity work must still stop before `backend-integrated`,
+`liveIntegration: true`, or `promoted` unless a separate operator-authorized runtime work order exists.
 
 ---
 


### PR DESCRIPTION
WO-TERRAPILOT-P12 authorization packet only for summarize_levy_rate_components. Scope: docs/brain evidence and program routing only. No tools/registry/tool-maturity.json mutation, no contract-covered/backend-integrated/live/promoted marking, no backend integration, no handler behavior change, no runtime code, no CI workflow, no schema/database migration, no deployment, no secrets, county data, PACS, SQL, or live DB access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TerraPilot work-order guidance to reflect the latest progression from WO-TERRAPILOT-P12 to the owner-authorized next step, WO-TERRAPILOT-P13.
  * Added an authorization-packet workflow for a narrowly scoped maturity metadata update, including required proof items, validation checks, owner decision options, and a targeted rollback path.
  * Strengthened guardrails clarifying that follow-on maturity/promotion steps must not proceed without explicit owner authorization and that live integration/promoted states remain blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->