### PR TITLE
WO-DEVEX-HOOKS-006 Reconcile Bootstrap Closeout

### DIFF
--- a/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
+++ b/docs/brain/workorders/PROGRAM_PLAYBOOK_REGISTER.md
@@ -50,7 +50,7 @@ This register is the canonical source of truth for all active TerraFusion work o
 | WO-DATA-BENTON-DUPE-001B requires data mutation authorization | WO-DATA-BENTON-DUPE-001B | SW-02 |
 | No Azure App Service environment provisioned | WO-DEPLOY-BENTON-003B, WO-AZURE-001 | — |
 | Backend full solution tests depend on Docker/Testcontainers SQL Server lane | Backend release readiness / integration validation | Classified in WO-BACKEND-OE-003 as segmented integration prerequisite; release gate criteria defined in WO-BACKEND-OE-009; operational runbook created in WO-BACKEND-OE-010 without Docker repair |
-| Local hook tooling cannot find Prettier/Vitest | All PR-finalization work | Local hook bypass authority wall; DevEx follow-up only |
+| Dependency-clean worktrees cannot resolve local Prettier/Vitest before explicit bootstrap | Local PR-finalization before bootstrap | Run the governed frozen bootstrap; unattended runs require `--ignore-scripts` and tracked mutation remains an authority wall |
 | Production deployment NOT authorized | All P1 WOs after 003D | SW-01 |
 | County production boundary packet requires explicit operator auth | WO-AZURE-006 | SW-01 + SW-09 |
 

--- a/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-006-BOOTSTRAP-VERIFICATION-PACKET.md
+++ b/docs/brain/workorders/evidence/WO-DEVEX-HOOKS-006-BOOTSTRAP-VERIFICATION-PACKET.md
@@ -21,12 +21,12 @@ not install dependencies during hook execution.
 
 | Check | Result |
 |-------|--------|
-| Worktree | `$HOME/.codex-worktrees/devex-hooks-006-bootstrap-verification` |
+| Worktree | `<HOME>/.codex-worktrees/devex-hooks-006-bootstrap-verification` |
 | Branch | `wo/devex-hooks-006-bootstrap-verification` |
 | Initial `HEAD` / `origin/main` | `2b97106cf5895562b2eeb63fc219327e672a5797` |
 | Initial status | Clean |
 | Package manager | `corepack pnpm`, repository-declared version `9.0.0` |
-| Bootstrap command | `corepack pnpm install --frozen-lockfile` (explicitly owner-authorized for this proof) |
+| Bootstrap command | `corepack pnpm install --frozen-lockfile` (explicitly owner-authorized; lifecycle scripts were not suppressed) |
 | Bootstrap result | PASS; lockfile resolution skipped because the lockfile was current |
 | Tracked mutation after bootstrap | None |
 | Hook-time install | None |
@@ -74,7 +74,7 @@ changed, but this run does not establish lifecycle scripts as safe for unattende
 
 `FROZEN_BOOTSTRAP_AUTO_PROCEED` is added to the Codex operator playbook. Automatic frozen installs in
 dedicated validation worktrees must also use `--ignore-scripts`; script-enabled bootstrap requires a
-separate pre-install lifecycle allowlist or explicit owner authorization. Manifests and lockfiles are
+separate pre-install lifecycle-script allowlist or explicit owner authorization. Manifests and lockfiles are
 hashed, only ignored dependency state is expected, protected resources are excluded, and any tracked
 change still causes an immediate stop.
 

--- a/docs/brain/workorders/operator/CODEX_OPERATOR_PLAYBOOK.md
+++ b/docs/brain/workorders/operator/CODEX_OPERATOR_PLAYBOOK.md
@@ -80,7 +80,7 @@ Codex may run a dependency bootstrap without owner approval when all are true:
 
 This rule authorizes local validation state only. It does not authorize package, lockfile, runtime,
 CI, deployment, or protected-resource changes. If the validation requires lifecycle scripts, Codex
-must first establish a bounded pre-install script allowlist or obtain explicit owner authorization;
+must first establish a bounded pre-install lifecycle-script allowlist or obtain explicit owner authorization;
 frozen lockfile mode alone does not make lifecycle side effects deterministic.
 
 ## Relationship To Existing Doctrine

--- a/docs/brain/workorders/programs/devex-hook-tooling.md
+++ b/docs/brain/workorders/programs/devex-hook-tooling.md
@@ -27,16 +27,18 @@ CI wiring, deployment, or county runtime work.
 - Active hooks are routed through `core.hooksPath=.husky`.
 - `.husky/pre-commit` and `.husky/pre-push` are active.
 - `.githooks/pre-commit` exists but is not active under current Git config.
-- Clean worktrees do not have root `node_modules` or `frontend/node_modules`.
-- `prettier` and `vitest` are not available on PATH.
-- Repo-local `node_modules/.bin/prettier` and `node_modules/.bin/vitest` are absent in clean
-  worktrees; on Windows the corresponding `.cmd` shims are also absent.
+- Dependency-clean worktrees do not begin with root `node_modules`; hooks fail fast with the
+  governed bootstrap instruction until dependencies are explicitly installed.
+- `prettier` and `vitest` need not be globally available because repaired hooks resolve the
+  repository-local tools through Corepack and the pinned pnpm contract.
+- After governed frozen bootstrap, repo-local Prettier, lint-staged, and Vitest resolve in clean
+  worktrees, including their Windows `.cmd` shims.
 - `npx --no-install` can resolve non-canonical global/cache tool versions, which is not acceptable
   as release-grade local hook proof.
-- The current pre-push hook may attempt `npm install --legacy-peer-deps` when `node_modules` is
-  missing; hook-time install mutation is not approved by this lane.
-- `scripts/setup/setup-atlas-hooks.sh` can set `core.hooksPath` to `.githooks`; that legacy hook
-  authority must be dispositioned before hook repair.
+- The repaired pre-push hook never installs dependencies; missing local tooling is an explicit
+  bootstrap failure.
+- `scripts/setup/setup-atlas-hooks.sh` is retired and no longer changes hook authority away from
+  `.husky`.
 
 ---
 


### PR DESCRIPTION
## Summary
Final WO-DEVEX-HOOKS-006 post-merge review reconciliation:
- use neutral `<HOME>` path notation
- label the recorded bootstrap as script-enabled and explicitly authorized
- standardize `pre-install lifecycle-script allowlist` terminology
- replace stale pre-repair hook/tool blockers with verified post-repair truth

## Scope
Exactly four docs/governance files. No package, lockfile, hook, workflow, runtime, backend, tools-sync, deployment, county, PACS, secret, or production changes.

## Validation
- `git diff --check`: PASS
- `wo-query --json`: PASS
- scoped local-tooling exception recorded for commit/push in this dependency-clean worktree