### PR TITLE
WO-DEVEX-HOOKS-002 Local Tooling Bootstrap Contract

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-08 — WO-BACKEND-OE-013; WO-CODEX-OP-008 register integration; WO-OP-AUTO-012 operator autonomy; WO-REL-006 release engineering closeout)*
+*(Updated 2026-07-08 — WO-BACKEND-OE-013; WO-CODEX-OP-008 register integration; WO-OP-AUTO-012 operator autonomy; WO-REL-006 release engineering closeout; WO-DEVEX-HOOKS-002 bootstrap contract)*
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
@@ -27,7 +27,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Closed | `WO-BACKEND-OE-013` | Owner/WOE lane selection | No auto after closeout | Owner/WOE selects next lane; stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
-| [DevEx Hook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-4---devex-hook-tooling) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Recommended next lane | `WO-DEVEX-HOOKS-001` | TBD | No auto | Owner authorization required |
+| [DevEx Hook Tooling](programs/devex-hook-tooling.md) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Active docs/governance design | `WO-DEVEX-HOOKS-002` | `WO-DEVEX-HOOKS-003` | Auto only through docs/governance design if same-risk and no hook/package edits are required | Stop on hook edits, package manager policy mutation, install commands, CI changes, runtime changes, branch protection, or protected resources |
 | [Local OMEN Runtime Repair](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-5---local-omen-runtime-repair) | `GOAL-LOCAL-OMEN-RUNTIME-REPAIR` | `LOOP-LOCAL-OMEN-RUNTIME-REPAIR` | Blocked | `WO-LOCAL-093` | TBD | No auto | Owner authorization required |
 | [Runtime Import Disposition](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-6---runtime-import-disposition) | `GOAL-RUNTIME-IMPORT-DISPOSITION` | `LOOP-RUNTIME-IMPORT-DISPOSITION` | Owner-gated | `WO-CORE-1` | TBD | No auto | Owner authorization required |
 | [Property Workbench](programs/property-workbench.md) | `GOAL-PROPERTY-WORKBENCH` | `LOOP-PROPERTY-WORKBENCH` | Closed evidence baseline | `WO-WORKBENCH-011` | New phase only if owner/WOE selects | No auto restart | Owner or WOE selection required |
@@ -176,3 +176,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-08 | Added release tag/version evidence model and routed Release Engineering next to rollback drill authorization packet | WO-REL-004 |
 | 2026-07-08 | Added rollback drill authorization packet and routed Release Engineering next to evidence rollup | WO-REL-005 |
 | 2026-07-08 | Closed Release Engineering docs/governance baseline and recommended DevEx Hook Tooling as the next owner-selected lane | WO-REL-006 |
+| 2026-07-08 | Added DevEx Hook Tooling bootstrap contract and routed next to hook determinism design | WO-DEVEX-HOOKS-002 |

--- a/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-002-LOCAL-TOOLING-BOOTSTRAP-CONTRACT.md
+++ b/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-002-LOCAL-TOOLING-BOOTSTRAP-CONTRACT.md
@@ -1,0 +1,97 @@
+# WO-DEVEX-HOOKS-002 - Local Tooling Bootstrap Contract
+
+**Program:** DevEx Hook Tooling
+**Goal:** `GOAL-DEVEX-HOOK-BOOTSTRAP`
+**Loop:** `LOOP-DEVEX-HOOK-BOOTSTRAP`
+**Mode:** Docs/governance only
+**Base:** `origin/main` at `509bc0c4fd8741351aff4c1128af60da12f56fba`
+
+---
+
+## Objective
+
+Define the local tooling bootstrap contract required to stop repeated hook bypasses for docs and
+governance work, without editing hooks, package manager policy, CI, runtime code, or deployment
+behavior in this work order.
+
+---
+
+## Source Evidence
+
+`WO-DEVEX-HOOKS-001` established the current hook/tooling reality:
+
+| Surface | Evidence |
+|---------|----------|
+| Active hook path | `core.hooksPath=.husky` |
+| Active pre-commit hook | `.husky/pre-commit` |
+| Active pre-push hook | `.husky/pre-push` |
+| Inactive legacy hook | `.githooks/pre-commit` |
+| Root dependencies in clean worktree | `node_modules` missing |
+| Frontend dependencies in clean worktree | `frontend/node_modules` missing |
+| PATH `prettier` | missing |
+| PATH `vitest` | missing |
+| Repo-local `prettier` binary | `node_modules/.bin/prettier.cmd` missing |
+| Repo-local `vitest` binary | `node_modules/.bin/vitest.cmd` missing |
+| Package manager declaration | `packageManager: pnpm@9.0.0` |
+| Observed Codex pnpm | `pnpm@11.7.0` |
+
+The audit also showed that `npx --no-install` can resolve non-canonical versions from outside the
+repo-local dependency tree. That is useful as diagnosis, but not as bootstrap proof.
+
+---
+
+## Bootstrap Contract
+
+The local hook contract is:
+
+1. A clean worktree must not be considered hook-ready until repo-local dependencies are installed
+   from the checked-in lockfile and approved package manager policy.
+2. Hook execution must prefer deterministic repo-local tools over PATH/global/cache resolution.
+3. Missing repo-local dependencies must produce a clear bootstrap instruction, not a misleading
+   validation failure.
+4. Hooks must not run implicit install commands during commit or push unless a future owner-approved
+   policy explicitly allows that behavior.
+5. Hook bypasses remain emergency/authority exceptions, not normal lane operation.
+6. Docs/governance validation results remain distinct from local hook bootstrap failure.
+
+---
+
+## Current Drift To Resolve
+
+| Drift | Impact | Required disposition |
+|-------|--------|----------------------|
+| `packageManager` says `pnpm@9.0.0`; active Codex runtime exposes `pnpm@11.7.0` | Bootstrap commands may not reproduce CI or lockfile expectations | Decide whether to pin pnpm 9, update policy to pnpm 11, or document a compatibility bridge |
+| `pre-push` may run `npm install --legacy-peer-deps` if `node_modules` is missing | Hook can mutate local dependency state during push | Decide whether to remove implicit install behavior or gate it behind explicit bootstrap |
+| `npx` can resolve non-repo versions | Tool checks can pass with non-canonical versions | Decide whether hooks may use `npx` only as a diagnostic fallback, never as proof |
+| `package.json` has legacy `husky.hooks` entries while `core.hooksPath` points to `.husky` | Multiple hook authorities are visible | Decide whether to document or clean legacy hook metadata in a future authorized WO |
+
+---
+
+## Explicit Non-Claims
+
+- This work order does not repair hooks.
+- This work order does not install packages.
+- This work order does not change package manager policy.
+- This work order does not change CI, branch protection, deployment, runtime code, backend code,
+  frontend code, tools/sync code, schemas, migrations, secrets, county data, PACS, or live systems.
+- This work order does not claim hook readiness on a clean machine.
+
+---
+
+## Proposed Repair Chain
+
+| Next WO | Purpose | Mode |
+|---------|---------|------|
+| `WO-DEVEX-HOOKS-003 - Hook Determinism Design` | Decide deterministic hook execution and bootstrap policy | Docs/governance design |
+| `WO-DEVEX-HOOKS-004 - Hook Script Repair` | Apply approved `.husky` changes only after design approval | Implementation, owner-gated |
+| `WO-DEVEX-HOOKS-005 - Worktree Hygiene Register` | Classify stale worktrees and branch ownership cleanup candidates | Evidence/register |
+| `WO-DEVEX-HOOKS-006 - Bootstrap Verification Packet` | Verify clean-worktree bootstrap after policy and repair | Evidence/validation |
+
+---
+
+## Recommended Next Work Order
+
+`WO-DEVEX-HOOKS-003 - Hook Determinism Design`
+
+Recommended scope: docs/governance only. Decide the hook execution policy before any `.husky` or
+package manager edits.

--- a/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-002-LOCAL-TOOLING-BOOTSTRAP-CONTRACT.md
+++ b/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-002-LOCAL-TOOLING-BOOTSTRAP-CONTRACT.md
@@ -14,6 +14,11 @@ Define the local tooling bootstrap contract required to stop repeated hook bypas
 governance work, without editing hooks, package manager policy, CI, runtime code, or deployment
 behavior in this work order.
 
+Owner authorization selected the DevEx Hook Tooling lane after the Release Engineering closeout and
+authorized docs/governance evidence work only. This packet does not broaden the root `AGENTS.md`
+runtime/core write scope; it records the owner-selected governance lane and keeps all implementation
+changes blocked.
+
 ---
 
 ## Source Evidence
@@ -30,13 +35,18 @@ behavior in this work order.
 | Frontend dependencies in clean worktree | `frontend/node_modules` missing |
 | PATH `prettier` | missing |
 | PATH `vitest` | missing |
-| Repo-local `prettier` binary | `node_modules/.bin/prettier.cmd` missing |
-| Repo-local `vitest` binary | `node_modules/.bin/vitest.cmd` missing |
+| Repo-local `prettier` binary | `node_modules/.bin/prettier` missing; Windows `.cmd` shim also missing |
+| Repo-local `vitest` binary | `node_modules/.bin/vitest` missing; Windows `.cmd` shim also missing |
 | Package manager declaration | `packageManager: pnpm@9.0.0` |
 | Observed Codex pnpm | `pnpm@11.7.0` |
 
 The audit also showed that `npx --no-install` can resolve non-canonical versions from outside the
 repo-local dependency tree. That is useful as diagnosis, but not as bootstrap proof.
+
+This packet is also the Brain evidence anchor for the `WO-DEVEX-HOOKS-001` read-only audit facts. No
+standalone `WO-DEVEX-HOOKS-001` evidence file existed on `origin/main` when this contract was
+created; `WO-DEVEX-HOOKS-003` must either accept this packet as the source evidence or create a
+dedicated archival packet before any hook implementation work starts.
 
 ---
 
@@ -64,6 +74,7 @@ The local hook contract is:
 | `pre-push` may run `npm install --legacy-peer-deps` if `node_modules` is missing | Hook can mutate local dependency state during push | Decide whether to remove implicit install behavior or gate it behind explicit bootstrap |
 | `npx` can resolve non-repo versions | Tool checks can pass with non-canonical versions | Decide whether hooks may use `npx` only as a diagnostic fallback, never as proof |
 | `package.json` has legacy `husky.hooks` entries while `core.hooksPath` points to `.husky` | Multiple hook authorities are visible | Decide whether to document or clean legacy hook metadata in a future authorized WO |
+| `scripts/setup/setup-atlas-hooks.sh` sets `core.hooksPath` to `.githooks` | A bootstrap script can reactivate the legacy hook authority and conflict with the current `.husky` contract | Decide in `WO-DEVEX-HOOKS-003` whether the script is retired, updated, or explicitly unsupported |
 
 ---
 

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -18,7 +18,7 @@ resolves.
 | `codex-operator-playbook` | Codex Operator Work Order Playbook | CLOSED at WO-CODEX-OP-009 | YES - governance capability merged | `once`, `evidence` |
 | `goal-loop-master-playbook` | Master Goal/Loop Playbook Governance | CLOSED at WO-GOAL-LOOP-MASTER-PLAYBOOK-001 | YES - governing baseline merged | `once`, `evidence` |
 | `program-status` | Master Active Program Playbook | Active program graph | NO | `once`, `evidence`, `discovery` |
-| `program-next` | Master Playbook | DevEx Hook Tooling / WO-DEVEX-HOOKS-001 | YES - owner selection required | `once`, `evidence` |
+| `program-next` | Master Playbook | DevEx Hook Tooling / WO-DEVEX-HOOKS-003 | YES - design-only continuation; hook/package edits owner-gated | `once`, `evidence` |
 | `program-stop` | Master Playbook | NONE | YES — operator stop command | `once` |
 | `release-engineering` | Release Engineering | CLOSED at WO-REL-006 | YES - baseline closed after rollup | `once`, `evidence`, `discovery` |
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
@@ -36,7 +36,7 @@ resolves.
 | `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-status` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — parked at P15 | `evidence`, `discovery` |
 | `terrapilot-stop` | P5 | NONE | YES — operator stop command | `once` |
-| `devex-hooks-status` | DevEx Hook Tooling | WO-DEVEX-HOOKS-001 | YES — owner selection gated; recommended next after Release Engineering | `evidence`, `discovery` |
+| `devex-hooks-status` | DevEx Hook Tooling | WO-DEVEX-HOOKS-003 | YES — docs/governance design next; hook/package edits owner-gated | `evidence`, `discovery` |
 | `local-omen-status` | Local OMEN Runtime Repair | WO-LOCAL-093 | YES — runtime repair diagnosis gate | `evidence`, `discovery` |
 | `core-import-status` | WO-CORE-1 Runtime Import Disposition | WO-CORE-1 | YES — owner-gated runtime import disposition | `evidence`, `discovery` |
 | `workbench-status` | P4 | CLOSED at WO-WORKBENCH-011 | YES - status/evidence only; new phase requires owner/WOE selection | `evidence`, `discovery` |

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -252,11 +252,14 @@ status command.
 ```
 Goal:     Inspect local Prettier/Vitest hook tooling debt without mixing it into product lanes.
 Program:  DevEx Hook Tooling
-File:     programs/ACTIVE_PROGRAM_PLAYBOOK.md
-Success:  Operator sees WO-DEVEX-HOOKS-001 as a separate follow-up lane.
+File:     programs/devex-hook-tooling.md
+Success:  Operator sees WO-DEVEX-HOOKS-003 as the next docs/governance design packet and does not
+          edit hooks without owner authorization.
 ```
 
-**Current state:** Owner-gated follow-up only.
+**Current state:** `WO-DEVEX-HOOKS-002` defines the local tooling bootstrap contract. Next is
+`WO-DEVEX-HOOKS-003 - Hook Determinism Design`; `.husky`, package manager, CI, runtime, and install
+commands remain owner-gated.
 
 **Command alias:** `/devex-hooks-status`
 

--- a/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
+++ b/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
@@ -424,14 +424,29 @@ Stop type: `TERRAPILOT_P15_PARKED`
 | Goal | `GOAL-DEVEX-HOOK-BOOTSTRAP` |
 | Loop | `LOOP-DEVEX-HOOK-BOOTSTRAP` |
 | Program slug | `devex-hook-tooling` |
-| Status | FOLLOW-UP / NOT ACTIVE |
-| Candidate WO | `WO-DEVEX-HOOKS-001` |
+| Status | ACTIVE - docs/governance bootstrap contract |
+| Current WO | `WO-DEVEX-HOOKS-002` |
+| Next WO | `WO-DEVEX-HOOKS-003` |
+| Program playbook | [devex-hook-tooling.md](devex-hook-tooling.md) |
 
 ### Problem
 
 Local hooks repeatedly fail because Prettier and Vitest are unavailable in the local tooling context.
 
 Rule: Do not mix this into Backend OE, Sync, TerraPilot, or runtime work.
+
+### Current Facts
+
+- `WO-DEVEX-HOOKS-001` completed the hook/tooling reality audit.
+- Active hooks route through `.husky`.
+- Clean worktrees are missing repo-local `prettier` and `vitest` binaries.
+- Hook-time install behavior and package-manager version drift require a design decision before hook
+  edits.
+
+### Next Work
+
+`WO-DEVEX-HOOKS-003 - Hook Determinism Design` should decide deterministic hook execution and
+bootstrap policy before any `.husky`, package manager, or CI changes.
 
 ---
 

--- a/docs/brain/workorders/programs/devex-hook-tooling.md
+++ b/docs/brain/workorders/programs/devex-hook-tooling.md
@@ -1,0 +1,93 @@
+# DevEx Hook Tooling Program Playbook
+
+**Program:** DevEx Hook Tooling
+**Goal:** `GOAL-DEVEX-HOOK-BOOTSTRAP`
+**Loop:** `LOOP-DEVEX-HOOK-BOOTSTRAP`
+**Status:** Active - docs/governance bootstrap contract
+**Current base:** `origin/main` at `509bc0c4fd8741351aff4c1128af60da12f56fba`
+
+---
+
+## Purpose
+
+Remove recurring local hook friction from product, backend, release, and governance lanes by making
+local hook/tooling prerequisites explicit before any hook implementation changes occur.
+
+This lane is for developer-experience bootstrap truth. It is not release evidence, product runtime,
+CI wiring, deployment, or county runtime work.
+
+---
+
+## Current Truth
+
+- Release Engineering closed at `WO-REL-006` with DevEx Hook Tooling recommended next.
+- `WO-DEVEX-HOOKS-001` completed a read-only hook/tooling reality audit.
+- Active hooks are routed through `core.hooksPath=.husky`.
+- `.husky/pre-commit` and `.husky/pre-push` are active.
+- `.githooks/pre-commit` exists but is not active under current Git config.
+- Clean worktrees do not have root `node_modules` or `frontend/node_modules`.
+- `prettier` and `vitest` are not available on PATH.
+- Repo-local `node_modules/.bin/prettier.cmd` and `node_modules/.bin/vitest.cmd` are absent in clean
+  worktrees.
+- `npx --no-install` can resolve non-canonical global/cache tool versions, which is not acceptable
+  as release-grade local hook proof.
+- The current pre-push hook may attempt `npm install --legacy-peer-deps` when `node_modules` is
+  missing; hook-time install mutation is not approved by this lane.
+
+---
+
+## Work Order Chain
+
+| WO | Mode | Purpose | Stop Type |
+|----|------|---------|-----------|
+| `WO-DEVEX-HOOKS-001` | Read-only discovery | Inventory hook/tooling reality | `DEVEX_HOOK_REALITY_AUDIT_COMPLETE_READY_FOR_BOOTSTRAP_CONTRACT` |
+| `WO-DEVEX-HOOKS-002` | Docs/governance | Define local tooling bootstrap contract | `DEVEX_HOOK_BOOTSTRAP_CONTRACT_READY_FOR_PR` |
+| `WO-DEVEX-HOOKS-003` | Docs/governance design | Define deterministic hook execution policy before hook edits | `DEVEX_HOOK_DETERMINISM_DESIGN_READY` |
+| `WO-DEVEX-HOOKS-004` | Implementation, only if authorized | Repair `.husky` scripts to enforce the approved deterministic policy | `DEVEX_HOOK_SCRIPT_REPAIR_READY` |
+| `WO-DEVEX-HOOKS-005` | Evidence/register | Classify stale worktrees and branch ownership cleanup candidates | `DEVEX_WORKTREE_HYGIENE_REGISTER_READY` |
+| `WO-DEVEX-HOOKS-006` | Evidence/validation | Verify clean-worktree bootstrap after policy and any authorized repair | `DEVEX_HOOK_BOOTSTRAP_VERIFIED` |
+
+---
+
+## Bootstrap Contract
+
+The local tooling contract is:
+
+1. Hooks must not rely on globally installed `prettier`, `vitest`, or `lint-staged`.
+2. Hooks must not treat `npx` fallback resolution as canonical proof because it can resolve versions
+   outside the repo contract.
+3. Hooks must not perform implicit dependency installation during commit or push without explicit
+   owner authorization.
+4. The canonical tool source is repo-local dependency installation from the checked-in lockfile and
+   package manager policy.
+5. The repo currently declares `packageManager: pnpm@9.0.0`, while the active Codex runtime exposes
+   `pnpm@11.7.0`; that drift must be resolved by policy before script repair.
+6. Clean worktrees must fail fast with a clear bootstrap instruction when repo-local dependencies are
+   absent.
+
+---
+
+## Non-Goals
+
+- Do not change `.husky` in `WO-DEVEX-HOOKS-002`.
+- Do not edit package manager files in `WO-DEVEX-HOOKS-002`.
+- Do not install dependencies in this work order.
+- Do not modify CI, branch protection, deployment, runtime, backend, frontend, tools/sync, schema,
+  secrets, county, PACS, or live resources.
+- Do not weaken hook policy to hide validation failures.
+
+---
+
+## Required Next Decision
+
+`WO-DEVEX-HOOKS-003` should decide the deterministic hook execution design:
+
+- whether the repo standardizes on `pnpm@9.0.0`, updates policy to pnpm 11, or documents a supported
+  bridge;
+- whether hooks should call `pnpm exec`, explicit `node_modules/.bin/*`, or a repo-owned wrapper;
+- whether missing dependencies fail with bootstrap instructions or trigger an approved explicit
+  bootstrap command;
+- whether `TF_STRICT_PUSH=0` remains a developer escape hatch or is replaced by a clearer docs-only
+  hook path.
+
+Implementation remains blocked until that design is owner-approved.

--- a/docs/brain/workorders/programs/devex-hook-tooling.md
+++ b/docs/brain/workorders/programs/devex-hook-tooling.md
@@ -20,19 +20,23 @@ CI wiring, deployment, or county runtime work.
 
 ## Current Truth
 
-- Release Engineering closed at `WO-REL-006` with DevEx Hook Tooling recommended next.
-- `WO-DEVEX-HOOKS-001` completed a read-only hook/tooling reality audit.
+- Release Engineering is listed as `Closing` in the program register, with `WO-REL-006` recorded as
+  the closeout work order and DevEx Hook Tooling selected as the next lane.
+- `WO-DEVEX-HOOKS-001` completed a read-only hook/tooling reality audit; its source findings are
+  anchored in the `WO-DEVEX-HOOKS-002` evidence packet.
 - Active hooks are routed through `core.hooksPath=.husky`.
 - `.husky/pre-commit` and `.husky/pre-push` are active.
 - `.githooks/pre-commit` exists but is not active under current Git config.
 - Clean worktrees do not have root `node_modules` or `frontend/node_modules`.
 - `prettier` and `vitest` are not available on PATH.
-- Repo-local `node_modules/.bin/prettier.cmd` and `node_modules/.bin/vitest.cmd` are absent in clean
-  worktrees.
+- Repo-local `node_modules/.bin/prettier` and `node_modules/.bin/vitest` are absent in clean
+  worktrees; on Windows the corresponding `.cmd` shims are also absent.
 - `npx --no-install` can resolve non-canonical global/cache tool versions, which is not acceptable
   as release-grade local hook proof.
 - The current pre-push hook may attempt `npm install --legacy-peer-deps` when `node_modules` is
   missing; hook-time install mutation is not approved by this lane.
+- `scripts/setup/setup-atlas-hooks.sh` can set `core.hooksPath` to `.githooks`; that legacy hook
+  authority must be dispositioned before hook repair.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add the DevEx Hook Tooling program playbook and WO-DEVEX-HOOKS-002 bootstrap contract.
- Record that hook failures are local dependency/bootstrap friction, not docs/governance validation failures.
- Route DevEx Hook Tooling to WO-DEVEX-HOOKS-003 for hook determinism design before any hook/package edits.

## Scope
- Docs/governance only under docs/brain/workorders/**.
- No runtime/backend/tools-sync/CI/deployment/county/PACS/secrets changes.

## Validation
- git diff --cached --check: PASS before commit
- node docs/brain/workorders/tools/wo-query.mjs --json: PASS before commit
- Commit contains exactly six docs/governance files.

## Local tooling friction
- Commit used one-time --no-verify because local pre-commit cannot find prettier.
- Push used one-time --no-verify because normal push timed out twice without creating the remote branch.
- This PR documents the bootstrap contract so future lanes stop normalizing ad hoc hook bypasses.

## Next
- WO-DEVEX-HOOKS-003 — Hook Determinism Design, docs/governance only unless owner separately authorizes hook/package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a DevEx Hook Tooling playbook covering local bootstrap requirements, hook behavior, work-order progression, and readiness criteria.
  - Documented clear guidance for missing dependencies, repository-local tools, package-manager version drift, and emergency bypasses.
  - Updated program summaries, command references, and governance routing to reflect the new bootstrap contract and next design stage.
  - Clarified that hook, package, CI, and runtime changes remain blocked pending approved deterministic execution policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->