### PR TITLE
ci(frontend): fix Bundle Analysis full-suite bug + deterministic fetch stub (WO-CI-FASTGATE-003)

### DIFF
--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -287,10 +287,13 @@ jobs:
 
       - name: Bundle Analysis (blocking - requires build)
         id: bundle-analysis
-        # Run vitest DIRECTLY on the single file. `pnpm run test:unit -- FILE` forwards `-- FILE`,
-        # which vitest treats as "no positional filter" and runs the WHOLE suite (~30 min). Calling
-        # the vitest binary with a positional path runs only this file. (WO-CI-FASTGATE-003)
-        run: pnpm -C frontend exec vitest run apps/os-shell/src/tests/performance/BundleAnalysis.test.ts
+        # Run the post-build performance tests via the vitest binary with a positional path.
+        # The former `pnpm run test:unit -- apps/.../BundleAnalysis.test.ts` had two bugs: (a) that
+        # file no longer exists (only MemoryLeakDetection.test.tsx + PerformanceBenchmarks.test.tsx
+        # remain), and (b) `pnpm run … -- FILE` forwards `-- FILE`, which vitest treats as no
+        # positional filter → it silently ran the WHOLE 692-file suite (~30 min). Target the real
+        # performance dir directly. (WO-CI-FASTGATE-003; codex #1260)
+        run: pnpm -C frontend exec vitest run apps/os-shell/src/tests/performance/
 
       - name: Frontend Checks Summary
         if: always()

--- a/.github/workflows/seal-gate-fast.yml
+++ b/.github/workflows/seal-gate-fast.yml
@@ -287,7 +287,10 @@ jobs:
 
       - name: Bundle Analysis (blocking - requires build)
         id: bundle-analysis
-        run: pnpm -C frontend run test:unit -- apps/os-shell/src/tests/performance/BundleAnalysis.test.ts
+        # Run vitest DIRECTLY on the single file. `pnpm run test:unit -- FILE` forwards `-- FILE`,
+        # which vitest treats as "no positional filter" and runs the WHOLE suite (~30 min). Calling
+        # the vitest binary with a positional path runs only this file. (WO-CI-FASTGATE-003)
+        run: pnpm -C frontend exec vitest run apps/os-shell/src/tests/performance/BundleAnalysis.test.ts
 
       - name: Frontend Checks Summary
         if: always()

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -160,12 +160,10 @@ if (!window.cancelAnimationFrame) {
 // unmocked fetches fail fast and deterministically. Tests that exercise fetch mock it themselves
 // (that per-test mock overrides this global). This changes no assertion — only makes the
 // already-failing unmocked path instant instead of runner-dependent.
-if (typeof globalThis.fetch !== 'function' || true) {
-  globalThis.fetch = vi.fn(() =>
-    Promise.reject(
-      new Error(
-        'fetch is not available in unit tests (WO-CI-FASTGATE-003 deterministic stub); mock it in your test if needed',
-      ),
+globalThis.fetch = vi.fn(() =>
+  Promise.reject(
+    new Error(
+      'fetch is not available in unit tests (WO-CI-FASTGATE-003 deterministic stub); mock it in your test if needed',
     ),
-  ) as unknown as typeof fetch;
-}
+  ),
+) as unknown as typeof fetch;

--- a/frontend/setupTests.vitest.ts
+++ b/frontend/setupTests.vitest.ts
@@ -151,3 +151,21 @@ if (!window.requestAnimationFrame) {
 if (!window.cancelAnimationFrame) {
   window.cancelAnimationFrame = (id) => window.clearTimeout(id);
 }
+
+// WO-CI-FASTGATE-003: deterministic default fetch.
+// Unmocked network calls otherwise depend on the CI runner's egress: a relative URL rejects
+// instantly, but an absolute URL to an unreachable host can HANG until the per-test timeout and,
+// with retry:2, balloon — which is what made one Frontend Fast Gate shard hang to the 30-min job
+// timeout on contended runners while sibling shards finished in ~4.5 min. Reject immediately so
+// unmocked fetches fail fast and deterministically. Tests that exercise fetch mock it themselves
+// (that per-test mock overrides this global). This changes no assertion — only makes the
+// already-failing unmocked path instant instead of runner-dependent.
+if (typeof globalThis.fetch !== 'function' || true) {
+  globalThis.fetch = vi.fn(() =>
+    Promise.reject(
+      new Error(
+        'fetch is not available in unit tests (WO-CI-FASTGATE-003 deterministic stub); mock it in your test if needed',
+      ),
+    ),
+  ) as unknown as typeof fetch;
+}


### PR DESCRIPTION
## WO-CI-FASTGATE-003 — follow-up (self-validating: touches setup so its own gate runs)

After the split (#1257), #1240 still failed on the split main. Precise durations from that run:
- unit shard 2/3: **4.7 min ✅**, shard 3/3: **4.4 min ✅**
- unit shard 1/3: **30.2 min ❌ (hang — orphan vitest/esbuild at kill)**
- Build & Checks: **30.3 min ❌ (stuck in Bundle Analysis)**

### Two root causes, two fixes
1. **Bundle Analysis ran the whole suite.** `pnpm run test:unit -- FILE` forwards `-- FILE`, which vitest treats as *no positional filter* → full 692-file suite (~30 min). **Fix:** call the vitest binary directly with a positional path → runs only `BundleAnalysis.test.ts`.
2. **Shard 1 hung on unmocked `fetch`.** Absolute-URL fetches to unreachable hosts hang until the per-test timeout and, with `retry: 2`, balloon on contended runners; relative URLs reject instantly — so it's runner-dependent (a good runner ran the full suite in 8.5 min). **Fix:** a deterministic default `fetch` stub in `setupTests.vitest.ts` that rejects immediately. Per-test fetch mocks override it. **No assertion changes** — it only makes the already-failing unmocked path instant instead of runner-dependent.

Both are authorized under the WO ("fix a hanging test / teardown defect", "test setup files"). This PR touches the setup file, so classify runs the frontend gates → it **self-validates** that the shards + checks now finish in-budget and that the fetch stub breaks no tests.

After merge: update #1240 → its gates run bounded → #1240 auto-merges.

## Summary by Sourcery

Stabilize and speed up the frontend Fast Gate by making bundle analysis run only its targeted test file and by introducing a deterministic default fetch stub in the unit test setup.

Enhancements:
- Add a global deterministic fetch stub in frontend unit test setup so unmocked network calls fail fast and consistently across CI runners.

CI:
- Update the frontend Fast Gate workflow to invoke vitest directly for the bundle analysis test file, preventing the full unit test suite from running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved bundle analysis test execution for more reliable build checks.
  * Added a deterministic network stub so unmocked requests fail immediately during unit tests.
  * Updated test guidance to require explicitly mocking network calls where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->