### PR TITLE
docs(terrapilot): record contract-covered stop gate

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-03 — WO-TERRAPILOT-P13)*
+*(Updated 2026-07-03 — WO-TERRAPILOT-P14)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P14 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P15 |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P14-CONTRACT-COVERED-STOP-GATE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P14-CONTRACT-COVERED-STOP-GATE-ROLLUP.md
@@ -1,0 +1,146 @@
+# WO-TERRAPILOT-P14 - Contract-Covered Metadata Stop-Gate Rollup
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Evidence/governance only. No runtime change, no backend integration, no live promotion.
+
+## Purpose
+
+This packet closes the evidence chain from P9 through P13 for
+`summarize_levy_rate_components`.
+
+The tool is now contract-covered in maturity metadata, but it is still not
+backend-integrated, live, promoted, or product-operational. P14 records that stop
+gate so the L2 metadata claim cannot be mistaken for an L3/L4 capability claim.
+
+## P9 Through P13 Summary
+
+| WO | Result | Boundary |
+|----|--------|----------|
+| WO-TERRAPILOT-P9 | Selected `summarize_levy_rate_components` as the first candidate path | Decision/evidence only; no promotion |
+| WO-TERRAPILOT-P10 | Recorded contract, handler, backend target, auth, trace, and rollback evidence | Evidence only; no runtime integration |
+| WO-TERRAPILOT-P11 | Decided the candidate could proceed toward contract-covered metadata | Decision only; no metadata mutation |
+| WO-TERRAPILOT-P12 | Captured owner authorization for the exact L2 metadata change | Authorization packet only |
+| WO-TERRAPILOT-P13 | Applied the authorized metadata change | Metadata only; no backend/live/promotion claim |
+
+## What Changed In P13
+
+P13 changed only the maturity metadata for `summarize_levy_rate_components` and
+supporting evidence/routing docs.
+
+The authorized metadata change was:
+
+- `level`: `L1` to `L2`
+- `state`: `stub-contract` to `contract-covered`
+- `liveIntegration`: remained `false`
+- `disclosureRequired`: remained `true`
+- `disclosure`: remained `tool layer in development`
+- L2 evidence references were added for contract, backing-service, verification,
+  and trace evidence.
+
+P13 did not populate promotion fields. The `promotion` object remains null-valued:
+
+- `targetState: null`
+- `operatorApproval: null`
+- `promotionDate: null`
+- `rollbackPath: null`
+
+## What Did Not Change
+
+P9 through P14 did not:
+
+- implement backend integration,
+- change handler behavior,
+- change runtime/product behavior,
+- mark any tool backend-integrated,
+- mark any tool live,
+- mark any tool promoted,
+- claim county/runtime availability,
+- change CI workflows,
+- change schema or database migrations,
+- deploy anything,
+- use secrets, credentials, county data, PACS, county SQL, or live DB access.
+
+## Stop Gate
+
+`summarize_levy_rate_components` is now L2 / `contract-covered` only.
+
+It must continue to disclose that the tool layer is in development until a
+separate owner-authorized runtime/backend integration work order proves an L3 or
+L4 claim.
+
+The stop gate is stricter after P13, not looser:
+
+- L2 is machine-readable.
+- L2 points to explicit evidence.
+- L2 still requires disclosure.
+- L2 still blocks live/backend/promoted claims.
+- L3/L4 still require separate owner authority and evidence.
+
+## Required Evidence Before Any Future L3/L4 Promotion
+
+Before any future work order may mark this tool `backend-integrated`, live, or
+promoted, it must provide all of the following:
+
+- owner authorization for a runtime/backend integration work order,
+- backing service endpoint and owner,
+- auth boundary and required permission model,
+- handler behavior proof against non-production data,
+- trace/correlation evidence,
+- county-boundary proof with no PACS/county SQL/live DB access unless separately
+  authorized,
+- UI/operator disclosure update plan,
+- rollback plan,
+- focused tests proving the new claim,
+- updated maturity metadata validation,
+- PR checks proving no governance regression.
+
+## Rollback Path
+
+If the L2 claim is later found to overclaim evidence, rollback is metadata-only:
+
+1. Revert only `summarize_levy_rate_components` from `L2` /
+   `contract-covered` back to `L1` / `stub-contract`.
+2. Remove L2-only evidence references if they no longer support the claim.
+3. Keep `liveIntegration: false`.
+4. Keep disclosure required.
+5. Do not change handler behavior while rolling back metadata.
+6. Add an evidence note explaining why the L2 claim was withdrawn.
+
+## Validation Summary
+
+Post-P13 merge validation passed before this P14 packet was written:
+
+- `git diff --check`
+- `pnpm run type-check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node --test os-platform/core/tests/tool-maturity.test.mjs`
+- `node --test os-platform/core/tests/phase83-tools.test.mjs`
+- `node -e "const Ajv=require('ajv'); const fs=require('fs'); const schema=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.schema.json','utf8')); const data=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.json','utf8')); const ajv=new Ajv({allErrors:true,strict:false}); const validate=ajv.compile(schema); if(!validate(data)){ console.error(JSON.stringify(validate.errors,null,2)); process.exit(1); } console.log('tool-maturity schema validation PASS');"`
+
+P14 must not weaken these gates and must not mutate runtime behavior.
+
+## Next Safe TerraPilot Work
+
+The next safe TerraPilot work order is:
+
+- `WO-TERRAPILOT-P15` - Future promotion authorization decision packet.
+
+P15 may be evidence/governance-only. It must not implement live integration. If
+the owner wants actual backend integration, that requires a separate runtime WO
+with explicit authority.
+
+## Done / Not Done
+
+Done:
+
+- L2 contract-covered metadata is evidenced.
+- The stop gate before live/backend integration is explicit.
+- No live/backend/promoted claim was made.
+
+Not done:
+
+- No live backend integration exists.
+- No product-operational TerraPilot tool is claimed.
+- No deployment, schema, secrets, county data, PACS, or live DB path was touched.

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P14-CONTRACT-COVERED-STOP-GATE-ROLLUP.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P14-CONTRACT-COVERED-STOP-GATE-ROLLUP.md
@@ -1,0 +1,148 @@
+# WO-TERRAPILOT-P14 - Contract-Covered Metadata Stop-Gate Rollup
+
+**Goal:** GOAL-TERRAPILOT-TOOL-MATURITY
+**Loop:** LOOP-TERRAPILOT-TOOL-MATURITY
+**Date:** 2026-07-03
+**Mode:** Evidence/governance only. No runtime change, no backend integration, no live promotion.
+
+## Purpose
+
+This packet closes the evidence chain from P9 through P13 for
+`summarize_levy_rate_components`.
+
+The tool is now contract-covered in maturity metadata, but it is still not
+backend-integrated, live, promoted, or product-operational. P14 records that stop
+gate so the L2 metadata claim cannot be mistaken for an L3/L4 capability claim.
+
+## P9 Through P13 Summary
+
+| WO | Result | Boundary |
+|----|--------|----------|
+| WO-TERRAPILOT-P9 | Selected `summarize_levy_rate_components` as the first candidate path | Decision/evidence only; no promotion |
+| WO-TERRAPILOT-P10 | Recorded contract, handler, backend target, auth, trace, and rollback evidence | Evidence only; no runtime integration |
+| WO-TERRAPILOT-P11 | Decided the candidate could proceed toward contract-covered metadata | Decision only; no metadata mutation |
+| WO-TERRAPILOT-P12 | Captured owner authorization for the exact L2 metadata change | Authorization packet only |
+| WO-TERRAPILOT-P13 | Applied the authorized metadata change | Metadata only; no backend/live/promotion claim |
+
+## What Changed In P13
+
+P13 changed only the maturity metadata for `summarize_levy_rate_components` and
+supporting evidence/routing docs.
+
+The authorized metadata change was:
+
+- `level`: `L1` to `L2`
+- `state`: `stub-contract` to `contract-covered`
+- `liveIntegration`: remained `false`
+- `disclosureRequired`: remained `true`
+- `disclosure`: remained `tool layer in development`
+- L2 evidence references were added for contract, backing-service, verification,
+  and trace evidence.
+
+P13 did not populate promotion fields. The `promotion` object remains null-valued:
+
+- `targetState: null`
+- `operatorApproval: null`
+- `promotionDate: null`
+- `rollbackPath: null`
+
+## What Did Not Change
+
+P9 through P14 did not:
+
+- implement backend integration,
+- change handler behavior,
+- change runtime/product behavior,
+- mark any tool backend-integrated,
+- mark any tool live,
+- mark any tool promoted,
+- claim county/runtime availability,
+- change CI workflows,
+- change schema or database migrations,
+- deploy anything,
+- use secrets, credentials, county data, PACS, county SQL, or live DB access.
+
+## Stop Gate
+
+`summarize_levy_rate_components` is now L2 / `contract-covered` only.
+
+It must continue to disclose that the tool layer is in development until a
+separate owner-authorized runtime/backend integration work order proves an L3 or
+L4 claim.
+
+The stop gate is stricter after P13, not looser:
+
+- L2 is machine-readable.
+- L2 points to explicit evidence.
+- L2 still requires disclosure.
+- L2 still blocks live/backend/promoted claims.
+- L3/L4 still require separate owner authority and evidence.
+
+## Required Evidence Before Any Future L3/L4 Promotion
+
+Before any future work order may mark this tool `backend-integrated`, live, or
+promoted, it must provide all of the following:
+
+- owner authorization for a runtime/backend integration work order,
+- backing service endpoint and owner,
+- auth boundary and required permission model,
+- handler behavior proof against non-production data,
+- trace/correlation evidence,
+- county-boundary proof with no PACS/county SQL/live DB access unless separately
+  authorized,
+- UI/operator disclosure update plan,
+- rollback plan,
+- focused tests proving the new claim,
+- updated maturity metadata validation,
+- PR checks proving no governance regression.
+
+## Rollback Path
+
+If the L2 claim is later found to overclaim evidence, rollback is metadata-only:
+
+1. Revert only `summarize_levy_rate_components` from `L2` /
+   `contract-covered` back to `L1` / `stub-contract`.
+2. Remove L2-only evidence references if they no longer support the claim.
+3. Keep `liveIntegration: false`.
+4. Keep disclosure required.
+5. Do not change handler behavior while rolling back metadata.
+6. Add an evidence note explaining why the L2 claim was withdrawn.
+
+## Validation Summary
+
+Post-P13 merge validation passed before this P14 packet was written:
+
+- `git diff --check`
+- `pnpm run type-check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node --test os-platform/core/tests/tool-maturity.test.mjs`
+- `node --test os-platform/core/tests/phase83-tools.test.mjs`
+- `node -e "const Ajv=require('ajv'); const fs=require('fs'); const schema=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.schema.json','utf8')); const data=JSON.parse(fs.readFileSync('tools/registry/tool-maturity.json','utf8')); const ajv=new Ajv({allErrors:true,strict:false}); const validate=ajv.compile(schema); if(!validate(data)){ console.error(JSON.stringify(validate.errors,null,2)); process.exit(1); } console.log('tool-maturity schema validation PASS');"`
+
+P14 must not weaken these gates and must not mutate runtime behavior.
+
+## Next Safe TerraPilot Work
+
+The next safe TerraPilot work order is:
+
+- `WO-TERRAPILOT-P15` - Future promotion authorization decision packet.
+
+P15 may be evidence/governance-only. It must not implement live integration. If
+the owner wants actual backend integration, that requires a separate runtime WO
+with explicit authority.
+
+## Done / Not Done
+
+Done:
+
+- L2 contract-covered metadata is evidenced.
+- The stop gate before live/backend integration is explicit.
+- No live/backend/promoted claim was made.
+
+Not done:
+
+- No governed L3/L4 `backend-integrated`, `live`, or `promoted` claim has been
+  approved for this tool. Existing handler or backend-post code paths remain
+  unpromoted unless a future runtime WO proves and authorizes the claim.
+- No product-operational TerraPilot tool is claimed.
+- No deployment, schema, secrets, county data, PACS, or live DB path was touched.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P14 | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P15 | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -132,7 +132,8 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | COMPLETE IN PR |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | COMPLETE IN PR |
-| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | NEXT — EVIDENCE/GOVERNANCE ONLY |
+| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | COMPLETE IN PR |
+| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | OWNER DECISION REQUIRED |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
@@ -140,8 +141,9 @@ recorded the exact owner-decision packet for whether to authorize that metadata 
 WO-TERRAPILOT-P13 applies only that authorized L2 / `contract-covered` metadata change while keeping
 `liveIntegration: false`. Any runtime promotion, backend integration, `liveIntegration: true` claim,
 deployment, secrets, county data, PACS, live DB access, or schema migration is a stop wall before any
-separate runtime promotion WO. WO-TERRAPILOT-P14 is the next evidence-only stop-gate rollup; it must
-not implement live/backend integration.
+separate runtime promotion WO. WO-TERRAPILOT-P14 is the evidence-only stop-gate rollup; it must
+not implement live/backend integration. WO-TERRAPILOT-P15 is an owner decision packet and remains
+blocked before any live/backend implementation.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -103,7 +103,9 @@ File:     programs/terrapilot-tool-maturity.md
 Success:  At least one tool reaches L3 (live-integrated); no tool is represented as working at L0/L1.
 ```
 
-**Current state:** WO-TERRAPILOT-P2 is next. WO-TERRAPILOT-P1 is partially done.
+**Current state:** WO-TERRAPILOT-P15 is next as an owner-decision packet. P2 through P14 have
+recorded maturity protocol, metadata enforcement, candidate evidence, the P13 L2 metadata change,
+and the P14 stop gate before any live/backend-integrated claim.
 
 **Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -46,7 +46,8 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P11 | Contract-covered metadata decision | **COMPLETE IN PR** | Decide whether P10 evidence is sufficient to justify a follow-up `contract-covered` metadata-change packet, without mutating metadata or claiming live integration |
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **COMPLETE IN PR** | Record the owner-decision packet for whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | **COMPLETE IN PR** | Update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
-| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | **NEXT — EVIDENCE/GOVERNANCE ONLY** | Close the L2 metadata chain and record the stop wall before live/backend integration |
+| WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | **COMPLETE IN PR** | Close the L2 metadata chain and record the stop wall before live/backend integration |
+| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | **OWNER DECISION REQUIRED** | Decide whether any future work may attempt live/backend integration; no implementation in this packet |
 
 ---
 
@@ -62,7 +63,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> stop before live/backend integration
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> P15 owner decision -> stop before live/backend integration
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -78,7 +79,7 @@ authorization packet for any actual metadata change. P13 applies only the owner-
 `contract-covered` metadata change. All TerraPilot maturity work must still stop before
 `backend-integrated`, `liveIntegration: true`, or `promoted` unless a separate operator-authorized
 runtime work order exists. P14 is evidence/governance only and must not implement live/backend
-integration.
+integration. P15 is an owner decision packet only; it must not implement live/backend integration.
 
 ---
 


### PR DESCRIPTION
WO-TERRAPILOT-P14 evidence/governance rollup after the P13 contract-covered metadata change.

Scope:
- Records the stop gate after `summarize_levy_rate_components` moved to L2 / contract-covered metadata.
- Confirms the tool is still not backend-integrated, live, promoted, or product-operational.
- Documents what future evidence would be required before any L3/L4 claim.
- Updates P5 routing to `WO-TERRAPILOT-P15` as an owner-decision packet only.

No runtime code, backend integration, handler behavior, CI workflow, schema/database migration, deployment, secrets, county data, PACS, SQL, or live DB access changed.