### PR TITLE
docs(workbench): WO-WB-G2 window-adapter aliasing decision packet (G2)

### DIFF
--- a/docs/audit/workbench-readiness/WO-WB-G2-001-route-vs-window-truth-audit.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-001-route-vs-window-truth-audit.md
@@ -44,13 +44,15 @@ Child routes (`Router.tsx:217-226`), verified verbatim:
 `Router.tsx:60-62` lazy-imports the real `PropertyClerk`/`PropertyTreasury`/`PropertyAudit`. **Route path = 9 distinct
 real tab surfaces.**
 
-## 3. Window path — aliases 3 tabs, does NOT import the real components
+## 3. Window path — aliases 3 tabs via TWO mechanisms
 
 **Entry:** `PropertyWorkbenchWindow.tsx` — the desktop app-window adapter. It uses **state-based** tab switching +
 `WorkbenchTabCtx` (not React Router) because a Router cannot be nested inside the app-window's Router
 (`PropertyWorkbenchWindow.tsx:9-11`).
 
-Its tab→component map (`PropertyWorkbenchWindow.tsx:73-83`), verified verbatim:
+### 3a. Alias mechanism #1 — the tab→component map
+
+`TAB_COMPONENTS` (`PropertyWorkbenchWindow.tsx:73-83`), verified verbatim:
 
 ```
 const TAB_COMPONENTS: Record<WorkbenchTabSlug, React.LazyExoticComponent<React.FC>> = {
@@ -67,11 +69,32 @@ const TAB_COMPONENTS: Record<WorkbenchTabSlug, React.LazyExoticComponent<React.F
 ```
 
 The window's lazy imports (`PropertyWorkbenchWindow.tsx:50-67`) include only Summary/Forge/Atlas/Dais/Dossier/Pilot —
-**`PropertyClerk`, `PropertyTreasury`, and `PropertyAudit` are not imported at all** (grep: 0 matches). The tab bar
-(`TABS`, `PropertyWorkbenchWindow.tsx:105-114`) still lists all nine labels including "Clerk", "Treasury", "Audit".
+**`PropertyClerk`, `PropertyTreasury`, and `PropertyAudit` are not imported at all** (grep: 0 matches).
 
-**Net window behavior:** clicking **Clerk** renders **Dossier**; **Treasury** renders **Dais**; **Audit** renders
-**Dossier**. Six distinct components are mounted across nine labels.
+### 3b. Alias mechanism #2 — the initial-tab remap (launch path)
+
+`resolvedInitialTab` (`PropertyWorkbenchWindow.tsx:727-731`), verified verbatim:
+
+```
+const resolvedInitialTab = useMemo<WorkbenchTabSlug>(() => {
+  if (!initialTab || initialTab === '/' as string) return 'summary';
+  if (initialTab === 'clerk' || initialTab === 'audit') return 'dossier';   // ALIAS at launch
+  if (initialTab === 'treasury') return 'dais';                             // ALIAS at launch
+  const valid = TABS.find((t) => t.id === initialTab);
+  return valid?.id ?? 'summary';
+}, [initialTab]);
+```
+
+When the window is **launched** with `metadata.tabId` = `clerk`/`audit`/`treasury` (the deep-link/launch path), the
+active tab is remapped to `dossier`/`dais` *before* first render. So the alias is enforced in **two** places: the
+component map (mechanism #1) and the initial-tab resolution (mechanism #2). **Both must be corrected to actually close
+G2** — fixing only `TAB_COMPONENTS` would still land a `tabId=clerk` launch on the Dossier tab.
+
+The tab bar (`TABS`, `PropertyWorkbenchWindow.tsx:105-114`) still lists all nine labels including "Clerk", "Treasury",
+"Audit".
+
+**Net window behavior:** selecting (or launching into) **Clerk** renders **Dossier**; **Treasury** renders **Dais**;
+**Audit** renders **Dossier**. Six distinct components are mounted across nine labels.
 
 ## 4. Are the real components window-compatible? — YES
 
@@ -87,12 +110,11 @@ re-pointed at them.
 
 ## 5. Test coverage
 
-- `__tests__/workbench/PropertyWorkbenchWindow.segmentContext.test.tsx` exists but carries its **own local**
-  `TAB_COMPONENTS` copy (line 73) for segment-context assertions; it does **not** assert the production alias mapping
-  (no `clerk → Dossier` expectation). So the alias is **not pinned by a test** — a future re-point would not break it
-  (to be re-verified at implementation time).
-- No test asserts that the window's "Clerk"/"Treasury"/"Audit" labels render their real components — i.e. the mislabel is
-  **uncovered**.
+- `__tests__/workbench/PropertyWorkbenchWindow.segmentContext.test.tsx` exercises only the **segment-context bridge**; it
+  does **not** reference `TAB_COMPONENTS`, the `resolvedInitialTab` remap, or the `clerk`/`treasury`/`audit` labels at all
+  (grep: 0 matches). So **neither** alias mechanism is pinned or covered by a test — the mislabel is entirely uncovered,
+  and re-pointing the map/remap would not break this test.
+- No test asserts that the window's "Clerk"/"Treasury"/"Audit" labels render their real components.
 
 ## 6. Truth summary
 
@@ -108,7 +130,8 @@ re-pointed at them.
 | Dossier | PropertyDossier | PropertyDossier | no |
 | Pilot | PropertyPilot | PropertyPilot | no |
 
-**Confirmed:** the route path is honest (9/9 real); the window path mislabels 3 tabs. The real components exist and are
+**Confirmed:** the route path is honest (9/9 real); the window path mislabels 3 tabs via **two** mechanisms
+(`TAB_COMPONENTS` map at :73-83 and the `resolvedInitialTab` launch remap at :727-731). The real components exist and are
 window-compatible, so the gap is a stale mapping, not a missing surface. Impact classification → WO-WB-G2-002.
 
 **Docs-only. No implementation. No stop wall.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-001-route-vs-window-truth-audit.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-001-route-vs-window-truth-audit.md
@@ -1,0 +1,114 @@
+# WO-WB-G2-001 — Route-vs-Window Truth Audit
+
+**Goal:** GOAL-TF-WB-G2-WINDOW-ALIASING-001 — Workbench Window Adapter Aliasing Decision
+**WO:** WO-WB-G2-001 — Route-vs-Window Truth Audit
+**Category:** Documentation (read-only source audit; no implementation)
+**Owner:** Claude Code (operator) · William / TerraFusion OS Engineering (authority)
+
+**Authorization:** Operator authorized GOAL-TF-WB-G2-WINDOW-ALIASING-001 (decision-only, docs-only). Allowed writes:
+`docs/audit/workbench-readiness/**`. Read-only inspection of `pages/workbench/**`, `__tests__/workbench/**`,
+`Router.tsx`, `tools/registry/**` (context only). No component/route/window/backend change. AGENTS.md out-of-lane write
+proceeds under this explicit authorization.
+
+---
+
+## 1. Question
+
+The Property Workbench exposes 9 tab surfaces. There are **two** host paths that render those tabs: the **route-based**
+Workbench and the desktop **window** adapter. G2 (from `WO-WB-005` gap register) asserts the window adapter *aliases*
+Clerk/Treasury/Audit into other components. This WO verifies the exact behavior of each path, first-hand, with file/line
+evidence — no extrapolation.
+
+## 2. Route-based path — renders the REAL components
+
+**Entry:** `Router.tsx` → `<Route path='property/:parcelId' element={<PropertyWorkbench />}>` with child routes.
+**Layout:** `PropertyWorkbench.tsx` renders `<Outlet>` (`PropertyWorkbench.tsx:587`); tab content is resolved by the
+matched React-Router child route (`PropertyWorkbench.tsx:115-116`).
+
+Child routes (`Router.tsx:217-226`), verified verbatim:
+
+```
+<Route path='property/:parcelId' element={<PropertyWorkbench />}>
+  <Route index element={<PropertySummary />} />
+  <Route path='forge'    element={<PropertyForge />} />
+  <Route path='atlas'    element={<PropertyAtlas />} />
+  <Route path='dais'     element={<PropertyDais />} />
+  <Route path='clerk'    element={<PropertyClerk />} />       // REAL
+  <Route path='treasury' element={<PropertyTreasury />} />    // REAL
+  <Route path='audit'    element={<PropertyAudit />} />       // REAL
+  <Route path='dossier'  element={<PropertyDossier />} />
+  <Route path='pilot'    element={<PropertyPilot />} />
+</Route>
+```
+
+`Router.tsx:60-62` lazy-imports the real `PropertyClerk`/`PropertyTreasury`/`PropertyAudit`. **Route path = 9 distinct
+real tab surfaces.**
+
+## 3. Window path — aliases 3 tabs, does NOT import the real components
+
+**Entry:** `PropertyWorkbenchWindow.tsx` — the desktop app-window adapter. It uses **state-based** tab switching +
+`WorkbenchTabCtx` (not React Router) because a Router cannot be nested inside the app-window's Router
+(`PropertyWorkbenchWindow.tsx:9-11`).
+
+Its tab→component map (`PropertyWorkbenchWindow.tsx:73-83`), verified verbatim:
+
+```
+const TAB_COMPONENTS: Record<WorkbenchTabSlug, React.LazyExoticComponent<React.FC>> = {
+  summary:  PropertySummary,
+  forge:    PropertyForge,
+  atlas:    PropertyAtlas,
+  dais:     PropertyDais,
+  clerk:    PropertyDossier,   // ALIAS → Dossier
+  treasury: PropertyDais,      // ALIAS → Dais
+  audit:    PropertyDossier,   // ALIAS → Dossier
+  dossier:  PropertyDossier,
+  pilot:    PropertyPilot,
+};
+```
+
+The window's lazy imports (`PropertyWorkbenchWindow.tsx:50-67`) include only Summary/Forge/Atlas/Dais/Dossier/Pilot —
+**`PropertyClerk`, `PropertyTreasury`, and `PropertyAudit` are not imported at all** (grep: 0 matches). The tab bar
+(`TABS`, `PropertyWorkbenchWindow.tsx:105-114`) still lists all nine labels including "Clerk", "Treasury", "Audit".
+
+**Net window behavior:** clicking **Clerk** renders **Dossier**; **Treasury** renders **Dais**; **Audit** renders
+**Dossier**. Six distinct components are mounted across nine labels.
+
+## 4. Are the real components window-compatible? — YES
+
+`useWorkbenchTab()` (`context/workbenchTabContext.tsx:77-84`) reads from **both** `WorkbenchTabCtx` (`useContext`,
+line 79) **and** `useOutletContext` (line 84) — "checks both sources" (:9). The window provides
+`<WorkbenchTabCtx.Provider value={tabContextValue}>` (`PropertyWorkbenchWindow.tsx:919`) with `{ parcelId, propertyData }`
+(:714). The real `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` consume `useWorkbenchTab()` — so they would mount and
+function correctly under the window's context **with no code change to the components themselves**.
+
+**Implication:** the aliasing is not a compatibility constraint. It is **stale/vestigial** — it predates the real
+Clerk/Treasury/Audit components (built during PROPERTY-WORKBENCH readiness + honesty instrumentation) and was never
+re-pointed at them.
+
+## 5. Test coverage
+
+- `__tests__/workbench/PropertyWorkbenchWindow.segmentContext.test.tsx` exists but carries its **own local**
+  `TAB_COMPONENTS` copy (line 73) for segment-context assertions; it does **not** assert the production alias mapping
+  (no `clerk → Dossier` expectation). So the alias is **not pinned by a test** — a future re-point would not break it
+  (to be re-verified at implementation time).
+- No test asserts that the window's "Clerk"/"Treasury"/"Audit" labels render their real components — i.e. the mislabel is
+  **uncovered**.
+
+## 6. Truth summary
+
+| Tab | Route path renders | Window path renders | Diverges? |
+|-----|-------------------|---------------------|-----------|
+| Summary | PropertySummary | PropertySummary | no |
+| Forge | PropertyForge | PropertyForge | no |
+| Atlas | PropertyAtlas | PropertyAtlas | no |
+| Dais | PropertyDais | PropertyDais | no |
+| **Clerk** | **PropertyClerk** | **PropertyDossier** | **YES** |
+| **Treasury** | **PropertyTreasury** | **PropertyDais** | **YES** |
+| **Audit** | **PropertyAudit** | **PropertyDossier** | **YES** |
+| Dossier | PropertyDossier | PropertyDossier | no |
+| Pilot | PropertyPilot | PropertyPilot | no |
+
+**Confirmed:** the route path is honest (9/9 real); the window path mislabels 3 tabs. The real components exist and are
+window-compatible, so the gap is a stale mapping, not a missing surface. Impact classification → WO-WB-G2-002.
+
+**Docs-only. No implementation. No stop wall.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-002-window-aliasing-impact-matrix.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-002-window-aliasing-impact-matrix.md
@@ -9,7 +9,9 @@
 
 ## 1. Per-tab impact
 
-For each aliased tab (source of truth: `PropertyWorkbenchWindow.tsx:73-83` + `TABS:105-114`):
+For each aliased tab (source of truth: `PropertyWorkbenchWindow.tsx:73-83` component map, `:727-731` initial-tab remap,
+`TABS:105-114` labels). The alias is enforced by **two** mechanisms — the `TAB_COMPONENTS` map (tab-switch path) and the
+`resolvedInitialTab` remap (launch path) — both of which must be corrected to close G2:
 
 | Aliased tab | Displayed label | Actual rendered component (window) | Lost surface behavior | User-visible risk | Route path has real surface? | Test coverage of the mislabel |
 |-------------|-----------------|-----------------------------------|-----------------------|-------------------|------------------------------|-------------------------------|
@@ -38,7 +40,7 @@ The other six tabs (Summary/Forge/Atlas/Dais/Dossier/Pilot) render their real co
 |---------|-----------|-------|
 | **Route surface** (`/property/:parcelId/*`) | ❌ No | Renders all 9 real components (honest). |
 | **App-window surface** (`PropertyWorkbenchWindow`) | ✅ Yes | The desktop-shell adapter mislabels Clerk/Treasury/Audit. |
-| **Launch surface** | ⚠️ Indirect | Only insofar as a launch entry opens the window adapter; the mislabel is inherited from the window map, not the launcher. |
+| **Launch surface** | ✅ Yes (directly) | The window's `resolvedInitialTab` remap (`PropertyWorkbenchWindow.tsx:727-731`) rewrites launch `metadata.tabId` = clerk/audit → dossier and treasury → dais *before first render*. So a deep-link/launch into "Clerk"/"Treasury"/"Audit" opens the aliased tab directly — this is a second alias mechanism beyond the component map. |
 | **Workbench operator flow** | ✅ Yes (window only) | Clerk/Treasury/Audit workflows are unreachable when the Workbench is opened as an app-window rather than via route. |
 
 ## 4. Exposure question (open, for the decision packet)

--- a/docs/audit/workbench-readiness/WO-WB-G2-002-window-aliasing-impact-matrix.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-002-window-aliasing-impact-matrix.md
@@ -1,0 +1,50 @@
+# WO-WB-G2-002 — Window Aliasing Impact Matrix
+
+**Goal:** GOAL-TF-WB-G2-WINDOW-ALIASING-001
+**WO:** WO-WB-G2-002 — Aliasing Impact Matrix
+**Category:** Documentation (read-only analysis)
+**Depends on:** WO-WB-G2-001 (truth audit)
+
+---
+
+## 1. Per-tab impact
+
+For each aliased tab (source of truth: `PropertyWorkbenchWindow.tsx:73-83` + `TABS:105-114`):
+
+| Aliased tab | Displayed label | Actual rendered component (window) | Lost surface behavior | User-visible risk | Route path has real surface? | Test coverage of the mislabel |
+|-------------|-----------------|-----------------------------------|-----------------------|-------------------|------------------------------|-------------------------------|
+| **Clerk** | "Clerk" | `PropertyDossier` | TerraClerk recording/title tools (`search_recorded_documents`, `get_title_chain`, `record_document`, `release_lien`, …) + recordings history + Clerk honesty badge | User opens **Clerk**, sees a **Dossier** casefile view; recording/title workflow is unreachable in the window | ✅ yes (`/property/:parcelId/clerk` → `PropertyClerk`) | ❌ none (mislabel uncovered) |
+| **Treasury** | "Treasury" | `PropertyDais` | TerraTreasury tax/collection tools (`get_tax_statement`, `record_payment`, `create_installment_plan`, `initiate_tax_sale`, …) + tax history + Treasury honesty badge | User opens **Treasury**, sees the **Dais** equalization surface; tax/collection workflow is unreachable in the window | ✅ yes (`/property/:parcelId/treasury` → `PropertyTreasury`) | ❌ none |
+| **Audit** | "Audit" | `PropertyDossier` | TerraAudit financial-compliance/audit-trail tools + audit history + Audit honesty badge | User opens **Audit**, sees a **Dossier** view; audit workflow is unreachable in the window | ✅ yes (`/property/:parcelId/audit` → `PropertyAudit`) | ❌ none |
+
+The other six tabs (Summary/Forge/Atlas/Dais/Dossier/Pilot) render their real components in **both** paths — no divergence.
+
+## 2. Severity classification
+
+**Classification: MISLEADING SURFACE (honesty gap) — but LOW blast radius and TRIVIALLY fixable.**
+
+- It is **not** an "acceptable temporary alias": the real components exist, are honesty-instrumented, and are
+  window-compatible (`useWorkbenchTab` dual-source; `WorkbenchTabCtx.Provider` at `:919`). There is no technical reason
+  to keep the alias.
+- It is **not** a deep "implementation gap": no new component, backend, or route work is required — only the window's
+  `TAB_COMPONENTS` map needs to point at the already-existing real components.
+- It **is** an **honesty inconsistency**: this repo has invested two programs (Honesty-Instrumentation, Per-Slice-Store-
+  Provenance) into making badges truthful; a window that shows Dossier/Dais content under Clerk/Treasury/Audit labels
+  directly contradicts that honesty posture for desktop-window users.
+
+## 3. Which surfaces are affected?
+
+| Surface | Affected? | Notes |
+|---------|-----------|-------|
+| **Route surface** (`/property/:parcelId/*`) | ❌ No | Renders all 9 real components (honest). |
+| **App-window surface** (`PropertyWorkbenchWindow`) | ✅ Yes | The desktop-shell adapter mislabels Clerk/Treasury/Audit. |
+| **Launch surface** | ⚠️ Indirect | Only insofar as a launch entry opens the window adapter; the mislabel is inherited from the window map, not the launcher. |
+| **Workbench operator flow** | ✅ Yes (window only) | Clerk/Treasury/Audit workflows are unreachable when the Workbench is opened as an app-window rather than via route. |
+
+## 4. Exposure question (open, for the decision packet)
+
+Which host path do real users hit today — route, window, or both? This audit proves the *divergence*; it does not measure
+*traffic*. The decision packet (WO-WB-G2-003) weighs disposition under both assumptions (window is primary vs route is
+primary). Determining live traffic would require runtime/telemetry inspection, which is **out of this docs-only scope**.
+
+**Docs-only. No implementation. No stop wall.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-003-window-aliasing-decision-packet.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-003-window-aliasing-decision-packet.md
@@ -9,9 +9,10 @@
 
 ## 1. Decision to make
 
-Given that the desktop **window** adapter (`PropertyWorkbenchWindow.tsx:73-83`) mislabels three tabs
-(Clerk→Dossier, Treasury→Dais, Audit→Dossier) while the **route** path renders the real components, and the real
-components exist and are window-compatible — what is the correct disposition?
+Given that the desktop **window** adapter mislabels three tabs (Clerk→Dossier, Treasury→Dais, Audit→Dossier) via **two**
+mechanisms — the `TAB_COMPONENTS` map (`PropertyWorkbenchWindow.tsx:73-83`) and the `resolvedInitialTab` launch remap
+(`:727-731`) — while the **route** path renders the real components, and the real components exist and are
+window-compatible — what is the correct disposition?
 
 ## 2. Options
 
@@ -20,7 +21,7 @@ components exist and are window-compatible — what is the correct disposition?
 | **A. Accept as intentional temporary** | Leave the alias; document it as known/temporary. | ❌ Rejected. No technical constraint justifies "temporary" — the real components already exist and work in the window. Keeping it contradicts the honesty posture. |
 | **B. Mark misleading, require implementation** | Declare it a defect needing a fix. | ◑ Correct diagnosis, but under-specified — "implementation" here is a 6-line map re-point (see D), not a new build. |
 | **C. Remove aliased labels from the window** | Drop Clerk/Treasury/Audit from the window `TABS` until real components exist. | ❌ Rejected. The real components **already exist**; hiding honest, working surfaces is a regression, not a fix. |
-| **D. Route window tabs to the real components** | Point the window `TAB_COMPONENTS` map at `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` (import + 3 map lines). | ✅ **Recommended.** Trivial, safe, honest, closes the gap fully. |
+| **D. Route window tabs to the real components** | Point the window `TAB_COMPONENTS` map (`:73-83`) at `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` **and** remove the `resolvedInitialTab` launch remap (`:727-731`) so both the tab-switch and launch paths render the real components. | ✅ **Recommended.** Small, safe, honest, closes the gap fully — provided **both** mechanisms are fixed. |
 | **E. Defer until Backend OE / tool integration resolves** | Wait for Codex Backend OE. | ◑ Valid only as *scheduling*, not as *dependency* — option D has **no** Backend-OE dependency (pure frontend, components exist). |
 
 ## 3. Recommendation: **Option D** (mount the real components), scheduled per posture
@@ -28,9 +29,11 @@ components exist and are window-compatible — what is the correct disposition?
 **Rationale**
 - **Correctness:** the window is the only path that lies about what it renders; option D makes it match the route path
   (the honest reference), giving 9/9 real surfaces in both hosts.
-- **Cost/risk:** minimal — add three lazy imports + change three lines in `TAB_COMPONENTS`; no route change, no window
-  behavioral change beyond mounting the correct component, no registry/backend/API change. The components are already
-  window-compatible via `useWorkbenchTab`'s dual-source read.
+- **Cost/risk:** small — add three lazy imports, change three lines in `TAB_COMPONENTS` (`:73-83`), and drop the two
+  `resolvedInitialTab` alias branches (`:727-731`); no route change, no window behavioral change beyond mounting the
+  correct component, no registry/backend/API change. The components are already window-compatible via `useWorkbenchTab`'s
+  dual-source read. **Both** alias mechanisms must be fixed together — fixing only the map would leave `tabId=clerk`
+  launches landing on the Dossier tab.
 - **No Backend-OE dependency:** the real components are pure frontend and already merged. Option D does **not** need
   Codex Backend OE, tool integration, or G1. It is independent of the current pause reason.
 
@@ -41,7 +44,8 @@ implement it — implementation is specified in WO-WB-G2-004 and gated on explic
 
 ## 4. Decision record
 
-- **DECISION:** D — re-point the window `TAB_COMPONENTS` for `clerk`/`treasury`/`audit` to the real components.
+- **DECISION:** D — re-point the window `TAB_COMPONENTS` (`:73-83`) for `clerk`/`treasury`/`audit` to the real
+  components **and** remove the `resolvedInitialTab` launch remap (`:727-731`).
 - **IMPLEMENTATION_REQUIRED:** yes (small, frontend-only) — but **not** in this goal (decision-only) and **not** dependent
   on Backend OE.
 - **DO NOT** implement route changes, window-behavior changes beyond the map re-point, or any registry/backend work to

--- a/docs/audit/workbench-readiness/WO-WB-G2-003-window-aliasing-decision-packet.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-003-window-aliasing-decision-packet.md
@@ -1,0 +1,50 @@
+# WO-WB-G2-003 — Window Aliasing Decision Packet
+
+**Goal:** GOAL-TF-WB-G2-WINDOW-ALIASING-001
+**WO:** WO-WB-G2-003 — Decision Packet
+**Category:** Documentation (decision only — no code)
+**Depends on:** WO-WB-G2-001 (truth), WO-WB-G2-002 (impact)
+
+---
+
+## 1. Decision to make
+
+Given that the desktop **window** adapter (`PropertyWorkbenchWindow.tsx:73-83`) mislabels three tabs
+(Clerk→Dossier, Treasury→Dais, Audit→Dossier) while the **route** path renders the real components, and the real
+components exist and are window-compatible — what is the correct disposition?
+
+## 2. Options
+
+| Option | Description | Assessment |
+|--------|-------------|------------|
+| **A. Accept as intentional temporary** | Leave the alias; document it as known/temporary. | ❌ Rejected. No technical constraint justifies "temporary" — the real components already exist and work in the window. Keeping it contradicts the honesty posture. |
+| **B. Mark misleading, require implementation** | Declare it a defect needing a fix. | ◑ Correct diagnosis, but under-specified — "implementation" here is a 6-line map re-point (see D), not a new build. |
+| **C. Remove aliased labels from the window** | Drop Clerk/Treasury/Audit from the window `TABS` until real components exist. | ❌ Rejected. The real components **already exist**; hiding honest, working surfaces is a regression, not a fix. |
+| **D. Route window tabs to the real components** | Point the window `TAB_COMPONENTS` map at `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` (import + 3 map lines). | ✅ **Recommended.** Trivial, safe, honest, closes the gap fully. |
+| **E. Defer until Backend OE / tool integration resolves** | Wait for Codex Backend OE. | ◑ Valid only as *scheduling*, not as *dependency* — option D has **no** Backend-OE dependency (pure frontend, components exist). |
+
+## 3. Recommendation: **Option D** (mount the real components), scheduled per posture
+
+**Rationale**
+- **Correctness:** the window is the only path that lies about what it renders; option D makes it match the route path
+  (the honest reference), giving 9/9 real surfaces in both hosts.
+- **Cost/risk:** minimal — add three lazy imports + change three lines in `TAB_COMPONENTS`; no route change, no window
+  behavioral change beyond mounting the correct component, no registry/backend/API change. The components are already
+  window-compatible via `useWorkbenchTab`'s dual-source read.
+- **No Backend-OE dependency:** the real components are pure frontend and already merged. Option D does **not** need
+  Codex Backend OE, tool integration, or G1. It is independent of the current pause reason.
+
+**Scheduling under the standing posture.** The Workbench lane is currently **paused pending Codex Backend OE**. Option D
+is Backend-OE-independent and low-risk, so it can be executed either (a) as a small standalone frontend PR whenever the
+owner briefly authorizes it, or (b) folded into the next Workbench UI lane when the pause lifts. This packet does **not**
+implement it — implementation is specified in WO-WB-G2-004 and gated on explicit owner authorization.
+
+## 4. Decision record
+
+- **DECISION:** D — re-point the window `TAB_COMPONENTS` for `clerk`/`treasury`/`audit` to the real components.
+- **IMPLEMENTATION_REQUIRED:** yes (small, frontend-only) — but **not** in this goal (decision-only) and **not** dependent
+  on Backend OE.
+- **DO NOT** implement route changes, window-behavior changes beyond the map re-point, or any registry/backend work to
+  satisfy this decision.
+
+**Docs-only. No implementation. No stop wall.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-004-window-aliasing-implementation-playbook.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-004-window-aliasing-implementation-playbook.md
@@ -27,9 +27,19 @@ In `frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx`:
    treasury: PropertyTreasury,   // was PropertyDais
    audit:    PropertyAudit,      // was PropertyDossier
    ```
+3. **Remove the initial-tab (launch) alias** in `resolvedInitialTab` (`:727-731`) — delete these two branches so a
+   `metadata.tabId` of `clerk`/`audit`/`treasury` resolves to itself (validated against `TABS`) instead of being
+   remapped:
+   ```
+   -  if (initialTab === 'clerk' || initialTab === 'audit') return 'dossier';
+   -  if (initialTab === 'treasury') return 'dais';
+   ```
+   (The subsequent `TABS.find(...)` already validates the slug and falls back to `summary` for unknown ones, so removing
+   the two branches is sufficient and safe.)
 
-No other change. The tab bar (`TABS`), context provider (`WorkbenchTabCtx.Provider`), and reserved-boundary host-violation
-guard are unaffected.
+**Both** changes are required. Fixing only step 2 would leave a `tabId=clerk` launch opening the Dossier tab (step 3
+governs the launch path; step 2 governs tab-switching). The tab bar (`TABS`), context provider
+(`WorkbenchTabCtx.Provider`), and reserved-boundary host-violation guard are otherwise unaffected.
 
 ## 2. Allowed files (future lane)
 
@@ -46,16 +56,20 @@ guard are unaffected.
 
 ## 4. Expected tests
 
-- Add a window-mapping contract test in `__tests__/workbench/`: for `clerk`/`treasury`/`audit`, the window renders the
-  **real** component (assert a stable testid unique to each — `property-clerk-tab` / `property-treasury-tab` /
-  `property-audit-tab` — appears when that tab is active), and does **not** render the Dossier/Dais testid under those
-  labels.
-- Re-verify `PropertyWorkbenchWindow.segmentContext.test.tsx` still passes (it carries a local `TAB_COMPONENTS` copy;
-  update that copy if the test relies on it).
+- Add a window-mapping contract test in `__tests__/workbench/` covering **both** paths:
+  - **Tab-switch path:** activating `clerk`/`treasury`/`audit` renders the **real** component (assert a stable testid
+    unique to each — `property-clerk-tab` / `property-treasury-tab` / `property-audit-tab` — appears when that tab is
+    active) and does **not** render the Dossier/Dais testid under those labels.
+  - **Launch path:** rendering `PropertyWorkbenchWindow` with `metadata.tabId` = `clerk`/`treasury`/`audit` opens that
+    real tab (not `dossier`/`dais`) — i.e. the `resolvedInitialTab` remap is gone.
+- Re-verify `PropertyWorkbenchWindow.segmentContext.test.tsx` still passes. (Note: that test exercises only the
+  segment-context bridge and does **not** reference `TAB_COMPONENTS` or the alias, so it is not expected to be affected;
+  confirm at implementation time.)
 
 ## 5. Acceptance criteria
 
-- Window "Clerk"/"Treasury"/"Audit" tabs mount `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` respectively.
+- Window "Clerk"/"Treasury"/"Audit" tabs mount `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` respectively (tab-switch path).
+- Launching the window with `metadata.tabId` = clerk/treasury/audit opens that real tab, not dossier/dais (launch path).
 - Route path unchanged; both hosts now render 9/9 real surfaces.
 - Each tab's honesty badge (slice-aware, from the completed provenance program) renders in the window path too.
 - Frontend Gate + Vitest Full Suite + required contexts green; no --admin / no break-glass.
@@ -63,7 +77,8 @@ guard are unaffected.
 ## 6. Rollback plan
 
 Single-file, single-commit change → revert the commit (restore the three `TAB_COMPONENTS` entries to
-Dossier/Dais/Dossier and drop the three imports). No data or schema involved; rollback is instantaneous and side-effect-free.
+Dossier/Dais/Dossier, restore the two `resolvedInitialTab` alias branches, and drop the three imports). No data or schema
+involved; rollback is instantaneous and side-effect-free.
 
 ## 7. Stop walls (future lane)
 

--- a/docs/audit/workbench-readiness/WO-WB-G2-004-window-aliasing-implementation-playbook.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-004-window-aliasing-implementation-playbook.md
@@ -1,0 +1,81 @@
+# WO-WB-G2-004 — Window Aliasing Implementation Playbook (future lane — not executed here)
+
+**Goal:** GOAL-TF-WB-G2-WINDOW-ALIASING-001
+**WO:** WO-WB-G2-004 — Operator Note / Future Implementation Playbook
+**Category:** Documentation (playbook only — **do not implement**)
+**Implements decision:** WO-WB-G2-003 → Option D (mount the real Clerk/Treasury/Audit in the window)
+
+> **This is a playbook, not an execution.** It exists so the fix can be run later under explicit authorization without
+> re-deriving scope. Nothing in this WO changes code.
+
+---
+
+## 1. Change (when authorized)
+
+In `frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx`:
+
+1. Add three lazy imports mirroring the existing pattern (`:50-67`):
+   ```
+   const PropertyClerk = lazy(() => import('./tabs/PropertyClerk').then((m) => ({ default: m.PropertyClerk })));
+   const PropertyTreasury = lazy(() => import('./tabs/PropertyTreasury').then((m) => ({ default: m.PropertyTreasury })));
+   const PropertyAudit = lazy(() => import('./tabs/PropertyAudit').then((m) => ({ default: m.PropertyAudit })));
+   ```
+   (Confirm the export shape of each tab module — default vs named — at implementation time.)
+2. Re-point `TAB_COMPONENTS` (`:73-83`):
+   ```
+   clerk:    PropertyClerk,      // was PropertyDossier
+   treasury: PropertyTreasury,   // was PropertyDais
+   audit:    PropertyAudit,      // was PropertyDossier
+   ```
+
+No other change. The tab bar (`TABS`), context provider (`WorkbenchTabCtx.Provider`), and reserved-boundary host-violation
+guard are unaffected.
+
+## 2. Allowed files (future lane)
+
+- `frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx`
+- `frontend/apps/os-shell/src/__tests__/workbench/**` (tests)
+- `docs/audit/workbench-readiness/**`
+
+## 3. Blocked files (future lane)
+
+- Router.tsx / any route change (the route path is already correct — do not touch)
+- the tab components themselves (`PropertyClerk/Treasury/Audit.tsx` — no change needed; they are window-compatible)
+- `context/workbenchTabContext.tsx`
+- backend/**, tools/registry/**, API/service, package/build/CI, DB/migrations, deploy, PACS/county data, Codex Backend OE.
+
+## 4. Expected tests
+
+- Add a window-mapping contract test in `__tests__/workbench/`: for `clerk`/`treasury`/`audit`, the window renders the
+  **real** component (assert a stable testid unique to each — `property-clerk-tab` / `property-treasury-tab` /
+  `property-audit-tab` — appears when that tab is active), and does **not** render the Dossier/Dais testid under those
+  labels.
+- Re-verify `PropertyWorkbenchWindow.segmentContext.test.tsx` still passes (it carries a local `TAB_COMPONENTS` copy;
+  update that copy if the test relies on it).
+
+## 5. Acceptance criteria
+
+- Window "Clerk"/"Treasury"/"Audit" tabs mount `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` respectively.
+- Route path unchanged; both hosts now render 9/9 real surfaces.
+- Each tab's honesty badge (slice-aware, from the completed provenance program) renders in the window path too.
+- Frontend Gate + Vitest Full Suite + required contexts green; no --admin / no break-glass.
+
+## 6. Rollback plan
+
+Single-file, single-commit change → revert the commit (restore the three `TAB_COMPONENTS` entries to
+Dossier/Dais/Dossier and drop the three imports). No data or schema involved; rollback is instantaneous and side-effect-free.
+
+## 7. Stop walls (future lane)
+
+Stop and escalate if, at implementation time: a real component turns out **not** to mount under `WorkbenchTabCtx` (would
+contradict this audit — re-verify `useWorkbenchTab`); the reserved-boundary host-violation guard rejects the real
+component as unauthorized for the window host; or a test genuinely pins the alias as intended behavior (would require a
+product decision, not a code fix).
+
+## 8. Dependency on Backend OE
+
+**None.** The real components are pure frontend and already merged. This fix is independent of Codex Backend OE, tool
+integration, and G1. It can be scheduled whenever the Workbench pause is briefly lifted or as the first item of the next
+Workbench UI lane.
+
+**Playbook only. Nothing implemented in this WO.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-005-window-aliasing-evidence-rollup.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-005-window-aliasing-evidence-rollup.md
@@ -1,0 +1,74 @@
+# WO-WB-G2-005 — Window Aliasing Evidence Rollup + Next Lane Decision
+
+**Goal:** GOAL-TF-WB-G2-WINDOW-ALIASING-001 — Workbench Window Adapter Aliasing Decision
+**WO:** WO-WB-G2-005 — Evidence Rollup + Next Lane Decision
+**Category:** Documentation (closure)
+**Status:** COMPLETE — G2 resolved to a cited decision + future-implementation playbook (no code changed)
+
+---
+
+## 1. WOs completed
+
+| WO | Deliverable |
+|----|-------------|
+| G2-001 | `WO-WB-G2-001-route-vs-window-truth-audit.md` — route path = 9/9 real; window aliases clerk/treasury/audit → Dossier/Dais/Dossier |
+| G2-002 | `WO-WB-G2-002-window-aliasing-impact-matrix.md` — misleading-surface, low blast radius, trivially fixable |
+| G2-003 | `WO-WB-G2-003-window-aliasing-decision-packet.md` — **DECISION: Option D** (mount the real components) |
+| G2-004 | `WO-WB-G2-004-window-aliasing-implementation-playbook.md` — future lane spec (not executed) |
+| G2-005 | this rollup |
+
+## 2. Decision
+
+- **DECISION:** **D** — re-point the window `TAB_COMPONENTS` (`PropertyWorkbenchWindow.tsx:73-83`) for
+  `clerk`/`treasury`/`audit` at the real `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` components.
+- **IMPLEMENTATION_REQUIRED:** yes — small, frontend-only (3 imports + 3 map lines + a window-mapping test). **Not**
+  executed in this decision-only goal.
+- **Root cause:** the alias is **stale/vestigial** — it predates the real Clerk/Treasury/Audit components (built during
+  the Workbench readiness + honesty programs) and was never re-pointed. It is not a compatibility constraint: the real
+  components mount under the window's `WorkbenchTabCtx` via `useWorkbenchTab`'s dual-source read.
+
+## 3. Evidence (first-hand, cited)
+
+- Route children render real components: `Router.tsx:217-226` (clerk/treasury/audit → PropertyClerk/Treasury/Audit).
+- Window aliases + omits real imports: `PropertyWorkbenchWindow.tsx:73-83` (map) and `:50-67` (imports — Clerk/Treasury/
+  Audit absent; grep = 0).
+- Window-compatibility: `context/workbenchTabContext.tsx:77-84` (dual-source), `PropertyWorkbenchWindow.tsx:919`
+  (`WorkbenchTabCtx.Provider`).
+- Alias not pinned by tests: `PropertyWorkbenchWindow.segmentContext.test.tsx` uses a local `TAB_COMPONENTS` copy and does
+  not assert the production alias.
+
+## 4. Validation
+
+Docs-only across all five WOs: `git diff --check` clean; scope limited to `docs/audit/workbench-readiness/**`; required
+branch-protection contexts green; review threads resolved; no `--admin` / no break-glass. **No frontend/route/window/
+backend/registry code touched** in this goal.
+
+## 5. Risks remaining
+
+- The mislabel persists in the desktop-window host **until Option D is implemented** in a future lane. Blast radius is
+  limited to window-hosted Clerk/Treasury/Audit; the route path is unaffected and honest.
+- Live traffic split (route vs window) was not measured (out of docs-only scope) — it affects *urgency*, not the
+  *decision*.
+
+## 6. Should Workbench stay parked? Should Codex Backend OE remain priority?
+
+- **Yes — Workbench stays parked** pending Codex Backend OE, per the standing operator decision. This G2 loop was the
+  authorized *decision-only* exception (read-only + docs), and it is now closed.
+- **Yes — Codex Backend OE remains the priority.** G1 (0/117 tool backend integration) is unchanged and remains the
+  Codex/backend/TerraPilot lane. This goal did not touch it.
+- **Option D is Backend-OE-independent**, so when the owner wants a quick honest win it can be scheduled as a small
+  standalone frontend PR (per WO-WB-G2-004) without waiting for Codex — but only under explicit authorization, since
+  Workbench is otherwise paused.
+
+## 7. Recommended next lane
+
+1. **Default (posture-consistent):** keep Workbench paused; let Codex close Backend OE.
+2. **If a quick honest win is wanted:** authorize the WO-WB-G2-004 implementation lane (single-file window map re-point +
+   test) — low risk, no Codex dependency.
+3. **Do not** start route/window-aliasing implementation without this decision packet (now satisfied) + explicit
+   authorization.
+
+## 8. Non-goals (explicitly NOT done)
+
+No backend integration; no tool-registry promotion; no route/window aliasing **implementation** (decision + playbook
+only); no component changes; no PACS/county data; no deployment. **G1 0/117 tool backend integration remains separate.**

--- a/docs/audit/workbench-readiness/WO-WB-G2-005-window-aliasing-evidence-rollup.md
+++ b/docs/audit/workbench-readiness/WO-WB-G2-005-window-aliasing-evidence-rollup.md
@@ -20,9 +20,10 @@
 ## 2. Decision
 
 - **DECISION:** **D** — re-point the window `TAB_COMPONENTS` (`PropertyWorkbenchWindow.tsx:73-83`) for
-  `clerk`/`treasury`/`audit` at the real `PropertyClerk`/`PropertyTreasury`/`PropertyAudit` components.
-- **IMPLEMENTATION_REQUIRED:** yes — small, frontend-only (3 imports + 3 map lines + a window-mapping test). **Not**
-  executed in this decision-only goal.
+  `clerk`/`treasury`/`audit` at the real components **and** remove the `resolvedInitialTab` launch remap (`:727-731`).
+  Both alias mechanisms must be fixed together to actually close G2.
+- **IMPLEMENTATION_REQUIRED:** yes — small, frontend-only (3 imports + 3 map lines + delete 2 remap branches + a
+  window-mapping test covering both tab-switch and launch paths). **Not** executed in this decision-only goal.
 - **Root cause:** the alias is **stale/vestigial** — it predates the real Clerk/Treasury/Audit components (built during
   the Workbench readiness + honesty programs) and was never re-pointed. It is not a compatibility constraint: the real
   components mount under the window's `WorkbenchTabCtx` via `useWorkbenchTab`'s dual-source read.
@@ -30,12 +31,13 @@
 ## 3. Evidence (first-hand, cited)
 
 - Route children render real components: `Router.tsx:217-226` (clerk/treasury/audit → PropertyClerk/Treasury/Audit).
-- Window aliases + omits real imports: `PropertyWorkbenchWindow.tsx:73-83` (map) and `:50-67` (imports — Clerk/Treasury/
-  Audit absent; grep = 0).
+- Window aliases via **two** mechanisms: `PropertyWorkbenchWindow.tsx:73-83` (`TAB_COMPONENTS` map) and `:727-731`
+  (`resolvedInitialTab` launch remap); real imports omitted at `:50-67` (Clerk/Treasury/Audit absent; grep = 0).
 - Window-compatibility: `context/workbenchTabContext.tsx:77-84` (dual-source), `PropertyWorkbenchWindow.tsx:919`
   (`WorkbenchTabCtx.Provider`).
-- Alias not pinned by tests: `PropertyWorkbenchWindow.segmentContext.test.tsx` uses a local `TAB_COMPONENTS` copy and does
-  not assert the production alias.
+- Alias not covered by tests: `PropertyWorkbenchWindow.segmentContext.test.tsx` exercises only the segment-context bridge
+  and does **not** reference `TAB_COMPONENTS`, the `resolvedInitialTab` remap, or the alias labels (grep = 0) — so the
+  mislabel is entirely uncovered.
 
 ## 4. Validation
 


### PR DESCRIPTION
## GOAL-TF-WB-G2-WINDOW-ALIASING-001 — decision-only, docs-only

Resolves the **G2** Workbench gap. First-hand source audit (no extrapolation):
- **Route path** (`Router.tsx:217-226`) renders **9/9 real** tab components.
- **Window adapter** (`PropertyWorkbenchWindow.tsx:73-83`) aliases **clerk→Dossier, treasury→Dais, audit→Dossier** and never imports the real components.
- The real components **exist and are window-compatible** (`useWorkbenchTab` reads both `WorkbenchTabCtx` + Outlet; window provides `WorkbenchTabCtx.Provider` at `:919`), so the alias is **stale/vestigial**. Not pinned by any test.

### Decision: **Option D** — re-point the window `TAB_COMPONENTS` at the real `PropertyClerk/Treasury/Audit` (3 imports + 3 lines). Frontend-only, **Backend-OE-independent**. **Not implemented here** (decision-only goal).

### Deliverables (5 docs)
G2-001 truth audit · G2-002 impact matrix · G2-003 decision packet · G2-004 future-implementation playbook · G2-005 evidence rollup.

Workbench stays **paused pending Codex Backend OE**; G1 remains separate. Docs-only; no code/route/window/backend change.