### PR TITLE
WO-BACKEND-OE-004 Health Readiness Semantics Proof

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,11 +17,11 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-05 — WO-BACKEND-OE-003)*
+*(Updated 2026-07-05 — WO-BACKEND-OE-004)*
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
-| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Active | `WO-BACKEND-OE-003` | `WO-BACKEND-OE-004` after OE-003 merges | Auto if same-risk docs/evidence | Stop on implementation, infra repair, secrets, protected data, or non-docs hook bypass; docs-only hook bypass requires evidence |
+| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Active | `WO-BACKEND-OE-004` | `WO-BACKEND-OE-005` after OE-004 merges | Auto if same-risk docs/evidence | Stop on implementation, infra repair, secrets, protected data, or non-docs hook bypass; docs-only hook bypass requires evidence |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
 | [DevEx Hook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-4---devex-hook-tooling) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Follow-up | `WO-DEVEX-HOOKS-001` | TBD | No auto | Owner authorization required |
@@ -154,3 +154,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-04 | Added master active-program playbook and global continuation/stop rules | WO-MASTER-PLAYBOOK-001 |
 | 2026-07-05 | Promoted active program graph to explicit goal/loop execution playbook and command routing | WO-GOAL-LOOP-MASTER-PLAYBOOK-001 |
 | 2026-07-05 | Classified Backend OE integration-test Docker/Testcontainers dependency and routed next to health/readiness semantics | WO-BACKEND-OE-003 |
+| 2026-07-05 | Classified backend health/readiness endpoint semantics and routed next to ServiceRegistry runtime validation | WO-BACKEND-OE-004 |

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
@@ -1,0 +1,140 @@
+# WO-BACKEND-OE-004 - Health and Readiness Semantics Proof
+
+| Field | Value |
+|-------|-------|
+| Work Order | `WO-BACKEND-OE-004` |
+| Program | Backend Operational Excellence |
+| Goal | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` |
+| Loop | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` |
+| Mode | Evidence and endpoint contract proof |
+| Base | `origin/main` at `28015b9dcfbc441d5f87398e2402de2c2e23251b` |
+| Runtime code changed | No |
+| Backend code changed | No |
+| Services started | No |
+| Docker/Testcontainers executed | No |
+| Secrets/county/PACS/live DB touched | No |
+
+## Objective
+
+Define what the current backend health and readiness endpoints prove, what they do not prove, and
+which endpoint semantics are safe to use in later release-gate work.
+
+This packet is source and existing-test evidence only. It does not start the API, connect to live
+services, change endpoint behavior, or promote any endpoint to release-gate authority by itself.
+
+## Source Evidence
+
+| Evidence | Finding |
+|----------|---------|
+| `backend/src/TerraFusion.API/Program.cs` | Registers ASP.NET health checks with `database`, `modules_consistency`, `pacs-contract`, and `speclock`. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps `/healthz` as liveness with `Predicate = _ => false`, so it proves process routability only. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps `/healthz/ready` as readiness with SpecLock, StateMesh, and registered readiness health-check entries. |
+| `backend/src/TerraFusion.API/Health/PacsReadinessHealthCheck.cs` | Implements PACS readiness semantics: fail closed when PACS is required and contract validation fails; degrade when PACS is not required. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps `/health/codex369` to health checks whose names contain `codex-369`. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps `/api/transcendence/health` as a minimal lightweight feature probe returning static `ok` metadata. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps Levy endpoints under `/levy`; Levy health is `/levy/health`, not `/api/levy/health`. |
+| `backend/src/TerraFusion.API/Controllers/SimpleHealthController.cs` | Provides `/health`, `/health/ready`, and `/health/live` controller endpoints separate from `/healthz`. |
+| `backend/src/TerraFusion.API/Controllers/HealthProofController.cs` | Provides `/healthz/proof` and controller-level `/healthz/ready` proof endpoints, but minimal API `/healthz/ready` is also mapped in `Program.cs`. |
+| `backend/TerraFusion.API.Tests/AuthenticationRateLimitTests.cs` | Verifies `/healthz` is routable and not throttled by auth rate limiting. |
+| `backend/tests/TerraFusion.Unit.Tests/Observability/PacsReadinessHealthCheckRegistrationTests.cs` | Verifies PACS readiness check behavior for required, not-required, and reachable states. |
+
+## Endpoint Semantics Matrix
+
+| Endpoint | Type | Auth evidence | Dependencies checked | Success means | Failure means | Release-gate use |
+|----------|------|---------------|----------------------|---------------|---------------|------------------|
+| `/healthz` | Liveness | Minimal API mapping; no explicit auth requirement in the mapping | None; predicate excludes all checks | Process is reachable and routing the liveness probe | Process is unavailable or pipeline is not serving route | Safe for liveness only; not release readiness |
+| `/healthz/ready` | Readiness | Minimal API mapping; no explicit auth requirement in the mapping | SpecLock, StateMesh, and readiness-tagged checks including PACS readiness | Guard verification passed and readiness checks did not report unhealthy | Readiness guard or dependency check failed; specific JSON reason for SpecLock/StateMesh failures | Best current candidate for backend readiness, but release gate must define required environment/config |
+| `/health/codex369` | Feature health | Minimal API mapping; no explicit auth requirement in the mapping | Health checks named with `codex-369` | Codex369-specific check set is healthy, if registered | Codex369 feature health is not healthy or no matching check behavior is ambiguous until registration is separately validated | Feature-specific only; not backend release readiness |
+| `/api/transcendence/health` | Feature liveness | Minimal API mapping; no explicit auth requirement in the mapping | No heavy services; returns lightweight static payload | Transcendence route is mapped and process can return a simple payload | Route unavailable or API process failure | Feature liveness only; not dependency readiness |
+| `/levy/health` | Feature/data dependency health | Minimal API mapping under `/levy`; no explicit auth requirement in the mapping | `LevyDbContext` provider and database connectivity; SQLite dev path may call `EnsureCreatedAsync` | Levy database provider is available or SQLite dev database can be ensured | Levy DB cannot connect or throws | Useful for Levy feature diagnostics; not whole-backend readiness |
+| `/health` | General API health | `SimpleHealthController` has `[AllowAnonymous]` | Environment/version/service/Git SHA metadata only | API process route responds with service metadata | API controller route failure | Informational liveness/status only |
+| `/health/ready` | Host-start readiness | `SimpleHealthController` has `[AllowAnonymous]` | `IHostApplicationLifetime.ApplicationStarted` only | Host has fired `ApplicationStarted` | Host startup not complete | Host-readiness only; weaker than `/healthz/ready` |
+| `/health/live` | Host liveness | `SimpleHealthController` has `[AllowAnonymous]` | None | Controller route is live | Controller route unavailable | Liveness only |
+
+## Readiness Contract Findings
+
+The backend has multiple health surfaces, but they do not all prove the same thing.
+
+- `/healthz` proves liveness only. It intentionally does not execute dependency checks.
+- `/healthz/ready` is the strongest current readiness candidate because it combines runtime guard
+  checks and readiness-tagged health checks, including PACS readiness.
+- `/health/ready` proves host-start state only. It is useful but should not be treated as dependency
+  readiness.
+- `/api/transcendence/health` and `/health/codex369` are feature health probes, not backend platform
+  readiness proof.
+- `/levy/health` is Levy-specific and may touch the Levy database context. It must not become a
+  whole-backend readiness gate without explicit release-gate policy.
+
+## Production-Safety Classification
+
+| Endpoint | Production-safety posture | Reason |
+|----------|---------------------------|--------|
+| `/healthz` | Safe liveness candidate | Static liveness payload; no dependency detail exposed. |
+| `/healthz/ready` | Conditionally safe readiness candidate | Emits guard/check names and readiness status; acceptable for ops, but release gate must define exposure and config. |
+| `/health/codex369` | Feature diagnostic | Scope is Codex369-specific; release relevance depends on feature registration proof. |
+| `/api/transcendence/health` | Lightweight feature diagnostic | Returns only static service/timestamp payload, but it does not prove heavy-service readiness. |
+| `/levy/health` | Internal/diagnostic until release policy says otherwise | Checks Levy DB provider/connectivity and can reveal provider/mode; should be governed before public exposure. |
+| `/health` | Public informational status | Exposes environment/version/service/Git SHA metadata; useful for status, not dependency readiness. |
+| `/health/ready` | Public host-readiness candidate | Confirms host started only; insufficient for backend dependency release gate. |
+| `/health/live` | Public liveness candidate | No dependency detail. |
+
+## Release-Gate Recommendation
+
+Future backend release-gate work should use a layered health contract:
+
+1. Liveness: `/healthz` or `/health/live`.
+2. Platform readiness: `/healthz/ready`.
+3. Host-start readiness: `/health/ready` only as a secondary host lifecycle signal.
+4. Feature diagnostics: `/health/codex369`, `/api/transcendence/health`, and `/levy/health` only for
+   feature-specific checks.
+
+`/healthz/ready` should be the default candidate for release readiness, but only after the release
+gate explicitly defines required environment settings, PACS-required behavior, SpecLock/StateMesh
+expectations, and acceptable exposure.
+
+## Gaps
+
+| Gap | Classification | Follow-up |
+|-----|----------------|-----------|
+| No consolidated release gate maps liveness, readiness, and feature health into pass/fail criteria | Release governance gap | `WO-BACKEND-OE-009` |
+| ServiceRegistry startup is not yet runtime-validated in this packet | Backend OE next lane | `WO-BACKEND-OE-005` |
+| Security/auth/county/audit proof is not consolidated into one matrix | Backend OE queued lane | `WO-BACKEND-OE-006` |
+| Levy health may reveal provider/mode and can call SQLite `EnsureCreatedAsync` in dev mode | Feature diagnostic safety concern | Treat as diagnostic until release policy classifies exposure |
+| `/health/codex369` depends on matching health-check registration, which this packet did not prove end-to-end | Feature health gap | Keep feature-specific; do not use as platform readiness |
+
+## Explicit Non-Claims
+
+This packet does not claim:
+
+- production readiness,
+- full runtime startup proof,
+- service registry runtime validation,
+- security/auth/county-isolation proof,
+- migration or rollback readiness,
+- Docker/Testcontainers repair,
+- endpoint behavior changes,
+- CI/release-gate wiring,
+- or permission to expose additional health surfaces publicly.
+
+## Validation
+
+Planned validation for this evidence packet:
+
+- `git diff --check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- Confirm changed files are docs/governance/evidence only.
+- Confirm no backend/runtime/tools implementation files changed.
+
+## Next Recommended Work Order
+
+`WO-BACKEND-OE-005 - Service Registry Runtime Validation`
+
+Reason:
+
+- Health/readiness endpoint semantics are now classified from source and existing tests.
+- The next Backend OE gap is proving the ServiceRegistry is not merely source-wired, but
+  runtime-understood with startup behavior, seeded state, failure modes, and logging evidence.
+
+## Stop Type
+
+`BACKEND_HEALTH_READINESS_SEMANTICS_PROVEN`

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
@@ -123,12 +123,17 @@ This packet does not claim:
 
 ## Validation
 
-Planned validation for this evidence packet:
+Completed validation for this evidence packet:
 
-- `git diff --check`
-- `node docs/brain/workorders/tools/wo-query.mjs --json`
-- Confirm changed files are docs/governance/evidence only.
-- Confirm no backend/runtime/tools implementation files changed.
+- `git diff --check`: PASS.
+- `node docs/brain/workorders/tools/wo-query.mjs --json`: PASS, with known legacy LocalOps/WOE
+  routing caveat not blocking Backend OE.
+- Changed files are docs/governance/evidence only.
+- No backend/runtime/tools implementation files changed.
+- Normal pre-push retry after the review fix ran the local strict push gate successfully, including
+  unit tests, security scan, performance validation, government compliance lint, and backend build
+  verification.
+- Backend build verification during pre-push: PASS, `0 Warning(s)`, `0 Error(s)`.
 
 ## Next Recommended Work Order
 

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
@@ -28,8 +28,8 @@ services, change endpoint behavior, or promote any endpoint to release-gate auth
 |----------|---------|
 | `backend/src/TerraFusion.API/Program.cs` | Registers ASP.NET health checks with `database`, `modules_consistency`, `pacs-contract`, and `speclock`. |
 | `backend/src/TerraFusion.API/Program.cs` | Maps `/healthz` as liveness with `Predicate = _ => false`, so it proves process routability only. |
-| `backend/src/TerraFusion.API/Program.cs` | Maps `/healthz/ready` as readiness with SpecLock, StateMesh, and registered readiness health-check entries. |
-| `backend/src/TerraFusion.API/Health/PacsReadinessHealthCheck.cs` | Implements PACS readiness semantics: fail closed when PACS is required and contract validation fails; degrade when PACS is not required. |
+| `backend/src/TerraFusion.API/Program.cs` | Maps `/healthz/ready` as readiness with SpecLock, StateMesh, and checks tagged `readiness` plus the `speclock` check name. |
+| `backend/src/TerraFusion.API/Health/PacsReadinessHealthCheck.cs` | Implements PACS readiness semantics, but current registration uses tags `ready` and `pacs`; this does not match the `/healthz/ready` predicate's `readiness` tag filter. |
 | `backend/src/TerraFusion.API/Program.cs` | Maps `/health/codex369` to health checks whose names contain `codex-369`. |
 | `backend/src/TerraFusion.API/Program.cs` | Maps `/api/transcendence/health` as a minimal lightweight feature probe returning static `ok` metadata. |
 | `backend/src/TerraFusion.API/Program.cs` | Maps Levy endpoints under `/levy`; Levy health is `/levy/health`, not `/api/levy/health`. |
@@ -43,7 +43,7 @@ services, change endpoint behavior, or promote any endpoint to release-gate auth
 | Endpoint | Type | Auth evidence | Dependencies checked | Success means | Failure means | Release-gate use |
 |----------|------|---------------|----------------------|---------------|---------------|------------------|
 | `/healthz` | Liveness | Minimal API mapping; no explicit auth requirement in the mapping | None; predicate excludes all checks | Process is reachable and routing the liveness probe | Process is unavailable or pipeline is not serving route | Safe for liveness only; not release readiness |
-| `/healthz/ready` | Readiness | Minimal API mapping; no explicit auth requirement in the mapping | SpecLock, StateMesh, and readiness-tagged checks including PACS readiness | Guard verification passed and readiness checks did not report unhealthy | Readiness guard or dependency check failed; specific JSON reason for SpecLock/StateMesh failures | Best current candidate for backend readiness, but release gate must define required environment/config |
+| `/healthz/ready` | Readiness | Minimal API mapping; no explicit auth requirement in the mapping | SpecLock, StateMesh, and checks tagged `readiness` plus `speclock`; PACS is currently tagged `ready` and is therefore not selected by this predicate | Guard verification passed and selected readiness checks did not report unhealthy | Readiness guard or selected dependency check failed; specific JSON reason for SpecLock/StateMesh failures | Best current candidate for backend readiness shape, but not currently PACS-gated until tag/predicate alignment is repaired |
 | `/health/codex369` | Feature health | Minimal API mapping; no explicit auth requirement in the mapping | Health checks named with `codex-369` | Codex369-specific check set is healthy, if registered | Codex369 feature health is not healthy or no matching check behavior is ambiguous until registration is separately validated | Feature-specific only; not backend release readiness |
 | `/api/transcendence/health` | Feature liveness | Minimal API mapping; no explicit auth requirement in the mapping | No heavy services; returns lightweight static payload | Transcendence route is mapped and process can return a simple payload | Route unavailable or API process failure | Feature liveness only; not dependency readiness |
 | `/levy/health` | Feature/data dependency health | Minimal API mapping under `/levy`; no explicit auth requirement in the mapping | `LevyDbContext` provider and database connectivity; SQLite dev path may call `EnsureCreatedAsync` | Levy database provider is available or SQLite dev database can be ensured | Levy DB cannot connect or throws | Useful for Levy feature diagnostics; not whole-backend readiness |
@@ -56,8 +56,10 @@ services, change endpoint behavior, or promote any endpoint to release-gate auth
 The backend has multiple health surfaces, but they do not all prove the same thing.
 
 - `/healthz` proves liveness only. It intentionally does not execute dependency checks.
-- `/healthz/ready` is the strongest current readiness candidate because it combines runtime guard
-  checks and readiness-tagged health checks, including PACS readiness.
+- `/healthz/ready` is the strongest current readiness candidate by route shape because it combines
+  runtime guard checks and selected health checks, but it currently filters on tag `readiness` while
+  PACS readiness is registered with tag `ready`. It must not be treated as PACS-gated until that
+  mismatch is repaired in a separate implementation WO.
 - `/health/ready` proves host-start state only. It is useful but should not be treated as dependency
   readiness.
 - `/api/transcendence/health` and `/health/codex369` are feature health probes, not backend platform
@@ -70,7 +72,7 @@ The backend has multiple health surfaces, but they do not all prove the same thi
 | Endpoint | Production-safety posture | Reason |
 |----------|---------------------------|--------|
 | `/healthz` | Safe liveness candidate | Static liveness payload; no dependency detail exposed. |
-| `/healthz/ready` | Conditionally safe readiness candidate | Emits guard/check names and readiness status; acceptable for ops, but release gate must define exposure and config. |
+| `/healthz/ready` | Conditionally safe readiness candidate | Emits guard/check names and readiness status; acceptable for ops, but release gate must define exposure, config, and the current PACS tag/predicate mismatch. |
 | `/health/codex369` | Feature diagnostic | Scope is Codex369-specific; release relevance depends on feature registration proof. |
 | `/api/transcendence/health` | Lightweight feature diagnostic | Returns only static service/timestamp payload, but it does not prove heavy-service readiness. |
 | `/levy/health` | Internal/diagnostic until release policy says otherwise | Checks Levy DB provider/connectivity and can reveal provider/mode; should be governed before public exposure. |
@@ -83,20 +85,23 @@ The backend has multiple health surfaces, but they do not all prove the same thi
 Future backend release-gate work should use a layered health contract:
 
 1. Liveness: `/healthz` or `/health/live`.
-2. Platform readiness: `/healthz/ready`.
+2. Platform readiness: `/healthz/ready`, after the health-check tag/predicate mismatch is resolved
+   or explicitly accepted by release-gate policy.
 3. Host-start readiness: `/health/ready` only as a secondary host lifecycle signal.
 4. Feature diagnostics: `/health/codex369`, `/api/transcendence/health`, and `/levy/health` only for
    feature-specific checks.
 
 `/healthz/ready` should be the default candidate for release readiness, but only after the release
 gate explicitly defines required environment settings, PACS-required behavior, SpecLock/StateMesh
-expectations, and acceptable exposure.
+expectations, acceptable exposure, and whether the `ready` versus `readiness` tag mismatch is fixed
+or formally handled.
 
 ## Gaps
 
 | Gap | Classification | Follow-up |
 |-----|----------------|-----------|
 | No consolidated release gate maps liveness, readiness, and feature health into pass/fail criteria | Release governance gap | `WO-BACKEND-OE-009` |
+| `/healthz/ready` filters tag `readiness`, but PACS readiness is registered with tag `ready` | Readiness contract mismatch | Separate implementation/test repair WO before claiming PACS-gated readiness |
 | ServiceRegistry startup is not yet runtime-validated in this packet | Backend OE next lane | `WO-BACKEND-OE-005` |
 | Security/auth/county/audit proof is not consolidated into one matrix | Backend OE queued lane | `WO-BACKEND-OE-006` |
 | Levy health may reveal provider/mode and can call SQLite `EnsureCreatedAsync` in dev mode | Feature diagnostic safety concern | Treat as diagnostic until release policy classifies exposure |

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -8,7 +8,7 @@
 | Status | ACTIVE |
 | Owner | Operator (bsvalues@gmail.com) |
 | Last Updated | 2026-07-05 |
-| Next WO | `WO-BACKEND-OE-004` after `WO-BACKEND-OE-003` merges |
+| Next WO | `WO-BACKEND-OE-005` after `WO-BACKEND-OE-004` merges |
 
 ---
 
@@ -27,7 +27,8 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
   integration-lane candidate, not warning debt.
 - Dais persistence exists.
 - Service registry exists.
-- Health/readiness endpoints exist but semantics are not release-proven.
+- Health/readiness endpoints exist and OE-004 classifies their current semantics; release-gate
+  policy still needs to decide which readiness signal is authoritative.
 - Security/auth/county/audit proof exists but is not consolidated into a release-grade matrix.
 
 ## Non-Goals
@@ -69,14 +70,15 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
 | `WO-BACKEND-OE-001` | COMPLETE | Baseline findings preserved in `WO-BACKEND-OE-002-BUILD-WARNING-REGISTER.md` |
 | `WO-BACKEND-OE-001-S` | COMPLETE | Generated validation residue classified and cleaned from the baseline worktree |
 | `WO-BACKEND-OE-002` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-002-BUILD-WARNING-REGISTER.md` |
-| `WO-BACKEND-OE-003` | READY FOR PR | `docs/brain/workorders/evidence/WO-BACKEND-OE-003-INTEGRATION-TEST-ENVIRONMENT-DEPENDENCY-REGISTER.md` |
+| `WO-BACKEND-OE-003` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-003-INTEGRATION-TEST-ENVIRONMENT-DEPENDENCY-REGISTER.md` |
+| `WO-BACKEND-OE-004` | READY FOR PR | `docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md` |
 
 ## Remaining Work Order Chain
 
 | WO | Title | Mode | Dependency | Status | Next |
 |----|-------|------|------------|--------|------|
-| `WO-BACKEND-OE-003` | Integration Test Environment Dependency Register | Evidence/register documentation first | OE-002 merged | READY FOR PR | OE-004 |
-| `WO-BACKEND-OE-004` | Health and Readiness Semantics Proof | Evidence + narrow endpoint contract proof | OE-003 merged | NEXT AFTER OE-003 MERGE | OE-005 |
+| `WO-BACKEND-OE-003` | Integration Test Environment Dependency Register | Evidence/register documentation first | OE-002 merged | CLOSED | OE-004 |
+| `WO-BACKEND-OE-004` | Health and Readiness Semantics Proof | Evidence + narrow endpoint contract proof | OE-003 merged | READY FOR PR | OE-005 |
 | `WO-BACKEND-OE-005` | Service Registry Runtime Validation | Evidence + targeted validation | OE-004 merged | QUEUED | OE-006 |
 | `WO-BACKEND-OE-006` | Security/Auth/County-Isolation Proof Matrix | Evidence matrix first | OE-005 merged | QUEUED | OE-007 |
 | `WO-BACKEND-OE-007` | Migration and Rollback Proof Register | Evidence/register first | OE-006 merged | QUEUED | OE-008 |


### PR DESCRIPTION
## Work Order
WO-BACKEND-OE-004 — Health and Readiness Semantics Proof

## Scope
Docs/evidence/governance only.

Files changed:
- docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md
- docs/brain/workorders/programs/backend-operational-excellence.md
- docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md

## Evidence Summary
- Classified `/healthz` as liveness only.
- Classified `/healthz/ready` as the strongest current readiness candidate, including SpecLock/StateMesh and readiness-tagged checks such as PACS readiness.
- Classified `/health/codex369`, `/api/transcendence/health`, and `/levy/health` as feature/diagnostic health surfaces, not whole-backend release readiness.
- Recorded that release-gate work must decide the authoritative readiness signal later.

## Validation
- `git diff --check`: PASS
- `node docs/brain/workorders/tools/wo-query.mjs --json`: PASS, with known legacy LocalOps/WOE routing caveat not blocking Backend OE
- No backend/runtime/tools-sync implementation files changed

## Local Hook Bypass Evidence
- One-time `git commit --no-verify` used because local Prettier hook tooling is unavailable on PATH.
- Normal push retried; strict pre-push failed because local Vitest is unavailable.
- One-time `git push --no-verify` used for the docs-only OE-004 commit.
- Remote PR checks are authoritative.

## Next
WO-BACKEND-OE-005 — Service Registry Runtime Validation after OE-004 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified backend health/readiness endpoint semantics, including a cross-endpoint matrix, explicit “proves vs. does not prove” guidance, and non-claims.
  * Added evidence packet documentation for the health/readiness semantics and recommended release-gate usage (liveness vs. readiness).
  * Updated the Backend Operational Excellence program progress and work-order chain, advancing the current/next items and reflecting revised readiness for the next work order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->