### PR TITLE
fix(workbench): Clerk honesty badge — parcel-scoped provenance + state-aware copy (WO-WB-INSTR-003 follow-up)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
@@ -167,6 +167,40 @@ describe('PropertyClerk source honesty contract', () => {
     expect(badgeSource()).toBe('live');
   });
 
+  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
+    // During parcel-to-parcel navigation the store can still hold the previous
+    // activeParcel for one frame; that must not read as live for this tab's parcel.
+    storeView = {
+      recordings: [
+        { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
+      ],
+      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    render(<TestWrapper parcelId={PARCEL_ID} />);
+    expect(badgeSource()).toBe('unavailable');
+  });
+
+  it('disclosure copy is state-aware — never claims live loading while the badge reads unavailable', () => {
+    // Idle: badge unavailable, so the copy must NOT assert the parcel is loaded live.
+    const { rerender } = render(<TestWrapper />);
+    let disclosure = screen.getByTestId('clerk-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/not currently available/i);
+    expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
+
+    // Loaded: badge live, so the copy asserts the live-loaded state.
+    storeView = {
+      recordings: [],
+      activeParcel: { parcelId: PARCEL_ID },
+      activeParcelLoading: false,
+      activeParcelError: null,
+    };
+    rerender(<TestWrapper />);
+    disclosure = screen.getByTestId('clerk-baseline-disclosure');
+    expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);
+  });
+
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
     storeView = {
       recordings: [],

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -85,15 +85,18 @@ interface RecordingSummaryResult {
 export const PropertyClerk: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const recordings = usePropertyStore((s) => s.recordings);
-  // Source provenance for the baseline disclosure badge. The parcel evidence
-  // bundle (recordings included) is loaded together in propertyStore.selectParcel;
-  // its load success is signalled by activeParcel being set with no active
-  // load/error — NOT by whether the recordings array happens to be non-empty
-  // (a live load can legitimately return zero recordings).
+  // Source provenance for the baseline disclosure badge. This reflects whether
+  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set
+  // for this parcelId, not loading, no error) — the honest signal the store
+  // exposes. It is NOT keyed on the recordings row count (a live load can
+  // legitimately return zero recordings), and it requires the loaded parcel to be
+  // this tab's parcel so a stale previous activeParcel during navigation does not
+  // read as live. propertyStore exposes no recording-slice-specific provenance, so
+  // the disclosure copy is scoped to parcel-context, not recording-evidence, load.
   const activeParcel = usePropertyStore((s) => s.activeParcel);
   const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
   const parcelError = usePropertyStore((s) => s.activeParcelError);
-  const evidenceLoaded = Boolean(activeParcel) && !parcelLoading && !parcelError;
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool
@@ -255,9 +258,11 @@ export const PropertyClerk: React.FC = () => {
 
       <div className='flex items-center justify-between gap-3 px-2' data-testid='clerk-baseline-disclosure'>
         <p className='text-xs tf-text-dim'>
-          This parcel's recording context is loaded from the live property evidence feed; recording and
-          title tools are invoked on demand through governed tooling and their results are shown only
-          after you run them, never inferred.
+          {evidenceLoaded
+            ? 'This parcel is loaded from the live property evidence feed.'
+            : 'Live property evidence for this parcel is not currently available.'}{' '}
+          Recording and title tools are invoked on demand through governed tooling; their results are
+          shown only after you run them, never inferred.
         </p>
         <WorkbenchSourceBadge source={evidenceLoaded ? 'live' : 'unavailable'} />
       </div>


### PR DESCRIPTION
## WO-WB-INSTR-003 follow-up — Clerk honesty corrections

Brings **PropertyClerk** (merged in #1205) in line with the two corrections that adversarial review surfaced later in the program on Treasury (#1207) and Audit (#1208). Same-risk, additive, same allowed files.

### Changes
1. **Parcel-scoped provenance** — `evidenceLoaded = activeParcel?.parcelId === parcelId && !activeParcelLoading && !activeParcelError` (was a bare `Boolean(activeParcel)`). During parcel-to-parcel navigation the store can hold the *previous* `activeParcel` for one frame; the old check would briefly read `live` for the wrong parcel (codex + copilot raised this on #1208).
2. **State-aware disclosure copy** — the sentence is now driven by `evidenceLoaded`, so it never asserts "This parcel is loaded from the live property evidence feed" while the badge reads `unavailable` (CodeRabbit raised this on #1207).

### Tests added
- badge reads `unavailable` when the store holds a **different** parcel (stale-nav frame);
- disclosure copy is state-aware (idle says 'not currently available' and never claims live; loaded asserts the live state).

### Non-goals (unchanged)
No backend, tool registry, routing, data-model, API-service, package/build/CI, deploy, or PACS/county-data changes.

### Validation
Frontend Gate + Vitest Full Suite + required contexts must pass; threads resolved before merge. No break-glass / no --admin.