### PR TITLE
WO-BRAIN-008 Canonical Continuation Narrow Reconciliation

### DIFF
--- a/docs/brain/workorders/AUTONOMOUS_CONTINUATION_GATE.md
+++ b/docs/brain/workorders/AUTONOMOUS_CONTINUATION_GATE.md
@@ -53,8 +53,8 @@ human may authorize.
 
 Among programs with a safe, unblocked next WO, select in this order:
 
-1. **Lowest risk class first** — R0 (read-only audit/discovery) before R1 (docs) before R2 (scoped code).
-   Never select R3/R4 autonomously (those are walls).
+1. **Lowest risk class first** — use the canonical WOE R0-R5 execution model. Selection may identify
+   a higher-risk candidate, but it never grants missing authority to execute it.
 2. **Continuity** — prefer a lane that directly extends the finding just produced (e.g. after a
    Pilot-stub finding, the terrapilot-maturity lane). Continuity keeps evidence coherent.
 3. **Dependency readiness** — prefer lanes whose prerequisites are merged/done.

--- a/docs/brain/workorders/CONTINUATION_RULEBOOK.md
+++ b/docs/brain/workorders/CONTINUATION_RULEBOOK.md
@@ -51,8 +51,8 @@ Under `/loop program` on a regular program, continue to the next WO only when AL
 
 1. the current WO has a COMPLETED result with evidence;
 2. the next WO is in the **same** active program;
-3. the next WO's risk class is **equal to or lower** than the current WO (R0 ≤ R1 ≤ R2; never auto-cross
-   into R3+/a wall — see [risk classes in LOOP_MODES.md](goal-loop/LOOP_MODES.md));
+3. the next WO's risk class is **equal to or lower** than the current WO, or the active goal/loop
+   packet explicitly authorizes the higher WOE R0-R5 execution class;
 4. all dependencies are satisfied (required PRs merged, prerequisite WOs done);
 5. the next WO crosses **no** authority wall (SW-01..SW-10);
 6. no conflicting canon and no failed out-of-scope validation gate.
@@ -70,7 +70,7 @@ If any item is uncertain, downgrade to `/loop once` or `/loop stop`.
 1. RECORD  the wall/exhaustion in the Wall Ledger (WORK_ORDER_PROGRAM_QUEUE.md §Global Walls).
 2. PARK    the blocked WO (never cross the wall to stay busy).
 3. SELECT  the next lane by Lane Priority: lowest-risk-first → continuity → dependency-readiness →
-           register order — only lanes whose next WO is UNBLOCKED, SAME-RISK-OR-LOWER, crossing NO wall.
+           register order — only lanes whose next WO is UNBLOCKED and crosses NO ungranted wall.
 4. ADVANCE run that lane's within-program queue (§3).
 5. REPEAT  until no safe lane remains.
 6. STOP    at ALL-LANES-PARKED — the only legitimate full stop of a portfolio run.
@@ -84,8 +84,8 @@ this rulebook for the scope boundary.
 
 ## 5. How walls park lanes
 
-A wall (`SW-01..SW-10`, or any R3+/deploy/data/secret/runtime/CI/schema/product change) **parks the
-lane** — it is never crossed to keep working:
+A wall (`SW-01..SW-10`, or any ungranted R2-R5 tooling/runtime/production/protected change) **parks
+the lane** — it is never crossed to keep working:
 
 - **RECORD** it in the Wall Ledger: `program | parked WO | wall | one-line reason | evidence`.
 - **PARK** the blocked WO; do not downgrade the wall ("just a small edit") to enter it; do not invent a
@@ -105,13 +105,13 @@ lane** — it is never crossed to keep working:
 | Portfolio run: a lane walls | do **not** stop — park + advance |
 | Portfolio run: ALL lanes parked/exhausted | **STOP** — All-Lanes-Parked report |
 | Bounded mode reaches its scope boundary | **STOP** per that mode |
-| Human authority wall (R3+, deploy, data, secrets, PACS, county, new external service) | **STOP** — always |
+| Ungranted authority wall (R2-R5 tooling/runtime/production/protected action) | **STOP** — always |
 | Merge requires human authority not already granted | **STOP** |
 | Conflicting canon, or an honesty invariant would be violated | **STOP** |
 
 **The human is the authority wall, not the per-WO dispatcher.** Safe, same-risk continuation *inside the
 active scope* is automatic and must not prompt "what next?". The human decides only at walls, risk-class
-increases, ALL-LANES-PARKED, merge-authority gaps, or canon conflicts. (This supersedes the older
+increases without prior authority, ALL-LANES-PARKED, merge-authority gaps, or canon conflicts. (This supersedes the older
 "the operator always makes the final call on which WO to execute next" line in
 [work-order-engine.md](programs/work-order-engine.md), which predates the continuation gate.)
 

--- a/docs/brain/workorders/NEXT_ACTION_MATRIX.md
+++ b/docs/brain/workorders/NEXT_ACTION_MATRIX.md
@@ -21,23 +21,23 @@ Evaluate top-to-bottom; first matching row wins.
 
 | # | Condition | Action |
 |---|-----------|--------|
-| 1 | Active WO's next step crosses a stop wall (SW-01..SW-10) | **STOP** at that wall. Emit `AUTHORITY_WALL`/`CANONICAL_CONFLICT`. `OPERATOR_ACTION_REQUIRED` set. |
-| 2 | A gate failed and the failure is **outside** current WO scope | **STOP** — `FAILED_GATE` (SW-06). |
-| 3 | A gate failed **inside** current WO scope | **RECOVER** — fix within scope (`/loop recovery`); not a wall. |
-| 4 | Open PR is `BEHIND` main, auto-merge queued | `gh pr update-branch`; keep watching. |
-| 5 | Open PR has unresolved bot/review threads blocking merge | Resolve in-scope threads (`resolveReviewThread`); keep watching. |
-| 6 | Open PR gates pending | Wait, re-check; do not block on it — start next WO if independent. |
-| 7 | PR merged AND `/loop program` active AND next WO same-risk + unblocked + in-register | **EXECUTE** next WO. Do not ask. |
-| 8 | PR merged AND `/loop once` | **STOP** — name `NEXT_WO`, do not execute. |
-| 9 | Next WO is higher-risk than current | **STOP** — surface; request authorization for the higher risk class. |
-| 10 | Next WO not in register | **STOP** — do not invent. Propose adding it to the register (docs WO). |
-| 11 | No unblocked WO remains AND loop is `/loop once`, `/loop evidence`, or `/loop discovery` | **STOP** — that mode's scope is complete; retain its existing stop semantics. Do **not** portfolio-reconcile. |
-| 12 | No unblocked WO remains (or next crosses a wall) in a **regular** program under `/loop program` (within-program scope) | **STOP** — surface the wall / queue-exhaustion. Do **not** auto-jump to another program. |
-| 13 | Active program is **portfolio-operator** AND its current lane walls or exhausts | **PORTFOLIO RECONCILE** — park the lane, select the next safe registered lane by Lane Priority (`AUTONOMOUS_CONTINUATION_GATE.md`); stop only at **ALL-LANES-PARKED**. |
+| 1 | Active program is **portfolio-operator** AND its current lane walls or exhausts | **PORTFOLIO RECONCILE** — park the lane, select the next safe registered lane by Lane Priority (`AUTONOMOUS_CONTINUATION_GATE.md`); stop only at **ALL-LANES-PARKED**. |
+| 2 | Active WO's next step crosses a stop wall (SW-01..SW-10) outside portfolio reconciliation | **STOP** at that wall. Emit `AUTHORITY_WALL`/`CANONICAL_CONFLICT`. `OPERATOR_ACTION_REQUIRED` set. |
+| 3 | A gate failed and the failure is **outside** current WO scope | **STOP** — `FAILED_GATE` (SW-06). |
+| 4 | A gate failed **inside** current WO scope | **RECOVER** — fix within scope (`/loop recovery`); not a wall. |
+| 5 | Open PR is `BEHIND` main, auto-merge queued | `gh pr update-branch`; keep watching. |
+| 6 | Open PR has unresolved bot/review threads blocking merge | Resolve in-scope threads (`resolveReviewThread`); keep watching. |
+| 7 | Open PR gates pending | Wait, re-check; do not block on it — start next WO if independent. |
+| 8 | PR merged AND `/loop program` active AND next WO same-risk + unblocked + in-register | **EXECUTE** next WO. Do not ask. |
+| 9 | PR merged AND `/loop once` | **STOP** — name `NEXT_WO`, do not execute. |
+| 10 | Next WO is higher-risk than current and the active goal/loop does not explicitly authorize it | **STOP** — surface; request authorization for the higher risk class. |
+| 11 | Next WO not in register | **STOP** — do not invent. Propose adding it to the register (docs WO). |
+| 12 | No unblocked WO remains AND loop is `/loop once`, `/loop evidence`, or `/loop discovery` | **STOP** — that mode's scope is complete; retain its existing stop semantics. Do **not** portfolio-reconcile. |
+| 13 | No unblocked WO remains (or next crosses a wall) in a **regular** program under `/loop program` (within-program scope) | **STOP** — surface the wall / queue-exhaustion. Do **not** auto-jump to another program. |
 | 14 | None of the above | Continue the loop procedure. |
 
 Continuation / portfolio / stop scope is canonical in [CONTINUATION_RULEBOOK.md](CONTINUATION_RULEBOOK.md)
-(WO-BRAIN-008): row 12 = within-program STOP; row 13 = portfolio-operator-only cross-program advance.
+(WO-BRAIN-008): row 13 = within-program STOP; row 1 = portfolio-operator-only cross-program advance.
 
 ---
 
@@ -48,13 +48,15 @@ Continuation / portfolio / stop scope is canonical in [CONTINUATION_RULEBOOK.md]
 ```
 R0  read-only discovery / evidence (no writes)
 R1  docs / registry / playbook authoring
-R2  scoped code change with tests, no runtime/behavior expansion
-R3  runtime behavior change (SW-09) — requires authorization
-R4  deploy / data mutation / secrets / go-live (SW-01..SW-04, SW-10) — always a wall
+R2  local developer tooling with no product/runtime behavior
+R3  CI/governance/tooling, hooks, or policy configuration
+R4  runtime/application behavior (SW-09 unless explicitly authorized)
+R5  production/security/protected data (SW-01..SW-04, SW-10)
 ```
 
-A loop that starts at R1 may run R1 and R0 WOs freely. It **stops** before the first R3/R4 WO and
-surfaces it. R2 continues only if the WO explicitly authorizes scoped code (as WO-P8-MGMT-003 did).
+A loop that starts at R1 may run R1 and R0 WOs freely. R2 through R5 require the active goal/loop to
+authorize that risk and must stop at every ungranted wall. Risk classification alone never grants
+execution authority.
 
 ---
 
@@ -93,6 +95,6 @@ See [GOAL_LOOP_AUTONOMY_RULES.md](GOAL_LOOP_AUTONOMY_RULES.md).
 | p8-management-dashboard | WO-P8-MGMT-004 (deployment authorization **packet** — docs, R1) | 7 | EXECUTE after #1125 merges |
 | p8-management-dashboard | *actual frontend deploy* | 1 (SW-01) | STOP — authorization packet only |
 | benton-data-quality | WO-DATA-BENTON-ADDR-001 (read-only audit, R0) | 7 | EXECUTE (no SW-02) |
-| benton-data-quality | WO-DATA-BENTON-DUPE-001B (delete rows, R4) | 1 (SW-02) | STOP — parked |
+| benton-data-quality | WO-DATA-BENTON-DUPE-001B (delete rows, R5) | 2 (SW-02) | STOP — parked |
 | benton-demo | WO-DEPLOY-BENTON-003D (smoke/evidence rollup, R0/R1) | 7 | EXECUTE only if authorized (touches live surface) |
 | work-order-engine | WO-WOE-012 (autonomous continuation gate, R1) | 7 | EXECUTE |

--- a/docs/brain/workorders/WORK_ORDER_PROGRAM_QUEUE.md
+++ b/docs/brain/workorders/WORK_ORDER_PROGRAM_QUEUE.md
@@ -71,8 +71,10 @@ continuation / portfolio / stop semantics are now canonical in
 | WO | State |
 |----|-------|
 | WO-WOE-001..010 | DONE |
-| **WO-WOE-011 Full Operator Playbook** | **THIS WO** |
-| WO-WOE-012 Autonomous Same-Risk Continuation Gate → 013 Program Queue UI/Report → 014 Cross-Program Dependency Graph | QUEUED |
+| WO-WOE-011 Full Operator Playbook | DONE |
+| WO-WOE-012 Autonomous Same-Risk Continuation Gate | DONE |
+| WO-WOE-013 Program Queue UI/Report | R2 UI SOFT WALL |
+| WO-WOE-014 Cross-Program Dependency Graph | DONE |
 
 ### brain-operator  (`/goal brain-operator`)
 | WO | State |
@@ -107,7 +109,7 @@ continuation / portfolio / stop semantics are now canonical in
 | property-workbench | SPA deploy / pilot runtime / reserved-office | SW-01 / SW-09 / SW-10 | reachability + runtime + auth | `WO_WORKBENCH_001_010_*` |
 | terrapilot-maturity | first-tool L3 promotion | SW-01 / SW-09 / SW-10 | deploy Node runtime + integrate | `WO_TERRAPILOT_P3_P6_*` |
 
-**Selected safe lane:** brain-operator at WO-BRAIN-008. WOE-012 and WOE-014 are complete; WOE-013
+**Selected safe lane:** brain-operator at WO-BRAIN-009. WOE-012 and WOE-014 are complete; WOE-013
 remains an R2 UI soft wall.
 
 ---

--- a/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
+++ b/docs/brain/workorders/goal-loop/COMMAND_TO_PROGRAM_MAP.md
@@ -18,7 +18,7 @@ resolves.
 | `codex-operator-playbook` | Codex Operator Work Order Playbook | CLOSED at WO-CODEX-OP-009 | YES - governance capability merged | `once`, `evidence` |
 | `goal-loop-master-playbook` | Master Goal/Loop Playbook Governance | CLOSED at WO-GOAL-LOOP-MASTER-PLAYBOOK-001 | YES - governing baseline merged | `once`, `evidence` |
 | `program-status` | Master Active Program Playbook | Active program graph | NO | `once`, `evidence`, `discovery` |
-| `program-next` | Portfolio Operator | Brain Operator / WO-BRAIN-008 | NO - continue selected evidence/docs chain | `program`, `evidence`, `discovery` |
+| `program-next` | Portfolio Operator | Brain Operator / WO-BRAIN-009 | NO - continue selected evidence/docs chain | `program`, `evidence`, `discovery` |
 | `program-stop` | Master Playbook | NONE | YES — operator stop command | `once` |
 | `release-engineering` | Release Engineering | CLOSED at WO-REL-006 | YES - baseline closed after rollup | `once`, `evidence`, `discovery` |
 | `benton-demo` | P1 | WO-DEPLOY-BENTON-003D | YES - live-surface smoke/evidence requires authority | `once`, `merge-watch`, `evidence` |
@@ -41,7 +41,7 @@ resolves.
 | `core-import-status` | WO-CORE-1 Runtime Import Disposition | WO-CORE-1 | YES — owner-gated runtime import disposition | `evidence`, `discovery` |
 | `workbench-status` | P4 | CLOSED at WO-WORKBENCH-011 | YES - status/evidence only; new phase requires owner/WOE selection | `evidence`, `discovery` |
 | `work-order-engine` | P6 | WO-WOE-013 | YES - R2 Program Queue UI soft wall; WOE-012/014 complete | `once`, `evidence` |
-| `brain-operator` | Brain Operator System | WO-BRAIN-008 | NO | `once`, `program`, `evidence`, `discovery` |
+| `brain-operator` | Brain Operator System | WO-BRAIN-009 | NO | `once`, `program`, `evidence`, `discovery` |
 | `azure-county-runtime` | P8 | WO-AZURE-001 | YES - SW-01 deployment/county boundary | `once`, `evidence`, `discovery` |
 
 ---
@@ -212,10 +212,10 @@ No active stop walls at WO-WOE-011 (after 010 merges).
 | WO-BRAIN-005 | Loop engine maturity review | COMPLETE |
 | WO-BRAIN-006 | Memory and provenance integration audit | COMPLETE |
 | WO-BRAIN-007 | Agent role and stop-gate matrix | COMPLETE |
-| WO-BRAIN-008 | Autonomous continuation rulebook reconciliation | **CURRENT** |
-| WO-BRAIN-009 | Brain/WOE integration evidence and closeout | QUEUED |
+| WO-BRAIN-008 | Autonomous continuation rulebook reconciliation | COMPLETE |
+| WO-BRAIN-009 | Brain/WOE integration evidence and closeout | **CURRENT** |
 
-No active stop walls at WO-BRAIN-008.
+No active stop walls at WO-BRAIN-009.
 
 ---
 

--- a/docs/brain/workorders/goal-loop/LOOP_MODES.md
+++ b/docs/brain/workorders/goal-loop/LOOP_MODES.md
@@ -48,7 +48,8 @@ Continue through same-risk WOs in the active program until a terminal condition 
 
 **Continues while:**
 - next WO is in the same program
-- next WO risk class is equal to or lower than the current WO
+- next WO risk class is equal to or lower than the current WO, or the active goal/loop packet
+  explicitly authorizes the higher risk
 - no authority wall is in the next WO's sovereignty boundary
 - all dependencies of the next WO are satisfied (merged PRs, completed WOs)
 - no failed validation gate in the active chain
@@ -169,7 +170,8 @@ A loop may continue to the next WO only when ALL of the following are true:
 
 1. The current WO has a COMPLETED result with evidence
 2. The next WO is in the same active program (or explicitly cross-program and approved)
-3. The next WO's risk class is not higher than the current WO
+3. The next WO's risk class is not higher than the current WO, or the active goal/loop packet
+   explicitly authorizes the higher risk
 4. The next WO has no unresolved dependencies (no pending-merge PRs that the next WO requires)
 5. The next WO does not cross an authority wall
 6. No conflicting canon between the current and next WO's sovereignty boundaries
@@ -182,13 +184,12 @@ If any item is uncertain, downgrade to `/loop once` or `/loop stop`.
 
 | Class | Examples |
 |-------|---------|
-| R0 — Read-only | Discovery, evidence collection, SQL SELECT |
-| R1 — Docs/registry | Markdown, evidence docs, WO register updates |
-| R2 — Config/tooling | appsettings, CI config, dev tool setup |
-| R3 — Code/backend | C# service, EF migration, API endpoint |
-| R4 — Deployment | Azure deploy, App Service config, production |
-| R5 — Data mutation | DELETE/UPDATE on production or demo DB |
-| R5 — Secrets | Credential rotation, key vault, secret injection |
+| R0 — Read-only | Discovery and evidence collection with no repository writes |
+| R1 — Docs/operator truth | Markdown, evidence, schemas, registers, playbooks |
+| R2 — Local developer tooling | Local bootstrap and dev-only tooling without product behavior |
+| R3 — CI/governance/tooling | Hooks, pipeline gates, policy configuration, branch hygiene |
+| R4 — Runtime/application | Backend, frontend, or OS-platform observable behavior |
+| R5 — Production/protected authority | Deploy, release, secrets, PACS, county SQL/data, security |
 
-`/loop program` may continue through same or lower risk. It must stop before crossing up a risk class
-that contains an authority wall.
+`/loop program` may continue through same or lower risk. A higher-risk node continues only when the
+active goal/loop packet explicitly grants that risk and no ungranted wall remains.

--- a/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
+++ b/docs/brain/workorders/programs/ACTIVE_PROGRAM_PLAYBOOK.md
@@ -474,8 +474,8 @@ from program evidence.
 | Selected program | Brain Operator System |
 | Active goal | `GOAL-BRAIN-OPERATOR-001` |
 | Active loop | `LOOP-BRAIN-OPERATOR-001` |
-| Current WO | `WO-BRAIN-008` |
-| Next WO | `WO-BRAIN-009` |
+| Current WO | `WO-BRAIN-009` |
+| Next WO | Portfolio reconciliation after closeout |
 
 Portfolio reconciliation excludes completed and walled lanes, then selects the lowest-risk
 dependency-cleared registered node. BRAIN-002 completed the domain-pack audit with candidate-only

--- a/docs/brain/workorders/programs/brain-operator-system.md
+++ b/docs/brain/workorders/programs/brain-operator-system.md
@@ -6,7 +6,7 @@
 
 **Loop:** `LOOP-BRAIN-OPERATOR-001`
 
-**Status:** ACTIVE at WO-BRAIN-008
+**Status:** ACTIVE at WO-BRAIN-009
 
 **Last Updated:** 2026-07-11
 
@@ -47,8 +47,8 @@ Operationalize the one-Brain model. TerraFusion Brain (Cortex) owns queue, seque
 | WO-BRAIN-005 | Loop engine maturity review | COMPLETE | `/loop` is real operator procedure; no standalone scheduler is implemented |
 | WO-BRAIN-006 | Memory/provenance integration | COMPLETE | Repository memory exists but freshness and loading are environment-dependent |
 | WO-BRAIN-007 | Agent role and stop-gate policy | COMPLETE | Functional roles consolidated under one operator and root stop gates |
-| WO-BRAIN-008 | Autonomous continuation rulebook | **CURRENT** | When can the Brain/Codex proceed autonomously? When must it stop? Formal rulebook. |
-| WO-BRAIN-009 | Brain/WOE integration evidence packet | QUEUED | Prove the Brain can query the WO Engine, score next WOs, and present a plan to the operator |
+| WO-BRAIN-008 | Autonomous continuation rulebook | COMPLETE | Canonical continuation rulebook merged in PR #1270 |
+| WO-BRAIN-009 | Brain/WOE integration evidence packet | **CURRENT** | Prove query, scoring, routing, walls, and operator surfaces agree |
 
 ---
 


### PR DESCRIPTION
## Summary
- reconcile canonical continuation routing after PR #1270
- advance Brain Operator routing to WO-BRAIN-009
- place portfolio reconciliation before the generic wall stop
- align continuation risk language with canonical WOE R0-R5 semantics
- reconcile WOE-011 through WOE-014 queue status

## Scope
- governance documentation only
- manually applied to current main; no merge, rebase, or cherry-pick from superseded PR #1269
- does not add the alternate BRAIN-008 evidence document
- does not replace or duplicate CONTINUATION_RULEBOOK.md
- no registry/query/scoring implementation changes
- no BRAIN-009 execution

## Validation
- git diff --check
- node docs/brain/workorders/tools/wo-query.mjs --json
- Prettier check on all eight files
- normal pre-commit hooks
- pre-push unit tests: 164 passed
- Snyk retry completed through the normal push path after a transient 504/TLS timeout

## Supersession
PR #1269 is closed and superseded by canonical PR #1270 plus this narrow reconciliation.

## Summary by Sourcery

Reconcile autonomous continuation and portfolio routing docs with canonical WOE R0–R5 semantics and advance the Brain Operator system to WO-BRAIN-009.

Enhancements:
- Prioritize portfolio reconciliation ahead of stop walls in the next-action matrix and clarify when higher-risk WOs may proceed based on explicit loop authority.
- Align risk class definitions and examples across loop modes and continuation rulebook docs with the canonical WOE R0–R5 execution model.
- Tighten authority wall language to distinguish ungranted R2–R5 actions and clarify human decision points for risk increases.
- Update command-to-program maps, active program queues, and playbooks to reflect WO-BRAIN-008 completion and WO-BRAIN-009 as the current Brain Operator work order.
- Clarify autonomous lane selection rules so higher-risk candidates can be surfaced without implicitly granting authority.