### PR TITLE
docs(terrapilot): add future promotion decision packet

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-03 — WO-TERRAPILOT-P14)*
+*(Updated 2026-07-03 — WO-TERRAPILOT-P15)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | ACTIVE | WO-TERRAPILOT-P15 |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | STOP GATE | Owner decision before any live/backend promotion |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -25,7 +25,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
 | P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
-| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | STOP GATE | Owner decision before any live/backend promotion |
+| P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | STOP GATE | WO-TERRAPILOT-P16 (blocked; owner authorization required) |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
 | P7 | [AI / Brain / Operator System](programs/brain-operator-system.md) | `/goal brain-operator` | QUEUED | WO-BRAIN-001 |
 | P8 | [Azure / DevOps / County Runtime](programs/azure-county-runtime.md) | `/goal azure-county-runtime` | ACTIVE | WO-AZURE-001 |

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
@@ -1,0 +1,137 @@
+# WO-TERRAPILOT-P15 — Future Promotion Authorization Decision Packet
+
+## Status
+
+Decision packet only. This work order does not authorize or implement live/backend integration.
+
+## Current Truth
+
+`summarize_levy_rate_components` is the current TerraPilot promotion-path candidate.
+
+Current maturity state:
+
+- `state`: `contract-covered`
+- `level`: `L2`
+- `liveIntegration`: `false`
+- Backend integrated: no
+- Live: no
+- Promoted: no
+- Handler behavior changed in this packet: no
+- Backend integration implemented in this packet: no
+
+WO-TERRAPILOT-P13 made only the owner-authorized contract-covered metadata change. WO-TERRAPILOT-P14 then recorded the stop gate: contract coverage is evidence of stable contract behavior, not proof of live backend/product integration.
+
+## Owner Decision Choices
+
+The owner has four valid choices after this packet:
+
+1. Hold at L2 / contract-covered.
+   - No future live/backend integration work starts.
+   - The tool remains contract-covered with `liveIntegration: false`.
+
+2. Authorize a future live-integration design packet only.
+   - The next WO may design the required backend/service integration path.
+   - No runtime implementation, metadata promotion, or live claim is allowed in the design packet.
+
+3. Authorize a future backend-integrated implementation WO.
+   - This requires an explicit new owner authorization and must name the backing service, integration surface, test plan, rollback path, and deployment boundary.
+   - The future WO must still stop before production deployment, secrets, county data, PACS, live DB access, or schema migration.
+
+4. Reject the promotion path.
+   - The tool remains contract-covered only, or a later owner-authorized metadata rollback packet may move it back to a lower maturity state if the L2 claim becomes misleading.
+
+## Evidence Required Before Any Future Live/Backend Promotion
+
+Any future WO that attempts to move beyond L2 must provide all of the following before metadata can claim backend integration or live operation:
+
+- Backing service name, owner, and source path.
+- Integration surface: endpoint, handler, command, or service boundary.
+- Authentication and authorization model.
+- Test data model using non-secret, non-county, non-PACS fixtures.
+- Handler behavior contract and failure behavior.
+- UI/operator disclosure behavior showing whether the result is contract-covered, simulated, or live.
+- Trace/correlation evidence for request and failure diagnosis.
+- County-boundary proof showing no protected county data is accessed without a separately authorized runtime packet.
+- Rollback path for metadata, handler behavior, and routing.
+- Validation gates that fail if the tool is overclaimed as live/backend-integrated without proof.
+
+## Required Tests For A Future Promotion WO
+
+A future live/backend promotion packet must define and pass focused tests for:
+
+- Tool maturity schema validation.
+- `os-platform/core/tests/tool-maturity.test.mjs`.
+- `os-platform/core/tests/phase83-tools.test.mjs`.
+- Handler contract behavior.
+- Failure and disclosure behavior.
+- Backing service contract behavior.
+- Trace/correlation output.
+- No-secret and no-protected-data execution.
+
+The existing core validation remains required:
+
+- `pnpm run type-check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- `node --test os-platform/core/tests/tool-maturity.test.mjs`
+- `node --test os-platform/core/tests/phase83-tools.test.mjs`
+
+## Stop Gates
+
+The TerraPilot loop must stop for owner authority before any of the following:
+
+- Mutating `tools/registry/tool-maturity.json` beyond the current L2 contract-covered state.
+- Setting `liveIntegration: true`.
+- Marking the tool backend-integrated, live, or promoted.
+- Implementing backend integration.
+- Changing handler or runtime behavior.
+- Changing CI workflow behavior.
+- Applying schema or database migrations.
+- Deploying.
+- Accessing secrets, credentials, county data, PACS, county SQL, or a live DB.
+
+## Rollback Path
+
+If future evidence shows that the L2 contract-covered state is misleading, the safe rollback is:
+
+1. Open a metadata rollback WO.
+2. Revert only the affected `summarize_levy_rate_components` maturity fields.
+3. Preserve explicit disclosure that the tool is not live/backend-integrated.
+4. Run maturity schema and phase83 validation.
+5. Record rollback evidence.
+
+Runtime rollback is intentionally not described here because this packet does not create runtime behavior.
+
+## P15 Decision
+
+P15 does not choose live promotion. It records the owner decision boundary and keeps TerraPilot at a safe stop gate.
+
+Recommended current posture:
+
+- Hold `summarize_levy_rate_components` at L2 / contract-covered.
+- Do not start live/backend integration until a separate owner-authorized runtime or design WO exists.
+- If future work continues, start with a design-only packet before implementation.
+
+## Next Recommended WO
+
+If owner wants to keep TerraPilot parked:
+
+- No immediate TerraPilot implementation WO. Move to another program lane.
+
+If owner wants to explore live integration later:
+
+- `WO-TERRAPILOT-P16 — Live Integration Design Packet`
+
+P16 must be design-only unless the owner explicitly authorizes runtime implementation.
+
+## Non-Changes
+
+- Runtime code changed: no
+- Handler behavior changed: no
+- Backend integration changed: no
+- Tool marked backend-integrated: no
+- Tool marked live: no
+- Tool marked promoted: no
+- CI workflow changed: no
+- Schema/database changed: no
+- Deployment changed: no
+- Secrets/county/PACS/SQL touched: no

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
@@ -137,7 +137,7 @@ If owner wants to explore live integration later:
 
 - `WO-TERRAPILOT-P16 — Live Integration Design Packet`
 
-P16 must be design-only unless the owner explicitly authorizes runtime implementation.
+P16 must remain design-only. Any runtime implementation requires a separate owner-authorized WO.
 
 ## Non-Changes
 

--- a/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
+++ b/docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md
@@ -4,6 +4,22 @@
 
 Decision packet only. This work order does not authorize or implement live/backend integration.
 
+## Authorization
+
+Owner authorization for WO-TERRAPILOT-P15 allowed evidence/governance documentation under
+`docs/brain/workorders/**` to create the future promotion decision packet and update the
+TerraPilot program routing docs. This authorization did not include runtime code, handler behavior,
+tool metadata mutation, CI workflow changes, schema/database changes, deployment, secrets, county
+data, PACS, SQL, or live DB access.
+
+Authorized file scope:
+
+- `docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md`
+- `docs/brain/workorders/evidence/WO-TERRAPILOT-P15-FUTURE-PROMOTION-AUTHORIZATION-DECISION.md`
+- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md`
+- `docs/brain/workorders/goal-loop/GOAL_COMMANDS.md`
+- `docs/brain/workorders/programs/terrapilot-tool-maturity.md`
+
 ## Current Truth
 
 `summarize_levy_rate_components` is the current TerraPilot promotion-path candidate.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P15 | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | Owner decision before live/backend promotion | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -133,17 +133,17 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | COMPLETE IN PR |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | COMPLETE IN PR |
 | WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | COMPLETE IN PR |
-| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | OWNER DECISION REQUIRED |
+| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | COMPLETE IN PR |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12
 recorded the exact owner-decision packet for whether to authorize that metadata change.
 WO-TERRAPILOT-P13 applies only that authorized L2 / `contract-covered` metadata change while keeping
-`liveIntegration: false`. Any runtime promotion, backend integration, `liveIntegration: true` claim,
-deployment, secrets, county data, PACS, live DB access, or schema migration is a stop wall before any
-separate runtime promotion WO. WO-TERRAPILOT-P14 is the evidence-only stop-gate rollup; it must
-not implement live/backend integration. WO-TERRAPILOT-P15 is an owner decision packet and remains
-blocked before any live/backend implementation.
+`liveIntegration: false`. WO-TERRAPILOT-P14 is the evidence-only stop-gate rollup. WO-TERRAPILOT-P15
+records the future promotion authorization choices and the required proof before any live/backend
+promotion path. Any runtime promotion, backend integration, `liveIntegration: true` claim, deployment,
+secrets, county data, PACS, live DB access, or schema migration remains a stop wall before a separate
+owner-authorized runtime promotion WO.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -17,7 +17,7 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
 | `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `terrapilot-maturity` | P5 | Owner decision before live/backend promotion | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
+| `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -134,6 +134,7 @@ No active stop walls at WO-WORKBENCH-001.
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | COMPLETE IN PR |
 | WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | COMPLETE IN PR |
 | WO-TERRAPILOT-P15 | Future promotion authorization decision packet | COMPLETE IN PR |
+| WO-TERRAPILOT-P16 | Live integration design packet | BLOCKED — owner authorization required |
 
 WO-TERRAPILOT-P11 decided that `summarize_levy_rate_components` remains a valid candidate for a
 future `contract-covered` metadata change, but it did not mutate maturity metadata. WO-TERRAPILOT-P12

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -100,12 +100,12 @@ Success:  All workbench tabs have live data, honest empty states, and validated 
 Goal:     Prevent TerraPilot manifest/handler/stub drift and mature tools toward verified integration.
 Program:  P5 — TerraPilot Tool Maturity
 File:     programs/terrapilot-tool-maturity.md
-Success:  At least one tool reaches L3 (live-integrated); no tool is represented as working at L0/L1.
+Success:  TerraPilot maturity claims are explicit, evidence-backed, and stopped before live/backend promotion unless separately authorized.
 ```
 
-**Current state:** WO-TERRAPILOT-P15 is next as an owner-decision packet. P2 through P14 have
-recorded maturity protocol, metadata enforcement, candidate evidence, the P13 L2 metadata change,
-and the P14 stop gate before any live/backend-integrated claim.
+**Current state:** WO-TERRAPILOT-P15 records the owner-decision boundary for any future live/backend
+promotion path. P2 through P14 recorded maturity protocol, metadata enforcement, candidate evidence,
+the P13 L2 metadata change, and the P14 stop gate before any live/backend-integrated claim.
 
 **Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -47,7 +47,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P12 | Contract-covered metadata change authorization packet | **COMPLETE IN PR** | Record the owner-decision packet for whether to authorize the actual L1/stub-contract to L2/contract-covered metadata change while keeping `liveIntegration: false` |
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | **COMPLETE IN PR** | Update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
 | WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | **COMPLETE IN PR** | Close the L2 metadata chain and record the stop wall before live/backend integration |
-| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | **OWNER DECISION REQUIRED** | Decide whether any future work may attempt live/backend integration; no implementation in this packet |
+| WO-TERRAPILOT-P15 | Future promotion authorization decision packet | **COMPLETE IN PR** | Record owner decision choices and evidence required before any future live/backend integration; no implementation in this packet |
 
 ---
 
@@ -63,7 +63,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> P15 owner decision -> stop before live/backend integration
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> P15 owner decision packet -> stop before live/backend integration
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work
@@ -79,7 +79,8 @@ authorization packet for any actual metadata change. P13 applies only the owner-
 `contract-covered` metadata change. All TerraPilot maturity work must still stop before
 `backend-integrated`, `liveIntegration: true`, or `promoted` unless a separate operator-authorized
 runtime work order exists. P14 is evidence/governance only and must not implement live/backend
-integration. P15 is an owner decision packet only; it must not implement live/backend integration.
+integration. P15 is an owner decision packet only; it must not implement live/backend integration and
+it does not authorize metadata promotion beyond the existing L2 / `contract-covered` state.
 
 ---
 

--- a/docs/brain/workorders/programs/terrapilot-tool-maturity.md
+++ b/docs/brain/workorders/programs/terrapilot-tool-maturity.md
@@ -48,6 +48,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 | WO-TERRAPILOT-P13 | Contract-covered metadata change | **COMPLETE IN PR** | Update only `summarize_levy_rate_components` maturity metadata and supporting evidence/routing docs |
 | WO-TERRAPILOT-P14 | Contract-covered metadata stop-gate rollup | **COMPLETE IN PR** | Close the L2 metadata chain and record the stop wall before live/backend integration |
 | WO-TERRAPILOT-P15 | Future promotion authorization decision packet | **COMPLETE IN PR** | Record owner decision choices and evidence required before any future live/backend integration; no implementation in this packet |
+| WO-TERRAPILOT-P16 | Live integration design packet | **BLOCKED — OWNER AUTHORIZATION REQUIRED** | Design-only packet for a possible future live/backend integration path; no implementation unless separately authorized |
 
 ---
 
@@ -63,7 +64,7 @@ A tool at L1 must be disclosed as "not yet integrated" in any UI and in any oper
 ## Dependency Chain
 
 ```
-P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> P15 owner decision packet -> stop before live/backend integration
+P1 (partial) -> P2 -> P3 -> P4 -> P5 -> P6 -> P7 -> P8 -> P9 decision -> P10 evidence packet -> P11 metadata decision -> P12 metadata authorization -> P13 metadata change -> P14 stop-gate rollup -> P15 owner decision packet -> P16 blocked until owner authorization
 ```
 
 P2-P7 are governance/evidence work. Any actual stub-to-live promotion is a separate runtime work


### PR DESCRIPTION
WO-TERRAPILOT-P15 evidence/governance packet for future promotion authorization. Scope: owner decision choices, evidence required before any live/backend-integrated path, rollback path, validation gates, and stop gates for summarize_levy_rate_components. No tool-maturity metadata mutation, no backend integration, no handler behavior change, no runtime code, no CI, no schema/database, no deployment, and no secrets/county/PACS/SQL access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TerraPilot maturity guidance to reflect a new owner-authorization checkpoint before any further progression.
  * Clarified that the next step is blocked until explicit approval is provided.
  * Added a new decision record outlining the available owner choices, required evidence, and stop-gate conditions.
  * Revised the goal-command guidance so maturity claims must be evidence-backed and cannot move forward without separate authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->