### PR TITLE
WO-DEVEX-HOOKS-006 Constrain Frozen Bootstrap Authority

### DIFF
--- a/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-006-BOOTSTRAP-VERIFICATION-PACKET.md
+++ b/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-006-BOOTSTRAP-VERIFICATION-PACKET.md
@@ -21,12 +21,12 @@ not install dependencies during hook execution.
 
 | Check | Result |
 |-------|--------|
-| Worktree | `C:/Users/bsval/.codex-worktrees/devex-hooks-006-bootstrap-verification` |
+| Worktree | `$HOME/.codex-worktrees/devex-hooks-006-bootstrap-verification` |
 | Branch | `wo/devex-hooks-006-bootstrap-verification` |
 | Initial `HEAD` / `origin/main` | `2b97106cf5895562b2eeb63fc219327e672a5797` |
 | Initial status | Clean |
 | Package manager | `corepack pnpm`, repository-declared version `9.0.0` |
-| Bootstrap command | `corepack pnpm install --frozen-lockfile` |
+| Bootstrap command | `corepack pnpm install --frozen-lockfile` (explicitly owner-authorized for this proof) |
 | Bootstrap result | PASS; lockfile resolution skipped because the lockfile was current |
 | Tracked mutation after bootstrap | None |
 | Hook-time install | None |
@@ -66,12 +66,17 @@ Windows repository-local command shims existed for all three tools under `node_m
 The synthetic runs replace gate command outcomes only; actual Corepack/pnpm and repository-local
 tool resolution were verified separately against the bootstrapped worktree.
 
+The owner-authorized bootstrap executed the repository's existing `prepare` lifecycle script, which
+ran `husky install`. No tracked file, manifest hash, lockfile hash, or effective `core.hooksPath`
+changed, but this run does not establish lifecycle scripts as safe for unattended auto-proceed.
+
 ## Standing Operator Policy
 
-`FROZEN_BOOTSTRAP_AUTO_PROCEED` is added to the Codex operator playbook. Ordinary frozen installs in
-dedicated validation worktrees are no longer owner stops when manifests and lockfiles are hashed,
-only ignored dependency state is expected, and protected resources are excluded. Any tracked change
-still causes an immediate stop.
+`FROZEN_BOOTSTRAP_AUTO_PROCEED` is added to the Codex operator playbook. Automatic frozen installs in
+dedicated validation worktrees must also use `--ignore-scripts`; script-enabled bootstrap requires a
+separate pre-install lifecycle allowlist or explicit owner authorization. Manifests and lockfiles are
+hashed, only ignored dependency state is expected, protected resources are excluded, and any tracked
+change still causes an immediate stop.
 
 ## Safety And Non-Claims
 

--- a/docs/brain/workorders/operator/CODEX_OPERATOR_PLAYBOOK.md
+++ b/docs/brain/workorders/operator/CODEX_OPERATOR_PLAYBOOK.md
@@ -71,6 +71,7 @@ Codex may run a dependency bootstrap without owner approval when all are true:
 - execution occurs in a dedicated clean worktree;
 - the repository's declared package manager is used;
 - frozen-lockfile mode is enabled;
+- lifecycle scripts are suppressed with `--ignore-scripts`;
 - expected mutation is ignored local dependency state only;
 - package manifests and lockfiles are hashed before and after;
 - no scripts connect to production, county systems, PACS, secrets, or external operational
@@ -78,7 +79,9 @@ Codex may run a dependency bootstrap without owner approval when all are true:
 - any tracked mutation causes an immediate stop.
 
 This rule authorizes local validation state only. It does not authorize package, lockfile, runtime,
-CI, deployment, or protected-resource changes.
+CI, deployment, or protected-resource changes. If the validation requires lifecycle scripts, Codex
+must first establish a bounded pre-install script allowlist or obtain explicit owner authorization;
+frozen lockfile mode alone does not make lifecycle side effects deterministic.
 
 ## Relationship To Existing Doctrine
 


### PR DESCRIPTION
## Summary
Post-merge remediation for two late PR #1255 review findings:
- redact the username-bearing local worktree path
- constrain FROZEN_BOOTSTRAP_AUTO_PROCEED to `--ignore-scripts`

## Policy correction
Frozen lockfile mode freezes dependency resolution, not lifecycle side effects. Automatic validation bootstraps must suppress lifecycle scripts. A script-enabled bootstrap requires a bounded lifecycle allowlist or explicit owner authorization.

## Evidence correction
The owner-authorized WO-006 run executed the existing root `prepare` script (`husky install`). Hashes, tracked state, and `core.hooksPath` remained unchanged, but the packet now explicitly avoids treating that as unattended lifecycle-script proof.

## Scope
Exactly two docs/governance files under `docs/brain/workorders/**`. No package, lockfile, hook, workflow, runtime, backend, tools-sync, deployment, county, PACS, secret, or production changes.

## Validation
- `git diff --check`: PASS
- `wo-query --json`: PASS
- commit/push used the existing scoped local-tooling exception because this fresh docs-only worktree has no dependencies installed

## Summary by Sourcery

Clarify operator policies and evidence around frozen bootstrap authority and lifecycle script handling for WO-DEVEX-HOOKS-006.

Documentation:
- Update the WO-DEVEX-HOOKS-006 verification packet to redact a user-specific worktree path and document that the bootstrap was explicitly owner-authorized and executed the existing prepare script.
- Refine the Codex operator playbook rules to require suppressing lifecycle scripts for unattended frozen bootstraps and to spell out conditions under which lifecycle scripts may be run with explicit authorization.