### PR TITLE
feat(workbench): mount real Clerk/Treasury/Audit in window adapter (WO-WB-G2-FIX-002/003/004)

### DIFF
--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbenchWindow.tabMapping.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbenchWindow.tabMapping.test.tsx
@@ -16,13 +16,17 @@
 
 import '@testing-library/jest-dom';
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { activateModuleMock, selectParcelMock, openWorkbenchWindowMock } = vi.hoisted(() => ({
+const ALL_TABS = ['summary', 'forge', 'atlas', 'dais', 'clerk', 'treasury', 'audit', 'dossier', 'pilot'];
+
+const { activateModuleMock, selectParcelMock, openWorkbenchWindowMock, visibleTabsHolder } = vi.hoisted(() => ({
   activateModuleMock: vi.fn(),
   selectParcelMock: vi.fn(),
   openWorkbenchWindowMock: vi.fn(),
+  // Mutable so a test can simulate a role whose defaults hide clerk/treasury/audit.
+  visibleTabsHolder: { value: ['summary', 'forge', 'atlas', 'dais', 'clerk', 'treasury', 'audit', 'dossier', 'pilot'] },
 }));
 
 // ── Tab module stubs (named exports mirror the window's lazy imports) ──────────
@@ -88,10 +92,10 @@ vi.mock('../../auth/useAuthContext', () => ({
   useAuthContext: () => ({ countyId: 'benton', userId: 'u-test', roles: ['assessor'] }),
 }));
 
-// All nine tabs visible so their buttons render and are in filteredTabs.
+// Visible-tab set is mutable per test (defaults to all nine).
 vi.mock('../../hooks/useWorkbenchRoles', () => ({
   useWorkbenchRoles: () => ({
-    visibleTabs: ['summary', 'forge', 'atlas', 'dais', 'clerk', 'treasury', 'audit', 'dossier', 'pilot'],
+    visibleTabs: visibleTabsHolder.value,
     hiddenCount: 0,
     showAll: true,
     toggleShowAll: vi.fn(),
@@ -115,6 +119,7 @@ const renderWindow = (tabId: string) =>
 describe('PropertyWorkbenchWindow tab→component mapping (G2 Option D)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    visibleTabsHolder.value = [...ALL_TABS];
   });
 
   // ── Launch path (proves the resolvedInitialTab remap is removed) ────────────
@@ -160,6 +165,18 @@ describe('PropertyWorkbenchWindow tab→component mapping (G2 Option D)', () => 
     await screen.findByTestId('stub-summary');
     fireEvent.click(screen.getByRole('tab', { name: /audit/i }));
     expect(await screen.findByTestId('stub-audit')).toBeInTheDocument();
+  });
+
+  // ── Deep-launch into a role-hidden tab still renders (no blank workbench) ────
+
+  it('deep-launching into a role-hidden tab (clerk) still mounts the real tab, not a blank panel', async () => {
+    // Simulate a role whose defaults hide clerk/treasury/audit. Removing the old
+    // remap must not leave activeTab absent from the render loop; the active tab is
+    // forced into the visible set so its panel still mounts.
+    visibleTabsHolder.value = ['summary', 'forge', 'atlas', 'dossier'];
+    renderWindow('clerk');
+    expect(await screen.findByTestId('stub-clerk')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dossier')).not.toBeInTheDocument();
   });
 
   // ── Regression: the six always-real tabs still render their own components ───

--- a/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbenchWindow.tabMapping.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/workbench/PropertyWorkbenchWindow.tabMapping.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * PropertyWorkbenchWindow.tabMapping.test.tsx
+ *
+ * WO-WB-G2-FIX-004 — proves the G2 Option D fix: the desktop window adapter mounts
+ * the REAL Clerk/Treasury/Audit components (matching the route-based Workbench),
+ * fixing BOTH alias mechanisms:
+ *   - TAB_COMPONENTS map (tab-switch path): selecting Clerk/Treasury/Audit renders
+ *     the real component, not Dossier/Dais.
+ *   - resolvedInitialTab launch remap (launch path): launching with tabId =
+ *     clerk/treasury/audit opens that real tab, not dossier/dais.
+ * Plus a regression check that the six always-real tabs still render.
+ *
+ * The nine tab modules are stubbed to lightweight testid markers so this test
+ * exercises the window's tab→component mapping, not each tab's internals.
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { activateModuleMock, selectParcelMock, openWorkbenchWindowMock } = vi.hoisted(() => ({
+  activateModuleMock: vi.fn(),
+  selectParcelMock: vi.fn(),
+  openWorkbenchWindowMock: vi.fn(),
+}));
+
+// ── Tab module stubs (named exports mirror the window's lazy imports) ──────────
+const stub = (name: string) => () => <div data-testid={`stub-${name}`}>{name}</div>;
+vi.mock('../../pages/workbench/tabs/PropertySummary', () => ({ PropertySummary: stub('summary') }));
+vi.mock('../../pages/workbench/tabs/PropertyForge', () => ({ PropertyForge: stub('forge') }));
+vi.mock('../../pages/workbench/tabs/PropertyAtlas', () => ({ PropertyAtlas: stub('atlas') }));
+vi.mock('../../pages/workbench/tabs/PropertyDais', () => ({ PropertyDais: stub('dais') }));
+vi.mock('../../pages/workbench/tabs/PropertyDossier', () => ({ PropertyDossier: stub('dossier') }));
+vi.mock('../../pages/workbench/tabs/PropertyPilot', () => ({ PropertyPilot: stub('pilot') }));
+vi.mock('../../pages/workbench/tabs/PropertyClerk', () => ({ PropertyClerk: stub('clerk') }));
+vi.mock('../../pages/workbench/tabs/PropertyTreasury', () => ({ PropertyTreasury: stub('treasury') }));
+vi.mock('../../pages/workbench/tabs/PropertyAudit', () => ({ PropertyAudit: stub('audit') }));
+
+// ── Heavy-dependency mocks (reused from the segment-context test) ──────────────
+vi.mock('@/orchestration/moduleActivation', () => ({
+  default: activateModuleMock,
+  activateModule: activateModuleMock,
+}));
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: any) => {
+    const state = {
+      activeParcel: {
+        parcelId: 'BC-1',
+        address: '1 Test Ave',
+        ownerName: 'Test Owner',
+        totalAssessedValue: 250000,
+        marketValue: 260000,
+        landValue: 80000,
+        improvementValue: 170000,
+        propertyType: 'Residential',
+        legalDescription: 'Lot 1',
+        dataSource: 'test',
+      },
+      activeParcelLoading: false,
+      selectParcel: selectParcelMock,
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../context/parcelContext', () => ({
+  useRecentParcels: () => [],
+  useRecentParcelMeta: () => ({}),
+  recordRecentParcelMeta: vi.fn(),
+  openWorkbenchWindow: openWorkbenchWindowMock,
+}));
+
+vi.mock('../../stores/commandPaletteStore', () => ({
+  useCommandPaletteStore: (selector: any) => selector({ open: vi.fn() }),
+}));
+
+vi.mock('../../shell/command-palette/useParcelSearch', () => ({
+  useParcelSearch: () => ({ results: [], totalCount: 0, isLoading: false }),
+}));
+
+vi.mock('../../auth/useSession', () => ({
+  useSession: () => ({ countyId: 'benton', userId: 'u-test', role: 'assessor' }),
+}));
+
+vi.mock('../../auth/useAuthContext', () => ({
+  useAuthContext: () => ({ countyId: 'benton', userId: 'u-test', roles: ['assessor'] }),
+}));
+
+// All nine tabs visible so their buttons render and are in filteredTabs.
+vi.mock('../../hooks/useWorkbenchRoles', () => ({
+  useWorkbenchRoles: () => ({
+    visibleTabs: ['summary', 'forge', 'atlas', 'dais', 'clerk', 'treasury', 'audit', 'dossier', 'pilot'],
+    hiddenCount: 0,
+    showAll: true,
+    toggleShowAll: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/badges', () => ({ BADGE_PROVIDERS: [] }));
+vi.mock('../../services/quickActions', () => ({ QUICK_ACTION_PROVIDERS: [] }));
+vi.mock('../../services/activityFeed', () => ({
+  useParcelActivity: () => ({ entries: [], loading: false }),
+}));
+// Stub the chrome so the test targets tab mapping, not ribbon/feed internals.
+vi.mock('../../components/workbench/ContextRibbon', () => ({ ContextRibbon: () => <div data-testid='ctx-ribbon' /> }));
+vi.mock('../../components/workbench/ActivityFeed', () => ({ ActivityFeed: () => <div data-testid='activity-feed' /> }));
+
+import PropertyWorkbenchWindow from '../../pages/workbench/PropertyWorkbenchWindow';
+
+const renderWindow = (tabId: string) =>
+  render(<PropertyWorkbenchWindow metadata={{ parcelId: 'BC-1', tabId }} />);
+
+describe('PropertyWorkbenchWindow tab→component mapping (G2 Option D)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Launch path (proves the resolvedInitialTab remap is removed) ────────────
+
+  it('launching with tabId=clerk opens the real Clerk tab (not Dossier)', async () => {
+    renderWindow('clerk');
+    expect(await screen.findByTestId('stub-clerk')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dossier')).not.toBeInTheDocument();
+  });
+
+  it('launching with tabId=treasury opens the real Treasury tab (not Dais)', async () => {
+    renderWindow('treasury');
+    expect(await screen.findByTestId('stub-treasury')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dais')).not.toBeInTheDocument();
+  });
+
+  it('launching with tabId=audit opens the real Audit tab (not Dossier)', async () => {
+    renderWindow('audit');
+    expect(await screen.findByTestId('stub-audit')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dossier')).not.toBeInTheDocument();
+  });
+
+  // ── Tab-switch path (proves the TAB_COMPONENTS map points at the real components) ──
+
+  it('selecting the Clerk tab renders the real Clerk component', async () => {
+    renderWindow('summary');
+    expect(await screen.findByTestId('stub-summary')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /clerk/i }));
+    expect(await screen.findByTestId('stub-clerk')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dossier')).not.toBeInTheDocument();
+  });
+
+  it('selecting the Treasury tab renders the real Treasury component', async () => {
+    renderWindow('summary');
+    await screen.findByTestId('stub-summary');
+    fireEvent.click(screen.getByRole('tab', { name: /treasury/i }));
+    expect(await screen.findByTestId('stub-treasury')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-dais')).not.toBeInTheDocument();
+  });
+
+  it('selecting the Audit tab renders the real Audit component', async () => {
+    renderWindow('summary');
+    await screen.findByTestId('stub-summary');
+    fireEvent.click(screen.getByRole('tab', { name: /audit/i }));
+    expect(await screen.findByTestId('stub-audit')).toBeInTheDocument();
+  });
+
+  // ── Regression: the six always-real tabs still render their own components ───
+
+  it.each([
+    ['summary', 'stub-summary'],
+    ['forge', 'stub-forge'],
+    ['atlas', 'stub-atlas'],
+    ['dais', 'stub-dais'],
+    ['dossier', 'stub-dossier'],
+    ['pilot', 'stub-pilot'],
+  ])('launching with tabId=%s still renders its real component', async (tabId, testid) => {
+    renderWindow(tabId);
+    expect(await screen.findByTestId(testid)).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
@@ -802,10 +802,19 @@ const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metad
   const { visibleTabs, hiddenCount, showAll, toggleShowAll } = useWorkbenchRoles(roles);
 
   /** Tabs filtered by role visibility — order preserved */
-  const filteredTabs = useMemo(
-    () => TABS.filter((tab) => visibleTabs.includes(tab.id)),
-    [visibleTabs]
-  );
+  const filteredTabs = useMemo(() => {
+    const base = TABS.filter((tab) => visibleTabs.includes(tab.id));
+    // Always keep the active tab renderable: a deep-launch (metadata.tabId) into a
+    // tab hidden by the current role's defaults would otherwise leave activeTab
+    // absent from the render loop and show a blank workbench. Force the requested
+    // tab into the visible set so its panel mounts (role hiding is a UX declutter
+    // with a show-all toggle, not a host-boundary gate — that is validateWorkbenchHost).
+    if (!base.some((tab) => tab.id === activeTab)) {
+      const active = TABS.find((tab) => tab.id === activeTab);
+      if (active) return [...base, active];
+    }
+    return base;
+  }, [visibleTabs, activeTab]);
 
   // Context value for tab components (via WorkbenchTabCtx)
   const tabContextValue = useMemo(

--- a/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
+++ b/frontend/apps/os-shell/src/pages/workbench/PropertyWorkbenchWindow.tsx
@@ -65,19 +65,30 @@ const PropertyDossier = lazy(() =>
 const PropertyPilot = lazy(() =>
   import('./tabs/PropertyPilot').then((m) => ({ default: m.PropertyPilot }))
 );
+const PropertyClerk = lazy(() =>
+  import('./tabs/PropertyClerk').then((m) => ({ default: m.PropertyClerk }))
+);
+const PropertyTreasury = lazy(() =>
+  import('./tabs/PropertyTreasury').then((m) => ({ default: m.PropertyTreasury }))
+);
+const PropertyAudit = lazy(() =>
+  import('./tabs/PropertyAudit').then((m) => ({ default: m.PropertyAudit }))
+);
 
 // ============================================================================
 // Tab → Component Map
 // ============================================================================
 
+// G2 fix (Option D): clerk/treasury/audit mount their REAL components — matching
+// the route-based Workbench (Router.tsx) — instead of aliasing to Dossier/Dais.
 const TAB_COMPONENTS: Record<WorkbenchTabSlug, React.LazyExoticComponent<React.FC>> = {
   summary: PropertySummary,
   forge: PropertyForge,
   atlas: PropertyAtlas,
   dais: PropertyDais,
-  clerk: PropertyDossier,
-  treasury: PropertyDais,
-  audit: PropertyDossier,
+  clerk: PropertyClerk,
+  treasury: PropertyTreasury,
+  audit: PropertyAudit,
   dossier: PropertyDossier,
   pilot: PropertyPilot,
 };
@@ -724,11 +735,12 @@ const PropertyWorkbenchWindow: React.FC<PropertyWorkbenchWindowProps> = ({ metad
   const session = useSession();
   const auth = useAuthContext();
 
-  // Resolve initial tab from metadata slug
+  // Resolve initial tab from metadata slug.
+  // G2 fix (Option D): no clerk/audit→dossier or treasury→dais remap — a
+  // deep-launch into clerk/treasury/audit opens the real tab. TABS.find still
+  // validates the slug and falls back to 'summary' for unknown ones.
   const resolvedInitialTab = useMemo<WorkbenchTabSlug>(() => {
     if (!initialTab || initialTab === '/' as string) return 'summary';
-    if (initialTab === 'clerk' || initialTab === 'audit') return 'dossier';
-    if (initialTab === 'treasury') return 'dais';
     const valid = TABS.find((t) => t.id === initialTab);
     return valid?.id ?? 'summary';
   }, [initialTab]);


### PR DESCRIPTION
## GOAL-TF-WB-G2-WINDOW-ALIASING-FIX-001 · WO-FIX-002 + 003 + 004

Implements the decided **G2 Option D** fix (decision packet #1221) in `PropertyWorkbenchWindow.tsx`, closing **both** alias mechanisms so the desktop/window Workbench matches the route-based Workbench.

### Changes (single component file + 1 test)
- **FIX-002 — TAB_COMPONENTS map:** `clerk/treasury/audit` now mount `PropertyClerk/PropertyTreasury/PropertyAudit` (3 lazy imports added, mirroring the existing named-export pattern) instead of aliasing to Dossier/Dais.
- **FIX-003 — resolvedInitialTab remap:** removed the `clerk/audit→dossier` and `treasury→dais` launch remap, so a deep-launch (`metadata.tabId`) into those tabs opens the real tab. `TABS.find` still validates + falls back to `summary`.
- **FIX-004 — tests:** `PropertyWorkbenchWindow.tabMapping.test.tsx` proves **both** paths — launch (`tabId=clerk`→Clerk, proves remap removal) and tab-switch (click Clerk→Clerk, proves map) render the real components and **not** Dossier/Dais — plus a regression check for the six always-real tabs. Tab modules are stubbed to testid markers so the test targets the window mapping.

### Safety
- Real components are window-compatible (`useWorkbenchTab` dual-source) and **lawfully hosted** — `objectPlacement.ts` classifies clerk/treasury/audit as `parcel-scoped-app` on `tier0-workbench`, so `validateWorkbenchHost` does not reject them (verified — no host-violation stop-wall).
- **Router.tsx / route-based Workbench untouched**; no tool registry, backend, API, package/build/CI, deploy, or PACS change.

### Validation
Frontend Gate + Vitest Full Suite + required contexts; review threads resolved; no --admin / no break-glass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workbench tabs can now open the real **Clerk**, **Treasury**, and **Audit** panels directly.
  * Selected tabs remain visible even when role-based tab filtering would normally hide them.

* **Bug Fixes**
  * Fixed deep links so tab launches use the requested tab instead of remapping to a different one.
  * Prevented blank workbench screens when the active tab isn’t available in the current role view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->