### PR TITLE
WO-BACKEND-OE-009 Backend Release Gate Definition

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -46,7 +46,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B | — |
 | WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
 | No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
-| Backend full solution tests depend on Docker/Testcontainers SQL Server lane | WO-BACKEND-OE-010 | Classified in WO-BACKEND-OE-003 as segmented integration prerequisite; release gate criteria defined in WO-BACKEND-OE-009; operational runbook handling still needed |
+| Backend full solution tests depend on Docker/Testcontainers SQL Server lane | Backend release readiness / integration validation | Classified in WO-BACKEND-OE-003 as segmented integration prerequisite; release gate criteria defined in WO-BACKEND-OE-009; operational runbook can proceed without Docker repair |
 | Local hook tooling cannot find Prettier/Vitest | All PR-finalization work | Local hook bypass authority wall; DevEx follow-up only |
 | Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
 | County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,11 +17,11 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-06 — WO-BACKEND-OE-008)*
+*(Updated 2026-07-06 — WO-BACKEND-OE-009)*
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
-| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Active | `WO-BACKEND-OE-008` | `WO-BACKEND-OE-009` after OE-008 merges | Auto if same-risk docs/evidence | Stop on implementation, infra repair, secrets, protected data, or non-docs hook bypass; docs-only hook bypass requires evidence |
+| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Active | `WO-BACKEND-OE-009` | `WO-BACKEND-OE-010` after OE-009 merges | Auto if same-risk docs/evidence | Stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass; docs-only hook bypass requires evidence |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
 | [DevEx Hook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-4---devex-hook-tooling) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Follow-up | `WO-DEVEX-HOOKS-001` | TBD | No auto | Owner authorization required |
@@ -46,7 +46,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | PR #1112 auto-merge pending (WO-CONFIG-BENTON-001) | WO-DEPLOY-BENTON-003B | — |
 | WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
 | No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
-| Backend full solution tests depend on Docker/Testcontainers SQL Server lane | WO-BACKEND-OE-009 | Classified in WO-BACKEND-OE-003 as segmented integration prerequisite; release gate policy still needed |
+| Backend full solution tests depend on Docker/Testcontainers SQL Server lane | WO-BACKEND-OE-010 | Classified in WO-BACKEND-OE-003 as segmented integration prerequisite; release gate criteria defined in WO-BACKEND-OE-009; operational runbook handling still needed |
 | Local hook tooling cannot find Prettier/Vitest | All PR-finalization work | Local hook bypass authority wall; DevEx follow-up only |
 | Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
 | County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |
@@ -159,3 +159,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-06 | Consolidated backend security/auth/county-isolation proof matrix and routed next to migration/rollback proof | WO-BACKEND-OE-006 |
 | 2026-07-06 | Inventoried backend migration and rollback source evidence and routed next to Dais E2E proof planning | WO-BACKEND-OE-007 |
 | 2026-07-06 | Planned Dais workflow E2E proof expansion and routed next to backend release gate definition | WO-BACKEND-OE-008 |
+| 2026-07-06 | Defined backend release gate criteria and routed next to operational runbook | WO-BACKEND-OE-009 |

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md
@@ -1,0 +1,143 @@
+# WO-BACKEND-OE-009 - Backend Release Gate Definition
+
+Date: 2026-07-06
+Work order: WO-BACKEND-OE-009
+Program: Backend Operational Excellence
+Goal: GOAL-BACKEND-OPERATIONAL-EXCELLENCE
+Loop: LOOP-BACKEND-OPERATIONAL-EXCELLENCE
+Mode: docs/governance/release checklist
+
+## Result
+
+RESULT: PASS_WITH_GAP
+
+Backend release readiness now has an explicit evidence-based gate. The gate does not mark the
+backend release-ready today. It defines what must be true before a backend release can be promoted,
+and it separates already-proven build/unit evidence from partial or deferred operational proof.
+
+No backend runtime behavior was changed in this work order. No tests were added, no CI workflows were
+wired, no migrations were created or applied, and no services were started.
+
+## Guardrails
+
+| Boundary | Result |
+|----------|--------|
+| Backend/runtime code changes | None |
+| Test implementation changes | None |
+| CI/release workflow wiring | Not changed |
+| Release automation or deployment | Not changed |
+| Migrations or database update | Not run |
+| Docker/Testcontainers repair | Not run |
+| Production/live/shared DB access | Not used |
+| County data, PACS, SQL, or secrets | Not touched |
+| Tools/sync implementation | Not changed |
+
+## Release Gate Verdict
+
+| Gate area | Current state | Release status | Required before backend release-ready claim |
+|-----------|---------------|----------------|---------------------------------------------|
+| Canonical backend build | `dotnet build backend/TerraFusion.sln` previously passed with `0 Warning(s)` and `0 Error(s)` in OE-001/OE-002 evidence. | PASS | Preserve zero-warning build; any new warning blocks release unless explicitly dispositioned. |
+| Warning threshold | OE-002 records warning count as zero and warning burn-down as not active work. | PASS | Threshold remains `0 Warning(s)` for canonical backend build. |
+| Unit test lane | OE-001 baseline recorded `TerraFusion.Unit.Tests` passing, and OE-006 focused security slices passed. | PASS_WITH_SCOPE | Release candidate must rerun the canonical unit lane on the release branch. |
+| Full solution/integration lane | OE-003 classifies Docker/Testcontainers SQL Server dependency as segmented integration prerequisite. | CONDITIONAL_BLOCKER | Release must either pass a Docker-capable integration lane or carry an explicit non-production/deferred integration-lane disposition. |
+| Docker/Testcontainers dependency | Docker/Testcontainers was not repaired in Backend OE; no Docker services were started. | CLASSIFIED_NOT_REPAIRED | Document Docker runtime/image prerequisites before requiring this lane in release validation. |
+| Health/readiness semantics | OE-004 maps `/healthz`, `/healthz/ready`, `/health/codex369`, `/api/transcendence/health`, `/levy/health`, and controller health endpoints. | PASS_WITH_GAP | Define authoritative readiness endpoint and resolve or formally disposition `/healthz/ready` tag mismatch before production-readiness claim. |
+| Service registry validation | OE-005 proves source wiring, startup hook, class-level behavior, and controller surface. | PASS_WITH_GAP | Prove writer/reader path alignment, seed path, stale/orphan behavior, and health semantics before treating registry as release-ready. |
+| Security/auth/county isolation | OE-006 consolidates auth, permission, county-claim, cross-county denial, and audit evidence. | PASS_WITH_GAP | Complete public endpoint allowlist, exhaustive controller/action policy map, and authorization-denial audit posture before production-readiness claim. |
+| Migration/rollback proof | OE-007 inventories migrations and `Down` methods; no apply/rollback execution was run. | PASS_WITH_GAP | Prove safe migration apply/rollback or explicitly scope release to source-present migration readiness only. |
+| Audit/trace proof | OE-006 proves selected audit event and audit trail behavior; OE-011 is still pending diagnostics mapping. | PARTIAL | Complete diagnostics/observability map and separate domain audit proof from middleware-level authorization-denial audit gaps. |
+| Dais E2E proof plan | OE-008 identifies Dais E2E proof gaps and future test slices. | PLAN_READY_NOT_IMPLEMENTED | Do not claim release-grade Dais E2E until HTTP pipeline, relational/restart, certification, cross-county mutation, and Dossier-boundary proof are addressed or deferred. |
+| Operational runbook | OE-010 is not complete yet. | BLOCKER | Backend operational runbook must exist before release-ready claim. |
+| Diagnostics map | OE-011 is not complete yet. | BLOCKER | Diagnostics/observability map must exist before release-ready claim. |
+| Operational packet | OE-012 is not complete yet. | BLOCKER | Backend operational packet must exist before program closeout/release handoff. |
+| Evidence rollup | OE-013 is not complete yet. | BLOCKER | Backend OE closeout rollup must link evidence, PRs, validations, deferred risks, and next lane. |
+
+## Required Release Gate Checklist
+
+A backend release candidate can be described as release-ready only when all applicable gates below are
+green or explicitly dispositioned in a release packet.
+
+| Gate | Required evidence | Pass criteria | Fail/block criteria |
+|------|-------------------|---------------|---------------------|
+| Build gate | Current `dotnet build backend/TerraFusion.sln` output. | Build passes with `0 Warning(s)` and `0 Error(s)`. | Any build error; any warning without explicit warning-register disposition. |
+| Unit gate | Current canonical backend unit test output. | Unit lane passes on release branch. | Unit failure not classified as environment-only. |
+| Integration gate | Docker/Testcontainers lane result or release disposition. | Docker-capable lane passes, or non-production/deferred disposition is explicitly documented. | Integration lane required but unavailable/failing without accepted release disposition. |
+| Health/readiness gate | OE-004 semantics plus current endpoint validation evidence. | Release packet identifies liveness, readiness, host-start, and feature-health endpoints and states which one gates release. | Readiness endpoint semantics ambiguous; `/healthz/ready` dependency coverage overclaimed. |
+| Service registry gate | OE-005 evidence plus any follow-up proof. | Registry writer/reader path, seed path, stale/orphan behavior, and registry health expectations are proven or explicitly deferred. | Registry used as release proof while still source-wired only. |
+| Security/auth gate | OE-006 matrix plus endpoint allowlist/policy map. | Protected endpoint policy and public endpoint allowlist are release-reviewed; auth denial and permission behavior are proven for release-critical paths. | Anonymous endpoint exposure or controller policy map remains unreviewed for production claim. |
+| County isolation gate | OE-006 matrix plus Dais/parcel/domain-specific proof. | Cross-county denial/non-leak proof covers release-critical domains or deferred gaps are explicit. | Cross-county mutation/read behavior is unproven for release-critical writes. |
+| Migration gate | OE-007 inventory plus apply/rollback or disposition evidence. | Migration contexts, automatic migration policy, SQL-only scripts, rollback path, and drift checks are proven or scoped. | Production/shared DB migration behavior ambiguous; SQL-only rollback unclassified. |
+| Audit/trace gate | OE-006 audit proof plus OE-011 diagnostics map. | Domain audit, request/error audit, and trace lookup expectations are mapped and release-critical gaps are dispositioned. | Audit claims include middleware-level 401/403 denial coverage without proof. |
+| Dais E2E gate | OE-008 proof plan plus any implementation follow-up. | Dais release claims are limited to proven coverage, or OE-008A-F slices are authorized and passed. | Dais marked release-grade E2E while planned gaps remain open. |
+| Runbook gate | OE-010 runbook. | Operator can validate, triage, rollback, capture evidence, and escalate without rediscovering system behavior. | No current backend runbook. |
+| Diagnostics gate | OE-011 map. | Logs, health/readiness, audit/security events, service registry signals, CI artifacts, and missing observability are mapped. | Diagnostics/observability surfaces are unknown or overclaimed. |
+| Operational packet gate | OE-012 packet. | Objective, sovereignty boundary, validation gates, rollback path, ownership, and done definition are assembled. | Backend OE evidence is scattered with no operator packet. |
+| Closeout gate | OE-013 rollup. | Completed WOs, PRs, commits, validations, risks, deferred WOs, and next lane are recorded. | Program closeout is missing or overclaims release readiness. |
+
+## Release-Blocking Versus Non-Release-Blocking Status
+
+| Item | Status | Release impact |
+|------|--------|----------------|
+| Zero-warning canonical build | Proven | Required pass; blocks release if regressed. |
+| Unit baseline | Proven previously; rerun required on release branch | Blocks release if current unit lane fails. |
+| Docker/Testcontainers integration lane | Classified prerequisite | Blocks production/full-integration readiness unless segmented/deferred by release packet. |
+| API.Tests Windows file lock from baseline | Environment/tooling caveat | Not warning debt; release packet must rerun or disposition affected lane. |
+| Health/readiness tag mismatch | Known readiness semantics gap | Blocks readiness overclaim; requires repair or release-policy disposition. |
+| ServiceRegistry path/health/orphan gaps | Known operational gap | Blocks treating registry as release-health proof. |
+| Public endpoint allowlist and policy map | Known security release gap | Blocks production security-readiness claim if not completed/dispositioned. |
+| Migration apply/rollback execution absent | Known persistence release gap | Blocks migration-readiness claim beyond source inventory. |
+| Dais E2E gaps | Planned proof gaps | Blocks Dais release-grade E2E claim, not existence of Dais implementation. |
+| Operational runbook missing | Remaining Backend OE WO | Blocks backend operational readiness until OE-010 merges. |
+| Diagnostics map missing | Remaining Backend OE WO | Blocks observability readiness until OE-011 merges. |
+| Operational packet missing | Remaining Backend OE WO | Blocks Backend OE closeout until OE-012 merges. |
+
+## Evidence References
+
+| Evidence | Release-gate use |
+|----------|------------------|
+| `WO-BACKEND-OE-002-BUILD-WARNING-REGISTER.md` | Build warning threshold and zero-warning posture. |
+| `WO-BACKEND-OE-003-INTEGRATION-TEST-ENVIRONMENT-DEPENDENCY-REGISTER.md` | Docker/Testcontainers lane classification and integration prerequisite policy. |
+| `WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md` | Health/readiness endpoint semantics and readiness candidate limits. |
+| `WO-BACKEND-OE-005-SERVICE-REGISTRY-RUNTIME-VALIDATION.md` | ServiceRegistry source/runtime-understanding proof and release gaps. |
+| `WO-BACKEND-OE-006-SECURITY-AUTH-COUNTY-ISOLATION-PROOF-MATRIX.md` | Security/auth/county/audit evidence and remaining release gaps. |
+| `WO-BACKEND-OE-007-MIGRATION-ROLLBACK-PROOF-REGISTER.md` | Migration inventory, rollback-source evidence, and migration-readiness gaps. |
+| `WO-BACKEND-OE-008-DAIS-WORKFLOW-E2E-PROOF-EXPANSION-PLAN.md` | Dais E2E proof plan and release-claim boundaries. |
+
+## Explicit Non-Claims
+
+This release gate does not claim:
+
+- production readiness,
+- full backend solution test pass,
+- Docker/Testcontainers repair,
+- CI workflow wiring,
+- release automation,
+- health/readiness behavior changes,
+- service registry repair,
+- migration apply/rollback execution,
+- Dais E2E implementation,
+- security policy changes,
+- or deployment authority.
+
+## Validation
+
+Planned validation for this work order:
+
+- `git diff --check`
+- `node docs/brain/workorders/tools/wo-query.mjs --json`
+- Scope inspection confirms only authorized docs/governance files changed.
+- No backend/runtime/tools-sync implementation files changed.
+
+## Next Work Order
+
+`WO-BACKEND-OE-010 - Backend Operational Runbook`
+
+Recommended scope:
+
+- Convert the release gate into operator procedure.
+- Cover build validation, zero-warning posture, unit/integration lane handling, health/readiness
+  interpretation, service registry triage, auth/county proof references, migration safety, Dais E2E
+  proof gaps, known blocker triage, evidence capture, and escalation triggers.
+- Do not start services, run migrations, wire CI, or change backend/runtime behavior.
+
+STOP_TYPE: BACKEND_RELEASE_GATE_DEFINED

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -8,7 +8,7 @@
 | Status | ACTIVE |
 | Owner | Operator (bsvalues@gmail.com) |
 | Last Updated | 2026-07-06 |
-| Next WO | `WO-BACKEND-OE-009` after `WO-BACKEND-OE-008` merges |
+| Next WO | `WO-BACKEND-OE-010` after `WO-BACKEND-OE-009` merges |
 
 ---
 
@@ -83,7 +83,8 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
 | `WO-BACKEND-OE-005` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-005-SERVICE-REGISTRY-RUNTIME-VALIDATION.md` |
 | `WO-BACKEND-OE-006` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-006-SECURITY-AUTH-COUNTY-ISOLATION-PROOF-MATRIX.md` |
 | `WO-BACKEND-OE-007` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-007-MIGRATION-ROLLBACK-PROOF-REGISTER.md` |
-| `WO-BACKEND-OE-008` | READY FOR PR | `docs/brain/workorders/evidence/WO-BACKEND-OE-008-DAIS-WORKFLOW-E2E-PROOF-EXPANSION-PLAN.md` |
+| `WO-BACKEND-OE-008` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-008-DAIS-WORKFLOW-E2E-PROOF-EXPANSION-PLAN.md` |
+| `WO-BACKEND-OE-009` | READY FOR PR | `docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md` |
 
 ## Remaining Work Order Chain
 
@@ -94,8 +95,8 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
 | `WO-BACKEND-OE-005` | Service Registry Runtime Validation | Evidence + targeted validation | OE-004 merged | CLOSED | OE-006 |
 | `WO-BACKEND-OE-006` | Security/Auth/County-Isolation Proof Matrix | Evidence matrix first | OE-005 merged | CLOSED | OE-007 |
 | `WO-BACKEND-OE-007` | Migration and Rollback Proof Register | Evidence/register first | OE-006 merged | CLOSED | OE-008 |
-| `WO-BACKEND-OE-008` | Dais Workflow E2E Proof Expansion Plan | Test-plan/evidence first | OE-007 merged | READY FOR PR | OE-009 |
-| `WO-BACKEND-OE-009` | Backend Release Gate Definition | Governance/release checklist | OE-008 merged | QUEUED | OE-010 |
+| `WO-BACKEND-OE-008` | Dais Workflow E2E Proof Expansion Plan | Test-plan/evidence first | OE-007 merged | CLOSED | OE-009 |
+| `WO-BACKEND-OE-009` | Backend Release Gate Definition | Governance/release checklist | OE-008 merged | READY FOR PR | OE-010 |
 | `WO-BACKEND-OE-010` | Backend Operational Runbook | Runbook creation | OE-009 merged | QUEUED | OE-011 |
 | `WO-BACKEND-OE-011` | Diagnostics and Observability Map | Evidence/docs | OE-010 merged | QUEUED | OE-012 |
 | `WO-BACKEND-OE-012` | Backend Operational Packet | Operational packet assembly | OE-011 merged | QUEUED | OE-013 |


### PR DESCRIPTION
## Summary

Creates WO-BACKEND-OE-009 Backend Release Gate Definition.

This release gate converts OE-003 through OE-008 evidence into explicit backend release-readiness criteria. It does not claim production readiness and does not wire CI, change runtime behavior, repair Docker/Testcontainers, add tests, or alter migrations.

## Scope

Changed files:
- docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md
- docs/brain/workorders/programs/backend-operational-excellence.md
- docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md

No backend/runtime/tools-sync implementation files changed.

## Validation

- git diff --check: PASS
- node docs/brain/workorders/tools/wo-query.mjs --json: PASS
- scope inspection: PASS, only authorized docs/governance files changed

## Release Gate Notes

- Backend build remains zero-warning per prior evidence.
- Docker/Testcontainers remains a segmented integration prerequisite, not repaired here.
- Health/readiness, service registry, security/county/audit, migration/rollback, and Dais E2E evidence are classified with explicit pass/gap/block statuses.
- Next WO: WO-BACKEND-OE-010 Backend Operational Runbook.