### PR TITLE
ci(frontend): keep dependency audit out of the fast gate (fixes #1242)

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -232,7 +232,12 @@ jobs:
 
       - name: Unit tests (blocking)
         id: unit-tests
-        run: pnpm -C frontend run test:tier0
+        # Fast gate runs Vitest directly (test:tier0 === `vitest run`) and EXCLUDES the
+        # network/registry-variable npm-audit test (~3 min) so it never consumes the
+        # 30-min fast-gate budget. That dependency-audit coverage remains in the scheduled
+        # Security & Compliance Pipeline dependency scan. --slowTestThreshold=1000 surfaces
+        # future slow tests without raising this gate's timeout. (Fix for #1242.)
+        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000
 
       - name: IPC tests (blocking)
         id: ipc-tests


### PR DESCRIPTION
## Fixes #1242 — Frontend Fast Gate suite timeout

**Problem:** the `🎨 Frontend Fast Gate` `Unit tests (blocking)` step ran the full os-shell vitest suite (~28 min) and hit its `timeout-minutes: 30`, getting CANCELLED — blocking every frontend PR (incl. #1240). Dominant cost: `apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts` (~188 s, network/registry-variable `npm audit`).

**Change (narrow, CI-only — one step):** `seal-gate-fast.yml` line ~235 — run Vitest directly (`test:tier0` === `vitest run`) with:
- `--exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts'` (keeps the ~3-min audit test off the fast-gate critical path; that coverage remains in the scheduled Security & Compliance Pipeline dependency scan)
- `--slowTestThreshold=1000` (surfaces future slow tests without raising the gate timeout)

**Attribution:** fix **designed by @codex** on #1242; its cloud container has no git remote / no `gh` and could not push, so **Claude Code delivered it per owner authorization** (`OWNER_DECISION: APPROVED`, scope = this one CI/test-gate fix only).

### Validation
- ✅ YAML parses (`yaml.safe_load`, utf-8)
- ✅ Diff is a single step (line 235); `git diff --check` clean
- CI validates the wall-clock (the whole point).

### Out of scope (intentionally NOT touched)
- Pre-existing semgrep finding at `seal-gate-fast.yml:683` (`run-shell-injection`, `${{ github… }}` in a `run:` step) — **unrelated to this fix and outside the authorized narrow scope**; flagged here for a separate hardening pass, not fixed in this PR.
- No product/runtime/backend code; no other workflows; no branch protection; no `#1240` changes.

After merge: Claude updates #1240 onto main and re-runs its Frontend Fast Gate to unblock it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the seal-gate-fast workflow to execute Vitest via pnpm with an exclusion for the dependency audit test and a lower slow test threshold to keep the fast gate within its time budget.