### PR TITLE
docs(backend): register operational excellence program

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,13 +17,13 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-03 — WO-TERRAPILOT-P15)*
+*(Updated 2026-07-03 — WO-BACKEND-000)*
 
 | # | Program | /goal command | Status | Next WO |
 |---|---------|--------------|--------|---------|
 | P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003D (if authorized) |
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
-| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | QUEUED | WO-BACKEND-001 |
+| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | ACTIVE | WO-BACKEND-000 until merged; then WO-BACKEND-001 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
 | P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | STOP GATE | WO-TERRAPILOT-P16 (blocked; owner authorization required) |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
@@ -140,3 +140,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-01 | Added Management Dashboard program (P8-MGMT), Operator Doctrine Layer, refreshed statuses; SW register extended to SW-01..SW-10 | WO-WOE-011 |
 | 2026-07-01 | Added Autonomous Same-Risk Continuation Gate (cross-program advance + wall ledger) | WO-WOE-012 |
 | 2026-07-01 | Added Cross-Program Dependency Graph (authorization→unblocks map, prerequisite chains) | WO-WOE-014 |
+| 2026-07-03 | Replaced stale backend program with Backend Operational Excellence hardening/proof/release discipline chain | WO-BACKEND-000 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -23,7 +23,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 |---|---------|--------------|--------|---------|
 | P1 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | ACTIVE | WO-DEPLOY-BENTON-003D (if authorized) |
 | P2 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | ACTIVE | WO-DATA-BENTON-ADDR-001 (DUPE-001B parked @ SW-02) |
-| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | ACTIVE | WO-BACKEND-000 until merged; then WO-BACKEND-001 |
+| P3 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `/goal backend-excellence` | ACTIVE | WO-BACKEND-000 |
 | P4 | [Property Workbench](programs/property-workbench.md) | `/goal property-workbench` | QUEUED | WO-WORKBENCH-001 |
 | P5 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `/goal terrapilot-maturity` | STOP GATE | WO-TERRAPILOT-P16 (blocked; owner authorization required) |
 | P6 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | ACTIVE | WO-WOE-012 (011 in PR) |
@@ -40,7 +40,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B | — |
 | WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
 | No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
-| Backend operational truth not established | WO-BACKEND-001+ | — |
+| Backend operational truth not established | WO-BACKEND-OE-001+ | — |
 | Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
 | County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |
 

--- a/docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md
@@ -57,19 +57,19 @@ Command aliases:
 The registered backend chain is:
 
 1. WO-BACKEND-000 — Backend Operational Excellence Program Playbook
-2. WO-BACKEND-001 — Backend Operational Excellence Baseline
-3. WO-BACKEND-002 — Build Warning Register
-4. WO-BACKEND-003 — Build Warning Burn-down
-5. WO-BACKEND-004 — Service Registry Runtime Validation
-6. WO-BACKEND-005 — Health and Readiness Truth
-7. WO-BACKEND-006 — Backend Security / Auth / County Isolation Proof
-8. WO-BACKEND-007 — Migration and Rollback Proof
-9. WO-BACKEND-008 — Broader Dais / Workflow E2E Proof
-10. WO-BACKEND-009 — Backend Release Gate Definition
-11. WO-BACKEND-010 — Backend Operational Runbook
-12. WO-BACKEND-011 — Backend Diagnostics and Observability Map
-13. WO-BACKEND-012 — Backend Operational Packet
-14. WO-BACKEND-013 — Evidence Rollup and Program Closeout
+2. WO-BACKEND-OE-001 — Backend Operational Excellence Baseline
+3. WO-BACKEND-OE-002 — Build Warning Register
+4. WO-BACKEND-OE-003 — Build Warning Burn-down
+5. WO-BACKEND-OE-004 — Service Registry Runtime Validation
+6. WO-BACKEND-OE-005 — Health and Readiness Truth
+7. WO-BACKEND-OE-006 — Backend Security / Auth / County Isolation Proof
+8. WO-BACKEND-OE-007 — Migration and Rollback Proof
+9. WO-BACKEND-OE-008 — Broader Dais / Workflow E2E Proof
+10. WO-BACKEND-OE-009 — Backend Release Gate Definition
+11. WO-BACKEND-OE-010 — Backend Operational Runbook
+12. WO-BACKEND-OE-011 — Backend Diagnostics and Observability Map
+13. WO-BACKEND-OE-012 — Backend Operational Packet
+14. WO-BACKEND-OE-013 — Evidence Rollup and Program Closeout
 
 ## Explicit Non-Changes
 
@@ -91,9 +91,9 @@ The registered backend chain is:
 
 After this playbook lands, the next recommended WO is:
 
-- `WO-BACKEND-001 — Backend Operational Excellence Baseline`
+- `WO-BACKEND-OE-001 — Backend Operational Excellence Baseline`
 
-WO-BACKEND-001 is read-only discovery and evidence baseline only. It should establish current backend
+WO-BACKEND-OE-001 is read-only discovery and evidence baseline only. It should establish current backend
 operational truth on `origin/main` before any implementation hardening begins.
 
 ## Stop Gate

--- a/docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md
@@ -1,0 +1,102 @@
+# WO-BACKEND-000 — Backend Operational Excellence Program Playbook
+
+## Status
+
+Program playbook creation only. No backend implementation is included.
+
+## Objective
+
+Create the Backend Operational Excellence program playbook and register it in the Work Order Engine /
+Goal-Loop system before starting backend hardening, warning burn-down, release-gate, or runtime-readiness
+work.
+
+## Context
+
+TerraPilot Tool Maturity is parked at P15. P16 remains blocked unless the owner explicitly authorizes a
+design-only continuation.
+
+Known backend baseline before this program:
+
+- `origin/main`: `2195309dacabc22eb4f0f0939178331d8ded86d4`
+- Backend/Dais foundation is believed implemented.
+- Service registry activation is believed implemented.
+- Previous backend build passed with warnings remaining.
+- The next backend work is production discipline, not foundation rebuild.
+
+## Files Authorized For This WO
+
+- `docs/brain/workorders/programs/backend-operational-excellence.md`
+- `docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md`
+- `docs/brain/workorders/goal-loop/GOAL_COMMANDS.md`
+- `docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md`
+- `docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md`
+
+## Program Registered
+
+Program:
+
+- Backend Operational Excellence
+
+Goal:
+
+- `GOAL-BACKEND-OPERATIONAL-EXCELLENCE`
+
+Loop:
+
+- `LOOP-BACKEND-OPERATIONAL-EXCELLENCE`
+
+Command aliases:
+
+- `/backend-start`
+- `/backend-status`
+- `/backend-next`
+- `/backend-stop`
+
+## Program Chain
+
+The registered backend chain is:
+
+1. WO-BACKEND-000 — Backend Operational Excellence Program Playbook
+2. WO-BACKEND-001 — Backend Operational Excellence Baseline
+3. WO-BACKEND-002 — Build Warning Register
+4. WO-BACKEND-003 — Build Warning Burn-down
+5. WO-BACKEND-004 — Service Registry Runtime Validation
+6. WO-BACKEND-005 — Health and Readiness Truth
+7. WO-BACKEND-006 — Backend Security / Auth / County Isolation Proof
+8. WO-BACKEND-007 — Migration and Rollback Proof
+9. WO-BACKEND-008 — Broader Dais / Workflow E2E Proof
+10. WO-BACKEND-009 — Backend Release Gate Definition
+11. WO-BACKEND-010 — Backend Operational Runbook
+12. WO-BACKEND-011 — Backend Diagnostics and Observability Map
+13. WO-BACKEND-012 — Backend Operational Packet
+14. WO-BACKEND-013 — Evidence Rollup and Program Closeout
+
+## Explicit Non-Changes
+
+- Backend runtime code changed: no
+- Frontend runtime code changed: no
+- OS platform runtime code changed: no
+- Tests added or changed: no
+- Warnings fixed: no
+- Schema/database changed: no
+- Migrations created or applied: no
+- App settings changed: no
+- Services started: no
+- Deployment changed: no
+- Secrets/county/PACS/SQL touched: no
+- TerraPilot P16 started: no
+- TerraPilot metadata changed: no
+
+## Next Step
+
+After this playbook lands, the next recommended WO is:
+
+- `WO-BACKEND-001 — Backend Operational Excellence Baseline`
+
+WO-BACKEND-001 is read-only discovery and evidence baseline only. It should establish current backend
+operational truth on `origin/main` before any implementation hardening begins.
+
+## Stop Gate
+
+This WO stops at the completed playbook. It does not authorize implementation, schema work, runtime
+mutation, service startup, deployment, production access, or protected data access.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -4,22 +4,23 @@
 **Last Updated:** 2026-07-03
 **Classification:** Operator Doctrine — current state snapshot
 
-This file maps every `/goal` command to its program, current next WO, blockers, allowed loop modes,
-and active stop walls. Update this file when a WO completes or a blocker resolves.
+This file maps every `/goal` command or command alias to its program, current next WO, blockers,
+allowed loop modes, and active stop walls. Update this file when a WO completes or a blocker
+resolves.
 
 ---
 
 ## Quick Reference Table
 
-| `/goal` command | Program | Next WO | Blocked? | Allowed /loop modes |
+| Command / alias | Program | Next WO | Blocked? | Allowed /loop modes |
 |-----------------|---------|---------|----------|---------------------|
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
-| `backend-excellence` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
-| `backend-start` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `program` |
-| `backend-status` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `evidence`, `discovery` |
-| `backend-next` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `once`, `evidence` |
-| `backend-stop` | P3 | Park backend loop at current WO | YES — operator stop command | `once` |
+| `backend-excellence` | P3 | WO-BACKEND-000 | NO | `once`, `program`, `evidence`, `discovery` |
+| `backend-start` | P3 | WO-BACKEND-000 | NO | `program` |
+| `backend-status` | P3 | WO-BACKEND-000 | NO | `evidence`, `discovery` |
+| `backend-next` | P3 | WO-BACKEND-000 | NO | `once`, `evidence` |
+| `backend-stop` | P3 | NONE | YES — operator stop command | `once` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
@@ -91,21 +92,21 @@ runbooks, diagnostics, rollback, and evidence rollup are explicit enough for WOE
 | WO | Title | Status |
 |----|-------|--------|
 | WO-BACKEND-000 | Backend Operational Excellence Program Playbook | **THIS WO** |
-| WO-BACKEND-001 | Backend Operational Excellence Baseline | **NEXT AFTER 000** |
-| WO-BACKEND-002 | Build Warning Register | QUEUED |
-| WO-BACKEND-003 | Build Warning Burn-down | QUEUED |
-| WO-BACKEND-004 | Service Registry Runtime Validation | QUEUED |
-| WO-BACKEND-005 | Health and Readiness Truth | QUEUED |
-| WO-BACKEND-006 | Backend Security / Auth / County Isolation Proof | QUEUED |
-| WO-BACKEND-007 | Migration and Rollback Proof | QUEUED |
-| WO-BACKEND-008 | Broader Dais / Workflow E2E Proof | QUEUED |
-| WO-BACKEND-009 | Backend Release Gate Definition | QUEUED |
-| WO-BACKEND-010 | Backend Operational Runbook | QUEUED |
-| WO-BACKEND-011 | Backend Diagnostics and Observability Map | QUEUED |
-| WO-BACKEND-012 | Backend Operational Packet | QUEUED |
-| WO-BACKEND-013 | Evidence Rollup and Program Closeout | QUEUED |
+| WO-BACKEND-OE-001 | Backend Operational Excellence Baseline | **NEXT AFTER 000** |
+| WO-BACKEND-OE-002 | Build Warning Register | QUEUED |
+| WO-BACKEND-OE-003 | Build Warning Burn-down | QUEUED |
+| WO-BACKEND-OE-004 | Service Registry Runtime Validation | QUEUED |
+| WO-BACKEND-OE-005 | Health and Readiness Truth | QUEUED |
+| WO-BACKEND-OE-006 | Backend Security / Auth / County Isolation Proof | QUEUED |
+| WO-BACKEND-OE-007 | Migration and Rollback Proof | QUEUED |
+| WO-BACKEND-OE-008 | Broader Dais / Workflow E2E Proof | QUEUED |
+| WO-BACKEND-OE-009 | Backend Release Gate Definition | QUEUED |
+| WO-BACKEND-OE-010 | Backend Operational Runbook | QUEUED |
+| WO-BACKEND-OE-011 | Backend Diagnostics and Observability Map | QUEUED |
+| WO-BACKEND-OE-012 | Backend Operational Packet | QUEUED |
+| WO-BACKEND-OE-013 | Evidence Rollup and Program Closeout | QUEUED |
 
-No active stop walls at WO-BACKEND-001. Stop walls begin if work requires production deployment,
+No active stop walls at WO-BACKEND-OE-001. Stop walls begin if work requires production deployment,
 secrets, county data, PACS, live DB, schema migration apply, TerraPilot P16, or backend runtime
 mutation outside the active WO.
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -15,7 +15,11 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 |-----------------|---------|---------|----------|---------------------|
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
-| `backend-excellence` | P3 | WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `backend-excellence` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `backend-start` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `program` |
+| `backend-status` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `evidence`, `discovery` |
+| `backend-next` | P3 | WO-BACKEND-000 until merged; then WO-BACKEND-001 | NO | `once`, `evidence` |
+| `backend-stop` | P3 | Park backend loop at current WO | YES — operator stop command | `once` |
 | `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
@@ -81,20 +85,29 @@ and active stop walls. Update this file when a WO completes or a blocker resolve
 ### /goal backend-excellence → P3
 
 **File:** [programs/backend-operational-excellence.md](../programs/backend-operational-excellence.md)  
-**Success condition:** Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+**Success condition:** Backend operational truth, warnings, runtime validation, release gates,
+runbooks, diagnostics, rollback, and evidence rollup are explicit enough for WOE to choose the next lane.
 
 | WO | Title | Status |
 |----|-------|--------|
-| WO-BACKEND-001 | Runtime truth audit | **NEXT** |
-| WO-BACKEND-002 | Health check contract | QUEUED |
-| WO-BACKEND-003 | Logging and observability | QUEUED |
-| WO-BACKEND-004 | Release hygiene | QUEUED |
-| WO-BACKEND-005 | Error handling sweep | QUEUED |
-| WO-BACKEND-006 | Performance baseline | QUEUED |
-| WO-BACKEND-007 | Integration test coverage | QUEUED |
-| WO-BACKEND-008 | Operational runbook | QUEUED |
+| WO-BACKEND-000 | Backend Operational Excellence Program Playbook | **THIS WO** |
+| WO-BACKEND-001 | Backend Operational Excellence Baseline | **NEXT AFTER 000** |
+| WO-BACKEND-002 | Build Warning Register | QUEUED |
+| WO-BACKEND-003 | Build Warning Burn-down | QUEUED |
+| WO-BACKEND-004 | Service Registry Runtime Validation | QUEUED |
+| WO-BACKEND-005 | Health and Readiness Truth | QUEUED |
+| WO-BACKEND-006 | Backend Security / Auth / County Isolation Proof | QUEUED |
+| WO-BACKEND-007 | Migration and Rollback Proof | QUEUED |
+| WO-BACKEND-008 | Broader Dais / Workflow E2E Proof | QUEUED |
+| WO-BACKEND-009 | Backend Release Gate Definition | QUEUED |
+| WO-BACKEND-010 | Backend Operational Runbook | QUEUED |
+| WO-BACKEND-011 | Backend Diagnostics and Observability Map | QUEUED |
+| WO-BACKEND-012 | Backend Operational Packet | QUEUED |
+| WO-BACKEND-013 | Evidence Rollup and Program Closeout | QUEUED |
 
-No active stop walls at WO-BACKEND-001.
+No active stop walls at WO-BACKEND-001. Stop walls begin if work requires production deployment,
+secrets, county data, PACS, live DB, schema migration apply, TerraPilot P16, or backend runtime
+mutation outside the active WO.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -78,7 +78,7 @@ Success:  Backend operational truth, warnings, runtime validation, release gates
 ```
 
 **Current state:** WO-BACKEND-000 registers the program playbook. After it lands,
-WO-BACKEND-001 is the read-only backend operational baseline. This lane is hardening/proof/release
+WO-BACKEND-OE-001 is the read-only backend operational baseline. This lane is hardening/proof/release
 discipline, not a foundation rebuild.
 
 **Allowed loop modes:** `once`, `program`, `evidence`, `discovery`

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -67,15 +67,26 @@ Success:  All open anomaly groups are documented with evidence; cleanup WOs are 
 ### /goal backend-excellence
 
 ```
-Goal:     Make the backend release-gated, diagnosable, and operationally governed.
+Goal:     Turn the backend into an operationally governed platform with explicit build health,
+          readiness proof, diagnostics, runtime validation, release criteria, evidence, and
+          rollback discipline.
 Program:  P3 — Backend Operational Excellence
 File:     programs/backend-operational-excellence.md
-Success:  Runtime truth passes all gates; operational runbook exists; release hygiene enforced.
+Success:  Backend operational truth, warnings, runtime validation, release gates, runbooks,
+          diagnostics, rollback, and evidence rollup are explicit enough for WOE to choose the
+          next lane.
 ```
 
-**Current state:** WO-BACKEND-001 is next (QUEUED). No blockers from current PRs.
+**Current state:** WO-BACKEND-000 registers the program playbook. After it lands,
+WO-BACKEND-001 is the read-only backend operational baseline. This lane is hardening/proof/release
+discipline, not a foundation rebuild.
 
 **Allowed loop modes:** `once`, `program`, `evidence`, `discovery`
+
+**Command aliases:** `/backend-start`, `/backend-status`, `/backend-next`, `/backend-stop`
+
+**Blocked:** production deployment, secrets, county data, PACS, live DB, schema migration apply,
+TerraPilot P16, and any backend runtime mutation not explicitly authorized by the current WO.
 
 ---
 

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -1,11 +1,13 @@
 # P3 — Backend Operational Excellence
 
-**Program:** P3
-**Goal:** `GOAL-BACKEND-OPERATIONAL-EXCELLENCE`
-**Loop:** `LOOP-BACKEND-OPERATIONAL-EXCELLENCE`
-**Status:** ACTIVE
-**Owner:** Operator (bsvalues@gmail.com)
-**Last Updated:** 2026-07-03
+| Field | Value |
+|-------|-------|
+| Program | P3 |
+| Goal | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` |
+| Loop | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` |
+| Status | ACTIVE |
+| Owner | Operator (bsvalues@gmail.com) |
+| Last Updated | 2026-07-03 |
 
 ---
 
@@ -17,7 +19,7 @@ and rollback discipline.
 
 ## Non-Goal
 
-Do not rebuild TerraDais persistence. Do not reopen foundation work unless WO-BACKEND-001 discovers a
+Do not rebuild TerraDais persistence. Do not reopen foundation work unless WO-BACKEND-OE-001 discovers a
 current regression. Do not treat passing slices as production readiness.
 
 ## Known Baseline
@@ -53,47 +55,51 @@ current regression. Do not treat passing slices as production readiness.
 
 ## Work Orders
 
+The `WO-BACKEND-OE-*` prefix is intentional. Earlier backend evidence packets
+already use `WO-BACKEND-001` through `WO-BACKEND-007`; this renewed operational
+excellence chain preserves those completed IDs and avoids ambiguous routing.
+
 | WO | Title | Mode | Status | Purpose |
 |----|-------|------|--------|---------|
 | WO-BACKEND-000 | Backend Operational Excellence Program Playbook | Docs/governance creation | **THIS WO** | Register the program, goal, loop, chain, scope, evidence, and stop gates |
-| WO-BACKEND-001 | Backend Operational Excellence Baseline | Read-only discovery / evidence baseline | NEXT | Establish current backend operational truth on `origin/main` |
-| WO-BACKEND-002 | Build Warning Register | Docs/evidence first | QUEUED | Capture every backend warning verbatim and classify release risk |
-| WO-BACKEND-003 | Build Warning Burn-down | Small implementation slices only | QUEUED | Fix only warning-register-approved warnings |
-| WO-BACKEND-004 | Service Registry Runtime Validation | Evidence + targeted tests | QUEUED | Prove service registry runtime behavior and failure modes |
-| WO-BACKEND-005 | Health and Readiness Truth | Audit + narrow implementation if authorized | QUEUED | Define what health/readiness endpoints actually prove |
-| WO-BACKEND-006 | Backend Security / Auth / County Isolation Proof | Evidence-first; tests if scoped | QUEUED | Prove protected paths enforce auth, role, county, and audit expectations |
-| WO-BACKEND-007 | Migration and Rollback Proof | Controlled validation; no production DB | QUEUED | Prove persistence can be migrated and recovered safely |
-| WO-BACKEND-008 | Broader Dais / Workflow E2E Proof | Targeted test expansion | QUEUED | Prove Dais behavior beyond happy-path audited slices |
-| WO-BACKEND-009 | Backend Release Gate Definition | Governance/docs + optional gate wiring later | QUEUED | Define objective backend release-ready criteria |
-| WO-BACKEND-010 | Backend Operational Runbook | Runbook creation | QUEUED | Create backend startup, validation, failure triage, rollback, and evidence runbook |
-| WO-BACKEND-011 | Backend Diagnostics and Observability Map | Evidence and docs first | QUEUED | Map logs, metrics, traces, audit events, health checks, and diagnostic signals |
-| WO-BACKEND-012 | Backend Operational Packet | Operational packet assembly | QUEUED | Consolidate the program into an executable operational packet |
-| WO-BACKEND-013 | Evidence Rollup and Program Closeout | Evidence rollup | QUEUED | Close the program with proof, gaps, deferred work, and next-lane recommendation |
+| WO-BACKEND-OE-001 | Backend Operational Excellence Baseline | Read-only discovery / evidence baseline | NEXT | Establish current backend operational truth on `origin/main` |
+| WO-BACKEND-OE-002 | Build Warning Register | Docs/evidence first | QUEUED | Capture every backend warning verbatim and classify release risk |
+| WO-BACKEND-OE-003 | Build Warning Burn-down | Small implementation slices only | QUEUED | Fix only warning-register-approved warnings |
+| WO-BACKEND-OE-004 | Service Registry Runtime Validation | Evidence + targeted tests | QUEUED | Prove service registry runtime behavior and failure modes |
+| WO-BACKEND-OE-005 | Health and Readiness Truth | Audit + narrow implementation if authorized | QUEUED | Define what health/readiness endpoints actually prove |
+| WO-BACKEND-OE-006 | Backend Security / Auth / County Isolation Proof | Evidence-first; tests if scoped | QUEUED | Prove protected paths enforce auth, role, county, and audit expectations |
+| WO-BACKEND-OE-007 | Migration and Rollback Proof | Controlled validation; no production DB | QUEUED | Prove persistence can be migrated and recovered safely |
+| WO-BACKEND-OE-008 | Broader Dais / Workflow E2E Proof | Targeted test expansion | QUEUED | Prove Dais behavior beyond happy-path audited slices |
+| WO-BACKEND-OE-009 | Backend Release Gate Definition | Governance/docs + optional gate wiring later | QUEUED | Define objective backend release-ready criteria |
+| WO-BACKEND-OE-010 | Backend Operational Runbook | Runbook creation | QUEUED | Create backend startup, validation, failure triage, rollback, and evidence runbook |
+| WO-BACKEND-OE-011 | Backend Diagnostics and Observability Map | Evidence and docs first | QUEUED | Map logs, metrics, traces, audit events, health checks, and diagnostic signals |
+| WO-BACKEND-OE-012 | Backend Operational Packet | Operational packet assembly | QUEUED | Consolidate the program into an executable operational packet |
+| WO-BACKEND-OE-013 | Evidence Rollup and Program Closeout | Evidence rollup | QUEUED | Close the program with proof, gaps, deferred work, and next-lane recommendation |
 
 ## Dependency Chain
 
 ```text
 WO-BACKEND-000
-  -> WO-BACKEND-001
-  -> WO-BACKEND-002
-  -> WO-BACKEND-003
-  -> WO-BACKEND-004
-  -> WO-BACKEND-005
-  -> WO-BACKEND-006
-  -> WO-BACKEND-007
-  -> WO-BACKEND-008
-  -> WO-BACKEND-009
-  -> WO-BACKEND-010
-  -> WO-BACKEND-011
-  -> WO-BACKEND-012
-  -> WO-BACKEND-013
+  -> WO-BACKEND-OE-001
+  -> WO-BACKEND-OE-002
+  -> WO-BACKEND-OE-003
+  -> WO-BACKEND-OE-004
+  -> WO-BACKEND-OE-005
+  -> WO-BACKEND-OE-006
+  -> WO-BACKEND-OE-007
+  -> WO-BACKEND-OE-008
+  -> WO-BACKEND-OE-009
+  -> WO-BACKEND-OE-010
+  -> WO-BACKEND-OE-011
+  -> WO-BACKEND-OE-012
+  -> WO-BACKEND-OE-013
 ```
 
 ---
 
 ## WO Definitions
 
-### WO-BACKEND-001 — Backend Operational Excellence Baseline
+### WO-BACKEND-OE-001 — Backend Operational Excellence Baseline
 
 **Mode:** read-only discovery / evidence baseline.
 
@@ -113,7 +119,7 @@ Output:
 - Health/readiness endpoint map.
 - Auth/security/county-isolation evidence map.
 - Release-readiness gap list.
-- Recommendation for WO-BACKEND-002.
+- Recommendation for WO-BACKEND-OE-002.
 
 Allowed:
 
@@ -134,7 +140,7 @@ Done:
 
 - Backend baseline report exists and the next WO is selected from evidence.
 
-### WO-BACKEND-002 — Build Warning Register
+### WO-BACKEND-OE-002 — Build Warning Register
 
 **Mode:** docs/evidence first; implementation only if explicitly authorized after register.
 
@@ -154,13 +160,13 @@ Done:
 
 - Warnings are no longer vague debt. Each warning has a disposition and next action.
 
-### WO-BACKEND-003 — Build Warning Burn-down
+### WO-BACKEND-OE-003 — Build Warning Burn-down
 
 **Mode:** small implementation slices only.
 
 Dependency:
 
-- WO-BACKEND-002 complete.
+- WO-BACKEND-OE-002 complete.
 
 Purpose:
 
@@ -187,7 +193,7 @@ Done:
 
 - Warning count reduced or justified, and no new warnings introduced.
 
-### WO-BACKEND-004 — Service Registry Runtime Validation
+### WO-BACKEND-OE-004 — Service Registry Runtime Validation
 
 **Mode:** evidence + targeted tests.
 
@@ -216,7 +222,7 @@ Done:
 
 - Service registry is not just present; it is operationally understandable and test-backed.
 
-### WO-BACKEND-005 — Health and Readiness Truth
+### WO-BACKEND-OE-005 — Health and Readiness Truth
 
 **Mode:** audit + implementation if narrow.
 
@@ -245,7 +251,7 @@ Done:
 
 - Health/readiness stops being a vague status page and becomes an operational contract.
 
-### WO-BACKEND-006 — Backend Security / Auth / County Isolation Proof
+### WO-BACKEND-OE-006 — Backend Security / Auth / County Isolation Proof
 
 **Mode:** evidence-first; tests if scoped.
 
@@ -281,7 +287,7 @@ Done:
 
 - Security posture is described from evidence, not assumption.
 
-### WO-BACKEND-007 — Migration and Rollback Proof
+### WO-BACKEND-OE-007 — Migration and Rollback Proof
 
 **Mode:** controlled validation; no production DB.
 
@@ -316,7 +322,7 @@ Done:
 
 - Persistence readiness includes rollback/recovery evidence, not just "migration file exists."
 
-### WO-BACKEND-008 — Broader Dais / Workflow E2E Proof
+### WO-BACKEND-OE-008 — Broader Dais / Workflow E2E Proof
 
 **Mode:** targeted test expansion.
 
@@ -339,7 +345,7 @@ Done:
 
 - Dais proof covers realistic failure modes, not only success slices.
 
-### WO-BACKEND-009 — Backend Release Gate Definition
+### WO-BACKEND-OE-009 — Backend Release Gate Definition
 
 **Mode:** governance/docs + optional gate wiring later.
 
@@ -373,7 +379,7 @@ Done:
 
 - No more implied production-readiness. Release readiness has a checklist.
 
-### WO-BACKEND-010 — Backend Operational Runbook
+### WO-BACKEND-OE-010 — Backend Operational Runbook
 
 **Mode:** runbook creation.
 
@@ -398,7 +404,7 @@ Done:
 
 - A future operator can validate and recover the backend without rediscovering the system.
 
-### WO-BACKEND-011 — Backend Diagnostics and Observability Map
+### WO-BACKEND-OE-011 — Backend Diagnostics and Observability Map
 
 **Mode:** evidence and docs first.
 
@@ -418,7 +424,7 @@ Done:
 
 - Operational visibility is mapped and gaps are explicit.
 
-### WO-BACKEND-012 — Backend Operational Packet
+### WO-BACKEND-OE-012 — Backend Operational Packet
 
 **Mode:** operational packet assembly.
 
@@ -446,7 +452,7 @@ Done:
 
 - Backend Operational Excellence can be operated, validated, evidenced, and recovered.
 
-### WO-BACKEND-013 — Evidence Rollup and Program Closeout
+### WO-BACKEND-OE-013 — Evidence Rollup and Program Closeout
 
 **Mode:** evidence rollup.
 
@@ -486,7 +492,7 @@ Stop and request owner authority if the work requires:
 
 ## Completion Criteria
 
-Program closeout requires WO-BACKEND-013 to show:
+Program closeout requires WO-BACKEND-OE-013 to show:
 
 - Build health evidence.
 - Warning disposition.

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -1,62 +1,499 @@
 # P3 — Backend Operational Excellence
 
-**Program:** P3  
-**Status:** QUEUED  
-**Owner:** Operator (bsvalues@gmail.com)  
-**Last Updated:** 2026-06-30
+**Program:** P3
+**Goal:** `GOAL-BACKEND-OPERATIONAL-EXCELLENCE`
+**Loop:** `LOOP-BACKEND-OPERATIONAL-EXCELLENCE`
+**Status:** ACTIVE
+**Owner:** Operator (bsvalues@gmail.com)
+**Last Updated:** 2026-07-03
 
 ---
 
 ## Goal
 
-Make the TerraFusion backend operable, diagnosable, and release-gated. This program establishes what "backend ready" means as a concrete evidence-backed contract, not a subjective judgment. No deployment until WO-BACKEND-007 (release gate definition) produces a gate the operator agrees with.
+Turn the backend from implemented and slice-verified into an operationally governed platform with
+explicit build health, readiness proof, diagnostics, runtime validation, release criteria, evidence,
+and rollback discipline.
+
+## Non-Goal
+
+Do not rebuild TerraDais persistence. Do not reopen foundation work unless WO-BACKEND-001 discovers a
+current regression. Do not treat passing slices as production readiness.
+
+## Known Baseline
+
+- TerraPilot Tool Maturity is parked at P15.
+- `origin/main` baseline for this program playbook: `2195309dacabc22eb4f0f0939178331d8ded86d4`.
+- Backend/Dais foundation is believed implemented.
+- Service registry activation is believed implemented.
+- Previous backend build passed with warnings remaining.
+- The next work is production discipline, not foundation rebuild.
+
+## Risk And Sovereignty Boundary
+
+| Area | Classification | Rule |
+|------|----------------|------|
+| Docs, evidence, runbooks | R1 / L1 | Allowed inside this program when scoped to backend operational truth |
+| Tests and warning fixes | R2 / L2 | Allowed only after evidence identifies a specific backend operational gap |
+| Runtime/backend behavior | R3+ | Requires the active WO to explicitly authorize the change |
+| Identity, audit rail, county data pipelines, release gates, governance controls | S4 Sovereign Core | Stop if scope is unclear or authority is missing |
+| Appeals, exemptions, valuation evidence, protected parcel context | S3 Assessor Protected | Evidence-first; no protected data access without explicit owner authorization |
+| Production, county data, PACS, secrets, live DB, deployment | Authority wall | Explicit owner authorization required |
+
+## Program Rules
+
+- Observe current backend truth before implementation.
+- Keep warning burn-down tied to a warning register; no broad cleanup.
+- Do not create EF migrations or apply database updates without an explicit migration WO.
+- Do not access production, live county services, PACS, protected county data, or secrets.
+- Do not continue TerraPilot P16, promote TerraPilot tools, or change tool maturity metadata.
+- Treat passing build/test slices as evidence, not as production readiness.
 
 ---
 
-## Sovereignty Boundary
+## Work Orders
 
-| Allowed | Blocked |
-|---------|---------|
-| Backend code changes (non-schema) | Schema changes / EF migrations |
-| Config changes | Production deployment |
-| Build warning fixes | PACS connection |
-| Health check improvements | Data mutation |
-| ADR documents | County-facing changes |
-
----
-
-## Work Orders (Ordered)
-
-| WO | Title | Status | Description |
-|----|-------|--------|-------------|
-| WO-BACKEND-001 | Backend runtime truth audit | **NEXT** | Enumerate all endpoints; verify which return data vs stubs vs 404 |
-| WO-BACKEND-002 | Build warning burn-down | QUEUED | Enumerate all `dotnet build` warnings; fix or document each |
-| WO-BACKEND-003 | Service registry validation | QUEUED | Verify all registered services have health checks; find orphaned registrations |
-| WO-BACKEND-004 | Health/readiness truth contract | QUEUED | Define what `/healthz` and `/healthz/ready` must verify for the demo to be operator-trusted |
-| WO-BACKEND-005 | Runtime configuration contract | QUEUED | Document every required runtime config key; verify all present in appsettings hierarchy |
-| WO-BACKEND-006 | Auth/security endpoint proof | QUEUED | Prove all protected endpoints reject unauthenticated requests; prove dev-token works in Development |
-| WO-BACKEND-007 | Release gate definition | QUEUED | Produce the formal "backend is release-ready" gate criteria — operator approves before 003D |
-| WO-BACKEND-008 | Backend operational packet and runbook | QUEUED | Produce final backend ops packet: startup, monitoring, restart, rollback |
-
----
+| WO | Title | Mode | Status | Purpose |
+|----|-------|------|--------|---------|
+| WO-BACKEND-000 | Backend Operational Excellence Program Playbook | Docs/governance creation | **THIS WO** | Register the program, goal, loop, chain, scope, evidence, and stop gates |
+| WO-BACKEND-001 | Backend Operational Excellence Baseline | Read-only discovery / evidence baseline | NEXT | Establish current backend operational truth on `origin/main` |
+| WO-BACKEND-002 | Build Warning Register | Docs/evidence first | QUEUED | Capture every backend warning verbatim and classify release risk |
+| WO-BACKEND-003 | Build Warning Burn-down | Small implementation slices only | QUEUED | Fix only warning-register-approved warnings |
+| WO-BACKEND-004 | Service Registry Runtime Validation | Evidence + targeted tests | QUEUED | Prove service registry runtime behavior and failure modes |
+| WO-BACKEND-005 | Health and Readiness Truth | Audit + narrow implementation if authorized | QUEUED | Define what health/readiness endpoints actually prove |
+| WO-BACKEND-006 | Backend Security / Auth / County Isolation Proof | Evidence-first; tests if scoped | QUEUED | Prove protected paths enforce auth, role, county, and audit expectations |
+| WO-BACKEND-007 | Migration and Rollback Proof | Controlled validation; no production DB | QUEUED | Prove persistence can be migrated and recovered safely |
+| WO-BACKEND-008 | Broader Dais / Workflow E2E Proof | Targeted test expansion | QUEUED | Prove Dais behavior beyond happy-path audited slices |
+| WO-BACKEND-009 | Backend Release Gate Definition | Governance/docs + optional gate wiring later | QUEUED | Define objective backend release-ready criteria |
+| WO-BACKEND-010 | Backend Operational Runbook | Runbook creation | QUEUED | Create backend startup, validation, failure triage, rollback, and evidence runbook |
+| WO-BACKEND-011 | Backend Diagnostics and Observability Map | Evidence and docs first | QUEUED | Map logs, metrics, traces, audit events, health checks, and diagnostic signals |
+| WO-BACKEND-012 | Backend Operational Packet | Operational packet assembly | QUEUED | Consolidate the program into an executable operational packet |
+| WO-BACKEND-013 | Evidence Rollup and Program Closeout | Evidence rollup | QUEUED | Close the program with proof, gaps, deferred work, and next-lane recommendation |
 
 ## Dependency Chain
 
+```text
+WO-BACKEND-000
+  -> WO-BACKEND-001
+  -> WO-BACKEND-002
+  -> WO-BACKEND-003
+  -> WO-BACKEND-004
+  -> WO-BACKEND-005
+  -> WO-BACKEND-006
+  -> WO-BACKEND-007
+  -> WO-BACKEND-008
+  -> WO-BACKEND-009
+  -> WO-BACKEND-010
+  -> WO-BACKEND-011
+  -> WO-BACKEND-012
+  -> WO-BACKEND-013
 ```
-001 → 002 → 003 → 004 → 005 → 006 → 007 → 008
-```
-
-WO-BACKEND-007 must be operator-approved before P1/WO-DEPLOY-BENTON-003D (App Service smoke) runs.
 
 ---
 
-## Interaction with P1
+## WO Definitions
 
-P3 runs in parallel with P1 where possible. P1/003D is blocked on P3/007. The operator may choose to run 003D before P3/007 for demo purposes — that is a documented risk acceptance, not a default.
+### WO-BACKEND-001 — Backend Operational Excellence Baseline
+
+**Mode:** read-only discovery / evidence baseline.
+
+Purpose:
+
+- Establish current backend operational truth on `origin/main`.
+
+Output:
+
+- Build result.
+- Warning count.
+- Warning categories.
+- Test inventory.
+- Test results.
+- Dais proof points.
+- Service registry proof points.
+- Health/readiness endpoint map.
+- Auth/security/county-isolation evidence map.
+- Release-readiness gap list.
+- Recommendation for WO-BACKEND-002.
+
+Allowed:
+
+- Read-only inspection.
+- `dotnet build`.
+- Existing tests if no external services or secrets are required.
+- `pnpm run type-check` if needed.
+
+Blocked:
+
+- Edits.
+- Commits.
+- Migrations.
+- Runtime config changes.
+- Live DB, PACS, or county resources.
+
+Done:
+
+- Backend baseline report exists and the next WO is selected from evidence.
+
+### WO-BACKEND-002 — Build Warning Register
+
+**Mode:** docs/evidence first; implementation only if explicitly authorized after register.
+
+Purpose:
+
+- Capture every backend warning verbatim and classify release risk.
+
+Output:
+
+- Warning ledger.
+- Category per warning: nullable/reference safety, obsolete API, dead/deprecated code, analyzer/style,
+  package/runtime concern, or configuration risk.
+- Owner/disposition per warning.
+- Fix/defer recommendation.
+
+Done:
+
+- Warnings are no longer vague debt. Each warning has a disposition and next action.
+
+### WO-BACKEND-003 — Build Warning Burn-down
+
+**Mode:** small implementation slices only.
+
+Dependency:
+
+- WO-BACKEND-002 complete.
+
+Purpose:
+
+- Fix high-signal warnings that affect runtime safety, maintainability, or release confidence.
+
+Scope:
+
+- Only warnings approved by the warning register.
+
+Blocked:
+
+- Broad cleanup.
+- Unrelated refactors.
+- Style-only churn unless explicitly approved.
+- Runtime behavior changes not tied to a warning.
+
+Validation:
+
+- `dotnet build backend/TerraFusion.sln`.
+- Relevant targeted tests.
+- `pnpm run type-check` if coupled.
+
+Done:
+
+- Warning count reduced or justified, and no new warnings introduced.
+
+### WO-BACKEND-004 — Service Registry Runtime Validation
+
+**Mode:** evidence + targeted tests.
+
+Purpose:
+
+- Move service registry from wired in startup to runtime-validated and failure-mode understood.
+
+Checks:
+
+- `Program.cs` registration path.
+- `StartupOrchestrationService` behavior.
+- Startup success path.
+- Degraded/failure path.
+- Registry drift behavior.
+- Logging/observability.
+- Environment-specific config behavior.
+
+Output:
+
+- Service registry validation report.
+- Failure-mode matrix.
+- Required test additions, if any.
+- Runtime proof if safe.
+
+Done:
+
+- Service registry is not just present; it is operationally understandable and test-backed.
+
+### WO-BACKEND-005 — Health and Readiness Truth
+
+**Mode:** audit + implementation if narrow.
+
+Purpose:
+
+- Define what backend health/readiness endpoints actually prove.
+
+Questions:
+
+- Which health endpoints exist?
+- Which readiness endpoints exist?
+- Which dependencies do they check?
+- Do they distinguish live, degraded, unavailable, and unauthenticated?
+- Are endpoints safe for production exposure?
+- Are they county/data safe?
+
+Output:
+
+- Endpoint inventory.
+- Readiness semantics table.
+- Missing checks.
+- Proposed endpoint contract.
+- Test plan.
+
+Done:
+
+- Health/readiness stops being a vague status page and becomes an operational contract.
+
+### WO-BACKEND-006 — Backend Security / Auth / County Isolation Proof
+
+**Mode:** evidence-first; tests if scoped.
+
+Purpose:
+
+- Prove backend protected paths enforce auth, role, county, and audit expectations.
+
+Scope:
+
+- Auth-required endpoints.
+- Role/permission checks.
+- `CountyId` filters.
+- Cross-county denial behavior.
+- Audit/security event emission where expected.
+- No owner-sensitive or county-sensitive leak in responses.
+
+Blocked:
+
+- Auth architecture rewrite.
+- New identity provider.
+- Secrets changes.
+- Production credentials.
+- County DB/PACS access.
+
+Output:
+
+- Security/readiness proof matrix.
+- Tests run.
+- Gaps by endpoint/domain.
+- Risk-ranked follow-up WOs.
+
+Done:
+
+- Security posture is described from evidence, not assumption.
+
+### WO-BACKEND-007 — Migration and Rollback Proof
+
+**Mode:** controlled validation; no production DB.
+
+Purpose:
+
+- Prove backend persistence can be migrated and recovered safely.
+
+Scope:
+
+- Migration presence.
+- Migration apply in safe/local/test context.
+- Rollback/down-path evidence where available.
+- Dais migration status.
+- Schema drift detection.
+- No accidental production mutation.
+
+Blocked:
+
+- Production database update.
+- Live county data.
+- Unapproved EF migration creation.
+- Destructive schema operations.
+
+Output:
+
+- Migration inventory.
+- Apply/rollback proof or documented blocker.
+- Schema risk register.
+- Recovery notes.
+
+Done:
+
+- Persistence readiness includes rollback/recovery evidence, not just "migration file exists."
+
+### WO-BACKEND-008 — Broader Dais / Workflow E2E Proof
+
+**Mode:** targeted test expansion.
+
+Purpose:
+
+- Prove Dais behavior beyond happy-path audited slices.
+
+Test targets:
+
+- Dais CRUD unhappy paths.
+- Malformed payloads.
+- Missing county context.
+- Cross-county denial.
+- Concurrency/update conflict.
+- Validation errors.
+- Audit/trace behavior.
+- Restart persistence if safe.
+
+Done:
+
+- Dais proof covers realistic failure modes, not only success slices.
+
+### WO-BACKEND-009 — Backend Release Gate Definition
+
+**Mode:** governance/docs + optional gate wiring later.
+
+Purpose:
+
+- Define objective criteria for backend release-ready.
+
+Release gate must include:
+
+- Build green.
+- Warning threshold met.
+- Test suite matrix green.
+- Migrations verified.
+- Rollback documented.
+- County isolation verified.
+- Auth/security proof present.
+- Service registry healthy.
+- Health/readiness semantics verified.
+- Audit/trace hooks verified.
+- Runbook updated.
+- Evidence attached.
+
+Output:
+
+- Backend release checklist.
+- Required validation commands.
+- Pass/fail definitions.
+- Promotion criteria.
+
+Done:
+
+- No more implied production-readiness. Release readiness has a checklist.
+
+### WO-BACKEND-010 — Backend Operational Runbook
+
+**Mode:** runbook creation.
+
+Purpose:
+
+- Create the operator runbook for backend startup, validation, failure triage, rollback, and evidence capture.
+
+Runbook must cover:
+
+- Local/dev validation.
+- Shared validation environment.
+- Build/test commands.
+- Health/readiness interpretation.
+- Service registry triage.
+- Migration safety.
+- Rollback procedure.
+- Log locations.
+- Evidence capture.
+- Escalation triggers.
+
+Done:
+
+- A future operator can validate and recover the backend without rediscovering the system.
+
+### WO-BACKEND-011 — Backend Diagnostics and Observability Map
+
+**Mode:** evidence and docs first.
+
+Purpose:
+
+- Map backend logs, metrics, traces, audit events, health checks, and diagnostic signals.
+
+Output:
+
+- Diagnostics inventory.
+- What each signal proves.
+- What is missing.
+- Minimum observability requirements for release.
+- Follow-up instrumentation WOs if needed.
+
+Done:
+
+- Operational visibility is mapped and gaps are explicit.
+
+### WO-BACKEND-012 — Backend Operational Packet
+
+**Mode:** operational packet assembly.
+
+Purpose:
+
+- Consolidate the backend program into an executable operational packet.
+
+Packet must include:
+
+- Objective.
+- Capability affected.
+- Canon references.
+- Sovereignty boundary.
+- Execution playbook.
+- Validation gates.
+- Evidence requirements.
+- Runbook impact.
+- ADR impact.
+- Operational ownership.
+- Rollback path.
+- Promotion criteria.
+- Done definition.
+
+Done:
+
+- Backend Operational Excellence can be operated, validated, evidenced, and recovered.
+
+### WO-BACKEND-013 — Evidence Rollup and Program Closeout
+
+**Mode:** evidence rollup.
+
+Purpose:
+
+- Close the program with proof, gaps, deferred work, and next-lane recommendation.
+
+Output:
+
+- Completed WO list.
+- Evidence links.
+- Validation summary.
+- Release-gate status.
+- Remaining risks.
+- Deferred WOs.
+- Recommendation: continue backend, move to Property Workbench, move to County Runtime, or move to
+  Release Engineering.
+
+Done:
+
+- Program state is clear enough that WOE can compute the next lane.
 
 ---
 
 ## Stop Conditions
 
-- If WO-BACKEND-001 finds a critical service failure that blocks the demo path, escalate to operator before continuing P1
-- If WO-BACKEND-007 produces gate criteria the operator cannot meet before the demo date, the operator decides: demo anyway with documented risk, or delay demo
+Stop and request owner authority if the work requires:
+
+- Production deployment.
+- Secrets, credentials, PACS, county SQL, live DB, or protected county data.
+- Schema migration creation or apply.
+- Destructive schema or data operation.
+- Auth architecture rewrite or identity-provider change.
+- Runtime behavior change outside the current WO.
+- Conflicting canon about backend readiness or release criteria.
+- Continuing TerraPilot P16 or promoting TerraPilot tools.
+
+## Completion Criteria
+
+Program closeout requires WO-BACKEND-013 to show:
+
+- Build health evidence.
+- Warning disposition.
+- Runtime validation evidence.
+- Release gate checklist.
+- Security/readiness proof.
+- Migration/rollback proof.
+- Operational runbook.
+- Diagnostics map.
+- Deferred risk register.


### PR DESCRIPTION
WO-BACKEND-000 creates the Backend Operational Excellence program playbook before any backend hardening work begins.

Scope:
- docs/brain/workorders/programs/backend-operational-excellence.md
- docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md
- docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
- docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
- docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md

Validation:
- git diff --check
- node docs/brain/workorders/tools/wo-query.mjs --json
- register/command mapping inspection

Non-changes:
- no backend runtime code
- no frontend runtime code
- no os-platform runtime code
- no tests, migrations, appsettings, services, secrets, county data, PACS, SQL, or TerraPilot P16 work

Next after merge: WO-BACKEND-001 read-only backend operational baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated backend program and goal-loop guidance to introduce a stricter operational excellence flow, including revised sequencing, evidence-first readiness expectations, and expanded stop/completion criteria.
  * Added a new playbook for the initial work order in the backend program.
  * Expanded command-to-program mapping and goal definitions with new backend command aliases and updated routing, plus refreshed the current program summary and work order progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->