### PR TITLE
fix(audit): county isolation + filter correctness on trail/search (WO-AUDIT-COUNTY-FILTER-001)

### DIFF
--- a/backend/src/TerraFusion.API/Controllers/AuditController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AuditController.cs
@@ -333,10 +333,8 @@ public class AuditController : ControllerBase
     // ── GET api/audit/trail ─────────────────────────────────────────
     // Per-parcel audit event trail, read from AuditEvents. Returns the
     // canonical AuditEvent[] shape consumed by the Dais AuditTab.
-    // NOTE: domain audit-event capture is not yet wired (AU-2 interceptor
-    // is unimplemented), so AuditEvents is currently empty and this returns
-    // [] honestly rather than 404. AuditEvents has no CountyId column, so
-    // isolation here is the authenticated county gate + per-parcel scope.
+    // NOTE: rows are row-level county-isolated (AuditEvents.CountyId) and per-parcel
+    // scoped, then paged. Empty when the parcel has no events for the caller's county.
 
     [HttpGet("trail")]
     public async Task<IActionResult> GetAuditTrail(
@@ -356,7 +354,7 @@ public class AuditController : ControllerBase
         var events = await _db.AuditEvents
             .AsNoTracking()
             .Where(e => e.CountyId == countyId.Value && e.EntityId == parcelId)
-            .OrderByDescending(e => e.Timestamp)
+            .OrderByDescending(e => e.Timestamp).ThenByDescending(e => e.Id) // stable paging tiebreaker
             .Skip(skip)
             .Take(take)
             .ToListAsync();
@@ -396,7 +394,7 @@ public class AuditController : ControllerBase
 
         var (skip, take) = Paginate(page, pageSize);
         var events = await query
-            .OrderByDescending(e => e.Timestamp)
+            .OrderByDescending(e => e.Timestamp).ThenByDescending(e => e.Id) // stable paging tiebreaker
             .Skip(skip)
             .Take(take)
             .ToListAsync();
@@ -409,11 +407,13 @@ public class AuditController : ControllerBase
     private const int DefaultPageSize = 200;
     private const int MaxPageSize = 500;
 
+    private const int MaxPage = 1_000_000; // caps skip well under int.MaxValue (1e6 * 500 = 5e8)
+
     private static (int Skip, int Take) Paginate(int? page, int? pageSize)
     {
-        var p = page is > 0 ? page.Value : 1;
+        var p = page is > 0 ? Math.Min(page.Value, MaxPage) : 1;
         var size = pageSize is > 0 ? Math.Min(pageSize.Value, MaxPageSize) : DefaultPageSize;
-        return ((p - 1) * size, size);
+        return ((p - 1) * size, size); // (p-1)*size ≤ (1e6-1)*500 < int.MaxValue → no overflow
     }
 
     /// <summary>

--- a/backend/src/TerraFusion.API/Controllers/AuditController.cs
+++ b/backend/src/TerraFusion.API/Controllers/AuditController.cs
@@ -339,7 +339,10 @@ public class AuditController : ControllerBase
     // isolation here is the authenticated county gate + per-parcel scope.
 
     [HttpGet("trail")]
-    public async Task<IActionResult> GetAuditTrail([FromQuery] string? parcelId)
+    public async Task<IActionResult> GetAuditTrail(
+        [FromQuery] string? parcelId,
+        [FromQuery] int? page = null,
+        [FromQuery] int? pageSize = null)
     {
         if (string.IsNullOrWhiteSpace(parcelId))
             return BadRequest(new { message = "parcelId is required" });
@@ -347,10 +350,15 @@ public class AuditController : ControllerBase
         var countyId = await ResolveCountyIdAsync();
         if (countyId is null) return Forbid();
 
+        // WO-AUDIT-COUNTY-FILTER-001: isolate rows to the caller's county (not just gate
+        // access), and page the result so a hot parcel can't return an unbounded response.
+        var (skip, take) = Paginate(page, pageSize);
         var events = await _db.AuditEvents
             .AsNoTracking()
-            .Where(e => e.EntityId == parcelId)
+            .Where(e => e.CountyId == countyId.Value && e.EntityId == parcelId)
             .OrderByDescending(e => e.Timestamp)
+            .Skip(skip)
+            .Take(take)
             .ToListAsync();
 
         return Ok(events.Select(AuditTrailMapper.Map).ToList());
@@ -366,29 +374,91 @@ public class AuditController : ControllerBase
         [FromQuery] string? endDate,
         [FromQuery] string? userId,
         [FromQuery] string? category,
-        [FromQuery] string? action)
+        [FromQuery] string? action,
+        [FromQuery] int? page = null,
+        [FromQuery] int? pageSize = null)
     {
         var countyId = await ResolveCountyIdAsync();
         if (countyId is null) return Forbid();
 
-        IQueryable<AuditEvent> query = _db.AuditEvents.AsNoTracking();
+        // WO-AUDIT-COUNTY-FILTER-001: county isolation on the row set (not just access).
+        IQueryable<AuditEvent> query = _db.AuditEvents.AsNoTracking()
+            .Where(e => e.CountyId == countyId.Value);
 
         if (!string.IsNullOrWhiteSpace(parcelId)) query = query.Where(e => e.EntityId == parcelId);
         if (!string.IsNullOrWhiteSpace(userId)) query = query.Where(e => e.UserId == userId);
         if (!string.IsNullOrWhiteSpace(action)) query = query.Where(e => e.Action.Contains(action));
         if (TryParseUtc(startDate, out var start)) query = query.Where(e => e.Timestamp >= start);
         if (TryParseUtc(endDate, out var end)) query = query.Where(e => e.Timestamp <= end);
+        // Category is derived from Entity; apply it in SQL BEFORE paging so a category
+        // filter can't silently drop matches that fell outside the page window.
+        if (!string.IsNullOrWhiteSpace(category)) query = ApplyCategoryFilter(query, category);
 
+        var (skip, take) = Paginate(page, pageSize);
         var events = await query
             .OrderByDescending(e => e.Timestamp)
-            .Take(500)
+            .Skip(skip)
+            .Take(take)
             .ToListAsync();
 
-        IEnumerable<AuditTrailEventDto> mapped = events.Select(AuditTrailMapper.Map);
-        if (!string.IsNullOrWhiteSpace(category))
-            mapped = mapped.Where(m => string.Equals(m.Category, category, StringComparison.OrdinalIgnoreCase));
+        return Ok(events.Select(AuditTrailMapper.Map).ToList());
+    }
 
-        return Ok(mapped.ToList());
+    // ── Paging + category helpers (WO-AUDIT-COUNTY-FILTER-001) ───────
+
+    private const int DefaultPageSize = 200;
+    private const int MaxPageSize = 500;
+
+    private static (int Skip, int Take) Paginate(int? page, int? pageSize)
+    {
+        var p = page is > 0 ? page.Value : 1;
+        var size = pageSize is > 0 ? Math.Min(pageSize.Value, MaxPageSize) : DefaultPageSize;
+        return ((p - 1) * size, size);
+    }
+
+    /// <summary>
+    /// Translatable Entity predicate that mirrors <see cref="AuditTrailMapper.MapCategory"/>
+    /// (case-insensitive substring, same precedence: appeal &gt; permit &gt; exemption &gt;
+    /// document &gt; field &gt; assessment &gt; system). Unknown category ⇒ no rows.
+    /// Applied in SQL so category filtering happens before the page window.
+    /// </summary>
+    private static IQueryable<AuditEvent> ApplyCategoryFilter(IQueryable<AuditEvent> q, string category)
+    {
+        switch (category.Trim().ToLowerInvariant())
+        {
+            case "appeal":
+                return q.Where(e => e.Entity.ToLower().Contains("appeal"));
+            case "permit":
+                return q.Where(e => e.Entity.ToLower().Contains("permit")
+                    && !e.Entity.ToLower().Contains("appeal"));
+            case "exemption":
+                return q.Where(e => e.Entity.ToLower().Contains("exemption")
+                    && !e.Entity.ToLower().Contains("appeal") && !e.Entity.ToLower().Contains("permit"));
+            case "document":
+                return q.Where(e => e.Entity.ToLower().Contains("document")
+                    && !e.Entity.ToLower().Contains("appeal") && !e.Entity.ToLower().Contains("permit")
+                    && !e.Entity.ToLower().Contains("exemption"));
+            case "field":
+                return q.Where(e => e.Entity.ToLower().Contains("field")
+                    && !e.Entity.ToLower().Contains("appeal") && !e.Entity.ToLower().Contains("permit")
+                    && !e.Entity.ToLower().Contains("exemption") && !e.Entity.ToLower().Contains("document"));
+            case "assessment":
+                return q.Where(e =>
+                    (e.Entity.ToLower().Contains("parcel") || e.Entity.ToLower().Contains("property")
+                        || e.Entity.ToLower().Contains("assessment") || e.Entity.ToLower().Contains("valuation"))
+                    && !e.Entity.ToLower().Contains("appeal") && !e.Entity.ToLower().Contains("permit")
+                    && !e.Entity.ToLower().Contains("exemption") && !e.Entity.ToLower().Contains("document")
+                    && !e.Entity.ToLower().Contains("field"));
+            case "system":
+                return q.Where(e =>
+                    !e.Entity.ToLower().Contains("appeal") && !e.Entity.ToLower().Contains("permit")
+                    && !e.Entity.ToLower().Contains("exemption") && !e.Entity.ToLower().Contains("document")
+                    && !e.Entity.ToLower().Contains("field") && !e.Entity.ToLower().Contains("parcel")
+                    && !e.Entity.ToLower().Contains("property") && !e.Entity.ToLower().Contains("assessment")
+                    && !e.Entity.ToLower().Contains("valuation"));
+            default:
+                return q.Where(e => false);
+        }
     }
 
     private static bool TryParseUtc(string? value, out DateTime utc)

--- a/backend/src/TerraFusion.API/Services/AuditEventWriter.cs
+++ b/backend/src/TerraFusion.API/Services/AuditEventWriter.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TerraFusion.Core.Auth;
 using TerraFusion.Core.DTOs;
@@ -60,7 +62,11 @@ public sealed class AuditEventWriter : IAuditEventWriter
             var actor = ctx.IsAuthenticated && !string.IsNullOrWhiteSpace(ctx.UserId)
                 ? ctx.UserId!
                 : SystemActor;
-            Guid? countyId = Guid.TryParse(ctx.CountyId, out var parsed) ? parsed : null;
+            // WO-AUDIT-COUNTY-FILTER-001: the request context's CountyId may be a countyCode
+            // (the accessor falls back to it), so resolve non-GUID values to the real county
+            // GUID — otherwise the row is written county-unattributed and the county-isolated
+            // trail/search can never surface it.
+            Guid? countyId = await ResolveCountyIdAsync(ctx.CountyId, cancellationToken);
 
             _db.AuditEvents.Add(new AuditEvent
             {
@@ -85,5 +91,27 @@ public sealed class AuditEventWriter : IAuditEventWriter
                 "Failed to write AuditEvent entity={Entity} entityId={EntityId} action={Action}",
                 entity, entityId, action);
         }
+    }
+
+    /// <summary>
+    /// Resolves the request's county claim (a GUID, or a countyCode/name/FIPS fallback) to
+    /// the canonical county GUID. Returns null when absent or unresolvable.
+    /// </summary>
+    private async Task<Guid?> ResolveCountyIdAsync(string? countyIdOrCode, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(countyIdOrCode)) return null;
+        if (Guid.TryParse(countyIdOrCode, out var direct)) return direct;
+
+        var code = countyIdOrCode.Trim();
+        var fipsPadded = code.All(char.IsDigit) ? code.PadLeft(3, '0') : code;
+
+        var match = await _db.Counties
+            .AsNoTracking()
+            .Where(c => c.Name == code
+                || (c.FipsCode != null && (c.FipsCode == code || c.FipsCode == fipsPadded)))
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(ct);
+
+        return match;
     }
 }

--- a/backend/src/TerraFusion.API/Services/AuditEventWriter.cs
+++ b/backend/src/TerraFusion.API/Services/AuditEventWriter.cs
@@ -103,11 +103,13 @@ public sealed class AuditEventWriter : IAuditEventWriter
         if (Guid.TryParse(countyIdOrCode, out var direct)) return direct;
 
         var code = countyIdOrCode.Trim();
+        var lowered = code.ToLowerInvariant();
         var fipsPadded = code.All(char.IsDigit) ? code.PadLeft(3, '0') : code;
 
+        // Case-insensitive name match (auth may supply "benton"/"BENTON"); exact FIPS.
         var match = await _db.Counties
             .AsNoTracking()
-            .Where(c => c.Name == code
+            .Where(c => c.Name.ToLower() == lowered
                 || (c.FipsCode != null && (c.FipsCode == code || c.FipsCode == fipsPadded)))
             .Select(c => (Guid?)c.Id)
             .FirstOrDefaultAsync(ct);

--- a/backend/tests/TerraFusion.Unit.Tests/Audit/AuditEventEmissionTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Audit/AuditEventEmissionTests.cs
@@ -75,6 +75,27 @@ public sealed class AuditEventEmissionTests
         row.CountyId.Should().BeNull();
     }
 
+    [Fact]
+    public async Task Writer_ResolvesCountyCodeClaimToCountyGuid()
+    {
+        // WO-AUDIT-COUNTY-FILTER-001: a countyCode/name claim (not a GUID) must resolve to the
+        // real county GUID so the county-isolated trail can surface the row.
+        await using var db = NewDb(nameof(Writer_ResolvesCountyCodeClaimToCountyGuid));
+        var countyGuid = Guid.NewGuid();
+        db.Counties.Add(new County { Id = countyGuid, Name = "Benton", State = "WA", FipsCode = "003" });
+        await db.SaveChangesAsync();
+
+        var accessor = new FakeUserContext
+        {
+            Current = new RequestUserContext(true, "u1", "Benton", Array.Empty<string>())
+        };
+        var writer = new AuditEventWriter(db, accessor, NullLogger<AuditEventWriter>.Instance);
+
+        await writer.WriteAsync("Appeal", "P1", "file_appeal", AuditEventType.Create);
+
+        db.AuditEvents.Single().CountyId.Should().Be(countyGuid);
+    }
+
     // ── GovernedToolAuditService emission ───────────────────────────────
 
     [Fact]

--- a/backend/tests/TerraFusion.Unit.Tests/Audit/AuditEventEmissionTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Audit/AuditEventEmissionTests.cs
@@ -87,7 +87,8 @@ public sealed class AuditEventEmissionTests
 
         var accessor = new FakeUserContext
         {
-            Current = new RequestUserContext(true, "u1", "Benton", Array.Empty<string>())
+            // lowercase — exercises the case-insensitive name match (County.Name = "Benton").
+            Current = new RequestUserContext(true, "u1", "benton", Array.Empty<string>())
         };
         var writer = new AuditEventWriter(db, accessor, NullLogger<AuditEventWriter>.Instance);
 

--- a/backend/tests/TerraFusion.Unit.Tests/Audit/AuditTrailEndpointsTests.cs
+++ b/backend/tests/TerraFusion.Unit.Tests/Audit/AuditTrailEndpointsTests.cs
@@ -44,12 +44,14 @@ public sealed class AuditTrailEndpointsTests
         return controller;
     }
 
+    private static readonly Guid OtherCountyId = new("22222222-2222-2222-2222-222222222222");
+
     private static async Task Seed(DataDbContext db)
     {
         db.AuditEvents.AddRange(
-            new AuditEvent { Id = "e1", Entity = "Parcel", EntityId = "P1", UserId = "u1", Action = "ValueChanged", Type = AuditEventType.Update, Timestamp = DateTime.UtcNow.AddMinutes(-5), DetailsJson = "{\"previousValue\":\"100\",\"newValue\":\"200\",\"details\":\"reval\"}" },
-            new AuditEvent { Id = "e2", Entity = "Appeal", EntityId = "P1", UserId = "u2", Action = "AppealFiled", Type = AuditEventType.Create, Timestamp = DateTime.UtcNow, DetailsJson = "not-json" },
-            new AuditEvent { Id = "e3", Entity = "Parcel", EntityId = "P2", UserId = "u1", Action = "Viewed", Type = AuditEventType.View, Timestamp = DateTime.UtcNow, DetailsJson = "" });
+            new AuditEvent { Id = "e1", Entity = "Parcel", EntityId = "P1", UserId = "u1", Action = "ValueChanged", Type = AuditEventType.Update, Timestamp = DateTime.UtcNow.AddMinutes(-5), CountyId = CountyId, DetailsJson = "{\"previousValue\":\"100\",\"newValue\":\"200\",\"details\":\"reval\"}" },
+            new AuditEvent { Id = "e2", Entity = "Appeal", EntityId = "P1", UserId = "u2", Action = "AppealFiled", Type = AuditEventType.Create, Timestamp = DateTime.UtcNow, CountyId = CountyId, DetailsJson = "not-json" },
+            new AuditEvent { Id = "e3", Entity = "Parcel", EntityId = "P2", UserId = "u1", Action = "Viewed", Type = AuditEventType.View, Timestamp = DateTime.UtcNow, CountyId = CountyId, DetailsJson = "" });
         await db.SaveChangesAsync();
     }
 
@@ -113,6 +115,66 @@ public sealed class AuditTrailEndpointsTests
             parcelId: null, startDate: null, endDate: null, userId: null, category: "appeal", action: null));
 
         events.Should().ContainSingle().Which.EventId.Should().Be("e2");
+    }
+
+    // ── WO-AUDIT-COUNTY-FILTER-001: county isolation ────────────────────
+
+    [Fact]
+    public async Task Trail_ExcludesEventsFromAnotherCounty()
+    {
+        await using var db = CreateDb(nameof(Trail_ExcludesEventsFromAnotherCounty));
+        await Seed(db); // e1,e2 on P1 in CountyId
+        db.AuditEvents.Add(new AuditEvent
+        {
+            Id = "x1", Entity = "Appeal", EntityId = "P1", UserId = "u9", Action = "AppealFiled",
+            Type = AuditEventType.Create, Timestamp = DateTime.UtcNow.AddMinutes(1),
+            CountyId = OtherCountyId, DetailsJson = "{}"
+        });
+        await db.SaveChangesAsync();
+
+        var events = Ok(await CreateController(db).GetAuditTrail("P1"));
+
+        events.Should().HaveCount(2);
+        events.Select(e => e.EventId).Should().BeEquivalentTo(new[] { "e1", "e2" });
+        events.Select(e => e.EventId).Should().NotContain("x1");
+    }
+
+    [Fact]
+    public async Task Search_ExcludesEventsFromAnotherCounty()
+    {
+        await using var db = CreateDb(nameof(Search_ExcludesEventsFromAnotherCounty));
+        await Seed(db);
+        db.AuditEvents.Add(new AuditEvent
+        {
+            Id = "x1", Entity = "Appeal", EntityId = "P1", UserId = "u9", Action = "AppealFiled",
+            Type = AuditEventType.Create, Timestamp = DateTime.UtcNow, CountyId = OtherCountyId, DetailsJson = "{}"
+        });
+        await db.SaveChangesAsync();
+
+        var events = Ok(await CreateController(db).SearchAuditTrail(
+            parcelId: null, startDate: null, endDate: null, userId: null, category: "appeal", action: null));
+
+        // Only the in-county appeal (e2), not the other-county one (x1).
+        events.Should().ContainSingle().Which.EventId.Should().Be("e2");
+    }
+
+    [Fact]
+    public async Task Search_CategoryFilter_AppliedBeforePaging()
+    {
+        // 3 non-matching Parcel events (newest) + 1 matching Appeal (oldest); pageSize 2.
+        // If category filtered AFTER paging, the Appeal would fall outside the window and be lost.
+        await using var db = CreateDb(nameof(Search_CategoryFilter_AppliedBeforePaging));
+        var baseTime = DateTime.UtcNow;
+        for (var i = 0; i < 3; i++)
+            db.AuditEvents.Add(new AuditEvent { Id = $"p{i}", Entity = "Parcel", EntityId = "P1", UserId = "u1", Action = "Viewed", Type = AuditEventType.View, Timestamp = baseTime.AddMinutes(i + 1), CountyId = CountyId, DetailsJson = "" });
+        db.AuditEvents.Add(new AuditEvent { Id = "app", Entity = "Appeal", EntityId = "P1", UserId = "u2", Action = "AppealFiled", Type = AuditEventType.Create, Timestamp = baseTime, CountyId = CountyId, DetailsJson = "{}" });
+        await db.SaveChangesAsync();
+
+        var events = Ok(await CreateController(db).SearchAuditTrail(
+            parcelId: null, startDate: null, endDate: null, userId: null, category: "appeal", action: null,
+            page: 1, pageSize: 2));
+
+        events.Should().ContainSingle().Which.EventId.Should().Be("app");
     }
 
     [Theory]

--- a/docs/data/WO_AUDIT_COUNTY_FILTER_001.md
+++ b/docs/data/WO_AUDIT_COUNTY_FILTER_001.md
@@ -1,0 +1,49 @@
+# WO-AUDIT-COUNTY-FILTER-001 — Audit Trail County Isolation + Filter Correctness
+
+**Date:** 2026-07-03
+**Authorization:** SW-09 (code). Closes the CodeRabbit **Critical** (county isolation) + two **Major** findings
+(category-after-cap, unbounded trail) raised on the audit PRs, plus the writer county-attribution gap.
+**Risk executed:** SW-09 — backend code + tests. No deploy (SW-01), no migration, no data mutation.
+
+## Findings addressed
+1. **🔴 Critical — county isolation not enforced on rows.** `/api/audit/trail` and `/search` resolved a county but
+   then queried `AuditEvents` **without constraining to it** — any authenticated caller could read another county's
+   audit rows once capture is populated. (Mitigated in the single-county demo; a real leak in multi-county.)
+2. **🟠 Major — category filter applied after `Take(500)`.** `search` mapped→filtered by `category` **in memory after**
+   the 500-row SQL cap, so `?category=appeal` could return empty/partial even when matching rows existed beyond the cap.
+3. **🟠 Major — unbounded trail.** `trail` returned every event for a parcel with no limit.
+4. **Writer county-attribution gap.** `AuditEventWriter` wrote `CountyId` only when the context claim parsed as a GUID;
+   a `countyCode`/name claim (the accessor falls back to it) was stored as **null**, so those rows could never surface
+   in the now-county-isolated trail.
+
+## Change
+**`AuditController` (trail + search):**
+- Both queries now filter `AuditEvents` by the resolved county: `Where(e => e.CountyId == countyId.Value)` — true
+  row-level isolation, not just an access gate.
+- `search` applies the **category filter in SQL before paging** via `ApplyCategoryFilter`, a translatable `Entity`
+  predicate that **mirrors `AuditTrailMapper.MapCategory` exactly** (case-insensitive substring, same precedence
+  appeal > permit > exemption > document > field > assessment > system; unknown category ⇒ no rows).
+- Both endpoints are **paged**: new optional `page`/`pageSize` query params (`Paginate` clamps: default 200, max 500,
+  page ≥ 1). Backward-compatible — the frontend sends neither and gets the first bounded page.
+
+**`AuditEventWriter`:** `ResolveCountyIdAsync(countyIdOrCode)` — GUID passes through; otherwise resolves the county by
+`Name`/`FipsCode` (incl. zero-padded FIPS) via `_db.Counties`, so emitted rows always carry a resolvable `CountyId`.
+
+## Verification
+- API `/warnaserror` build: **0 warnings / 0 errors**.
+- `Category=Audit|Stage2`: **102/102** pass, incl. new:
+  - `Trail_ExcludesEventsFromAnotherCounty` / `Search_ExcludesEventsFromAnotherCounty` — a different-county event is
+    not returned.
+  - `Search_CategoryFilter_AppliedBeforePaging` — with `pageSize=2` and the only matching (oldest) event outside the
+    newest-2 window, it is still returned (proves category filters before the page cap).
+  - `Writer_ResolvesCountyCodeClaimToCountyGuid` — a `countyCode` claim ("Benton") resolves to the seeded county GUID.
+  - Existing trail/search/mapping tests updated to seed `CountyId` (they now assert under isolation).
+- **Not deployed.** Live county-isolation verification against the demo is an SW-01 deploy (this WO is code-only). The
+  existing single-county e2e (`AU25B-E2E-TEST`, CountyId=Benton) remains satisfied by construction — its event carries
+  the Benton GUID and the caller resolves to Benton.
+
+## Scope honored / deferred
+- ✅ county filter · ✅ category-before-Take · ✅ paging · ✅ writer countyCode resolution · ✅ tests + gates · no deploy/migration/mutation.
+- **Deferred (noted, out of this WO):** consolidating `CollaborationService.CreateAuditEventAsync` to write through
+  `IAuditEventWriter` (single emission path) — a separate refactor touching another service; it already writes
+  `AuditEvents` directly and is not an ETL/isolation regression.


### PR DESCRIPTION
## WO-AUDIT-COUNTY-FILTER-001 (SW-09)

Closes the CodeRabbit **🔴 Critical** (county isolation) + two **🟠 Major** findings on the audit endpoints, plus the writer county-attribution gap.

### Fixes
1. **County isolation (Critical):** `trail` + `search` now filter `AuditEvents` by resolved `CountyId` (row-level, not just an access gate).
2. **Category-before-paging (Major):** `search` applies category in SQL **before** the page cap via `ApplyCategoryFilter` — a translatable `Entity` predicate that mirrors `AuditTrailMapper.MapCategory` precedence exactly. (Was: mapped→filtered in memory after `Take(500)`, silently dropping matches.)
3. **Paging (Major):** both endpoints take optional `page`/`pageSize` (default 200, max 500, page ≥ 1); backward-compatible.
4. **Writer resolution:** `AuditEventWriter` resolves a `countyCode`/name/FIPS claim → county GUID (via `_db.Counties`), so emitted rows are county-attributed and surface under isolation (previously written null).

### Verification
- `/warnaserror`: **0 warnings**
- `Category=Audit|Stage2`: **102/102**, incl. cross-county exclusion (trail+search), category-filter-before-paging, and writer countyCode→GUID resolution. Existing tests updated to seed `CountyId`.
- **No deploy / migration / mutation.** Live county-isolation verification is an SW-01 deploy; the existing single-county e2e (`AU25B-E2E-TEST`, Benton) is satisfied by construction.

### Deferred (noted)
Consolidating `CollaborationService` audit writes through `IAuditEventWriter` — separate refactor, not an isolation regression.

Evidence: `docs/data/WO_AUDIT_COUNTY_FILTER_001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit trail and audit search now support paging for larger result sets.
  * Audit records are now tied to the active county so users only see relevant events.
* **Bug Fixes**
  * Improved audit search so category matches are returned correctly, even when results span multiple pages.
  * Audit event entries now resolve county information more reliably from different county identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->