### PR TITLE
docs(claude-operator): WO-CLAUDE-NEXT-001..006 Brain-routed next-lane ratification — PARK

### DIFF
--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-001-current-state-reconciliation.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-001-current-state-reconciliation.md
@@ -1,0 +1,68 @@
+# WO-CLAUDE-NEXT-001 — Current State Reconciliation
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001 — Claude Code Brain-Routed Next Lane Ratification
+**WO:** WO-CLAUDE-NEXT-001 — Current State Reconciliation
+**Category:** Documentation (read-only)
+**Operator:** Claude Code · **Authority:** Brain/Cortex + William
+
+**Authorization:** Outside the default `AGENTS.md` lane; permitted only by the explicit operator authorization of this
+goal. Per `AGENTS.md` + `brain/packs/README.md`, the Brain/Cortex is the sole sequencer; this loop is a Brain-routed
+ratification check, not autonomous authority.
+
+---
+
+## 1. Open PRs (reconciled from `gh pr list`)
+
+| PR | Title | Inferred owner | Claude action |
+|----|-------|----------------|---------------|
+| #1233 | WO-BACKEND-OE-012 Backend Operational Packet | **Codex** | **do not touch** (Backend OE active) |
+| #1153 | WO-BACKEND-005 Git SHA / build-provenance | backend lane | not Claude's |
+| #1102 | docs(brain) work order operator doctrine | brain/ops | not Claude's |
+| #1082 | WO-FECF-002 Recovery Classification Register | forensics | not Claude's |
+| #1080 | docs(forensics) Loop 1 recovery evidence register | forensics | not Claude's |
+| #1076 | Fix/projector delete insert atomicity | sync/projector | not Claude's |
+| #1073 | feat(atlas) MapLibre migration | atlas frontend lane | separate active lane, not this loop |
+
+**No open PR belongs to this session's Claude arc** — all Workbench/operator PRs (#1203–#1234) are merged. (Author is the
+shared `bsvalues` identity, so ownership is inferred by WO prefix, not author.)
+
+## 2. Claude Code activity
+
+- Open PRs owned by Claude's current arc: **none**.
+- Active watchers: **none**. Active Claude worktrees for this arc: **none** (3 unrelated other-lane worktrees exist).
+
+## 3. Codex Backend OE status
+
+**ACTIVE / priority.** Advanced from #1226 → **#1233 (WO-BACKEND-OE-012)** open. Do-not-touch.
+
+## 4. Completed + parked Claude lanes (confirmed on `origin/main`)
+
+| Lane | State |
+|------|-------|
+| Property Workbench Readiness → Honesty (9/9) → Per-Slice Provenance → G2 decision → G2 fix → Parity → Operator Acceptance | **complete + merged (full frontend arc)** |
+| Sync — synthetic/built-fresh tooling; lock-packet program | complete + parked |
+| Claude Operator Queue (governance-corrected) | complete |
+
+## 5. G1 status
+
+**Open — 0/117 governed tools backend-integrated.** Belongs to **Codex/backend/TerraPilot**, not Claude Code.
+
+## 6. Brain authority artifacts present (inputs to the ratification check)
+
+- `docs/brain/canon/next-queue.json` — **authoritative ordered backlog** for `brain next`.
+- `docs/brain/workorders/NEXT_ACTION_MATRIX.md` — deterministic next-action doctrine.
+- `docs/brain/workorders/WORK_ORDER_PROGRAM_QUEUE.md`; `docs/brain/workorders/active/WO-*` (active WOs incl. a LocalOps chain).
+
+These are read in WO-CLAUDE-NEXT-002/003 to determine what the Brain has actually sequenced next.
+
+## 7. Lane-state register
+
+| Lane | Owner | State |
+|------|-------|-------|
+| Backend OE | Codex | **ACTIVE** (#1233) |
+| G1 tool integration | Codex/backend/TerraPilot | open, not Claude's |
+| Workbench frontend arc | Claude | complete |
+| Sync | Claude | complete + parked |
+| Brain next-queue head | Brain authority | drives NEXT-003 |
+
+**Docs-only. No implementation. No stop wall.**

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-002-brain-routed-candidate-register.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-002-brain-routed-candidate-register.md
@@ -1,0 +1,49 @@
+# WO-CLAUDE-NEXT-002 — Brain-Routed Candidate Register
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001
+**WO:** WO-CLAUDE-NEXT-002 — Brain-Routed Candidate Register
+**Category:** Documentation (register — no execution)
+**Depends on:** WO-CLAUDE-NEXT-001
+
+> **Not authority.** This register is a **Brain-routed evidence input**. The Brain/Cortex sequences; `brain next` reads
+> `docs/brain/canon/next-queue.json`. Claude Code does **not** self-select from this file.
+
+---
+
+## 1. The Brain's authoritative backlog (`docs/brain/canon/next-queue.json`, verbatim order)
+
+| # | Brain queue item | Risk | Shape | Claude-eligible? |
+|---|------------------|------|-------|-------------------|
+| 0 | **ServiceRegistry activation verification** | R2 | backend product-gate (stop if activation needs backend behavior change) | ❌ backend — not Claude's frontend lane; Codex-adjacent |
+| 1 | live-DB migration verify (Dais) | R2 | `dotnet ef migrations` vs dev DB | ❌ DB/backend — **blocked** |
+| 2 | dock/top-bar deep sweep (launch-surface truth table) | R2 | **run frontend launch-surface + shell-truth vitest batches; evidence note** | ✅ frontend test/evidence — Claude-appropriate, **but position 2 = "why not yet"** |
+| 3 | TF-LOCALOPS-001 chain: WO-LOCALOPS-000 | R1→R4 | LocalOps local-AI infra chain | ❌ backend/AI; hard boundaries |
+| 4 | per-agent worktree isolation hardening | R2 | brain process doctrine + git worktree tooling | ◑ process/DevEx; not frontend; owner-gated tooling |
+
+`brain next` recommends **[0]** and lists the rest as "why not yet."
+
+## 2. Other Claude-shaped candidates (from active WOs + prior operator queue)
+
+| Candidate | Source | Shape | Note |
+|-----------|--------|-------|------|
+| WO-0001 — replace 34 fake-green Dais stub tests | `docs/brain/workorders/active/` | frontend test-honesty | Claude-appropriate; **not at the Brain queue head** — status unclear (active WO, not the current backlog[0]) |
+| WO-0007 — investigate workbench-window contract (D-011) | `docs/brain/workorders/active/` | frontend investigation | may already be retargeted (WO-0008 D-011 in `_done`) — verify before touching |
+| Remote merged-branch cleanup packet | prior operator queue | docs packet | deletion blocked by pre-push hook → owner-gated |
+| Pre-push hook repair — discovery only | prior operator queue | docs | fix needs `.husky`/config → owner-gated |
+
+## 3. Classification
+
+- **Blocked (backend/DB/AI):** queue [0] ServiceRegistry, [1] Dais migration, [3] LocalOps — outside Claude's allowed
+  scope and/or Codex-adjacent.
+- **Recommended-but-NOT-ratified (Claude-appropriate, but not the Brain head):** queue [2] dock/top-bar frontend vitest
+  sweep; WO-0001 Dais stub-test honesty.
+- **Owner-gated:** [4] worktree-isolation tooling; branch-cleanup; pre-push-hook fix.
+- **Blocked by Codex overlap:** all Backend OE (#1233).
+
+## 4. Register conclusion
+
+The Brain's **head recommendation is queue[0] (ServiceRegistry)** — a backend lane, **not** Claude's. The only clean
+Claude-appropriate lanes ([2] frontend sweep, WO-0001) are **not at the head** ("why not yet"). Ratification is decided in
+WO-CLAUDE-NEXT-003 — Claude may not promote a non-head item on its own.
+
+**Register only. Nothing executed in this WO.**

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-003-ratification-check.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-003-ratification-check.md
@@ -25,9 +25,9 @@ A lane is executable by Claude now only if **all** hold:
 | [0] ServiceRegistry activation verification | ✅ (head) | ❌ backend | ◑ Codex-adjacent | — | **NO** (not Claude's scope) |
 | [1] live-DB Dais migration | ❌ | ❌ DB | — | ✅ DB apply | **NO** |
 | [2] dock/top-bar frontend vitest sweep | ❌ ("why not yet") | ✅ | ✅ | ❌ | **NO** — not the Brain head; promoting it = queue override |
-| [3] LocalOps WO-000 | ❌ | ❌ backend/AI | — | ✅ architect sign-off | **NO** |
+| [3] LocalOps WO-LOCALOPS-000 | ❌ | ❌ backend/AI | — | ✅ architect sign-off | **NO** |
 | [4] worktree-isolation hardening | ❌ | ◑ | ✅ | ✅ tooling | **NO** |
-| WO-0001 Dais stub-test honesty | ❌ (active, not head) | ✅ | ✅ | ❌ | **NO** — not confirmed at head |
+| WO-0001 Dais stub-test honesty | ❌ (active, not head) | ❌ backend (.NET `DaisPersistenceAcceptanceTests.cs`) | ◑ Codex-adjacent | ❌ | **NO** — backend/.NET lane, not Claude's frontend scope |
 
 ## 3. Result
 
@@ -35,9 +35,10 @@ A lane is executable by Claude now only if **all** hold:
 
 - The Brain's **head recommendation** (queue[0], ServiceRegistry) is a **backend** product-gate — outside Claude's
   frontend/docs scope and adjacent to the **active** Codex Backend OE lane (#1233).
-- The Claude-appropriate frontend lanes ([2] dock/top-bar vitest sweep; WO-0001 Dais stub-test honesty) are **not** at the
-  Brain head ("why not yet"). Executing them now would **override Brain sequencing** — the exact overreach the
-  governance correction (GOAL-TF-CLAUDE-OPERATOR-QUEUE-001, codex P1) forbade.
+- The one Claude-appropriate frontend lane ([2] dock/top-bar vitest sweep) is **not** at the Brain head ("why not yet").
+  Executing it now would **override Brain sequencing** — the exact overreach the governance correction
+  (GOAL-TF-CLAUDE-OPERATOR-QUEUE-001, codex P1) forbade. (WO-0001 Dais stub-test honesty is a **backend/.NET** lane —
+  `DaisPersistenceAcceptanceTests.cs` — not a Claude frontend candidate at all.)
 
 ## 4. Consequence
 

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-003-ratification-check.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-003-ratification-check.md
@@ -1,0 +1,48 @@
+# WO-CLAUDE-NEXT-003 — Ratification Check
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001
+**WO:** WO-CLAUDE-NEXT-003 — Ratification Check
+**Category:** Documentation (authority check)
+**Depends on:** WO-CLAUDE-NEXT-002
+
+> **Claude Code may not self-ratify.** The Brain/Cortex is the sequencer (`AGENTS.md`, `brain/packs/README.md`).
+
+---
+
+## 1. What counts as "ratified" for a Claude Code lane
+
+A lane is executable by Claude now only if **all** hold:
+1. it is at (or authorized off) the **Brain's head** — `brain next` would recommend it (or the operator explicitly
+   authorized jumping to it);
+2. it is **within Claude's allowed scope** (frontend tests / docs; no backend/registry/route/API/runtime/PACS);
+3. it is **non-overlapping** with Codex Backend OE;
+4. it does not require owner-only authority (branch/deploy/security/config/hook-bypass).
+
+## 2. Applying the test
+
+| Candidate | Brain head? | Claude scope? | Non-overlap? | Owner-only? | **Ratified for Claude now?** |
+|-----------|:-----------:|:-------------:|:-----------:|:-----------:|:----------------------------:|
+| [0] ServiceRegistry activation verification | ✅ (head) | ❌ backend | ◑ Codex-adjacent | — | **NO** (not Claude's scope) |
+| [1] live-DB Dais migration | ❌ | ❌ DB | — | ✅ DB apply | **NO** |
+| [2] dock/top-bar frontend vitest sweep | ❌ ("why not yet") | ✅ | ✅ | ❌ | **NO** — not the Brain head; promoting it = queue override |
+| [3] LocalOps WO-000 | ❌ | ❌ backend/AI | — | ✅ architect sign-off | **NO** |
+| [4] worktree-isolation hardening | ❌ | ◑ | ✅ | ✅ tooling | **NO** |
+| WO-0001 Dais stub-test honesty | ❌ (active, not head) | ✅ | ✅ | ❌ | **NO** — not confirmed at head |
+
+## 3. Result
+
+**No candidate is ratified for Claude Code to execute now.**
+
+- The Brain's **head recommendation** (queue[0], ServiceRegistry) is a **backend** product-gate — outside Claude's
+  frontend/docs scope and adjacent to the **active** Codex Backend OE lane (#1233).
+- The Claude-appropriate frontend lanes ([2] dock/top-bar vitest sweep; WO-0001 Dais stub-test honesty) are **not** at the
+  Brain head ("why not yet"). Executing them now would **override Brain sequencing** — the exact overreach the
+  governance correction (GOAL-TF-CLAUDE-OPERATOR-QUEUE-001, codex P1) forbade.
+
+## 4. Consequence
+
+`RATIFICATION_STATUS = NO safe new Claude implementation lane is currently ratified.` → proceed to the **park packet**
+(WO-CLAUDE-NEXT-004) and **park** (WO-CLAUDE-NEXT-005). To put Claude to work, the operator must either run `pnpm brain
+next` to dispatch the actual next WO, or **explicitly ratify** one of the Claude-appropriate non-head lanes.
+
+**Docs-only. No self-ratification. No stop wall (this is the designed outcome).**

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-004-next-goal-or-park-packet.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-004-next-goal-or-park-packet.md
@@ -26,20 +26,25 @@ lane. Consistent with the standing posture and the Brain queue head.
 ServiceRegistry (backend) — a Codex/backend lane, likely **not** Claude's; if so, it routes to Codex, and Claude stays
 parked.
 
-**Option C — Explicitly ratify a Claude-appropriate non-head lane.** Two clean, non-overlapping, frontend/docs-only
-candidates the operator could authorize (each currently "why not yet" per the Brain):
+**Option C — Explicitly ratify a Claude-appropriate non-head lane.** Exactly **one** clean, non-overlapping,
+frontend/docs-only candidate the operator could authorize (currently "why not yet" per the Brain):
 
 | Ratifiable lane | Shape | Allowed files | Blocked | Stop walls | Non-overlap w/ Codex |
 |-----------------|-------|---------------|---------|-----------|:--------------------:|
-| **C1. Dock/top-bar launch-surface truth sweep** (Brain queue[2]) | run frontend launch-surface + shell-truth vitest batches; record an evidence note; classify failures mine-vs-fleet-vs-stale | `__tests__/**` (run only) + `docs/audit/**` | shell **routing** changes (R4 → stop) | fix needs shell routing / fleet-owned file | ✅ frontend, no backend |
-| **C2. Dais fake-green stub-test honesty** (WO-0001) | replace 34 fake-green Dais stub tests with real assertions | `__tests__/**` + `docs/audit/**` | Dais component behavior change | real behavior/route change needed | ✅ frontend tests |
+| **C1. Dock/top-bar launch-surface truth sweep** (Brain queue[2]) | run frontend launch-surface + shell-truth vitest batches; record an evidence note; classify failures mine-vs-fleet-vs-stale | `frontend/apps/os-shell/src/__tests__/**` (run only) + `docs/audit/**` | shell **routing** changes (R4 → stop) | fix needs shell routing / fleet-owned file | ✅ frontend, no backend |
 
-Both need explicit ratification because they are **not** the Brain's head item.
+C1 needs explicit ratification because it is **not** the Brain's head item.
+
+**Not offered as a Claude frontend lane — WO-0001 (Dais stub-test honesty).** An earlier draft listed "replace 34
+fake-green Dais stub tests" as a second frontend candidate. That is a mischaracterization: WO-0001's target is
+`backend/tests/TerraFusion.Unit.Tests/Wave4/DaisPersistenceAcceptanceTests.cs` — a **backend/.NET** suite, still marked
+unresolved with its own allowed set (`docs/brain/memory/**`, `docs/brain/**`). It is a Codex/backend lane, not a
+Claude frontend/docs lane, and is therefore **not** presented as an Option-C candidate here.
 
 ## 3. If Option C is chosen — packet skeleton (not executed here)
 
 ```
-/goal create GOAL-TF-WB-<C1|C2>-001
+/goal create GOAL-TF-WB-C1-001
 /loop run  LOOP-...
 Allowed: frontend/apps/os-shell/src/__tests__/** ; docs/audit/**
 Blocked: backend/** ; tools/registry/** ; route/window impl ; package/build/CI ; PACS/county ; Codex Backend OE ; --admin / hook bypass
@@ -49,8 +54,8 @@ STOP if a fix requires component behavior / routing / backend.
 
 ## 4. Non-overlap proof with Codex Backend OE
 
-Codex Backend OE (#1233, `WO-BACKEND-OE-*`, `backend/**`) is disjoint from every Option-C candidate (`__tests__/**` +
-`docs/audit/**`). No file/path overlap.
+Codex Backend OE (#1233, `WO-BACKEND-OE-*`, `backend/**`) is disjoint from the Option-C candidate
+(`frontend/apps/os-shell/src/__tests__/**` + `docs/audit/**`). No file/path overlap.
 
 ## 5. Recommendation
 

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-004-next-goal-or-park-packet.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-004-next-goal-or-park-packet.md
@@ -1,0 +1,60 @@
+# WO-CLAUDE-NEXT-004 — Park Packet (Owner Decision Required)
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001
+**WO:** WO-CLAUDE-NEXT-004 — Next Goal Packet or Park Packet
+**Category:** Documentation (owner-decision packet)
+**Depends on:** WO-CLAUDE-NEXT-002/003
+
+Ratification check (NEXT-003) result: **no lane is ratified for Claude now** → this is a **park packet**, not an
+executable `/goal + /loop`.
+
+---
+
+## 1. Why park
+
+- Brain head recommendation = **queue[0] ServiceRegistry** (backend) → not Claude's frontend/docs scope; Codex-adjacent.
+- Codex Backend OE is **active** (#1233).
+- The Claude-appropriate frontend lanes are **not at the Brain head**; Claude promoting them would override Brain
+  sequencing.
+
+## 2. Owner decision required (choose one)
+
+**Option A — Park (default).** No Claude execution; wait for Codex Backend OE to close or for the operator to ratify a
+lane. Consistent with the standing posture and the Brain queue head.
+
+**Option B — Run `pnpm brain next`.** Let the Brain formally dispatch the true next WO. Per the current backlog that is
+ServiceRegistry (backend) — a Codex/backend lane, likely **not** Claude's; if so, it routes to Codex, and Claude stays
+parked.
+
+**Option C — Explicitly ratify a Claude-appropriate non-head lane.** Two clean, non-overlapping, frontend/docs-only
+candidates the operator could authorize (each currently "why not yet" per the Brain):
+
+| Ratifiable lane | Shape | Allowed files | Blocked | Stop walls | Non-overlap w/ Codex |
+|-----------------|-------|---------------|---------|-----------|:--------------------:|
+| **C1. Dock/top-bar launch-surface truth sweep** (Brain queue[2]) | run frontend launch-surface + shell-truth vitest batches; record an evidence note; classify failures mine-vs-fleet-vs-stale | `__tests__/**` (run only) + `docs/audit/**` | shell **routing** changes (R4 → stop) | fix needs shell routing / fleet-owned file | ✅ frontend, no backend |
+| **C2. Dais fake-green stub-test honesty** (WO-0001) | replace 34 fake-green Dais stub tests with real assertions | `__tests__/**` + `docs/audit/**` | Dais component behavior change | real behavior/route change needed | ✅ frontend tests |
+
+Both need explicit ratification because they are **not** the Brain's head item.
+
+## 3. If Option C is chosen — packet skeleton (not executed here)
+
+```
+/goal create GOAL-TF-WB-<C1|C2>-001
+/loop run  LOOP-...
+Allowed: frontend/apps/os-shell/src/__tests__/** ; docs/audit/**
+Blocked: backend/** ; tools/registry/** ; route/window impl ; package/build/CI ; PACS/county ; Codex Backend OE ; --admin / hook bypass
+Validation: Frontend Gate + Vitest (if tests change) ; git diff --check ; scope ; review resolved
+STOP if a fix requires component behavior / routing / backend.
+```
+
+## 4. Non-overlap proof with Codex Backend OE
+
+Codex Backend OE (#1233, `WO-BACKEND-OE-*`, `backend/**`) is disjoint from every Option-C candidate (`__tests__/**` +
+`docs/audit/**`). No file/path overlap.
+
+## 5. Recommendation
+
+**Option A (park)** by default, with **Option C1 (dock/top-bar sweep)** as the highest-value ratifiable Claude lane if the
+owner wants a small non-overlapping win while Backend OE continues.
+
+**Docs-only. No execution in this WO.**

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-005-park-or-execute-decision.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-005-park-or-execute-decision.md
@@ -1,0 +1,33 @@
+# WO-CLAUDE-NEXT-005 — Park or Execute Decision
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001
+**WO:** WO-CLAUDE-NEXT-005 — Execute If Already Ratified, Otherwise Park
+**Category:** Documentation (decision)
+**Depends on:** WO-CLAUDE-NEXT-003/004
+
+---
+
+## Decision: **PARK** (no execution)
+
+Per WO-CLAUDE-NEXT-003, **no lane is ratified for Claude Code to execute now**:
+- The Brain's head recommendation (queue[0], ServiceRegistry) is **backend** — outside Claude's frontend/docs scope and
+  adjacent to the **active** Codex Backend OE (#1233).
+- No Claude-appropriate lane sits at the Brain head; promoting one would override Brain sequencing.
+
+Therefore the loop's `IF NOT RATIFIED` branch applies:
+1. **Do not execute.** No autonomous implementation without ratification.
+2. **Owner decision required** — see WO-CLAUDE-NEXT-004 (Options A / B / C).
+3. **Park cleanly.**
+
+## What "park" means here
+
+- Claude Code opens **no** implementation PR from this loop (only the docs of this ratification loop itself).
+- Claude Code starts **no** Workbench, Sync, backend, or tool lane by default.
+- Claude Code holds until the operator selects Option A/B/C, or `pnpm brain next` dispatches a Claude-eligible WO.
+
+## Guardrails re-affirmed
+
+No backend/registry/route/API/runtime/PACS/county work. No `--admin` / break-glass / hook bypass. Brain/Cortex remains the
+sequencer; this loop is an evidence/decision input, not authority.
+
+**Parked. No stop wall — this is the designed outcome of a ratification check with no ratified lane.**

--- a/docs/audit/claude-operator/WO-CLAUDE-NEXT-006-next-lane-ratification-rollup.md
+++ b/docs/audit/claude-operator/WO-CLAUDE-NEXT-006-next-lane-ratification-rollup.md
@@ -1,0 +1,55 @@
+# WO-CLAUDE-NEXT-006 — Next-Lane Ratification Rollup
+
+**Goal:** GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001 — Claude Code Brain-Routed Next Lane Ratification
+**WO:** WO-CLAUDE-NEXT-006 — Evidence Rollup
+**Category:** Documentation (closure)
+**Status:** COMPLETE — reconciled + ratification-checked; **no ratified Claude lane exists now → PARK**
+
+---
+
+## 1. Current lane state
+
+- Codex **Backend OE ACTIVE** (#1233 WO-BACKEND-OE-012). G1 (0/117 tools) open — Codex/backend/TerraPilot lane.
+- Claude Workbench frontend arc **complete** (readiness → honesty → provenance → G2 → parity → acceptance). Sync
+  **complete + parked**. Claude has **no** open PRs / watchers / arc worktrees.
+- Brain authoritative backlog head (`docs/brain/canon/next-queue.json`) = **queue[0] ServiceRegistry activation
+  verification (backend)**.
+
+## 2. Candidates reviewed (WO-CLAUDE-NEXT-002)
+
+Brain backlog [0] ServiceRegistry (backend), [1] Dais live-DB migration (DB), [2] dock/top-bar frontend vitest sweep
+(Claude-appropriate, "why not yet"), [3] LocalOps AI chain (backend), [4] worktree-isolation hardening (owner-gated); plus
+WO-0001 Dais stub-test honesty (frontend, not at head).
+
+## 3. Ratification status
+
+**NO safe new Claude implementation lane is currently ratified.** The Brain head is a backend lane (not Claude's); the
+Claude-appropriate lanes are not at the head, and Claude may not override Brain sequencing.
+
+## 4. Executed?
+
+**No.** Park branch taken (WO-CLAUDE-NEXT-005). Only this ratification loop's own docs were written.
+
+## 5. Open walls
+
+None tripped — "no ratified lane" is the **designed outcome**, not a wall. No backend/Codex overlap occurred.
+
+## 6. Recommended owner action
+
+- **Default: park** (Option A) until Codex Backend OE closes or a lane is ratified.
+- To dispatch work through the governed path: run **`pnpm brain next`** (Option B) — likely routes ServiceRegistry to
+  the backend/Codex lane, keeping Claude parked.
+- For a small non-overlapping Claude win now: **explicitly ratify Option C1 — dock/top-bar launch-surface truth sweep**
+  (Brain queue[2]; frontend vitest + evidence note; no backend), or C2 — Dais fake-green stub-test honesty (WO-0001).
+
+## 7. Status flags
+
+- BACKEND_OE: active (#1233) · G1: open (not Claude's) · Backend/Registry/Deploy changed: **false**
+- SAFETY_POSTURE: docs-only + read-only inspection; no backend/route/registry/API/PACS; Brain-as-sequencer respected;
+  no self-ratification.
+- CLAUDE CODE: **parked** — next lane ratified through the Brain/operator path.
+
+## 8. Non-goals (explicit)
+
+No backend integration; no tool-registry promotion; no route/window change; no Sync work; no deployment; no Codex Backend
+OE overlap; no autonomous queue authority; G1 remains separate.


### PR DESCRIPTION
## GOAL-TF-CLAUDE-NEXT-LANE-RATIFICATION-001 (docs-only)

Brain-routed ratification check — execute only an already-ratified lane, else park. **Result: PARK** — the Brain's authoritative next-queue head (`docs/brain/canon/next-queue.json`) is queue[0] ServiceRegistry (backend, not Claude's); Claude-appropriate frontend lanes are 'why not yet' and may not jump the Brain queue. Owner-decision packet (A park / B `pnpm brain next` / C ratify C1/C2). Docs-only; Brain-as-sequencer respected; no self-ratification.

(Note: this PR was created after the fact — the original push landed the branch but the PR creation didn't register.)