### PR TITLE
fix(workbench): parcel-identity guard for Dossier honesty badge (WO-WB-PROV-007)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyDossier.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyDossier.honesty.contract.test.tsx
@@ -146,6 +146,19 @@ describe('PropertyDossier source honesty contract', () => {
     });
   });
 
+  it('baseline disclosure badge stays "unavailable" when loaded details belong to a DIFFERENT parcel (stale nav)', async () => {
+    // useDossierDetails keeps the previous parcel's data until the new fetch
+    // resolves; the getDetails mock returns details for parcel 12345-001, but the
+    // current route parcel is 99999-999. The parcel-identity guard must keep the
+    // badge unavailable rather than reading live for the stale detail.
+    render(<TestWrapper parcelId='99999-999' />);
+    const disclosure = screen.getByTestId('dossier-baseline-disclosure');
+    // Wait until the (mismatched) detail has actually loaded into the component.
+    await screen.findByText('456 Oak Ave, Kennewick, WA');
+    const badge = disclosure.querySelector('[data-testid="workbench-source-badge"]');
+    expect(badge).toHaveAttribute('data-source', 'unavailable');
+  });
+
   it('all badges avoid synthetic live claims at idle', () => {
     render(<TestWrapper parcelId='12345-001' />);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyDossier.tsx
@@ -709,7 +709,11 @@ export const PropertyDossier: React.FC = () => {
           Dossier documents, evidence, and casefile summaries are requested via governed tooling;
           values shown are returned from the tool response or the live dossier API, never inferred.
         </p>
-        <WorkbenchSourceBadge source={dossierDetails.data ? 'live' : 'unavailable'} />
+        {/* Parcel-identity guard: useDossierDetails keeps the previous parcel's
+            data until the new fetch resolves (it only clears on parcelId->null),
+            so gate on the loaded detail belonging to THIS parcel to avoid reading
+            live for a stale previous parcel's dossier during navigation. */}
+        <WorkbenchSourceBadge source={dossierDetails.data?.parcelId === parcelId ? 'live' : 'unavailable'} />
       </div>
 
       {/* Documents on File from Store */}


### PR DESCRIPTION
## WO-WB-PROV-007 — Dossier parcel-identity guard

Design review (#1213) found Dossier's badge is keyed to `dossierDetails.data` but **not parcel-keyed**: `useDossierDetails` clears `data` only when `parcelId` becomes null, not when it *changes*, so after navigating A→B the badge read `live` for parcel A's stale detail while B was fetching.

The `useDossierDetails` hook lives in `hooks/**` (outside this program's allowed write set), so this fixes it at the **component level**: gate the badge on the loaded detail belonging to the current parcel — `source={dossierDetails.data?.parcelId === parcelId ? 'live' : 'unavailable'}` — mirroring the C-tabs' parcel-identity discipline. Contract test added: a loaded detail for a different parcel reads `unavailable`.

Scope: `PropertyDossier.tsx` + its honesty test. No backend/hook/registry/route change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parcel detail status so live data is shown only when it matches the currently selected parcel.
  * Prevented outdated dossier information from briefly appearing as live after switching to another parcel.
  * Added coverage to ensure the source badge stays unavailable during stale or mismatched detail loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->