### PR TITLE
WO-BACKEND-OE-013 Backend OE Evidence Rollup and Closeout

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -21,13 +21,13 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
-| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Closed | `WO-BACKEND-OE-013` | Property Workbench recommended | No auto after closeout | Owner/WOE selects next lane; stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass |
+| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Closed | `WO-BACKEND-OE-013` | Owner/WOE lane selection | No auto after closeout | Owner/WOE selects next lane; stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
 | [DevEx Hook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-4---devex-hook-tooling) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Follow-up | `WO-DEVEX-HOOKS-001` | TBD | No auto | Owner authorization required |
 | [Local OMEN Runtime Repair](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-5---local-omen-runtime-repair) | `GOAL-LOCAL-OMEN-RUNTIME-REPAIR` | `LOOP-LOCAL-OMEN-RUNTIME-REPAIR` | Blocked | `WO-LOCAL-093` | TBD | No auto | Owner authorization required |
 | [Runtime Import Disposition](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-6---runtime-import-disposition) | `GOAL-RUNTIME-IMPORT-DISPOSITION` | `LOOP-RUNTIME-IMPORT-DISPOSITION` | Owner-gated | `WO-CORE-1` | TBD | No auto | Owner authorization required |
-| [Property Workbench](programs/property-workbench.md) | `GOAL-PROPERTY-WORKBENCH` | `LOOP-PROPERTY-WORKBENCH` | Future | `WO-WORKBENCH-001` | `WO-WORKBENCH-002` | No auto until selected | Owner or WOE selection required |
+| [Property Workbench](programs/property-workbench.md) | `GOAL-PROPERTY-WORKBENCH` | `LOOP-PROPERTY-WORKBENCH` | Closed evidence baseline | `WO-WORKBENCH-011` | New phase only if owner/WOE selects | No auto restart | Owner or WOE selection required |
 | [Benton Demo / Deployment Readiness](programs/benton-demo-deployment.md) | `/goal benton-demo` | `/loop merge-watch` / `/loop once` | Active | `WO-DEPLOY-BENTON-003B` | `WO-DEPLOY-BENTON-003D` if authorized | No auto deploy | Stop on deployment authorization |
 | [Benton Data Quality](programs/benton-data-quality.md) | `/goal benton-data-quality` | `/loop evidence` | Active | `WO-DATA-BENTON-DUPE-001B` | `WO-DATA-BENTON-ADDR-001` | Evidence-only until mutation auth | Stop on data mutation |
 | [Work Order Engine](programs/work-order-engine.md) | `/goal work-order-engine` | `/loop program` | Active | `WO-WOE-012` | `WO-WOE-013` | Auto within WOE docs/governance | Stop on schema/tooling scope expansion |
@@ -163,4 +163,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-06 | Created backend operational runbook and routed next to diagnostics/observability map | WO-BACKEND-OE-010 |
 | 2026-07-06 | Mapped backend diagnostics and observability signals and routed next to operational packet | WO-BACKEND-OE-011 |
 | 2026-07-06 | Assembled backend operational packet and routed next to program closeout | WO-BACKEND-OE-012 |
-| 2026-07-07 | Closed Backend Operational Excellence with evidence rollup and recommended Property Workbench as next lane | WO-BACKEND-OE-013 |
+| 2026-07-07 | Closed Backend Operational Excellence with evidence rollup and routed next action to owner/WOE lane selection | WO-BACKEND-OE-013 |

--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,11 +17,11 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-06 — WO-BACKEND-OE-012)*
+*(Updated 2026-07-07 — WO-BACKEND-OE-013)*
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
-| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Active | `WO-BACKEND-OE-012` | `WO-BACKEND-OE-013` after OE-012 merges | Auto if same-risk docs/evidence | Stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass; docs-only hook bypass requires evidence |
+| [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Closed | `WO-BACKEND-OE-013` | Property Workbench recommended | No auto after closeout | Owner/WOE selects next lane; stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
 | [DevEx Hook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-4---devex-hook-tooling) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Follow-up | `WO-DEVEX-HOOKS-001` | TBD | No auto | Owner authorization required |
@@ -163,3 +163,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-06 | Created backend operational runbook and routed next to diagnostics/observability map | WO-BACKEND-OE-010 |
 | 2026-07-06 | Mapped backend diagnostics and observability signals and routed next to operational packet | WO-BACKEND-OE-011 |
 | 2026-07-06 | Assembled backend operational packet and routed next to program closeout | WO-BACKEND-OE-012 |
+| 2026-07-07 | Closed Backend Operational Excellence with evidence rollup and recommended Property Workbench as next lane | WO-BACKEND-OE-013 |

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-013-EVIDENCE-ROLLUP-PROGRAM-CLOSEOUT.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-013-EVIDENCE-ROLLUP-PROGRAM-CLOSEOUT.md
@@ -1,0 +1,137 @@
+# WO-BACKEND-OE-013 - Evidence Rollup And Program Closeout
+
+Date: 2026-07-07
+Work order: WO-BACKEND-OE-013
+Program: Backend Operational Excellence
+Goal: GOAL-BACKEND-OPERATIONAL-EXCELLENCE
+Loop: LOOP-BACKEND-OPERATIONAL-EXCELLENCE
+Mode: evidence rollup / closeout
+
+## Result
+
+RESULT: PASS_WITH_GAP
+
+Backend Operational Excellence is closed as an evidence-backed operational baseline. The program
+created explicit backend build/warning truth, integration dependency classification,
+health/readiness semantics, service registry validation, security/auth/county proof, migration and
+rollback proof, Dais E2E proof planning, release gates, runbook, diagnostics map, and operational
+packet.
+
+This closeout does not claim backend production readiness. It states what is proven, what remains
+partial, and what must be completed before release or production promotion.
+
+No backend runtime, test implementation, CI workflow, schema, deployment, secrets, PACS, county SQL,
+county data, or live service changes were made by OE-013.
+
+## Completed Work Orders
+
+| WO | Evidence | PR | Merge commit | State |
+|----|----------|----|--------------|-------|
+| WO-BACKEND-000 | `docs/brain/workorders/evidence/WO-BACKEND-000-PROGRAM-PLAYBOOK.md` | #1188 | `64291909e2f6b8c6fe9a503009c118b05a6c67a5` | Program opened |
+| WO-BACKEND-OE-002 | `docs/brain/workorders/evidence/WO-BACKEND-OE-002-BUILD-WARNING-REGISTER.md` | #1189 | `f6851368f695ce359c0b39f26e3722365d8fed95` | Zero-warning register |
+| WO-BACKEND-OE-PLAYBOOK-REFRESH | `docs/brain/workorders/evidence/WO-BACKEND-OE-PLAYBOOK-REFRESH.md` | #1190 | `1f3dcc1628845450e3232e32a8e78dfe95483e47` | Full chain defined |
+| WO-BACKEND-OE-003 | `docs/brain/workorders/evidence/WO-BACKEND-OE-003-INTEGRATION-TEST-ENVIRONMENT-DEPENDENCY-REGISTER.md` | #1206 | `28015b9dcfbc441d5f87398e2402de2c2e23251b` | Dependency classified |
+| WO-BACKEND-OE-004 | `docs/brain/workorders/evidence/WO-BACKEND-OE-004-HEALTH-READINESS-SEMANTICS-PROOF.md` | #1209 | `14d13f072ec789c73b194a51f03c121a98fa218d` | Health/readiness mapped |
+| WO-BACKEND-OE-005 | `docs/brain/workorders/evidence/WO-BACKEND-OE-005-SERVICE-REGISTRY-RUNTIME-VALIDATION.md` | #1211 | `78690659a30d50314fac2db1f43ca7011167d349` | Service registry validated with gaps |
+| WO-BACKEND-OE-006 | `docs/brain/workorders/evidence/WO-BACKEND-OE-006-SECURITY-AUTH-COUNTY-ISOLATION-PROOF-MATRIX.md` | #1215 | `24533e9b8104b294934c7d3f14a36620428f6372` | Security proof consolidated |
+| WO-BACKEND-OE-007 | `docs/brain/workorders/evidence/WO-BACKEND-OE-007-MIGRATION-ROLLBACK-PROOF-REGISTER.md` | #1218 | `e170b4a348f5069ab64917de6f28e9d71190b791` | Migration/rollback source inventoried |
+| WO-BACKEND-OE-008 | `docs/brain/workorders/evidence/WO-BACKEND-OE-008-DAIS-WORKFLOW-E2E-PROOF-EXPANSION-PLAN.md` | #1220 | `f33e1e98328e08443fd33984ddc8fdedc0bdca62` | Dais proof expansion planned |
+| WO-BACKEND-OE-009 | `docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md` | #1224 | `7c80b1bbb4480c685216801491ac701d9fef763a` | Release gate defined |
+| WO-BACKEND-OE-010 | `docs/brain/workorders/evidence/WO-BACKEND-OE-010-BACKEND-OPERATIONAL-RUNBOOK.md` and `docs/brain/workorders/runbooks/BACKEND_OPERATIONAL_RUNBOOK.md` | #1226 | `d7de0a19acf44942982bbe3cf7ae502b259fd44b` | Runbook created |
+| WO-BACKEND-OE-011 | `docs/brain/workorders/evidence/WO-BACKEND-OE-011-DIAGNOSTICS-OBSERVABILITY-MAP.md` | #1232 | `7fd36e01c9548c1d04f97343dfb6f4c7c1291591` | Diagnostics mapped |
+| WO-BACKEND-OE-012 | `docs/brain/workorders/evidence/WO-BACKEND-OE-012-BACKEND-OPERATIONAL-PACKET.md` | #1233 | `7ed226bcf2c6e38eaa9152bf0ea43f485ecfdf61` | Operational packet assembled |
+
+WO-BACKEND-OE-001 and WO-BACKEND-OE-001-S are represented through the baseline findings and residue
+classification carried into OE-002.
+
+## Validation Summary
+
+| Area | Result |
+|------|--------|
+| Backend build/warning state | Canonical backend solution recorded as PASS with `0 Warning(s)` and `0 Error(s)`. |
+| Unit test baseline | Baseline recorded unit-test pass evidence from OE-001/OE-002. |
+| Full solution test lane | Not fully green without Docker/Testcontainers SQL Server environment; classified in OE-003. |
+| Work-order query | `node docs/brain/workorders/tools/wo-query.mjs --json` remained passing during Backend OE WOs, with legacy LocalOps routing noted as a tracked reconciliation item. |
+| PR checks | OE-003 through OE-012 merged through PR checks. |
+| OE-013 local validation | `git diff --check` and `wo-query` required before PR. |
+
+## Proven State
+
+- Backend warning debt is currently empty: canonical build warning count is zero.
+- Docker/Testcontainers SQL Server dependency is an environment prerequisite, not warning debt.
+- Backend health/readiness endpoints are inventoried and semantically classified.
+- ServiceRegistry and StartupOrchestrationService source/test evidence is mapped.
+- Security/auth/county/audit evidence is consolidated into a release-grade matrix with gaps.
+- Backend migration source and rollback-source evidence are inventoried without applying migrations.
+- Dais workflow proof gaps are planned without rebuilding persistence.
+- Backend release gate exists and separates release-blocking from non-release-blocking evidence.
+- Backend operational runbook exists.
+- Diagnostics and observability surfaces are mapped, including exception/error-path surfaces.
+- Backend Operational Packet exists and packages the program for operator use.
+
+## Partial Or Missing State
+
+- Full solution test pass remains dependent on a safe Docker/Testcontainers SQL Server lane.
+- Service registry runtime proof remains partial where registered-service health, orphan/drift, and writer/reader path alignment are not fully proven.
+- Health/readiness endpoints are mapped, but authoritative production readiness semantics remain a release-gate decision.
+- Migration apply/rollback execution proof is not claimed.
+- Dais authenticated HTTP pipeline, relational/restart persistence, certification gate, cross-county mutation, and Dais-Dossier boundary tests remain future proof slices.
+- Diagnostics map identifies signals, but it does not add instrumentation or observability platform wiring.
+- Release gate exists as governance, not CI/release workflow automation.
+
+## Deferred Work Orders
+
+| Deferred item | Why deferred | Required authority |
+|---------------|--------------|--------------------|
+| Docker/Testcontainers integration-lane repair or CI segmentation | Requires environment/tooling and possible CI workflow decisions | Owner authorization for Docker/CI lane |
+| Backend release-gate automation | OE-009 defines criteria but does not wire CI/release enforcement | Owner authorization for CI/release wiring |
+| Migration apply/rollback execution proof | Database mutation and rollback execution are higher risk | Explicit migration/database authorization |
+| Dais E2E implementation slices | OE-008 defines proof plan only | Separate backend/test implementation WOs |
+| Observability instrumentation | OE-011 maps gaps only | Runtime/telemetry implementation authorization |
+| DevEx hook bootstrap | Local Prettier/Vitest tooling gaps are outside Backend OE | Separate DevEx Hook Tooling lane |
+
+## Release Gate State
+
+Backend release readiness is not claimed. The release gate is defined and now has evidence inputs, but
+release promotion requires passing or formally dispositioning the gate, including integration,
+security, migration/rollback, diagnostics, and deployment evidence as applicable.
+
+## Safety Posture
+
+- Runtime code changed: no.
+- Backend implementation changed: no.
+- Test implementation changed: no.
+- CI workflow changed: no.
+- Schema/migration changed: no.
+- Deployment changed: no.
+- Secrets, county data, PACS, county SQL, live DB, or production resources touched: no.
+- TerraPilot tool promotion/live integration: no.
+
+## Next Program Recommendation
+
+Recommended next lane: Property Workbench.
+
+Reason: Backend OE is now closed as an operational baseline. Remaining backend items are classified
+follow-up lanes rather than blockers to planning the next product/operator proof lane. Property
+Workbench should proceed only under its own goal/loop, beginning with evidence/discovery and without
+product behavior changes unless separately authorized.
+
+Alternate owner-selected lanes:
+
+- Release Engineering, if the priority is automating OE-009 release gates.
+- DevEx Hook Tooling, if repeated local Prettier/Vitest hook failures become the dominant operator blocker.
+- County Runtime, if the next priority is deployment/runtime proof under explicit production and data boundaries.
+
+## Done Definition
+
+WO-BACKEND-OE-013 is done when:
+
+- this evidence rollup exists,
+- Backend OE program/register status is updated to closed,
+- validation passes,
+- PR checks are green/acceptable,
+- review threads are resolved,
+- no runtime/backend/tools-sync implementation files changed,
+- and the merge lands on `origin/main`.
+
+STOP_TYPE: BACKEND_OPERATIONAL_EXCELLENCE_PROGRAM_CLOSED

--- a/docs/brain/workorders/evidence/WO-BACKEND-OE-013-EVIDENCE-ROLLUP-PROGRAM-CLOSEOUT.md
+++ b/docs/brain/workorders/evidence/WO-BACKEND-OE-013-EVIDENCE-ROLLUP-PROGRAM-CLOSEOUT.md
@@ -109,18 +109,19 @@ security, migration/rollback, diagnostics, and deployment evidence as applicable
 
 ## Next Program Recommendation
 
-Recommended next lane: Property Workbench.
+Recommended next action: owner/WOE lane selection.
 
 Reason: Backend OE is now closed as an operational baseline. Remaining backend items are classified
-follow-up lanes rather than blockers to planning the next product/operator proof lane. Property
-Workbench should proceed only under its own goal/loop, beginning with evidence/discovery and without
-product behavior changes unless separately authorized.
+follow-up lanes rather than blockers to choosing the next governed program. Property Workbench is not
+recommended as an automatic restart target because its evidence baseline already closed in
+`WO-WORKBENCH-011`; any future Workbench work must be a new owner/WOE-selected phase.
 
 Alternate owner-selected lanes:
 
 - Release Engineering, if the priority is automating OE-009 release gates.
 - DevEx Hook Tooling, if repeated local Prettier/Vitest hook failures become the dominant operator blocker.
 - County Runtime, if the next priority is deployment/runtime proof under explicit production and data boundaries.
+- TerraPilot P16 design-only, only if the owner explicitly reopens the parked TerraPilot lane.
 
 ## Done Definition
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -16,27 +16,27 @@ resolves.
 |-----------------|---------|---------|----------|---------------------|
 | `goal-loop-master-playbook` | Master Goal/Loop Playbook Governance | WO-GOAL-LOOP-MASTER-PLAYBOOK-001 | NO | `once`, `evidence` |
 | `program-status` | Master Active Program Playbook | Active program graph | NO | `once`, `evidence`, `discovery` |
-| `program-next` | Master Playbook | WO-BACKEND-OE-003 | NO | `once`, `program`, `evidence` |
+| `program-next` | Master Playbook | Owner/WOE lane selection after Backend OE closeout | YES - Backend OE and Workbench evidence chains are closed | `once`, `program`, `evidence` |
 | `program-stop` | Master Playbook | NONE | YES — operator stop command | `once` |
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
 | `benton-data-quality` | P2 | WO-DATA-BENTON-DUPE-001B | YES — SW-02 data mutation wall | `evidence`, `discovery` |
-| `backend-excellence` | P3 | WO-BACKEND-OE-003 | NO | `once`, `program`, `evidence`, `discovery` |
-| `backend-start` | P3 | WO-BACKEND-OE-003 | NO | `program` |
-| `backend-status` | P3 | WO-BACKEND-OE-003 | NO | `evidence`, `discovery` |
-| `backend-next` | P3 | WO-BACKEND-OE-003 | NO | `once`, `evidence` |
+| `backend-excellence` | P3 | CLOSED at WO-BACKEND-OE-013 | YES - program closed; owner/WOE selects any follow-up lane | `once`, `program`, `evidence`, `discovery` |
+| `backend-start` | P3 | CLOSED at WO-BACKEND-OE-013 | YES - do not restart Backend OE chain | `program` |
+| `backend-status` | P3 | CLOSED at WO-BACKEND-OE-013 | YES - status/evidence only | `evidence`, `discovery` |
+| `backend-next` | P3 | Owner/WOE lane selection after closeout | YES - no automatic backend continuation | `once`, `evidence` |
 | `backend-stop` | P3 | NONE | YES — operator stop command | `once` |
 | `sync-workbook-tooling` | Sovereign Sync Workbook Tooling | WO-SYNC-132 | YES — owner selection gated | `once`, `evidence`, `discovery` |
 | `sync-status` | Sovereign Sync Workbook Tooling | WO-SYNC-132 | YES — owner selection gated | `evidence`, `discovery` |
 | `sync-next` | Sovereign Sync Workbook Tooling | WO-SYNC-132 | YES — owner selection gated | `once`, `evidence` |
 | `sync-stop` | Sovereign Sync Workbook Tooling | NONE | YES — operator stop command | `once` |
-| `property-workbench` | P4 | WO-WORKBENCH-001 | NO | `once`, `program`, `evidence`, `discovery` |
+| `property-workbench` | P4 | CLOSED at WO-WORKBENCH-011 | YES - do not restart closed Workbench evidence chain | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-status` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — parked at P15 | `evidence`, `discovery` |
 | `terrapilot-stop` | P5 | NONE | YES — operator stop command | `once` |
 | `devex-hooks-status` | DevEx Hook Tooling | WO-DEVEX-HOOKS-001 | YES — owner-gated follow-up | `evidence`, `discovery` |
 | `local-omen-status` | Local OMEN Runtime Repair | WO-LOCAL-093 | YES — runtime repair diagnosis gate | `evidence`, `discovery` |
 | `core-import-status` | WO-CORE-1 Runtime Import Disposition | WO-CORE-1 | YES — owner-gated runtime import disposition | `evidence`, `discovery` |
-| `workbench-status` | P4 | WO-WORKBENCH-001 | YES — future lane, owner/WOE selection required | `evidence`, `discovery` |
+| `workbench-status` | P4 | CLOSED at WO-WORKBENCH-011 | YES - status/evidence only; new phase requires owner/WOE selection | `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-010 → WO-WOE-011 | NO (010 executing) | `once`, `program`, `evidence` |
 | `brain-operator` | P7 | WO-BRAIN-001 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | NO | `once`, `evidence`, `discovery` |
@@ -110,21 +110,21 @@ runbooks, diagnostics, rollback, and evidence rollup are explicit enough for WOE
 | WO-BACKEND-OE-001-S | Baseline generated residue classification | COMPLETE |
 | WO-BACKEND-OE-002 | Build Warning Register | CLOSED |
 | WO-BACKEND-OE-PLAYBOOK-REFRESH | Full Backend OE Work Order Playbook | CLOSED |
-| WO-BACKEND-OE-003 | Integration Test Environment Dependency Register | NEXT |
-| WO-BACKEND-OE-004 | Health and Readiness Semantics Proof | QUEUED |
-| WO-BACKEND-OE-005 | Service Registry Runtime Validation | QUEUED |
-| WO-BACKEND-OE-006 | Security/Auth/County-Isolation Proof Matrix | QUEUED |
-| WO-BACKEND-OE-007 | Migration and Rollback Proof Register | QUEUED |
-| WO-BACKEND-OE-008 | Dais Workflow E2E Proof Expansion Plan | QUEUED |
-| WO-BACKEND-OE-009 | Backend Release Gate Definition | QUEUED |
-| WO-BACKEND-OE-010 | Backend Operational Runbook | QUEUED |
-| WO-BACKEND-OE-011 | Diagnostics and Observability Map | QUEUED |
-| WO-BACKEND-OE-012 | Backend Operational Packet | QUEUED |
-| WO-BACKEND-OE-013 | Evidence Rollup and Program Closeout | QUEUED |
+| WO-BACKEND-OE-003 | Integration Test Environment Dependency Register | CLOSED |
+| WO-BACKEND-OE-004 | Health and Readiness Semantics Proof | CLOSED |
+| WO-BACKEND-OE-005 | Service Registry Runtime Validation | CLOSED |
+| WO-BACKEND-OE-006 | Security/Auth/County-Isolation Proof Matrix | CLOSED |
+| WO-BACKEND-OE-007 | Migration and Rollback Proof Register | CLOSED |
+| WO-BACKEND-OE-008 | Dais Workflow E2E Proof Expansion Plan | CLOSED |
+| WO-BACKEND-OE-009 | Backend Release Gate Definition | CLOSED |
+| WO-BACKEND-OE-010 | Backend Operational Runbook | CLOSED |
+| WO-BACKEND-OE-011 | Diagnostics and Observability Map | CLOSED |
+| WO-BACKEND-OE-012 | Backend Operational Packet | CLOSED |
+| WO-BACKEND-OE-013 | Evidence Rollup and Program Closeout | CLOSING IN PR #1239 |
 
-No active stop walls at WO-BACKEND-OE-003. Stop walls begin if work requires production deployment,
-secrets, county data, PACS, live DB, schema migration apply, TerraPilot P16, or backend runtime
-mutation outside the active WO.
+Backend OE has no automatic next WO after OE-013. Owner/WOE must select any follow-up lane, especially
+if the work requires production deployment, secrets, county data, PACS, live DB, schema migration
+apply, TerraPilot P16, backend runtime mutation, CI wiring, or release-gate automation.
 
 ---
 
@@ -135,10 +135,11 @@ mutation outside the active WO.
 
 | WO | Title | Status |
 |----|-------|--------|
-| WO-WORKBENCH-001 | Parcel dossier data contract | **NEXT** |
-| (WOs 002–010) | Tab integration, empty states, owners, geom, etc. | QUEUED |
+| WO-WORKBENCH-001 through WO-WORKBENCH-010 | Workbench evidence baseline chain | CLOSED |
+| WO-WORKBENCH-011 | Evidence Rollup | CLOSED |
 
-No active stop walls at WO-WORKBENCH-001.
+Property Workbench is not a current executable restart target. Any future Workbench work requires a
+new owner/WOE-selected phase and must not rerun the closed evidence baseline chain.
 
 ---
 

--- a/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
+++ b/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
@@ -131,8 +131,9 @@ Routing note:
 - `wo-query` currently reports an older LocalOps/Work Order Engine recommendation. Until the registry
   backing `wo-query` is refreshed, this mismatch is a routing reconciliation gate, not authority to
   run both lanes.
-- After merge and owner authorization, proceed to Program 1 / Backend Operational Excellence at
-  `WO-BACKEND-OE-003` unless the owner selects a different active program.
+- Backend Operational Excellence has since run through `WO-BACKEND-OE-013` and is closed. Do not
+  route back to `WO-BACKEND-OE-003`; the next lane now requires owner/WOE selection from the
+  remaining parked or follow-up programs.
 
 ---
 
@@ -143,14 +144,15 @@ Routing note:
 | Goal | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` |
 | Loop | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` |
 | Program slug | `backend-operational-excellence` |
-| Status | ACTIVE |
-| Next executable WO | `WO-BACKEND-OE-003` |
+| Status | CLOSED |
+| Next executable WO | None - program closed; owner/WOE selects next lane |
 
 ### Current State
 
 Backend foundation is implemented and slice-verified. The canonical backend build is green with zero
-warnings. Warning burn-down is not active work. The remaining work is operational proof, environment
-classification, release gates, runbooks, and evidence.
+warnings. Backend OE is closed as an evidence-backed operational baseline, not as production-ready
+runtime certification. Remaining work is deferred into follow-up lanes such as release-gate
+automation, DevEx hook bootstrap, county runtime proof, or future product-lane execution.
 
 ### Completed Work Orders
 
@@ -160,6 +162,8 @@ classification, release gates, runbooks, and evidence.
 - `WO-BACKEND-OE-002` - Backend Build Warning Register.
 - `WO-BACKEND-OE-PLAYBOOK-REFRESH` - Full Backend OE chain.
 - `WO-MASTER-PLAYBOOK-001` / `WO-GOAL-LOOP-MASTER-PLAYBOOK-001` - Master active program playbook.
+- `WO-BACKEND-OE-003` through `WO-BACKEND-OE-013` - Backend OE evidence, gates, runbook,
+  diagnostics, operational packet, and closeout.
 
 ### Current Facts
 
@@ -190,10 +194,10 @@ classification, release gates, runbooks, and evidence.
 
 ### Continuation Rule
 
-Backend OE may continue automatically after each docs/evidence WO merges if the next WO remains
-inside the Backend OE chain, same-risk, and does not require backend/runtime implementation, CI
-wiring, Docker/Testcontainers repair, secrets, county/PACS/live resources, migrations, deployment, or
-local hook bypass.
+Backend OE does not continue automatically after `WO-BACKEND-OE-013`. Any new backend work must be a
+new owner/WOE-selected lane, especially if it requires release-gate automation, implementation,
+Docker/Testcontainers repair, CI wiring, migrations, deployment, secrets, county/PACS/live resources,
+or local hook tooling repair.
 
 ---
 
@@ -361,12 +365,13 @@ Possible outcomes:
 | Goal | `GOAL-PROPERTY-WORKBENCH` |
 | Loop | `LOOP-PROPERTY-WORKBENCH` |
 | Program slug | `property-workbench` |
-| Status | FUTURE HIGH-VALUE PRODUCT LANE |
-| Next if selected | `WO-WORKBENCH-001` |
+| Status | CLOSED / EVIDENCE BASELINE COMPLETE |
+| Next if selected | No restart; owner must authorize a new Workbench phase |
 
-Rule: Do not start until owner selects it or WOE ranking selects it.
+Rule: Do not restart the closed Workbench evidence chain. Any future Workbench work must be a new
+phase selected by owner/WOE, not a rerun of `WO-WORKBENCH-001`.
 
-Future chain:
+Closed evidence chain:
 
 - `WO-WORKBENCH-001` - Workbench Reality Audit.
 - `WO-WORKBENCH-002` - Routing and Deep-Link Gate Audit.

--- a/docs/brain/workorders/programs/backend-operational-excellence.md
+++ b/docs/brain/workorders/programs/backend-operational-excellence.md
@@ -5,10 +5,10 @@
 | Program | P3 |
 | Goal | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` |
 | Loop | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` |
-| Status | ACTIVE |
+| Status | CLOSED |
 | Owner | Operator (bsvalues@gmail.com) |
-| Last Updated | 2026-07-06 |
-| Next WO | `WO-BACKEND-OE-013` after `WO-BACKEND-OE-012` merges |
+| Last Updated | 2026-07-07 |
+| Next WO | Program closed; next recommended lane is Property Workbench |
 
 ---
 
@@ -87,7 +87,8 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
 | `WO-BACKEND-OE-009` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-009-BACKEND-RELEASE-GATE-DEFINITION.md` |
 | `WO-BACKEND-OE-010` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-010-BACKEND-OPERATIONAL-RUNBOOK.md`; `docs/brain/workorders/runbooks/BACKEND_OPERATIONAL_RUNBOOK.md` |
 | `WO-BACKEND-OE-011` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-011-DIAGNOSTICS-OBSERVABILITY-MAP.md` |
-| `WO-BACKEND-OE-012` | READY FOR PR | `docs/brain/workorders/evidence/WO-BACKEND-OE-012-BACKEND-OPERATIONAL-PACKET.md` |
+| `WO-BACKEND-OE-012` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-012-BACKEND-OPERATIONAL-PACKET.md` |
+| `WO-BACKEND-OE-013` | CLOSED | `docs/brain/workorders/evidence/WO-BACKEND-OE-013-EVIDENCE-ROLLUP-PROGRAM-CLOSEOUT.md` |
 
 ## Remaining Work Order Chain
 
@@ -102,8 +103,8 @@ evidence, release gates, runbooks, diagnostics, and closeout evidence.
 | `WO-BACKEND-OE-009` | Backend Release Gate Definition | Governance/release checklist | OE-008 merged | CLOSED | OE-010 |
 | `WO-BACKEND-OE-010` | Backend Operational Runbook | Runbook creation | OE-009 merged | CLOSED | OE-011 |
 | `WO-BACKEND-OE-011` | Diagnostics and Observability Map | Evidence/docs | OE-010 merged | CLOSED | OE-012 |
-| `WO-BACKEND-OE-012` | Backend Operational Packet | Operational packet assembly | OE-011 merged | READY FOR PR | OE-013 |
-| `WO-BACKEND-OE-013` | Evidence Rollup and Program Closeout | Evidence rollup / closeout | OE-012 merged | QUEUED | Program close |
+| `WO-BACKEND-OE-012` | Backend Operational Packet | Operational packet assembly | OE-011 merged | CLOSED | OE-013 |
+| `WO-BACKEND-OE-013` | Evidence Rollup and Program Closeout | Evidence rollup / closeout | OE-012 merged | CLOSED | Program close |
 
 ```text
 WO-BACKEND-000


### PR DESCRIPTION
## Summary
- closes Backend Operational Excellence with WO-BACKEND-OE-013 evidence rollup and program closeout
- records completed Backend OE work orders, PRs, merge commits, validation state, remaining risks, and deferred follow-up lanes
- recommends Property Workbench as the next lane after Backend OE closeout

## Safety / Scope
- docs/governance/evidence only
- no runtime code changed
- no backend implementation changed
- no tools/sync code changed
- no CI workflow, schema, migration, deployment, secrets, county data, PACS, SQL, or live resources touched
- does not claim production readiness; closes the evidence-backed operational baseline with explicit gaps

## Validation
- git diff --check: PASS
- node docs/brain/workorders/tools/wo-query.mjs --json: PASS
- local commit used one-time no-verify under standing Backend OE docs-only policy because local Prettier is unavailable
- local push used one-time no-verify under standing Backend OE docs-only policy because local Vitest/pre-push tooling is unavailable
- remote PR checks are authoritative

## Worktree Note
- failed OE-013 worktree path was removed from git worktree registration, but leftover filesystem/metadata residue was not manually deleted; replacement worktree is clean and based on origin/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the Backend Operational Excellence program as closed and updated the latest status and next-step guidance.
  * Added a new closeout record summarizing the completed work, validation results, remaining gaps, and recommended next lane.
  * Updated the change log to reflect the program closeout and final recommendation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->