### PR TITLE
feat(workbench): state-driven honesty badge for Treasury tab (WO-WB-INSTR-004)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
@@ -161,6 +161,19 @@ describe('PropertyTreasury source honesty contract', () => {
     expect(badgeSource()).toBe('live');
   });
 
+  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
+    // During parcel-to-parcel navigation the store can still hold the previous
+    // activeParcel for one frame; that must not read as live for this tab's parcel.
+    storeView = {
+      taxStatements: oneStatement,
+      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper parcelId={PARCEL_ID} />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
     storeView = {
       taxStatements: oneStatement,

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
@@ -53,10 +53,6 @@ vi.mock('../../stores/propertyStore', () => ({
     typeof selector === 'function' ? selector(storeView) : storeView,
 }));
 
-vi.mock('../../runtime/env', () => ({
-  getEnv: () => ({ VITE_API_URL: 'http://localhost:5000' }),
-}));
-
 vi.mock('../../components/workbench', () => ({
   ParcelContextHeader: ({ title, parcelId, subtitle }: { title: string; parcelId: string; subtitle?: string }) => (
     <div>

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
@@ -174,6 +174,25 @@ describe('PropertyTreasury source honesty contract', () => {
     }
   });
 
+  it('disclosure copy is state-aware — never claims live loading while the badge reads unavailable', () => {
+    // Idle: badge unavailable, so the copy must NOT assert the parcel is loaded live.
+    const { rerender } = render(<TestWrapper />);
+    let disclosure = screen.getByTestId('treasury-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/not currently available/i);
+    expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
+
+    // Loaded: badge live, so the copy asserts the live-loaded state.
+    storeView = {
+      taxStatements: oneStatement,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    disclosure = screen.getByTestId('treasury-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);
+  });
+
   it('does not use aspirational "AI-powered" language', () => {
     render(<TestWrapper />);
     expect(screen.getByTestId('property-treasury-tab').textContent).not.toMatch(/AI-powered/i);

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * PropertyTreasury.honesty.contract.test.tsx
+ *
+ * Source honesty contract for the PropertyTreasury tab (WO-WB-INSTR-004).
+ * Mirrors the Clerk/Pilot/Dossier/Dais honesty contracts. Ensures:
+ *   1. Baseline disclosure box carries a WorkbenchSourceBadge
+ *   2. That badge shows "unavailable" before/while the parcel evidence loads and on error
+ *   3. It reflects "live" once the parcel evidence bundle loads successfully —
+ *      including a successful load that returns zero tax statements (load-success
+ *      provenance, NOT statement row count), and it flips on the empty -> loaded
+ *      transition (not memoized at mount)
+ *   4. No aspirational "AI-powered" language
+ *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
+ *   6. No tool is invoked on mount (the tab only lists tools)
+ *
+ * Reuses the mock setup from PropertyTreasury.test.tsx.
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as pilotApi from '../../api/pilotApi';
+import PropertyTreasury from '../../pages/workbench/tabs/PropertyTreasury';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../api/pilotApi');
+
+interface StoreView {
+  taxStatements: Array<{
+    statementId: string;
+    taxYear: number;
+    totalTaxDue: number;
+    totalPaid: number;
+    delinquent: boolean;
+  }>;
+  activeParcel: { parcelId: string } | null;
+  activeParcelLoading: boolean;
+  activeParcelError: { message: string } | null;
+}
+
+let storeView: StoreView = {
+  taxStatements: [],
+  activeParcel: null,
+  activeParcelLoading: false,
+  activeParcelError: null,
+};
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: (s: StoreView) => unknown) =>
+    typeof selector === 'function' ? selector(storeView) : storeView,
+}));
+
+vi.mock('../../runtime/env', () => ({
+  getEnv: () => ({ VITE_API_URL: 'http://localhost:5000' }),
+}));
+
+vi.mock('../../components/workbench', () => ({
+  ParcelContextHeader: ({ title, parcelId, subtitle }: { title: string; parcelId: string; subtitle?: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{parcelId}</span>
+      {subtitle && <p>{subtitle}</p>}
+    </div>
+  ),
+  InvocationHistory: () => <div data-testid='invocation-history' />,
+  WorkbenchSourceBadge: ({ source }: { source: string }) => (
+    <span data-testid='workbench-source-badge' data-source={source} />
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockInvokeTool = pilotApi.invokeTool as ReturnType<typeof vi.fn>;
+
+const PARCEL_ID = 'BC-2026-001';
+
+const TestWrapper: React.FC<{ parcelId?: string }> = ({ parcelId = PARCEL_ID }) => (
+  <MemoryRouter initialEntries={[`/property/${parcelId}/treasury`]}>
+    <Routes>
+      <Route
+        path='/property/:parcelId'
+        element={<Outlet context={{ parcelId, propertyData: {}, workMode: 'overview' }} />}
+      >
+        <Route path='treasury' element={<PropertyTreasury />} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+);
+
+const badgeSource = () =>
+  screen
+    .getByTestId('treasury-baseline-disclosure')
+    .querySelector('[data-testid="workbench-source-badge"]')
+    ?.getAttribute('data-source');
+
+const oneStatement = [
+  { statementId: 'TS-2026', taxYear: 2026, totalTaxDue: 3200, totalPaid: 1600, delinquent: false },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PropertyTreasury source honesty contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeView = {
+      taxStatements: [],
+      activeParcel: null,
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+  });
+
+  it('baseline disclosure box carries a WorkbenchSourceBadge', () => {
+    render(<TestWrapper />);
+    const disclosure = screen.getByTestId('treasury-baseline-disclosure');
+    expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
+  });
+
+  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
+    storeView = { ...storeView, activeParcelLoading: true };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
+    storeView = {
+      ...storeView,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelError: { message: 'load failed' },
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge reflects "live" on a successful evidence load even with zero tax statements', () => {
+    storeView = {
+      taxStatements: [],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
+  });
+
+  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+    const { rerender } = render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+
+    storeView = {
+      taxStatements: oneStatement,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
+  });
+
+  it('all badges avoid synthetic claims (unavailable or live only)', () => {
+    storeView = {
+      taxStatements: oneStatement,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper />);
+    for (const badge of screen.getAllByTestId('workbench-source-badge')) {
+      expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
+    }
+  });
+
+  it('does not use aspirational "AI-powered" language', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('property-treasury-tab').textContent).not.toMatch(/AI-powered/i);
+  });
+
+  it('baseline disclosure uses governed / live-evidence / never-inferred wording', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('treasury-baseline-disclosure').textContent).toMatch(
+      /governed|live property evidence|never inferred/i,
+    );
+  });
+
+  it('does not invoke any tool on mount without user action', () => {
+    render(<TestWrapper />);
+    expect(mockInvokeTool).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
@@ -114,11 +114,12 @@ interface TaxSaleResult {
 export const PropertyTreasury: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const taxStatements = usePropertyStore((s) => s.taxStatements);
-  // Source provenance for the baseline disclosure badge. The parcel evidence
-  // bundle (taxStatements included) is loaded together in propertyStore.selectParcel;
-  // its load success is signalled by activeParcel being set with no active
-  // load/error — NOT by whether the taxStatements array happens to be non-empty
-  // (a live load can legitimately return zero statements).
+  // Source provenance for the baseline disclosure badge. This reflects whether
+  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set,
+  // not loading, no error) — the honest signal the store exposes. It is NOT keyed
+  // on the taxStatements row count (a live load can legitimately return zero
+  // statements); propertyStore exposes no tax-slice-specific load provenance, so
+  // the disclosure copy is scoped to parcel-context, not tax-evidence, load state.
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
   const parcelError = usePropertyStore((s) => s.activeParcelError);
@@ -304,9 +305,9 @@ export const PropertyTreasury: React.FC = () => {
 
       <div className='flex items-center justify-between gap-3 px-2' data-testid='treasury-baseline-disclosure'>
         <p className='text-xs tf-text-dim'>
-          This parcel's tax context is loaded from the live property evidence feed; tax and collection
-          tools are invoked on demand through governed tooling and their results are shown only after
-          you run them, never inferred.
+          This parcel is loaded from the live property evidence feed. Tax and collection tools are
+          invoked on demand through governed tooling; their results are shown only after you run them,
+          never inferred.
         </p>
         <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
       </div>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
@@ -21,6 +21,7 @@ import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
 import {
     InvocationHistory,
     ParcelContextHeader,
+    WorkbenchSourceBadge,
     type InvocationRecord,
 } from '../../../components/workbench';
 import type { ErrorInfo } from '../../../hooks/useErrorHandler';
@@ -113,6 +114,15 @@ interface TaxSaleResult {
 export const PropertyTreasury: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const taxStatements = usePropertyStore((s) => s.taxStatements);
+  // Source provenance for the baseline disclosure badge. The parcel evidence
+  // bundle (taxStatements included) is loaded together in propertyStore.selectParcel;
+  // its load success is signalled by activeParcel being set with no active
+  // load/error — NOT by whether the taxStatements array happens to be non-empty
+  // (a live load can legitimately return zero statements).
+  const activeParcel = usePropertyStore((s) => s.activeParcel);
+  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
+  const parcelError = usePropertyStore((s) => s.activeParcelError);
+  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool
@@ -289,8 +299,17 @@ export const PropertyTreasury: React.FC = () => {
   // ── Render ──
 
   return (
-    <div className='tf-suite-treasury space-y-4'>
+    <div className='tf-suite-treasury space-y-4' data-testid='property-treasury-tab'>
       <ParcelContextHeader icon='💰' title='TerraTreasury' parcelId={parcelId} subtitle={`Tax & collection services for ${parcelId}`} />
+
+      <div className='flex items-center justify-between gap-3 px-2' data-testid='treasury-baseline-disclosure'>
+        <p className='text-xs tf-text-dim'>
+          This parcel's tax context is loaded from the live property evidence feed; tax and collection
+          tools are invoked on demand through governed tooling and their results are shown only after
+          you run them, never inferred.
+        </p>
+        <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
+      </div>
 
       {/* Tax History from Store */}
       {taxStatements.length > 0 && (

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
@@ -305,9 +305,11 @@ export const PropertyTreasury: React.FC = () => {
 
       <div className='flex items-center justify-between gap-3 px-2' data-testid='treasury-baseline-disclosure'>
         <p className='text-xs tf-text-dim'>
-          This parcel is loaded from the live property evidence feed. Tax and collection tools are
-          invoked on demand through governed tooling; their results are shown only after you run them,
-          never inferred.
+          {evidenceLoaded
+            ? 'This parcel is loaded from the live property evidence feed.'
+            : 'Live property evidence for this parcel is not currently available.'}{' '}
+          Tax and collection tools are invoked on demand through governed tooling; their results are
+          shown only after you run them, never inferred.
         </p>
         <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
       </div>

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
@@ -123,7 +123,10 @@ export const PropertyTreasury: React.FC = () => {
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
   const parcelError = usePropertyStore((s) => s.activeParcelError);
-  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
+  // Require the loaded parcel to be THIS tab's parcel: during parcel-to-parcel
+  // navigation the store can still hold the previous activeParcel for one frame
+  // (before selectParcel runs), which must not read as live for the new parcel.
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool


### PR DESCRIPTION
## WO-WB-INSTR-004 — PropertyTreasury honesty instrumentation

Part of **WORKBENCH-HONESTY-INSTRUMENTATION** (Dossier→Pilot→Clerk→**Treasury**→Audit→rollup), moving honesty-contract coverage **7/9 → 8/9**.

### Change (additive only)
- **PropertyTreasury.tsx**: root `data-testid='property-treasury-tab'` + a baseline source-disclosure box after the header carrying a **state-driven** `WorkbenchSourceBadge`. Source derives from parcel evidence **load-success provenance** — `activeParcel && !activeParcelLoading && !activeParcelError` — not the `taxStatements` row count, so a live parcel load that legitimately returns zero statements reads `live`, not `unavailable` (same fix as Clerk #1205 / Pilot #1204). Disclosure copy states tools are invoked on demand and results are shown only after you run them, never inferred.
- **PropertyTreasury.honesty.contract.test.tsx** (new): asserts the badge is present; `unavailable` before load / while loading / on error; `live` on a successful load with zero statements; flips `unavailable → live` on the empty→loaded `rerender`; badges are only `unavailable|live`; no "AI-powered" copy; governed wording; and **no tool invoked on mount**.

### Non-goals (unchanged)
No backend, tool registry, routing, data-model, API-service, package/build/CI, deploy, or PACS/county-data changes.

### Validation
Frontend Gate + Vitest Full Suite + required branch-protection contexts must pass; review threads resolved before merge. No break-glass / no --admin.

## Summary by Sourcery

Instrument the PropertyTreasury workbench tab with a state-driven source honesty badge and baseline disclosure tied to parcel evidence load state.

New Features:
- Add a baseline disclosure box with governed wording and a WorkbenchSourceBadge to the PropertyTreasury tab, driven by parcel evidence load success rather than tax statement count.

Tests:
- Introduce a dedicated PropertyTreasury honesty contract test suite validating badge states across load/error scenarios, governed disclosure language, and that no tools are invoked on mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new disclosure row in the Property Treasury tab to show whether parcel evidence is live or unavailable.
  * Updated the tab header to display clearer source-status information alongside the existing content.

* **Bug Fixes**
  * Source status now updates correctly as data loads, fails, or becomes available after rerendering.
  * The disclosure text now consistently uses clearer “governed / live-evidence / never-inferred” wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->