### PR TITLE
docs(audit): WO-WB-C1-001 — honesty-contract backfill design / scope correction

### DIFF
--- a/docs/audit/workbench-readiness/WO-WB-C1-001-honesty-contract-backfill-design.md
+++ b/docs/audit/workbench-readiness/WO-WB-C1-001-honesty-contract-backfill-design.md
@@ -1,11 +1,11 @@
 # WO-WB-C1-001 — Honesty-Contract Backfill Design / Scope Correction
 
 **Program:** WORKBENCH-HONESTY-CONTRACT-BACKFILL (revised C1) · **Owner:** Claude Code · **Mode:** DESIGN / docs-only
-**Repo:** `terrafusion_os_1.0` · **Base:** `origin/main` @ `0ba65618` · **Method:** first-hand reads of the proven honesty-contract template + the 5 candidate tab components; cited `file:line`.
+**Repo:** `terrafusion_os_1.0` · **Base:** `origin/main` @ `0ba65618` · **Method:** first-hand reads of the proven honesty-contract template + the 5 candidate tab components, cited by file/path with line numbers where quoted, plus `git grep` evidence.
 
 > **Write-surface authorization.** `docs/audit/**` sits outside the repo-root `AGENTS.md` "CORE GOVERNANCE SURFACE (ALLOWED SCOPE)", which states *"Anything outside this scope requires explicit authorization."* The operator explicitly authorized `docs/audit/workbench-readiness/` for this program; no core-governance or component code is touched by this WO.
 
-This design WO records a **scope correction** discovered while planning C1: the original goal — backfill honesty-contract tests for the 5 uncovered tabs to reach 9/9 — is **not achievable tests-only**, because 4 of the 5 lack the honesty *instrumentation* the contract asserts. The revised, in-boundary target is **4/9 → 5/9** (Dossier only); the remaining 4 tabs require a separate implementation lane.
+This design WO records a **scope correction** discovered while planning C1: the original goal — backfill honesty-contract tests for the 5 uncovered tabs to reach 9/9 — is **not achievable tests-only**, because **none** of the 5 renders the honesty instrumentation the contract asserts *at idle*. Four (Clerk/Treasury/Audit/Pilot) render no `WorkbenchSourceBadge` at all; the fifth (Dossier) renders badges only **after a tool invocation** (`correlationId`-gated, hardcoded `source='live'`) — never an idle `unavailable` badge. So the revised **tests-only** target is **4/9 → 4/9** (no tab is addable tests-only); **all five** uncovered tabs require a separate, explicitly-authorized instrumentation lane.
 
 ---
 
@@ -24,46 +24,49 @@ Assertions 1–4 are **positive** — they require the component to *render* sou
 
 ## 2. Instrumentation vs test coverage (the two different counts)
 
-Reading each component (`git grep WorkbenchSourceBadge origin/main -- pages/workbench/**`):
+Reading each component (`git grep WorkbenchSourceBadge origin/main -- frontend/apps/os-shell/src/pages/workbench/**`):
 
-| Tab | Renders `WorkbenchSourceBadge`? | Has honesty-contract test? |
-|-----|-------------------------------|----------------------------|
-| Summary | ✅ | ✅ `PropertySummary.honesty.contract.test.tsx` |
-| Forge | ✅ | ✅ `PropertyForge.honesty.contract.test.tsx` |
-| Atlas | ✅ | ✅ `PropertyAtlas.honesty.contract.test.tsx` |
-| Dais | ✅ | ✅ `PropertyDais.honesty.contract.test.tsx` |
-| **Dossier** | ✅ (4 refs; root `data-testid='property-dossier-tab'`, `PropertyDossier.tsx`) | ❌ **none** |
-| **Clerk** | ❌ **0 refs** (`PropertyClerk.tsx`) | ❌ |
-| **Treasury** | ❌ **0 refs** (`PropertyTreasury.tsx`) | ❌ |
-| **Audit** | ❌ **0 refs** (`PropertyAudit.tsx`) | ❌ |
-| **Pilot** | ❌ **0 refs** (`PropertyPilot.tsx`) | ❌ |
+| Tab | Renders `WorkbenchSourceBadge`? | Renders an **idle `unavailable`** badge (what the Dais contract asserts)? | Has honesty-contract test? |
+|-----|-------------------------------|--------------------------------|----------------------------|
+| Summary | ✅ | ✅ | ✅ `PropertySummary.honesty.contract.test.tsx` |
+| Forge | ✅ | ✅ | ✅ `PropertyForge.honesty.contract.test.tsx` |
+| Atlas | ✅ | ✅ | ✅ `PropertyAtlas.honesty.contract.test.tsx` |
+| Dais | ✅ | ✅ | ✅ `PropertyDais.honesty.contract.test.tsx` |
+| **Dossier** | ⚠️ conditional | ❌ — badges are **post-invocation only**, `correlationId`-gated + hardcoded `source='live'` (`PropertyDossier.tsx:755,793,800`); root `data-testid='property-dossier-tab'` | ❌ **none** |
+| **Clerk** | ❌ 0 refs (`PropertyClerk.tsx`) | ❌ | ❌ |
+| **Treasury** | ❌ 0 refs (`PropertyTreasury.tsx`) | ❌ | ❌ |
+| **Audit** | ❌ 0 refs (`PropertyAudit.tsx`) | ❌ | ❌ |
+| **Pilot** | ❌ 0 refs (`PropertyPilot.tsx`) | ❌ | ❌ |
 
-- **Badge instrumentation: 5/9** (Summary, Forge, Atlas, Dais, Dossier).
-- **Honesty-contract test coverage: 4/9** (the same minus Dossier).
+- **Renders any source badge: 5/9** (Summary, Forge, Atlas, Dais, Dossier).
+- **Renders an idle `unavailable` badge (the testable honesty invariant): 4/9** (Summary, Forge, Atlas, Dais).
+- **Honesty-contract test coverage: 4/9** (the same four).
 
-Clerk/Treasury/Audit render **no** container `data-testid` and **no** badge; they rely on the shared `ParcelContextHeader` + `InvocationHistory` + the workbench-wide "evidence unavailable" blocker for honesty — but not per-element source badges. Pilot renders `property-pilot-tab` / `pilot-muse-scope` testids but likewise **no** source badge.
+Clerk/Treasury/Audit render **no** container `data-testid` and **no** badge; they rely on the shared `ParcelContextHeader` + `InvocationHistory` + the workbench-wide "evidence unavailable" blocker for honesty — but not per-element source badges. Pilot renders `property-pilot-tab` / `pilot-muse-scope` testids but likewise **no** source badge. **Dossier** renders badges (`PropertyDossier.tsx:755,793,800`) but each is inside a `correlationId && …` guard and hardcoded `source='live'` — so at idle (no invocation) it renders **no** badge, and it never renders `unavailable`.
 
 ## 3. The finding — an *instrumentation* gap, not a *test* gap
 
-- **Dossier is tests-only viable.** It already renders source badges and a root testid, so a Dais-style honesty contract can be written for it **without touching component code**.
-- **Clerk / Treasury / Audit / Pilot are not tests-only viable.** A Dais-style test would *fail* (assertions 1–4) because these components render no source badge. Making it pass requires **adding `WorkbenchSourceBadge` + disclosure boxes + testids to the components** — a runtime/component change, outside a tests-only backfill.
+- **No tab among the 5 is tests-only viable** for a Dais-style *idle* honesty contract:
+  - **Clerk / Treasury / Audit / Pilot** render **no** source badge at all — assertions 1–4 fail; making them pass needs badge/disclosure instrumentation added to the components.
+  - **Dossier** renders badges, but only **post-invocation** (`correlationId`-gated, `source='live'`); at idle it renders **no** badge and never `unavailable` — so the idle assertions (1–2) fail too. Making them pass needs an **idle disclosure badge** added to the component.
+- In every case, passing the contract requires a **runtime/component change** — outside a tests-only backfill.
 
-Therefore the honesty-coverage gap (readiness audit **G3**) is really an **instrumentation gap**: those 4 tab components are not yet instrumented for per-element source disclosure. This also **refines WO-WB-003**, which implied uniform per-element source-badge disclosure across surfaces — that holds for 5 of 9 tabs, not all 9. (It does **not** contradict WO-WB-004's "no mock" verdict: these tabs are still honest via the shared header + evidence blocker; they simply lack per-element badges.)
+Therefore the honesty-coverage gap (readiness audit **G3**) is really an **instrumentation gap**: the 5 tab components are not instrumented for an **idle** per-element source disclosure. This also **refines WO-WB-003**, which implied uniform per-element source-badge disclosure across surfaces — the *idle unavailable* badge holds for 4 of 9 tabs, not all 9 (Dossier's badges are post-invocation only). (It does **not** contradict WO-WB-004's "no mock" verdict: these tabs are still honest via the shared header + evidence blocker; they simply lack per-element idle badges.)
 
 ## 4. Revised scope
 
 | | Original C1 | Revised C1 (this program) |
 |---|---|---|
-| Target | 4/9 → 9/9, tests-only | **4/9 → 5/9, tests-only** |
-| Deliverable | 5 tab tests | **1 tab test (Dossier)** |
-| Out of scope | — | Clerk/Treasury/Audit/Pilot instrumentation → separate WO |
+| Target | 4/9 → 9/9, tests-only | **4/9 → 4/9, tests-only (no net test tab addable)** |
+| Deliverable | 5 tab tests | **0 tab tests** — the design finding itself is the deliverable |
+| Out of scope | — | **all 5** (Clerk/Treasury/Audit/Pilot/Dossier) idle-badge instrumentation → separate WO |
 
-- **WO-WB-C1-002** adds the Dossier honesty-contract test (tests-only; authorized because Dossier is already instrumented).
-- **WO-WB-C1-003** rolls up C1 and emits a candidate packet for the follow-on **WORKBENCH-HONESTY-INSTRUMENTATION** program (Clerk/Treasury/Audit/Pilot) — which is real frontend implementation and requires its own explicit authorization.
+- **WO-WB-C1-002** (Dossier test) **stops per its own rule** — *"Stop if the Dossier test cannot be made to pass without component changes."* It cannot: Dossier has no idle `unavailable` badge, so a Dais-style idle test fails without adding one. Recorded, not executed.
+- **WO-WB-C1-003** rolls up C1 and emits a candidate packet for the follow-on **WORKBENCH-HONESTY-INSTRUMENTATION** program covering **all 5** tabs (Clerk/Treasury/Audit/Pilot need a full badge; Dossier needs an *idle* badge added to its existing post-invocation ones) — real frontend implementation requiring its own explicit authorization.
 
-## 5. Why the four are *deferred*, not done here
+## 5. Why all five are *deferred*, not done here
 
-Adding source-badge/disclosure UI to Clerk/Treasury/Audit/Pilot is **frontend implementation**, not a tests-only backfill. Per the C1 boundary (tests-only; copy-only component changes at most) and the stop rule *"a tab cannot be tested without changing runtime behavior"*, those four are correctly **out of this program** and belong to a separately-authorized lane.
+Adding idle source-badge/disclosure UI to these tabs is **frontend implementation**, not a tests-only backfill. Per the C1 boundary (tests-only; copy-only component changes at most) and the stop rule *"a tab cannot be tested without changing runtime behavior"*, all five are correctly **out of this program** and belong to a separately-authorized lane. Dossier is the *smallest* of the five (it already has the badge component + a root testid; it needs only an idle-state badge), so it is the natural first target of that lane.
 
 ## 6. Validation
 

--- a/docs/audit/workbench-readiness/WO-WB-C1-001-honesty-contract-backfill-design.md
+++ b/docs/audit/workbench-readiness/WO-WB-C1-001-honesty-contract-backfill-design.md
@@ -1,0 +1,74 @@
+# WO-WB-C1-001 — Honesty-Contract Backfill Design / Scope Correction
+
+**Program:** WORKBENCH-HONESTY-CONTRACT-BACKFILL (revised C1) · **Owner:** Claude Code · **Mode:** DESIGN / docs-only
+**Repo:** `terrafusion_os_1.0` · **Base:** `origin/main` @ `0ba65618` · **Method:** first-hand reads of the proven honesty-contract template + the 5 candidate tab components; cited `file:line`.
+
+> **Write-surface authorization.** `docs/audit/**` sits outside the repo-root `AGENTS.md` "CORE GOVERNANCE SURFACE (ALLOWED SCOPE)", which states *"Anything outside this scope requires explicit authorization."* The operator explicitly authorized `docs/audit/workbench-readiness/` for this program; no core-governance or component code is touched by this WO.
+
+This design WO records a **scope correction** discovered while planning C1: the original goal — backfill honesty-contract tests for the 5 uncovered tabs to reach 9/9 — is **not achievable tests-only**, because 4 of the 5 lack the honesty *instrumentation* the contract asserts. The revised, in-boundary target is **4/9 → 5/9** (Dossier only); the remaining 4 tabs require a separate implementation lane.
+
+---
+
+## 1. The proven template
+
+`PropertyDais.honesty.contract.test.tsx` is the reference honesty contract (archetype-C tab). It asserts, at idle and without user action:
+
+1. a disclosure box carries a `WorkbenchSourceBadge` (`data-testid="workbench-source-badge"`);
+2. that badge shows `data-source="unavailable"` (no premature live claim);
+3. all badges are `unavailable` or `live` (never a synthetic claim);
+4. the subtitle uses **governed-tool disclosure wording** (`/requested via|returned from/`), not aspirational language;
+5. it contains **no** `AI-powered` language;
+6. **no** tool (`invokeTool`) fires on mount.
+
+Assertions 1–4 are **positive** — they require the component to *render* source-badge instrumentation. That is the crux of the scope correction.
+
+## 2. Instrumentation vs test coverage (the two different counts)
+
+Reading each component (`git grep WorkbenchSourceBadge origin/main -- pages/workbench/**`):
+
+| Tab | Renders `WorkbenchSourceBadge`? | Has honesty-contract test? |
+|-----|-------------------------------|----------------------------|
+| Summary | ✅ | ✅ `PropertySummary.honesty.contract.test.tsx` |
+| Forge | ✅ | ✅ `PropertyForge.honesty.contract.test.tsx` |
+| Atlas | ✅ | ✅ `PropertyAtlas.honesty.contract.test.tsx` |
+| Dais | ✅ | ✅ `PropertyDais.honesty.contract.test.tsx` |
+| **Dossier** | ✅ (4 refs; root `data-testid='property-dossier-tab'`, `PropertyDossier.tsx`) | ❌ **none** |
+| **Clerk** | ❌ **0 refs** (`PropertyClerk.tsx`) | ❌ |
+| **Treasury** | ❌ **0 refs** (`PropertyTreasury.tsx`) | ❌ |
+| **Audit** | ❌ **0 refs** (`PropertyAudit.tsx`) | ❌ |
+| **Pilot** | ❌ **0 refs** (`PropertyPilot.tsx`) | ❌ |
+
+- **Badge instrumentation: 5/9** (Summary, Forge, Atlas, Dais, Dossier).
+- **Honesty-contract test coverage: 4/9** (the same minus Dossier).
+
+Clerk/Treasury/Audit render **no** container `data-testid` and **no** badge; they rely on the shared `ParcelContextHeader` + `InvocationHistory` + the workbench-wide "evidence unavailable" blocker for honesty — but not per-element source badges. Pilot renders `property-pilot-tab` / `pilot-muse-scope` testids but likewise **no** source badge.
+
+## 3. The finding — an *instrumentation* gap, not a *test* gap
+
+- **Dossier is tests-only viable.** It already renders source badges and a root testid, so a Dais-style honesty contract can be written for it **without touching component code**.
+- **Clerk / Treasury / Audit / Pilot are not tests-only viable.** A Dais-style test would *fail* (assertions 1–4) because these components render no source badge. Making it pass requires **adding `WorkbenchSourceBadge` + disclosure boxes + testids to the components** — a runtime/component change, outside a tests-only backfill.
+
+Therefore the honesty-coverage gap (readiness audit **G3**) is really an **instrumentation gap**: those 4 tab components are not yet instrumented for per-element source disclosure. This also **refines WO-WB-003**, which implied uniform per-element source-badge disclosure across surfaces — that holds for 5 of 9 tabs, not all 9. (It does **not** contradict WO-WB-004's "no mock" verdict: these tabs are still honest via the shared header + evidence blocker; they simply lack per-element badges.)
+
+## 4. Revised scope
+
+| | Original C1 | Revised C1 (this program) |
+|---|---|---|
+| Target | 4/9 → 9/9, tests-only | **4/9 → 5/9, tests-only** |
+| Deliverable | 5 tab tests | **1 tab test (Dossier)** |
+| Out of scope | — | Clerk/Treasury/Audit/Pilot instrumentation → separate WO |
+
+- **WO-WB-C1-002** adds the Dossier honesty-contract test (tests-only; authorized because Dossier is already instrumented).
+- **WO-WB-C1-003** rolls up C1 and emits a candidate packet for the follow-on **WORKBENCH-HONESTY-INSTRUMENTATION** program (Clerk/Treasury/Audit/Pilot) — which is real frontend implementation and requires its own explicit authorization.
+
+## 5. Why the four are *deferred*, not done here
+
+Adding source-badge/disclosure UI to Clerk/Treasury/Audit/Pilot is **frontend implementation**, not a tests-only backfill. Per the C1 boundary (tests-only; copy-only component changes at most) and the stop rule *"a tab cannot be tested without changing runtime behavior"*, those four are correctly **out of this program** and belong to a separately-authorized lane.
+
+## 6. Validation
+
+- `git diff --check` — clean.
+- docs/audit scope check — only `docs/audit/workbench-readiness/**` touched.
+- **no** runtime/frontend/backend/tool-registry changes.
+
+**STOP_TYPE:** `WB_C1_DESIGN_SCOPE_CORRECTION_COMPLETE`


### PR DESCRIPTION
## WO-WB-C1-001 — Honesty-Contract Backfill Design / Scope Correction (DESIGN / docs-only)

Revised C1 program, step 1. Records a **scope correction** found while planning the honesty-contract backfill. Docs only; no component code touched.

### The finding
The Dais honesty contract *positively asserts* a `WorkbenchSourceBadge` at idle. `git grep` confirms:
- **Badge instrumentation: 5/9** (Summary, Forge, Atlas, Dais, **Dossier**).
- **Test coverage: 4/9** (the same minus Dossier).
- **Clerk / Treasury / Audit / Pilot render NO source badge (0 refs)** — they rely on the shared header + evidence blocker, not per-element badges.

So the 4 uncovered tool-console tabs can't get Dais-style tests **without adding badge/disclosure instrumentation** = component change = **out of tests-only scope**. This is an **instrumentation gap, not just a test gap** (refines WO-WB-003; does not contradict WO-WB-004's no-mock verdict).

### Revised scope
Tests-only target **4/9 → 5/9** via **Dossier** (already instrumented). 9/9 requires a separate authorized implementation lane (**WORKBENCH-HONESTY-INSTRUMENTATION**), emitted as a candidate packet in WO-WB-C1-003.

### Validation
scope-clean · diff-check · prettier · no runtime/frontend/backend/tool-registry changes. STOP_TYPE: `WB_C1_DESIGN_SCOPE_CORRECTION_COMPLETE`. Next: WO-WB-C1-002 (Dossier honesty-contract test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a design/readiness document detailing honesty-contract expectations, current badge/test coverage across workbench tabs, and the revised C1 scope limited to Dossier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the workbench readiness plan to reflect a revised, realistic scope.
  * Clarified which tabs are currently covered by honesty-contract checks and which still need additional runtime support.
  * Added the updated target outcome and documented follow-up items for remaining gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->