### PR TITLE
docs(claude-operator): WO-CLAUDE-QUEUE-001/002/003 operator-queue setup

### DIFF
--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-001-active-lane-state.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-001-active-lane-state.md
@@ -1,0 +1,75 @@
+# WO-CLAUDE-QUEUE-001 — Active Lane State Reconciliation
+
+**Goal:** GOAL-TF-CLAUDE-OPERATOR-QUEUE-001 — Claude Code Non-Overlapping Operator Queue
+**WO:** WO-CLAUDE-QUEUE-001 — Active Lane State Reconciliation
+**Category:** Documentation (read-only reconciliation)
+**Operator:** Claude Code · **Owner/authority:** William / TerraFusion OS Engineering
+
+**Authorization:** Operator authorized GOAL-TF-CLAUDE-OPERATOR-QUEUE-001. Allowed writes: `docs/audit/claude-operator/**`,
+`docs/audit/workbench-readiness/**`, `frontend/apps/os-shell/src/__tests__/workbench/**` (only if a selected goal needs
+tests). Read-only inspection elsewhere. AGENTS.md out-of-lane write under this authorization.
+
+---
+
+## 1. Purpose
+
+Establish current cross-agent truth so Claude Code neither collides with Codex nor restarts completed lanes, before
+selecting the next lane. Reconciled first-hand from `origin/main`, `gh pr list`, and local worktrees.
+
+## 2. Ownership caveat
+
+All PRs are authored under the shared `bsvalues` / "TerraFusion Copilot" identity, so **author does not distinguish
+Codex from Claude**. Ownership is inferred from the WO prefix: `WO-BACKEND-OE-*` = **Codex**; `WO-WB-*` / `WO-CLAUDE-*` =
+**Claude**; other prefixes = prior/other lanes.
+
+## 3. Open PRs (reconciled)
+
+| PR | WO / title | Inferred owner | Lane | Claude action |
+|----|-----------|----------------|------|---------------|
+| #1226 | WO-BACKEND-OE-010 Backend Operational Runbook | **Codex** | Backend OE (ACTIVE) | **do not touch** |
+| #1153 | WO-BACKEND-005 Git SHA / build-provenance truth | backend lane | Backend | do not touch |
+| #1102 | docs(brain) work order operator doctrine | brain/ops lane | Ops doctrine | not Claude's |
+| #1082 | WO-FECF-002 Recovery Classification Register | forensics lane | Forensics | not Claude's |
+| #1080 | docs(forensics) Loop 1 recovery evidence register | forensics lane | Forensics | not Claude's |
+| #1076 | Fix/projector delete insert atomicity | sync/projector lane | Sync-adjacent | not Claude's |
+| #1073 | feat(atlas) MapLibre migration + parcel overlay | atlas lane | Frontend/Atlas | not this queue (separate active lane) |
+
+**No open PR belongs to this session's Claude Workbench work** — all Workbench PRs (#1203–#1225) are merged.
+
+## 4. Lane-state register
+
+| Lane | Owner | State |
+|------|-------|-------|
+| Backend Operational Excellence | Codex | **ACTIVE / priority** (#1226 open) |
+| G1 — 0/117 tool backend integration | Codex / backend / TerraPilot | Not started; **not Claude's lane** |
+| Workbench Readiness | Claude | Complete (merged) |
+| Workbench Honesty Instrumentation | Claude | Complete — 9/9 tabs |
+| Workbench Per-Slice Store Provenance | Claude | Complete (merged) |
+| Workbench G2 Window Aliasing (decision) | Claude | Complete (#1221) |
+| Workbench G2 Window Aliasing (fix) | Claude | Complete (#1222/#1223/#1225) |
+| Sync — synthetic/built-fresh tooling | Claude | Complete + **parked** |
+| Sync — lock-packet program | Claude | Complete + **parked** |
+| Atlas MapLibre migration | (separate frontend lane) | Active (#1073) — not this queue |
+| Forensics / FECF / brain doctrine | (other lanes) | Open PRs — not Claude's queue |
+
+## 5. Claude Code activity check
+
+- **Open PRs owned by this queue's Claude work:** none.
+- **Active watchers:** none.
+- **Active Claude worktrees for this work:** none. (Three unrelated worktrees exist — `wo-brain-001`,
+  `wo-ops-clean-main`, `wo-sales-002b` — belonging to other lanes; not touched.)
+- **Housekeeping:** ~14 already-merged `wo/wb-*` remote branches persist (auto-merge did not always `--delete-branch`);
+  harmless, cleanup is a candidate lane (see WO-CLAUDE-QUEUE-002).
+
+## 6. Do-not-touch list (this queue)
+
+`backend/**`, `tools/registry/**`, `tools/sync/**`, Codex Backend OE files (`WO-BACKEND-OE-*`), G1 tool integration,
+API/service implementation, route architecture, DB/schema/migrations, package/build/CI config, deploy/runtime, PACS,
+county SQL/data, secrets, production config. No `--admin` / break-glass / hook bypass.
+
+## 7. Safe Claude lanes (candidates → WO-CLAUDE-QUEUE-002)
+
+Frontend/workbench tests + docs, `docs/audit/**` closeout/maintenance, decision packets for future frontend lanes,
+read-only reconciliation, and small merged-branch/DevEx **discovery** (no config writes). Ranked in WO-CLAUDE-QUEUE-002.
+
+**Docs-only. Read-only source inspection. No stop wall.**

--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-001-active-lane-state.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-001-active-lane-state.md
@@ -7,7 +7,14 @@
 
 **Authorization:** Operator authorized GOAL-TF-CLAUDE-OPERATOR-QUEUE-001. Allowed writes: `docs/audit/claude-operator/**`,
 `docs/audit/workbench-readiness/**`, `frontend/apps/os-shell/src/__tests__/workbench/**` (only if a selected goal needs
-tests). Read-only inspection elsewhere. AGENTS.md out-of-lane write under this authorization.
+tests). Read-only inspection elsewhere. These paths are **outside the default `AGENTS.md` write lane**; this write is
+permitted **only** because of the explicit operator authorization above (`AGENTS.md` allows out-of-lane writes with such
+authorization). No governance-surface files are touched.
+
+> **Governance (authority routing).** Per root `AGENTS.md` and `brain/packs/README.md`, the Brain/Cortex is the sole
+> authority for queue/sequencing/work-orders. This document and its sibling queue register are **non-authoritative
+> evidence/selection inputs** to that governed path — not a self-granted autonomous scheduling authority and not a bypass
+> of `pnpm brain next`.
 
 ---
 

--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-002-approved-non-overlapping-queue.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-002-approved-non-overlapping-queue.md
@@ -7,10 +7,19 @@
 
 ---
 
+> **Governance (authority routing).** Per root `AGENTS.md` and `brain/packs/README.md`, the **Brain/Cortex is the sole
+> authority** for queue, sequencing, work orders, proof, review-diff, and commit-plan; agent-local autonomous queues /
+> separate governance are **not** permitted. This register is therefore a **non-authoritative evidence + selection
+> input** to that governed path — a *recommendation* the Brain/operator ratifies, **not** a self-granted scheduling
+> authority and **not** a bypass of `pnpm brain next`. "Non-overlapping" + "no courier" means: once a lane is ratified,
+> Claude Code executes its WOs without re-couriering each step — it does **not** mean Claude self-selects and
+> self-authorizes work from this file.
+
 ## 1. Purpose
 
-A ranked queue of work Claude Code may execute autonomously (no courier), each **non-overlapping** with Codex Backend OE
-and free of backend/tool-registry/runtime/PACS. Ranked by value ÷ risk. **No candidate is executed in this WO.**
+A ranked list of **candidate** non-overlapping lanes for the Brain/operator to select from — each disjoint from Codex
+Backend OE and free of backend/tool-registry/runtime/PACS. Ranked by value ÷ risk. **No candidate is executed in this WO,
+and selection is ratified through the governed Brain path, not this document.**
 
 ## 2. Ranked queue
 

--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-002-approved-non-overlapping-queue.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-002-approved-non-overlapping-queue.md
@@ -1,0 +1,45 @@
+# WO-CLAUDE-QUEUE-002 — Approved Non-Overlapping Queue Register
+
+**Goal:** GOAL-TF-CLAUDE-OPERATOR-QUEUE-001
+**WO:** WO-CLAUDE-QUEUE-002 — Approved Non-Overlapping Queue Register
+**Category:** Documentation (register only — no execution)
+**Depends on:** WO-CLAUDE-QUEUE-001 (lane state)
+
+---
+
+## 1. Purpose
+
+A ranked queue of work Claude Code may execute autonomously (no courier), each **non-overlapping** with Codex Backend OE
+and free of backend/tool-registry/runtime/PACS. Ranked by value ÷ risk. **No candidate is executed in this WO.**
+
+## 2. Ranked queue
+
+| # | Candidate | Risk | Allowed paths | Blocked | Codex dep? | Stop walls |
+|---|-----------|------|---------------|---------|-----------|-----------|
+| 1 | **Workbench Route/Window Parity Proof** (`GOAL-TF-WB-PARITY-PROOF-001`) | low | `__tests__/workbench/**`, `docs/audit/workbench-readiness/**`; read-only `pages/workbench/**`, `Router.tsx` | window/route impl (unless tiny regression fix), backend, registry | none | impl beyond test/docs; route/window ambiguity |
+| 2 | Workbench operator documentation refresh | low | `docs/audit/workbench-readiness/**` | code | none | source contradicts docs |
+| 3 | Frontend honesty/provenance maintenance rollup | low | `docs/audit/workbench-readiness/**` | code | none | none |
+| 4 | Remote merged-branch cleanup decision packet | low | `docs/audit/claude-operator/**` | actually deleting via hook-blocked push | none | push blocked by pre-push hook (needs bypass auth) |
+| 5 | DevEx pre-push hook repair — **discovery only** | med | `docs/audit/claude-operator/**` | `.husky/**`, `package.json`, any CI/build config write | none | fixing it needs config write (owner-gated) |
+| 6 | Mapping workbook retention policy decision packet | low | `docs/audit/**` | any Sync code/data | none | Sync is parked; owner-gated to un-park |
+| 7 | Source-derived Sync governance decision packet | med | `docs/audit/**` | Sync code/data/tooling | none | **owner-gated** (Sync parked) |
+| 8 | Backend OE overlap (any) | — | — | — | **YES** | **BLOCKED — Codex lane** |
+
+## 3. Classification notes
+
+- **#1 Parity Proof** — highest value now: G2 was just fixed; a parity proof + contract hardens against reintroducing
+  aliasing and is pure test/docs. Directly builds on merged work; zero Codex overlap. **Default selection.**
+- **#2/#3 doc refresh/rollup** — low value on their own right now (recently written); defer.
+- **#4 branch cleanup** — real housekeeping (14 merged branches), but deleting them is blocked by the repo pre-push hook;
+  a **decision packet** is safe, the deletion itself needs a hook-bypass authorization → owner-gated. Register as a packet.
+- **#5 pre-push hook repair** — discovery (why the hook rejects delete-pushes) is safe docs; the **fix** touches `.husky`/
+  config → owner-gated. Discovery-only if selected.
+- **#6/#7 Sync packets** — Sync is parked; **owner-gated** to select. Do not self-select.
+- **#8** — Backend OE is Codex's; **blocked**.
+
+## 4. Default next candidate
+
+**#1 — `GOAL-TF-WB-PARITY-PROOF-001` (Workbench Route/Window Parity Proof).** Safe, non-overlapping, high-value,
+test+docs only, no Codex dependency. Selection packet → WO-CLAUDE-QUEUE-003.
+
+**Register only. Nothing executed in this WO.**

--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-003-next-goal-selection-packet.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-003-next-goal-selection-packet.md
@@ -1,0 +1,48 @@
+# WO-CLAUDE-QUEUE-003 — Next Goal Selection Packet
+
+**Goal:** GOAL-TF-CLAUDE-OPERATOR-QUEUE-001
+**WO:** WO-CLAUDE-QUEUE-003 — Next Goal Selection Packet
+**Category:** Documentation (selection only)
+**Depends on:** WO-CLAUDE-QUEUE-002 (queue register)
+
+---
+
+## 1. Selection
+
+From the ranked queue (WO-CLAUDE-QUEUE-002), the highest-value non-overlapping candidate is **#1**:
+
+**Selected goal: `GOAL-TF-WB-PARITY-PROOF-001` — Workbench Route/Window Parity Proof.**
+
+## 2. Non-overlap + scope confirmation
+
+- **No Codex Backend OE collision:** touches only `frontend/apps/os-shell/src/__tests__/workbench/**` and
+  `docs/audit/workbench-readiness/**`; read-only elsewhere. Codex Backend OE (#1226) is under `backend/**` /
+  `WO-BACKEND-OE-*` — disjoint.
+- **No backend/tool-registry/API/runtime work:** parity is proven from existing source (`Router.tsx` child routes +
+  `PropertyWorkbenchWindow.tsx` `TAB_COMPONENTS`) + tests; no new integration.
+- **No route/window architecture change:** read-only inspection; the only permitted code write is a *tiny in-scope fix*
+  **iff** a parity test reveals a regression — otherwise test/docs only.
+- **Expected validation:** `git diff --check`, scope check, required branch-protection contexts; Frontend Gate + Vitest
+  Full Suite for any test change; review threads resolved; no `--admin` / break-glass / hook bypass.
+
+## 3. Sub-loop to execute (LOOP-TF-WB-PARITY-PROOF-001)
+
+1. WO-WB-PARITY-001 — Route/Window Parity Scope Audit (docs)
+2. WO-WB-PARITY-002 — Existing Test Coverage Matrix (docs)
+3. WO-WB-PARITY-003 — Route/Window Parity Test Backfill (test, only if a gap exists)
+4. WO-WB-PARITY-004 — Parity Contract Documentation (docs)
+5. WO-WB-PARITY-005 — Evidence Rollup (docs)
+
+## 4. Why this over the others
+
+G2 was just fixed; the natural next safe step is to **lock in** that both hosts stay aligned (a parity proof + contract)
+so a future edit cannot silently reintroduce aliasing. It is pure test/docs, builds directly on merged work, and has zero
+Codex dependency. All other queue items are lower value now, owner-gated (Sync), or blocked (Backend OE).
+
+## 5. Result
+
+- **SELECTED:** `GOAL-TF-WB-PARITY-PROOF-001`.
+- Not `OPERATOR_QUEUE_EMPTY` — a safe candidate exists.
+- Execution proceeds under WO-CLAUDE-QUEUE-004.
+
+**Selection only. Execution begins in WO-CLAUDE-QUEUE-004.**

--- a/docs/audit/claude-operator/WO-CLAUDE-QUEUE-003-next-goal-selection-packet.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-QUEUE-003-next-goal-selection-packet.md
@@ -5,6 +5,11 @@
 **Category:** Documentation (selection only)
 **Depends on:** WO-CLAUDE-QUEUE-002 (queue register)
 
+> **Governance (authority routing).** Per root `AGENTS.md` and `brain/packs/README.md`, the Brain/Cortex is the sole
+> sequencing authority. This "selection" is a **recommendation** for Brain/operator ratification — not a self-granted
+> authorization and not a bypass of `pnpm brain next`. In this run the operator explicitly authorized the recommended
+> goal before execution.
+
 ---
 
 ## 1. Selection


### PR DESCRIPTION
## GOAL-TF-CLAUDE-OPERATOR-QUEUE-001 · QUEUE-001/002/003 (docs-only)

Stands up the standing Claude Code non-overlapping operator queue.
- **QUEUE-001** lane-state: Codex Backend OE **active** (#1226) = do-not-touch; all Claude Workbench PRs merged; Claude idle.
- **QUEUE-002** ranked queue of 8 non-overlapping candidates (Sync packets owner-gated; Backend OE blocked); default = parity proof.
- **QUEUE-003** selects **GOAL-TF-WB-PARITY-PROOF-001** (test+docs only, zero Codex overlap) for execution under QUEUE-004.

New `docs/audit/claude-operator/` tree. Docs-only. No code/backend/registry change.