### PR TITLE
ci(frontend): shard Frontend Fast Gate unit tests 3-way (fixes #1242, WO-CI-FASTGATE-003)

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -208,13 +208,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # WO-CI-FASTGATE-003: only the unit-test step is sharded; the non-unit steps below run
+      # once (shard 1) so build/bundle/lint/type-check are not redundantly repeated per shard.
       - name: Lint (loud, temporary non-blocking)
         id: lint
+        if: matrix.shard == 1
         run: pnpm -C frontend run lint
         continue-on-error: true
 
       - name: Lint escape hatch (expires 2026-07-31)
-        if: steps.lint.outcome == 'failure'
+        if: matrix.shard == 1 && steps.lint.outcome == 'failure'
         shell: bash
         run: |
           set -euo pipefail
@@ -228,6 +231,7 @@ jobs:
 
       - name: Type check (blocking)
         id: typecheck
+        if: matrix.shard == 1
         shell: bash
         run: |
           set -euo pipefail
@@ -253,18 +257,22 @@ jobs:
 
       - name: IPC tests (blocking)
         id: ipc-tests
+        if: matrix.shard == 1
         run: pnpm -C frontend run test:ipc
 
       - name: Build (blocking)
         id: build
+        if: matrix.shard == 1
         run: pnpm -C frontend run build
 
       - name: Bundle Analysis (blocking - requires build)
         id: bundle-analysis
+        if: matrix.shard == 1
         run: pnpm -C frontend run test:unit -- apps/os-shell/src/tests/performance/BundleAnalysis.test.ts
 
       - name: Frontend Summary
-        if: always()
+        # Only shard 1 runs all non-unit steps, so only it writes the complete summary table.
+        if: always() && matrix.shard == 1
         shell: bash
         run: |
           echo "## 🎨 Frontend Fast Gate" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -180,7 +180,9 @@ jobs:
   frontend-fast:
     name: 🎨 Frontend Fast Gate
     runs-on: ${{ vars.BENTON_RUNNER == 'true' && fromJSON('["self-hosted", "benton", "linux-x64"]') || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    # DIAGNOSTIC (WO-CI-FASTGATE-003, temporary): raised 30→50 so the suite completes
+    # instead of being cut, to identify the ~19-min silent block. REVERT before final fix.
+    timeout-minutes: 50
     needs: classify
     if: needs.classify.outputs.skip_frontend != 'true' && needs.classify.outputs.docs_only != 'true'
 
@@ -237,7 +239,10 @@ jobs:
         # 30-min fast-gate budget. That dependency-audit coverage remains in the scheduled
         # Security & Compliance Pipeline dependency scan. --slowTestThreshold=1000 surfaces
         # future slow tests without raising this gate's timeout. (Fix for #1242.)
-        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000
+        # DIAGNOSTIC (WO-CI-FASTGATE-003, temporary): --reporter=verbose prints each test live so
+        # the file whose tests crawl during the ~19-min silent block is named. retry/testTimeout
+        # left at config defaults so this reflects real conditions. REVERT with the timeout above.
+        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000 --reporter=verbose
 
       - name: IPC tests (blocking)
         id: ipc-tests

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -178,13 +178,21 @@ jobs:
   # Frontend Fast Gate (lint + type-check + unit tests + build)
   # ═══════════════════════════════════════════════════════════════════════════
   frontend-fast:
-    name: 🎨 Frontend Fast Gate
+    name: 🎨 Frontend Fast Gate (shard ${{ matrix.shard }}/3)
     runs-on: ${{ vars.BENTON_RUNNER == 'true' && fromJSON('["self-hosted", "benton", "linux-x64"]') || 'ubuntu-latest' }}
-    # DIAGNOSTIC (WO-CI-FASTGATE-003, temporary): raised 30→50 so the suite completes
-    # instead of being cut, to identify the ~19-min silent block. REVERT before final fix.
-    timeout-minutes: 50
+    timeout-minutes: 30
     needs: classify
     if: needs.classify.outputs.skip_frontend != 'true' && needs.classify.outputs.docs_only != 'true'
+    # WO-CI-FASTGATE-003: the os-shell Vitest suite (692 files / ~7970 tests) is too large to
+    # reliably finish in one 30-min job on contended runners (measured 8.5 min median, 28+ min tail;
+    # no single hanging test — dominated by per-file jsdom environment + collect overhead). Shard the
+    # unit tests across 3 parallel runners so each shard finishes with wide margin. The required
+    # 🔒 Seal Gate `needs: frontend-fast`, so ALL shards must pass — full coverage is still enforced.
+    # (🎨 Frontend Fast Gate is not itself a required context.)
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -234,15 +242,14 @@ jobs:
 
       - name: Unit tests (blocking)
         id: unit-tests
-        # Fast gate runs Vitest directly (test:tier0 === `vitest run`) and EXCLUDES the
-        # network/registry-variable npm-audit test (~3 min) so it never consumes the
-        # 30-min fast-gate budget. That dependency-audit coverage remains in the scheduled
-        # Security & Compliance Pipeline dependency scan. --slowTestThreshold=1000 surfaces
-        # future slow tests without raising this gate's timeout. (Fix for #1242.)
-        # DIAGNOSTIC (WO-CI-FASTGATE-003, temporary): --reporter=verbose prints each test live so
-        # the file whose tests crawl during the ~19-min silent block is named. retry/testTimeout
-        # left at config defaults so this reflects real conditions. REVERT with the timeout above.
-        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000 --reporter=verbose
+        # Fast gate runs Vitest directly (test:tier0 === `vitest run`), SHARDED across 3 runners
+        # (see strategy.matrix above) so this large suite finishes with margin on contended runners.
+        # Still EXCLUDES the network/registry-variable npm-audit test (covered by the scheduled
+        # Security & Compliance Pipeline scan); --slowTestThreshold=1000 surfaces future slow tests.
+        # Fixes #1242 / WO-CI-FASTGATE-003. (SHARD via env var, not inline ${{ }}, per shell-injection guard.)
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000 --shard="$SHARD/3"
 
       - name: IPC tests (blocking)
         id: ipc-tests

--- a/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 
-// DIAGNOSTIC trigger (WO-CI-FASTGATE-003, temporary): forces classify to run the Frontend
-// Fast Gate so the instrumented (verbose, 50-min) diagnostic actually executes. REVERT with the fix.
+// WO-CI-FASTGATE-003: this frontend touch makes `classify` run the (now sharded) Frontend
+// Fast Gate on this PR so the 3-way shard is validated before merge. Harmless comment.
 
 describe('os-shell smoke', () => {
   it('has a working test harness in apps/os-shell', () => {

--- a/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom';
 
+// DIAGNOSTIC trigger (WO-CI-FASTGATE-003, temporary): forces classify to run the Frontend
+// Fast Gate so the instrumented (verbose, 50-min) diagnostic actually executes. REVERT with the fix.
+
 describe('os-shell smoke', () => {
   it('has a working test harness in apps/os-shell', () => {
     expect(true).toBe(true);

--- a/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
+++ b/frontend/apps/os-shell/src/__tests__/smoke/os-shell-smoke.test.tsx
@@ -1,8 +1,5 @@
 import '@testing-library/jest-dom';
 
-// WO-CI-FASTGATE-003: this frontend touch makes `classify` run the (now sharded) Frontend
-// Fast Gate on this PR so the 3-way shard is validated before merge. Harmless comment.
-
 describe('os-shell smoke', () => {
   it('has a working test harness in apps/os-shell', () => {
     expect(true).toBe(true);

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,3 +1,5 @@
+// WO-CI-FASTGATE-003: touching this vitest config (an authorized path) makes `classify` run the
+// now-sharded Frontend Fast Gate on this PR so the 3-way unit-test shard is validated before merge.
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vitest/config';


### PR DESCRIPTION
## Fixes #1242 · WO-CI-FASTGATE-003 (GOAL-TF-FRONTEND-FAST-GATE-RELIABILITY-001)

### Diagnosis (evidence-first, per the WO — not a timeout mask)
Instrumented the gate (verbose reporter + 50-min budget) and it **completed in 8.5 min / 692 files / 7970 tests**:
- **No single hanging test** — only 2 mildly-slow (`settingsStore` 5s, `moduleActivation` 3s).
- Time is dominated by **per-file jsdom environment (481s cum) + collect (234s cum)** — inherent to a 692-file suite.
- The 28-min cut on #1240 was this large suite running ~3× slower on a **contended runner**. It's a size/variance problem, not a defect in one test.

### Fix — decision-hierarchy #3 (aggregate runtime too large → shard)
Run the unit tests across a **3-shard matrix** (`--shard=$SHARD/3`) so each shard finishes with wide margin even on slow runners.
- **Behavior-preserving:** no `retry`/`testTimeout`/mock changes → no test can newly pass or fail. Lowest-risk fix.
- **Coverage still enforced:** the required `🔒 TerraFusion Seal Gate` `needs: frontend-fast`, so **all 3 shards must pass**.
- **No branch-protection impact:** `🎨 Frontend Fast Gate` is **not** a required context (verified: required = governed-spine, phase85/86-tools, 🔒 Seal Gate, 🧪 Tier-1 UI Harness), so matrix check-name suffixes don't affect merges.
- Reverts the temporary diagnostic (verbose reporter + 50-min timeout, back to 30). Keeps the #1245 audit-exclude + `--slowTestThreshold=1000`.
- The `os-shell-smoke.test.tsx` comment is a harmless frontend touch so this PR's own (now sharded) gate runs and validates the shards.

### Not touched
No product/runtime/backend code; no other workflows; no branch protection; no `retry`/`testTimeout` semantics. Pre-existing unrelated semgrep finding at `seal-gate-fast.yml:~695` left alone (flagged separately).

After merge: update #1240 from main → its sharded gate runs → auto-merge.