### PR TITLE
WO-DEVEX-HOOKS-005 Worktree Hygiene Register

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -17,7 +17,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 
 ## Current Program Summary
 
-*(Updated 2026-07-10 — WO-BACKEND-OE-013; WO-CODEX-OP-008 register integration; WO-OP-AUTO-012 operator autonomy; WO-REL-006 release engineering closeout; WO-DEVEX-HOOKS-004 hook repair)*
+*(Updated 2026-07-10 — WO-BACKEND-OE-013; WO-CODEX-OP-008 register integration; WO-OP-AUTO-012 operator autonomy; WO-REL-006 release engineering closeout; WO-DEVEX-HOOKS-005 worktree hygiene register)*
 
 | Program | Goal | Loop | Status | Current WO | Next WO | Continuation | Stop Rules |
 |---------|------|------|--------|------------|---------|--------------|------------|
@@ -27,7 +27,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | [Backend Operational Excellence](programs/backend-operational-excellence.md) | `GOAL-BACKEND-OPERATIONAL-EXCELLENCE` | `LOOP-BACKEND-OPERATIONAL-EXCELLENCE` | Closed | `WO-BACKEND-OE-013` | Owner/WOE lane selection | No auto after closeout | Owner/WOE selects next lane; stop on implementation, infra repair outside standing repair rules, secrets, protected data, or non-docs hook bypass |
 | [Sovereign Sync Workbook Tooling](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-2---sovereign-sync-workbook-tooling) | `GOAL-SYNC-WORKBOOK-TOOLING` | `LOOP-SYNC-WORKBOOK-TOOLING` | Owner-selection gated | `WO-SYNC-132` | `WO-SYNC-133` | Auto only after owner selects Sync | Stop on Gate 14, forbidden content scan shape, live data, or cross-lane implementation |
 | [TerraPilot Tool Maturity](programs/terrapilot-tool-maturity.md) | `GOAL-TERRAPILOT-TOOL-MATURITY` | `LOOP-TERRAPILOT-TOOL-MATURITY` | Parked | P15 | P16 design-only | No auto | Owner authorization required |
-| [DevEx Hook Tooling](programs/devex-hook-tooling.md) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Active - evidence/register | `WO-DEVEX-HOOKS-004` | `WO-DEVEX-HOOKS-005` | Auto into evidence-only hygiene classification; no cleanup | Stop on deletion, force cleanup, branch removal, installs, CI/runtime changes, or protected resources |
+| [DevEx Hook Tooling](programs/devex-hook-tooling.md) | `GOAL-DEVEX-HOOK-BOOTSTRAP` | `LOOP-DEVEX-HOOK-BOOTSTRAP` | Active - bootstrap verification owner-gated | `WO-DEVEX-HOOKS-005` | `WO-DEVEX-HOOKS-006` | No auto into dependency installation | Stop on installs, dependency/lockfile mutation, cleanup, CI/runtime changes, or protected resources |
 | [Local OMEN Runtime Repair](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-5---local-omen-runtime-repair) | `GOAL-LOCAL-OMEN-RUNTIME-REPAIR` | `LOOP-LOCAL-OMEN-RUNTIME-REPAIR` | Blocked | `WO-LOCAL-093` | TBD | No auto | Owner authorization required |
 | [Runtime Import Disposition](programs/ACTIVE_PROGRAM_PLAYBOOK.md#program-6---runtime-import-disposition) | `GOAL-RUNTIME-IMPORT-DISPOSITION` | `LOOP-RUNTIME-IMPORT-DISPOSITION` | Owner-gated | `WO-CORE-1` | TBD | No auto | Owner authorization required |
 | [Property Workbench](programs/property-workbench.md) | `GOAL-PROPERTY-WORKBENCH` | `LOOP-PROPERTY-WORKBENCH` | Closed evidence baseline | `WO-WORKBENCH-011` | New phase only if owner/WOE selects | No auto restart | Owner or WOE selection required |
@@ -179,3 +179,4 @@ The command layer binds this register to `/goal` and `/loop` operating commands.
 | 2026-07-08 | Added DevEx Hook Tooling bootstrap contract and routed next to hook determinism design | WO-DEVEX-HOOKS-002 |
 | 2026-07-10 | Defined deterministic hook execution policy and routed implementation to explicit owner authorization | WO-DEVEX-HOOKS-003 |
 | 2026-07-10 | Repaired deterministic hooks without package/lockfile mutation and routed next to worktree hygiene evidence | WO-DEVEX-HOOKS-004 |
+| 2026-07-10 | Classified 54 worktrees without cleanup and routed next to clean-worktree bootstrap verification | WO-DEVEX-HOOKS-005 |

--- a/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-005-WORKTREE-HYGIENE-REGISTER.md
+++ b/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-005-WORKTREE-HYGIENE-REGISTER.md
@@ -1,0 +1,199 @@
+# WO-DEVEX-HOOKS-005 - Worktree Hygiene Register
+
+**Program:** DevEx Hook Tooling
+**Goal:** `GOAL-DEVEX-HOOK-BOOTSTRAP`
+**Loop:** `LOOP-DEVEX-HOOK-BOOTSTRAP`
+**Mode:** Read-only classification and evidence register
+**Base:** `origin/main` at `6e9833b8f2c79620dbbf667ce0833ec38694f23b`
+
+---
+
+## Objective
+
+Classify registered TerraFusion worktrees and their branch/PR ownership after the deterministic hook
+repair. This packet identifies cleanup candidates and quarantine boundaries; it does not remove,
+unlock, prune, reset, clean, or delete anything.
+
+---
+
+## Method
+
+The register correlated live evidence from:
+
+- `git worktree list --porcelain`;
+- `git status --porcelain --untracked-files=all` for unlocked paths;
+- branch ahead/behind counts relative to `origin/main`;
+- `gh pr list --state all` for branch-to-PR disposition;
+- lock and detached state reported by Git.
+
+Squash-merged branches can retain commits that are not ancestors of `main`. A nonzero ahead count is
+therefore not deletion authority. Merged PR state plus a clean worktree makes a path a candidate for
+later owner-authorized cleanup, not an automatically disposable path.
+
+---
+
+## Inventory Summary
+
+| Classification | Count | Meaning |
+|----------------|------:|---------|
+| Active WO | 1 | Current isolated WO-005 worktree |
+| Active PR | 3 | Open PR owns branch; preserve |
+| Merged clean candidate | 28 | Clean path with merged PR; candidate only |
+| Dirty quarantine | 6 | Local changes present; do not clean or remove |
+| Locked quarantine | 4 | Git reports locked initialization; do not force-remove |
+| Main ownership conflict | 1 | Stale linked worktree owns local `main` branch |
+| Closed unmerged review | 2 | Closed PR did not merge; owner disposition required |
+| Detached review | 1 | Detached worktree; provenance review required |
+| No-PR review | 8 | No matching PR found; branch provenance required |
+| **Total** | **54** | Registered worktrees in the live snapshot |
+
+---
+
+## Active Work
+
+| Path | Branch | PR | Disposition |
+|------|--------|----|-------------|
+| `C:\Users\bsval\.codex-worktrees\devex-hooks-005-worktree-hygiene-register` | `wo/devex-hooks-005-worktree-hygiene-register` | Current WO | Preserve |
+| `C:\Users\bsval\terrafusion_os_1.0\.claude\worktrees\atlas-cherry-pick` | `feat/atlas-maplibre-migration` | #1073 open | Preserve |
+| `C:\Users\bsval\tf-worktrees\tfos10-support` | `claude/backend-oe-support-packets` | #1238 open | Preserve |
+| `C:\Users\bsval\tf-worktrees\tfos10-tilecontract` | `claude/wb-suite-tile-contract` | #1240 open | Preserve |
+
+---
+
+## Hard Quarantine
+
+### Dirty paths
+
+| Path | Branch | Dirty entries | PR |
+|------|--------|--------------:|----|
+| `C:\Users\bsval\terrafusion_os_1.0` | `claude/forensic-estate-audit-4kzp3e` | 246 | #1081 merged |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\benton-cama-gla-gap` | `loop/benton-cama-gla-gap` | 1 | none found |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\compsforge-prometheus-comp-audit-v2` | `codex/compsforge-prometheus-comp-audit-v2` | 9 | none found |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\june10-operational-calm-polish` | `codex/release-auth-smoke-timeout` | 8 | #870 closed |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\salt-lake-county-pack` | `feat/salt-lake-county-pack` | 1 | none found |
+| `C:\Users\bsval\tf-worktrees\wo-ops-clean-main` | `wo/audit-county-filter-001` | 1 | #1187 merged |
+
+No `git clean`, reset, stash, checkout, restore, or removal is authorized for these paths.
+
+### Locked paths
+
+| Path | Branch | PR |
+|------|--------|----|
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\dais-queue-500-root-cause` | `codex/dais-queue-500-root-cause` | none found |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\production-provisioned-auth-db-backed` | `codex/production-provisioned-auth-db-backed` | none found |
+| `C:\Users\bsval\tf-worktrees\wo-brain-001` | `wo/benton-data-evidence-rollup` | #1152 merged |
+| `C:\Users\bsval\tf-worktrees\wo-sales-002b` | `docs/benton-demo-db-completion` | #1092 merged |
+
+These paths require separate forensic confirmation and explicit force-removal authority, if removal
+is later selected.
+
+### Main ownership conflict
+
+`C:\Users\bsval\.codex-worktrees\backend-oe-009-release-gate-definition` is clean but owns local
+branch `main` at `5585afa8f`, while `origin/main` is `6e9833b8f`. This prevents normal local-main
+ownership elsewhere and has already caused post-merge local synchronization friction. It is not safe
+to remove under this register; a dedicated branch/worktree repair decision is required.
+
+---
+
+## Provenance Review Required
+
+### Closed but unmerged PRs
+
+| Path | Branch | PR |
+|------|--------|----|
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\cuforge-case-state-persistence` | `codex/cuforge-case-state-persistence` | #876 closed |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\intelligence-preview` | `feat/intelligence-preview` | #886 closed |
+
+### Detached worktree
+
+- `C:\Users\bsval\terrafusion_os_1.0\.claude\worktrees\busy-payne-7aefde` at `3d2e7c825`.
+
+### No matching PR found
+
+| Path | Branch | Ahead / behind `origin/main` |
+|------|--------|-----------------------------|
+| `C:\Users\bsval\.codex-worktrees\backend-oe-007-migration-rollback-proof` | `wo/backend-oe-007-migration-rollback-proof` | 0 / 35 |
+| `C:\Users\bsval\.codex-worktrees\devex-hooks-001-reality-audit` | `wo/devex-hooks-001-reality-audit` | 0 / 4 |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\codex-county-studio-context-stabilization` | `codex/county-studio-r1-context-stabilization` | 0 / 353 |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\compsforge-diagnosis` | `feat/compsforge-property-universe-guard` | 259 / 379 |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\compsforge-prometheus-comp-audit` | `codex/compsforge-prometheus-comp-audit` | 0 / 359 |
+| `C:\Users\bsval\.config\superpowers\worktrees\terrafusion_os_1.0\sec-shell-quote` | `fix/sec-shell-quote-override` | 0 / 325 |
+| `C:\Users\bsval\terrafusion_os_1.0\.claude\worktrees\atlas-parcel-slice-01` | `worktree-atlas-parcel-slice-01` | 6 / 277 |
+| `C:\Users\bsval\terrafusion_os_1.0\.claude\worktrees\feat+terra-atlas-parcel-slice-01` | `worktree-feat+terra-atlas-parcel-slice-01` | 0 / 277 |
+
+No-PR paths need branch provenance and ownership confirmation before cleanup. The two zero-ahead
+Codex evidence paths may be low-risk candidates, but this packet does not authorize their removal.
+
+---
+
+## Merged Clean Candidates
+
+Every path below was clean and mapped to a merged PR at discovery time. Cleanup still requires a
+separate owner-authorized batch and a fresh pre-removal check.
+
+| Worktree | Branch | PR |
+|----------|--------|----|
+| `backend-oe-007-migration-rollback-proof-2` | `wo/backend-oe-007-migration-rollback-proof-2` | #1218 |
+| `backend-oe-008-dais-e2e-proof-plan` | `wo/backend-oe-008-dais-e2e-proof-plan` | #1220 |
+| `backend-oe-010-operational-runbook` | `wo/backend-oe-010-operational-runbook` | #1226 |
+| `backend-oe-011-diagnostics-observability-map` | `wo/backend-oe-011-diagnostics-observability-map` | #1232 |
+| `backend-oe-012-operational-packet` | `wo/backend-oe-012-operational-packet` | #1233 |
+| `backend-oe-013-evidence-rollup-closeout-2` | `wo/backend-oe-013-evidence-rollup-closeout` | #1239 |
+| `codex-operator-playbook` | `wo/codex-operator-playbook` | #1241 |
+| `devex-hooks-002-bootstrap-contract` | `wo/devex-hooks-002-bootstrap-contract` | #1250 |
+| `devex-hooks-003-determinism-design` | `wo/devex-hooks-003-determinism-design` | #1251 |
+| `devex-hooks-004-hook-script-repair` | `wo/devex-hooks-004-hook-script-repair` | #1253 |
+| `goal-loop-master-playbook` | `wo/goal-loop-master-playbook` | #1202 |
+| `op-auto-000-012-operator-autonomy` | `wo/op-auto-000-012-operator-autonomy` | #1244 |
+| `rel-002-release-gate-evidence-contract` | `wo/rel-002-release-gate-evidence-contract` | #1243 |
+| `rel-003-release-candidate-evidence-template` | `wo/rel-003-release-candidate-evidence-template` | #1246 |
+| `rel-004-release-tag-version-evidence-model` | `wo/rel-004-release-tag-version-evidence-model` | #1247 |
+| `rel-005-rollback-drill-authorization-packet` | `wo/rel-005-rollback-drill-authorization-packet` | #1248 |
+| `rel-006-release-engineering-evidence-rollup` | `wo/rel-006-release-engineering-evidence-rollup` | #1249 |
+| `add-uiux-skill` | `chore/ui-ux-pro-max-skill` | #929 |
+| `benton-owner-runtime-proof` | `codex/benton-owner-runtime-proof` | #915 |
+| `incomeforge-readiness-desk` | `codex/incomeforge-readiness-desk` | #888 |
+| `os-canon-bottom-tab-aria` | `chore/os-canon-bottom-tab-aria` | #926 |
+| `property-workbench-comps-review-desk` | `codex/compsforge-review-desk` | #890 |
+| `property-workbench-production-smoke` | `codex/property-workbench-production-smoke` | #897 |
+| `property-workbench-routing-ci-fix` | `codex/property-workbench-comps-review-desk` | #889 |
+| `terracanon-ide-package` | `feat/os-canon-diff-risk-viewer` | #932 |
+| `workbench-parcel-boot` | `fix/workbench-parcel-boot-auth-gate` | #927 |
+| `tfos10-cifix` | `ci/frontend-fast-gate-audit-exclude` | #1245 |
+| `tfos10-fastgate` | `ci/fastgate-silent-block-003` | #1252 |
+
+---
+
+## Recommended Cleanup Strategy
+
+1. Keep all active PR, current WO, dirty, locked, detached, closed-unmerged, and no-PR paths intact.
+2. Resolve the stale `main` ownership conflict in a dedicated owner-authorized repair WO before any
+   broad cleanup batch.
+3. If cleanup is selected, start with recent clean merged `.codex-worktrees` entries and verify each
+   PR, branch, cleanliness, and unique-commit disposition immediately before removal.
+4. Use `git worktree remove` and `git worktree prune`; never use broad filesystem deletion, `git
+   clean`, or `git reset --hard`.
+5. Delete a branch only after its exact worktree is removed and its merged/squash provenance is
+   reconfirmed.
+
+---
+
+## Explicit Non-Actions
+
+- No worktree removed, unlocked, repaired, pruned, moved, or manually deleted.
+- No branch deleted, reset, rebased, force-pushed, or checked out.
+- No dirty file inspected beyond path/count classification.
+- No PR changed.
+- No runtime, package, lockfile, CI, deployment, county, PACS, secret, or production resource
+  changed.
+
+---
+
+## Verdict
+
+**PASS - worktree hygiene is classified, not cleaned.**
+
+The next routed work order is `WO-DEVEX-HOOKS-006 - Bootstrap Verification Packet`. It requires a
+fresh clean-worktree dependency bootstrap and is therefore an install/mutation authority boundary,
+not automatic evidence-only continuation.

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -18,7 +18,7 @@ resolves.
 | `codex-operator-playbook` | Codex Operator Work Order Playbook | CLOSED at WO-CODEX-OP-009 | YES - governance capability merged | `once`, `evidence` |
 | `goal-loop-master-playbook` | Master Goal/Loop Playbook Governance | CLOSED at WO-GOAL-LOOP-MASTER-PLAYBOOK-001 | YES - governing baseline merged | `once`, `evidence` |
 | `program-status` | Master Active Program Playbook | Active program graph | NO | `once`, `evidence`, `discovery` |
-| `program-next` | Master Playbook | DevEx Hook Tooling / WO-DEVEX-HOOKS-005 | YES - evidence-only hygiene register; no cleanup | `once`, `evidence` |
+| `program-next` | Master Playbook | DevEx Hook Tooling / WO-DEVEX-HOOKS-006 | YES - owner decision packet for clean-worktree dependency bootstrap | `once`, `evidence` |
 | `program-stop` | Master Playbook | NONE | YES — operator stop command | `once` |
 | `release-engineering` | Release Engineering | CLOSED at WO-REL-006 | YES - baseline closed after rollup | `once`, `evidence`, `discovery` |
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003B | YES — PR #1112 not merged | `once`, `merge-watch`, `evidence` |
@@ -36,7 +36,7 @@ resolves.
 | `terrapilot-maturity` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — live promotion remains an owner/runtime decision | `once`, `program`, `evidence`, `discovery` |
 | `terrapilot-status` | P5 | WO-TERRAPILOT-P16 (blocked; owner authorization required) | YES — parked at P15 | `evidence`, `discovery` |
 | `terrapilot-stop` | P5 | NONE | YES — operator stop command | `once` |
-| `devex-hooks-status` | DevEx Hook Tooling | WO-DEVEX-HOOKS-005 | YES — hook repair complete; worktree/branch classification only, no cleanup | `evidence`, `discovery` |
+| `devex-hooks-status` | DevEx Hook Tooling | WO-DEVEX-HOOKS-006 | YES — worktree hygiene classified; dependency install and bootstrap proof owner-gated | `evidence`, `discovery` |
 | `local-omen-status` | Local OMEN Runtime Repair | WO-LOCAL-093 | YES — runtime repair diagnosis gate | `evidence`, `discovery` |
 | `core-import-status` | WO-CORE-1 Runtime Import Disposition | WO-CORE-1 | YES — owner-gated runtime import disposition | `evidence`, `discovery` |
 | `workbench-status` | P4 | CLOSED at WO-WORKBENCH-011 | YES - status/evidence only; new phase requires owner/WOE selection | `evidence`, `discovery` |

--- a/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
+++ b/docs/brain/workorders/goal-loop/GOAL_COMMANDS.md
@@ -253,13 +253,13 @@ status command.
 Goal:     Inspect local Prettier/Vitest hook tooling debt without mixing it into product lanes.
 Program:  DevEx Hook Tooling
 File:     programs/devex-hook-tooling.md
-Success:  Operator sees the deterministic hook repair as complete and WO-DEVEX-HOOKS-005 as an
-          evidence-only worktree hygiene register with no cleanup authority.
+Success:  Operator sees worktree hygiene as classified and WO-DEVEX-HOOKS-006 as an owner-gated
+          clean-worktree bootstrap verification packet.
 ```
 
-**Current state:** `WO-DEVEX-HOOKS-004` implements deterministic hook execution without package,
-lockfile, CI, or product-runtime changes. Next is `WO-DEVEX-HOOKS-005 - Worktree Hygiene Register`;
-classification is allowed, but deletion and force cleanup remain owner-gated.
+**Current state:** `WO-DEVEX-HOOKS-005` classifies 54 worktrees without cleanup. Next is
+`WO-DEVEX-HOOKS-006 - Bootstrap Verification Packet`; dependency installation, lockfile mutation,
+and worktree cleanup remain owner-gated.
 
 **Command alias:** `/devex-hooks-status`
 

--- a/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
+++ b/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
@@ -424,9 +424,9 @@ Stop type: `TERRAPILOT_P15_PARKED`
 | Goal | `GOAL-DEVEX-HOOK-BOOTSTRAP` |
 | Loop | `LOOP-DEVEX-HOOK-BOOTSTRAP` |
 | Program slug | `devex-hook-tooling` |
-| Status | ACTIVE - hook repair complete; evidence/register next |
-| Current WO | `WO-DEVEX-HOOKS-004` |
-| Next WO | `WO-DEVEX-HOOKS-005` |
+| Status | ACTIVE - worktree hygiene classified; bootstrap verification owner-gated |
+| Current WO | `WO-DEVEX-HOOKS-005` |
+| Next WO | `WO-DEVEX-HOOKS-006` |
 | Program playbook | [devex-hook-tooling.md](devex-hook-tooling.md) |
 
 ### Problem
@@ -454,8 +454,12 @@ and prohibits implicit hook installs or silent missing-tool skips.
 `WO-DEVEX-HOOKS-004 - Hook Script Repair` applies the deterministic policy without package,
 lockfile, CI, or product-runtime changes.
 
-`WO-DEVEX-HOOKS-005 - Worktree Hygiene Register` is the next evidence-only packet. It may classify
-stale worktrees and branch ownership, but no cleanup is authorized.
+`WO-DEVEX-HOOKS-005 - Worktree Hygiene Register` classifies registered worktrees, active PRs,
+cleanup candidates, dirty/locked quarantines, and the stale local-main ownership conflict. It performs
+no cleanup.
+
+`WO-DEVEX-HOOKS-006 - Bootstrap Verification Packet` is next and requires owner authority for an
+explicit clean-worktree dependency install.
 
 ---
 

--- a/docs/brain/workorders/programs/devex-hook-tooling.md
+++ b/docs/brain/workorders/programs/devex-hook-tooling.md
@@ -3,8 +3,8 @@
 **Program:** DevEx Hook Tooling
 **Goal:** `GOAL-DEVEX-HOOK-BOOTSTRAP`
 **Loop:** `LOOP-DEVEX-HOOK-BOOTSTRAP`
-**Status:** Active - hook repair complete; worktree hygiene evidence next
-**Current base:** `origin/main` at `bba74f3227fa5e208cbd34e9bc4e581ff1e94404`
+**Status:** Active - worktree hygiene classified; bootstrap verification owner-gated
+**Current base:** `origin/main` at `6e9833b8f2c79620dbbf667ce0833ec38694f23b`
 
 ---
 
@@ -108,5 +108,8 @@ the exact owner-authorized `WO-DEVEX-HOOKS-004` implementation scope.
 `.husky/pre-push`, and `scripts/setup/setup-atlas-hooks.sh`. It did not change packages, lockfiles,
 CI, or product runtime.
 
-`WO-DEVEX-HOOKS-005 - Worktree Hygiene Register` is next. It is evidence/register only and may
-classify stale worktree and branch cleanup candidates, but it must not remove them.
+`WO-DEVEX-HOOKS-005 - Worktree Hygiene Register` classified 54 registered worktrees without cleanup.
+Dirty, locked, detached, active-PR, no-PR, and stale-main ownership boundaries remain preserved.
+
+`WO-DEVEX-HOOKS-006 - Bootstrap Verification Packet` is next. It requires an explicit clean-worktree
+dependency install and therefore remains owner-gated.


### PR DESCRIPTION
## Summary
- register the live worktree inventory and hygiene classifications
- preserve dirty, locked, active-PR, detached, and no-PR states without cleanup
- route DevEx Hook Tooling to WO-DEVEX-HOOKS-006

## Evidence
- 54 worktrees classified from live repository state
- no worktree removal, pruning, branch deletion, or cleanup performed
- runtime, backend, tools-sync, CI, deployment, county, PACS, and secret changes: none
- `git diff --check`: pass
- `node docs/brain/workorders/tools/wo-query.mjs --json`: pass

## Local tooling
The scoped docs commit and push used the standing local-tooling exception because this dependency-clean worktree intentionally lacks repo-local hook dependencies. Repository validation passed before publication.

## Next
WO-DEVEX-HOOKS-006 requires an explicitly authorized clean-worktree dependency bootstrap verification.