### PR TITLE
feat(workbench): state-driven honesty badge for Audit tab (WO-WB-INSTR-005)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
@@ -160,6 +160,19 @@ describe('PropertyAudit source honesty contract', () => {
     expect(badgeSource()).toBe('live');
   });
 
+  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
+    // During parcel-to-parcel navigation the store can still hold the previous
+    // activeParcel for one frame; that must not read as live for this tab's parcel.
+    storeView = {
+      auditTrail: oneEntry,
+      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper parcelId={PARCEL_ID} />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
     storeView = {
       auditTrail: oneEntry,

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * PropertyAudit.honesty.contract.test.tsx
+ *
+ * Source honesty contract for the PropertyAudit tab (WO-WB-INSTR-005).
+ * Mirrors the Treasury/Clerk/Pilot/Dossier/Dais honesty contracts. Ensures:
+ *   1. Baseline disclosure box carries a WorkbenchSourceBadge
+ *   2. That badge shows "unavailable" before/while the parcel evidence loads and on error
+ *   3. It reflects "live" once the parcel evidence bundle loads successfully —
+ *      including a successful load that returns zero audit entries (load-success
+ *      provenance, NOT audit row count), and it flips on the empty -> loaded
+ *      transition (not memoized at mount)
+ *   4. No aspirational "AI-powered" language
+ *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
+ *   6. No tool is invoked on mount (the tab only lists tools)
+ *
+ * Reuses the mock setup from PropertyAudit.test.tsx.
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as pilotApi from '../../api/pilotApi';
+import PropertyAudit from '../../pages/workbench/tabs/PropertyAudit';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../api/pilotApi');
+
+interface StoreView {
+  auditTrail: Array<{
+    entryId: string;
+    action: string;
+    actor: string;
+    timestamp: string;
+  }>;
+  activeParcel: { parcelId: string } | null;
+  activeParcelLoading: boolean;
+  activeParcelError: { message: string } | null;
+}
+
+let storeView: StoreView = {
+  auditTrail: [],
+  activeParcel: null,
+  activeParcelLoading: false,
+  activeParcelError: null,
+};
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: (s: StoreView) => unknown) =>
+    typeof selector === 'function' ? selector(storeView) : storeView,
+}));
+
+vi.mock('../../components/workbench', () => ({
+  ParcelContextHeader: ({ title, parcelId, subtitle }: { title: string; parcelId: string; subtitle?: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{parcelId}</span>
+      {subtitle && <p>{subtitle}</p>}
+    </div>
+  ),
+  InvocationHistory: () => <div data-testid='invocation-history' />,
+  WorkbenchSourceBadge: ({ source }: { source: string }) => (
+    <span data-testid='workbench-source-badge' data-source={source} />
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockInvokeTool = pilotApi.invokeTool as ReturnType<typeof vi.fn>;
+
+const PARCEL_ID = 'BC-2026-001';
+
+const TestWrapper: React.FC<{ parcelId?: string }> = ({ parcelId = PARCEL_ID }) => (
+  <MemoryRouter initialEntries={[`/property/${parcelId}/audit`]}>
+    <Routes>
+      <Route
+        path='/property/:parcelId'
+        element={<Outlet context={{ parcelId, propertyData: {}, workMode: 'overview' }} />}
+      >
+        <Route path='audit' element={<PropertyAudit />} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+);
+
+const badgeSource = () =>
+  screen
+    .getByTestId('audit-baseline-disclosure')
+    .querySelector('[data-testid="workbench-source-badge"]')
+    ?.getAttribute('data-source');
+
+const oneEntry = [
+  { entryId: 'AU-1', action: 'value_change', actor: 'assessor', timestamp: '2026-01-15T10:00:00Z' },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PropertyAudit source honesty contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeView = {
+      auditTrail: [],
+      activeParcel: null,
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+  });
+
+  it('baseline disclosure box carries a WorkbenchSourceBadge', () => {
+    render(<TestWrapper />);
+    const disclosure = screen.getByTestId('audit-baseline-disclosure');
+    expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
+  });
+
+  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
+    storeView = { ...storeView, activeParcelLoading: true };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
+    storeView = {
+      ...storeView,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelError: { message: 'load failed' },
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('baseline badge reflects "live" on a successful evidence load even with zero audit entries', () => {
+    storeView = {
+      auditTrail: [],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
+  });
+
+  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+    const { rerender } = render(<TestWrapper />);
+    expect(badgeSource()).toBe('unavailable');
+
+    storeView = {
+      auditTrail: oneEntry,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    expect(badgeSource()).toBe('live');
+  });
+
+  it('all badges avoid synthetic claims (unavailable or live only)', () => {
+    storeView = {
+      auditTrail: oneEntry,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper />);
+    for (const badge of screen.getAllByTestId('workbench-source-badge')) {
+      expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
+    }
+  });
+
+  it('disclosure copy is state-aware — never claims live loading while the badge reads unavailable', () => {
+    // Idle: badge unavailable, so the copy must NOT assert the parcel is loaded live.
+    const { rerender } = render(<TestWrapper />);
+    let disclosure = screen.getByTestId('audit-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/not currently available/i);
+    expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
+
+    // Loaded: badge live, so the copy asserts the live-loaded state.
+    storeView = {
+      auditTrail: oneEntry,
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    disclosure = screen.getByTestId('audit-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);
+  });
+
+  it('does not use aspirational "AI-powered" language', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('property-audit-tab').textContent).not.toMatch(/AI-powered/i);
+  });
+
+  it('baseline disclosure uses governed / live-evidence / never-inferred wording', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('audit-baseline-disclosure').textContent).toMatch(
+      /governed|live property evidence|never inferred/i,
+    );
+  });
+
+  it('does not invoke any tool on mount without user action', () => {
+    render(<TestWrapper />);
+    expect(mockInvokeTool).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
@@ -19,6 +19,7 @@ import { ErrorDisplay } from '../../../components/errors/ErrorDisplay';
 import {
     InvocationHistory,
     ParcelContextHeader,
+    WorkbenchSourceBadge,
     type InvocationRecord,
 } from '../../../components/workbench';
 import type { ErrorInfo } from '../../../hooks/useErrorHandler';
@@ -94,6 +95,16 @@ interface ComplianceReportResult {
 export const PropertyAudit: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const auditTrail = usePropertyStore((s) => s.auditTrail);
+  // Source provenance for the baseline disclosure badge. This reflects whether
+  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set,
+  // not loading, no error) — the honest signal the store exposes. It is NOT keyed
+  // on the auditTrail row count (a live load can legitimately return zero entries);
+  // propertyStore exposes no audit-slice-specific load provenance, so the
+  // disclosure copy is scoped to parcel-context, not audit-evidence, load state.
+  const activeParcel = usePropertyStore((s) => s.activeParcel);
+  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
+  const parcelError = usePropertyStore((s) => s.activeParcelError);
+  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool
@@ -228,8 +239,19 @@ export const PropertyAudit: React.FC = () => {
   // ── Render ──
 
   return (
-    <div className='tf-suite-audit space-y-4'>
+    <div className='tf-suite-audit space-y-4' data-testid='property-audit-tab'>
       <ParcelContextHeader icon='🔍' title='TerraAudit' parcelId={parcelId} subtitle={`Financial compliance & audit for ${parcelId}`} />
+
+      <div className='flex items-center justify-between gap-3 px-2' data-testid='audit-baseline-disclosure'>
+        <p className='text-xs tf-text-dim'>
+          {evidenceLoaded
+            ? 'This parcel is loaded from the live property evidence feed.'
+            : 'Live property evidence for this parcel is not currently available.'}{' '}
+          Compliance and audit tools are invoked on demand through governed tooling; their results are
+          shown only after you run them, never inferred.
+        </p>
+        <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
+      </div>
 
       {/* Audit History from Store */}
       {auditTrail.length > 0 && (

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
@@ -104,7 +104,10 @@ export const PropertyAudit: React.FC = () => {
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
   const parcelError = usePropertyStore((s) => s.activeParcelError);
-  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
+  // Require the loaded parcel to be THIS tab's parcel: during parcel-to-parcel
+  // navigation the store can still hold the previous activeParcel for one frame
+  // (before selectParcel runs), which must not read as live for the new parcel.
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool


### PR DESCRIPTION
## WO-WB-INSTR-005 — PropertyAudit honesty instrumentation

Final tab in **WORKBENCH-HONESTY-INSTRUMENTATION** (Dossier→Pilot→Clerk→Treasury→**Audit**→rollup), moving honesty-contract coverage **8/9 → 9/9**.

### Change (additive only)
- **PropertyAudit.tsx**: root `data-testid='property-audit-tab'` + a baseline source-disclosure box carrying a **state-driven** `WorkbenchSourceBadge`. Source derives from parcel evidence **load-success provenance** — `activeParcel && !activeParcelLoading && !activeParcelError` (the honest signal the store exposes; a live load returning zero audit entries reads `live`). The disclosure copy is **scoped to parcel-context** (not audit-slice) load state and is **state-aware**, so it never claims live loading while the badge reads `unavailable`. Mirrors the Clerk #1205 / Treasury #1207 provenance + the CodeRabbit state-aware-copy fix.
- **PropertyAudit.honesty.contract.test.tsx** (new): badge present; `unavailable` before load / while loading / on error; `live` on a successful load with zero entries; `unavailable → live` on the empty→loaded `rerender`; state-aware copy (idle says 'not currently available', loaded asserts live); badges only `unavailable|live`; no "AI-powered" copy; governed wording; and **no tool invoked on mount**.

### Non-goals (unchanged)
No backend, tool registry, routing, data-model, API-service, package/build/CI, deploy, or PACS/county-data changes. Per-slice (audit-specific) load provenance would need a propertyStore change, out of this program's scope — noted for a follow-up WO.

### Validation
Frontend Gate + Vitest Full Suite + required branch-protection contexts must pass; review threads resolved before merge. No break-glass / no --admin.