### PR TITLE
test(workbench): re-author Phase-16 parcel→workbench launch contract (WO-WB-P16)

### DIFF
--- a/docs/audit/workbench-readiness/WO-WB-P16-001-launch-contract-current-state-audit.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-001-launch-contract-current-state-audit.md
@@ -48,13 +48,21 @@ crash vector (§WO-WB-P16-002). Tests: Forge/Atlas/Dossier → `/property/:parce
 re-entry same URL; structural URL proof; broken module → no navigation; **standalone → asserted
 `navigate('/statistics-studio')` etc.**; no-parcel → `/property?openTab=forge`.
 
-## 4. The one staleness the re-author must correct
+## 4. Stale/false assertions the re-author must correct
 
-The original test 7 asserts standalone tiles call `navigate('/:moduleId')`. Since **WO-SUITE-ROUTING-001**, standalone
-launch calls `activateModule(mod.moduleId ?? mod.id, { source: 'system' })` instead (the bare navigate had no registered
-route and silently no-op'd). A verbatim restore would assert behavior the product no longer has and **fail**. The
-re-author updates test 7 to the shipped behavior. This is a **test-truth correction, not a product change** — no product
-file is edited in this lane.
+**(a) Standalone behavior.** The original test 7 asserts standalone tiles call `navigate('/:moduleId')`. Since
+**WO-SUITE-ROUTING-001**, standalone launch calls `activateModule(mod.moduleId ?? mod.id, { source: 'system' })` instead
+(the bare navigate had no registered route and silently no-op'd). A verbatim restore would assert behavior the product no
+longer has and **fail**. The re-author updates test 7 to the shipped behavior.
+
+**(b) False Forge/Atlas workbench cases (codex #1237 P2).** The original test asserted Forge and Atlas tiles route into
+the workbench. Verified first-hand: the shipped **Atlas suite is all `standalone`** (`AtlasSuiteHome`) and **Forge does
+not use `SuiteModuleGrid`** at all — so those cases claim launches the app does not perform. The re-author drops them and
+uses fixtures that mirror the **real** workbench tiles (Dais `certification` → `dais`; Dossier `documents` → `dossier`;
+`defense` → `dais`) and real standalone tiles (`atlas`, `terra-levy`, `management-dashboard`).
+
+Both are **test-truth corrections, not product changes** — no product file is edited in this lane. A residual gap (the
+test does not drive the module-private real arrays through the grid) is flagged for a follow-up lane.
 
 ## 5. Conclusion
 

--- a/docs/audit/workbench-readiness/WO-WB-P16-001-launch-contract-current-state-audit.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-001-launch-contract-current-state-audit.md
@@ -1,0 +1,62 @@
+# WO-WB-P16-001 — Parcel→Workbench Launch-Contract Current-State Audit
+
+**Goal:** GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel-to-Workbench Launch Contract
+**WO:** WO-WB-P16-001 — Current-State Audit
+**Category:** Documentation (read-only audit)
+**Operator:** Claude Code · ratified tests-only follow-up (post-#1236 NLR record)
+
+**Authorization:** Operator-ratified Phase-16 lane. **MODE: tests-only / shallow mocks / no product behavior change.**
+Allowed writes: `frontend/apps/os-shell/src/__tests__/**`, `docs/audit/workbench-readiness/**`; read-only elsewhere
+(Router.tsx, pages/workbench, SuiteModuleGrid product code). Backend / tool-registry / route-behavior / package / CI
+out of scope.
+
+---
+
+## 1. Purpose
+
+Establish the exact current state of the Phase-16 launch-contract test before re-authoring it, so the re-author is a
+faithful restoration + a single behavior-truth correction, not an invention.
+
+## 2. What exists on `origin/main` today
+
+**Test file** — `frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx`:
+a 36-line **skipped stub**. Its top-of-file note (dated 2026-04-25) records that the original test imported the real
+`SuiteModuleGrid`, whose transitive graph
+(`orchestration/moduleActivation` → `config/moduleComponents` → `desktopStore` + `moduleLoaderStore` +
+`notificationStore` + telemetry) crashed the vitest worker (`Worker exited unexpectedly`, tinypool). The stub is
+`describe.skip(...)` with one intentionally-empty `it`.
+
+**Product under test** — `frontend/apps/os-shell/src/components/suites/SuiteModuleGrid.tsx`, `handleLaunch(mod)`
+(verified on `origin/main`):
+
+| Condition | Behavior |
+|-----------|----------|
+| `launchMode === 'workbench'` && no `workbenchTab` | `return;` (silent guard, no navigation) |
+| `launchMode === 'workbench'` && active parcel | `navigate('/property/${parcelId}/${mod.workbenchTab}')` |
+| `launchMode === 'workbench'` && no active parcel | `navigate('/property?openTab=${mod.workbenchTab}')` |
+| `launchMode === 'standalone'` | `activateModule(mod.moduleId ?? mod.id, { source: 'system' })` |
+
+`SuiteModuleDef` type (source of truth for fixtures): `id`, `label`, `icon: LucideIcon`, `description`,
+`launchMode: 'workbench' \| 'standalone'`, optional `workbenchTab: WorkbenchTabSlug`, optional `moduleId` (defaults to
+`id`), optional `priority` / `telemetryLabel` / `truthState`.
+
+## 3. What the original test asserted (recovered from commit `9cc1a1977`, 321 lines / 8 tests)
+
+Mocks present: `react-router-dom` (`useNavigate → mockNavigate`), `lucide-react` (Proxy icon), `stores/propertyStore`
+(selector over `mockActiveParcel`). **The `orchestration/moduleActivation` module was NOT mocked** — that omission is the
+crash vector (§WO-WB-P16-002). Tests: Forge/Atlas/Dossier → `/property/:parcelId/:tab` containing the parcel id;
+re-entry same URL; structural URL proof; broken module → no navigation; **standalone → asserted
+`navigate('/statistics-studio')` etc.**; no-parcel → `/property?openTab=forge`.
+
+## 4. The one staleness the re-author must correct
+
+The original test 7 asserts standalone tiles call `navigate('/:moduleId')`. Since **WO-SUITE-ROUTING-001**, standalone
+launch calls `activateModule(mod.moduleId ?? mod.id, { source: 'system' })` instead (the bare navigate had no registered
+route and silently no-op'd). A verbatim restore would assert behavior the product no longer has and **fail**. The
+re-author updates test 7 to the shipped behavior. This is a **test-truth correction, not a product change** — no product
+file is edited in this lane.
+
+## 5. Conclusion
+
+The re-author is: restore tests 1–6 + the no-parcel bonus faithfully, ADD the missing `moduleActivation` shallow mock,
+ADAPT test 7 to `activateModule`, and remove `describe.skip`. Product behavior is unchanged and unobserved by this lane.

--- a/docs/audit/workbench-readiness/WO-WB-P16-002-skip-root-cause-confirmation.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-002-skip-root-cause-confirmation.md
@@ -1,0 +1,49 @@
+# WO-WB-P16-002 — Skip Root-Cause Confirmation
+
+**Goal:** GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel-to-Workbench Launch Contract
+**WO:** WO-WB-P16-002 — Skip Root-Cause Confirmation
+**Category:** Documentation (read-only analysis)
+**Operator:** Claude Code · ratified tests-only follow-up
+
+**Authorization:** Operator-ratified Phase-16 lane (tests-only / shallow mocks / no product behavior change). Allowed
+writes: `frontend/apps/os-shell/src/__tests__/**`, `docs/audit/workbench-readiness/**`.
+
+---
+
+## 1. Purpose
+
+Confirm the precise reason the original Phase-16 test was quarantined, so the re-author fixes the actual cause rather than
+working around a symptom.
+
+## 2. The claimed cause (top-of-file skip note)
+
+The 2026-04-25 note states: importing the real `SuiteModuleGrid` transitively pulls
+`orchestration/moduleActivation → config/moduleComponents → desktopStore + moduleLoaderStore + notificationStore +
+telemetry`, and that graph crashes the vitest worker (`Worker exited unexpectedly`, from tinypool).
+
+## 3. Confirmation via import trace (verified on `origin/main`)
+
+`SuiteModuleGrid.tsx` top-level imports include:
+
+```ts
+import { usePropertyStore } from '../../stores/propertyStore';        // MOCKED in original test
+import { activateModule } from '../../orchestration/moduleActivation'; // NOT mocked → crash vector
+```
+
+`usePropertyStore` was already shallow-mocked in the original test, so it is not the cause. `activateModule` is imported
+at **module-evaluation time**; because `orchestration/moduleActivation` was left un-mocked, vitest evaluated the real
+module and its entire downstream graph (module component registry + three Zustand stores + telemetry) during test
+collection. That eager evaluation — not any runtime call — is what destabilized the worker.
+
+## 4. Why the fix is a single shallow mock
+
+`handleLaunch` only ever calls `activateModule(targetId, { source: 'system' })`. The test never needs the real activation
+side effects — it only needs to assert the call shape. Replacing the module with a `vi.fn()` stub via `vi.hoisted` +
+`vi.mock('../../orchestration/moduleActivation', ...)` removes the heavy graph from evaluation entirely while preserving
+the real `SuiteModuleGrid` (the actual unit under test). This is the minimal, honest fix: mock the crash-inducing
+boundary, keep the product component real.
+
+## 5. Conclusion
+
+Root cause **confirmed**: a missing shallow mock for `orchestration/moduleActivation`, evaluated eagerly at import. The
+re-author adds exactly that mock (see WO-WB-P16-003) — no product change, no test-behavior compromise.

--- a/docs/audit/workbench-readiness/WO-WB-P16-003-shallow-mock-design.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-003-shallow-mock-design.md
@@ -1,0 +1,59 @@
+# WO-WB-P16-003 — Shallow-Mock Design
+
+**Goal:** GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel-to-Workbench Launch Contract
+**WO:** WO-WB-P16-003 — Shallow-Mock Design
+**Category:** Documentation (design)
+**Operator:** Claude Code · ratified tests-only follow-up
+
+**Authorization:** Operator-ratified Phase-16 lane (tests-only / shallow mocks / no product behavior change). Allowed
+writes: `frontend/apps/os-shell/src/__tests__/**`, `docs/audit/workbench-readiness/**`.
+
+---
+
+## 1. Purpose
+
+Specify the exact mock surface for the re-authored test so it renders the **real** `SuiteModuleGrid` while excluding the
+heavy graphs that crashed the worker — nothing more.
+
+## 2. Mock surface (four boundaries, all shallow)
+
+| Boundary | Mock | Why |
+|----------|------|-----|
+| `../../orchestration/moduleActivation` | `{ activateModule: vi.fn() }` via `vi.hoisted` | **The fix.** Removes the crash-inducing transitive graph from evaluation; lets the test assert the standalone call shape. |
+| `react-router-dom` | spread actual, override `useNavigate → mockNavigate` | Capture navigation targets without a real router; `MemoryRouter` still wraps the tree. |
+| `lucide-react` | Proxy returning a stub `<span data-slot="icon">` | Icons are irrelevant to the launch contract; avoids pulling real SVG components. |
+| `../../stores/propertyStore` | `usePropertyStore(selector)` over `{ activeParcel: mockActiveParcel }` | Drives the parcel/no-parcel branch deterministically. Already present in the original test. |
+
+Everything else — `SuiteModuleGrid` itself, `contracts/workbench` types — is imported **real**. The component under test
+is not mocked.
+
+## 3. `vi.hoisted` requirement
+
+`vi.mock` factories are hoisted above imports, so the `activateModule` spy must be created in a hoisted block to be
+referenceable both inside the factory and inside test assertions:
+
+```ts
+const { mockActivateModule } = vi.hoisted(() => ({ mockActivateModule: vi.fn() }));
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: mockActivateModule,
+  default: mockActivateModule,
+}));
+```
+
+`default` is included defensively so the mock satisfies both named and default import styles; the product uses the named
+import.
+
+## 4. Assertion contract (what each mock enables)
+
+- **Workbench + parcel:** `expect(mockNavigate).toHaveBeenCalledWith('/property/<parcelId>/<tab>')` — asserted via
+  substring/regex on the single navigate call, and `expect(mockActivateModule).not.toHaveBeenCalled()`.
+- **Workbench + no parcel:** navigate contains `/property` and `openTab=<tab>`.
+- **Standalone:** `expect(mockActivateModule).toHaveBeenCalledWith('<moduleId>', { source: 'system' })` and
+  `expect(mockNavigate).not.toHaveBeenCalled()`.
+- **Broken (no `workbenchTab`):** neither spy called.
+
+## 5. Non-goals
+
+No mocking of the component under test; no deep-rendering of activated modules; no change to any product file; no new
+route or registry entry. The mock set is the minimum that both (a) prevents the worker crash and (b) lets the real
+`SuiteModuleGrid` branch logic be observed directly.

--- a/docs/audit/workbench-readiness/WO-WB-P16-005-launch-contract-regression-matrix.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-005-launch-contract-regression-matrix.md
@@ -1,0 +1,46 @@
+# WO-WB-P16-005 — Launch-Contract Regression Matrix
+
+**Goal:** GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel-to-Workbench Launch Contract
+**WO:** WO-WB-P16-005 — Regression Matrix
+**Category:** Documentation (coverage matrix)
+**Operator:** Claude Code · ratified tests-only follow-up
+
+**Authorization:** Operator-ratified Phase-16 lane (tests-only / shallow mocks / no product behavior change).
+
+---
+
+## 1. Purpose
+
+Map each re-authored test to the launch-contract invariant it locks, so the coverage is auditable and future regressions
+have a named guard.
+
+## 2. Invariant → test map
+
+| # | Test | Invariant enforced | Product path guarded |
+|---|------|--------------------|----------------------|
+| 1 | Forge → workbench | Parcel action routes into Workbench, not a standalone Forge window | `workbench` + parcel → `/property/:id/forge` |
+| 2 | Atlas → workbench | Same, Atlas tab | `/property/:id/atlas` |
+| 3 | Dossier → workbench | Same, Dossier tab | `/property/:id/dossier` |
+| 4 | Same parcel+tab re-entry | Window reuse: identical URL ⇒ React Router reuses the mounted component (no window multiplication) | URL identity |
+| 5 | Structural URL proof | `parcelId` + `tab` encoded in path; `countyId` travels in header, not path (FISMA isolation) | `/property/:id/:tab` shape |
+| 6 | Broken module (no `workbenchTab`) | Guard: malformed workbench def no-ops instead of routing to `/property/:id/undefined` | `if (!mod.workbenchTab) return;` |
+| 7 | Standalone tools (ratio / batch / calibration) | Cross-parcel tools open standalone via `activateModule`, never touch `/property/` | `standalone → activateModule(moduleId, {source:'system'})` |
+| bonus | No active parcel | Workbench tile falls back to `/property?openTab=:tab`, not a standalone window | no-parcel branch |
+
+## 3. Behavior-truth note (test 7)
+
+Test 7 asserts the **current** standalone behavior (`activateModule`), which diverged from the original test's
+`navigate('/:moduleId')` at **WO-SUITE-ROUTING-001**. The matrix records this as an intentional test correction; no
+product behavior changed in this lane.
+
+## 4. Run of record
+
+Vitest cannot run in the sparse worktree (no `node_modules`; a full local sweep hangs ~30 min). **CI is the run of
+record** — Frontend Gate + Vitest full suite on the PR. This matrix is verified green there before merge; local static
+review (`git diff --check`, mock-path/type check against `SuiteModuleGrid` source) is the pre-push gate.
+
+## 5. Coverage honesty
+
+No redundant tests were added. Each row above is a distinct branch or invariant of `handleLaunch`. The re-author restores
+the original coverage and corrects a single stale assertion; it does not manufacture additional cases beyond the eight
+the contract requires.

--- a/docs/audit/workbench-readiness/WO-WB-P16-005-launch-contract-regression-matrix.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-005-launch-contract-regression-matrix.md
@@ -16,22 +16,38 @@ have a named guard.
 
 ## 2. Invariant → test map
 
+Fixtures are synthetic but each **mirrors a real shipped tile** (Dais/Dossier workbench tiles; Atlas/Dais standalone
+tiles) so every asserted launch reflects real behavior — see §3.
+
 | # | Test | Invariant enforced | Product path guarded |
 |---|------|--------------------|----------------------|
-| 1 | Forge → workbench | Parcel action routes into Workbench, not a standalone Forge window | `workbench` + parcel → `/property/:id/forge` |
-| 2 | Atlas → workbench | Same, Atlas tab | `/property/:id/atlas` |
-| 3 | Dossier → workbench | Same, Dossier tab | `/property/:id/dossier` |
+| 1 | Dais workbench tile → workbench | Parcel action routes into Workbench, not a standalone window | `workbench` + parcel → `/property/:id/dais` |
+| 2 | Dossier workbench tile → workbench | Same, Dossier tab | `/property/:id/dossier` |
+| 3 | Cross-tab tile (Dossier "Defense" → Dais) | Destination follows `workbenchTab`, not the owning suite | `/property/:id/dais` |
 | 4 | Same parcel+tab re-entry | Window reuse: identical URL ⇒ React Router reuses the mounted component (no window multiplication) | URL identity |
 | 5 | Structural URL proof | `parcelId` + `tab` encoded in path; `countyId` travels in header, not path (FISMA isolation) | `/property/:id/:tab` shape |
 | 6 | Broken module (no `workbenchTab`) | Guard: malformed workbench def no-ops instead of routing to `/property/:id/undefined` | `if (!mod.workbenchTab) return;` |
-| 7 | Standalone tools (ratio / batch / calibration) | Cross-parcel tools open standalone via `activateModule`, never touch `/property/` | `standalone → activateModule(moduleId, {source:'system'})` |
+| 7 | Standalone tiles (Atlas GIS / TerraLevy / Management) | Standalone tiles open via `activateModule`, never touch `/property/` | `standalone → activateModule(moduleId, {source:'system'})` |
 | bonus | No active parcel | Workbench tile falls back to `/property?openTab=:tab`, not a standalone window | no-parcel branch |
 
-## 3. Behavior-truth note (test 7)
+## 3. Truth-fidelity of fixtures (codex #1237 review)
 
-Test 7 asserts the **current** standalone behavior (`activateModule`), which diverged from the original test's
-`navigate('/:moduleId')` at **WO-SUITE-ROUTING-001**. The matrix records this as an intentional test correction; no
-product behavior changed in this lane.
+The re-author uses synthetic `SuiteModuleDef` fixtures but binds them to **real** launch modes/tabs so the contract
+cannot pass on counterfactual behavior:
+
+- **Corrected false cases:** an earlier draft asserted **Forge → workbench** and **Atlas → workbench**. Neither is real —
+  the shipped Atlas suite is **all standalone** (`AtlasSuiteHome`) and **Forge does not use `SuiteModuleGrid`** at all.
+  Those cases were removed; the workbench cases now mirror the real Dais (`certification` → `dais`) and Dossier
+  (`documents` → `dossier`; `defense` → `dais`) tiles.
+- **Standalone cases** now mirror real standalone tiles (`atlas`, `terra-levy`, `management-dashboard`).
+- **Test 7 behavior-truth:** standalone launch asserts the **current** `activateModule(moduleId, {source})` behavior,
+  which diverged from the original `navigate('/:moduleId')` at **WO-SUITE-ROUTING-001**. Intentional test correction; no
+  product behavior changed.
+
+**Known coverage gap (flagged, not closed here):** this guards the grid ROUTING MECHANISM, not the literal shipped tile
+arrays. `DAIS_MODULES` / `DOSSIER_MODULES` / `ATLAS_MODULES` are module-private and the suite-home deeplink tests **stub**
+`SuiteModuleGrid`, so no test drives the real tile defs through the real grid. Closing that needs a product `export`
+(outside this tests-only lane) → **follow-up:** a small lane to export the arrays and assert their launch modes directly.
 
 ## 4. Run of record
 

--- a/docs/audit/workbench-readiness/WO-WB-P16-006-launch-contract-evidence-rollup.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-006-launch-contract-evidence-rollup.md
@@ -42,12 +42,22 @@ The real `SuiteModuleGrid` is imported and rendered — it is the actual unit un
 
 **Five docs** — P16-001/002/003/005/006 in `docs/audit/workbench-readiness/`.
 
-## 3. Behavior-truth correction (only substantive delta from the original)
+## 3. Behavior-truth corrections (test-only; no product file edited)
 
-Original test 7 asserted standalone tiles call `navigate('/:moduleId')`. Since WO-SUITE-ROUTING-001 the product calls
-`activateModule(mod.moduleId ?? mod.id, { source: 'system' })`. Test 7 now asserts the shipped behavior
-(`activateModule` called with the moduleId + `source: 'system'`, and `navigate` NOT called). **No product file was
-edited** — the correction aligns the test with already-shipped behavior.
+1. **Standalone behavior (test 7).** Original test 7 asserted standalone tiles call `navigate('/:moduleId')`. Since
+   WO-SUITE-ROUTING-001 the product calls `activateModule(mod.moduleId ?? mod.id, { source: 'system' })`. Test 7 now
+   asserts the shipped behavior (`activateModule` with the moduleId + `source: 'system'`; `navigate` NOT called).
+2. **False Forge/Atlas workbench cases (codex #1237 P2).** The original/first-draft test asserted **Forge → workbench**
+   and **Atlas → workbench**. Verified first-hand against the suite homes: the shipped **Atlas suite is all standalone**
+   and **Forge does not use `SuiteModuleGrid`** — so those cases claimed launches the app does not perform. Removed; the
+   workbench cases now mirror the real **Dais** (`certification` → `dais`) and **Dossier** (`documents` → `dossier`;
+   `defense` → `dais`) tiles, and standalone cases mirror real tiles (`atlas`, `terra-levy`, `management-dashboard`).
+
+Both are test-only corrections aligning the test with already-shipped behavior — no product file was edited.
+
+**Known coverage gap (flagged, not closed):** the test guards the grid routing *mechanism*, not the literal shipped tile
+arrays (`DAIS_MODULES`/`DOSSIER_MODULES`/`ATLAS_MODULES` are module-private; suite-home deeplink tests stub the grid).
+Closing it needs a product `export` (outside this tests-only lane) → recommended small follow-up lane.
 
 ## 4. What was intentionally NOT touched
 
@@ -63,9 +73,10 @@ scope = allowed files only; no `--admin` / no break-glass.
 
 ## 6. Coverage honesty
 
-No redundant tests were manufactured. The re-author restores the eight cases the contract requires and corrects one
-stale assertion. The skipped test is now a live guard against parcel actions leaking into standalone windows (and vice
-versa).
+No redundant tests were manufactured. The re-author restores the eight cases the contract requires, corrects two stale
+assertions (standalone behavior + false Forge/Atlas workbench cases), and binds every fixture to a real shipped launch
+mode. The skipped test is now a live guard against parcel actions leaking into standalone windows (and vice versa), with
+the residual real-tile-array coverage gap explicitly flagged for follow-up.
 
 ## 7. Next lane
 

--- a/docs/audit/workbench-readiness/WO-WB-P16-006-launch-contract-evidence-rollup.md
+++ b/docs/audit/workbench-readiness/WO-WB-P16-006-launch-contract-evidence-rollup.md
@@ -1,0 +1,74 @@
+# WO-WB-P16-006 — Launch-Contract Evidence Rollup
+
+**Goal:** GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel-to-Workbench Launch Contract
+**WO:** WO-WB-P16-006 — Evidence Rollup + Next-Lane Decision
+**Category:** Documentation (closure)
+**Operator:** Claude Code · ratified tests-only follow-up
+**Status:** COMPLETE — skipped Phase-16 contract test re-authored and un-skipped; no product behavior change.
+
+**Authorization:** Operator-ratified Phase-16 lane. **MODE: tests-only / shallow mocks / no product behavior change.**
+Allowed writes: `frontend/apps/os-shell/src/__tests__/**`, `docs/audit/workbench-readiness/**`; read-only elsewhere.
+AGENTS.md out-of-lane write is under this ratified authorization; no governance-surface / product / backend / registry
+file was touched.
+
+---
+
+## 1. WOs completed
+
+| WO | Deliverable |
+|----|-------------|
+| P16-001 | Current-state audit (skipped stub + product `handleLaunch` behavior) |
+| P16-002 | Skip root-cause confirmation (missing `moduleActivation` mock, eager evaluation) |
+| P16-003 | Shallow-mock design (four boundaries; `vi.hoisted` activateModule spy) |
+| P16-004 | Re-authored contract test (un-skipped) |
+| P16-005 | Regression matrix (invariant → test map) |
+| P16-006 | This rollup |
+
+## 2. What changed
+
+**One test file** — `frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx`:
+the 36-line `describe.skip` stub was replaced with the re-authored contract test (8 cases). The fix that removed the skip
+is a single added shallow mock:
+
+```ts
+const { mockActivateModule } = vi.hoisted(() => ({ mockActivateModule: vi.fn() }));
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: mockActivateModule,
+  default: mockActivateModule,
+}));
+```
+
+The real `SuiteModuleGrid` is imported and rendered — it is the actual unit under test, not mocked.
+
+**Five docs** — P16-001/002/003/005/006 in `docs/audit/workbench-readiness/`.
+
+## 3. Behavior-truth correction (only substantive delta from the original)
+
+Original test 7 asserted standalone tiles call `navigate('/:moduleId')`. Since WO-SUITE-ROUTING-001 the product calls
+`activateModule(mod.moduleId ?? mod.id, { source: 'system' })`. Test 7 now asserts the shipped behavior
+(`activateModule` called with the moduleId + `source: 'system'`, and `navigate` NOT called). **No product file was
+edited** — the correction aligns the test with already-shipped behavior.
+
+## 4. What was intentionally NOT touched
+
+`SuiteModuleGrid.tsx` and all product code; `Router.tsx`; `pages/workbench/**`; tool registry; backend; API/service;
+package / build / CI config; deploy / migrations; PACS / county data; Codex Backend OE files. No new route, no new
+registry entry, no behavior change.
+
+## 5. CI validation
+
+Vitest cannot run in the sparse worktree (no `node_modules`); **CI is the run of record**. Frontend Gate + Vitest full
+suite + required branch-protection contexts must be green on the PR; review threads resolved; `git diff --check` clean;
+scope = allowed files only; no `--admin` / no break-glass.
+
+## 6. Coverage honesty
+
+No redundant tests were manufactured. The re-author restores the eight cases the contract requires and corrects one
+stale assertion. The skipped test is now a live guard against parcel actions leaking into standalone windows (and vice
+versa).
+
+## 7. Next lane
+
+Phase-16 is closed. Per posture, **Claude Code parks** after this lane. Codex Backend OE remains the priority lane; G1
+(0/117 tool backend integration) remains the separate Codex/backend surface. No further Claude Code Workbench work is
+self-queued — any next lane is ratified through the Brain/operator.

--- a/frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx
@@ -1,35 +1,41 @@
 /**
  * launchSurfaceContractParcelWorkbench.contract.test.tsx
  *
- * Phase 16 — Parcel-to-Workbench Launch Contract
- * ================================================
+ * Phase 16 — Parcel-to-Workbench Launch Contract (SuiteModuleGrid routing mechanism)
+ * =================================================================================
  *
- * Enforces the constitutional invariant:
- *   Every parcel-scoped action routes into the Property Workbench.
- *   No parcel tool opens as a standalone window.
- *   Cross-parcel operational tools remain standalone.
- *   Window reuse: same parcel + tab = same URL = no window multiplication.
+ * Enforces the routing invariant of `SuiteModuleGrid.handleLaunch`:
+ *   - launchMode 'workbench' + active parcel → navigate('/property/:parcelId/:tab')
+ *     (every parcel-scoped tile routes INTO the Property Workbench, never a standalone window)
+ *   - launchMode 'workbench' + NO active parcel → navigate('/property?openTab=:tab')
+ *   - launchMode 'standalone' → activateModule(moduleId, {source}) — never /property/, never navigate
+ *   - the destination tab is driven by `workbenchTab`, independent of which suite owns the tile
+ *   - same parcel + same tab = same URL = natural window reuse (URL identity)
+ *   - a workbench tile with no `workbenchTab` is a silent no-op (guard)
  *
- * Proves SuiteModuleGrid.handleLaunch routes correctly based on
- * launchMode: 'workbench' | 'standalone'.
- *
- * Contract invariants:
- *   1. launchMode='workbench' + active parcel → navigate('/property/:parcelId/:tab')
- *   2. launchMode='workbench' + NO active parcel → navigate('/property?openTab=:tab')
- *   3. launchMode='standalone' → activateModule(moduleId) — never /property/, never navigate
- *   4. Same parcel + same tab = same URL = natural window reuse (URL identity)
- *   5. countyId + parcelId + tab survive: URL is source of truth (structural)
- *   6. workbenchTab missing → no navigation (guard protects against broken defs)
- *   7. Cross-parcel tools (ratio study, calibration, batch) never touch /property/
+ * SCOPE (read before extending this test):
+ *   This guards the GRID ROUTING MECHANISM, not per-suite tile configuration. The fixtures
+ *   below are synthetic, but each one MIRRORS a real shipped tile so the contract reflects
+ *   real behavior rather than a counterfactual:
+ *     - workbench tiles mirror the real Dais tiles (certification/appeals → tab 'dais') and
+ *       Dossier tiles (documents/evidence → tab 'dossier'; defense → tab 'dais')
+ *     - standalone tiles mirror the real Atlas ('atlas') and Dais ('terra-levy',
+ *       'management-dashboard') tiles, which really launch via activateModule
+ *   It does NOT assert which suite marks which tile workbench-vs-standalone. Notably the real
+ *   Atlas suite is ALL standalone and Forge does not use SuiteModuleGrid at all — so this test
+ *   deliberately does NOT claim Forge/Atlas launch into the Workbench. Guarding the literal
+ *   shipped arrays (DAIS_MODULES / DOSSIER_MODULES / ATLAS_MODULES) is a SEPARATE coverage gap:
+ *   those arrays are module-private and the suite-home deeplink tests stub SuiteModuleGrid, so
+ *   no test currently exercises the real tile defs through the real grid. Closing that needs a
+ *   product `export` (out of this tests-only lane) and is flagged as a follow-up.
  *
  * RE-AUTHORIZED (WO-WB-P16-004): un-skipped by adding the missing shallow mock for
- * `orchestration/moduleActivation` — SuiteModuleGrid imports `activateModule` from it,
- * and the real module's transitive graph (config/moduleComponents → desktopStore +
- * moduleLoaderStore + notificationStore + telemetry) crashed the vitest worker
- * ("Worker exited unexpectedly" / tinypool). Stubbing that one import lets the real
- * SuiteModuleGrid render safely. Test 3/7 (standalone) is updated to the current
- * behavior: standalone launch now calls `activateModule(targetId)` (WO-SUITE-ROUTING-001),
- * not a bare navigate('/:moduleId') — a test-only correction, no product change.
+ * `orchestration/moduleActivation` — SuiteModuleGrid imports `activateModule` from it, and the
+ * real module's transitive graph (config/moduleComponents → desktopStore + moduleLoaderStore +
+ * notificationStore + telemetry) crashed the vitest worker ("Worker exited unexpectedly" /
+ * tinypool). Stubbing that one import lets the real SuiteModuleGrid render safely. The standalone
+ * assertion reflects current behavior: standalone launch calls `activateModule(targetId, {source})`
+ * (WO-SUITE-ROUTING-001), not a bare navigate('/:moduleId') — a test-only correction, no product change.
  *
  * @see src/components/suites/SuiteModuleGrid.tsx — handleLaunch()
  */
@@ -79,68 +85,72 @@ vi.mock('../../stores/propertyStore', () => ({
 }));
 
 // ── Test Fixtures ─────────────────────────────────────────────────────────────
+// Synthetic, but each mirrors a REAL shipped tile (see SCOPE note above).
 
-/** A parcel-scoped Forge workbench module */
-const forgeWorkbenchMod: SuiteModuleDef = {
-  id: 'costforge',
-  label: 'CostForge',
-  icon: () => React.createElement('span', null, '🔥'),
-  description: 'Cost approach calculator',
+/** Mirrors a real Dais workbench tile (DaisSuiteHome: certification/appeals → tab 'dais'). */
+const daisWorkbenchTile: SuiteModuleDef = {
+  id: 'certification',
+  label: 'Certification',
+  icon: () => React.createElement('span', null, '✅'),
+  description: 'Assessment roll certification workflow',
   launchMode: 'workbench',
-  workbenchTab: 'forge',
+  workbenchTab: 'dais',
 };
 
-/** A parcel-scoped Atlas workbench module */
-const atlasWorkbenchMod: SuiteModuleDef = {
-  id: 'gis',
-  label: 'TerraGIS',
-  icon: () => React.createElement('span', null, '🗺️'),
-  description: 'GIS viewer',
-  launchMode: 'workbench',
-  workbenchTab: 'atlas',
-};
-
-/** A parcel-scoped Dossier workbench module */
-const dossierWorkbenchMod: SuiteModuleDef = {
-  id: 'dossier-view',
-  label: 'Dossier',
+/** Mirrors a real Dossier workbench tile (DossierSuiteHome: documents/evidence → tab 'dossier'). */
+const dossierWorkbenchTile: SuiteModuleDef = {
+  id: 'documents',
+  label: 'Document Manager',
   icon: () => React.createElement('span', null, '📁'),
-  description: 'Parcel document viewer',
+  description: 'Parcel document repository',
   launchMode: 'workbench',
   workbenchTab: 'dossier',
 };
 
-/** Cross-parcel standalone tool — ratio study */
-const ratioStudyStandaloneMod: SuiteModuleDef = {
-  id: 'statistics-studio',
-  label: 'Ratio Study',
+/**
+ * Mirrors the real Dossier "Defense Packets" tile, which launches the DAIS tab from the
+ * Dossier suite — proves the destination follows `workbenchTab`, not the owning suite.
+ */
+const crossTabWorkbenchTile: SuiteModuleDef = {
+  id: 'defense',
+  label: 'Defense Packets',
+  icon: () => React.createElement('span', null, '🛡️'),
+  description: 'BOE appeal defense packet assembly via the Dais workbench flow',
+  launchMode: 'workbench',
+  workbenchTab: 'dais',
+};
+
+/** Mirrors the real Atlas TerraGIS tile — genuinely standalone (moduleId 'atlas'). */
+const atlasStandaloneTile: SuiteModuleDef = {
+  id: 'gis',
+  label: 'TerraGIS',
+  icon: () => React.createElement('span', null, '🗺️'),
+  description: 'GIS surface',
+  launchMode: 'standalone',
+  moduleId: 'atlas',
+};
+
+/** Mirrors the real Dais TerraLevy tile — standalone (moduleId 'terra-levy'). */
+const levyStandaloneTile: SuiteModuleDef = {
+  id: 'terra-levy',
+  label: 'TerraLevy',
+  icon: () => React.createElement('span', null, '🧾'),
+  description: 'County-wide levy rates by district',
+  launchMode: 'standalone',
+  moduleId: 'terra-levy',
+};
+
+/** Mirrors the real Dais Management tile — standalone (moduleId 'management-dashboard'). */
+const mgmtStandaloneTile: SuiteModuleDef = {
+  id: 'management-dashboard',
+  label: 'Management',
   icon: () => React.createElement('span', null, '📊'),
-  description: 'County-wide ratio study',
+  description: 'Assessor operations dashboard',
   launchMode: 'standalone',
-  moduleId: 'statistics-studio',
+  moduleId: 'management-dashboard',
 };
 
-/** Cross-parcel standalone tool — batch cost run */
-const batchCostStandaloneMod: SuiteModuleDef = {
-  id: 'batch-cost-run',
-  label: 'Batch Cost Runs',
-  icon: () => React.createElement('span', null, '⚙️'),
-  description: 'Batch cost model runs',
-  launchMode: 'standalone',
-  moduleId: 'batch-cost-run',
-};
-
-/** Cross-parcel standalone tool — calibration */
-const calibrationStandaloneMod: SuiteModuleDef = {
-  id: 'regression-studio',
-  label: 'Regression Studio',
-  icon: () => React.createElement('span', null, '📉'),
-  description: 'MRA regression models',
-  launchMode: 'standalone',
-  moduleId: 'regression-studio',
-};
-
-/** Broken workbench module — missing workbenchTab */
+/** Broken workbench module — missing workbenchTab (guard case). */
 const brokenWorkbenchMod: SuiteModuleDef = {
   id: 'broken-mod',
   label: 'Broken Module',
@@ -172,83 +182,78 @@ describe('launchSurfaceContractParcelWorkbench', () => {
     vi.clearAllMocks();
   });
 
-  // ── 1. Forge parcel actions route into Property Workbench ──────────────────
+  // ── 1. A Dais workbench tile routes into the Property Workbench Dais tab ────
 
-  it('routes Forge parcel actions into Property Workbench, not standalone Forge windows', async () => {
+  it('routes a Dais workbench tile into the Property Workbench, not a standalone window', async () => {
     const user = userEvent.setup();
-    renderGrid([forgeWorkbenchMod]);
+    renderGrid([daisWorkbenchTile]);
 
-    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    await user.click(screen.getByRole('button', { name: /Certification/i }));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     const destination = mockNavigate.mock.calls[0][0] as string;
     expect(destination).toMatch(/^\/property\//);
-    expect(destination).toContain('/forge');
+    expect(destination).toContain('/dais');
     expect(destination).toContain('benton-12345');
-    expect(destination).not.toBe('/costforge');
-    expect(destination).not.toBe('/forge');
     // Parcel action must not fall through to a standalone module window.
     expect(mockActivateModule).not.toHaveBeenCalled();
   });
 
-  // ── 2. Atlas parcel actions route into Property Workbench ──────────────────
+  // ── 2. A Dossier workbench tile routes into the Property Workbench Dossier tab ─
 
-  it('routes Atlas parcel actions into Property Workbench, not standalone GIS windows', async () => {
+  it('routes a Dossier workbench tile into the Property Workbench, not a standalone document window', async () => {
     const user = userEvent.setup();
-    renderGrid([atlasWorkbenchMod]);
+    renderGrid([dossierWorkbenchTile]);
 
-    await user.click(screen.getByRole('button', { name: /TerraGIS/i }));
-
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    const destination = mockNavigate.mock.calls[0][0] as string;
-    expect(destination).toMatch(/^\/property\//);
-    expect(destination).toContain('/atlas');
-    expect(destination).toContain('benton-12345');
-    expect(destination).not.toBe('/gis');
-    expect(destination).not.toBe('/terra-gis');
-  });
-
-  // ── 3. Dossier parcel actions route into Property Workbench ───────────────
-
-  it('routes Dossier parcel actions into Property Workbench, not standalone document windows', async () => {
-    const user = userEvent.setup();
-    renderGrid([dossierWorkbenchMod]);
-
-    await user.click(screen.getByRole('button', { name: /Dossier/i }));
+    await user.click(screen.getByRole('button', { name: /Document Manager/i }));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     const destination = mockNavigate.mock.calls[0][0] as string;
     expect(destination).toMatch(/^\/property\//);
     expect(destination).toContain('/dossier');
     expect(destination).toContain('benton-12345');
+    expect(mockActivateModule).not.toHaveBeenCalled();
+  });
+
+  // ── 3. Destination follows workbenchTab, not the owning suite ──────────────
+
+  it('routes to the tab named by workbenchTab even when a different suite owns the tile', async () => {
+    // Real case: the Dossier "Defense Packets" tile launches the Dais tab.
+    const user = userEvent.setup();
+    renderGrid([crossTabWorkbenchTile]);
+
+    await user.click(screen.getByRole('button', { name: /Defense Packets/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const destination = mockNavigate.mock.calls[0][0] as string;
+    expect(destination).toBe('/property/benton-12345/dais');
   });
 
   // ── 4. Same parcel + tab re-entry → same URL = natural window reuse ────────
 
   it('reuses the existing workbench window for same parcel+tab re-entry', async () => {
     const user = userEvent.setup();
-    renderGrid([forgeWorkbenchMod]);
+    renderGrid([daisWorkbenchTile]);
 
-    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    await user.click(screen.getByRole('button', { name: /Certification/i }));
     const firstUrl = mockNavigate.mock.calls[0][0] as string;
 
     mockNavigate.mockClear();
 
-    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    await user.click(screen.getByRole('button', { name: /Certification/i }));
     const secondUrl = mockNavigate.mock.calls[0][0] as string;
 
     // Same URL = same route = React Router reuses the existing mounted component.
     expect(secondUrl).toBe(firstUrl);
   });
 
-  // ── 5. Context survives refresh/navigation — structural proof ──────────────
+  // ── 5. Context is encoded in the URL — structural proof ────────────────────
 
-  it('preserves countyId + parcelId + tab slug across refresh and browser navigation', () => {
-    // Structural proof: tab state and parcel context are encoded in the URL.
-    // /property/benton-12345/forge encodes parcelId (route param) + tab (sub-route);
-    // countyId travels in the x-county-id header (FISMA isolation), not the path.
+  it('encodes parcelId + tab slug in the URL, with countyId carried out-of-band', () => {
+    // Structural proof: parcelId (route param) + tab (sub-route) live in the path;
+    // countyId travels in the x-county-id header (FISMA isolation), NOT the path.
     const parcelId = 'R112233445566';
-    const tab = 'forge';
+    const tab = 'dais';
     const countyId = 'benton';
 
     const workbenchUrl = `/property/${parcelId}/${tab}`;
@@ -273,47 +278,47 @@ describe('launchSurfaceContractParcelWorkbench', () => {
     expect(mockActivateModule).not.toHaveBeenCalled();
   });
 
-  // ── 7. Cross-parcel tools remain standalone — activateModule, never /property/ ─
+  // ── 7. Standalone tiles activate a module — never route into /property/ ─────
 
-  it('launches cross-parcel operational tools as standalone modules (never into the Workbench)', async () => {
+  it('launches standalone tiles via activateModule (never into the Workbench)', async () => {
     // Current behavior (WO-SUITE-ROUTING-001): standalone tiles call
-    // activateModule(moduleId) to open a desktop window — NOT navigate('/:moduleId')
-    // (that path had no registered route and silently no-op'd). This test enforces
-    // that standalone tools open standalone and never route into /property/.
+    // activateModule(moduleId, {source}) to open a desktop window — NOT
+    // navigate('/:moduleId') (that path had no registered route and silently no-op'd).
+    // Fixtures mirror the real standalone tiles: Atlas TerraGIS, Dais TerraLevy/Management.
     const user = userEvent.setup();
-    renderGrid([ratioStudyStandaloneMod, batchCostStandaloneMod, calibrationStandaloneMod]);
+    renderGrid([atlasStandaloneTile, levyStandaloneTile, mgmtStandaloneTile]);
 
-    await user.click(screen.getByRole('button', { name: /Ratio Study/i }));
-    expect(mockActivateModule).toHaveBeenCalledWith('statistics-studio', expect.objectContaining({ source: 'system' }));
+    await user.click(screen.getByRole('button', { name: /TerraGIS/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('atlas', expect.objectContaining({ source: 'system' }));
     expect(mockNavigate).not.toHaveBeenCalled();
 
     mockActivateModule.mockClear();
 
-    await user.click(screen.getByRole('button', { name: /Batch Cost/i }));
-    expect(mockActivateModule).toHaveBeenCalledWith('batch-cost-run', expect.objectContaining({ source: 'system' }));
+    await user.click(screen.getByRole('button', { name: /TerraLevy/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('terra-levy', expect.objectContaining({ source: 'system' }));
     expect(mockNavigate).not.toHaveBeenCalled();
 
     mockActivateModule.mockClear();
 
-    await user.click(screen.getByRole('button', { name: /Regression/i }));
-    expect(mockActivateModule).toHaveBeenCalledWith('regression-studio', expect.objectContaining({ source: 'system' }));
+    await user.click(screen.getByRole('button', { name: /Management/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('management-dashboard', expect.objectContaining({ source: 'system' }));
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   // ── Bonus: no-parcel fallback routes to property search with tab intent ────
 
-  it('routes workbench modules to property search when no parcel is active', async () => {
+  it('routes workbench tiles to property search when no parcel is active', async () => {
     mockActiveParcel = null;
     const user = userEvent.setup();
-    renderGrid([forgeWorkbenchMod]);
+    renderGrid([daisWorkbenchTile]);
 
-    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    await user.click(screen.getByRole('button', { name: /Certification/i }));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     const destination = mockNavigate.mock.calls[0][0] as string;
-    // Falls back to /property?openTab=forge — not a standalone window.
+    // Falls back to /property?openTab=dais — not a standalone window.
     expect(destination).toContain('/property');
-    expect(destination).toContain('openTab=forge');
-    expect(destination).not.toMatch(/^\/costforge/);
+    expect(destination).toContain('openTab=dais');
+    expect(mockActivateModule).not.toHaveBeenCalled();
   });
 });

--- a/frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx
@@ -10,27 +10,310 @@
  *   Cross-parcel operational tools remain standalone.
  *   Window reuse: same parcel + tab = same URL = no window multiplication.
  *
+ * Proves SuiteModuleGrid.handleLaunch routes correctly based on
+ * launchMode: 'workbench' | 'standalone'.
+ *
+ * Contract invariants:
+ *   1. launchMode='workbench' + active parcel → navigate('/property/:parcelId/:tab')
+ *   2. launchMode='workbench' + NO active parcel → navigate('/property?openTab=:tab')
+ *   3. launchMode='standalone' → activateModule(moduleId) — never /property/, never navigate
+ *   4. Same parcel + same tab = same URL = natural window reuse (URL identity)
+ *   5. countyId + parcelId + tab survive: URL is source of truth (structural)
+ *   6. workbenchTab missing → no navigation (guard protects against broken defs)
+ *   7. Cross-parcel tools (ratio study, calibration, batch) never touch /property/
+ *
+ * RE-AUTHORIZED (WO-WB-P16-004): un-skipped by adding the missing shallow mock for
+ * `orchestration/moduleActivation` — SuiteModuleGrid imports `activateModule` from it,
+ * and the real module's transitive graph (config/moduleComponents → desktopStore +
+ * moduleLoaderStore + notificationStore + telemetry) crashed the vitest worker
+ * ("Worker exited unexpectedly" / tinypool). Stubbing that one import lets the real
+ * SuiteModuleGrid render safely. Test 3/7 (standalone) is updated to the current
+ * behavior: standalone launch now calls `activateModule(targetId)` (WO-SUITE-ROUTING-001),
+ * not a bare navigate('/:moduleId') — a test-only correction, no product change.
+ *
  * @see src/components/suites/SuiteModuleGrid.tsx — handleLaunch()
- *
- * SKIP NOTE (2026-04-25): the original test imports SuiteModuleGrid,
- * which transitively pulls in orchestration/moduleActivation →
- * config/moduleComponents → desktopStore + moduleLoaderStore +
- * notificationStore + telemetry. That graph crashes the vitest worker
- * during module evaluation ('Worker exited unexpectedly' from
- * tinypool), regardless of pool=forks/threads, isolate, or
- * single-fork mode. Combined with the global retry: 2 in
- * vitest.config.ts this made a full sweep hang for ~30 minutes.
- *
- * The full historical content is preserved in git history (latest
- * pre-skip commit on main). Re-author: shallow-mock activateModule
- * and the propertyStore selector, then verify navigation through the
- * mocked useNavigate without rendering the real SuiteModuleGrid
- * (or render a thin handleLaunch helper instead).
  */
-import { describe, it } from 'vitest';
+import React from 'react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { SuiteModuleDef } from '../../components/suites/SuiteModuleGrid';
+import { SuiteModuleGrid } from '../../components/suites/SuiteModuleGrid';
 
-describe.skip('Parcel→Workbench launch contract (skipped — see top-of-file note)', () => {
-  it('quarantined: rebuild without importing the real SuiteModuleGrid', () => {
-    // Intentionally empty.
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+// Shallow-mock the standalone-launch path. SuiteModuleGrid imports `activateModule`
+// from orchestration/moduleActivation; the REAL module transitively pulls
+// config/moduleComponents + desktopStore + moduleLoaderStore + notificationStore +
+// telemetry, which crashes the vitest worker during evaluation. Stubbing it here is
+// the sole reason the original test was skipped (2026-04-25).
+const { mockActivateModule } = vi.hoisted(() => ({ mockActivateModule: vi.fn() }));
+vi.mock('../../orchestration/moduleActivation', () => ({
+  activateModule: mockActivateModule,
+  default: mockActivateModule,
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('lucide-react', () => {
+  const Icon = (props: Record<string, unknown>) =>
+    React.createElement('span', { 'data-slot': 'icon', ...props });
+  return new Proxy({}, { get: () => Icon });
+});
+
+// Property store mock — controls active parcel
+let mockActiveParcel: { parcelId: string; countyId?: string } | null = {
+  parcelId: 'benton-12345',
+  countyId: 'benton',
+};
+
+vi.mock('../../stores/propertyStore', () => ({
+  usePropertyStore: (selector: (s: { activeParcel: typeof mockActiveParcel }) => unknown) =>
+    selector({ activeParcel: mockActiveParcel }),
+}));
+
+// ── Test Fixtures ─────────────────────────────────────────────────────────────
+
+/** A parcel-scoped Forge workbench module */
+const forgeWorkbenchMod: SuiteModuleDef = {
+  id: 'costforge',
+  label: 'CostForge',
+  icon: () => React.createElement('span', null, '🔥'),
+  description: 'Cost approach calculator',
+  launchMode: 'workbench',
+  workbenchTab: 'forge',
+};
+
+/** A parcel-scoped Atlas workbench module */
+const atlasWorkbenchMod: SuiteModuleDef = {
+  id: 'gis',
+  label: 'TerraGIS',
+  icon: () => React.createElement('span', null, '🗺️'),
+  description: 'GIS viewer',
+  launchMode: 'workbench',
+  workbenchTab: 'atlas',
+};
+
+/** A parcel-scoped Dossier workbench module */
+const dossierWorkbenchMod: SuiteModuleDef = {
+  id: 'dossier-view',
+  label: 'Dossier',
+  icon: () => React.createElement('span', null, '📁'),
+  description: 'Parcel document viewer',
+  launchMode: 'workbench',
+  workbenchTab: 'dossier',
+};
+
+/** Cross-parcel standalone tool — ratio study */
+const ratioStudyStandaloneMod: SuiteModuleDef = {
+  id: 'statistics-studio',
+  label: 'Ratio Study',
+  icon: () => React.createElement('span', null, '📊'),
+  description: 'County-wide ratio study',
+  launchMode: 'standalone',
+  moduleId: 'statistics-studio',
+};
+
+/** Cross-parcel standalone tool — batch cost run */
+const batchCostStandaloneMod: SuiteModuleDef = {
+  id: 'batch-cost-run',
+  label: 'Batch Cost Runs',
+  icon: () => React.createElement('span', null, '⚙️'),
+  description: 'Batch cost model runs',
+  launchMode: 'standalone',
+  moduleId: 'batch-cost-run',
+};
+
+/** Cross-parcel standalone tool — calibration */
+const calibrationStandaloneMod: SuiteModuleDef = {
+  id: 'regression-studio',
+  label: 'Regression Studio',
+  icon: () => React.createElement('span', null, '📉'),
+  description: 'MRA regression models',
+  launchMode: 'standalone',
+  moduleId: 'regression-studio',
+};
+
+/** Broken workbench module — missing workbenchTab */
+const brokenWorkbenchMod: SuiteModuleDef = {
+  id: 'broken-mod',
+  label: 'Broken Module',
+  icon: () => React.createElement('span', null, '💀'),
+  description: 'Missing tab def',
+  launchMode: 'workbench',
+  // workbenchTab intentionally omitted
+};
+
+function renderGrid(modules: SuiteModuleDef[]) {
+  return render(
+    <MemoryRouter>
+      <SuiteModuleGrid modules={modules} />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('launchSurfaceContractParcelWorkbench', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockActivateModule.mockClear();
+    mockActiveParcel = { parcelId: 'benton-12345', countyId: 'benton' };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // ── 1. Forge parcel actions route into Property Workbench ──────────────────
+
+  it('routes Forge parcel actions into Property Workbench, not standalone Forge windows', async () => {
+    const user = userEvent.setup();
+    renderGrid([forgeWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const destination = mockNavigate.mock.calls[0][0] as string;
+    expect(destination).toMatch(/^\/property\//);
+    expect(destination).toContain('/forge');
+    expect(destination).toContain('benton-12345');
+    expect(destination).not.toBe('/costforge');
+    expect(destination).not.toBe('/forge');
+    // Parcel action must not fall through to a standalone module window.
+    expect(mockActivateModule).not.toHaveBeenCalled();
+  });
+
+  // ── 2. Atlas parcel actions route into Property Workbench ──────────────────
+
+  it('routes Atlas parcel actions into Property Workbench, not standalone GIS windows', async () => {
+    const user = userEvent.setup();
+    renderGrid([atlasWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /TerraGIS/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const destination = mockNavigate.mock.calls[0][0] as string;
+    expect(destination).toMatch(/^\/property\//);
+    expect(destination).toContain('/atlas');
+    expect(destination).toContain('benton-12345');
+    expect(destination).not.toBe('/gis');
+    expect(destination).not.toBe('/terra-gis');
+  });
+
+  // ── 3. Dossier parcel actions route into Property Workbench ───────────────
+
+  it('routes Dossier parcel actions into Property Workbench, not standalone document windows', async () => {
+    const user = userEvent.setup();
+    renderGrid([dossierWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /Dossier/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const destination = mockNavigate.mock.calls[0][0] as string;
+    expect(destination).toMatch(/^\/property\//);
+    expect(destination).toContain('/dossier');
+    expect(destination).toContain('benton-12345');
+  });
+
+  // ── 4. Same parcel + tab re-entry → same URL = natural window reuse ────────
+
+  it('reuses the existing workbench window for same parcel+tab re-entry', async () => {
+    const user = userEvent.setup();
+    renderGrid([forgeWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    const firstUrl = mockNavigate.mock.calls[0][0] as string;
+
+    mockNavigate.mockClear();
+
+    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+    const secondUrl = mockNavigate.mock.calls[0][0] as string;
+
+    // Same URL = same route = React Router reuses the existing mounted component.
+    expect(secondUrl).toBe(firstUrl);
+  });
+
+  // ── 5. Context survives refresh/navigation — structural proof ──────────────
+
+  it('preserves countyId + parcelId + tab slug across refresh and browser navigation', () => {
+    // Structural proof: tab state and parcel context are encoded in the URL.
+    // /property/benton-12345/forge encodes parcelId (route param) + tab (sub-route);
+    // countyId travels in the x-county-id header (FISMA isolation), not the path.
+    const parcelId = 'R112233445566';
+    const tab = 'forge';
+    const countyId = 'benton';
+
+    const workbenchUrl = `/property/${parcelId}/${tab}`;
+
+    expect(workbenchUrl).toContain(parcelId);
+    expect(workbenchUrl).toContain(tab);
+    expect(workbenchUrl).not.toContain(countyId);
+    expect(workbenchUrl).toMatch(/^\/property\/[^/]+\/[^/]+$/);
+  });
+
+  // ── 6. Invalid workbenchTab → no navigation (guard) ────────────────────────
+
+  it('drops workbench modules with a missing tab slug without navigating', async () => {
+    // SuiteModuleGrid guards: if (!mod.workbenchTab) return; — prevents a
+    // /property/parcelId/undefined URL. The guard is a silent no-op.
+    const user = userEvent.setup();
+    renderGrid([brokenWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /Broken Module/i }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockActivateModule).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Cross-parcel tools remain standalone — activateModule, never /property/ ─
+
+  it('launches cross-parcel operational tools as standalone modules (never into the Workbench)', async () => {
+    // Current behavior (WO-SUITE-ROUTING-001): standalone tiles call
+    // activateModule(moduleId) to open a desktop window — NOT navigate('/:moduleId')
+    // (that path had no registered route and silently no-op'd). This test enforces
+    // that standalone tools open standalone and never route into /property/.
+    const user = userEvent.setup();
+    renderGrid([ratioStudyStandaloneMod, batchCostStandaloneMod, calibrationStandaloneMod]);
+
+    await user.click(screen.getByRole('button', { name: /Ratio Study/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('statistics-studio', expect.objectContaining({ source: 'system' }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    mockActivateModule.mockClear();
+
+    await user.click(screen.getByRole('button', { name: /Batch Cost/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('batch-cost-run', expect.objectContaining({ source: 'system' }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    mockActivateModule.mockClear();
+
+    await user.click(screen.getByRole('button', { name: /Regression/i }));
+    expect(mockActivateModule).toHaveBeenCalledWith('regression-studio', expect.objectContaining({ source: 'system' }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  // ── Bonus: no-parcel fallback routes to property search with tab intent ────
+
+  it('routes workbench modules to property search when no parcel is active', async () => {
+    mockActiveParcel = null;
+    const user = userEvent.setup();
+    renderGrid([forgeWorkbenchMod]);
+
+    await user.click(screen.getByRole('button', { name: /CostForge/i }));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const destination = mockNavigate.mock.calls[0][0] as string;
+    // Falls back to /property?openTab=forge — not a standalone window.
+    expect(destination).toContain('/property');
+    expect(destination).toContain('openTab=forge');
+    expect(destination).not.toMatch(/^\/costforge/);
   });
 });


### PR DESCRIPTION
## GOAL-TF-WB-PHASE16-LAUNCH-CONTRACT-001 — Re-author Parcel→Workbench Launch Contract

**Mode:** tests-only / shallow mocks / **no product behavior change**. Operator-ratified follow-up (post-#1236 NLR record).

### What & why
The Phase-16 contract test `launchSurfaceContractParcelWorkbench.contract.test.tsx` was a 36-line `describe.skip` stub. Root cause (WO-WB-P16-002): the test imported the real `SuiteModuleGrid` but left `orchestration/moduleActivation` un-mocked, so vitest eagerly evaluated its heavy transitive graph (moduleComponents + 3 Zustand stores + telemetry) and crashed the worker (`Worker exited unexpectedly`, tinypool).

The fix is a **single added shallow mock**:
```ts
const { mockActivateModule } = vi.hoisted(() => ({ mockActivateModule: vi.fn() }));
vi.mock('../../orchestration/moduleActivation', () => ({ activateModule: mockActivateModule, default: mockActivateModule }));
```
The real `SuiteModuleGrid` is imported and rendered — it is the unit under test, not mocked.

### The one behavior-truth correction (test 7)
The original test asserted standalone tiles call `navigate('/:moduleId')`. Since **WO-SUITE-ROUTING-001** the product calls `activateModule(mod.moduleId ?? mod.id, { source: 'system' })`. Test 7 now asserts the **shipped** behavior. No product file is edited — this aligns the test with already-shipped behavior.

### Coverage (8 cases — WO-WB-P16-005)
Forge/Atlas/Dossier → `/property/:id/:tab` · same-parcel+tab re-entry (window reuse) · structural URL proof · broken-module guard (no nav) · standalone → `activateModule` (never `/property/`) · no-parcel → `/property?openTab=:tab`.

### Files
- `frontend/apps/os-shell/src/__tests__/shell/launchSurfaceContractParcelWorkbench.contract.test.tsx` — re-authored, un-skipped.
- `docs/audit/workbench-readiness/WO-WB-P16-001..006` — audit / root-cause / mock-design / matrix / rollup.

### Return block
- **BACKEND_CHANGED:** false
- **TOOL_REGISTRY_CHANGED:** false
- **ROUTES_CHANGED:** false
- **FRONTEND_CODE_CHANGED:** false (product) — tests + docs only
- **TESTS_CHANGED:** true (1 test un-skipped/re-authored)
- **VALIDATION:** CI is run-of-record (no node_modules in sparse worktree). `git diff --check` clean; mock paths + type shape verified against `SuiteModuleGrid` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)