### PR TITLE
docs(terrapilot): apply contract-covered metadata change

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | Stop before backend-integrated/live promotion without separate runtime WO |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P14 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-03 — WO-TERRAPILOT-P12)*
+*(Updated 2026-07-03 — WO-TERRAPILOT-P13)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P13 (owner authorization required) |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | Stop before backend-integrated/live promotion without separate runtime WO |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md
@@ -108,7 +108,7 @@ Executed validation:
 - `node docs/brain/workorders/tools/wo-query.mjs --json`
 - `node --test os-platform/core/tests/tool-maturity.test.mjs`
 - `node --test os-platform/core/tests/phase83-tools.test.mjs`
-- `node -e "<AJV schema validation for tools/registry/tool-maturity.json>"`
+- `node -e "const Ajv=require('ajv'); const fs=require('fs'); const schema=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.schema.json','utf8')); const data=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.json','utf8')); const ajv=new Ajv({allErrors:true,strict:false}); const validate=ajv.compile(schema); if(!validate(data)){ console.error(JSON.stringify(validate.errors,null,2)); process.exit(1); } console.log('tool-maturity schema validation PASS');"`
 
 ## Rollback Path
 

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md
@@ -1,0 +1,132 @@
+# WO-TERRAPILOT-P13 - Contract-Covered Metadata Change
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Metadata change only. No runtime change, no backend integration, no live promotion.
+
+## Decision
+
+Owner authorization from the merged P12 packet permits the exact metadata change for
+`summarize_levy_rate_components`:
+
+- move `level` from `L1` to `L2`,
+- move `state` from `stub-contract` to `contract-covered`,
+- keep `liveIntegration: false`,
+- keep disclosure required,
+- add machine-readable evidence references for the L2 claim.
+
+This change records contract coverage only. It does not mark the tool `backend-integrated`, does
+not mark it `promoted`, does not claim live backend service execution, and does not change handler
+behavior.
+
+## Metadata Changed
+
+File changed:
+
+- `tools/registry/tool-maturity.json`
+
+Tool changed:
+
+- `summarize_levy_rate_components`
+
+Authorized fields changed:
+
+| Field | Before | After |
+|-------|--------|-------|
+| `level` | `L1` | `L2` |
+| `state` | `stub-contract` | `contract-covered` |
+| `liveIntegration` | `false` | `false` |
+| `disclosureRequired` | `true` | `true` |
+| `disclosure` | `tool layer in development` | `tool layer in development` |
+
+The metadata also records L2 evidence references in the existing `evidence` object:
+
+- `contract`,
+- `backingService`,
+- `verificationCommand`,
+- `traceEvidence`.
+
+## Evidence Basis
+
+The L2 claim is based on previously merged P10/P11/P12 evidence:
+
+- P10 recorded the current manifest contract, handler reference, backend target, county boundary,
+  auth boundary, and test evidence for `summarize_levy_rate_components`.
+- P11 decided the tool remains a valid candidate for contract-covered metadata.
+- P12 authorized this exact metadata change while preserving the stop wall before live/backend
+  integration.
+
+The evidence references in `tool-maturity.json` point back to P10 contract, backing-service,
+verification, and trace/test evidence sections.
+
+## Explicit Non-Claims
+
+This P13 work order does not claim:
+
+- live backend integration,
+- production readiness,
+- promoted user-facing capability,
+- service availability in any county environment,
+- successful live execution against county data,
+- UI/operator readiness beyond existing disclosure.
+
+## Explicit Non-Changes
+
+- No handler behavior changed.
+- No backend integration was implemented.
+- No runtime/product behavior changed.
+- No CI workflow changed.
+- No schema migration or database operation was performed.
+- No deployment behavior changed.
+- No secrets, credentials, county data, PACS, county SQL, or live database access were used.
+- No tool was marked `backend-integrated`.
+- No tool was marked `promoted`.
+- No tool was marked live.
+
+## Validation Gates
+
+P13 validation must include:
+
+```powershell
+git diff --check
+pnpm run type-check
+node docs/brain/workorders/tools/wo-query.mjs --json
+node --test os-platform/core/tests/tool-maturity.test.mjs
+node --test os-platform/core/tests/phase83-tools.test.mjs
+```
+
+AJV/schema validation should also be run if an existing repo command is available without adding a
+dependency.
+
+Validation result: PASS.
+
+Executed validation:
+
+- `git diff --check`
+- `pnpm run type-check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node --test os-platform/core/tests/tool-maturity.test.mjs`
+- `node --test os-platform/core/tests/phase83-tools.test.mjs`
+- `node -e "<AJV schema validation for tools/registry/tool-maturity.json>"`
+
+## Rollback Path
+
+If this metadata change is later found to overclaim evidence, rollback is:
+
+1. Revert only the `summarize_levy_rate_components` maturity entry to `L1` / `stub-contract`.
+2. Remove the L2-only evidence fields added by P13 if they no longer support the metadata claim.
+3. Revert supporting evidence/routing docs changed by P13.
+4. Keep `liveIntegration: false`.
+5. Keep disclosure required.
+6. Add a follow-up evidence note explaining why the metadata claim was rolled back.
+7. Do not change handler behavior or backend integration while rolling back metadata.
+
+## Next Recommended Work
+
+Stop before live/backend integration.
+
+The next TerraPilot maturity step requires a separate owner-authorized runtime/backend integration
+work order if the owner wants to pursue `backend-integrated` maturity. Until then,
+`summarize_levy_rate_components` remains contract-covered only and must continue disclosing that the
+tool layer is in development.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P13 | YES — metadata change and live promotion remain owner decisions | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | Stop before live/backend integration | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -131,14 +131,15 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | COMPLETE IN PR |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | COMPLETE IN PR |
-| WO-TERRAPILOT-P13 | Contract-covered metadata change | **NEXT — OWNER AUTHORIZATION REQUIRED** |
+| WO-TERRAPILOT-P13 | Contract-covered metadata change | COMPLETE IN PR |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
-records the exact owner-decision packet for whether to authorize that metadata change. WO-TERRAPILOT-P13
-must not start unless the owner explicitly authorizes the metadata change. Any runtime promotion,
-backend integration, `liveIntegration: true` claim, deployment, secrets, county data, PACS, live DB
-access, or schema migration is a stop wall before any separate runtime promotion WO.
+recorded the exact owner-decision packet for whether to authorize that metadata change.
+WO-TERRAPILOT-P13 applies only that authorized L2 / `contract-covered` metadata change while keeping
+`liveIntegration: false`. Any runtime promotion, backend integration, `liveIntegration: true` claim,
+deployment, secrets, county data, PACS, live DB access, or schema migration is a stop wall before any
+separate runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | Stop before live/backend integration | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P14 | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -132,6 +132,7 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | COMPLETE IN PR |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | COMPLETE IN PR |
+| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | NEXT — EVIDENCE/GOVERNANCE ONLY |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
@@ -139,7 +140,8 @@ recorded the exact owner-decision packet for whether to authorize that metadata 
 WO-TERRAPILOT-P13 applies only that authorized L2 / `contract-covered` metadata change while keeping
 `liveIntegration: false`. Any runtime promotion, backend integration, `liveIntegration: true` claim,
 deployment, secrets, county data, PACS, live DB access, or schema migration is a stop wall before any
-separate runtime promotion WO.
+separate runtime promotion WO. WO-TERRAPILOT-P14 is the next evidence-only stop-gate rollup; it must
+not implement live/backend integration.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -45,7 +45,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P10 | Contract-covered candidate evidence packet | **COMPLETE IN PR** | Document contract, owner, backing target, auth boundary, verification method, trace requirement, UI disclosure, and rollback path for the first candidate |
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | **COMPLETE IN PR** | Decide whether P10 evidence is sufficient to justify a follow-up `contract-covered` metadata-change packet, without mutating metadata or claiming live integration |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **COMPLETE IN PR** | Record the owner-decision packet for whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
-| WO-TERRAPILOT-P13 | Contract-covered metadata change | **NEXT — OWNER AUTHORIZATION REQUIRED** | If authorized, update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
+| WO-TERRAPILOT-P13 | Contract-covered metadata change | **COMPLETE IN PR** | Update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
 
 ---
 
@@ -61,7 +61,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> stop before live/backend integration
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -73,9 +73,10 @@ or `promoted`.
 
 P10 records candidate evidence only. P11 records that `summarize_levy_rate_components` remains a
 candidate for `contract-covered`, but it does not change maturity metadata. P12 records the owner
-authorization packet for any actual metadata change. P13 must not start unless that metadata change is
-explicitly authorized. All TerraPilot maturity work must still stop before `backend-integrated`,
-`liveIntegration: true`, or `promoted` unless a separate operator-authorized runtime work order exists.
+authorization packet for any actual metadata change. P13 applies only the owner-authorized L2 /
+`contract-covered` metadata change. All TerraPilot maturity work must still stop before
+`backend-integrated`, `liveIntegration: true`, or `promoted` unless a separate operator-authorized
+runtime work order exists.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -46,6 +46,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | **COMPLETE IN PR** | Decide whether P10 evidence is sufficient to justify a follow-up `contract-covered` metadata-change packet, without mutating metadata or claiming live integration |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **COMPLETE IN PR** | Record the owner-decision packet for whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | **COMPLETE IN PR** | Update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
+| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | **NEXT — EVIDENCE/GOVERNANCE ONLY** | Close the L2 metadata chain and record the stop wall before live/backend integration |
 
 ---
 
@@ -61,7 +62,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> stop before live/backend integration
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> stop before live/backend integration
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -76,7 +77,8 @@ candidate for `contract-covered`, but it does not change maturity metadata. P12 
 authorization packet for any actual metadata change. P13 applies only the owner-authorized L2 /
 `contract-covered` metadata change. All TerraPilot maturity work must still stop before
 `backend-integrated`, `liveIntegration: true`, or `promoted` unless a separate operator-authorized
-runtime work order exists.
+runtime work order exists. P14 is evidence/governance only and must not implement live/backend
+integration.
 
 ---
 

--- a/tools/registry/tool-maturity.json
+++ b/tools/registry/tool-maturity.json
@@ -335,8 +335,8 @@
     },
     {
       "toolId": "summarize_levy_rate_components",
-      "level": "L1",
-      "state": "stub-contract",
+      "level": "L2",
+      "state": "contract-covered",
       "liveIntegration": false,
       "disclosureRequired": true,
       "disclosure": "tool layer in development",
@@ -344,13 +344,17 @@
       "evidence": {
         "manifest": "tools/registry/terrapilot.tools.json",
         "handlerParity": "docs/brain/workorders/evidence/WO-TERRAPILOT-P3-P6-MATURITY-EVIDENCE.md",
-        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md"
+        "promotionProtocol": "docs/brain/workorders/programs/terrapilot-promotion-protocol.md",
+        "contract": "docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md#current-manifest-contract",
+        "backingService": "docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md#current-handler-evidence",
+        "verificationCommand": "node --test os-platform/core/tests/tool-maturity.test.mjs && node --test os-platform/core/tests/phase83-tools.test.mjs",
+        "traceEvidence": "docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md#current-test-evidence"
       },
       "promotion": {
-        "targetState": null,
-        "operatorApproval": null,
-        "promotionDate": null,
-        "rollbackPath": null
+        "targetState": "contract-covered",
+        "operatorApproval": "MERGE + OWNER AUTHORIZATION - TERRAPILOT P12 -> P13 (2026-07-03)",
+        "promotionDate": "2026-07-03",
+        "rollbackPath": "docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md#rollback-path"
       }
     },
     {

--- a/tools/registry/tool-maturity.json
+++ b/tools/registry/tool-maturity.json
@@ -351,10 +351,10 @@
         "traceEvidence": "docs/brain/workorders/evidence/WO-TERRAPILOT-P10-SUMMARIZE-LEVY-RATE-EVIDENCE-PACKET.md#current-test-evidence"
       },
       "promotion": {
-        "targetState": "contract-covered",
-        "operatorApproval": "MERGE + OWNER AUTHORIZATION - TERRAPILOT P12 -> P13 (2026-07-03)",
-        "promotionDate": "2026-07-03",
-        "rollbackPath": "docs/brain/workorders/evidence/WO-TERRAPILOT-P13-CONTRACT-COVERED-METADATA-CHANGE.md#rollback-path"
+        "targetState": null,
+        "operatorApproval": null,
+        "promotionDate": null,
+        "rollbackPath": null
       }
     },
     {


### PR DESCRIPTION
## Summary

WO-TERRAPILOT-P13 applies the owner-authorized contract-covered metadata change for `summarize_levy_rate_components`.

Scope:
- Move only `summarize_levy_rate_components` from `L1` / `stub-contract` to `L2` / `contract-covered`.
- Keep `liveIntegration: false`.
- Keep disclosure required.
- Add machine-readable evidence references for `contract`, `backingService`, `verificationCommand`, and `traceEvidence`.
- Add P13 evidence and update P5 routing/docs.

Explicit non-changes:
- No backend integration.
- No handler behavior change.
- No runtime behavior change.
- No live promotion.
- No `backend-integrated` or `promoted` state.
- No CI workflow, schema/database, deployment, secrets, county data, PACS, SQL, or live DB access.

Validation:
- `git diff --check`
- `pnpm run type-check`
- `node docs/brain/workorders/tools/wo-query.mjs --json`
- `node --test os-platform/core/tests/tool-maturity.test.mjs`
- `node --test os-platform/core/tests/phase83-tools.test.mjs`
- AJV schema validation for `tools/registry/tool-maturity.json`
- Normal pre-commit and pre-push gates passed