### PR TITLE
ci(frontend): split unit shards from build/checks (WO-CI-FASTGATE-003 follow-up)

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -175,7 +175,10 @@ jobs:
           fi
 
   # ═══════════════════════════════════════════════════════════════════════════
-  # Frontend Fast Gate (lint + type-check + unit tests + build)
+  # Frontend Fast Gate — split (WO-CI-FASTGATE-003):
+  #   frontend-fast   = sharded unit tests only (matrix 1..3)
+  #   frontend-checks = lint + type-check + ipc + build + bundle (once)
+  # so no runner carries both a unit shard and the build. Seal Gate needs both.
   # ═══════════════════════════════════════════════════════════════════════════
   frontend-fast:
     name: 🎨 Frontend Fast Gate (unit shard ${{ matrix.shard }}/3)
@@ -731,12 +734,22 @@ jobs:
             echo "✅ Classify: passed"
           fi
 
-          # Frontend (may be skipped)
+          # Frontend unit shards (may be skipped)
           case "${{ needs.frontend-fast.result }}" in
-            success) echo "✅ Frontend: passed" ;;
-            skipped) echo "⏭️ Frontend: skipped (no changes)" ;;
+            success) echo "✅ Frontend unit shards: passed" ;;
+            skipped) echo "⏭️ Frontend unit shards: skipped (no changes)" ;;
             *)
-              echo "❌ Frontend: FAILED"
+              echo "❌ Frontend unit shards: FAILED"
+              FAILED=1
+              ;;
+          esac
+
+          # Frontend build & checks (may be skipped)
+          case "${{ needs.frontend-checks.result }}" in
+            success) echo "✅ Frontend build & checks: passed" ;;
+            skipped) echo "⏭️ Frontend build & checks: skipped (no changes)" ;;
+            *)
+              echo "❌ Frontend build & checks: FAILED"
               FAILED=1
               ;;
           esac
@@ -776,9 +789,14 @@ jobs:
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Classify | ${{ needs.classify.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           case "${{ needs.frontend-fast.result }}" in
-            success) echo "| Frontend | ✅ |" >> $GITHUB_STEP_SUMMARY ;;
-            skipped) echo "| Frontend | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
-            *) echo "| Frontend | ❌ |" >> $GITHUB_STEP_SUMMARY ;;
+            success) echo "| Frontend unit shards | ✅ |" >> $GITHUB_STEP_SUMMARY ;;
+            skipped) echo "| Frontend unit shards | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo "| Frontend unit shards | ❌ |" >> $GITHUB_STEP_SUMMARY ;;
+          esac
+          case "${{ needs.frontend-checks.result }}" in
+            success) echo "| Frontend build & checks | ✅ |" >> $GITHUB_STEP_SUMMARY ;;
+            skipped) echo "| Frontend build & checks | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo "| Frontend build & checks | ❌ |" >> $GITHUB_STEP_SUMMARY ;;
           esac
           case "${{ needs.backend-fast.result }}" in
             success) echo "| Backend | ✅ |" >> $GITHUB_STEP_SUMMARY ;;

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -178,17 +178,17 @@ jobs:
   # Frontend Fast Gate (lint + type-check + unit tests + build)
   # ═══════════════════════════════════════════════════════════════════════════
   frontend-fast:
-    name: 🎨 Frontend Fast Gate (shard ${{ matrix.shard }}/3)
+    name: 🎨 Frontend Fast Gate (unit shard ${{ matrix.shard }}/3)
     runs-on: ${{ vars.BENTON_RUNNER == 'true' && fromJSON('["self-hosted", "benton", "linux-x64"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     needs: classify
     if: needs.classify.outputs.skip_frontend != 'true' && needs.classify.outputs.docs_only != 'true'
-    # WO-CI-FASTGATE-003: the os-shell Vitest suite (692 files / ~7970 tests) is too large to
-    # reliably finish in one 30-min job on contended runners (measured 8.5 min median, 28+ min tail;
-    # no single hanging test — dominated by per-file jsdom environment + collect overhead). Shard the
-    # unit tests across 3 parallel runners so each shard finishes with wide margin. The required
-    # 🔒 Seal Gate `needs: frontend-fast`, so ALL shards must pass — full coverage is still enforced.
-    # (🎨 Frontend Fast Gate is not itself a required context.)
+    # WO-CI-FASTGATE-003: the os-shell Vitest suite (692 files / ~7970 tests) is too large/variable to
+    # finish in one 30-min job on contended runners (8.5 min median, 30+ min tail; no single hanging
+    # test — dominated by per-file jsdom environment + collect overhead). This job runs ONLY the unit
+    # tests, sharded across 3 runners. The non-unit checks (lint/type-check/ipc/build/bundle) run once
+    # in the separate `frontend-checks` job, so no runner carries both a unit shard AND the build.
+    # The required 🔒 Seal Gate needs both jobs → all 3 shards + all checks must pass (full coverage).
     strategy:
       fail-fast: false
       matrix:
@@ -208,16 +208,47 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # WO-CI-FASTGATE-003: only the unit-test step is sharded; the non-unit steps below run
-      # once (shard 1) so build/bundle/lint/type-check are not redundantly repeated per shard.
+      - name: Unit tests (blocking, sharded)
+        id: unit-tests
+        # Vitest run (test:tier0 === `vitest run`), sharded across 3 runners (strategy.matrix above).
+        # EXCLUDES the network/registry-variable npm-audit test (covered by the scheduled Security &
+        # Compliance Pipeline scan); --slowTestThreshold=1000 surfaces future slow tests.
+        # Fixes #1242 / WO-CI-FASTGATE-003. (SHARD via env var, not inline ${{ }}, per shell-injection guard.)
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000 --shard="$SHARD/3"
+
+  frontend-checks:
+    name: 🎨 Frontend Build & Checks
+    runs-on: ${{ vars.BENTON_RUNNER == 'true' && fromJSON('["self-hosted", "benton", "linux-x64"]') || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    needs: classify
+    if: needs.classify.outputs.skip_frontend != 'true' && needs.classify.outputs.docs_only != 'true'
+    # WO-CI-FASTGATE-003: non-unit frontend checks (lint, type-check, ipc, build, bundle) run once here,
+    # separate from the sharded unit tests (frontend-fast), so no runner carries both a unit shard and
+    # the build. The required 🔒 Seal Gate needs both jobs.
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Lint (loud, temporary non-blocking)
         id: lint
-        if: matrix.shard == 1
         run: pnpm -C frontend run lint
         continue-on-error: true
 
       - name: Lint escape hatch (expires 2026-07-31)
-        if: matrix.shard == 1 && steps.lint.outcome == 'failure'
+        if: steps.lint.outcome == 'failure'
         shell: bash
         run: |
           set -euo pipefail
@@ -231,7 +262,6 @@ jobs:
 
       - name: Type check (blocking)
         id: typecheck
-        if: matrix.shard == 1
         shell: bash
         run: |
           set -euo pipefail
@@ -244,44 +274,28 @@ jobs:
             exit 1
           fi
 
-      - name: Unit tests (blocking)
-        id: unit-tests
-        # Fast gate runs Vitest directly (test:tier0 === `vitest run`), SHARDED across 3 runners
-        # (see strategy.matrix above) so this large suite finishes with margin on contended runners.
-        # Still EXCLUDES the network/registry-variable npm-audit test (covered by the scheduled
-        # Security & Compliance Pipeline scan); --slowTestThreshold=1000 surfaces future slow tests.
-        # Fixes #1242 / WO-CI-FASTGATE-003. (SHARD via env var, not inline ${{ }}, per shell-injection guard.)
-        env:
-          SHARD: ${{ matrix.shard }}
-        run: pnpm -C frontend exec vitest run --exclude 'apps/os-shell/src/tests/security/DependencyVulnerabilities.test.ts' --slowTestThreshold=1000 --shard="$SHARD/3"
-
       - name: IPC tests (blocking)
         id: ipc-tests
-        if: matrix.shard == 1
         run: pnpm -C frontend run test:ipc
 
       - name: Build (blocking)
         id: build
-        if: matrix.shard == 1
         run: pnpm -C frontend run build
 
       - name: Bundle Analysis (blocking - requires build)
         id: bundle-analysis
-        if: matrix.shard == 1
         run: pnpm -C frontend run test:unit -- apps/os-shell/src/tests/performance/BundleAnalysis.test.ts
 
-      - name: Frontend Summary
-        # Only shard 1 runs all non-unit steps, so only it writes the complete summary table.
-        if: always() && matrix.shard == 1
+      - name: Frontend Checks Summary
+        if: always()
         shell: bash
         run: |
-          echo "## 🎨 Frontend Fast Gate" >> $GITHUB_STEP_SUMMARY
+          echo "## 🎨 Frontend Build & Checks" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Lint | ${{ steps.lint.outcome == 'success' && '✅' || '⚠️ Soft (expires 2026-07-31)' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Type Check | ${{ steps.typecheck.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Unit Tests | ${{ steps.unit-tests.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| IPC Tests | ${{ steps.ipc-tests.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build | ${{ steps.build.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Bundle | ${{ steps.bundle-analysis.outcome == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
@@ -695,7 +709,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: always()
-    needs: [classify, frontend-fast, backend-fast, governance-fast]
+    needs: [classify, frontend-fast, frontend-checks, backend-fast, governance-fast]
 
     steps:
       - name: Check all gates

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,5 +1,5 @@
 // WO-CI-FASTGATE-003: touching this vitest config (an authorized path) makes `classify` run the
-// now-sharded Frontend Fast Gate on this PR so the 3-way unit-test shard is validated before merge.
+// Frontend gates on this PR so the split unit-shard / build-checks jobs are validated before merge.
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vitest/config';


### PR DESCRIPTION
## WO-CI-FASTGATE-003 — follow-up to #1252

**Why:** #1252 sharded the unit tests but gated the non-unit steps to `if: matrix.shard==1`, so **shard 1 carried a unit-third PLUS build+bundle+type-check+ipc**. On a contended runner that overloaded shard 1 — **measured: #1240's shard 1 ran 30.2 min and hit the 30-min timeout** (cancelled); shards 2/3 (unit-only) passed. So the gate still isn't reliably in-budget.

**Fix (Codex's original suggestion):** two jobs so no runner carries both a unit shard *and* the build:
- **`frontend-fast`** — matrix `[1,2,3]`, runs **only** the sharded unit tests.
- **`frontend-checks`** — no matrix, runs lint / type-check / ipc / build / bundle **once**.
- Required `🔒 TerraFusion Seal Gate` now `needs: [frontend-fast, frontend-checks, …]` → **all 3 shards + all checks must pass** (full coverage preserved).

**Behavior-preserving:** no `retry`/`testTimeout`/mock changes; just where steps run. `git diff --check` clean; YAML validated.

Pre-existing unrelated semgrep finding at `seal-gate-fast.yml` (`run-shell-injection`) left untouched (out of scope, flagged separately).

After merge: update #1240 → its unit shards + checks run in-budget → #1240 auto-merges.

## Summary by Sourcery

Split frontend CI into separate sharded unit-test and single-run build/check jobs to keep all gates within time budget while preserving coverage.

CI:
- Adjust the `frontend-fast` workflow job to run only sharded frontend unit tests across three shards.
- Introduce a new `frontend-checks` workflow job to run lint, type-check, IPC tests, build, and bundle analysis once per workflow run.
- Update the TerraFusion Seal Gate workflow dependencies so it requires both frontend unit shards and frontend checks to pass.
- Refresh Vitest config commentary to reflect the new split between unit shards and build/checks jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Frontend validation is now split into parallel unit-test shards and a separate set of checks.
  * Linting, type-checking, IPC tests, builds, and bundle analysis run once per validation cycle.
  * Release gating now reports frontend unit tests separately from frontend build and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->