### PR TITLE
feat(workbench): slice-aware badges for Treasury + Audit (WO-WB-PROV-004/005)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyAudit.honesty.contract.test.tsx
@@ -1,19 +1,18 @@
 /**
  * PropertyAudit.honesty.contract.test.tsx
  *
- * Source honesty contract for the PropertyAudit tab (WO-WB-INSTR-005).
- * Mirrors the Treasury/Clerk/Pilot/Dossier/Dais honesty contracts. Ensures:
+ * Source honesty contract for the PropertyAudit tab (WO-WB-INSTR-005, slice-aware
+ * under WO-WB-PROV-005). Ensures:
  *   1. Baseline disclosure box carries a WorkbenchSourceBadge
- *   2. That badge shows "unavailable" before/while the parcel evidence loads and on error
- *   3. It reflects "live" once the parcel evidence bundle loads successfully —
- *      including a successful load that returns zero audit entries (load-success
- *      provenance, NOT audit row count), and it flips on the empty -> loaded
- *      transition (not memoized at mount)
- *   4. No aspirational "AI-powered" language
- *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
+ *   2. That badge shows "unavailable" until the related-data bundle (which holds the
+ *      auditTrail slice) has loaded — including while the parcel shell is up but the
+ *      bundle is still loading, and after a bundle load error
+ *   3. It reflects "live" once relatedDataStatus === 'loaded' for THIS parcel —
+ *      including a load that returns zero audit entries (load-success provenance,
+ *      NOT row count), and it flips on the transition (not memoized at mount)
+ *   4. A stale previous parcel's loaded status does not read as live (parcelId guard)
+ *   5. No aspirational "AI-powered" language; state-aware disclosure copy
  *   6. No tool is invoked on mount (the tab only lists tools)
- *
- * Reuses the mock setup from PropertyAudit.test.tsx.
  */
 
 import '@testing-library/jest-dom';
@@ -23,6 +22,8 @@ import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import * as pilotApi from '../../api/pilotApi';
 import PropertyAudit from '../../pages/workbench/tabs/PropertyAudit';
+// Type-only import (erased at runtime) so the status union stays aligned with the store.
+import type { RelatedDataStatus } from '../../stores/propertyStore';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -36,15 +37,13 @@ interface StoreView {
     timestamp: string;
   }>;
   activeParcel: { parcelId: string } | null;
-  activeParcelLoading: boolean;
-  activeParcelError: { message: string } | null;
+  relatedDataStatus: RelatedDataStatus;
 }
 
 let storeView: StoreView = {
   auditTrail: [],
   activeParcel: null,
-  activeParcelLoading: false,
-  activeParcelError: null,
+  relatedDataStatus: 'idle',
 };
 
 vi.mock('../../stores/propertyStore', () => ({
@@ -95,6 +94,12 @@ const oneEntry = [
   { entryId: 'AU-1', action: 'value_change', actor: 'assessor', timestamp: '2026-01-15T10:00:00Z' },
 ];
 
+const loadedFor = (parcelId: string, auditTrail: StoreView['auditTrail'] = []): StoreView => ({
+  auditTrail,
+  activeParcel: { parcelId },
+  relatedDataStatus: 'loaded',
+});
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('PropertyAudit source honesty contract', () => {
@@ -103,8 +108,7 @@ describe('PropertyAudit source honesty contract', () => {
     storeView = {
       auditTrail: [],
       activeParcel: null,
-      activeParcelLoading: false,
-      activeParcelError: null,
+      relatedDataStatus: 'idle',
     };
   });
 
@@ -114,72 +118,47 @@ describe('PropertyAudit source honesty contract', () => {
     expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
   });
 
-  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
+  it('baseline badge shows "unavailable" before the parcel evidence loads (idle)', () => {
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
-    storeView = { ...storeView, activeParcelLoading: true };
+  it('baseline badge shows "unavailable" while the parcel shell is up but the related bundle is still loading', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
-    storeView = {
-      ...storeView,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelError: { message: 'load failed' },
-    };
+  it('baseline badge shows "unavailable" when the related evidence bundle load errored', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'error' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge reflects "live" on a successful evidence load even with zero audit entries', () => {
-    storeView = {
-      auditTrail: [],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+  it('baseline badge reflects "live" on a loaded bundle even with zero audit entries', () => {
+    storeView = loadedFor(PARCEL_ID, []);
     render(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+  it('baseline badge flips unavailable -> live on the loading -> loaded transition (not memoized)', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     const { rerender } = render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
 
-    storeView = {
-      auditTrail: oneEntry,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneEntry);
     rerender(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
-    // During parcel-to-parcel navigation the store can still hold the previous
-    // activeParcel for one frame; that must not read as live for this tab's parcel.
-    storeView = {
-      auditTrail: oneEntry,
-      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+  it('baseline badge shows "unavailable" when a DIFFERENT parcel bundle is loaded (stale nav frame)', () => {
+    storeView = loadedFor('SOME-OTHER-PARCEL', oneEntry);
     render(<TestWrapper parcelId={PARCEL_ID} />);
     expect(badgeSource()).toBe('unavailable');
   });
 
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
-    storeView = {
-      auditTrail: oneEntry,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneEntry);
     render(<TestWrapper />);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {
       expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
@@ -187,19 +166,12 @@ describe('PropertyAudit source honesty contract', () => {
   });
 
   it('disclosure copy is state-aware — never claims live loading while the badge reads unavailable', () => {
-    // Idle: badge unavailable, so the copy must NOT assert the parcel is loaded live.
     const { rerender } = render(<TestWrapper />);
     let disclosure = screen.getByTestId('audit-baseline-disclosure');
     expect(disclosure.textContent).toMatch(/not currently available/i);
     expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
 
-    // Loaded: badge live, so the copy asserts the live-loaded state.
-    storeView = {
-      auditTrail: oneEntry,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneEntry);
     rerender(<TestWrapper />);
     disclosure = screen.getByTestId('audit-baseline-disclosure');
     expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyTreasury.honesty.contract.test.tsx
@@ -1,19 +1,18 @@
 /**
  * PropertyTreasury.honesty.contract.test.tsx
  *
- * Source honesty contract for the PropertyTreasury tab (WO-WB-INSTR-004).
- * Mirrors the Clerk/Pilot/Dossier/Dais honesty contracts. Ensures:
+ * Source honesty contract for the PropertyTreasury tab (WO-WB-INSTR-004, slice-aware
+ * under WO-WB-PROV-004). Ensures:
  *   1. Baseline disclosure box carries a WorkbenchSourceBadge
- *   2. That badge shows "unavailable" before/while the parcel evidence loads and on error
- *   3. It reflects "live" once the parcel evidence bundle loads successfully —
- *      including a successful load that returns zero tax statements (load-success
- *      provenance, NOT statement row count), and it flips on the empty -> loaded
- *      transition (not memoized at mount)
- *   4. No aspirational "AI-powered" language
- *   5. Baseline disclosure uses governed / live-evidence / never-inferred wording
+ *   2. That badge shows "unavailable" until the related-data bundle (which holds the
+ *      taxStatements slice) has loaded — including while the parcel shell is up but
+ *      the bundle is still loading, and after a bundle load error
+ *   3. It reflects "live" once relatedDataStatus === 'loaded' for THIS parcel —
+ *      including a load that returns zero tax statements (load-success provenance,
+ *      NOT row count), and it flips on the transition (not memoized at mount)
+ *   4. A stale previous parcel's loaded status does not read as live (parcelId guard)
+ *   5. No aspirational "AI-powered" language; state-aware disclosure copy
  *   6. No tool is invoked on mount (the tab only lists tools)
- *
- * Reuses the mock setup from PropertyTreasury.test.tsx.
  */
 
 import '@testing-library/jest-dom';
@@ -23,6 +22,8 @@ import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import * as pilotApi from '../../api/pilotApi';
 import PropertyTreasury from '../../pages/workbench/tabs/PropertyTreasury';
+// Type-only import (erased at runtime) so the status union stays aligned with the store.
+import type { RelatedDataStatus } from '../../stores/propertyStore';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -37,15 +38,13 @@ interface StoreView {
     delinquent: boolean;
   }>;
   activeParcel: { parcelId: string } | null;
-  activeParcelLoading: boolean;
-  activeParcelError: { message: string } | null;
+  relatedDataStatus: RelatedDataStatus;
 }
 
 let storeView: StoreView = {
   taxStatements: [],
   activeParcel: null,
-  activeParcelLoading: false,
-  activeParcelError: null,
+  relatedDataStatus: 'idle',
 };
 
 vi.mock('../../stores/propertyStore', () => ({
@@ -96,6 +95,12 @@ const oneStatement = [
   { statementId: 'TS-2026', taxYear: 2026, totalTaxDue: 3200, totalPaid: 1600, delinquent: false },
 ];
 
+const loadedFor = (parcelId: string, taxStatements: StoreView['taxStatements'] = []): StoreView => ({
+  taxStatements,
+  activeParcel: { parcelId },
+  relatedDataStatus: 'loaded',
+});
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('PropertyTreasury source honesty contract', () => {
@@ -104,8 +109,7 @@ describe('PropertyTreasury source honesty contract', () => {
     storeView = {
       taxStatements: [],
       activeParcel: null,
-      activeParcelLoading: false,
-      activeParcelError: null,
+      relatedDataStatus: 'idle',
     };
   });
 
@@ -115,72 +119,47 @@ describe('PropertyTreasury source honesty contract', () => {
     expect(disclosure.querySelector('[data-testid="workbench-source-badge"]')).toBeInTheDocument();
   });
 
-  it('baseline badge shows "unavailable" before the parcel evidence loads', () => {
+  it('baseline badge shows "unavailable" before the parcel evidence loads (idle)', () => {
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" while the parcel evidence is loading', () => {
-    storeView = { ...storeView, activeParcelLoading: true };
+  it('baseline badge shows "unavailable" while the parcel shell is up but the related bundle is still loading', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge shows "unavailable" when the parcel evidence load errored', () => {
-    storeView = {
-      ...storeView,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelError: { message: 'load failed' },
-    };
+  it('baseline badge shows "unavailable" when the related evidence bundle load errored', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'error' };
     render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
   });
 
-  it('baseline badge reflects "live" on a successful evidence load even with zero tax statements', () => {
-    storeView = {
-      taxStatements: [],
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+  it('baseline badge reflects "live" on a loaded bundle even with zero tax statements', () => {
+    storeView = loadedFor(PARCEL_ID, []);
     render(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge flips unavailable -> live on the empty -> loaded transition (not memoized)', () => {
+  it('baseline badge flips unavailable -> live on the loading -> loaded transition (not memoized)', () => {
+    storeView = { ...storeView, activeParcel: { parcelId: PARCEL_ID }, relatedDataStatus: 'loading' };
     const { rerender } = render(<TestWrapper />);
     expect(badgeSource()).toBe('unavailable');
 
-    storeView = {
-      taxStatements: oneStatement,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneStatement);
     rerender(<TestWrapper />);
     expect(badgeSource()).toBe('live');
   });
 
-  it('baseline badge shows "unavailable" when the store holds a DIFFERENT parcel (stale nav frame)', () => {
-    // During parcel-to-parcel navigation the store can still hold the previous
-    // activeParcel for one frame; that must not read as live for this tab's parcel.
-    storeView = {
-      taxStatements: oneStatement,
-      activeParcel: { parcelId: 'SOME-OTHER-PARCEL' },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+  it('baseline badge shows "unavailable" when a DIFFERENT parcel bundle is loaded (stale nav frame)', () => {
+    storeView = loadedFor('SOME-OTHER-PARCEL', oneStatement);
     render(<TestWrapper parcelId={PARCEL_ID} />);
     expect(badgeSource()).toBe('unavailable');
   });
 
   it('all badges avoid synthetic claims (unavailable or live only)', () => {
-    storeView = {
-      taxStatements: oneStatement,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneStatement);
     render(<TestWrapper />);
     for (const badge of screen.getAllByTestId('workbench-source-badge')) {
       expect(['unavailable', 'live']).toContain(badge.getAttribute('data-source'));
@@ -188,19 +167,12 @@ describe('PropertyTreasury source honesty contract', () => {
   });
 
   it('disclosure copy is state-aware — never claims live loading while the badge reads unavailable', () => {
-    // Idle: badge unavailable, so the copy must NOT assert the parcel is loaded live.
     const { rerender } = render(<TestWrapper />);
     let disclosure = screen.getByTestId('treasury-baseline-disclosure');
     expect(disclosure.textContent).toMatch(/not currently available/i);
     expect(disclosure.textContent).not.toMatch(/is loaded from the live property evidence feed/i);
 
-    // Loaded: badge live, so the copy asserts the live-loaded state.
-    storeView = {
-      taxStatements: oneStatement,
-      activeParcel: { parcelId: PARCEL_ID },
-      activeParcelLoading: false,
-      activeParcelError: null,
-    };
+    storeView = loadedFor(PARCEL_ID, oneStatement);
     rerender(<TestWrapper />);
     disclosure = screen.getByTestId('treasury-baseline-disclosure');
     expect(disclosure.textContent).toMatch(/is loaded from the live property evidence feed/i);

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyAudit.tsx
@@ -95,19 +95,16 @@ interface ComplianceReportResult {
 export const PropertyAudit: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const auditTrail = usePropertyStore((s) => s.auditTrail);
-  // Source provenance for the baseline disclosure badge. This reflects whether
-  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set,
-  // not loading, no error) — the honest signal the store exposes. It is NOT keyed
-  // on the auditTrail row count (a live load can legitimately return zero entries);
-  // propertyStore exposes no audit-slice-specific load provenance, so the
-  // disclosure copy is scoped to parcel-context, not audit-evidence, load state.
+  // Source provenance for the baseline disclosure badge — SLICE-AWARE: auditTrail
+  // lives in the eager related-data bundle, whose load lifecycle the store tracks via
+  // relatedDataStatus. The badge reads live only once that bundle has actually loaded
+  // for THIS parcel — not merely when the parcel shell loaded (activeParcelLoading
+  // clears before the bundle resolves). The parcelId guard prevents a stale previous
+  // parcel's 'loaded' status from reading live during navigation. It is NOT keyed on
+  // the auditTrail row count (a live load can legitimately return zero entries).
   const activeParcel = usePropertyStore((s) => s.activeParcel);
-  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
-  const parcelError = usePropertyStore((s) => s.activeParcelError);
-  // Require the loaded parcel to be THIS tab's parcel: during parcel-to-parcel
-  // navigation the store can still hold the previous activeParcel for one frame
-  // (before selectParcel runs), which must not read as live for the new parcel.
-  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
+  const relatedDataStatus = usePropertyStore((s) => s.relatedDataStatus);
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && relatedDataStatus === 'loaded';
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool

--- a/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/tabs/PropertyTreasury.tsx
@@ -114,19 +114,16 @@ interface TaxSaleResult {
 export const PropertyTreasury: React.FC = () => {
   const { parcelId } = useWorkbenchTab();
   const taxStatements = usePropertyStore((s) => s.taxStatements);
-  // Source provenance for the baseline disclosure badge. This reflects whether
-  // THIS PARCEL was loaded from the live property evidence feed (activeParcel set,
-  // not loading, no error) — the honest signal the store exposes. It is NOT keyed
-  // on the taxStatements row count (a live load can legitimately return zero
-  // statements); propertyStore exposes no tax-slice-specific load provenance, so
-  // the disclosure copy is scoped to parcel-context, not tax-evidence, load state.
+  // Source provenance for the baseline disclosure badge — SLICE-AWARE: taxStatements
+  // live in the eager related-data bundle, whose load lifecycle the store tracks via
+  // relatedDataStatus. The badge reads live only once that bundle has actually loaded
+  // for THIS parcel — not merely when the parcel shell loaded (activeParcelLoading
+  // clears before the bundle resolves). The parcelId guard prevents a stale previous
+  // parcel's 'loaded' status from reading live during navigation. It is NOT keyed on
+  // the taxStatements row count (a live load can legitimately return zero statements).
   const activeParcel = usePropertyStore((s) => s.activeParcel);
-  const parcelLoading = usePropertyStore((s) => s.activeParcelLoading);
-  const parcelError = usePropertyStore((s) => s.activeParcelError);
-  // Require the loaded parcel to be THIS tab's parcel: during parcel-to-parcel
-  // navigation the store can still hold the previous activeParcel for one frame
-  // (before selectParcel runs), which must not read as live for the new parcel.
-  const evidenceLoaded = activeParcel?.parcelId === parcelId && !parcelLoading && !parcelError;
+  const relatedDataStatus = usePropertyStore((s) => s.relatedDataStatus);
+  const evidenceLoaded = activeParcel?.parcelId === parcelId && relatedDataStatus === 'loaded';
   const [invocationHistory, setInvocationHistory] = useState<InvocationRecord[]>([]);
 
   // State for each tool


### PR DESCRIPTION
## WO-WB-PROV-004 + WO-WB-PROV-005

Wires PropertyTreasury (PROV-004) and PropertyAudit (PROV-005) to the slice-aware `relatedDataStatus` provenance added in #1214, completing the C-tab migration.

### Change (both tabs, identical mechanical wiring)
`evidenceLoaded` changes from coarse parcel-shell state (`!activeParcelLoading && !activeParcelError`, which clear *before* the eager related-data bundle resolves) to `activeParcel?.parcelId === parcelId && relatedDataStatus === 'loaded'`. Each badge now reads `live` only once the bundle holding its slice (`taxStatements` / `auditTrail`) has actually loaded for **this** parcel.

Both honesty tests updated to drive `relatedDataStatus` (type-imported from the store) and prove: shell-up-but-bundle-loading → `unavailable`; loaded → `live` (incl. zero rows); loading→loaded transition; stale-parcel guard; state-aware copy.

Combined into one PR as two same-risk, mechanically-identical wire-ups. Scope: Treasury/Audit tabs + their honesty tests. No backend/store/registry/route change (consumes the field from #1214).