### PR TITLE
feat(workbench): slice-aware store provenance + Clerk consumer (WO-WB-PROV-002/003)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
@@ -1,19 +1,19 @@
 /**
  * PropertyClerk.honesty.contract.test.tsx
  *
- * Source honesty contract for the PropertyClerk tab (WO-WB-INSTR-003).
- * Mirrors the Dossier/Pilot/Dais honesty contracts. Ensures:
+ * Source honesty contract for the PropertyClerk tab (WO-WB-INSTR-003, slice-aware
+ * under WO-WB-PROV-003). Ensures:
  *   1. Baseline disclosure box carries a WorkbenchSourceBadge
- *   2. That badge shows "unavailable" when the parcel evidence has not loaded
- *   3. It reflects "live" once the parcel evidence bundle loads successfully —
+ *   2. That badge shows "unavailable" until the related-data bundle (which holds
+ *      the recordings slice) has loaded — including while the parcel shell is up
+ *      but the bundle is still loading, and after a bundle load error
+ *   3. It reflects "live" once relatedDataStatus === 'loaded' for THIS parcel —
  *      including a successful load that returns zero recordings (load-success
- *      provenance, NOT recording row count), and it flips on the empty -> loaded
- *      transition (not memoized at mount)
- *   4. No aspirational "AI-powered" language
- *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
+ *      provenance, NOT recording row count), and it flips on the transition
+ *      (not memoized at mount)
+ *   4. A stale previous parcel's loaded status does not read as live (parcelId guard)
+ *   5. No aspirational "AI-powered" language; state-aware disclosure copy
  *   6. No tool is invoked on mount (the tab only lists tools)
- *
- * Reuses the mock setup from PropertyClerk.test.tsx.
  */
 
 import '@testing-library/jest-dom';
@@ -28,7 +28,9 @@ import PropertyClerk from '../../pages/workbench/tabs/PropertyClerk';
 
 vi.mock('../../api/pilotApi');
 
-// Mutable store view driven per-test to exercise the load-provenance states.
+type RelatedDataStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+// Mutable store view driven per-test to exercise the slice-load-provenance states.
 interface StoreView {
   recordings: Array<{
     recordingId: string;
@@ -38,24 +40,18 @@ interface StoreView {
     recordingDate: string;
   }>;
   activeParcel: { parcelId: string } | null;
-  activeParcelLoading: boolean;
-  activeParcelError: { message: string } | null;
+  relatedDataStatus: RelatedDataStatus;
 }
 
 let storeView: StoreView = {
   recordings: [],
   activeParcel: null,
-  activeParcelLoading: false,
-  activeParcelError: null,
+  relatedDataStatus: 'idle',
 };
 
 vi.mock('../../stores/propertyStore', () => ({
   usePropertyStore: (selector: (s: StoreView) => unknown) =>
     typeof selector === 'function' ? selector(storeView) : storeView,
-}));
-
-vi.mock('../../runtime/env', () => ({
-  getEnv: () => ({ VITE_API_URL: 'http://localhost:5000' }),
 }));
 
 vi.mock('../../components/workbench', () => ({
@@ -97,6 +93,12 @@ const badgeSource = () =>
     .querySelector('[data-testid="workbench-source-badge"]')
     ?.getAttribute('data-source');
 
+const loadedFor = (parcelId: string, recordings: StoreView['recordings'] = []): StoreView => ({
+  recordings,
+  activeParcel: { parcelId },
+  relatedDataStatus: 'loaded',
+});
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('PropertyClerk source honesty contract', () => {
@@ -105,8 +107,7 @@ describe('PropertyClerk source honesty contract', () => {
     storeView = {
       recordings: [],
       activeParcel: null,
-      activeParcelLoading: false,
-      activeParcelError: null,
+      relatedDataStatus: 'idle',
     };
   });
 
@@ -116,68 +117,52 @@ describe('PropertyClerk source honesty contract', () => {
     expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
   });
 
-  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
+  it('baseline badge shows "unavailable" before the parcel evidence loads (idle)', () => {
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
-    storeView = { ...storeView, activeParcelLoading: true };
+  it('baseline badge shows "unavailable" while the parcel shell is up but the related bundle is still loading', () => {
+    // Slice-aware: activeParcel is set for this parcel, but relatedDataStatus is
+    // 'loading' — the recordings bundle has not resolved, so the badge is NOT live.
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
-    storeView = {
-      ...storeView,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelError: { message: 'load failed' },
-    };
+  it('baseline badge shows "unavailable" when the related evidence bundle load errored', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'error' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge reflects "live" on a successful evidence load even with zero recordings', () => {
-    // Load-success provenance, NOT row count: a live load returning no recordings
+  it('baseline badge reflects "live" on a loaded bundle even with zero recordings', () => {
+    // Load-success provenance, NOT row count: a loaded bundle with no recordings
     // is still live, not unavailable.
-    storeView = {
-      recordings: [],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, []);
     render(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+  it('baseline badge flips unavailable -> live on the loading -> loaded transition (not memoized)', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     const { rerender } = render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
 
-    // Parcel evidence finishes loading successfully.
-    storeView = {
-      recordings: [
-        { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
-      ],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    // Related bundle finishes loading successfully.
+    storeView = loadedFor(PARCEL_ID, [
+      { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
+    ]);
     rerender(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
+  it('baseline badge shows "unavailable" when a DIFFERENT parcel bundle is loaded (stale nav frame)', () => {
     // During parcel-to-parcel navigation the store can still hold the previous
-    // activeParcel for one frame; that must not read as live for this tab's parcel.
-    storeView = {
-      recordings: [
-        { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
-      ],
-      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    // parcel's loaded bundle for one frame; that must not read as live here.
+    storeView = loadedFor('SOME-OTHER-PARCEL', [
+      { recordingId: 'REC-1', documentType: 'Deed', grantor: 'Alice', grantee: 'Bob', recordingDate: '2026-01-15' },
+    ]);
     render(<TestWrapper parcelId={PARCEL_ID} />);
     expect(badgeSource()).toBe('unavailable');
   });
@@ -190,24 +175,14 @@ describe('PropertyClerk source honesty contract', () => {
     expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
 
     // Loaded: badge live, so the copy asserts the live-loaded state.
-    storeView = {
-      recordings: [],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, []);
     rerender(<TestWrapper />);
     disclosure = screen.getByTestId('clerk-baseline-disclosure');
     expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);
   });
 
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
-    storeView = {
-      recordings: [],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, []);
     render(<TestWrapper />);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {
       expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyClerk.honesty.contract.test.tsx
@@ -23,12 +23,13 @@ import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import * as pilotApi from '../../api/pilotApi';
 import PropertyClerk from '../../pages/workbench/tabs/PropertyClerk';
+// Type-only import (erased at runtime) so the test's status union stays aligned
+// with the store's real state machine while the module is still runtime-mocked below.
+import type { RelatedDataStatus } from '../../stores/propertyStore';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('../../api/pilotApi');
-
-type RelatedDataStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 // Mutable store view driven per-test to exercise the slice-load-provenance states.
 interface StoreView {

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyClerk.tsx
@@ -85,18 +85,17 @@ interface RecordingSummaryResult {
 export const PropertyClerk: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const recordings = usePropertyStore((s) => s.recordings);
-  // Source provenance for the baseline disclosure badge. This reflects whether
-  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set
-  // for this parcelId, not loading, no error) — the honest signal the store
-  // exposes. It is NOT keyed on the recordings row count (a live load can
-  // legitimately return zero recordings), and it requires the loaded parcel to be
-  // this tab's parcel so a stale previous activeParcel during navigation does not
-  // read as live. propertyStore exposes no recording-slice-specific provenance, so
-  // the disclosure copy is scoped to parcel-context, not recording-evidence, load.
+  // Source provenance for the baseline disclosure badge. This is SLICE-AWARE:
+  // recordings live in the eager related-data bundle, whose load lifecycle the
+  // store now tracks via relatedDataStatus. The badge reads live only once that
+  // bundle has actually loaded for THIS parcel — not merely when the parcel shell
+  // loaded (activeParcelLoading clears before the bundle resolves). The parcelId
+  // guard prevents a stale previous parcel's 'loaded' status from reading live
+  // during navigation. It is NOT keyed on the recordings row count (a live load
+  // can legitimately return zero recordings).
   const activeParcel = usePropertyStore((s) => s.activeParcel);
-  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
-  const parcelError = usePropertyStore((s) => s.activeParcelError);
-  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
+  const relatedDataStatus = usePropertyStore((s) => s.relatedDataStatus);
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && relatedDataStatus === 'loaded';
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool

--- a/frontend/apps/os-shell/src/stores/__tests__/propertyStore.relatedDataStatus.test.ts
+++ b/frontend/apps/os-shell/src/stores/__tests__/propertyStore.relatedDataStatus.test.ts
@@ -123,6 +123,37 @@ describe('propertyStore relatedDataStatus provenance', () => {
     expect(usePropertyStore.getState().activeParcelError?.status).toBe(404);
   });
 
+  it('ignores a stale related-data completion when the same parcel is re-selected', async () => {
+    // codex race: re-selecting/refreshing the same parcel while an earlier bundle
+    // is in flight must not let the stale bundle overwrite the newer load's status.
+    let rejectStale: (reason?: unknown) => void = () => {};
+    const stalePending = new Promise((_, reject) => {
+      rejectStale = reject;
+    });
+    // First select's tax call hangs (stale bundle in flight); second select's resolves.
+    providerMock.getTaxStatements
+      .mockReturnValueOnce(stalePending)
+      .mockResolvedValueOnce([]);
+
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+    await waitFor(() => {
+      expect(usePropertyStore.getState().relatedDataStatus).toBe('loading');
+    });
+
+    // Re-select the same parcel — a newer bundle supersedes the stale one.
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+    await waitFor(() => {
+      expect(usePropertyStore.getState().relatedDataStatus).toBe('loaded');
+    });
+
+    // The stale first bundle now REJECTS — its continuation must bail, not clobber.
+    rejectStale(new Error('stale bundle rejected'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(usePropertyStore.getState().relatedDataStatus).toBe('loaded');
+  });
+
   it('resets to "idle" on clearParcel', async () => {
     void usePropertyStore.getState().selectParcel('P-PROV-001');
     await waitFor(() => {

--- a/frontend/apps/os-shell/src/stores/__tests__/propertyStore.relatedDataStatus.test.ts
+++ b/frontend/apps/os-shell/src/stores/__tests__/propertyStore.relatedDataStatus.test.ts
@@ -1,0 +1,135 @@
+/**
+ * propertyStore.relatedDataStatus.test.ts
+ *
+ * WO-WB-PROV-002 — verifies the frontend-only relatedDataStatus provenance flag
+ * that backs slice-aware Workbench honesty badges. The related-data bundle
+ * (assessments/documents/appeals/taxStatements/recordings/auditTrail/operations)
+ * loads all-or-nothing in selectParcel; relatedDataStatus records its lifecycle:
+ *   idle -> loading (shell loaded, bundle in flight) -> loaded (bundle resolved)
+ *   idle -> loading -> error (bundle rejected)
+ *   idle after a not-found parcel (no bundle fired)
+ */
+
+import { waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePropertyStore } from '../propertyStore';
+
+const providerMock = vi.hoisted(() => ({
+  getParcel: vi.fn(),
+  getAssessments: vi.fn(),
+  getDocuments: vi.fn(),
+  getAppeals: vi.fn(),
+  getTaxStatements: vi.fn(),
+  getRecordingHistory: vi.fn(),
+  getAuditTrail: vi.fn(),
+  getRecentOperations: vi.fn(),
+}));
+
+vi.mock('../../services/dataProvider', () => ({
+  getDataProvider: () => providerMock,
+}));
+
+const parcel = {
+  parcelId: 'P-PROV-001',
+  address: '1 Provenance Way',
+  city: 'Prosser',
+  ownerName: 'Prov Tester',
+  totalAssessedValue: 250000,
+  propertyType: 'Residential',
+  assessmentYear: 2025,
+};
+
+const resolveAllBundle = () => {
+  providerMock.getAssessments.mockResolvedValue([]);
+  providerMock.getDocuments.mockResolvedValue([]);
+  providerMock.getAppeals.mockResolvedValue([]);
+  providerMock.getTaxStatements.mockResolvedValue([]);
+  providerMock.getRecordingHistory.mockResolvedValue([]);
+  providerMock.getAuditTrail.mockResolvedValue([]);
+  providerMock.getRecentOperations.mockResolvedValue([]);
+};
+
+describe('propertyStore relatedDataStatus provenance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    usePropertyStore.setState({
+      activeParcel: null,
+      activeParcelLoading: false,
+      activeParcelError: null,
+      assessments: [],
+      documents: [],
+      appeals: [],
+      taxStatements: [],
+      recordings: [],
+      auditTrail: [],
+      operations: [],
+      relatedDataStatus: 'idle',
+      recentParcels: [],
+    });
+    providerMock.getParcel.mockResolvedValue(parcel);
+    resolveAllBundle();
+  });
+
+  it('starts idle', () => {
+    expect(usePropertyStore.getState().relatedDataStatus).toBe('idle');
+  });
+
+  it('transitions to "loaded" once the related-data bundle resolves', async () => {
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+
+    await waitFor(() => {
+      expect(usePropertyStore.getState().activeParcel?.parcelId).toBe('P-PROV-001');
+    });
+    await waitFor(() => {
+      expect(usePropertyStore.getState().relatedDataStatus).toBe('loaded');
+    });
+  });
+
+  it('is "loading" (not "loaded") while the parcel shell is up but the bundle is in flight', async () => {
+    // Hold one bundle slice pending so the Promise.all never settles.
+    providerMock.getRecordingHistory.mockReturnValue(new Promise(() => {}));
+
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+
+    await waitFor(() => {
+      expect(usePropertyStore.getState().activeParcel?.parcelId).toBe('P-PROV-001');
+    });
+    // Shell is up but the bundle has not resolved.
+    expect(usePropertyStore.getState().activeParcelLoading).toBe(false);
+    expect(usePropertyStore.getState().relatedDataStatus).toBe('loading');
+  });
+
+  it('transitions to "error" and clears slices when the bundle rejects', async () => {
+    providerMock.getTaxStatements.mockRejectedValue(new Error('bundle boom'));
+
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+
+    await waitFor(() => {
+      expect(usePropertyStore.getState().relatedDataStatus).toBe('error');
+    });
+    expect(usePropertyStore.getState().taxStatements).toEqual([]);
+    expect(usePropertyStore.getState().recordings).toEqual([]);
+    expect(usePropertyStore.getState().auditTrail).toEqual([]);
+  });
+
+  it('stays "idle" for a not-found parcel (no bundle fired)', async () => {
+    providerMock.getParcel.mockResolvedValue(null);
+
+    await usePropertyStore.getState().selectParcel('P-MISSING');
+
+    expect(usePropertyStore.getState().relatedDataStatus).toBe('idle');
+    expect(usePropertyStore.getState().activeParcelError?.status).toBe(404);
+  });
+
+  it('resets to "idle" on clearParcel', async () => {
+    void usePropertyStore.getState().selectParcel('P-PROV-001');
+    await waitFor(() => {
+      expect(usePropertyStore.getState().relatedDataStatus).toBe('loaded');
+    });
+
+    usePropertyStore.getState().clearParcel();
+    expect(usePropertyStore.getState().relatedDataStatus).toBe('idle');
+  });
+});

--- a/frontend/apps/os-shell/src/stores/propertyStore.ts
+++ b/frontend/apps/os-shell/src/stores/propertyStore.ts
@@ -87,6 +87,13 @@ interface PropertyState {
 
 const MAX_RECENT = 10;
 const PARCEL_EVIDENCE_TIMEOUT_MS = 20_000;
+
+// Monotonic token for the latest selectParcel() invocation. Each call captures
+// its own requestSeq; the shell and related-data (bundle) continuations bail if a
+// newer selectParcel has started — even for the SAME parcelId (re-select/refresh),
+// where a parcelId-only guard would let a stale bundle overwrite the newer load's
+// slices or relatedDataStatus.
+let selectParcelSeq = 0;
 const EMPTY_RELATED_DATA = {
   assessments: [],
   documents: [],
@@ -161,6 +168,7 @@ export const usePropertyStore = create<PropertyState>()(
 
       // Select a parcel — sets active and eagerly loads all related data
       selectParcel: async (parcelId: string) => {
+        const requestSeq = ++selectParcelSeq;
         set({
           activeParcelLoading: true,
           activeParcelLoadingParcelId: parcelId,
@@ -171,7 +179,7 @@ export const usePropertyStore = create<PropertyState>()(
         try {
           const provider = getDataProvider();
           const parcel = await withParcelEvidenceTimeout(parcelId, provider.getParcel(parcelId));
-          if (get().activeParcelLoadingParcelId !== parcelId) return;
+          if (selectParcelSeq !== requestSeq) return;
           if (!parcel) {
             set({
               activeParcel: null,
@@ -224,7 +232,7 @@ export const usePropertyStore = create<PropertyState>()(
               provider.getRecentOperations(parcelId),
             ])
             .then(([assessments, documents, appeals, taxStatements, recordings, auditTrail, operations]) => {
-              if (get().activeParcel?.parcelId !== parcel.parcelId) return;
+              if (selectParcelSeq !== requestSeq) return;
               set({
                 assessments,
                 documents,
@@ -237,7 +245,7 @@ export const usePropertyStore = create<PropertyState>()(
               });
             })
             .catch(() => {
-              if (get().activeParcel?.parcelId !== parcel.parcelId) return;
+              if (selectParcelSeq !== requestSeq) return;
               set({
                 assessments: [],
                 documents: [],
@@ -250,7 +258,7 @@ export const usePropertyStore = create<PropertyState>()(
               });
             });
         } catch (error) {
-          if (get().activeParcelLoadingParcelId !== parcelId) return;
+          if (selectParcelSeq !== requestSeq) return;
           set({
             activeParcel: null,
             activeParcelLoading: false,

--- a/frontend/apps/os-shell/src/stores/propertyStore.ts
+++ b/frontend/apps/os-shell/src/stores/propertyStore.ts
@@ -32,6 +32,14 @@ import { isApiFetchError } from '../services/LiveDataProvider';
 // State Shape
 // ---------------------------------------------------------------------------
 
+/**
+ * Provenance of the eager related-data bundle (assessments/documents/appeals/
+ * taxStatements/recordings/auditTrail/operations) for the active parcel.
+ * The bundle is loaded all-or-nothing in selectParcel, so 'loaded' means every
+ * rendered related slice is available. Drives slice-aware Workbench honesty badges.
+ */
+export type RelatedDataStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
 interface PropertyState {
   // Active parcel (selected via search or navigation)
   activeParcel: Property | null;
@@ -58,6 +66,10 @@ interface PropertyState {
   recordings: RecordingEntry[];
   auditTrail: AuditEntry[];
   operations: OperationTrace[];
+
+  // Provenance of the eager related-data bundle for the active parcel (see
+  // RelatedDataStatus). 'loaded' means the rendered related slice is available.
+  relatedDataStatus: RelatedDataStatus;
 
   // History
   recentParcels: PropertySearchResult[];
@@ -125,6 +137,7 @@ export const usePropertyStore = create<PropertyState>()(
       recordings: [],
       auditTrail: [],
       operations: [],
+      relatedDataStatus: 'idle',
       recentParcels: [],
 
       // Search parcels
@@ -152,6 +165,7 @@ export const usePropertyStore = create<PropertyState>()(
           activeParcelLoading: true,
           activeParcelLoadingParcelId: parcelId,
           activeParcelError: null,
+          relatedDataStatus: 'idle',
           ...EMPTY_RELATED_DATA,
         });
         try {
@@ -163,6 +177,7 @@ export const usePropertyStore = create<PropertyState>()(
               activeParcel: null,
               activeParcelLoading: false,
               activeParcelLoadingParcelId: null,
+              relatedDataStatus: 'idle',
               ...EMPTY_RELATED_DATA,
               activeParcelError: {
                 parcelId,
@@ -194,6 +209,7 @@ export const usePropertyStore = create<PropertyState>()(
             activeParcelLoading: false,
             activeParcelLoadingParcelId: null,
             activeParcelError: null,
+            relatedDataStatus: 'loading',
             ...EMPTY_RELATED_DATA,
           });
 
@@ -217,6 +233,7 @@ export const usePropertyStore = create<PropertyState>()(
                 recordings,
                 auditTrail,
                 operations,
+                relatedDataStatus: 'loaded',
               });
             })
             .catch(() => {
@@ -229,6 +246,7 @@ export const usePropertyStore = create<PropertyState>()(
                 recordings: [],
                 auditTrail: [],
                 operations: [],
+                relatedDataStatus: 'error',
               });
             });
         } catch (error) {
@@ -237,6 +255,7 @@ export const usePropertyStore = create<PropertyState>()(
             activeParcel: null,
             activeParcelLoading: false,
             activeParcelLoadingParcelId: null,
+            relatedDataStatus: 'idle',
             ...EMPTY_RELATED_DATA,
             activeParcelError: isApiFetchError(error)
               ? {
@@ -267,6 +286,7 @@ export const usePropertyStore = create<PropertyState>()(
           activeParcelLoading: false,
           activeParcelLoadingParcelId: null,
           activeParcelError: null,
+          relatedDataStatus: 'idle',
           ...EMPTY_RELATED_DATA,
         });
       },


### PR DESCRIPTION
## WO-WB-PROV-002 + WO-WB-PROV-003

Second implementation step of **WORKBENCH-PER-SLICE-STORE-PROVENANCE**. Combines the store field (PROV-002) with its first consumer (PROV-003, Clerk) — a store field with zero readers would be dead code.

### PROV-002 — `relatedDataStatus` store flag
Adds a frontend-only `relatedDataStatus: 'idle' | 'loading' | 'loaded' | 'error'` to `propertyStore`, tracking the lifecycle of the **existing** eager related-data `Promise.all` in `selectParcel`:
- `idle` at start / not-found (404) / shell error / `clearParcel`;
- `loading` once the parcel shell is up and the bundle is in flight;
- `loaded` when the bundle resolves; `error` when it rejects.

No new fetch, no new data loading, no API-shape change, **not persisted** (partialize keeps only `recentParcels`). Because the bundle is all-or-nothing, `loaded` is per-slice-accurate. New store test: `stores/__tests__/propertyStore.relatedDataStatus.test.ts` (idle→loading→loaded, →error+slice-clear, not-found stays idle, clearParcel resets).

### PROV-003 — Clerk slice-aware badge
`evidenceLoaded` changes from coarse parcel-shell state (`!activeParcelLoading && !activeParcelError`, which clear *before* the bundle resolves) to `activeParcel?.parcelId === parcelId && relatedDataStatus === 'loaded'`. The badge now reads `live` only once the recordings bundle has actually loaded for **this** parcel. Contract test updated to prove: shell-up-but-bundle-loading → `unavailable`; loaded (incl. zero recordings) → `live`; loading→loaded transition; stale-parcel guard; state-aware copy.

### Scope
Files: `stores/propertyStore.ts`, `stores/__tests__/propertyStore.relatedDataStatus.test.ts`, `pages/workbench/tabs/PropertyClerk.tsx`, `__tests__/workbench/PropertyClerk.honesty.contract.test.tsx`. No backend/registry/route/window/API/deploy/PACS. Strictly more truthful than before.

### Validation
Frontend Gate + Vitest Full Suite + required contexts; threads resolved; no --admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer live/unavailable status for PropertyClerk based on whether related parcel data is actually available for the current parcel.
  * Introduced more reliable loading state tracking for parcel-related evidence.

* **Bug Fixes**
  * Prevented stale data from showing as live when it belongs to a different parcel.
  * Kept the status unavailable during loading, errors, and empty results until the current parcel’s data is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->