### PR TITLE
feat(workbench): WO-WB-INSTR-002 — Pilot idle honesty badge + contract test

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyPilot.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyPilot.honesty.contract.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * PropertyPilot.honesty.contract.test.tsx
+ *
+ * Source honesty contract for the PropertyPilot tab (WO-WB-INSTR-002).
+ * Mirrors the Dossier/Dais honesty contracts. Ensures:
+ *   1. Baseline disclosure box carries a WorkbenchSourceBadge
+ *   2. That badge shows "unavailable" while the tool list is loading/empty
+ *   3. It reflects "live" once the governed tool list loads (state-driven, not hardcoded)
+ *   4. No aspirational "AI-powered" language
+ *   5. Baseline disclosure uses governed read-only wording
+ *   6. No tool is invoked on mount (the tab only lists tools)
+ *
+ * Reuses the mock setup from PropertyPilot.museFirst.test.tsx.
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const listPilotToolsMock = vi.fn();
+const invokeMock = vi.fn();
+
+vi.mock('../../api/pilotApi', async () => {
+  const actual = await vi.importActual<typeof import('../../api/pilotApi')>('../../api/pilotApi');
+  return {
+    ...actual,
+    listPilotTools: (...args: unknown[]) => listPilotToolsMock(...args),
+  };
+});
+
+vi.mock('../../context/workbenchTabContext', () => ({
+  useWorkbenchTab: () => ({ parcelId: 'P-100' }),
+}));
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: (state: { operations: unknown[] }) => unknown) =>
+    selector({ operations: [] }),
+}));
+
+vi.mock('../../hooks/useToolInvocation', () => ({
+  useToolInvocation: () => ({
+    invoke: invokeMock,
+    confirm: vi.fn(),
+    cancel: vi.fn(),
+    reset: vi.fn(),
+    state: {
+      phase: 'idle',
+      toolId: null,
+      correlationId: null,
+      errorCode: null,
+      response: null,
+      validation: null,
+      confirmation: null,
+      params: null,
+      error: null,
+    },
+  }),
+}));
+
+vi.mock('../../hooks/usePilotTraceList', () => ({
+  usePilotTraceList: () => ({ phase: 'ready', events: [], error: null, refresh: vi.fn() }),
+}));
+
+vi.mock('../../components/pilot/ExecutionConsole', () => ({
+  ExecutionConsole: () => <div data-testid='execution-console' />,
+}));
+
+vi.mock('../../components/pilot/EvidenceRail', () => ({
+  EvidenceRail: () => <div data-testid='evidence-rail' />,
+}));
+
+vi.mock('../../components/workbench', () => ({
+  ParcelContextHeader: ({ title, subtitle }: { title: string; subtitle: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+  InvocationHistory: () => <div data-testid='invocation-history' />,
+  WorkbenchSourceBadge: ({ source }: { source: string }) => (
+    <span data-testid='workbench-source-badge' data-source={source} />
+  ),
+}));
+
+vi.mock('../../ui/materials/BentoCard', () => ({
+  BentoCard: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+import { PropertyPilot } from '../../pages/workbench/tabs/PropertyPilot';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <MemoryRouter initialEntries={['/property/P-100/pilot']}>
+    <Routes>
+      <Route path='/property/:parcelId' element={<Outlet context={{ parcelId: 'P-100' }} />}>
+        <Route path='pilot' element={children} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+);
+
+describe('PropertyPilot source honesty contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listPilotToolsMock.mockResolvedValue({
+      count: 1,
+      tools: [
+        {
+          toolId: 'explain_value_change',
+          displayName: 'Explain Value Change',
+          suite: 'forge',
+          mode: 'muse',
+          risk: 'read_only',
+          description: 'Explain the assessed value delta.',
+        },
+      ],
+    });
+  });
+
+  it('baseline disclosure box carries a WorkbenchSourceBadge', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    const disclosure = screen.getByTestId('pilot-baseline-disclosure');
+    expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
+  });
+
+  it('baseline badge shows "unavailable" while the tool list is loading', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    const disclosure = screen.getByTestId('pilot-baseline-disclosure');
+    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
+    expect(badge).toHaveAttribute('data-source', 'unavailable');
+  });
+
+  it('baseline badge reflects live once the governed tool list loads', async () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    const disclosure = screen.getByTestId('pilot-baseline-disclosure');
+    await waitFor(() => {
+      expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toHaveAttribute('data-source', 'live');
+    });
+  });
+
+  it('all badges avoid synthetic claims (unavailable or live only)', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    for (const badge of screen.getAllByTestId('workbench-source-badge')) {
+      expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
+    }
+  });
+
+  it('does not use aspirational "AI-powered" language', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    expect(screen.getByTestId('property-pilot-tab').textContent).not.toMatch(/AI-powered/i);
+  });
+
+  it('baseline disclosure uses governed read-only wording', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    expect(screen.getByTestId('pilot-baseline-disclosure').textContent).toMatch(/read-only|returned from|governed/i);
+  });
+
+  it('does not invoke any tool on mount without user action', () => {
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyPilot.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyPilot.honesty.contract.test.tsx
@@ -139,6 +139,18 @@ describe('PropertyPilot source honesty contract', () => {
     });
   });
 
+  it('shows live on a successful registry load even when no eligible tools return', async () => {
+    // Registry reachable but nothing passes filterMuseReadOnlyTools — this is a live
+    // (successful) result, not an unavailable one. The badge must reflect load success,
+    // not tool count.
+    listPilotToolsMock.mockResolvedValueOnce({ count: 0, tools: [] });
+    render(<Wrapper><PropertyPilot /></Wrapper>);
+    const disclosure = screen.getByTestId('pilot-baseline-disclosure');
+    await waitFor(() => {
+      expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toHaveAttribute('data-source', 'live');
+    });
+  });
+
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
     render(<Wrapper><PropertyPilot /></Wrapper>);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
@@ -21,6 +21,7 @@ import {
 import {
   InvocationHistory,
   ParcelContextHeader,
+  WorkbenchSourceBadge,
   type InvocationRecord,
 } from '../../../components/workbench';
 import { ExecutionConsole } from '../../../components/pilot/ExecutionConsole';
@@ -148,7 +149,7 @@ export const PropertyPilot: React.FC = () => {
         icon='🎮'
         title='Pilot'
         parcelId={parcelId}
-        subtitle={`AI analysis tools for parcel ${parcelId}`}
+        subtitle={`Read-only reasoning & explanation tools for parcel ${parcelId}`}
         actions={
           <button
             onClick={() => window.open(`/property/${encodeURIComponent(parcelId)}/pilot`, '_blank')}
@@ -158,6 +159,14 @@ export const PropertyPilot: React.FC = () => {
           </button>
         }
       />
+
+      <div className='flex items-center justify-between gap-3 px-2' data-testid='pilot-baseline-disclosure'>
+        <p className='text-xs tf-text-dim'>
+          This panel lists governed read-only reasoning tools returned from the tool registry;
+          it never invokes a tool or infers a result on its own.
+        </p>
+        <WorkbenchSourceBadge source={tools.length > 0 ? 'live' : 'unavailable'} />
+      </div>
 
       {!toolsLoading && !toolsError && (
         <div className='tf-status-info rounded-xl p-4' data-testid='pilot-muse-scope'>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyPilot.tsx
@@ -165,7 +165,7 @@ export const PropertyPilot: React.FC = () => {
           This panel lists governed read-only reasoning tools returned from the tool registry;
           it never invokes a tool or infers a result on its own.
         </p>
-        <WorkbenchSourceBadge source={tools.length > 0 ? 'live' : 'unavailable'} />
+        <WorkbenchSourceBadge source={!toolsLoading && !toolsError ? 'live' : 'unavailable'} />
       </div>
 
       {!toolsLoading && !toolsError && (


### PR DESCRIPTION
## WO-WB-INSTR-002 — Pilot Honesty Instrumentation + Contract Test

`WORKBENCH-HONESTY-INSTRUMENTATION` step 2. Honesty-contract coverage **5/9 → 6/9**.

### Change
- **Component:** `PropertyPilot.tsx` — a **state-driven** baseline disclosure badge (`source={tools.length > 0 ? 'live' : 'unavailable'}` — unavailable while the muse tool list loads, live once `listPilotTools` resolves; **never hardcoded**, per the Dossier lesson). Also rewords the aspirational subtitle **"AI analysis tools" → "Read-only reasoning & explanation tools"** to match the honest muse-scope copy.
- **Test:** `PropertyPilot.honesty.contract.test.tsx` reusing the existing museFirst mock setup — asserts badge **unavailable-at-load → live-after-load**, no "AI-powered", governed read-only wording, and **no tool invocation on mount**.

### Scope
Only `pages/workbench/tabs/PropertyPilot.tsx` + `__tests__/workbench/`. No backend/registry/route/data changes. Validated by CI **Frontend Gate + Vitest**.

NEXT: INSTR-003 (Clerk). STOP_TYPE: (pending CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an honesty-focused source badge and disclosure copy to the Property Pilot workbench tab and cover it with a source-honesty contract test.

New Features:
- Expose a baseline disclosure panel in PropertyPilot with a governed read-only description and a WorkbenchSourceBadge that reflects live vs unavailable state based on tool loading.

Tests:
- Add a PropertyPilot honesty contract test suite ensuring the baseline disclosure badge state transitions correctly, uses governed read-only wording, avoids aspirational AI language, and performs no tool invocation on mount.