### PR TITLE
feat(workbench): state-driven honesty badge for Clerk tab (WO-WB-INSTR-003)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
@@ -4,10 +4,13 @@
  * Source honesty contract for the PropertyClerk tab (WO-WB-INSTR-003).
  * Mirrors the Dossier/Pilot/Dais honesty contracts. Ensures:
  *   1. Baseline disclosure box carries a WorkbenchSourceBadge
- *   2. That badge shows "unavailable" when no recording history is loaded
- *   3. It reflects "live" once recording history is loaded (state-driven, not hardcoded)
+ *   2. That badge shows "unavailable" when the parcel evidence has not loaded
+ *   3. It reflects "live" once the parcel evidence bundle loads successfully —
+ *      including a successful load that returns zero recordings (load-success
+ *      provenance, NOT recording row count), and it flips on the empty -> loaded
+ *      transition (not memoized at mount)
  *   4. No aspirational "AI-powered" language
- *   5. Baseline disclosure uses governed / returned-from wording
+ *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
  *   6. No tool is invoked on mount (the tab only lists tools)
  *
  * Reuses the mock setup from PropertyClerk.test.tsx.
@@ -25,19 +28,30 @@ import PropertyClerk from '../../pages/workbench/tabs/PropertyClerk';
 
 vi.mock('../../api/pilotApi');
 
-let clerkRecordings: Array<{
-  recordingId: string;
-  documentType: string;
-  grantor?: string;
-  grantee?: string;
-  recordingDate: string;
-}> = [];
+// Mutable store view driven per-test to exercise the load-provenance states.
+interface StoreView {
+  recordings: Array<{
+    recordingId: string;
+    documentType: string;
+    grantor?: string;
+    grantee?: string;
+    recordingDate: string;
+  }>;
+  activeParcel: { parcelId: string } | null;
+  activeParcelLoading: boolean;
+  activeParcelError: { message: string } | null;
+}
+
+let storeView: StoreView = {
+  recordings: [],
+  activeParcel: null,
+  activeParcelLoading: false,
+  activeParcelError: null,
+};
 
 vi.mock('../../stores/propertyStore', () => ({
-  usePropertyStore: (selector: (s: { recordings: typeof clerkRecordings }) => unknown) => {
-    const state = { recordings: clerkRecordings };
-    return typeof selector === 'function' ? selector(state) : state;
-  },
+  usePropertyStore: (selector: (s: StoreView) => unknown) =>
+    typeof selector === 'function' ? selector(storeView) : storeView,
 }));
 
 vi.mock('../../runtime/env', () => ({
@@ -77,22 +91,23 @@ const TestWrapper: React.FC<{ parcelId?: string }> = ({ parcelId = PARCEL_ID }) 
   </MemoryRouter>
 );
 
-const oneRecording = [
-  {
-    recordingId: 'REC-1',
-    documentType: 'Deed',
-    grantor: 'Alice',
-    grantee: 'Bob',
-    recordingDate: '2026-01-15',
-  },
-];
+const badgeSource = () =>
+  screen
+    .getByTestId('clerk-baseline-disclosure')
+    .querySelector('[data-testid="workbench-source-badge"]')
+    ?.getAttribute('data-source');
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('PropertyClerk source honesty contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    clerkRecordings = [];
+    storeView = {
+      recordings: [],
+      activeParcel: null,
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
   });
 
   it('baseline disclosure box carries a WorkbenchSourceBadge', () => {
@@ -101,24 +116,64 @@ describe('PropertyClerk source honesty contract', () => {
     expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
   });
 
-  it('baseline badge shows "unavailable" when no recording history is loaded', () => {
-    clerkRecordings = [];
+  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
     render(<TestWrapper />);
-    const disclosure = screen.getByTestId('clerk-baseline-disclosure');
-    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
-    expect(badge).toHaveAttribute('data-source', 'unavailable');
+    expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge reflects live once recording history is loaded', () => {
-    clerkRecordings = oneRecording;
+  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
+    storeView = { ...storeView, activeParcelLoading: true };
     render(<TestWrapper />);
-    const disclosure = screen.getByTestId('clerk-baseline-disclosure');
-    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
-    expect(badge).toHaveAttribute('data-source', 'live');
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
+    storeView = {
+      ...storeView,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelError: { message: 'load failed' },
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge reflects "live" on a successful evidence load even with zero recordings', () => {
+    // Load-success provenance, NOT row count: a live load returning no recordings
+    // is still live, not unavailable.
+    storeView = {
+      recordings: [],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
+  });
+
+  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+    const { rerender } = render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+
+    // Parcel evidence finishes loading successfully.
+    storeView = {
+      recordings: [
+        { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
+      ],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
   });
 
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
-    clerkRecordings = oneRecording;
+    storeView = {
+      recordings: [],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
     render(<TestWrapper />);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {
       expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
@@ -130,9 +185,11 @@ describe('PropertyClerk source honesty contract', () => {
     expect(screen.getByTestId('property-clerk-tab').textContent).not.toMatch(/AI-powered/i);
   });
 
-  it('baseline disclosure uses governed / returned-from wording', () => {
+  it('baseline disclosure uses governed / live-evidence / never-inferred wording', () => {
     render(<TestWrapper />);
-    expect(screen.getByTestId('clerk-baseline-disclosure').textContent).toMatch(/governed|returned from|never inferred/i);
+    expect(screen.getByTestId('clerk-baseline-disclosure').textContent).toMatch(
+      /governed|live property evidence|never inferred/i,
+    );
   });
 
   it('does not invoke any tool on mount without user action', () => {

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * PropertyClerk.honesty.contract.test.tsx
+ *
+ * Source honesty contract for the PropertyClerk tab (WO-WB-INSTR-003).
+ * Mirrors the Dossier/Pilot/Dais honesty contracts. Ensures:
+ *   1. Baseline disclosure box carries a WorkbenchSourceBadge
+ *   2. That badge shows "unavailable" when no recording history is loaded
+ *   3. It reflects "live" once recording history is loaded (state-driven, not hardcoded)
+ *   4. No aspirational "AI-powered" language
+ *   5. Baseline disclosure uses governed / returned-from wording
+ *   6. No tool is invoked on mount (the tab only lists tools)
+ *
+ * Reuses the mock setup from PropertyClerk.test.tsx.
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as pilotApi from '../../api/pilotApi';
+import PropertyClerk from '../../pages/workbench/tabs/PropertyClerk';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../api/pilotApi');
+
+let clerkRecordings: Array<{
+  recordingId: string;
+  documentType: string;
+  grantor?: string;
+  grantee?: string;
+  recordingDate: string;
+}> = [];
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: (s: { recordings: typeof clerkRecordings }) => unknown) => {
+    const state = { recordings: clerkRecordings };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../runtime/env', () => ({
+  getEnv: () => ({ VITE_API_URL: 'http://localhost:5000' }),
+}));
+
+vi.mock('../../components/workbench', () => ({
+  ParcelContextHeader: ({ title, parcelId, subtitle }: { title: string; parcelId: string; subtitle?: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{parcelId}</span>
+      {subtitle && <p>{subtitle}</p>}
+    </div>
+  ),
+  InvocationHistory: () => <div data-testid='invocation-history' />,
+  WorkbenchSourceBadge: ({ source }: { source: string }) => (
+    <span data-testid='workbench-source-badge' data-source={source} />
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockInvokeTool = pilotApi.invokeTool as ReturnType<typeof vi.fn>;
+
+const PARCEL_ID = 'BC-2026-001';
+
+const TestWrapper: React.FC<{ parcelId?: string }> = ({ parcelId = PARCEL_ID }) => (
+  <MemoryRouter initialEntries={[`/property/${parcelId}/clerk`]}>
+    <Routes>
+      <Route
+        path='/property/:parcelId'
+        element={<Outlet context={{ parcelId, propertyData: {}, workMode: 'overview' }} />}
+      >
+        <Route path='clerk' element={<PropertyClerk />} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+);
+
+const oneRecording = [
+  {
+    recordingId: 'REC-1',
+    documentType: 'Deed',
+    grantor: 'Alice',
+    grantee: 'Bob',
+    recordingDate: '2026-01-15',
+  },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PropertyClerk source honesty contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clerkRecordings = [];
+  });
+
+  it('baseline disclosure box carries a WorkbenchSourceBadge', () => {
+    render(<TestWrapper />);
+    const disclosure = screen.getByTestId('clerk-baseline-disclosure');
+    expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
+  });
+
+  it('baseline badge shows "unavailable" when no recording history is loaded', () => {
+    clerkRecordings = [];
+    render(<TestWrapper />);
+    const disclosure = screen.getByTestId('clerk-baseline-disclosure');
+    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
+    expect(badge).toHaveAttribute('data-source', 'unavailable');
+  });
+
+  it('baseline badge reflects live once recording history is loaded', () => {
+    clerkRecordings = oneRecording;
+    render(<TestWrapper />);
+    const disclosure = screen.getByTestId('clerk-baseline-disclosure');
+    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
+    expect(badge).toHaveAttribute('data-source', 'live');
+  });
+
+  it('all badges avoid synthetic claims (unavailable or live only)', () => {
+    clerkRecordings = oneRecording;
+    render(<TestWrapper />);
+    for (const badge of screen.getAllByTestId('workbench-source-badge')) {
+      expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
+    }
+  });
+
+  it('does not use aspirational "AI-powered" language', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('property-clerk-tab').textContent).not.toMatch(/AI-powered/i);
+  });
+
+  it('baseline disclosure uses governed / returned-from wording', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('clerk-baseline-disclosure').textContent).toMatch(/governed|returned from|never inferred/i);
+  });
+
+  it('does not invoke any tool on mount without user action', () => {
+    render(<TestWrapper />);
+    expect(mockInvokeTool).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -85,6 +85,15 @@ interface RecordingSummaryResult {
 export const PropertyClerk: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const recordings = usePropertyStore((s) => s.recordings);
+  // Source provenance for the baseline disclosure badge. The parcel evidence
+  // bundle (recordings included) is loaded together in propertyStore.selectParcel;
+  // its load success is signalled by activeParcel being set with no active
+  // load/error — NOT by whether the recordings array happens to be non-empty
+  // (a live load can legitimately return zero recordings).
+  const activeParcel = usePropertyStore((s) => s.activeParcel);
+  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
+  const parcelError = usePropertyStore((s) => s.activeParcelError);
+  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool
@@ -246,10 +255,11 @@ export const PropertyClerk: React.FC = () => {
 
       <div className='flex items-center justify-between gap-3 px-2' data-testid='clerk-baseline-disclosure'>
         <p className='text-xs tf-text-dim'>
-          Recording and title tools are invoked on demand through governed tooling; values shown are
-          returned from the tool response or the recording history loaded for this parcel, never inferred.
+          This parcel's recording context is loaded from the live property evidence feed; recording and
+          title tools are invoked on demand through governed tooling and their results are shown only
+          after you run them, never inferred.
         </p>
-        <WorkbenchSourceBadge source={recordings.length > 0 ? 'live' : 'unavailable'} />
+        <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
       </div>
 
       {/* Recording history from store */}

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -20,6 +20,7 @@ import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
 import {
     InvocationHistory,
     ParcelContextHeader,
+    WorkbenchSourceBadge,
     type InvocationRecord,
 } from '../../../components/workbench';
 import type { ErrorInfo } from '../../../hooks/useErrorHandler';
@@ -240,8 +241,16 @@ export const PropertyClerk: React.FC = () => {
   // ── Render ──
 
   return (
-    <div className='tf-suite-clerk space-y-4'>
+    <div className='tf-suite-clerk space-y-4' data-testid='property-clerk-tab'>
       <ParcelContextHeader icon='📜' title='TerraClerk' parcelId={parcelId} subtitle={`Recording & title services for ${parcelId}`} />
+
+      <div className='flex items-center justify-between gap-3 px-2' data-testid='clerk-baseline-disclosure'>
+        <p className='text-xs tf-text-dim'>
+          Recording and title tools are invoked on demand through governed tooling; values shown are
+          returned from the tool response or the recording history loaded for this parcel, never inferred.
+        </p>
+        <WorkbenchSourceBadge source={recordings.length > 0 ? 'live' : 'unavailable'} />
+      </div>
 
       {/* Recording history from store */}
       {recordings.length > 0 && (


### PR DESCRIPTION
## WO-WB-INSTR-003 — PropertyClerk honesty instrumentation

Part of the **WORKBENCH-HONESTY-INSTRUMENTATION** program (Dossier→Pilot→**Clerk**→Treasury→Audit→rollup), moving honesty-contract coverage **6/9 → 7/9**.

### Change (additive only)
- **PropertyClerk.tsx**: root `data-testid='property-clerk-tab'` + a baseline source-disclosure box after the header carrying a **state-driven** `WorkbenchSourceBadge` — `source={recordings.length > 0 ? 'live' : 'unavailable'}` (live only when recording history is actually loaded for the parcel; never hardcoded). Disclosure copy states tools are invoked on demand and values are returned from the tool response or loaded history, never inferred.
- **PropertyClerk.honesty.contract.test.tsx** (new): asserts the badge is present, `unavailable` with no loaded recordings, `live` once recordings load, badges are only `unavailable|live`, no "AI-powered" copy, governed wording, and **no tool invoked on mount**.

### Non-goals (unchanged)
No backend, tool registry, routing, data-model, API-service, package/build/CI, deploy, or PACS/county-data changes.

### Validation
Frontend Gate (React/TypeScript) + Vitest Full Suite (merge gate) + required branch-protection contexts must pass; review threads resolved before merge. No break-glass / no --admin.

## Summary by Sourcery

Add a state-driven source honesty disclosure to the PropertyClerk workbench tab and cover it with an explicit honesty contract test suite.

New Features:
- Display a baseline disclosure box in the PropertyClerk tab that explains how recording and title data is obtained and labeled.
- Show a Workbench source badge on the PropertyClerk tab that reflects live versus unavailable recording history based on current state.

Tests:
- Introduce a dedicated honesty contract test suite for PropertyClerk to verify badge states, governed disclosure wording, absence of aspirational AI language, and that no tools are invoked on mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a source badge in the workbench to show whether property-clerk content is live or unavailable.
  * Improved the on-screen disclosure text with clearer wording about how the information is presented.

* **Tests**
  * Added coverage to verify the badge and disclosure behave consistently and only show approved source states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->